### PR TITLE
Iceberg Plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
         <dep.tempto.version>1.49</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
-
         <!-- use a fractional hour timezone offset for tests -->
         <air.test.timezone>Asia/Katmandu</air.test.timezone>
         <air.test.parallel>methods</air.test.parallel>
@@ -123,6 +122,7 @@
         <module>presto-memory-context</module>
         <module>presto-proxy</module>
         <module>presto-kudu</module>
+        <module>presto-iceberg</module>
     </modules>
 
     <dependencyManagement>
@@ -210,6 +210,12 @@
             <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-hive-hadoop2</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-iceberg</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -155,7 +155,7 @@ public class HivePartitionManager
         return new HivePartitionResult(partitionColumns, partitionsIterable, compactEffectivePredicate, remainingTupleDomain, enforcedTupleDomain, hiveBucketHandle, bucketFilter);
     }
 
-    private static TupleDomain<HiveColumnHandle> toCompactTupleDomain(TupleDomain<ColumnHandle> effectivePredicate, int threshold)
+    public static TupleDomain<HiveColumnHandle> toCompactTupleDomain(TupleDomain<ColumnHandle> effectivePredicate, int threshold)
     {
         ImmutableMap.Builder<HiveColumnHandle, Domain> builder = ImmutableMap.builder();
         effectivePredicate.getDomains().ifPresent(domains -> {

--- a/presto-iceberg/README.md
+++ b/presto-iceberg/README.md
@@ -1,0 +1,46 @@
+This plugin allows presto to interact with [iceberg][iceberg]  tables.
+
+[iceberg]: https://github.com/Netflix/iceberg
+
+## Status
+
+Currently this plugin supports create, CTAS, drop and reading from iceberg table. Support for other DDL operation will be added soon.
+
+
+## How to configure
+
+The plugin extends from hive-plugin so it needs metastore configs and s3 configs if you use s3. In addition the current implementation relies
+on [HiveTables][HiveTables]  implementation which relies on `metastore.thrift.uris` and `hive.metastore.warehouse.dir` values from the hive-site.xml. 
+
+You can look at the sample configuration under `presto-main/etc/catalog/iceberg.properties`
+
+[HiveTables]: https://github.com/Netflix/iceberg/tree/master/hive/src/main/java/com/netflix/iceberg/hive
+
+### How to create an iceberg table
+Just like a hive table, the only difference is you will specify the iceberg catalog instead of a hive catalog.
+
+## Unpartitioned Tables
+``` sql
+create table iceberg.testdb.sample (
+    i int, 
+    s varchar
+);
+```
+## Partitioned Tables
+Currently we only support identity partitions so there is no difference in hive vs iceberg syntax. Just like unpartitioned table you must specify iceberg catalog to create iceberg tables.
+
+``` sql
+create table iceberg.testdb.sample_partitioned (
+    b boolean,
+    dateint integer,
+    l bigint,
+    f real,
+    d double,
+    de decimal(12,2),
+    dt date,
+    ts timestamp,
+    s varchar,
+    bi varbinary
+ )
+WITH (partitioned_by = ARRAY['dateint', 's']);
+```

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.213-SNAPSHOT</version>
+    </parent>
+
+
+    <artifactId>presto-iceberg</artifactId>
+    <name>presto-iceberg</name>
+    <description>Presto - Iceberg Connector</description>
+    <packaging>presto-plugin</packaging>
+
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+
+    </repositories>
+
+    <properties>
+        <parquet.version>1.10.0</parquet.version>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <!--<air.check.skip-dependency>true</air.check.skip-dependency>-->
+        <!--<air.check.skip-duplicate-finder>true</air.check.skip-duplicate-finder>-->
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.facebook.presto.hadoop</groupId>
+            <artifactId>hadoop-apache2</artifactId>
+            <!--<scope>runtime</scope>-->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.Netflix.iceberg</groupId>
+            <artifactId>iceberg-presto-runtime</artifactId>
+            <version>0.3.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-hive</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto.hive</groupId>
+            <artifactId>hive-apache</artifactId>
+            <version>1.2.0-2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>event</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+
+        <!-- Presto SPI -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+            <version>${dep.jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${dep.jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${dep.jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <version>6.5.9</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>aircompressor</artifactId>
+            <version>0.12</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- test scope -->
+        <!--<dependency>-->
+            <!--<groupId>com.facebook.presto</groupId>-->
+            <!--<artifactId>presto-main</artifactId>-->
+            <!--<scope>test</scope>-->
+        <!--</dependency>-->
+
+        <!--<dependency>-->
+            <!--<groupId>com.facebook.presto</groupId>-->
+            <!--<artifactId>presto-tests</artifactId>-->
+            <!--<scope>test</scope>-->
+        <!--</dependency>-->
+
+        <!--<dependency>-->
+            <!--<groupId>org.testng</groupId>-->
+            <!--<artifactId>testng</artifactId>-->
+            <!--<scope>test</scope>-->
+        <!--</dependency>-->
+
+        <!--<dependency>-->
+            <!--<groupId>io.airlift</groupId>-->
+            <!--<artifactId>testing</artifactId>-->
+            <!--<scope>test</scope>-->
+        <!--</dependency>-->
+
+        <!--<dependency>-->
+            <!--<groupId>org.anarres.lzo</groupId>-->
+            <!--<artifactId>lzo-hadoop</artifactId>-->
+            <!--<scope>test</scope>-->
+        <!--</dependency>-->
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>analyze</id>
+                                <goals>
+                                    <goal>analyze-only</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>true</skip>
+                                    <ignoredDependencies>
+                                        <ignoredDependency>org.slf4j:slf4j-api</ignoredDependency>
+                                    </ignoredDependencies>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.basepom.maven</groupId>
+                        <artifactId>duplicate-finder-maven-plugin</artifactId>
+                        <configuration>
+                            <ignoredResourcePatterns>
+                                <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
+                                <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                            </ignoredResourcePatterns>
+                            <ignoredDependencies>
+                                <dependency>
+                                    <groupId>org.apache.avro</groupId>
+                                    <artifactId>avro</artifactId>
+                                </dependency>
+                            </ignoredDependencies>
+                        </configuration>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CommitTaskData.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CommitTaskData.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CommitTaskData
+{
+    private String path;
+    private String metricsJson;
+    private String partitionPath;
+
+    @JsonCreator
+    public CommitTaskData(
+            @JsonProperty("path") String path,
+            @JsonProperty("metricsJson") String metricsJson,
+            @JsonProperty("partitionPath") String partitionPath)
+    {
+        this.path = path;
+        this.metricsJson = metricsJson;
+        this.partitionPath = partitionPath;
+    }
+
+    @JsonProperty
+    public String getPath()
+    {
+        return path;
+    }
+
+    @JsonProperty
+    public String getMetricsJson()
+    {
+        return metricsJson;
+    }
+
+    @JsonProperty
+    public String getPartitionPath()
+    {
+        return partitionPath;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ExpressionConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ExpressionConverter.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.iceberg.type.TypeConveter;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.EquatableValueSet;
+import com.facebook.presto.spi.predicate.Marker;
+import com.facebook.presto.spi.predicate.Range;
+import com.facebook.presto.spi.predicate.SortedRangeSet;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.type.DateTimeEncoding;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.RealType;
+import com.facebook.presto.spi.type.TimeType;
+import com.facebook.presto.spi.type.TimeWithTimeZoneType;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.TimestampWithTimeZoneType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.expressions.And;
+import com.netflix.iceberg.expressions.BoundReference;
+import com.netflix.iceberg.expressions.Expression;
+import com.netflix.iceberg.expressions.Expressions;
+import com.netflix.iceberg.expressions.NamedReference;
+import com.netflix.iceberg.expressions.Not;
+import com.netflix.iceberg.expressions.Or;
+import com.netflix.iceberg.expressions.Predicate;
+import com.netflix.iceberg.expressions.Reference;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static com.facebook.presto.spi.predicate.Domain.create;
+import static com.facebook.presto.spi.predicate.Marker.Bound.ABOVE;
+import static com.facebook.presto.spi.predicate.Marker.Bound.BELOW;
+import static com.facebook.presto.spi.predicate.Marker.Bound.EXACTLY;
+import static com.facebook.presto.spi.predicate.ValueSet.ofRanges;
+import static com.facebook.presto.spi.type.Decimals.MAX_SHORT_PRECISION;
+import static com.facebook.presto.spi.type.Decimals.encodeScaledValue;
+import static com.facebook.presto.spi.type.StandardTypes.TIME;
+import static com.facebook.presto.spi.type.StandardTypes.TIMESTAMP;
+import static com.facebook.presto.spi.type.StandardTypes.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.StandardTypes.TIME_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.StandardTypes.VARBINARY;
+import static com.facebook.presto.spi.type.StandardTypes.VARCHAR;
+import static com.netflix.iceberg.expressions.Expressions.and;
+import static com.netflix.iceberg.expressions.Expressions.equal;
+import static com.netflix.iceberg.expressions.Expressions.greaterThan;
+import static com.netflix.iceberg.expressions.Expressions.greaterThanOrEqual;
+import static com.netflix.iceberg.expressions.Expressions.lessThan;
+import static com.netflix.iceberg.expressions.Expressions.lessThanOrEqual;
+import static com.netflix.iceberg.expressions.Expressions.or;
+
+// TODO Wish there was a way to actually get condition expressions instead of dealing with Domain
+public class ExpressionConverter
+{
+    private ExpressionConverter()
+    {}
+
+    public static Expression toIceberg(TupleDomain<HiveColumnHandle> tupleDomain, ConnectorSession session)
+    {
+        if (tupleDomain.isAll()) {
+            return Expressions.alwaysTrue();
+        }
+        else if (tupleDomain.isNone()) {
+            return Expressions.alwaysFalse();
+        }
+        else {
+            final Map<HiveColumnHandle, Domain> tDomainMap = tupleDomain.getDomains().get();
+            Expression expression = Expressions.alwaysTrue();
+            for (Map.Entry<HiveColumnHandle, Domain> tDomainEntry : tDomainMap.entrySet()) {
+                final HiveColumnHandle key = tDomainEntry.getKey();
+                final Domain domain = tDomainEntry.getValue();
+                expression = Expressions.and(expression, toIceberg(key, domain, session));
+            }
+            return expression;
+        }
+    }
+
+    private static Expression toIceberg(HiveColumnHandle column, Domain domain, ConnectorSession session)
+    {
+        String columnName = column.getName();
+        if (domain.isAll()) {
+            return Expressions.alwaysTrue();
+        }
+        else if (domain.isNone()) {
+            return Expressions.alwaysFalse();
+        }
+        else if (domain.isOnlyNull()) {
+            return Expressions.isNull(columnName);
+        }
+        else {
+            final ValueSet domainValues = domain.getValues();
+            Expression expression = null;
+            if (domain.isNullAllowed()) {
+                expression = Expressions.isNull(columnName);
+            }
+
+            if (domainValues instanceof EquatableValueSet) {
+                expression = (expression == null ? Expressions.alwaysFalse() : expression);
+                if (((EquatableValueSet) domainValues).isWhiteList()) {
+                    // if whitelist is true than this is a case of "in", otherwise this is a case of "not in".
+                    return or(expression, equal(columnName, ((EquatableValueSet) domainValues).getValues()));
+                }
+                else {
+                    return or(expression, Expressions.notEqual(columnName, ((EquatableValueSet) domainValues).getValues()));
+                }
+            }
+            else {
+                if (domainValues instanceof SortedRangeSet) {
+                    final List<Range> orderedRanges = ((SortedRangeSet) domainValues).getOrderedRanges();
+                    expression = (expression == null ? Expressions.alwaysFalse() : expression);
+                    for (Range range : orderedRanges) {
+                        final Marker low = range.getLow();
+                        final Marker high = range.getHigh();
+                        final Marker.Bound lowBound = low.getBound();
+                        final Marker.Bound highBound = high.getBound();
+
+                        // case col <> 'val' is represented as (col < 'val' or col > 'val')
+                        if (lowBound.equals(EXACTLY) && highBound.equals(EXACTLY)) {
+                            // case ==
+                            if (getValue(column, low, session).equals(getValue(column, high, session))) {
+                                expression = or(expression, equal(columnName, getValue(column, low, session)));
+                            }
+                            else { // case between
+                                final Expression between = and(greaterThanOrEqual(columnName, getValue(column, low, session)), lessThanOrEqual(columnName, getValue(column, high, session)));
+                                expression = or(expression, between);
+                            }
+                        }
+                        else {
+                            if (lowBound.equals(EXACTLY) && low.getValueBlock().isPresent()) {
+                                // case >=
+                                expression = or(expression, greaterThanOrEqual(columnName, getValue(column, low, session)));
+                            }
+                            else if (lowBound.equals(ABOVE) && low.getValueBlock().isPresent()) {
+                                // case >
+                                expression = or(expression, greaterThan(columnName, getValue(column, low, session)));
+                            }
+
+                            if (highBound.equals(EXACTLY) && high.getValueBlock().isPresent()) {
+                                // case <=
+                                expression = or(expression, lessThanOrEqual(columnName, getValue(column, high, session)));
+                            }
+                            else if (highBound.equals(BELOW) && high.getValueBlock().isPresent()) {
+                                // case <
+                                expression = or(expression, lessThan(columnName, getValue(column, high, session)));
+                            }
+                        }
+                    }
+                }
+                else {
+                    throw new IllegalStateException("Did not expect a domain value set other than SortedRangeSet and EquatableValueSet but got " + domainValues.getClass().getSimpleName());
+                }
+            }
+            return expression;
+        }
+    }
+
+    private static Object getValue(HiveColumnHandle columnHandle, Marker marker, ConnectorSession session)
+    {
+        final String base = columnHandle.getTypeSignature().getBase();
+        if (base.equals(TIMESTAMP_WITH_TIME_ZONE) || base.equals(TIME_WITH_TIME_ZONE)) {
+            return TimeUnit.MILLISECONDS.toNanos(DateTimeEncoding.unpackMillisUtc((Long) marker.getValue()));
+        }
+        else if (base.equals(TIME) || base.equals(TIMESTAMP)) {
+            return TimeUnit.MILLISECONDS.toNanos((Long) marker.getValue());
+        }
+        else if (base.equals(VARCHAR)) {
+            return marker.getPrintableValue(session);
+        }
+        else if (base.equals(VARBINARY)) {
+            return ((Slice) marker.getValue()).getBytes();
+        }
+        return marker.getValue();
+    }
+
+    private static Object getValue(Type type, Object value)
+    {
+        if (type instanceof TimestampType || type instanceof TimestampWithTimeZoneType || type instanceof TimeType || type instanceof TimeWithTimeZoneType) {
+            // iceberg does not support zone preservation.
+            return TimeUnit.NANOSECONDS.toMillis((Long) value);
+        }
+        else if (type instanceof VarcharType) {
+            return Slices.utf8Slice(value.toString());
+        }
+        else if (type instanceof DecimalType) {
+            if (((DecimalType) type).getPrecision() <= MAX_SHORT_PRECISION) {
+                return value;
+            }
+            else {
+                return encodeScaledValue(new BigDecimal(String.valueOf(value)));
+            }
+        }
+        else if (type instanceof IntegerType && value instanceof Integer) {
+            // TODO this is not good, The range creation internally uses a Util class that validates if the value type matches with type's java class
+            // representation. But does not coerce for things like IntegerType which is represented with java `long` but the value it self could be int.
+            return Long.valueOf((Integer) value);
+        }
+        else if (type instanceof RealType && value instanceof Float) {
+            return Long.valueOf(Float.floatToIntBits((Float) value));
+        }
+        return value;
+    }
+
+    public static TupleDomain<HiveColumnHandle> fromIceberg(Expression expression, Map<String, HiveColumnHandle> hiveColumnHandleMap, Schema schema, TypeManager typeManager)
+    {
+        // this assumes that null allowed would be a separate domainTuple
+        final boolean nullAllowed = false;
+        switch (expression.op()) {
+            case TRUE:
+                return TupleDomain.all();
+            case FALSE:
+                return TupleDomain.none();
+            case AND:
+                final And and = (And) expression;
+                TupleDomain<HiveColumnHandle> left = fromIceberg(and.left(), hiveColumnHandleMap, schema, typeManager);
+                TupleDomain<HiveColumnHandle> right = fromIceberg(and.right(), hiveColumnHandleMap, schema, typeManager);
+                return left.intersect(right);
+            case OR:
+                final Or or = (Or) expression;
+                left = fromIceberg(or.left(), hiveColumnHandleMap, schema, typeManager);
+                right = fromIceberg(or.right(), hiveColumnHandleMap, schema, typeManager);
+                return TupleDomain.columnWiseUnion(left, right);
+            case NOT:
+                return fromIceberg(((Not) expression).child(), hiveColumnHandleMap, schema, typeManager);
+            case IS_NULL:
+                return fromIceberg(expression, hiveColumnHandleMap, schema, typeManager, Domain::onlyNull);
+            case NOT_NULL:
+                return fromIceberg(expression, hiveColumnHandleMap, schema, typeManager, Domain::notNull);
+            case EQ:
+                return fromIceberg(expression, schema, typeManager, hiveColumnHandleMap, nullAllowed, Range::equal);
+            case NOT_EQ:
+                Predicate<?, Reference> predicate = (Predicate) expression;
+                int fieldId = getFieldIdByName(predicate.ref(), schema);
+                Type type = TypeConveter.convert(schema.findType(fieldId), typeManager);
+                ValueSet values = ofRanges(Range.lessThan(type, getValue(type, predicate.literal().value())), Range.greaterThan(type, getValue(type, predicate.literal().value()))).complement();
+                return TupleDomain.withColumnDomains(ImmutableMap.of(hiveColumnHandleMap.get(schema.findColumnName(fieldId)), create(values, nullAllowed)));
+            case LT:
+                return fromIceberg(expression, schema, typeManager, hiveColumnHandleMap, nullAllowed, Range::lessThan);
+            case GT:
+                return fromIceberg(expression, schema, typeManager, hiveColumnHandleMap, nullAllowed, Range::greaterThan);
+            case LT_EQ:
+                return fromIceberg(expression, schema, typeManager, hiveColumnHandleMap, nullAllowed, Range::lessThanOrEqual);
+            case GT_EQ:
+                return fromIceberg(expression, schema, typeManager, hiveColumnHandleMap, nullAllowed, Range::greaterThanOrEqual);
+            case IN: // implemented through chaining EQ operation with OR
+            case NOT_IN: // implemented through chaining NOT_EQ operation with OR
+                throw new RuntimeException("IN and NOT_IN expression are not expected as those expressions are represented by chaining EQ/NOT_EQ with OR.");
+            default:
+                throw new RuntimeException("Can't handle operation " + expression.op());
+        }
+    }
+
+    private static TupleDomain fromIceberg(Expression expression,
+            Schema schema,
+            TypeManager typeManager,
+            Map<String, HiveColumnHandle> hiveColumnHandleMap,
+            boolean nullAllowed, BiFunction<Type, Object, Range> valueExtractor)
+    {
+        Predicate<?, Reference> predicate = (Predicate) expression;
+        int fieldId = getFieldIdByName(predicate.ref(), schema);
+        Type type = TypeConveter.convert(schema.findType(fieldId), typeManager);
+        ValueSet values = ofRanges(valueExtractor.apply(type, getValue(type, predicate.literal().value())));
+        return TupleDomain.withColumnDomains(ImmutableMap.of(hiveColumnHandleMap.get(schema.findColumnName(fieldId)), create(values, nullAllowed)));
+    }
+
+    private static TupleDomain<HiveColumnHandle> fromIceberg(Expression expression,
+            Map<String, HiveColumnHandle> hiveColumnHandleMap,
+            Schema schema,
+            TypeManager typeManager,
+            Function<Type, Domain> domainExtractor)
+    {
+        Predicate<?, Reference> predicate = (Predicate) expression;
+        int fieldId = getFieldIdByName(predicate.ref(), schema);
+        Type type = TypeConveter.convert(schema.findType(fieldId), typeManager);
+        return TupleDomain.withColumnDomains(ImmutableMap.of(hiveColumnHandleMap.get(schema.findColumnName(fieldId)), domainExtractor.apply(type)));
+    }
+
+    private static <R extends Reference> int getFieldIdByName(R reference, Schema schema)
+    {
+        if (reference instanceof BoundReference) {
+            return ((BoundReference) reference).fieldId();
+        }
+        else if (reference instanceof NamedReference) {
+            return schema.findField(((NamedReference) reference).name()).fieldId();
+        }
+        else {
+            throw new UnsupportedOperationException("Iceberg Predicates should only be of BoundReference or NamedReference type but got " + reference.getClass().getSimpleName());
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HiveTransactionHandle;
+import com.facebook.presto.hive.HiveTransactionManager;
+import com.facebook.presto.spi.SystemTable;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorAccessControl;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata;
+import com.facebook.presto.spi.session.PropertyMetadata;
+import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.log.Logger;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.spi.transaction.IsolationLevel.READ_UNCOMMITTED;
+import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergConnector
+        implements Connector
+{
+    private static final Logger log = Logger.get(IcebergConnector.class);
+
+    private final LifeCycleManager lifeCycleManager;
+    private final IcebergMetadataFactory metadataFactory;
+    private final HiveTransactionManager transactionManager;
+    private final ConnectorSplitManager splitManager;
+    private final ConnectorPageSourceProvider pageSourceProvider;
+    private final ConnectorPageSinkProvider pageSinkProvider;
+    private final ConnectorNodePartitioningProvider connectorNodePartitioningProvider;
+    private final Set<SystemTable> systemTables;
+    private final List<PropertyMetadata<?>> sessionProperties;
+    private final List<PropertyMetadata<?>> schemaProperties;
+    private final List<PropertyMetadata<?>> tableProperties;
+    private final ConnectorAccessControl accessControl;
+    private final ClassLoader classLoader;
+
+    @Override
+    public ConnectorNodePartitioningProvider getNodePartitioningProvider()
+    {
+        return this.connectorNodePartitioningProvider;
+    }
+
+    public IcebergConnector(
+            LifeCycleManager lifeCycleManager,
+            IcebergMetadataFactory metadataFactory,
+            HiveTransactionManager transactionManager,
+            ConnectorSplitManager splitManager,
+            ConnectorPageSourceProvider pageSourceProvider,
+            ConnectorPageSinkProvider pageSinkProvider,
+            ConnectorNodePartitioningProvider connectorNodePartitioningProvider,
+            Set<SystemTable> systemTables,
+            List<PropertyMetadata<?>> sessionProperties,
+            List<PropertyMetadata<?>> schemaProperties,
+            List<PropertyMetadata<?>> tableProperties,
+            ConnectorAccessControl accessControl,
+            ClassLoader classLoader)
+    {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
+        this.metadataFactory = metadataFactory;
+        this.transactionManager = transactionManager;
+        this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
+        this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
+        this.connectorNodePartitioningProvider = requireNonNull(connectorNodePartitioningProvider, "pageSinkProvider is null");
+        this.systemTables = ImmutableSet.copyOf(requireNonNull(systemTables, "systemTables is null"));
+        this.sessionProperties = ImmutableList.copyOf(requireNonNull(sessionProperties, "sessionProperties is null"));
+        this.schemaProperties = ImmutableList.copyOf(requireNonNull(schemaProperties, "schemaProperties is null"));
+        this.tableProperties = ImmutableList.copyOf(requireNonNull(tableProperties, "tableProperties is null"));
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
+    {
+        ConnectorMetadata metadata = transactionManager.get(transaction);
+        checkArgument(metadata != null, "no such transaction: %s", transaction);
+        return new ClassLoaderSafeConnectorMetadata(metadata, classLoader);
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager()
+    {
+        return splitManager;
+    }
+
+    @Override
+    public ConnectorPageSourceProvider getPageSourceProvider()
+    {
+        return pageSourceProvider;
+    }
+
+    @Override
+    public ConnectorPageSinkProvider getPageSinkProvider()
+    {
+        return pageSinkProvider;
+    }
+
+    @Override
+    public Set<SystemTable> getSystemTables()
+    {
+        return systemTables;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSchemaProperties()
+    {
+        return schemaProperties;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties;
+    }
+
+    @Override
+    public ConnectorAccessControl getAccessControl()
+    {
+        return accessControl;
+    }
+
+    @Override
+    public boolean isSingleStatementWritesOnly()
+    {
+        return false;
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
+    {
+        checkConnectorSupports(READ_UNCOMMITTED, isolationLevel);
+        ConnectorTransactionHandle transaction = new HiveTransactionHandle();
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            transactionManager.put(transaction, metadataFactory.get());
+        }
+        return transaction;
+    }
+
+    @Override
+    public void commit(ConnectorTransactionHandle transaction)
+    {
+        ConnectorMetadata metadata = transactionManager.remove(transaction);
+        checkArgument(metadata != null, "no such transaction: %s", transaction);
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            if (metadata instanceof IcebergMetadata) {
+                ((IcebergMetadata) metadata).commit();
+            }
+        }
+    }
+
+    @Override
+    public void rollback(ConnectorTransactionHandle transaction)
+    {
+        ConnectorMetadata metadata = transactionManager.remove(transaction);
+        checkArgument(metadata != null, "no such transaction: %s", transaction);
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            if (metadata instanceof IcebergMetadata) {
+                ((IcebergMetadata) metadata).rollback();
+            }
+        }
+    }
+
+    @Override
+    public final void shutdown()
+    {
+        try {
+            lifeCycleManager.stop();
+        }
+        catch (Exception e) {
+            log.error(e, "Error shutting down connector");
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnectorFactory.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HiveSchemaProperties;
+import com.facebook.presto.hive.HiveSessionProperties;
+import com.facebook.presto.hive.HiveTableProperties;
+import com.facebook.presto.hive.HiveTransactionManager;
+import com.facebook.presto.hive.NodeVersion;
+import com.facebook.presto.hive.RebindSafeMBeanServer;
+import com.facebook.presto.hive.authentication.HiveAuthenticationModule;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
+import com.facebook.presto.hive.metastore.thrift.HiveMetastore;
+import com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore;
+import com.facebook.presto.hive.s3.HiveS3Module;
+import com.facebook.presto.hive.security.HiveSecurityModule;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorAccessControl;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPageSinkProvider;
+import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorSplitManager;
+import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeNodePartitioningProvider;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.event.client.EventModule;
+import io.airlift.json.JsonModule;
+import org.weakref.jmx.guice.MBeanModule;
+
+import javax.management.MBeanServer;
+
+import java.lang.management.ManagementFactory;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergConnectorFactory
+        implements ConnectorFactory
+{
+    private final String name;
+    private final ClassLoader classLoader;
+
+    public IcebergConnectorFactory(String name, ClassLoader classLoader)
+    {
+        checkArgument(!isNullOrEmpty(name), "name is null or empty");
+        this.name = name;
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public ConnectorHandleResolver getHandleResolver()
+    {
+        return new IcebergHandleResolver();
+    }
+
+    @Override
+    public Connector create(String connectorId, Map<String, String> config, ConnectorContext context)
+    {
+        requireNonNull(config, "config is null");
+
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            Bootstrap app = new Bootstrap(
+                    new EventModule(),
+                    new MBeanModule(),
+                    new JsonModule(),
+                    new IcebergModule(connectorId, context.getTypeManager(), context.getPageIndexerFactory(), context.getNodeManager()),
+                    new HiveS3Module(connectorId),
+                    new HiveSecurityModule(),
+                    new HiveAuthenticationModule(),
+                    binder -> {
+                        MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+                        binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(platformMBeanServer));
+                        binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
+                        binder.bind(NodeManager.class).toInstance(context.getNodeManager());
+                        binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                        binder.bind(HiveMetastore.class).to(ThriftHiveMetastore.class).in(Scopes.SINGLETON);
+                        binder.bind(ExtendedHiveMetastore.class).to(BridgingHiveMetastore.class).in(Scopes.SINGLETON);
+                    });
+
+            Injector injector = app
+                    .strictConfig()
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
+            IcebergMetadataFactory metadataFactory = injector.getInstance(IcebergMetadataFactory.class);
+            HiveTransactionManager transactionManager = injector.getInstance(HiveTransactionManager.class);
+            ConnectorSplitManager splitManager = injector.getInstance(ConnectorSplitManager.class);
+            ConnectorPageSourceProvider connectorPageSource = injector.getInstance(ConnectorPageSourceProvider.class);
+            ConnectorPageSinkProvider pageSinkProvider = injector.getInstance(ConnectorPageSinkProvider.class);
+            ConnectorNodePartitioningProvider connectorDistributionProvider = injector.getInstance(ConnectorNodePartitioningProvider.class);
+            HiveSessionProperties hiveSessionProperties = injector.getInstance(HiveSessionProperties.class);
+            HiveTableProperties hiveTableProperties = injector.getInstance(HiveTableProperties.class);
+            ConnectorAccessControl accessControl = injector.getInstance(ConnectorAccessControl.class);
+
+            return new IcebergConnector(
+                    lifeCycleManager,
+                    metadataFactory,
+                    transactionManager,
+                    new ClassLoaderSafeConnectorSplitManager(splitManager, classLoader),
+                    new ClassLoaderSafeConnectorPageSourceProvider(connectorPageSource, classLoader),
+                    new ClassLoaderSafeConnectorPageSinkProvider(pageSinkProvider, classLoader),
+                    new ClassLoaderSafeNodePartitioningProvider(connectorDistributionProvider, classLoader),
+                    ImmutableSet.of(),
+                    hiveSessionProperties.getSessionProperties(),
+                    HiveSchemaProperties.SCHEMA_PROPERTIES,
+                    hiveTableProperties.getTableProperties(),
+                    accessControl,
+                    classLoader);
+        }
+        catch (Exception e) {
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHandleResolver.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHandleResolver.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HivePartitioningHandle;
+import com.facebook.presto.hive.HiveTransactionHandle;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+public class IcebergHandleResolver
+        implements ConnectorHandleResolver
+{
+    @Override
+    public Class<? extends ConnectorTableHandle> getTableHandleClass()
+    {
+        return IcebergTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTableLayoutHandle> getTableLayoutHandleClass()
+    {
+        return IcebergTableLayoutHandle.class;
+    }
+
+    @Override
+    public Class<? extends ColumnHandle> getColumnHandleClass()
+    {
+        return HiveColumnHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorSplit> getSplitClass()
+    {
+        return IcebergSplit.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorOutputTableHandle> getOutputTableHandleClass()
+    {
+        return IcebergInsertTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorInsertTableHandle> getInsertTableHandleClass()
+    {
+        return IcebergInsertTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTransactionHandle> getTransactionHandleClass()
+    {
+        return HiveTransactionHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorPartitioningHandle> getPartitioningHandleClass()
+    {
+        return HivePartitioningHandle.class;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netflix.iceberg.FileFormat;
+
+import java.util.List;
+
+public class IcebergInsertTableHandle
+        implements ConnectorInsertTableHandle, ConnectorOutputTableHandle
+{
+    private final String schemaName;
+    private final String tableName;
+    private final String schemaAsJson;
+    private final List<HiveColumnHandle> inputColumns;
+    private final String filePrefix;
+    private final FileFormat fileFormat;
+
+    @JsonProperty("schemaName")
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @JsonProperty("tableName")
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @JsonProperty("schemaAsJson")
+    public String getSchemaAsJson()
+    {
+        return schemaAsJson;
+    }
+
+    @JsonProperty("inputColumns")
+    public List<HiveColumnHandle> getInputColumns()
+    {
+        return inputColumns;
+    }
+
+    @JsonProperty("filePrefix")
+    public String getFilePrefix()
+    {
+        return filePrefix;
+    }
+
+    @JsonProperty("fileFormat")
+    public FileFormat getFileFormat()
+    {
+        return fileFormat;
+    }
+
+    @JsonCreator
+    public IcebergInsertTableHandle(
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("schemaAsJson") String schemaAsJson,
+            @JsonProperty("inputColumns") List<HiveColumnHandle> inputColumns,
+            @JsonProperty("filePrefix") String filePrefix,
+            @JsonProperty("fileFormat") FileFormat fileFormat)
+    {
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+        this.schemaAsJson = schemaAsJson;
+        this.inputColumns = inputColumns;
+        this.filePrefix = filePrefix;
+        this.fileFormat = fileFormat;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadata.java
@@ -1,0 +1,467 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HiveWrittenPartitions;
+import com.facebook.presto.hive.TransactionalMetadata;
+import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.iceberg.type.TypeConveter;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorNewTableLayout;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayout;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutResult;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.netflix.iceberg.AppendFiles;
+import com.netflix.iceberg.DataFiles;
+import com.netflix.iceberg.FileFormat;
+import com.netflix.iceberg.PartitionSpec;
+import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.SchemaParser;
+import com.netflix.iceberg.Transaction;
+import com.netflix.iceberg.hadoop.HadoopInputFile;
+import com.netflix.iceberg.hive.HiveTables;
+import com.netflix.iceberg.types.Types;
+import io.airlift.json.JsonCodec;
+import io.airlift.slice.Slice;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.hive.HiveTableProperties.getPartitionedBy;
+import static com.facebook.presto.hive.HiveUtil.schemaTableName;
+import static com.facebook.presto.hive.util.ConfigurationUtils.getInitialConfiguration;
+import static com.facebook.presto.iceberg.IcebergUtil.getDataPath;
+import static com.facebook.presto.iceberg.IcebergUtil.getIcebergTable;
+import static com.facebook.presto.iceberg.IcebergUtil.getTablePath;
+import static com.facebook.presto.iceberg.IcebergUtil.isIcebergTable;
+import static com.netflix.iceberg.types.Types.NestedField.required;
+import static java.util.Collections.EMPTY_LIST;
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.empty;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+public class IcebergMetadata
+        implements ConnectorMetadata, TransactionalMetadata
+{
+    private static final String SCHEMA_PROPERTY = "schema";
+    private static final String PARTITION_SPEC_PROPERTY = "partition_spec";
+    private static final String TABLE_PROPERTIES = "table_properties";
+    private final HdfsEnvironment hdfsEnvironment;
+    private final TypeManager typeManager;
+    private final SemiTransactionalHiveMetastore metastore;
+    private final JsonCodec<CommitTaskData> jsonCodec;
+    private Transaction transaction;
+
+    public IcebergMetadata(
+            SemiTransactionalHiveMetastore metastore,
+            HdfsEnvironment hdfsEnvironment,
+            TypeManager typeManager,
+            JsonCodec<CommitTaskData> jsonCodec)
+    {
+        this.hdfsEnvironment = hdfsEnvironment;
+        this.typeManager = typeManager;
+        this.metastore = metastore;
+        this.jsonCodec = jsonCodec;
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        return metastore.getAllDatabases();
+    }
+
+    @Override
+    public IcebergTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
+    {
+        final Optional<Table> table = metastore.getTable(tableName.getSchemaName(), tableName.getTableName());
+        if (table.isPresent()) {
+            if (isIcebergTable(table.get())) {
+                return new IcebergTableHandle(tableName.getSchemaName(), tableName.getTableName());
+            }
+            else {
+                throw new RuntimeException(String.format("%s is not an iceberg table please query using hive catalog", tableName));
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session,
+            ConnectorTableHandle tbl,
+            Constraint<ColumnHandle> constraint,
+            Optional<Set<ColumnHandle>> desiredColumns)
+    {
+        IcebergTableHandle tableHandle = (IcebergTableHandle) tbl;
+        final Map<String, HiveColumnHandle> nameToHiveColumnHandleMap = desiredColumns
+                .map(cols -> cols.stream().map(col -> HiveColumnHandle.class.cast(col))
+                        .collect(toMap(HiveColumnHandle::getName, identity())))
+                .orElse(emptyMap());
+        // TODO Optimization opportunity if we provide proper IcebergTableLayoutHandle.
+        final IcebergTableLayoutHandle icebergTableLayoutHandle = new IcebergTableLayoutHandle(tableHandle.getSchemaName(), tableHandle.getTableName(), constraint.getSummary(), nameToHiveColumnHandleMap);
+        return ImmutableList.of(new ConnectorTableLayoutResult(new ConnectorTableLayout(icebergTableLayoutHandle), constraint.getSummary()));
+    }
+
+    @Override
+    public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
+    {
+        return new ConnectorTableLayout(handle);
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
+    {
+        final IcebergTableHandle tbl = (IcebergTableHandle) table;
+        return getTableMetadata(tbl.getSchemaName(), tbl.getTableName(), session);
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> optionalSchema)
+    {
+        final List<String> schemas = optionalSchema.<List<String>>map(ImmutableList::of)
+                .orElseGet(metastore::getAllDatabases);
+        ImmutableList.Builder<SchemaTableName> tableNames = ImmutableList.builder();
+        for (String schema : schemas) {
+            final Optional<List<String>> allTables = metastore.getAllTables(schema);
+            final List<SchemaTableName> schemaTableNames = allTables
+                    .map(tables -> tables.stream().map(table -> new SchemaTableName(schema, table)).collect(toList()))
+                    .orElse(EMPTY_LIST);
+            tableNames.addAll(schemaTableNames);
+        }
+        return tableNames.build();
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        IcebergTableHandle tbl = (IcebergTableHandle) tableHandle;
+        final Configuration configuration = getConfiguration(session, tbl.getSchemaName());
+        final com.netflix.iceberg.Table icebergTable = getIcebergTable(tbl.getSchemaName(), tbl.getTableName(), configuration);
+        final List<HiveColumnHandle> columns = IcebergUtil.getColumns(icebergTable.schema(), icebergTable.spec(), typeManager);
+        return columns.stream().collect(toMap(col -> col.getName(), identity()));
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        final HiveColumnHandle column = (HiveColumnHandle) columnHandle;
+        return new ColumnMetadata(column.getName(), typeManager.getType(column.getTypeSignature()));
+    }
+
+    @Override
+    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        // TODO we need to query the metastore to both check for existance and to get all tables with matching prefix
+        requireNonNull(prefix, "prefix is null");
+        final Configuration configuration = getConfiguration(session, prefix.getSchemaName());
+        final com.netflix.iceberg.Table icebergTable = getIcebergTable(prefix.getSchemaName(), prefix.getTableName(), configuration);
+        final List<ColumnMetadata> columnMetadatas = getColumnMetadatas(icebergTable);
+        return ImmutableMap.<SchemaTableName, List<ColumnMetadata>>builder().put(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()), columnMetadatas).build();
+    }
+
+    /**
+     * Get statistics for table for given filtering constraint.
+     */
+    @Override
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint<ColumnHandle> constraint)
+    {
+        return TableStatistics.empty();
+    }
+
+    /**
+     * Creates a table using the specified table metadata.
+     */
+    @Override
+    public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
+    {
+        SchemaTableName schemaTableName = tableMetadata.getTable();
+        String schemaName = schemaTableName.getSchemaName();
+        String tableName = schemaTableName.getTableName();
+        List<String> partitionedBy = getPartitionedBy(tableMetadata.getProperties());
+        final List<ColumnMetadata> columns = tableMetadata.getColumns();
+        Schema schema = new Schema(toIceberg(columns));
+
+        final PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
+        partitionedBy.forEach(builder::identity);
+        final PartitionSpec partitionSpec = builder.build();
+
+        final Configuration configuration = getConfiguration(session, schemaName);
+        final HiveTables hiveTables = IcebergUtil.getHiveTables(configuration);
+
+        if (ignoreExisting) {
+            final Optional<Table> table = metastore.getTable(schemaName, tableName);
+            if (table.isPresent()) {
+                return;
+            }
+        }
+        hiveTables.create(schema, partitionSpec, schemaName, tableName);
+    }
+
+    /**
+     * Get the physical layout for a new table.
+     */
+    @Override
+    public Optional<ConnectorNewTableLayout> getNewTableLayout(ConnectorSession session, ConnectorTableMetadata tableMetadata)
+    {
+        return empty();
+    }
+
+    /**
+     * Get the physical layout for a inserting into an existing table.
+     */
+    @Override
+    public Optional<ConnectorNewTableLayout> getInsertLayout(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        // TODO We need to provide proper partitioning handle and columns here, we need it for bucketing support but for non bucketed tables it is not required.
+        return empty();
+    }
+
+    /**
+     * Begin the atomic creation of a table with data.
+     */
+    @Override
+    public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session,
+            ConnectorTableMetadata tableMetadata,
+            Optional<ConnectorNewTableLayout> layout)
+    {
+        SchemaTableName schemaTableName = tableMetadata.getTable();
+        String schemaName = schemaTableName.getSchemaName();
+        String tableName = schemaTableName.getTableName();
+
+        Schema schema = new Schema(toIceberg(tableMetadata.getColumns()));
+        List<String> partitionedBy = getPartitionedBy(tableMetadata.getProperties());
+        final PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
+        partitionedBy.forEach(builder::identity);
+        final PartitionSpec partitionSpec = builder.build();
+
+        final Configuration configuration = getConfiguration(session, schemaName);
+        final HiveTables table = IcebergUtil.getHiveTables(configuration);
+        //TODO see if there is a way to store this as transaction state.
+        this.transaction = table.beginCreate(schema, partitionSpec, schemaName, tableName);
+        final List<HiveColumnHandle> hiveColumnHandles = IcebergUtil.getColumns(schema, partitionSpec, typeManager);
+        return new IcebergInsertTableHandle(
+                schemaName,
+                tableName,
+                SchemaParser.toJson(transaction.table().schema()),
+                hiveColumnHandles,
+                getDataPath(getTablePath(schemaName, tableName, configuration)),
+                FileFormat.PARQUET);
+    }
+
+    /**
+     * Finish a table creation with data after the data is written.
+     */
+    @Override
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session,
+            ConnectorOutputTableHandle tableHandle,
+            Collection<Slice> fragments,
+            Collection<ComputedStatistics> computedStatistics)
+    {
+        return finishInsert(session, (IcebergInsertTableHandle) tableHandle, fragments, computedStatistics);
+    }
+
+    /**
+     * Begin insert query
+     */
+    @Override
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        IcebergTableHandle tbl = (IcebergTableHandle) tableHandle;
+        final Configuration configuration = getConfiguration(session, tbl.getSchemaName());
+        final com.netflix.iceberg.Table icebergTable = getIcebergTable(tbl.getSchemaName(), tbl.getTableName(), configuration);
+        this.transaction = icebergTable.newTransaction();
+        String location = icebergTable.location();
+        final List<HiveColumnHandle> columns = IcebergUtil.getColumns(icebergTable.schema(), icebergTable.spec(), typeManager);
+        return new IcebergInsertTableHandle(
+                tbl.getSchemaName(),
+                tbl.getTableName(),
+                SchemaParser.toJson(icebergTable.schema()),
+                columns,
+                getDataPath(location),
+                IcebergUtil.getFileFormat(icebergTable));
+    }
+
+    /**
+     * Finish insert query
+     */
+    @Override
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session,
+            ConnectorInsertTableHandle insertHandle,
+            Collection<Slice> fragments,
+            Collection<ComputedStatistics> computedStatistics)
+    {
+        final List<CommitTaskData> commitTasks = fragments.stream().map(slice -> jsonCodec.fromJson(slice.getBytes())).collect(toList());
+        IcebergInsertTableHandle icebergTable = (IcebergInsertTableHandle) insertHandle;
+
+        final AppendFiles appendFiles = transaction.newFastAppend();
+        for (CommitTaskData commitTaskData : commitTasks) {
+            final DataFiles.Builder builder;
+            builder = DataFiles.builder(transaction.table().spec())
+                    .withInputFile(HadoopInputFile.fromLocation(commitTaskData.getPath(), getInitialConfiguration()))
+                    .withFormat(icebergTable.getFileFormat())
+                    .withMetrics(MetricsParser.fromJson(commitTaskData.getMetricsJson()));
+
+            if (!transaction.table().spec().fields().isEmpty()) {
+                builder.withPartitionPath(commitTaskData.getPartitionPath());
+            }
+            appendFiles.appendFile(builder.build());
+        }
+
+        appendFiles.commit();
+        transaction.commitTransaction();
+        return Optional.of(new HiveWrittenPartitions(commitTasks.stream().map(ct -> ct.getPartitionPath()).collect(toList())));
+    }
+
+    @Override
+    public Optional<Object> getInfo(ConnectorTableLayoutHandle layoutHandle)
+    {
+        // TODO this is passed to event stream so we may get wrong metrics if this does not have correct info
+        return empty();
+    }
+
+    @Override
+    public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
+
+        if (!metastore.getTable(handle.getSchemaName(), handle.getTableName()).isPresent()) {
+            throw new TableNotFoundException(schemaTableName(tableHandle));
+        }
+        metastore.dropTable(session, handle.getSchemaName(), handle.getTableName());
+    }
+
+    @Override
+    public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTableName)
+    {
+        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
+        metastore.renameTable(handle.getSchemaName(), handle.getTableName(), newTableName.getSchemaName(), newTableName.getTableName());
+    }
+
+    @Override
+    public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
+    {
+        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
+        final Configuration configuration = getConfiguration(session, handle.getSchemaName());
+        final com.netflix.iceberg.Table icebergTable = IcebergUtil.getIcebergTable(handle.getSchemaName(), handle.getTableName(), configuration);
+        icebergTable.updateSchema().addColumn(column.getName(), TypeConveter.convert(column.getType())).commit();
+    }
+
+    public void dropColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column)
+    {
+        IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
+        HiveColumnHandle handle = (HiveColumnHandle) column;
+        final Configuration configuration = getConfiguration(session, icebergTableHandle.getSchemaName());
+        final com.netflix.iceberg.Table icebergTable = IcebergUtil.getIcebergTable(icebergTableHandle.getSchemaName(), icebergTableHandle.getTableName(), configuration);
+        icebergTable.updateSchema().deleteColumn(handle.getName()).commit();
+    }
+
+    public void renameColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle source, String target)
+    {
+        IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
+        HiveColumnHandle columnHandle = (HiveColumnHandle) source;
+        final Configuration configuration = getConfiguration(session, icebergTableHandle.getSchemaName());
+        final com.netflix.iceberg.Table icebergTable = IcebergUtil.getIcebergTable(icebergTableHandle.getSchemaName(), icebergTableHandle.getTableName(), configuration);
+        icebergTable.updateSchema().renameColumn(columnHandle.getName(), target).commit();
+    }
+
+    private ConnectorTableMetadata getTableMetadata(String schema, String tableName, ConnectorSession session)
+    {
+        Optional<Table> table = metastore.getTable(schema, tableName);
+        if (!table.isPresent()) {
+            throw new TableNotFoundException(new SchemaTableName(schema, tableName));
+        }
+        final Configuration configuration = hdfsEnvironment.getConfiguration(new HdfsEnvironment.HdfsContext(session, schema), new Path("file:///tmp"));
+
+        final com.netflix.iceberg.Table icebergTable = getIcebergTable(schema, tableName, configuration);
+
+        final List<ColumnMetadata> columns = getColumnMetadatas(icebergTable);
+
+        final ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+        properties.put(TABLE_PROPERTIES, icebergTable.properties());
+        properties.put(SCHEMA_PROPERTY, icebergTable.schema());
+        properties.put(PARTITION_SPEC_PROPERTY, icebergTable.spec());
+
+        return new ConnectorTableMetadata(new SchemaTableName(schema, tableName), columns, properties.build(), Optional.empty());
+    }
+
+    private List<ColumnMetadata> getColumnMetadatas(com.netflix.iceberg.Table icebergTable)
+    {
+        return icebergTable.schema().columns().stream()
+                .map(c -> new ColumnMetadata(c.name(), TypeConveter.convert(c.type(), typeManager)))
+                .collect(toList());
+    }
+
+    private List<Types.NestedField> toIceberg(List<ColumnMetadata> columns)
+    {
+        List<Types.NestedField> icebergColumns = new ArrayList<>();
+        for (ColumnMetadata column : columns) {
+            final String name = column.getName();
+            final Type type = column.getType();
+            final com.netflix.iceberg.types.Type icebergType = TypeConveter.convert(type);
+            icebergColumns.add(required(icebergColumns.size(), name, icebergType));
+        }
+        return icebergColumns;
+    }
+
+    private Configuration getConfiguration(ConnectorSession session, String schemaName)
+    {
+        return hdfsEnvironment.getConfiguration(new HdfsEnvironment.HdfsContext(session, schemaName), new Path("file:///tmp"));
+    }
+
+    @Override
+    public void rollback()
+    {
+        metastore.rollback();
+    }
+
+    @Override
+    public void commit()
+    {
+        metastore.commit();
+    }
+
+    public SemiTransactionalHiveMetastore getMetastore()
+    {
+        return metastore;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataFactory.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.ForHiveClient;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.TransactionalMetadata;
+import com.facebook.presto.hive.metastore.CachingHiveMetastore;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
+import com.facebook.presto.spi.type.TypeManager;
+import io.airlift.concurrent.BoundedExecutor;
+import io.airlift.json.JsonCodec;
+
+import javax.inject.Inject;
+
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+public class IcebergMetadataFactory
+        implements Supplier<TransactionalMetadata>
+{
+    @Override
+    public TransactionalMetadata get()
+    {
+        SemiTransactionalHiveMetastore metastore = new SemiTransactionalHiveMetastore(
+                hdfsEnvironment,
+                CachingHiveMetastore.memoizeMetastore(this.metastore, perTransactionCacheMaximumSize), // per-transaction cache
+                renameExecution,
+                skipDeletionForAlter);
+
+        return new IcebergMetadata(
+                metastore,
+                hdfsEnvironment,
+                typeManager,
+                taskCommitCodec);
+    }
+
+    private final boolean skipDeletionForAlter;
+    private final long perTransactionCacheMaximumSize;
+    private final ExtendedHiveMetastore metastore;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final TypeManager typeManager;
+    private final JsonCodec<CommitTaskData> taskCommitCodec;
+    private final BoundedExecutor renameExecution;
+
+    @Inject
+    @SuppressWarnings("deprecation")
+    public IcebergMetadataFactory(
+            HiveClientConfig hiveClientConfig,
+            ExtendedHiveMetastore metastore,
+            HdfsEnvironment hdfsEnvironment,
+            @ForHiveClient ExecutorService executorService,
+            TypeManager typeManager,
+            JsonCodec<CommitTaskData> commitTaskDataJsonCodec)
+    {
+        this(
+                metastore,
+                hdfsEnvironment,
+                hiveClientConfig.getMaxConcurrentFileRenames(),
+                hiveClientConfig.isSkipDeletionForAlter(),
+                hiveClientConfig.getPerTransactionMetastoreCacheMaximumSize(),
+                typeManager,
+                executorService,
+                commitTaskDataJsonCodec);
+    }
+
+    public IcebergMetadataFactory(
+            ExtendedHiveMetastore metastore,
+            HdfsEnvironment hdfsEnvironment,
+            int maxConcurrentFileRenames,
+            boolean skipDeletionForAlter,
+            long perTransactionCacheMaximumSize,
+            TypeManager typeManager,
+            ExecutorService executorService,
+            JsonCodec<CommitTaskData> commitTaskDataJsonCodec)
+    {
+        this.skipDeletionForAlter = skipDeletionForAlter;
+        this.perTransactionCacheMaximumSize = perTransactionCacheMaximumSize;
+
+        this.metastore = requireNonNull(metastore, "metastore is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+
+        renameExecution = new BoundedExecutor(executorService, maxConcurrentFileRenames);
+        this.taskCommitCodec = commitTaskDataJsonCodec;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.CoercionPolicy;
+import com.facebook.presto.hive.DirectoryLister;
+import com.facebook.presto.hive.FileFormatDataSourceStats;
+import com.facebook.presto.hive.ForHiveClient;
+import com.facebook.presto.hive.GenericHiveRecordCursorProvider;
+import com.facebook.presto.hive.HadoopDirectoryLister;
+import com.facebook.presto.hive.HdfsConfiguration;
+import com.facebook.presto.hive.HdfsConfigurationUpdater;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveCoercionPolicy;
+import com.facebook.presto.hive.HiveConnectorId;
+import com.facebook.presto.hive.HiveFileWriterFactory;
+import com.facebook.presto.hive.HiveHdfsConfiguration;
+import com.facebook.presto.hive.HiveLocationService;
+import com.facebook.presto.hive.HiveNodePartitioningProvider;
+import com.facebook.presto.hive.HivePageSourceFactory;
+import com.facebook.presto.hive.HivePartitionManager;
+import com.facebook.presto.hive.HiveRecordCursorProvider;
+import com.facebook.presto.hive.HiveSessionProperties;
+import com.facebook.presto.hive.HiveTableProperties;
+import com.facebook.presto.hive.HiveTransactionHandle;
+import com.facebook.presto.hive.HiveTransactionManager;
+import com.facebook.presto.hive.HiveTypeTranslator;
+import com.facebook.presto.hive.LocationService;
+import com.facebook.presto.hive.NamenodeStats;
+import com.facebook.presto.hive.OrcFileWriterConfig;
+import com.facebook.presto.hive.PartitionUpdate;
+import com.facebook.presto.hive.RcFileFileWriterFactory;
+import com.facebook.presto.hive.TableParameterCodec;
+import com.facebook.presto.hive.TypeTranslator;
+import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
+import com.facebook.presto.hive.metastore.thrift.HiveCluster;
+import com.facebook.presto.hive.metastore.thrift.HiveMetastoreClientFactory;
+import com.facebook.presto.hive.metastore.thrift.StaticHiveCluster;
+import com.facebook.presto.hive.metastore.thrift.StaticMetastoreConfig;
+import com.facebook.presto.hive.orc.DwrfPageSourceFactory;
+import com.facebook.presto.hive.orc.OrcPageSourceFactory;
+import com.facebook.presto.hive.parquet.ParquetPageSourceFactory;
+import com.facebook.presto.hive.rcfile.RcFilePageSourceFactory;
+import com.facebook.presto.hive.s3.HiveS3Config;
+import com.facebook.presto.iceberg.parquet.ParquetRecordCursorProvider;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.PageIndexerFactory;
+import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+
+import javax.inject.Singleton;
+
+import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.weakref.jmx.ObjectNames.generatedNameOf;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+/**
+ * Created by parth on 2/3/18.
+ */
+public class IcebergModule
+        implements Module
+{
+    private final String connectorId;
+    private final TypeManager typeManager;
+    private final NodeManager nodeManager;
+    private final PageIndexerFactory pageIndexerFactory;
+
+    public IcebergModule(String connectorId, TypeManager typeManager, PageIndexerFactory pageIndexerFactory, NodeManager nodeManager)
+    {
+        this.connectorId = connectorId;
+        this.typeManager = typeManager;
+        this.nodeManager = nodeManager;
+        this.pageIndexerFactory = pageIndexerFactory;
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(HiveConnectorId.class).toInstance(new HiveConnectorId(connectorId));
+        binder.bind(TypeTranslator.class).toInstance(new HiveTypeTranslator());
+        binder.bind(CoercionPolicy.class).to(HiveCoercionPolicy.class).in(Scopes.SINGLETON);
+        binder.bind(HdfsConfigurationUpdater.class).in(Scopes.SINGLETON);
+        binder.bind(HdfsConfiguration.class).to(HiveHdfsConfiguration.class).in(Scopes.SINGLETON);
+        binder.bind(HdfsEnvironment.class).in(Scopes.SINGLETON);
+        binder.bind(DirectoryLister.class).to(HadoopDirectoryLister.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(HiveClientConfig.class);
+        configBinder(binder).bindConfig(HiveS3Config.class);
+        binder.bind(HiveSessionProperties.class).in(Scopes.SINGLETON);
+        binder.bind(HiveTableProperties.class).in(Scopes.SINGLETON);
+        binder.bind(NamenodeStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(NamenodeStats.class).as(generatedNameOf(NamenodeStats.class, connectorId));
+        binder.bind(HiveMetastoreClientFactory.class).in(Scopes.SINGLETON);
+        binder.bind(HiveCluster.class).to(StaticHiveCluster.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(StaticMetastoreConfig.class);
+        configBinder(binder).bindConfig(OrcFileWriterConfig.class);
+        binder.bind(NodeManager.class).toInstance(nodeManager);
+        binder.bind(TypeManager.class).toInstance(typeManager);
+        binder.bind(PageIndexerFactory.class).toInstance(pageIndexerFactory);
+        binder.bind(ConnectorSplitManager.class).to(IcebergSplitManager.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorPageSourceProvider.class).to(IcebergPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorPageSinkProvider.class).to(IcebergPageSinkProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorNodePartitioningProvider.class).to(HiveNodePartitioningProvider.class).in(Scopes.SINGLETON);
+
+        Multibinder<HiveRecordCursorProvider> recordCursorProviderBinder = newSetBinder(binder, HiveRecordCursorProvider.class);
+        recordCursorProviderBinder.addBinding().to(ParquetRecordCursorProvider.class).in(Scopes.SINGLETON);
+        recordCursorProviderBinder.addBinding().to(GenericHiveRecordCursorProvider.class).in(Scopes.SINGLETON);
+        binder.bind(HivePartitionManager.class).in(Scopes.SINGLETON);
+        binder.bind(LocationService.class).to(HiveLocationService.class).in(Scopes.SINGLETON);
+        binder.bind(TableParameterCodec.class).in(Scopes.SINGLETON);
+        binder.bind(IcebergMetadataFactory.class).in(Scopes.SINGLETON);
+        binder.bind(HiveTransactionManager.class).in(Scopes.SINGLETON);
+
+        jsonCodecBinder(binder).bindJsonCodec(PartitionUpdate.class);
+        jsonCodecBinder(binder).bindJsonCodec(CommitTaskData.class);
+
+        binder.bind(FileFormatDataSourceStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(FileFormatDataSourceStats.class).as(generatedNameOf(FileFormatDataSourceStats.class, connectorId));
+        Multibinder<HivePageSourceFactory> pageSourceFactoryBinder = newSetBinder(binder, HivePageSourceFactory.class);
+        pageSourceFactoryBinder.addBinding().to(OrcPageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(DwrfPageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(ParquetPageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(RcFilePageSourceFactory.class).in(Scopes.SINGLETON);
+        Multibinder<HiveFileWriterFactory> fileWriterFactoryBinder = newSetBinder(binder, HiveFileWriterFactory.class);
+        fileWriterFactoryBinder.addBinding().to(RcFileFileWriterFactory.class).in(Scopes.SINGLETON);
+    }
+
+    @ForHiveClient
+    @Singleton
+    @Provides
+    public ExecutorService createHiveClientExecutor(HiveConnectorId hiveClientId)
+    {
+        return newCachedThreadPool(daemonThreadsNamed("iceberg-" + hiveClientId + "-%s"));
+    }
+
+    @Singleton
+    @Provides
+    public Function<HiveTransactionHandle, SemiTransactionalHiveMetastore> createMetastoreGetter(HiveTransactionManager transactionManager)
+    {
+        return transactionHandle -> ((IcebergMetadata) transactionManager.get(transactionHandle)).getMetastore();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HiveWriteUtils;
+import com.facebook.presto.iceberg.parquet.writer.PrestoWriteSupport;
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.base.Joiner;
+import com.google.common.primitives.Ints;
+import com.netflix.iceberg.FileFormat;
+import com.netflix.iceberg.Metrics;
+import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.exceptions.RuntimeIOException;
+import com.netflix.iceberg.hadoop.HadoopOutputFile;
+import com.netflix.iceberg.io.FileAppender;
+import com.netflix.iceberg.io.OutputFile;
+import com.netflix.iceberg.parquet.Parquet;
+import com.netflix.iceberg.parquet.TypeToMessageType;
+import io.airlift.json.JsonCodec;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
+import static com.facebook.presto.iceberg.MetricsParser.toJson;
+import static java.util.UUID.randomUUID;
+import static java.util.stream.Collectors.toList;
+
+public class IcebergPageSink
+        implements ConnectorPageSink
+{
+    private Schema outputSchema;
+    private String outputDir;
+    private Configuration configuration;
+    private List<HiveColumnHandle> inputColumns;
+    private List<HiveColumnHandle> partitionColumns;
+    private Map<String, PartitionWriteContext> partitionToWriterContext;
+    private Map<String, String> partitionToFile;
+    private JsonCodec<CommitTaskData> jsonCodec;
+    private final ConnectorSession session;
+    private final TypeManager typeManager;
+    private final FileFormat fileFormat;
+    final List<Type> partitionTypes;
+    private static final String PATH_SEPERATOR = "/";
+    private static final Joiner PATH_JOINER = Joiner.on(PATH_SEPERATOR);
+    private static final TypeToMessageType typeToMessageType = new TypeToMessageType();
+
+    public IcebergPageSink(Schema outputSchema,
+            String outputDir,
+            Configuration configuration,
+            List<HiveColumnHandle> inputColumns,
+            TypeManager typeManager,
+            JsonCodec<CommitTaskData> jsonCodec,
+            ConnectorSession session, FileFormat fileFormat)
+    {
+        this.outputSchema = outputSchema;
+        this.outputDir = outputDir;
+        this.configuration = configuration;
+        // TODO we only mark identity columns as partition columns as of now but we need to extract the schema on the coordinator side and provide partition
+        // transforms in ConnectorOutputTableHandle
+        this.partitionColumns = inputColumns.stream().filter(col -> col.isPartitionKey()).collect(toList());
+        this.jsonCodec = jsonCodec;
+        this.session = session;
+        this.typeManager = typeManager;
+        this.fileFormat = fileFormat;
+        this.partitionToWriterContext = new HashMap<>();
+        this.partitionToFile = new HashMap<>();
+        this.partitionTypes = partitionColumns.stream().map(col -> typeManager.getType(col.getTypeSignature())).collect(toList());
+        this.inputColumns = inputColumns;
+    }
+
+    @Override
+    public CompletableFuture<?> appendPage(Page page)
+    {
+        final int numRows = page.getPositionCount();
+
+        for (int rowNum = 0; rowNum < numRows; rowNum++) {
+            final String partitionPath = getPartitionPath(page, rowNum);
+
+            if (!partitionToWriterContext.containsKey(partitionPath)) {
+                partitionToWriterContext.put(partitionPath, new PartitionWriteContext(new ArrayList<>(), addWriter(partitionPath)));
+            }
+            partitionToWriterContext.get(partitionPath).getRowNum().add(rowNum);
+        }
+
+        for (Map.Entry<String, PartitionWriteContext> partitionToWriter : partitionToWriterContext.entrySet()) {
+            final List<Integer> rowNums = partitionToWriter.getValue().getRowNum();
+            final FileAppender<Page> writer = partitionToWriter.getValue().getWriter();
+            Page partition = page.getPositions(Ints.toArray(rowNums), 0, rowNums.size());
+            writer.add(partition);
+        }
+
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        Collection<Slice> commitTasks = new ArrayList<>();
+        for (String partition : partitionToFile.keySet()) {
+            String file = partitionToFile.get(partition);
+            final FileAppender<Page> fileAppender = partitionToWriterContext.get(partition).getWriter();
+            try {
+                fileAppender.close();
+            }
+            catch (IOException e) {
+                abort();
+                throw new PrestoException(HIVE_WRITER_CLOSE_ERROR, "Failed to close" + file);
+            }
+            final Metrics metrics = fileAppender.metrics();
+            commitTasks.add(Slices.wrappedBuffer(jsonCodec.toJsonBytes(new CommitTaskData(file, toJson(metrics), partition))));
+        }
+
+        return CompletableFuture.completedFuture(commitTasks);
+    }
+
+    @Override
+    public void abort()
+    {
+        partitionToFile.values().stream().forEach(s -> {
+            try {
+                new Path(s).getFileSystem(configuration).delete(new Path(s), false);
+            }
+            catch (IOException e) {
+                throw new RuntimeIOException(e);
+            }
+        });
+    }
+
+    private FileAppender<Page> addWriter(String partitionPath)
+    {
+        final Path dataDir = new Path(outputDir);
+        final String pathUUId = randomUUID().toString();
+        final Path outputPath = (partitionPath != null && !partitionPath.isEmpty()) ? new Path(new Path(dataDir, partitionPath), pathUUId) : new Path(dataDir, pathUUId);
+        final String outputFilePath = fileFormat.addExtension(outputPath.toString());
+        final OutputFile outputFile = HadoopOutputFile.fromPath(new Path(outputFilePath), configuration);
+        switch (fileFormat) {
+            case PARQUET:
+                try {
+                    final FileAppender<Page> writer = Parquet.write(outputFile)
+                            .set("spark.sql.parquet.writeLegacyFormat", "false")
+                            .set("spark.sql.parquet.binaryAsString", "false")
+                            .set("spark.sql.parquet.int96AsTimestamp", "false")
+                            .set("spark.sql.parquet.outputTimestampType", "TIMESTAMP_MICROS")
+                            .schema(outputSchema)
+                            .writeSupport(new PrestoWriteSupport(inputColumns, typeToMessageType.convert(outputSchema, "presto_schema"), outputSchema, typeManager, session))
+                            .build();
+                    partitionToFile.put(partitionPath, outputFile.location());
+                    return writer;
+                }
+                catch (IOException e) {
+                    throw new RuntimeIOException("Could not create writer ", e);
+                }
+            case ORC:
+            case AVRO:
+            default:
+                throw new UnsupportedOperationException("Only parquet is supported for iceberg as of now");
+        }
+    }
+
+    private final String getPartitionPath(Page page, int rowNum)
+    {
+        // TODO only handles identity columns right now, handle all transforms
+        List<String> paths = new ArrayList<>();
+        for (int i = 0; i < partitionColumns.size(); i++) {
+            final HiveColumnHandle columnHandle = partitionColumns.get(i);
+            final Type type = partitionTypes.get(i);
+            paths.add(columnHandle.getName() + "=" + HiveWriteUtils.getField(type, page.getBlock(columnHandle.getHiveColumnIndex()), rowNum));
+        }
+
+        return PATH_JOINER.join(paths);
+    }
+
+    private class PartitionWriteContext
+    {
+        private final List<Integer> rowNum;
+        private final FileAppender<Page> writer;
+
+        private PartitionWriteContext(List<Integer> rowNum, FileAppender<Page> writer)
+        {
+            this.rowNum = rowNum;
+            this.writer = writer;
+        }
+
+        public List<Integer> getRowNum()
+        {
+            return rowNum;
+        }
+
+        public FileAppender<Page> getWriter()
+        {
+            return writer;
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSinkProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.util.ConfigurationUtils;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.type.TypeManager;
+import com.netflix.iceberg.SchemaParser;
+import io.airlift.json.JsonCodec;
+
+import javax.inject.Inject;
+
+public class IcebergPageSinkProvider
+        implements ConnectorPageSinkProvider
+{
+    private final HdfsEnvironment hdfsEnvironment;
+    private JsonCodec<CommitTaskData> jsonCodec;
+    private TypeManager typeManager;
+
+    @Inject
+    public IcebergPageSinkProvider(HdfsEnvironment hdfsEnvironment,
+            JsonCodec<CommitTaskData> jsonCodec,
+            TypeManager typeManager)
+    {
+        this.hdfsEnvironment = hdfsEnvironment;
+        this.jsonCodec = jsonCodec;
+        this.typeManager = typeManager;
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle)
+    {
+        return createPageSink(transactionHandle, session, (ConnectorInsertTableHandle) outputTableHandle);
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle)
+    {
+        final IcebergInsertTableHandle tableHandle = (IcebergInsertTableHandle) insertTableHandle;
+        return new IcebergPageSink(
+                SchemaParser.fromJson(tableHandle.getSchemaAsJson()),
+                tableHandle.getFilePrefix(),
+                ConfigurationUtils.getInitialConfiguration(),
+                tableHandle.getInputColumns(),
+                typeManager,
+                jsonCodec,
+                session,
+                tableHandle.getFileFormat());
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HivePageSource;
+import com.facebook.presto.hive.HivePageSourceProvider;
+import com.facebook.presto.hive.HivePartitionKey;
+import com.facebook.presto.iceberg.parquet.ParquetDataSource;
+import com.facebook.presto.iceberg.parquet.ParquetPageSource;
+import com.facebook.presto.iceberg.parquet.memory.AggregatedMemoryContext;
+import com.facebook.presto.iceberg.parquet.predicate.ParquetPredicate;
+import com.facebook.presto.iceberg.parquet.reader.ParquetMetadataReader;
+import com.facebook.presto.iceberg.parquet.reader.ParquetReader;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.TypeManager;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
+import org.joda.time.DateTimeZone;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Properties;
+
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_MISSING_DATA;
+import static com.facebook.presto.hive.HivePageSourceProvider.ColumnMapping.buildColumnMappings;
+import static com.facebook.presto.hive.util.ConfigurationUtils.getInitialConfiguration;
+import static com.facebook.presto.iceberg.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
+import static com.facebook.presto.iceberg.parquet.ParquetTypeUtils.getParquetType;
+import static com.facebook.presto.iceberg.parquet.predicate.ParquetPredicateUtils.buildParquetPredicate;
+import static com.facebook.presto.iceberg.parquet.predicate.ParquetPredicateUtils.predicateMatches;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public class IcebergPageSourceProvider
+        implements ConnectorPageSourceProvider
+{
+    private final HdfsEnvironment hdfsEnvironment;
+    private final TypeManager typeManager;
+    private final HiveClientConfig hiveClientConfig;
+
+    @Inject
+    public IcebergPageSourceProvider(
+            HiveClientConfig hiveClientConfig,
+            HdfsEnvironment hdfsEnvironment,
+            TypeManager typeManager)
+    {
+        requireNonNull(hiveClientConfig, "hiveClientConfig is null");
+        this.hiveClientConfig = hiveClientConfig;
+        this.hdfsEnvironment = hdfsEnvironment;
+        this.typeManager = typeManager;
+    }
+
+    @Override
+    public ConnectorPageSource createPageSource(ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorSplit split,
+            List<ColumnHandle> columns)
+    {
+        IcebergSplit icebergSplit = (IcebergSplit) split;
+        final Path path = new Path(icebergSplit.getPath());
+        final long start = icebergSplit.getStart();
+        final long length = icebergSplit.getLength();
+        List<HiveColumnHandle> hiveColumns = columns.stream()
+                .map(HiveColumnHandle.class::cast)
+                .collect(toList());
+        return createParquetPageSource(hdfsEnvironment,
+                session.getUser(),
+                getInitialConfiguration(),
+                path,
+                start,
+                length,
+                hiveColumns,
+                icebergSplit.getNameToId(),
+                hiveClientConfig.isUseParquetColumnNames(),
+                typeManager,
+                icebergSplit.getEffectivePredicate(),
+                ((IcebergSplit) split).getPartitionKeys());
+    }
+
+    public static ConnectorPageSource createParquetPageSource(
+            HdfsEnvironment hdfsEnvironment,
+            String user,
+            Configuration configuration,
+            Path path,
+            long start,
+            long length,
+            List<HiveColumnHandle> columns,
+            Map<String, Integer> icebergNameToId,
+            boolean useParquetColumnNames,
+            TypeManager typeManager,
+            TupleDomain<HiveColumnHandle> effectivePredicate,
+            List<HivePartitionKey> partitionKeys)
+    {
+        AggregatedMemoryContext systemMemoryContext = new AggregatedMemoryContext();
+
+        ParquetDataSource dataSource = null;
+        try {
+            FileSystem fileSystem = hdfsEnvironment.getFileSystem(user, path, configuration);
+            dataSource = buildHdfsParquetDataSource(fileSystem, path, start, length);
+            ParquetMetadata parquetMetadata = ParquetMetadataReader.readFooter(fileSystem, path);
+            FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
+            MessageType fileSchema = fileMetaData.getSchema();
+
+            // We need to transform columns so they have the parquet column name and not table column name.
+            // In order to make that transformation we need to pass the iceberg schema (not the hive schema) in split and
+            // use that here to map from iceberg schema column name to ID, lookup parquet column with same ID and all of its children
+            // and use the index of all those columns as requested schema.
+
+            final List<HiveColumnHandle> parquetColumns = convertToParquetNames(columns, icebergNameToId, fileSchema);
+            List<org.apache.parquet.schema.Type> fields = parquetColumns.stream()
+                    .filter(column -> column.getColumnType() == REGULAR)
+                    .map(column -> getParquetType(column, fileSchema, true)) // we always use parquet column names in case of iceberg.
+                    .filter(Objects::nonNull)
+                    .collect(toList());
+
+            MessageType requestedSchema = new MessageType(fileSchema.getName(), fields);
+
+            List<BlockMetaData> blocks = new ArrayList<>();
+            for (BlockMetaData block : parquetMetadata.getBlocks()) {
+                long firstDataPage = block.getColumns().get(0).getFirstDataPageOffset();
+                if (firstDataPage >= start && firstDataPage < start + length) {
+                    blocks.add(block);
+                }
+            }
+
+            ParquetPredicate parquetPredicate = buildParquetPredicate(parquetColumns, effectivePredicate, fileMetaData.getSchema(), typeManager);
+            final ParquetDataSource finalDataSource = dataSource;
+            blocks = blocks.stream()
+                    .filter(block -> predicateMatches(parquetPredicate, block, finalDataSource, requestedSchema, effectivePredicate))
+                    .collect(toList());
+
+            ParquetReader parquetReader = new ParquetReader(
+                    fileSchema,
+                    requestedSchema,
+                    blocks,
+                    dataSource,
+                    typeManager,
+                    systemMemoryContext);
+
+            List<HivePageSourceProvider.ColumnMapping> columnMappings = buildColumnMappings(partitionKeys, columns, Collections.EMPTY_LIST, Collections.emptyMap(), path, OptionalInt.empty());
+
+            return new HivePageSource(
+                    columnMappings,
+                    Optional.empty(),
+                    DateTimeZone.UTC,
+                    typeManager,
+                    new ParquetPageSource(
+                            parquetReader,
+                            dataSource,
+                            fileSchema,
+                            requestedSchema,
+                            length,
+                            new Properties(), // unused.
+                            parquetColumns.stream().filter(col -> col.getColumnType().equals(REGULAR)).collect(toList()),
+                            effectivePredicate,
+                            typeManager,
+                            useParquetColumnNames,
+                            systemMemoryContext));
+        }
+        catch (Exception e) {
+            try {
+                if (dataSource != null) {
+                    dataSource.close();
+                }
+            }
+            catch (IOException ignored) {
+            }
+            if (e instanceof PrestoException) {
+                throw (PrestoException) e;
+            }
+            String message = format("Error opening Hive split %s (offset=%s, length=%s): %s", path, start, length, e.getMessage());
+            if (e.getClass().getSimpleName().equals("BlockMissingException")) {
+                throw new PrestoException(HIVE_MISSING_DATA, message, e);
+            }
+            throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, message, e);
+        }
+    }
+
+    /**
+     * This method maps the iceberg column names to corresponding parquet column names by matching their Ids rather then relying on name or index.
+     * If no id match is found, it will return the original column name as is.
+     *
+     * @param columns iceberg columns
+     * @param icebergNameToId
+     * @param parquetSchema
+     * @return columns with iceberg column names replaced with parquet column names.
+     */
+    private static List<HiveColumnHandle> convertToParquetNames(List<HiveColumnHandle> columns, Map<String, Integer> icebergNameToId, MessageType parquetSchema)
+    {
+        final List<Type> fields = parquetSchema.getFields();
+        final List<HiveColumnHandle> result = new ArrayList<>();
+        for (HiveColumnHandle column : columns) {
+            Integer parquetId = icebergNameToId.get(column.getName());
+            //we default to parquet name when no match is found to support migrated tables, this should be controlled by a config.
+            final String parquetName = fields.stream().filter(f -> f.getId() != null && f.getId().intValue() == parquetId).map(m -> m.getName()).findFirst().orElse(column.getName());
+            result.add(new HiveColumnHandle(parquetName, column.getHiveType(), column.getTypeSignature(), column.getHiveColumnIndex(), column.getColumnType(), column.getComment()));
+        }
+        return result;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPlugin.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPlugin.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.common.collect.ImmutableList;
+
+public class IcebergPlugin
+        implements Plugin
+{
+    private static ClassLoader getClassLoader()
+    {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = IcebergPlugin.class.getClassLoader();
+        }
+        return classLoader;
+    }
+
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(new IcebergConnectorFactory("iceberg", getClassLoader()));
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HivePartitionKey;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class IcebergSplit
+        implements ConnectorSplit
+{
+    private final String database;
+    private final String table;
+    private final String path;
+    private final long start;
+    private final long length;
+    private final Map<String, Integer> nameToId;
+    private final List<HostAddress> addresses;
+    private final TupleDomain<HiveColumnHandle> effectivePredicate;
+    private final List<HivePartitionKey> partitionKeys;
+    private final boolean forceLocalScheduling;
+
+    @JsonCreator
+    public IcebergSplit(
+            @JsonProperty("database") String database,
+            @JsonProperty("table") String table,
+            @JsonProperty("path") String path,
+            @JsonProperty("start") long start,
+            @JsonProperty("length") long length,
+            @JsonProperty("addresses") List<HostAddress> addresses,
+            @JsonProperty("nameToId") Map<String, Integer> nameToId,
+            @JsonProperty("effectivePredicate") TupleDomain<HiveColumnHandle> effectivePredicate,
+            @JsonProperty("partitionKeys") List<HivePartitionKey> partitionKeys,
+            @JsonProperty("forceLocalScheduling") boolean forceLocalScheduling)
+    {
+        this.database = database;
+        this.table = table;
+        this.path = path;
+        this.start = start;
+        this.length = length;
+        this.nameToId = nameToId;
+        this.addresses = addresses;
+        this.effectivePredicate = effectivePredicate;
+        this.partitionKeys = partitionKeys;
+        this.forceLocalScheduling = forceLocalScheduling;
+    }
+
+    @Override
+    public boolean isRemotelyAccessible()
+    {
+        return true;
+    }
+
+    @JsonProperty
+    @Override
+    public List<HostAddress> getAddresses()
+    {
+        return addresses;
+    }
+
+    @Override
+    public Object getInfo()
+    {
+        return ImmutableMap.builder()
+                .put("database", database)
+                .put("table", table)
+                .put("path", path)
+                .put("start", start)
+                .put("length", length)
+                .put("hosts", addresses)
+                .put("forceLocalScheduling", forceLocalScheduling)
+                .build();
+    }
+
+    @JsonProperty
+    public String getDatabase()
+    {
+        return database;
+    }
+
+    @JsonProperty
+    public String getTable()
+    {
+        return table;
+    }
+
+    @JsonProperty
+    public String getPath()
+    {
+        return path;
+    }
+
+    @JsonProperty
+    public long getStart()
+    {
+        return start;
+    }
+
+    @JsonProperty
+    public long getLength()
+    {
+        return length;
+    }
+
+    @JsonProperty
+    public Map<String, Integer> getNameToId()
+    {
+        return nameToId;
+    }
+
+    @JsonProperty
+    public TupleDomain<HiveColumnHandle> getEffectivePredicate()
+    {
+        return effectivePredicate;
+    }
+
+    @JsonProperty
+    public List<HivePartitionKey> getPartitionKeys()
+    {
+        return partitionKeys;
+    }
+
+    @JsonProperty
+    public boolean isForceLocalScheduling()
+    {
+        return forceLocalScheduling;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(path)
+                .addValue(start)
+                .addValue(length)
+                .addValue(effectivePredicate)
+                .toString();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.TypeTranslator;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorSplitSource;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.TypeManager;
+import com.netflix.iceberg.Table;
+import com.netflix.iceberg.TableScan;
+import com.netflix.iceberg.expressions.Expression;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import javax.inject.Inject;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.iceberg.IcebergUtil.getIcebergTable;
+
+public class IcebergSplitManager
+        implements ConnectorSplitManager
+{
+    private final HdfsEnvironment hdfsEnvironment;
+    private final TypeTranslator typeTranslator;
+    private final TypeManager typeRegistry;
+
+    @Inject
+    public IcebergSplitManager(
+            HdfsEnvironment hdfsEnvironment,
+            TypeTranslator typeTranslator,
+            TypeManager typeRegistry)
+    {
+        this.hdfsEnvironment = hdfsEnvironment;
+        this.typeTranslator = typeTranslator;
+        this.typeRegistry = typeRegistry;
+    }
+
+    @Override
+    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingStrategy splitSchedulingStrategy)
+    {
+        final IcebergTableLayoutHandle tbl = (IcebergTableLayoutHandle) layout;
+        final TupleDomain<HiveColumnHandle> predicates = tbl.getPredicates().getDomains()
+                .map(m -> m.entrySet().stream().collect(Collectors.toMap((x) -> HiveColumnHandle.class.cast(x.getKey()), Map.Entry::getValue)))
+                .map(m -> TupleDomain.withColumnDomains(m)).orElse(TupleDomain.none());
+        final Configuration configuration = hdfsEnvironment.getConfiguration(new HdfsEnvironment.HdfsContext(session, tbl.getDatabase()), new Path("file:///tmp"));
+        final Table icebergTable = getIcebergTable(tbl.getDatabase(), tbl.getTableName(), configuration);
+        final Expression expression = ExpressionConverter.toIceberg(predicates, session);
+        final TableScan tableScan = icebergTable.newScan().filter(expression);
+        // TODO Use residual and move to scan tasks, Right now there is no way to propagate residual to presto.
+        final IcebergSplitSource icebergSplitSource = new IcebergSplitSource(
+                tbl.getDatabase(),
+                tbl.getTableName(),
+                tableScan.planFiles().iterator(),
+                predicates,
+                session,
+                icebergTable.schema(),
+                hdfsEnvironment,
+                typeTranslator,
+                typeRegistry,
+                tbl.getNameToColumnHandle());
+        return new ClassLoaderSafeConnectorSplitSource(icebergSplitSource, Thread.currentThread().getContextClassLoader());
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HivePartitionKey;
+import com.facebook.presto.hive.HiveSessionProperties;
+import com.facebook.presto.hive.TypeTranslator;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.Lists;
+import com.netflix.iceberg.FileScanTask;
+import com.netflix.iceberg.PartitionField;
+import com.netflix.iceberg.PartitionSpec;
+import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.StructLike;
+import com.netflix.iceberg.types.Type;
+import com.netflix.iceberg.types.Types.NestedField;
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.iceberg.IcebergUtil.getIdentityPartitions;
+
+/**
+ * Created by parth on 2/27/18.
+ */
+public class IcebergSplitSource
+        implements ConnectorSplitSource
+{
+    public static final String LOCALHOST = "localhost";
+
+    private final String database;
+    private final String tableName;
+    private final Iterator<FileScanTask> fileScanTaskIterator;
+    private final TupleDomain<HiveColumnHandle> predicates;
+    private final ConnectorSession session;
+    private final Schema tableSchema;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final TypeTranslator typeTranslator;
+    private final TypeManager typeRegistry;
+    private final HdfsEnvironment.HdfsContext hdfsContext;
+    private boolean closed;
+    private Map<String, HiveColumnHandle> columnNameToHiveColumnHandleMap;
+
+    public IcebergSplitSource(String database,
+            String tableName,
+            Iterator<FileScanTask> fileScanTaskIterator,
+            TupleDomain<HiveColumnHandle> predicates,
+            ConnectorSession session,
+            Schema schema,
+            HdfsEnvironment hdfsEnvironment,
+            TypeTranslator typeTranslator,
+            TypeManager typeRegistry,
+            Map<String, HiveColumnHandle> columnNameToHiveColumnHandleMap)
+    {
+        this.database = database;
+        this.tableName = tableName;
+        this.fileScanTaskIterator = fileScanTaskIterator;
+        this.predicates = predicates;
+        this.session = session;
+        this.tableSchema = schema;
+        this.hdfsEnvironment = hdfsEnvironment;
+        this.hdfsContext = new HdfsEnvironment.HdfsContext(session, database, tableName);
+        this.typeTranslator = typeTranslator;
+        this.typeRegistry = typeRegistry;
+        this.columnNameToHiveColumnHandleMap = columnNameToHiveColumnHandleMap;
+    }
+
+    @Override
+    public CompletableFuture<ConnectorSplitBatch> getNextBatch(ConnectorPartitionHandle partitionHandle, int maxSize)
+    {
+        List<ConnectorSplit> splits = new ArrayList<>();
+        while (fileScanTaskIterator.hasNext() && maxSize != 0) {
+            FileScanTask scanTask = fileScanTaskIterator.next();
+            final List<HivePartitionKey> partitionKeys = getPartitionKeys(scanTask);
+            List<HostAddress> addresses = getHostAddresses(scanTask.file().path().toString(), scanTask.start(), scanTask.length());
+            // final TupleDomain<HiveColumnHandle> residualExpression = ExpressionConverter.fromIceberg(Binder.bind(tableSchema.asStruct(), scanTask.residual()), columnNameToHiveColumnHandleMap, tableSchema, typeRegistry);
+
+            splits.add(new IcebergSplit(this.database,
+                    this.tableName,
+                    scanTask.file().path().toString(),
+                    scanTask.start(),
+                    scanTask.length(),
+                    addresses,
+                    this.tableSchema.columns().stream().collect(Collectors.toMap(NestedField::name, NestedField::fieldId)),
+                    predicates, //TODO this should be replaced by residualExpression once we can address the type issues. This will cause time columns to incorrectly filter for now.
+                    partitionKeys,
+                    HiveSessionProperties.isForceLocalScheduling(this.session)));
+
+            maxSize--;
+        }
+        if (!fileScanTaskIterator.hasNext()) {
+            this.closed = true;
+        }
+        return CompletableFuture.completedFuture(new ConnectorSplitBatch(splits, !fileScanTaskIterator.hasNext()));
+    }
+
+    private List<HivePartitionKey> getPartitionKeys(FileScanTask scanTask)
+    {
+        final StructLike partition = scanTask.file().partition();
+        final PartitionSpec spec = scanTask.spec();
+        final List<PartitionField> fields = getIdentityPartitions(spec);
+        List<HivePartitionKey> partitionKeys = new ArrayList<>();
+
+        for (int i = 0; i < fields.size(); i++) {
+            PartitionField field = fields.get(i);
+            final String name = field.name();
+            Type sourceType = spec.schema().findType(field.sourceId());
+            final Type partitionType = field.transform().getResultType(sourceType);
+            final Class<?> javaClass = partitionType.typeId().javaClass();
+            final String value = partition.get(i, javaClass).toString();
+            partitionKeys.add(new HivePartitionKey(name, value));
+        }
+        return partitionKeys;
+    }
+
+    private List<HostAddress> getHostAddresses(String path, long start, long length)
+    {
+        try {
+            final Path hadoopPath = new Path(path);
+            final BlockLocation[] blocks = hdfsEnvironment.getFileSystem(hdfsContext, hadoopPath).getFileBlockLocations(hadoopPath, start, length);
+            return Arrays.stream(blocks[0].getHosts()).map(h -> HostAddress.fromString(h)).collect(Collectors.toList());
+        }
+        catch (IOException e) {
+            // ignore the exception as it only means localization will not happen.
+            return Lists.newArrayList(HostAddress.fromString(LOCALHOST + ":-1"));
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        this.closed = true;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return closed;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class IcebergTableHandle
+        implements ConnectorTableHandle
+{
+    private final String schemaName;
+    private final String tableName;
+
+    public IcebergTableHandle(@JsonProperty("schemaName") String schemaName, @JsonProperty("tableName") String tableName)
+    {
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+    }
+
+    @JsonProperty
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        IcebergTableHandle that = (IcebergTableHandle) o;
+
+        if (schemaName != null ? !schemaName.equals(that.schemaName) : that.schemaName != null) {
+            return false;
+        }
+        return tableName != null ? tableName.equals(that.tableName) : that.tableName == null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = schemaName != null ? schemaName.hashCode() : 0;
+        result = 31 * result + (tableName != null ? tableName.hashCode() : 0);
+        return result;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableLayoutHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableLayoutHandle.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class IcebergTableLayoutHandle
+        implements ConnectorTableLayoutHandle
+{
+    private final String database;
+    private final String tableName;
+    private final TupleDomain<ColumnHandle> predicates;
+    private final Map<String, HiveColumnHandle> nameToColumnHandle;
+
+    @JsonCreator
+    public IcebergTableLayoutHandle(
+            @JsonProperty("database") String database,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("predicates") TupleDomain<ColumnHandle> predicates,
+            @JsonProperty("nameToColumnHandle") Map<String, HiveColumnHandle> nameToColumnHandle)
+    {
+        this.database = database;
+        this.tableName = tableName;
+        this.predicates = predicates;
+        this.nameToColumnHandle = nameToColumnHandle;
+    }
+
+    @JsonProperty
+    public String getDatabase()
+    {
+        return this.database;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return this.tableName;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getPredicates()
+    {
+        return this.predicates;
+    }
+
+    @JsonProperty
+    public Map<String, HiveColumnHandle> getNameToColumnHandle()
+    {
+        return this.nameToColumnHandle;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.hive.HiveTypeTranslator;
+import com.facebook.presto.hive.TypeTranslator;
+import com.facebook.presto.iceberg.type.TypeConveter;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.ImmutableList;
+import com.netflix.iceberg.FileFormat;
+import com.netflix.iceberg.PartitionField;
+import com.netflix.iceberg.PartitionSpec;
+import com.netflix.iceberg.Schema;
+import com.netflix.iceberg.Table;
+import com.netflix.iceberg.hive.HiveTables;
+import com.netflix.iceberg.types.Type;
+import com.netflix.iceberg.types.Types;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.netflix.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
+import static com.netflix.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
+
+class IcebergUtil
+{
+    public static final String ICEBERG_PROPERTY_NAME = "table_type";
+    public static final String ICEBERG_PROPERTY_VALUE = "iceberg";
+    public static final String HIVE_WAREHOUSE_DIR = "metastore.warehouse.dir";
+    private static final TypeTranslator hiveTypeTranslator = new HiveTypeTranslator();
+    private static final String PATH_SEPERATOR = "/";
+    public static final String DATA_DIR_NAME = "data";
+
+    private IcebergUtil() {}
+
+    public static final boolean isIcebergTable(com.facebook.presto.hive.metastore.Table table)
+    {
+        final Map<String, String> parameters = table.getParameters();
+        return parameters != null && !parameters.isEmpty() && ICEBERG_PROPERTY_VALUE.equalsIgnoreCase(parameters.get(ICEBERG_PROPERTY_NAME));
+    }
+
+    public static Table getIcebergTable(String database, String tableName, Configuration configuration)
+    {
+        return getHiveTables(configuration).load(database, tableName);
+    }
+
+    public static HiveTables getHiveTables(Configuration configuration)
+    {
+        return new HiveTables(configuration);
+    }
+
+    public static final List<HiveColumnHandle> getColumns(Schema schema, PartitionSpec spec, TypeManager typeManager)
+    {
+        final List<Types.NestedField> columns = schema.columns();
+        int columnIndex = 0;
+        ImmutableList.Builder builder = ImmutableList.builder();
+        final List<PartitionField> partitionFields = getIdentityPartitions(spec);
+        final Map<String, PartitionField> partitionColumnNames = partitionFields.stream().collect(Collectors.toMap(PartitionField::name, Function.identity()));
+        // Iceberg may or may not store identity columns in data file and the identity transformations have the same name as data column.
+        // So we remove the identity columns from the set of regular columns which does not work with some of presto validation.
+
+        for (Types.NestedField column : columns) {
+            Type type = column.type();
+            HiveColumnHandle.ColumnType columnType = REGULAR;
+            if (partitionColumnNames.containsKey(column.name())) {
+                final PartitionField partitionField = partitionColumnNames.get(column.name());
+                Type sourceType = schema.findType(partitionField.sourceId());
+                type = partitionField.transform().getResultType(sourceType);
+                columnType = PARTITION_KEY;
+            }
+            final com.facebook.presto.spi.type.Type prestoType = TypeConveter.convert(type, typeManager);
+            final HiveType hiveType = HiveType.toHiveType(hiveTypeTranslator, coerceForHive(prestoType));
+            final HiveColumnHandle columnHandle = new HiveColumnHandle(column.name(), hiveType, prestoType.getTypeSignature(), columnIndex++, columnType, Optional.empty());
+            builder.add(columnHandle);
+        }
+
+        return builder.build();
+    }
+
+    public static final com.facebook.presto.spi.type.Type coerceForHive(com.facebook.presto.spi.type.Type prestoType)
+    {
+        if (prestoType.equals(TIMESTAMP_WITH_TIME_ZONE)) {
+            return TimestampType.TIMESTAMP;
+        }
+        return prestoType;
+    }
+
+    public static final List<PartitionField> getIdentityPartitions(PartitionSpec partitionSpec)
+    {
+        //TODO We are only treating identity column as partition columns as we do not want all other columns to be projectable or filterable.
+        // Identity class is not public so no way to really identify if a transformation is identity transformation or not other than checking toString as of now.
+        // Need to make changes to iceberg so we can identify transform in a better way.
+        return partitionSpec.fields().stream().filter(partitionField -> partitionField.transform().toString().equals("identity")).collect(Collectors.toList());
+    }
+
+    public static final String getDataPath(String icebergLocation)
+    {
+        return icebergLocation.endsWith(PATH_SEPERATOR) ? icebergLocation + DATA_DIR_NAME : icebergLocation + PATH_SEPERATOR + DATA_DIR_NAME;
+    }
+
+    public static final String getTablePath(String schemaName, String tableName, Configuration configuration)
+    {
+        return new Path(new Path(configuration.get(HIVE_WAREHOUSE_DIR), String.format("%s.db", schemaName)), tableName).toString();
+    }
+
+    public static final FileFormat getFileFormat(Table table)
+    {
+        return FileFormat.valueOf(table.properties()
+                .getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT)
+                .toUpperCase(Locale.ENGLISH));
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/MetricsParser.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/MetricsParser.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.netflix.iceberg.Metrics;
+import com.netflix.iceberg.exceptions.RuntimeIOException;
+import com.netflix.iceberg.util.JsonUtil;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.netflix.iceberg.util.JsonUtil.factory;
+
+// TODO this needs to part of Iceberg otherwise we could miss metrics that are newly added on iceberg side.
+public class MetricsParser
+{
+    private static final String COLUMN_SIZES = "columnSizes";
+    private static final String NULL_VALUE_COUNTS = "nullValueCounts";
+    private static final String VALUE_COUNTS = "valueCounts";
+    private static final String RECORD_COUNT = "recordCount";
+    private static final String LOWER_BOUNDS = "lowerBounds";
+    private static final String UPPER_BOUNDS = "upperBounds";
+    private static final String KEY = "key";
+    private static final String VALUE = "value";
+
+    private MetricsParser()
+    {
+    }
+
+    public static String toJson(Metrics metrics)
+    {
+        try {
+            StringWriter writer = new StringWriter();
+            JsonGenerator generator = factory().createGenerator(writer);
+            generator.writeStartObject();
+            writeMap(generator, metrics.columnSizes(), COLUMN_SIZES);
+            writeMap(generator, metrics.nullValueCounts(), NULL_VALUE_COUNTS);
+            writeMap(generator, metrics.valueCounts(), VALUE_COUNTS);
+            generator.writeNumberField(RECORD_COUNT, metrics.recordCount());
+            writeMap(generator, metrics.lowerBounds(), LOWER_BOUNDS);
+            writeMap(generator, metrics.upperBounds(), UPPER_BOUNDS);
+            generator.writeEndObject();
+            generator.flush();
+            return writer.toString();
+        }
+        catch (IOException e) {
+            throw new RuntimeIOException("Json conversion failed for metrics = " + metrics, e);
+        }
+    }
+
+    public static void writeMap(JsonGenerator generator, Map<Integer, ?> map, String fieldName)
+            throws IOException
+    {
+        generator.writeArrayFieldStart(fieldName);
+        if (map != null) {
+            for (Map.Entry<Integer, ?> entry : map.entrySet()) {
+                generator.writeStartObject();
+                generator.writeNumberField(KEY, entry.getKey());
+                if (entry.getValue() instanceof ByteBuffer) {
+                    generator.writeBinaryField(VALUE, ((ByteBuffer) entry.getValue()).array());
+                }
+                else {
+                    generator.writeNumberField(VALUE, (Long) entry.getValue());
+                }
+                generator.writeEndObject();
+            }
+        }
+        generator.writeEndArray();
+    }
+
+    public static <V> Map<Integer, V> readMap(JsonNode arrayNode, Class<V> clazz)
+            throws IOException
+    {
+        Map<Integer, V> map = new HashMap();
+        for (JsonNode jsonNode : arrayNode) {
+            final int key = jsonNode.get(KEY).intValue();
+            if (clazz.equals(ByteBuffer.class)) {
+                map.put(key, (V) ByteBuffer.wrap(jsonNode.get(VALUE).binaryValue()));
+            }
+            else if ((clazz.equals(Long.class))) {
+                map.put(key, (V) Long.valueOf(jsonNode.get(VALUE).longValue()));
+            }
+            else {
+                throw new UnsupportedOperationException("class = " + clazz + " is unsupported");
+            }
+        }
+        return map;
+    }
+
+    public static Metrics fromJson(String json)
+    {
+        try {
+            final JsonNode jsonNode = JsonUtil.mapper().readTree(json);
+            final Map<Integer, Long> columnSizes = readMap(jsonNode.get(COLUMN_SIZES), Long.class);
+            final Map<Integer, Long> nullValueCounts = readMap(jsonNode.get(NULL_VALUE_COUNTS), Long.class);
+            final Map<Integer, Long> valueCounts = readMap(jsonNode.get(VALUE_COUNTS), Long.class);
+            final Long recordCount = jsonNode.get(RECORD_COUNT).asLong();
+            final Map<Integer, ByteBuffer> lowerBounds = readMap(jsonNode.get(LOWER_BOUNDS), ByteBuffer.class);
+            final Map<Integer, ByteBuffer> upperBounds = readMap(jsonNode.get(UPPER_BOUNDS), ByteBuffer.class);
+            return new Metrics(recordCount, columnSizes, valueCounts, nullValueCounts, lowerBounds, upperBounds);
+        }
+        catch (IOException e) {
+            throw new RuntimeIOException("Failed to fromIceberg to Metrics instance for json = " + json, e);
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/HdfsParquetDataSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/HdfsParquetDataSource.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import com.facebook.presto.spi.PrestoException;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
+import static com.google.common.base.Strings.nullToEmpty;
+import static java.lang.String.format;
+
+public class HdfsParquetDataSource
+        implements ParquetDataSource
+{
+    private final String name;
+    private final long size;
+    private final FSDataInputStream inputStream;
+    private long readBytes;
+
+    public HdfsParquetDataSource(Path path, long size, FSDataInputStream inputStream)
+    {
+        this.name = path.toString();
+        this.size = size;
+        this.inputStream = inputStream;
+    }
+
+    @Override
+    public final long getReadBytes()
+    {
+        return readBytes;
+    }
+
+    @Override
+    public final long getSize()
+    {
+        return size;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        inputStream.close();
+    }
+
+    @Override
+    public final void readFully(long position, byte[] buffer)
+            throws IOException
+    {
+        readFully(position, buffer, 0, buffer.length);
+    }
+
+    @Override
+    public final void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException
+    {
+        readInternal(position, buffer, bufferOffset, bufferLength);
+        readBytes += bufferLength;
+    }
+
+    private void readInternal(long position, byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException
+    {
+        try {
+            inputStream.readFully(position, buffer, bufferOffset, bufferLength);
+        }
+        catch (PrestoException e) {
+            // just in case there is a Presto wrapper or hook
+            throw e;
+        }
+        catch (Exception e) {
+            throw new PrestoException(HIVE_FILESYSTEM_ERROR, format("Error reading from %s at position %s", name, position), e);
+        }
+    }
+
+    public static HdfsParquetDataSource buildHdfsParquetDataSource(FileSystem fileSystem, Path path, long start, long length)
+    {
+        try {
+            long size = fileSystem.getFileStatus(path).getLen();
+            FSDataInputStream inputStream = fileSystem.open(path);
+            return new HdfsParquetDataSource(path, size, inputStream);
+        }
+        catch (Exception e) {
+            if (nullToEmpty(e.getMessage()).trim().equals("Filesystem closed") ||
+                    e instanceof FileNotFoundException) {
+                throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, e);
+            }
+            throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, format("Error opening Hive split %s (offset=%s, length=%s): %s", path, start, length, e.getMessage()), e);
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetCompressionUtils.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetCompressionUtils.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import io.airlift.compress.Decompressor;
+import io.airlift.compress.lzo.LzoDecompressor;
+import io.airlift.compress.snappy.SnappyDecompressor;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import org.apache.parquet.format.CompressionCodec;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.GZIPInputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.util.Objects.requireNonNull;
+import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+
+public final class ParquetCompressionUtils
+{
+    private static final int GZIP_BUFFER_SIZE = 8 * 1024;
+
+    private ParquetCompressionUtils() {}
+
+    private static final Map<CompressionCodec, CompressionCodecName> map = Collections.unmodifiableMap(Stream.of(
+            new AbstractMap.SimpleEntry<>(CompressionCodec.BROTLI, CompressionCodecName.BROTLI),
+            new AbstractMap.SimpleEntry<>(CompressionCodec.GZIP, CompressionCodecName.GZIP),
+            new AbstractMap.SimpleEntry<>(CompressionCodec.LZO, CompressionCodecName.LZO),
+            new AbstractMap.SimpleEntry<>(CompressionCodec.SNAPPY, CompressionCodecName.SNAPPY),
+            new AbstractMap.SimpleEntry<>(CompressionCodec.UNCOMPRESSED, CompressionCodecName.UNCOMPRESSED)
+    ).collect(Collectors.toMap((e) -> e.getKey(), (e) -> e.getValue())));
+
+    public static CompressionCodecName fromCompressionCodec(CompressionCodec codec)
+    {
+        if (map.containsKey(codec)) {
+            return map.get(codec);
+        }
+        else {
+            throw new UnsupportedOperationException("Presto's version of parquet does not support " + codec + " Add the mapping from this type to CompressionCodecName in this file and rebuild presto.");
+        }
+    }
+
+    public static Slice decompress(CompressionCodecName codec, Slice input, int uncompressedSize)
+            throws IOException
+    {
+        requireNonNull(input, "input is null");
+
+        if (input.length() == 0) {
+            return EMPTY_SLICE;
+        }
+
+        switch (codec) {
+            case GZIP:
+                return decompressGzip(input, uncompressedSize);
+            case SNAPPY:
+                return decompressSnappy(input, uncompressedSize);
+            case UNCOMPRESSED:
+                return input;
+            case LZO:
+                return decompressLZO(input, uncompressedSize);
+            default:
+                throw new ParquetCorruptionException("Codec not supported in Parquet: " + codec);
+        }
+    }
+
+    private static Slice decompressSnappy(Slice input, int uncompressedSize)
+    {
+        byte[] buffer = new byte[uncompressedSize];
+        decompress(new SnappyDecompressor(), input, 0, input.length(), buffer, 0);
+        return wrappedBuffer(buffer);
+    }
+
+    private static Slice decompressGzip(Slice input, int uncompressedSize)
+            throws IOException
+    {
+        if (uncompressedSize == 0) {
+            return EMPTY_SLICE;
+        }
+
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(uncompressedSize);
+        byte[] buffer = new byte[uncompressedSize];
+        try (InputStream gzipInputStream = new GZIPInputStream(input.getInput(), GZIP_BUFFER_SIZE)) {
+            int bytesRead;
+            while ((bytesRead = gzipInputStream.read(buffer)) != -1) {
+                sliceOutput.write(buffer, 0, bytesRead);
+            }
+            return sliceOutput.getUnderlyingSlice();
+        }
+    }
+
+    private static Slice decompressLZO(Slice input, int uncompressedSize)
+    {
+        LzoDecompressor lzoDecompressor = new LzoDecompressor();
+        long totalDecompressedCount = 0;
+        // over allocate buffer which makes decompression easier
+        byte[] output = new byte[uncompressedSize + SIZE_OF_LONG];
+        int outputOffset = 0;
+        int inputOffset = 0;
+        int cumulativeUncompressedBlockLength = 0;
+
+        while (totalDecompressedCount < uncompressedSize) {
+            if (totalDecompressedCount == cumulativeUncompressedBlockLength) {
+                cumulativeUncompressedBlockLength += Integer.reverseBytes(input.getInt(inputOffset));
+                inputOffset += SIZE_OF_INT;
+            }
+            int compressedChunkLength = Integer.reverseBytes(input.getInt(inputOffset));
+            inputOffset += SIZE_OF_INT;
+            int decompressionSize = decompress(lzoDecompressor, input, inputOffset, compressedChunkLength, output, outputOffset);
+            totalDecompressedCount += decompressionSize;
+            outputOffset += decompressionSize;
+            inputOffset += compressedChunkLength;
+        }
+        checkArgument(outputOffset == uncompressedSize);
+        return wrappedBuffer(output, 0, uncompressedSize);
+    }
+
+    private static int decompress(Decompressor decompressor, Slice input, int inputOffset, int inputLength, byte[] output, int outputOffset)
+    {
+        byte[] byteArray = (byte[]) input.getBase();
+        int byteArrayOffset = inputOffset + (int) (input.getAddress() - ARRAY_BYTE_BASE_OFFSET);
+        int size = decompressor.decompress(byteArray, byteArrayOffset, inputLength, output, outputOffset, output.length - outputOffset);
+        return size;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetCorruptionException.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetCorruptionException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import java.io.IOException;
+
+import static java.lang.String.format;
+
+public class ParquetCorruptionException
+        extends IOException
+{
+    public ParquetCorruptionException(String message)
+    {
+        super(message);
+    }
+
+    public ParquetCorruptionException(String messageFormat, Object... args)
+    {
+        super(format(messageFormat, args));
+    }
+
+    public ParquetCorruptionException(Throwable cause, String messageFormat, Object... args)
+    {
+        super(format(messageFormat, args), cause);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetDataPage.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetDataPage.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+public abstract class ParquetDataPage
+        extends ParquetPage
+{
+    protected final int valueCount;
+
+    public ParquetDataPage(int compressedSize, int uncompressedSize, int valueCount)
+    {
+        super(compressedSize, uncompressedSize);
+        this.valueCount = valueCount;
+    }
+
+    public int getValueCount()
+    {
+        return valueCount;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetDataPageV1.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetDataPageV1.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import io.airlift.slice.Slice;
+import org.apache.parquet.column.statistics.Statistics;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class ParquetDataPageV1
+        extends ParquetDataPage
+{
+    private final Slice slice;
+    private final Statistics<?> statistics;
+    private final ParquetEncoding repetitionLevelEncoding;
+    private final ParquetEncoding definitionLevelEncoding;
+    private final ParquetEncoding valuesEncoding;
+
+    public ParquetDataPageV1(
+            Slice slice,
+            int valueCount,
+            int uncompressedSize,
+            Statistics<?> statistics,
+            ParquetEncoding repetitionLevelEncoding,
+            ParquetEncoding definitionLevelEncoding,
+            ParquetEncoding valuesEncoding)
+    {
+        super(slice.length(), uncompressedSize, valueCount);
+        this.slice = requireNonNull(slice, "slice is null");
+        this.statistics = statistics;
+        this.repetitionLevelEncoding = repetitionLevelEncoding;
+        this.definitionLevelEncoding = definitionLevelEncoding;
+        this.valuesEncoding = valuesEncoding;
+    }
+
+    public Slice getSlice()
+    {
+        return slice;
+    }
+
+    public Statistics<?> getStatistics()
+    {
+        return statistics;
+    }
+
+    public ParquetEncoding getDefinitionLevelEncoding()
+    {
+        return definitionLevelEncoding;
+    }
+
+    public ParquetEncoding getRepetitionLevelEncoding()
+    {
+        return repetitionLevelEncoding;
+    }
+
+    public ParquetEncoding getValueEncoding()
+    {
+        return valuesEncoding;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("slice", slice)
+                .add("statistics", statistics)
+                .add("repetitionLevelEncoding", repetitionLevelEncoding)
+                .add("definitionLevelEncoding", definitionLevelEncoding)
+                .add("valuesEncoding", valuesEncoding)
+                .add("valueCount", valueCount)
+                .add("compressedSize", compressedSize)
+                .add("uncompressedSize", uncompressedSize)
+                .toString();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetDataPageV2.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetDataPageV2.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import io.airlift.slice.Slice;
+import org.apache.parquet.column.statistics.Statistics;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class ParquetDataPageV2
+        extends ParquetDataPage
+{
+    private final int rowCount;
+    private final int nullCount;
+    private final Slice repetitionLevels;
+    private final Slice definitionLevels;
+    private final ParquetEncoding dataEncoding;
+    private final Slice slice;
+    private final Statistics<?> statistics;
+    private final boolean isCompressed;
+
+    public ParquetDataPageV2(
+            int rowCount,
+            int nullCount,
+            int valueCount,
+            Slice repetitionLevels,
+            Slice definitionLevels,
+            ParquetEncoding dataEncoding,
+            Slice slice,
+            int uncompressedSize,
+            Statistics<?> statistics,
+            boolean isCompressed)
+    {
+        super(repetitionLevels.length() + definitionLevels.length() + slice.length(), uncompressedSize, valueCount);
+        this.rowCount = rowCount;
+        this.nullCount = nullCount;
+        this.repetitionLevels = requireNonNull(repetitionLevels, "repetitionLevels slice is null");
+        this.definitionLevels = requireNonNull(definitionLevels, "definitionLevels slice is null");
+        this.dataEncoding = dataEncoding;
+        this.slice = requireNonNull(slice, "slice is null");
+        this.statistics = statistics;
+        this.isCompressed = isCompressed;
+    }
+
+    public int getRowCount()
+    {
+        return rowCount;
+    }
+
+    public int getNullCount()
+    {
+        return nullCount;
+    }
+
+    public Slice getRepetitionLevels()
+    {
+        return repetitionLevels;
+    }
+
+    public Slice getDefinitionLevels()
+    {
+        return definitionLevels;
+    }
+
+    public ParquetEncoding getDataEncoding()
+    {
+        return dataEncoding;
+    }
+
+    public Slice getSlice()
+    {
+        return slice;
+    }
+
+    public Statistics<?> getStatistics()
+    {
+        return statistics;
+    }
+
+    public boolean isCompressed()
+    {
+        return isCompressed;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("rowCount", rowCount)
+                .add("nullCount", nullCount)
+                .add("repetitionLevels", repetitionLevels)
+                .add("definitionLevels", definitionLevels)
+                .add("dataEncoding", dataEncoding)
+                .add("slice", slice)
+                .add("statistics", statistics)
+                .add("isCompressed", isCompressed)
+                .add("valueCount", valueCount)
+                .add("compressedSize", compressedSize)
+                .add("uncompressedSize", uncompressedSize)
+                .toString();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetDataSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetDataSource.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public interface ParquetDataSource
+        extends Closeable
+{
+    long getReadBytes();
+
+    long getSize();
+
+    void readFully(long position, byte[] buffer)
+            throws IOException;
+
+    void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException;
+
+    @Override
+    default void close()
+            throws IOException
+    {
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetDictionaryPage.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetDictionaryPage.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import io.airlift.slice.Slice;
+
+import java.util.Arrays;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.util.Objects.requireNonNull;
+
+public class ParquetDictionaryPage
+        extends ParquetPage
+{
+    private final Slice slice;
+    private final int dictionarySize;
+    private final ParquetEncoding encoding;
+
+    public ParquetDictionaryPage(Slice slice, int dictionarySize, ParquetEncoding encoding)
+    {
+        this(requireNonNull(slice, "slice is null"),
+                slice.length(),
+                dictionarySize,
+                requireNonNull(encoding, "encoding is null"));
+    }
+
+    public ParquetDictionaryPage(Slice slice, int uncompressedSize, int dictionarySize, ParquetEncoding encoding)
+    {
+        super(requireNonNull(slice, "slice is null").length(), uncompressedSize);
+        this.slice = slice;
+        this.dictionarySize = dictionarySize;
+        this.encoding = requireNonNull(encoding, "encoding is null");
+    }
+
+    public Slice getSlice()
+    {
+        return slice;
+    }
+
+    public int getDictionarySize()
+    {
+        return dictionarySize;
+    }
+
+    public ParquetEncoding getEncoding()
+    {
+        return encoding;
+    }
+
+    public ParquetDictionaryPage copy()
+    {
+        return new ParquetDictionaryPage(wrappedBuffer(Arrays.copyOf(slice.getBytes(), slice.length())), getUncompressedSize(), dictionarySize, encoding);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("slice", slice)
+                .add("dictionarySize", dictionarySize)
+                .add("encoding", encoding)
+                .add("compressedSize", compressedSize)
+                .add("uncompressedSize", uncompressedSize)
+                .toString();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetEncoding.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetEncoding.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import com.facebook.presto.iceberg.parquet.dictionary.ParquetBinaryDictionary;
+import com.facebook.presto.iceberg.parquet.dictionary.ParquetDictionary;
+import com.facebook.presto.iceberg.parquet.dictionary.ParquetDictionaryReader;
+import com.facebook.presto.iceberg.parquet.dictionary.ParquetDoubleDictionary;
+import com.facebook.presto.iceberg.parquet.dictionary.ParquetFloatDictionary;
+import com.facebook.presto.iceberg.parquet.dictionary.ParquetIntegerDictionary;
+import com.facebook.presto.iceberg.parquet.dictionary.ParquetLongDictionary;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.bitpacking.ByteBitPackingValuesReader;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesReader;
+import org.apache.parquet.column.values.deltastrings.DeltaByteArrayReader;
+import org.apache.parquet.column.values.plain.BinaryPlainValuesReader;
+import org.apache.parquet.column.values.plain.BooleanPlainValuesReader;
+import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesReader;
+import org.apache.parquet.column.values.plain.PlainValuesReader.DoublePlainValuesReader;
+import org.apache.parquet.column.values.plain.PlainValuesReader.FloatPlainValuesReader;
+import org.apache.parquet.column.values.plain.PlainValuesReader.IntegerPlainValuesReader;
+import org.apache.parquet.column.values.plain.PlainValuesReader.LongPlainValuesReader;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesReader;
+import org.apache.parquet.column.values.rle.ZeroIntegerValuesReader;
+import org.apache.parquet.io.ParquetDecodingException;
+
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.parquet.column.values.bitpacking.Packer.BIG_ENDIAN;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+
+public enum ParquetEncoding
+{
+    PLAIN {
+        @Override
+        public ValuesReader getValuesReader(ColumnDescriptor descriptor, ParquetValuesType valuesType)
+        {
+            switch (descriptor.getType()) {
+                case BOOLEAN:
+                    return new BooleanPlainValuesReader();
+                case BINARY:
+                    return new BinaryPlainValuesReader();
+                case FLOAT:
+                    return new FloatPlainValuesReader();
+                case DOUBLE:
+                    return new DoublePlainValuesReader();
+                case INT32:
+                    return new IntegerPlainValuesReader();
+                case INT64:
+                    return new LongPlainValuesReader();
+                case INT96:
+                    return new FixedLenByteArrayPlainValuesReader(INT96_TYPE_LENGTH);
+                case FIXED_LEN_BYTE_ARRAY:
+                    return new FixedLenByteArrayPlainValuesReader(descriptor.getTypeLength());
+                default:
+                    throw new ParquetDecodingException("Plain values reader does not support: " + descriptor.getType());
+            }
+        }
+
+        @Override
+        public ParquetDictionary initDictionary(ColumnDescriptor descriptor, ParquetDictionaryPage dictionaryPage)
+                throws IOException
+        {
+            switch (descriptor.getType()) {
+                case BINARY:
+                    return new ParquetBinaryDictionary(dictionaryPage);
+                case FIXED_LEN_BYTE_ARRAY:
+                    return new ParquetBinaryDictionary(dictionaryPage, descriptor.getTypeLength());
+                case INT96:
+                    return new ParquetBinaryDictionary(dictionaryPage, INT96_TYPE_LENGTH);
+                case INT64:
+                    return new ParquetLongDictionary(dictionaryPage);
+                case DOUBLE:
+                    return new ParquetDoubleDictionary(dictionaryPage);
+                case INT32:
+                    return new ParquetIntegerDictionary(dictionaryPage);
+                case FLOAT:
+                    return new ParquetFloatDictionary(dictionaryPage);
+                default:
+                    throw new ParquetDecodingException("Dictionary encoding does not support: " + descriptor.getType());
+            }
+        }
+    },
+
+    RLE {
+        @Override
+        public ValuesReader getValuesReader(ColumnDescriptor descriptor, ParquetValuesType valuesType)
+        {
+            int bitWidth = BytesUtils.getWidthFromMaxInt(getMaxLevel(descriptor, valuesType));
+            if (bitWidth == 0) {
+                return new ZeroIntegerValuesReader();
+            }
+            return new RunLengthBitPackingHybridValuesReader(bitWidth);
+        }
+    },
+
+    BIT_PACKED {
+        @Override
+        public ValuesReader getValuesReader(ColumnDescriptor descriptor, ParquetValuesType valuesType)
+        {
+            return new ByteBitPackingValuesReader(getMaxLevel(descriptor, valuesType), BIG_ENDIAN);
+        }
+    },
+
+    PLAIN_DICTIONARY {
+        @Override
+        public ValuesReader getDictionaryBasedValuesReader(ColumnDescriptor descriptor, ParquetValuesType valuesType, ParquetDictionary dictionary)
+        {
+            return RLE_DICTIONARY.getDictionaryBasedValuesReader(descriptor, valuesType, dictionary);
+        }
+
+        @Override
+        public ParquetDictionary initDictionary(ColumnDescriptor descriptor, ParquetDictionaryPage dictionaryPage)
+                throws IOException
+        {
+            return PLAIN.initDictionary(descriptor, dictionaryPage);
+        }
+
+        @Override
+        public boolean usesDictionary()
+        {
+            return true;
+        }
+    },
+
+    DELTA_BINARY_PACKED {
+        @Override
+        public ValuesReader getValuesReader(ColumnDescriptor descriptor, ParquetValuesType valuesType)
+        {
+            checkArgument(descriptor.getType() == INT32, "Encoding DELTA_BINARY_PACKED is only supported for type INT32");
+            return new DeltaBinaryPackingValuesReader();
+        }
+    },
+
+    DELTA_LENGTH_BYTE_ARRAY {
+        @Override
+        public ValuesReader getValuesReader(ColumnDescriptor descriptor, ParquetValuesType valuesType)
+        {
+            checkArgument(descriptor.getType() == BINARY, "Encoding DELTA_LENGTH_BYTE_ARRAY is only supported for type BINARY");
+            return new DeltaLengthByteArrayValuesReader();
+        }
+    },
+
+    DELTA_BYTE_ARRAY {
+        @Override
+        public ValuesReader getValuesReader(ColumnDescriptor descriptor, ParquetValuesType valuesType)
+        {
+            checkArgument(
+                    descriptor.getType() == BINARY || descriptor.getType() == FIXED_LEN_BYTE_ARRAY,
+                    "Encoding DELTA_BYTE_ARRAY is only supported for type BINARY and FIXED_LEN_BYTE_ARRAY");
+            return new DeltaByteArrayReader();
+        }
+    },
+
+    RLE_DICTIONARY {
+        @Override
+        public ValuesReader getDictionaryBasedValuesReader(ColumnDescriptor descriptor, ParquetValuesType valuesType, ParquetDictionary dictionary)
+        {
+            return new ParquetDictionaryReader(dictionary);
+        }
+
+        @Override
+        public ParquetDictionary initDictionary(ColumnDescriptor descriptor, ParquetDictionaryPage dictionaryPage)
+                throws IOException
+        {
+            return PLAIN.initDictionary(descriptor, dictionaryPage);
+        }
+
+        @Override
+        public boolean usesDictionary()
+        {
+            return true;
+        }
+    };
+
+    static final int INT96_TYPE_LENGTH = 12;
+
+    static int getMaxLevel(ColumnDescriptor descriptor, ParquetValuesType valuesType)
+    {
+        switch (valuesType) {
+            case REPETITION_LEVEL:
+                return descriptor.getMaxRepetitionLevel();
+            case DEFINITION_LEVEL:
+                return descriptor.getMaxDefinitionLevel();
+            case VALUES:
+                if (descriptor.getType() == BOOLEAN) {
+                    return 1;
+                }
+            default:
+                throw new ParquetDecodingException("Unsupported Parquet values type: " + valuesType);
+        }
+    }
+
+    public boolean usesDictionary()
+    {
+        return false;
+    }
+
+    public ParquetDictionary initDictionary(ColumnDescriptor descriptor, ParquetDictionaryPage dictionaryPage)
+            throws IOException
+    {
+        throw new UnsupportedOperationException("Parquet Dictionary encoding is not supported for: " + name());
+    }
+
+    public ValuesReader getValuesReader(ColumnDescriptor descriptor, ParquetValuesType valuesType)
+    {
+        throw new UnsupportedOperationException("Error decoding Parquet values in encoding: " + this.name());
+    }
+
+    public ValuesReader getDictionaryBasedValuesReader(ColumnDescriptor descriptor, ParquetValuesType valuesType, ParquetDictionary dictionary)
+    {
+        throw new UnsupportedOperationException("Parquet Dictionary encoding is not supported for: " + name());
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetHiveRecordCursor.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetHiveRecordCursor.java
@@ -1,0 +1,1363 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.util.DecimalUtils;
+import com.facebook.presto.iceberg.parquet.predicate.ParquetPredicate;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.PageBuilderStatus;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.Decimals;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetInputSplit;
+import org.apache.parquet.hadoop.ParquetRecordReader;
+import org.apache.parquet.hadoop.api.ReadSupport;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.hadoop.util.ContextUtil;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.Converter;
+import org.apache.parquet.io.api.GroupConverter;
+import org.apache.parquet.io.api.PrimitiveConverter;
+import org.apache.parquet.io.api.RecordMaterializer;
+import org.apache.parquet.schema.DecimalMetadata;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_MISSING_DATA;
+import static com.facebook.presto.hive.HiveUtil.closeWithSuppression;
+import static com.facebook.presto.hive.HiveUtil.getDecimalType;
+import static com.facebook.presto.iceberg.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
+import static com.facebook.presto.iceberg.parquet.ParquetTypeUtils.getParquetType;
+import static com.facebook.presto.iceberg.parquet.predicate.ParquetPredicateUtils.buildParquetPredicate;
+import static com.facebook.presto.iceberg.parquet.predicate.ParquetPredicateUtils.predicateMatches;
+import static com.facebook.presto.spi.type.Chars.isCharType;
+import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
+import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
+import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
+import static com.facebook.presto.spi.type.StandardTypes.MAP;
+import static com.facebook.presto.spi.type.StandardTypes.ROW;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
+import static com.facebook.presto.spi.type.Varchars.truncateToLength;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
+import static org.apache.parquet.schema.OriginalType.DECIMAL;
+import static org.apache.parquet.schema.OriginalType.MAP_KEY_VALUE;
+
+public class ParquetHiveRecordCursor
+        implements RecordCursor
+{
+    private final ParquetRecordReader<FakeParquetRecord> recordReader;
+
+    private final Type[] types;
+
+    private final boolean[] booleans;
+    private final long[] longs;
+    private final double[] doubles;
+    private final Slice[] slices;
+    private final Object[] objects;
+    private final boolean[] nulls;
+
+    private final long totalBytes;
+    private long completedBytes;
+    private boolean closed;
+
+    public ParquetHiveRecordCursor(
+            HdfsEnvironment hdfsEnvironment,
+            String sessionUser,
+            Configuration configuration,
+            Path path,
+            long start,
+            long length,
+            Properties splitSchema,
+            List<HiveColumnHandle> columns,
+            boolean useParquetColumnNames,
+            TypeManager typeManager,
+            boolean predicatePushdownEnabled,
+            TupleDomain<HiveColumnHandle> effectivePredicate)
+    {
+        requireNonNull(path, "path is null");
+        checkArgument(length >= 0, "length is negative");
+        requireNonNull(splitSchema, "splitSchema is null");
+        requireNonNull(columns, "columns is null");
+
+        this.totalBytes = length;
+
+        int size = columns.size();
+
+        this.types = new Type[size];
+
+        this.booleans = new boolean[size];
+        this.longs = new long[size];
+        this.doubles = new double[size];
+        this.slices = new Slice[size];
+        this.objects = new Object[size];
+        this.nulls = new boolean[size];
+
+        for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+            HiveColumnHandle column = columns.get(columnIndex);
+            checkState(column.getColumnType() == REGULAR, "column type must be regular");
+
+            types[columnIndex] = typeManager.getType(column.getTypeSignature());
+        }
+
+        this.recordReader = createParquetRecordReader(
+                hdfsEnvironment,
+                sessionUser,
+                configuration,
+                path,
+                start,
+                length,
+                columns,
+                useParquetColumnNames,
+                typeManager,
+                predicatePushdownEnabled,
+                effectivePredicate);
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        if (!closed) {
+            updateCompletedBytes();
+        }
+        return completedBytes;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return 0;
+    }
+
+    private void updateCompletedBytes()
+    {
+        try {
+            long newCompletedBytes = (long) (totalBytes * recordReader.getProgress());
+            completedBytes = min(totalBytes, max(completedBytes, newCompletedBytes));
+        }
+        catch (IOException ignored) {
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public Type getType(int field)
+    {
+        return types[field];
+    }
+
+    @Override
+    public boolean advanceNextPosition()
+    {
+        try {
+            // reset null flags
+            Arrays.fill(nulls, true);
+
+            if (closed || !recordReader.nextKeyValue()) {
+                close();
+                return false;
+            }
+
+            return true;
+        }
+        catch (IOException | RuntimeException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+
+            closeWithSuppression(this, e);
+            throw new PrestoException(HIVE_CURSOR_ERROR, e);
+        }
+    }
+
+    @Override
+    public boolean getBoolean(int fieldId)
+    {
+        checkState(!closed, "Cursor is closed");
+
+        validateType(fieldId, boolean.class);
+        return booleans[fieldId];
+    }
+
+    @Override
+    public long getLong(int fieldId)
+    {
+        checkState(!closed, "Cursor is closed");
+
+        validateType(fieldId, long.class);
+        return longs[fieldId];
+    }
+
+    @Override
+    public double getDouble(int fieldId)
+    {
+        checkState(!closed, "Cursor is closed");
+
+        validateType(fieldId, double.class);
+        return doubles[fieldId];
+    }
+
+    @Override
+    public Slice getSlice(int fieldId)
+    {
+        checkState(!closed, "Cursor is closed");
+
+        validateType(fieldId, Slice.class);
+        return slices[fieldId];
+    }
+
+    @Override
+    public Object getObject(int fieldId)
+    {
+        checkState(!closed, "Cursor is closed");
+
+        validateType(fieldId, Block.class);
+        return objects[fieldId];
+    }
+
+    @Override
+    public boolean isNull(int fieldId)
+    {
+        checkState(!closed, "Cursor is closed");
+        return nulls[fieldId];
+    }
+
+    private void validateType(int fieldId, Class<?> javaType)
+    {
+        if (types[fieldId].getJavaType() != javaType) {
+            // we don't use Preconditions.checkArgument because it requires boxing fieldId, which affects inner loop performance
+            throw new IllegalArgumentException(format("Expected field to be %s, actual %s (field %s)", javaType.getName(), types[fieldId].getJavaType().getName(), fieldId));
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        // some hive input formats are broken and bad things can happen if you close them multiple times
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        updateCompletedBytes();
+
+        try {
+            recordReader.close();
+        }
+        catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    private ParquetRecordReader<FakeParquetRecord> createParquetRecordReader(
+            HdfsEnvironment hdfsEnvironment,
+            String sessionUser,
+            Configuration configuration,
+            Path path,
+            long start,
+            long length,
+            List<HiveColumnHandle> columns,
+            boolean useParquetColumnNames,
+            TypeManager typeManager,
+            boolean predicatePushdownEnabled,
+            TupleDomain<HiveColumnHandle> effectivePredicate)
+    {
+        ParquetDataSource dataSource = null;
+        try {
+            FileSystem fileSystem = hdfsEnvironment.getFileSystem(sessionUser, path, configuration);
+            dataSource = buildHdfsParquetDataSource(fileSystem, path, start, length);
+            ParquetMetadata parquetMetadata = hdfsEnvironment.doAs(sessionUser, () -> ParquetFileReader.readFooter(configuration, path, NO_FILTER));
+            List<BlockMetaData> blocks = parquetMetadata.getBlocks();
+            FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
+            MessageType fileSchema = fileMetaData.getSchema();
+
+            PrestoReadSupport readSupport = new PrestoReadSupport(useParquetColumnNames, columns, fileSchema);
+
+            List<org.apache.parquet.schema.Type> fields = columns.stream()
+                    .filter(column -> column.getColumnType() == REGULAR)
+                    .map(column -> getParquetType(column, fileSchema, useParquetColumnNames))
+                    .filter(Objects::nonNull)
+                    .collect(toList());
+
+            MessageType requestedSchema = new MessageType(fileSchema.getName(), fields);
+
+            LongArrayList offsets = new LongArrayList(blocks.size());
+            for (BlockMetaData block : blocks) {
+                long firstDataPage = block.getColumns().get(0).getFirstDataPageOffset();
+                if (firstDataPage >= start && firstDataPage < start + length) {
+                    if (predicatePushdownEnabled) {
+                        ParquetPredicate parquetPredicate = buildParquetPredicate(columns, effectivePredicate, fileMetaData.getSchema(), typeManager);
+                        if (predicateMatches(parquetPredicate, block, dataSource, requestedSchema, effectivePredicate)) {
+                            offsets.add(block.getStartingPos());
+                        }
+                    }
+                    else {
+                        offsets.add(block.getStartingPos());
+                    }
+                }
+            }
+
+            ParquetInputSplit split = new ParquetInputSplit(path, start, start + length, length, null, offsets.toLongArray());
+
+            TaskAttemptContext taskContext = ContextUtil.newTaskAttemptContext(configuration, new TaskAttemptID());
+
+            return hdfsEnvironment.doAs(sessionUser, () -> {
+                ParquetRecordReader<FakeParquetRecord> realReader = new PrestoParquetRecordReader(readSupport);
+                realReader.initialize(split, taskContext);
+                return realReader;
+            });
+        }
+        catch (Exception e) {
+            Throwables.propagateIfInstanceOf(e, PrestoException.class);
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                throw Throwables.propagate(e);
+            }
+            String message = format("Error opening Hive split %s (offset=%s, length=%s): %s", path, start, length, e.getMessage());
+            if (e.getClass().getSimpleName().equals("BlockMissingException")) {
+                throw new PrestoException(HIVE_MISSING_DATA, message, e);
+            }
+            throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, message, e);
+        }
+        finally {
+            if (dataSource != null) {
+                try {
+                    dataSource.close();
+                }
+                catch (IOException ignored) {
+                }
+            }
+        }
+    }
+
+    public class PrestoParquetRecordReader
+            extends ParquetRecordReader<FakeParquetRecord>
+    {
+        public PrestoParquetRecordReader(PrestoReadSupport readSupport)
+        {
+            super(readSupport);
+        }
+    }
+
+    public final class PrestoReadSupport
+            extends ReadSupport<FakeParquetRecord>
+    {
+        private final boolean useParquetColumnNames;
+        private final List<HiveColumnHandle> columns;
+        private final List<Converter> converters;
+
+        public PrestoReadSupport(boolean useParquetColumnNames, List<HiveColumnHandle> columns, MessageType messageType)
+        {
+            this.columns = columns;
+            this.useParquetColumnNames = useParquetColumnNames;
+
+            ImmutableList.Builder<Converter> converters = ImmutableList.builder();
+            for (int i = 0; i < columns.size(); i++) {
+                HiveColumnHandle column = columns.get(i);
+                if (column.getColumnType() == REGULAR) {
+                    org.apache.parquet.schema.Type parquetType = getParquetType(column, messageType, useParquetColumnNames);
+                    if (parquetType == null) {
+                        continue;
+                    }
+                    if (parquetType.isPrimitive()) {
+                        Optional<DecimalType> decimalType = getDecimalType(column.getHiveType());
+                        if (decimalType.isPresent()) {
+                            converters.add(new ParquetDecimalColumnConverter(i, decimalType.get()));
+                        }
+                        else {
+                            converters.add(new ParquetPrimitiveColumnConverter(i));
+                        }
+                    }
+                    else {
+                        converters.add(new ParquetColumnConverter(createGroupConverter(types[i], parquetType.getName(), parquetType, i), i));
+                    }
+                }
+            }
+            this.converters = converters.build();
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public ReadContext init(
+                Configuration configuration,
+                Map<String, String> keyValueMetaData,
+                MessageType messageType)
+        {
+            List<org.apache.parquet.schema.Type> fields = columns.stream()
+                    .filter(column -> column.getColumnType() == REGULAR)
+                    .map(column -> getParquetType(column, messageType, useParquetColumnNames))
+                    .filter(Objects::nonNull)
+                    .collect(toList());
+            MessageType requestedProjection = new MessageType(messageType.getName(), fields);
+            return new ReadContext(requestedProjection);
+        }
+
+        @Override
+        public RecordMaterializer<FakeParquetRecord> prepareForRead(
+                Configuration configuration,
+                Map<String, String> keyValueMetaData,
+                MessageType fileSchema,
+                ReadContext readContext)
+        {
+            return new ParquetRecordConverter(converters);
+        }
+    }
+
+    private static class ParquetRecordConverter
+            extends RecordMaterializer<FakeParquetRecord>
+    {
+        private final ParquetGroupConverter groupConverter;
+
+        public ParquetRecordConverter(List<Converter> converters)
+        {
+            groupConverter = new ParquetGroupConverter(converters);
+        }
+
+        @Override
+        public FakeParquetRecord getCurrentRecord()
+        {
+            // Parquet skips the record if it is null, so we need non-null record
+            return FakeParquetRecord.MATERIALIZE_RECORD;
+        }
+
+        @Override
+        public GroupConverter getRootConverter()
+        {
+            return groupConverter;
+        }
+    }
+
+    private enum FakeParquetRecord
+    {
+        MATERIALIZE_RECORD
+    }
+
+    public static class ParquetGroupConverter
+            extends GroupConverter
+    {
+        private final List<Converter> converters;
+
+        public ParquetGroupConverter(List<Converter> converters)
+        {
+            this.converters = converters;
+        }
+
+        @Override
+        public Converter getConverter(int fieldIndex)
+        {
+            return converters.get(fieldIndex);
+        }
+
+        @Override
+        public void start()
+        {
+        }
+
+        @Override
+        public void end()
+        {
+        }
+    }
+
+    @SuppressWarnings("AccessingNonPublicFieldOfAnotherObject")
+    private class ParquetPrimitiveColumnConverter
+            extends PrimitiveConverter
+    {
+        private final int fieldIndex;
+
+        private ParquetPrimitiveColumnConverter(int fieldIndex)
+        {
+            this.fieldIndex = fieldIndex;
+        }
+
+        @Override
+        public boolean isPrimitive()
+        {
+            return true;
+        }
+
+        @Override
+        public PrimitiveConverter asPrimitiveConverter()
+        {
+            return this;
+        }
+
+        @Override
+        public boolean hasDictionarySupport()
+        {
+            return false;
+        }
+
+        @Override
+        public void setDictionary(Dictionary dictionary)
+        {
+        }
+
+        @Override
+        public void addValueFromDictionary(int dictionaryId)
+        {
+        }
+
+        @Override
+        public void addBoolean(boolean value)
+        {
+            nulls[fieldIndex] = false;
+            booleans[fieldIndex] = value;
+        }
+
+        @Override
+        public void addDouble(double value)
+        {
+            nulls[fieldIndex] = false;
+            doubles[fieldIndex] = value;
+        }
+
+        @Override
+        public void addLong(long value)
+        {
+            nulls[fieldIndex] = false;
+            longs[fieldIndex] = value;
+        }
+
+        @Override
+        public void addBinary(Binary value)
+        {
+            nulls[fieldIndex] = false;
+            Type type = types[fieldIndex];
+            if (type == TIMESTAMP) {
+                longs[fieldIndex] = ParquetTimestampUtils.getTimestampMillis(value);
+            }
+            else if (isVarcharType(type)) {
+                slices[fieldIndex] = truncateToLength(wrappedBuffer(value.getBytes()), type);
+            }
+            else if (isCharType(type)) {
+                slices[fieldIndex] = truncateToLengthAndTrimSpaces(wrappedBuffer(value.getBytes()), type);
+            }
+            else {
+                slices[fieldIndex] = wrappedBuffer(value.getBytes());
+            }
+        }
+
+        @Override
+        public void addFloat(float value)
+        {
+            nulls[fieldIndex] = false;
+            longs[fieldIndex] = floatToRawIntBits(value);
+        }
+
+        @Override
+        public void addInt(int value)
+        {
+            nulls[fieldIndex] = false;
+            longs[fieldIndex] = value;
+        }
+    }
+
+    private class ParquetDecimalColumnConverter
+            extends PrimitiveConverter
+    {
+        private final int fieldIndex;
+        private final DecimalType decimalType;
+
+        private ParquetDecimalColumnConverter(int fieldIndex, DecimalType decimalType)
+        {
+            this.fieldIndex = fieldIndex;
+            this.decimalType = requireNonNull(decimalType, "decimalType is null");
+        }
+
+        public void addBinary(Binary value)
+        {
+            nulls[fieldIndex] = false;
+            if (decimalType.isShort()) {
+                longs[fieldIndex] = DecimalUtils.getShortDecimalValue(value.getBytes());
+            }
+            else {
+                slices[fieldIndex] = Decimals.encodeUnscaledValue(new BigInteger(value.getBytes()));
+            }
+        }
+    }
+
+    public class ParquetColumnConverter
+            extends GroupConverter
+    {
+        private final GroupedConverter groupedConverter;
+        private final int fieldIndex;
+
+        public ParquetColumnConverter(GroupedConverter groupedConverter, int fieldIndex)
+        {
+            this.groupedConverter = groupedConverter;
+            this.fieldIndex = fieldIndex;
+        }
+
+        @Override
+        public Converter getConverter(int fieldIndex)
+        {
+            return groupedConverter.getConverter(fieldIndex);
+        }
+
+        @Override
+        public void start()
+        {
+            groupedConverter.beforeValue(null);
+            groupedConverter.start();
+        }
+
+        @Override
+        public void end()
+        {
+            groupedConverter.afterValue();
+            groupedConverter.end();
+
+            nulls[fieldIndex] = false;
+
+            objects[fieldIndex] = groupedConverter.getBlock();
+        }
+    }
+
+    private interface BlockConverter
+    {
+        void beforeValue(BlockBuilder builder);
+
+        void afterValue();
+    }
+
+    private abstract static class GroupedConverter
+            extends GroupConverter
+            implements BlockConverter
+    {
+        public abstract Block getBlock();
+    }
+
+    private static BlockConverter createConverter(Type prestoType, String columnName, org.apache.parquet.schema.Type parquetType, int fieldIndex)
+    {
+        if (parquetType.isPrimitive()) {
+            if (parquetType.getOriginalType() == DECIMAL) {
+                DecimalMetadata decimalMetadata = ((PrimitiveType) parquetType).getDecimalMetadata();
+                return new ParquetDecimalConverter(createDecimalType(decimalMetadata.getPrecision(), decimalMetadata.getScale()));
+            }
+            else {
+                return new ParquetPrimitiveConverter(prestoType, fieldIndex);
+            }
+        }
+
+        return createGroupConverter(prestoType, columnName, parquetType, fieldIndex);
+    }
+
+    private static GroupedConverter createGroupConverter(Type prestoType, String columnName, org.apache.parquet.schema.Type parquetType, int fieldIndex)
+    {
+        GroupType groupType = parquetType.asGroupType();
+        switch (prestoType.getTypeSignature().getBase()) {
+            case ARRAY:
+                return new ParquetListConverter(prestoType, columnName, groupType, fieldIndex);
+            case MAP:
+                return new ParquetMapConverter(prestoType, columnName, groupType, fieldIndex);
+            case ROW:
+                return new ParquetStructConverter(prestoType, columnName, groupType, fieldIndex);
+            default:
+                throw new IllegalArgumentException("Column " + columnName + " type " + parquetType.getOriginalType() + " not supported");
+        }
+    }
+
+    private static class ParquetStructConverter
+            extends GroupedConverter
+    {
+        private static final int NULL_BUILDER_POSITIONS_THRESHOLD = 100;
+        private static final int NULL_BUILDER_SIZE_IN_BYTES_THRESHOLD = 32768;
+
+        private final Type rowType;
+        private final int fieldIndex;
+
+        private final List<BlockConverter> converters;
+        private BlockBuilder builder;
+        private BlockBuilder nullBuilder; // used internally when builder is set to null
+        private BlockBuilder currentEntryBuilder;
+
+        public ParquetStructConverter(Type prestoType, String columnName, GroupType entryType, int fieldIndex)
+        {
+            checkArgument(ROW.equals(prestoType.getTypeSignature().getBase()));
+            List<Type> prestoTypeParameters = prestoType.getTypeParameters();
+            List<org.apache.parquet.schema.Type> fieldTypes = entryType.getFields();
+            checkArgument(
+                    prestoTypeParameters.size() == fieldTypes.size(),
+                    "Schema mismatch, metastore schema for row column %s has %s fields but parquet schema has %s fields",
+                    columnName,
+                    prestoTypeParameters.size(),
+                    fieldTypes.size());
+
+            this.rowType = prestoType;
+            this.fieldIndex = fieldIndex;
+
+            ImmutableList.Builder<BlockConverter> converters = ImmutableList.builder();
+            for (int i = 0; i < prestoTypeParameters.size(); i++) {
+                org.apache.parquet.schema.Type fieldType = fieldTypes.get(i);
+                converters.add(createConverter(prestoTypeParameters.get(i), columnName + "." + fieldType.getName(), fieldType, i));
+            }
+            this.converters = converters.build();
+        }
+
+        @Override
+        public Converter getConverter(int fieldIndex)
+        {
+            return (Converter) converters.get(fieldIndex);
+        }
+
+        @Override
+        public void beforeValue(BlockBuilder builder)
+        {
+            this.builder = builder;
+        }
+
+        @Override
+        public void start()
+        {
+            if (builder == null) {
+                if (nullBuilder == null || (nullBuilder.getPositionCount() >= NULL_BUILDER_POSITIONS_THRESHOLD && nullBuilder.getSizeInBytes() >= NULL_BUILDER_SIZE_IN_BYTES_THRESHOLD)) {
+                    nullBuilder = rowType.createBlockBuilder(new PageBuilderStatus().createBlockBuilderStatus(), NULL_BUILDER_POSITIONS_THRESHOLD);
+                }
+                currentEntryBuilder = nullBuilder.beginBlockEntry();
+            }
+            else {
+                while (builder.getPositionCount() < fieldIndex) {
+                    builder.appendNull();
+                }
+                currentEntryBuilder = builder.beginBlockEntry();
+            }
+            for (BlockConverter converter : converters) {
+                converter.beforeValue(currentEntryBuilder);
+            }
+        }
+
+        @Override
+        public void end()
+        {
+            for (BlockConverter converter : converters) {
+                converter.afterValue();
+            }
+            while (currentEntryBuilder.getPositionCount() < converters.size()) {
+                currentEntryBuilder.appendNull();
+            }
+
+            if (builder == null) {
+                nullBuilder.closeEntry();
+            }
+            else {
+                builder.closeEntry();
+            }
+        }
+
+        @Override
+        public void afterValue()
+        {
+        }
+
+        @Override
+        public Block getBlock()
+        {
+            checkState(builder == null && nullBuilder != null); // check that user requested a result block (builder == null), and the program followed the request (nullBuilder != null)
+            return nullBuilder.getObject(nullBuilder.getPositionCount() - 1, Block.class);
+        }
+    }
+
+    private static class ParquetListConverter
+            extends GroupedConverter
+    {
+        private static final int NULL_BUILDER_POSITIONS_THRESHOLD = 100;
+        private static final int NULL_BUILDER_SIZE_IN_BYTES_THRESHOLD = 32768;
+
+        private final Type arrayType;
+        private final int fieldIndex;
+
+        private final BlockConverter elementConverter;
+        private BlockBuilder builder;
+        private BlockBuilder nullBuilder; // used internally when builder is set to null
+        private BlockBuilder currentEntryBuilder;
+
+        public ParquetListConverter(Type prestoType, String columnName, GroupType listType, int fieldIndex)
+        {
+            checkArgument(
+                    listType.getFieldCount() == 1,
+                    "Expected LIST column '%s' to only have one field, but has %s fields",
+                    columnName,
+                    listType.getFieldCount());
+            checkArgument(ARRAY.equals(prestoType.getTypeSignature().getBase()));
+
+            this.arrayType = prestoType;
+            this.fieldIndex = fieldIndex;
+
+            // The Parquet specification requires that the element value of a
+            // LIST type be wrapped in an inner repeated group, like so:
+            //
+            // optional group listField (LIST) {
+            //   repeated group list {
+            //     optional int element
+            //   }
+            // }
+            //
+            // However, some parquet libraries don't follow this spec. The
+            // compatibility rules used here are specified in the Parquet
+            // documentation at http://git.io/vOpNz.
+            org.apache.parquet.schema.Type elementType = listType.getType(0);
+            if (isElementType(elementType, listType.getName())) {
+                elementConverter = createConverter(prestoType.getTypeParameters().get(0), columnName + ".element", elementType, 0);
+            }
+            else {
+                elementConverter = new ParquetListEntryConverter(prestoType.getTypeParameters().get(0), columnName, elementType.asGroupType());
+            }
+        }
+
+        //copied over from Apache Hive
+        private boolean isElementType(org.apache.parquet.schema.Type repeatedType, String parentName)
+        {
+            if (repeatedType.isPrimitive() ||
+                    (repeatedType.asGroupType().getFieldCount() > 1)) {
+                return true;
+            }
+
+            if (repeatedType.getName().equals("array")) {
+                return true; // existing avro data
+            }
+
+            if (repeatedType.getName().equals(parentName + "_tuple")) {
+                return true; // existing thrift data
+            }
+            // false for the following cases:
+            // * name is "list", which matches the spec
+            // * name is "bag", which indicates existing hive or pig data
+            // * ambiguous case, which should be assumed is 3-level according to spec
+            return false;
+        }
+
+        @Override
+        public void beforeValue(BlockBuilder builder)
+        {
+            this.builder = builder;
+        }
+
+        @Override
+        public Converter getConverter(int fieldIndex)
+        {
+            if (fieldIndex == 0) {
+                return (Converter) elementConverter;
+            }
+            throw new IllegalArgumentException("LIST field must be 0 not " + fieldIndex);
+        }
+
+        @Override
+        public void start()
+        {
+            if (builder == null) {
+                if (nullBuilder == null || (nullBuilder.getPositionCount() >= NULL_BUILDER_POSITIONS_THRESHOLD && nullBuilder.getSizeInBytes() >= NULL_BUILDER_SIZE_IN_BYTES_THRESHOLD)) {
+                    nullBuilder = arrayType.createBlockBuilder(new PageBuilderStatus().createBlockBuilderStatus(), NULL_BUILDER_POSITIONS_THRESHOLD);
+                }
+                currentEntryBuilder = nullBuilder.beginBlockEntry();
+            }
+            else {
+                while (builder.getPositionCount() < fieldIndex) {
+                    builder.appendNull();
+                }
+                currentEntryBuilder = builder.beginBlockEntry();
+            }
+            elementConverter.beforeValue(currentEntryBuilder);
+        }
+
+        @Override
+        public void end()
+        {
+            elementConverter.afterValue();
+
+            if (builder == null) {
+                nullBuilder.closeEntry();
+            }
+            else {
+                builder.closeEntry();
+            }
+        }
+
+        @Override
+        public void afterValue()
+        {
+        }
+
+        @Override
+        public Block getBlock()
+        {
+            checkState(builder == null && nullBuilder != null); // check that user requested a result block (builder == null), and the program followed the request (nullBuilder != null)
+            return nullBuilder.getObject(nullBuilder.getPositionCount() - 1, Block.class);
+        }
+    }
+
+    private static class ParquetListEntryConverter
+            extends GroupConverter
+            implements BlockConverter
+    {
+        private final BlockConverter elementConverter;
+
+        private BlockBuilder builder;
+        private int startingPosition;
+
+        public ParquetListEntryConverter(Type prestoType, String columnName, GroupType elementType)
+        {
+            checkArgument(
+                    elementType.getOriginalType() == null,
+                    "Expected LIST column '%s' field to be type STRUCT, but is %s",
+                    columnName,
+                    elementType);
+
+            checkArgument(
+                    elementType.getFieldCount() == 1,
+                    "Expected LIST column '%s' element to have one field, but has %s fields",
+                    columnName,
+                    elementType.getFieldCount());
+
+            elementConverter = createConverter(prestoType, columnName + ".element", elementType.getType(0), 0);
+        }
+
+        @Override
+        public Converter getConverter(int fieldIndex)
+        {
+            if (fieldIndex == 0) {
+                return (Converter) elementConverter;
+            }
+            throw new IllegalArgumentException("LIST entry field must be 0 not " + fieldIndex);
+        }
+
+        @Override
+        public void beforeValue(BlockBuilder builder)
+        {
+            this.builder = builder;
+        }
+
+        @Override
+        public void start()
+        {
+            elementConverter.beforeValue(builder);
+            startingPosition = builder.getPositionCount();
+        }
+
+        @Override
+        public void end()
+        {
+            elementConverter.afterValue();
+            // we have read nothing, this means there is a null element in this list
+            if (builder.getPositionCount() == startingPosition) {
+                builder.appendNull();
+            }
+        }
+
+        @Override
+        public void afterValue()
+        {
+        }
+    }
+
+    private static class ParquetMapConverter
+            extends GroupedConverter
+    {
+        private static final int NULL_BUILDER_POSITIONS_THRESHOLD = 100;
+        private static final int NULL_BUILDER_SIZE_IN_BYTES_THRESHOLD = 32768;
+
+        private final Type mapType;
+        private final int fieldIndex;
+
+        private final ParquetMapEntryConverter entryConverter;
+        private BlockBuilder builder;
+        private BlockBuilder nullBuilder; // used internally when builder is set to null
+        private BlockBuilder currentEntryBuilder;
+
+        public ParquetMapConverter(Type type, String columnName, GroupType mapType, int fieldIndex)
+        {
+            checkArgument(
+                    mapType.getFieldCount() == 1,
+                    "Expected MAP column '%s' to only have one field, but has %s fields",
+                    mapType.getName(),
+                    mapType.getFieldCount());
+
+            this.mapType = type;
+            this.fieldIndex = fieldIndex;
+
+            org.apache.parquet.schema.Type entryType = mapType.getFields().get(0);
+
+            entryConverter = new ParquetMapEntryConverter(type, columnName + ".entry", entryType.asGroupType());
+        }
+
+        @Override
+        public void beforeValue(BlockBuilder builder)
+        {
+            this.builder = builder;
+        }
+
+        @Override
+        public Converter getConverter(int fieldIndex)
+        {
+            if (fieldIndex == 0) {
+                return entryConverter;
+            }
+            throw new IllegalArgumentException("Map field must be 0 not " + fieldIndex);
+        }
+
+        @Override
+        public void start()
+        {
+            if (builder == null) {
+                if (nullBuilder == null || (nullBuilder.getPositionCount() >= NULL_BUILDER_POSITIONS_THRESHOLD && nullBuilder.getSizeInBytes() >= NULL_BUILDER_SIZE_IN_BYTES_THRESHOLD)) {
+                    nullBuilder = mapType.createBlockBuilder(new PageBuilderStatus().createBlockBuilderStatus(), NULL_BUILDER_POSITIONS_THRESHOLD);
+                }
+                currentEntryBuilder = nullBuilder.beginBlockEntry();
+            }
+            else {
+                while (builder.getPositionCount() < fieldIndex) {
+                    builder.appendNull();
+                }
+                currentEntryBuilder = builder.beginBlockEntry();
+            }
+            entryConverter.beforeValue(currentEntryBuilder);
+        }
+
+        @Override
+        public void end()
+        {
+            entryConverter.afterValue();
+
+            if (builder == null) {
+                nullBuilder.closeEntry();
+            }
+            else {
+                builder.closeEntry();
+            }
+        }
+
+        @Override
+        public void afterValue()
+        {
+        }
+
+        @Override
+        public Block getBlock()
+        {
+            checkState(builder == null && nullBuilder != null); // check that user requested a result block (builder == null), and the program followed the request (nullBuilder != null)
+            return nullBuilder.getObject(nullBuilder.getPositionCount() - 1, Block.class);
+        }
+    }
+
+    private static class ParquetMapEntryConverter
+            extends GroupConverter
+            implements BlockConverter
+    {
+        private final BlockConverter keyConverter;
+        private final BlockConverter valueConverter;
+
+        private BlockBuilder builder;
+
+        public ParquetMapEntryConverter(Type prestoType, String columnName, GroupType entryType)
+        {
+            checkArgument(MAP.equals(prestoType.getTypeSignature().getBase()));
+            // original version of parquet used null for entry due to a bug
+            if (entryType.getOriginalType() != null) {
+                checkArgument(
+                        entryType.getOriginalType() == MAP_KEY_VALUE,
+                        "Expected MAP column '%s' field to be type %s, but is %s",
+                        columnName,
+                        MAP_KEY_VALUE,
+                        entryType);
+            }
+
+            GroupType entryGroupType = entryType.asGroupType();
+            checkArgument(
+                    entryGroupType.getFieldCount() == 2,
+                    "Expected MAP column '%s' entry to have two fields, but has %s fields",
+                    columnName,
+                    entryGroupType.getFieldCount());
+            checkArgument(
+                    entryGroupType.getFieldName(0).equals("key"),
+                    "Expected MAP column '%s' entry field 0 to be named 'key', but is named %s",
+                    columnName,
+                    entryGroupType.getFieldName(0));
+            checkArgument(
+                    entryGroupType.getFieldName(1).equals("value"),
+                    "Expected MAP column '%s' entry field 1 to be named 'value', but is named %s",
+                    columnName,
+                    entryGroupType.getFieldName(1));
+            checkArgument(
+                    entryGroupType.getType(0).isPrimitive(),
+                    "Expected MAP column '%s' entry field 0 to be primitive, but is %s",
+                    columnName,
+                    entryGroupType.getType(0));
+
+            keyConverter = createConverter(prestoType.getTypeParameters().get(0), columnName + ".key", entryGroupType.getFields().get(0), 0);
+            valueConverter = createConverter(prestoType.getTypeParameters().get(1), columnName + ".value", entryGroupType.getFields().get(1), 1);
+        }
+
+        @Override
+        public Converter getConverter(int fieldIndex)
+        {
+            if (fieldIndex == 0) {
+                return (Converter) keyConverter;
+            }
+            if (fieldIndex == 1) {
+                return (Converter) valueConverter;
+            }
+            throw new IllegalArgumentException("Map entry field must be 0 or 1 not " + fieldIndex);
+        }
+
+        @Override
+        public void beforeValue(BlockBuilder builder)
+        {
+            this.builder = builder;
+        }
+
+        @Override
+        public void start()
+        {
+            keyConverter.beforeValue(builder);
+            valueConverter.beforeValue(builder);
+        }
+
+        @Override
+        public void end()
+        {
+            keyConverter.afterValue();
+            valueConverter.afterValue();
+            // handle the case where we have a key, but the value is null
+            // null keys are not supported anyway, so we can ignore that case here
+            if (builder.getPositionCount() % 2 != 0) {
+                builder.appendNull();
+            }
+        }
+
+        @Override
+        public void afterValue()
+        {
+        }
+    }
+
+    private static class ParquetPrimitiveConverter
+            extends PrimitiveConverter
+            implements BlockConverter
+    {
+        private final Type type;
+        private final int fieldIndex;
+        private BlockBuilder builder;
+
+        public ParquetPrimitiveConverter(Type type, int fieldIndex)
+        {
+            this.type = type;
+            this.fieldIndex = fieldIndex;
+        }
+
+        @Override
+        public void beforeValue(BlockBuilder builder)
+        {
+            this.builder = requireNonNull(builder, "parent builder is null");
+        }
+
+        @Override
+        public void afterValue()
+        {
+        }
+
+        private void addMissingValues()
+        {
+            while (builder.getPositionCount() < fieldIndex) {
+                builder.appendNull();
+            }
+        }
+
+        @Override
+        public boolean isPrimitive()
+        {
+            return true;
+        }
+
+        @Override
+        public PrimitiveConverter asPrimitiveConverter()
+        {
+            return this;
+        }
+
+        @Override
+        public boolean hasDictionarySupport()
+        {
+            return false;
+        }
+
+        @Override
+        public void setDictionary(Dictionary dictionary)
+        {
+        }
+
+        @Override
+        public void addValueFromDictionary(int dictionaryId)
+        {
+        }
+
+        @Override
+        public void addBoolean(boolean value)
+        {
+            addMissingValues();
+            type.writeBoolean(builder, value);
+        }
+
+        @Override
+        public void addDouble(double value)
+        {
+            addMissingValues();
+            type.writeDouble(builder, value);
+        }
+
+        @Override
+        public void addLong(long value)
+        {
+            addMissingValues();
+            type.writeLong(builder, value);
+        }
+
+        @Override
+        public void addBinary(Binary value)
+        {
+            addMissingValues();
+            if (type == TIMESTAMP) {
+                type.writeLong(builder, ParquetTimestampUtils.getTimestampMillis(value));
+            }
+            else if (isVarcharType(type)) {
+                type.writeSlice(builder, truncateToLength(wrappedBuffer(value.getBytes()), type));
+            }
+            else if (isCharType(type)) {
+                type.writeSlice(builder, truncateToLengthAndTrimSpaces(wrappedBuffer(value.getBytes()), type));
+            }
+            else {
+                type.writeSlice(builder, wrappedBuffer(value.getBytes()));
+            }
+        }
+
+        @Override
+        public void addFloat(float value)
+        {
+            addMissingValues();
+            type.writeLong(builder, floatToRawIntBits(value));
+        }
+
+        @Override
+        public void addInt(int value)
+        {
+            addMissingValues();
+            type.writeLong(builder, value);
+        }
+    }
+
+    private static class ParquetDecimalConverter
+            extends PrimitiveConverter
+            implements BlockConverter
+    {
+        private final DecimalType decimalType;
+        private BlockBuilder builder;
+        private boolean wroteValue;
+
+        public ParquetDecimalConverter(DecimalType decimalType)
+        {
+            this.decimalType = requireNonNull(decimalType, "decimalType is null");
+        }
+
+        @Override
+        public void beforeValue(BlockBuilder builder)
+        {
+            this.builder = requireNonNull(builder, "parent builder is null");
+            wroteValue = false;
+        }
+
+        @Override
+        public void afterValue()
+        {
+            if (wroteValue) {
+                return;
+            }
+
+            builder.appendNull();
+        }
+
+        @Override
+        public boolean isPrimitive()
+        {
+            return true;
+        }
+
+        @Override
+        public PrimitiveConverter asPrimitiveConverter()
+        {
+            return this;
+        }
+
+        @Override
+        public boolean hasDictionarySupport()
+        {
+            return false;
+        }
+
+        @Override
+        public void addBinary(Binary value)
+        {
+            if (decimalType.isShort()) {
+                decimalType.writeLong(builder, DecimalUtils.getShortDecimalValue(value.getBytes()));
+            }
+            else {
+                BigInteger unboundedDecimal = new BigInteger(value.getBytes());
+                decimalType.writeSlice(builder, Decimals.encodeUnscaledValue(unboundedDecimal));
+            }
+            wroteValue = true;
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetPage.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetPage.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+public abstract class ParquetPage
+{
+    protected final int compressedSize;
+    protected final int uncompressedSize;
+
+    public ParquetPage(int compressedSize, int uncompressedSize)
+    {
+        this.compressedSize = compressedSize;
+        this.uncompressedSize = uncompressedSize;
+    }
+
+    public int getCompressedSize()
+    {
+        return compressedSize;
+    }
+
+    public int getUncompressedSize()
+    {
+        return uncompressedSize;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetPageSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetPageSource.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.iceberg.parquet.memory.AggregatedMemoryContext;
+import com.facebook.presto.iceberg.parquet.reader.ParquetReader;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.LazyBlock;
+import com.facebook.presto.spi.block.LazyBlockLoader;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.MessageType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
+import static com.facebook.presto.iceberg.parquet.ParquetTypeUtils.getDescriptor;
+import static com.facebook.presto.iceberg.parquet.ParquetTypeUtils.getFieldIndex;
+import static com.facebook.presto.iceberg.parquet.ParquetTypeUtils.getParquetType;
+import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
+import static com.facebook.presto.spi.type.StandardTypes.MAP;
+import static com.facebook.presto.spi.type.StandardTypes.ROW;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class ParquetPageSource
+        implements ConnectorPageSource
+{
+    private static final int MAX_VECTOR_LENGTH = 1024;
+
+    private final ParquetReader parquetReader;
+    private final ParquetDataSource dataSource;
+    private final MessageType fileSchema;
+    // for debugging heap dump
+    private final MessageType requestedSchema;
+    private final List<String> columnNames;
+    private final List<Type> types;
+
+    private final Block[] constantBlocks;
+    private final int[] hiveColumnIndexes;
+
+    private final long totalBytes;
+    private int batchId;
+    private boolean closed;
+    private long readTimeNanos;
+    private final boolean useParquetColumnNames;
+
+    private final AggregatedMemoryContext systemMemoryContext;
+
+    public ParquetPageSource(
+            ParquetReader parquetReader,
+            ParquetDataSource dataSource,
+            MessageType fileSchema,
+            MessageType requestedSchema,
+            long totalBytes,
+            Properties splitSchema,
+            List<HiveColumnHandle> columns,
+            TupleDomain<HiveColumnHandle> effectivePredicate,
+            TypeManager typeManager,
+            boolean useParquetColumnNames,
+            AggregatedMemoryContext systemMemoryContext)
+    {
+        checkArgument(totalBytes >= 0, "totalBytes is negative");
+        requireNonNull(splitSchema, "splitSchema is null");
+        requireNonNull(columns, "columns is null");
+        requireNonNull(effectivePredicate, "effectivePredicate is null");
+
+        this.parquetReader = requireNonNull(parquetReader, "parquetReader is null");
+        this.dataSource = requireNonNull(dataSource, "dataSource is null");
+        this.fileSchema = requireNonNull(fileSchema, "fileSchema is null");
+        this.requestedSchema = requireNonNull(requestedSchema, "requestedSchema is null");
+        this.totalBytes = totalBytes;
+        this.useParquetColumnNames = useParquetColumnNames;
+
+        int size = columns.size();
+        this.constantBlocks = new Block[size];
+        this.hiveColumnIndexes = new int[size];
+
+        ImmutableList.Builder<String> namesBuilder = ImmutableList.builder();
+        ImmutableList.Builder<Type> typesBuilder = ImmutableList.builder();
+        for (int columnIndex = 0; columnIndex < size; columnIndex++) {
+            HiveColumnHandle column = columns.get(columnIndex);
+            checkState(column.getColumnType() == REGULAR, "column type must be regular");
+
+            String name = column.getName();
+            Type type = typeManager.getType(column.getTypeSignature());
+
+            namesBuilder.add(name);
+            typesBuilder.add(type);
+
+            hiveColumnIndexes[columnIndex] = column.getHiveColumnIndex();
+
+            if (getParquetType(column, fileSchema, useParquetColumnNames) == null) {
+                constantBlocks[columnIndex] = RunLengthEncodedBlock.create(type, null, MAX_VECTOR_LENGTH);
+            }
+        }
+        types = typesBuilder.build();
+        columnNames = namesBuilder.build();
+        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return dataSource.getReadBytes();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return closed;
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return systemMemoryContext.getBytes();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        try {
+            batchId++;
+            long start = System.nanoTime();
+
+            int batchSize = parquetReader.nextBatch();
+
+            readTimeNanos += System.nanoTime() - start;
+
+            if (closed || batchSize <= 0) {
+                close();
+                return null;
+            }
+
+            Block[] blocks = new Block[hiveColumnIndexes.length];
+            for (int fieldId = 0; fieldId < blocks.length; fieldId++) {
+                if (constantBlocks[fieldId] != null) {
+                    blocks[fieldId] = constantBlocks[fieldId].getRegion(0, batchSize);
+                }
+                else {
+                    Type type = types.get(fieldId);
+                    int fieldIndex;
+                    if (useParquetColumnNames) {
+                        fieldIndex = getFieldIndex(fileSchema, columnNames.get(fieldId));
+                    }
+                    else {
+                        fieldIndex = hiveColumnIndexes[fieldId];
+                    }
+
+                    if (fieldIndex == -1) {
+                        blocks[fieldId] = RunLengthEncodedBlock.create(type, null, batchSize);
+                        continue;
+                    }
+
+                    String fieldName = fileSchema.getFields().get(fieldIndex).getName();
+                    List<String> path = new ArrayList<>();
+                    path.add(fieldName);
+                    if (ROW.equals(type.getTypeSignature().getBase())) {
+                        blocks[fieldId] = parquetReader.readStruct(type, path);
+                    }
+                    else if (MAP.equals(type.getTypeSignature().getBase())) {
+                        blocks[fieldId] = parquetReader.readMap(type, path);
+                    }
+                    else if (ARRAY.equals(type.getTypeSignature().getBase())) {
+                        blocks[fieldId] = parquetReader.readArray(type, path);
+                    }
+                    else {
+                        Optional<RichColumnDescriptor> descriptor = getDescriptor(fileSchema, requestedSchema, path);
+                        if (descriptor.isPresent()) {
+                            blocks[fieldId] = new LazyBlock(batchSize, new ParquetBlockLoader(descriptor.get(), type));
+                        }
+                        else {
+                            blocks[fieldId] = RunLengthEncodedBlock.create(type, null, batchSize);
+                        }
+                    }
+                }
+            }
+            return new Page(batchSize, blocks);
+        }
+        catch (PrestoException e) {
+            closeWithSuppression(e);
+            throw e;
+        }
+        catch (IOException | RuntimeException e) {
+            closeWithSuppression(e);
+            throw new PrestoException(HIVE_CURSOR_ERROR, e);
+        }
+    }
+
+    private void closeWithSuppression(Throwable throwable)
+    {
+        requireNonNull(throwable, "throwable is null");
+        try {
+            close();
+        }
+        catch (RuntimeException e) {
+            // Self-suppression not permitted
+            if (e != throwable) {
+                throwable.addSuppressed(e);
+            }
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        try {
+            parquetReader.close();
+        }
+        catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    private final class ParquetBlockLoader
+            implements LazyBlockLoader<LazyBlock>
+    {
+        private final int expectedBatchId = batchId;
+        private final ColumnDescriptor columnDescriptor;
+        private final Type type;
+        private boolean loaded;
+
+        public ParquetBlockLoader(ColumnDescriptor columnDescriptor, Type type)
+        {
+            this.columnDescriptor = columnDescriptor;
+            this.type = requireNonNull(type, "type is null");
+        }
+
+        @Override
+        public final void load(LazyBlock lazyBlock)
+        {
+            if (loaded) {
+                return;
+            }
+
+            checkState(batchId == expectedBatchId);
+
+            try {
+                Block block = parquetReader.readPrimitive(columnDescriptor, type);
+                lazyBlock.setBlock(block);
+            }
+            catch (IOException e) {
+                throw new PrestoException(HIVE_CURSOR_ERROR, e);
+            }
+            loaded = true;
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetRecordCursorProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetRecordCursorProvider.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HiveRecordCursorProvider;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.joda.time.DateTimeZone;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+import static com.facebook.presto.hive.HiveUtil.getDeserializerClassName;
+import static java.util.Objects.requireNonNull;
+
+public class ParquetRecordCursorProvider
+        implements HiveRecordCursorProvider
+{
+    private static final Set<String> PARQUET_SERDE_CLASS_NAMES = ImmutableSet.<String>builder()
+            .add("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")
+            .add("parquet.hive.serde.ParquetHiveSerDe")
+            .build();
+
+    private final boolean useParquetColumnNames;
+    private final HdfsEnvironment hdfsEnvironment;
+
+    @Inject
+    public ParquetRecordCursorProvider(HiveClientConfig hiveClientConfig, HdfsEnvironment hdfsEnvironment)
+    {
+        this(requireNonNull(hiveClientConfig, "hiveClientConfig is null").isUseParquetColumnNames(), hdfsEnvironment);
+    }
+
+    public ParquetRecordCursorProvider(boolean useParquetColumnNames, HdfsEnvironment hdfsEnvironment)
+    {
+        this.useParquetColumnNames = useParquetColumnNames;
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+    }
+
+    @Override
+    public Optional<RecordCursor> createRecordCursor(Configuration configuration,
+            ConnectorSession session,
+            Path path,
+            long start,
+            long length,
+            long fileSize,
+            Properties schema,
+            List<HiveColumnHandle> columns,
+            TupleDomain<HiveColumnHandle> effectivePredicate,
+            DateTimeZone hiveStorageTimeZone,
+            TypeManager typeManager)
+    {
+        if (!PARQUET_SERDE_CLASS_NAMES.contains(getDeserializerClassName(schema))) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new ParquetHiveRecordCursor(
+                hdfsEnvironment,
+                session.getUser(),
+                configuration,
+                path,
+                start,
+                length,
+                schema,
+                columns,
+                useParquetColumnNames,
+                typeManager,
+                true, //predicatePushdownEnabled
+                effectivePredicate));
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetTimestampUtils.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetTimestampUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import org.apache.parquet.io.api.Binary;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
+
+/**
+ * Utility class for decoding INT96 encoded parquet timestamp to timestamp millis in GMT.
+ * <p>
+ * This class is equivalent of @see org.apache.hadoop.hive.ql.io.parquet.timestamp.NanoTime,
+ * which produces less intermediate objects during decoding.
+ */
+public final class ParquetTimestampUtils
+{
+    private static final int JULIAN_EPOCH_OFFSET_DAYS = 2_440_588;
+    private static final long MILLIS_IN_DAY = TimeUnit.DAYS.toMillis(1);
+    private static final long NANOS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toNanos(1);
+
+    private ParquetTimestampUtils() {}
+
+    /**
+     * Returns GMT timestamp from binary encoded parquet timestamp (12 bytes - julian date + time of day nanos).
+     *
+     * @param timestampBinary INT96 parquet timestamp
+     * @return timestamp in millis, GMT timezone
+     */
+    public static long getTimestampMillis(Binary timestampBinary)
+    {
+        if (timestampBinary.length() != 12) {
+            throw new PrestoException(HIVE_BAD_DATA, "Parquet timestamp must be 12 bytes, actual " + timestampBinary.length());
+        }
+        byte[] bytes = timestampBinary.getBytes();
+
+        // little endian encoding - need to invert byte order
+        long timeOfDayNanos = Longs.fromBytes(bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2], bytes[1], bytes[0]);
+        int julianDay = Ints.fromBytes(bytes[11], bytes[10], bytes[9], bytes[8]);
+
+        return julianDayToMillis(julianDay) + (timeOfDayNanos / NANOS_PER_MILLISECOND);
+    }
+
+    private static long julianDayToMillis(int julianDay)
+    {
+        return (julianDay - JULIAN_EPOCH_OFFSET_DAYS) * MILLIS_IN_DAY;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetTypeUtils.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetTypeUtils.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.io.ColumnIO;
+import org.apache.parquet.io.ColumnIOFactory;
+import org.apache.parquet.io.InvalidRecordException;
+import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.io.PrimitiveColumnIO;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Optional.empty;
+
+public final class ParquetTypeUtils
+{
+    private ParquetTypeUtils()
+    {
+    }
+
+    public static List<PrimitiveColumnIO> getColumns(MessageType fileSchema, MessageType requestedSchema)
+    {
+        return (new ColumnIOFactory()).getColumnIO(requestedSchema, fileSchema, true).getLeaves();
+    }
+
+    public static Optional<RichColumnDescriptor> getDescriptor(MessageType fileSchema, MessageType requestedSchema, List<String> path)
+    {
+        checkArgument(path.size() >= 1, "Parquet nested path should have at least one component");
+        int level = path.size();
+        for (PrimitiveColumnIO columnIO : getColumns(fileSchema, requestedSchema)) {
+            ColumnIO[] fields = columnIO.getPath();
+            if (fields.length <= level) {
+                continue;
+            }
+            if (fields[level].getName().equalsIgnoreCase(path.get(level - 1))) {
+                boolean match = true;
+                for (int i = 0; i < level - 1; i++) {
+                    if (!fields[i + 1].getName().equalsIgnoreCase(path.get(i))) {
+                        match = false;
+                    }
+                }
+
+                if (match) {
+                    ColumnDescriptor descriptor = columnIO.getColumnDescriptor();
+                    return Optional.of(new RichColumnDescriptor(descriptor.getPath(), columnIO.getType().asPrimitiveType(), descriptor.getMaxRepetitionLevel(), descriptor.getMaxDefinitionLevel()));
+                }
+            }
+        }
+        return empty();
+    }
+
+    public static int getFieldIndex(MessageType fileSchema, String name)
+    {
+        try {
+            return fileSchema.getFieldIndex(name);
+        }
+        catch (InvalidRecordException e) {
+            for (Type type : fileSchema.getFields()) {
+                if (type.getName().equalsIgnoreCase(name)) {
+                    return fileSchema.getFieldIndex(type.getName());
+                }
+            }
+            return -1;
+        }
+    }
+
+    public static Type getParquetType(HiveColumnHandle column, MessageType messageType, boolean useParquetColumnNames)
+    {
+        if (useParquetColumnNames) {
+            return getParquetTypeByName(column.getName(), messageType);
+        }
+
+        if (column.getHiveColumnIndex() < messageType.getFieldCount()) {
+            return messageType.getType(column.getHiveColumnIndex());
+        }
+        return null;
+    }
+
+    public static ParquetEncoding getParquetEncoding(Encoding encoding)
+    {
+        switch (encoding) {
+            case PLAIN:
+                return ParquetEncoding.PLAIN;
+            case RLE:
+                return ParquetEncoding.RLE;
+            case BIT_PACKED:
+                return ParquetEncoding.BIT_PACKED;
+            case PLAIN_DICTIONARY:
+                return ParquetEncoding.PLAIN_DICTIONARY;
+            case DELTA_BINARY_PACKED:
+                return ParquetEncoding.DELTA_BINARY_PACKED;
+            case DELTA_LENGTH_BYTE_ARRAY:
+                return ParquetEncoding.DELTA_LENGTH_BYTE_ARRAY;
+            case DELTA_BYTE_ARRAY:
+                return ParquetEncoding.DELTA_BYTE_ARRAY;
+            case RLE_DICTIONARY:
+                return ParquetEncoding.RLE_DICTIONARY;
+            default:
+                throw new ParquetDecodingException("Unsupported Parquet encoding: " + encoding);
+        }
+    }
+
+    private static Type getParquetTypeByName(String columnName, MessageType messageType)
+    {
+        if (messageType.containsField(columnName)) {
+            return messageType.getType(columnName);
+        }
+        // parquet is case-sensitive, but hive is not. all hive columns get converted to lowercase
+        // check for direct match above but if no match found, try case-insensitive match
+        for (Type type : messageType.getFields()) {
+            if (type.getName().equalsIgnoreCase(columnName)) {
+                return type;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * For non required fields:
+     * definitionLevel == columnDescriptor.getMaxDefinitionLevel()     => Value is defined
+     * definitionLevel == columnDescriptor.getMaxDefinitionLevel() - 1 => Value is null
+     * definitionLevel < columnDescriptor.getMaxDefinitionLevel() - 1  => Value does not exist, because one of its optional parent fields is null
+     */
+    public static boolean isValueNull(boolean required, int definitionLevel, int maxDefinitionLevel)
+    {
+        return !required && (definitionLevel == maxDefinitionLevel - 1);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetValidationUtils.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetValidationUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import static java.lang.String.format;
+
+public final class ParquetValidationUtils
+{
+    private ParquetValidationUtils()
+    {
+    }
+
+    public static void validateParquet(boolean condition, String formatString, Object... args)
+            throws ParquetCorruptionException
+    {
+        if (!condition) {
+            throw new ParquetCorruptionException(format(formatString, args));
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetValuesType.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/ParquetValuesType.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+public enum ParquetValuesType
+{
+    REPETITION_LEVEL,
+    DEFINITION_LEVEL,
+    VALUES
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/RichColumnDescriptor.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/RichColumnDescriptor.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet;
+
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.PrimitiveType;
+
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+
+// extension of parquet's ColumnDescriptor. Exposes full Primitive type information
+public class RichColumnDescriptor
+        extends ColumnDescriptor
+{
+    private final PrimitiveType primitiveType;
+
+    public RichColumnDescriptor(
+            String[] path,
+            PrimitiveType primitiveType,
+            int maxRep,
+            int maxDef)
+    {
+        super(path, primitiveType.getPrimitiveTypeName(), primitiveType.getTypeLength(), maxRep, maxDef);
+        this.primitiveType = primitiveType;
+    }
+
+    public PrimitiveType getPrimitiveType()
+    {
+        return primitiveType;
+    }
+
+    public boolean isRequired()
+    {
+        return primitiveType.getRepetition() == REQUIRED;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetBinaryDictionary.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetBinaryDictionary.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.dictionary;
+
+import com.facebook.presto.iceberg.parquet.ParquetDictionaryPage;
+import org.apache.parquet.io.api.Binary;
+
+import java.io.IOException;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndian;
+
+public class ParquetBinaryDictionary
+        extends ParquetDictionary
+{
+    private final Binary[] content;
+
+    public ParquetBinaryDictionary(ParquetDictionaryPage dictionaryPage)
+            throws IOException
+    {
+        this(dictionaryPage, null);
+    }
+
+    public ParquetBinaryDictionary(ParquetDictionaryPage dictionaryPage, Integer length)
+            throws IOException
+    {
+        super(dictionaryPage.getEncoding());
+        byte[] dictionaryBytes = dictionaryPage.getSlice().getBytes();
+        content = new Binary[dictionaryPage.getDictionarySize()];
+        int offset = 0;
+        if (length == null) {
+            for (int i = 0; i < content.length; i++) {
+                int len = readIntLittleEndian(dictionaryBytes, offset);
+                offset += 4;
+                content[i] = Binary.fromByteArray(dictionaryBytes, offset, len);
+                offset += len;
+            }
+        }
+        else {
+            checkArgument(length > 0, "Invalid byte array length: " + length);
+            for (int i = 0; i < content.length; i++) {
+                content[i] = Binary.fromByteArray(dictionaryBytes, offset, length);
+                offset += length;
+            }
+        }
+    }
+
+    @Override
+    public Binary decodeToBinary(int id)
+    {
+        return content[id];
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("content", content)
+                .toString();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetDictionary.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetDictionary.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.dictionary;
+
+import com.facebook.presto.iceberg.parquet.ParquetEncoding;
+import org.apache.parquet.io.api.Binary;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public abstract class ParquetDictionary
+{
+    private final ParquetEncoding encoding;
+
+    public ParquetDictionary(ParquetEncoding encoding)
+    {
+        checkArgument(
+                encoding == ParquetEncoding.PLAIN_DICTIONARY || encoding == ParquetEncoding.PLAIN,
+                "Parquet dictionary does not support encoding: " + encoding);
+        this.encoding = encoding;
+    }
+
+    public ParquetEncoding getEncoding()
+    {
+        return encoding;
+    }
+
+    public Binary decodeToBinary(int id)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    public int decodeToInt(int id)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    public long decodeToLong(int id)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    public float decodeToFloat(int id)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    public double decodeToDouble(int id)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetDictionaryReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetDictionaryReader.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.dictionary;
+
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
+import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.io.api.Binary;
+
+import java.io.IOException;
+
+public class ParquetDictionaryReader
+        extends ValuesReader
+{
+    private final ParquetDictionary dictionary;
+    private RunLengthBitPackingHybridDecoder decoder;
+
+    public ParquetDictionaryReader(ParquetDictionary dictionary)
+    {
+        this.dictionary = dictionary;
+    }
+
+    @Override
+    public void initFromPage(int valueCount, ByteBufferInputStream in)
+            throws IOException
+    {
+        int bitWidth = BytesUtils.readIntLittleEndianOnOneByte(in);
+        decoder = new RunLengthBitPackingHybridDecoder(bitWidth, in);
+    }
+
+    @Override
+    public int readValueDictionaryId()
+    {
+        return readInt();
+    }
+
+    @Override
+    public Binary readBytes()
+    {
+        return dictionary.decodeToBinary(readInt());
+    }
+
+    @Override
+    public float readFloat()
+    {
+        return dictionary.decodeToFloat(readInt());
+    }
+
+    @Override
+    public double readDouble()
+    {
+        return dictionary.decodeToDouble(readInt());
+    }
+
+    @Override
+    public int readInteger()
+    {
+        return dictionary.decodeToInt(readInt());
+    }
+
+    @Override
+    public long readLong()
+    {
+        return dictionary.decodeToLong(readInt());
+    }
+
+    @Override
+    public void skip()
+    {
+        readInt();
+    }
+
+    private int readInt()
+    {
+        try {
+            return decoder.readInt();
+        }
+        catch (IOException e) {
+            throw new ParquetDecodingException(e);
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetDoubleDictionary.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetDoubleDictionary.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.dictionary;
+
+import com.facebook.presto.iceberg.parquet.ParquetDictionaryPage;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.plain.PlainValuesReader.DoublePlainValuesReader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class ParquetDoubleDictionary
+        extends ParquetDictionary
+{
+    private final double[] content;
+
+    public ParquetDoubleDictionary(ParquetDictionaryPage dictionaryPage)
+            throws IOException
+    {
+        super(dictionaryPage.getEncoding());
+        content = new double[dictionaryPage.getDictionarySize()];
+        DoublePlainValuesReader doubleReader = new DoublePlainValuesReader();
+        doubleReader.initFromPage(dictionaryPage.getDictionarySize(), ByteBufferInputStream.wrap(ByteBuffer.wrap(dictionaryPage.getSlice().getBytes())));
+        for (int i = 0; i < content.length; i++) {
+            content[i] = doubleReader.readDouble();
+        }
+    }
+
+    @Override
+    public double decodeToDouble(int id)
+    {
+        return content[id];
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("content", content)
+                .toString();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetFloatDictionary.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetFloatDictionary.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.dictionary;
+
+import com.facebook.presto.iceberg.parquet.ParquetDictionaryPage;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.plain.PlainValuesReader.FloatPlainValuesReader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class ParquetFloatDictionary
+        extends ParquetDictionary
+{
+    private final float[] content;
+
+    public ParquetFloatDictionary(ParquetDictionaryPage dictionaryPage)
+            throws IOException
+    {
+        super(dictionaryPage.getEncoding());
+        content = new float[dictionaryPage.getDictionarySize()];
+        FloatPlainValuesReader floatReader = new FloatPlainValuesReader();
+        floatReader.initFromPage(dictionaryPage.getDictionarySize(), ByteBufferInputStream.wrap(ByteBuffer.wrap(dictionaryPage.getSlice().getBytes())));
+        for (int i = 0; i < content.length; i++) {
+            content[i] = floatReader.readFloat();
+        }
+    }
+
+    @Override
+    public float decodeToFloat(int id)
+    {
+        return content[id];
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("content", content)
+                .toString();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetIntegerDictionary.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetIntegerDictionary.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.dictionary;
+
+import com.facebook.presto.iceberg.parquet.ParquetDictionaryPage;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.plain.PlainValuesReader.IntegerPlainValuesReader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class ParquetIntegerDictionary
+        extends ParquetDictionary
+{
+    private final int[] content;
+
+    public ParquetIntegerDictionary(ParquetDictionaryPage dictionaryPage)
+            throws IOException
+    {
+        super(dictionaryPage.getEncoding());
+        content = new int[dictionaryPage.getDictionarySize()];
+        IntegerPlainValuesReader intReader = new IntegerPlainValuesReader();
+        intReader.initFromPage(dictionaryPage.getDictionarySize(), ByteBufferInputStream.wrap(ByteBuffer.wrap(dictionaryPage.getSlice().getBytes())));
+        for (int i = 0; i < content.length; i++) {
+            content[i] = intReader.readInteger();
+        }
+    }
+
+    @Override
+    public int decodeToInt(int id)
+    {
+        return content[id];
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("content", content)
+                .toString();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetLongDictionary.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/dictionary/ParquetLongDictionary.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.dictionary;
+
+import com.facebook.presto.iceberg.parquet.ParquetDictionaryPage;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.plain.PlainValuesReader.LongPlainValuesReader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class ParquetLongDictionary
+        extends ParquetDictionary
+{
+    private final long[] content;
+
+    public ParquetLongDictionary(ParquetDictionaryPage dictionaryPage)
+            throws IOException
+    {
+        super(dictionaryPage.getEncoding());
+        content = new long[dictionaryPage.getDictionarySize()];
+        LongPlainValuesReader longReader = new LongPlainValuesReader();
+        longReader.initFromPage(dictionaryPage.getDictionarySize(), ByteBufferInputStream.wrap(ByteBuffer.wrap(dictionaryPage.getSlice().getBytes())));
+        for (int i = 0; i < content.length; i++) {
+            content[i] = longReader.readLong();
+        }
+    }
+
+    @Override
+    public long decodeToLong(int id)
+    {
+        return content[id];
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("content", content)
+                .toString();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/memory/AbstractAggregatedMemoryContext.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/memory/AbstractAggregatedMemoryContext.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.memory;
+
+public abstract class AbstractAggregatedMemoryContext
+{
+    // This class should remain exactly the same as AbstractAggregatedMemoryContext in com.facebook.presto.memory
+
+    // AbstractMemoryContext class is only necessary because we need implementations that bridge
+    // AggregatedMemoryContext with the existing memory tracking APIs in XxxxContext. Once they
+    // are refactored, there will be only one implementation of this abstract class, and this class
+    // can be removed.
+
+    protected abstract void updateBytes(long bytes);
+
+    public AggregatedMemoryContext newAggregatedMemoryContext()
+    {
+        return new AggregatedMemoryContext(this);
+    }
+
+    public LocalMemoryContext newLocalMemoryContext()
+    {
+        return new LocalMemoryContext(this);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/memory/AggregatedMemoryContext.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/memory/AggregatedMemoryContext.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.memory;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class AggregatedMemoryContext
+        extends AbstractAggregatedMemoryContext
+{
+    // This class should remain exactly the same as AggregatedMemoryContext in com.facebook.presto.memory
+
+    private final AbstractAggregatedMemoryContext parentMemoryContext;
+    private long usedBytes;
+    private boolean closed;
+
+    public AggregatedMemoryContext()
+    {
+        this.parentMemoryContext = null;
+    }
+
+    public AggregatedMemoryContext(AbstractAggregatedMemoryContext parentMemoryContext)
+    {
+        this.parentMemoryContext = requireNonNull(parentMemoryContext, "parentMemoryContext is null");
+    }
+
+    public long getBytes()
+    {
+        checkState(!closed);
+        return usedBytes;
+    }
+
+    @Override
+    protected void updateBytes(long bytes)
+    {
+        checkState(!closed);
+        if (parentMemoryContext != null) {
+            parentMemoryContext.updateBytes(bytes);
+        }
+        usedBytes += bytes;
+    }
+
+    public void close()
+    {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (parentMemoryContext != null) {
+            parentMemoryContext.updateBytes(-usedBytes);
+        }
+        usedBytes = 0;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("usedBytes", usedBytes)
+                .add("closed", closed)
+                .toString();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/memory/LocalMemoryContext.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/memory/LocalMemoryContext.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.memory;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class LocalMemoryContext
+{
+    private final AbstractAggregatedMemoryContext parentMemoryContext;
+    private long usedBytes;
+
+    public LocalMemoryContext(AbstractAggregatedMemoryContext parentMemoryContext)
+    {
+        this.parentMemoryContext = requireNonNull(parentMemoryContext, "parentMemoryContext is null");
+    }
+
+    public long getBytes()
+    {
+        return usedBytes;
+    }
+
+    public void setBytes(long bytes)
+    {
+        long oldLocalUsedBytes = this.usedBytes;
+        this.usedBytes = bytes;
+        parentMemoryContext.updateBytes(this.usedBytes - oldLocalUsedBytes);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("usedBytes", usedBytes)
+                .toString();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetDictionaryDescriptor.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetDictionaryDescriptor.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.predicate;
+
+import com.facebook.presto.iceberg.parquet.ParquetDictionaryPage;
+import org.apache.parquet.column.ColumnDescriptor;
+
+import java.util.Optional;
+
+public class ParquetDictionaryDescriptor
+{
+    private final ColumnDescriptor columnDescriptor;
+    private final Optional<ParquetDictionaryPage> dictionaryPage;
+
+    public ParquetDictionaryDescriptor(ColumnDescriptor columnDescriptor, Optional<ParquetDictionaryPage> dictionaryPage)
+    {
+        this.columnDescriptor = columnDescriptor;
+        this.dictionaryPage = dictionaryPage;
+    }
+
+    public ColumnDescriptor getColumnDescriptor()
+    {
+        return columnDescriptor;
+    }
+
+    public Optional<ParquetDictionaryPage> getDictionaryPage()
+    {
+        return dictionaryPage;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetDoubleStatistics.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetDoubleStatistics.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.predicate;
+
+public class ParquetDoubleStatistics
+        implements ParquetRangeStatistics<Double>
+{
+    private final Double minimum;
+    private final Double maximum;
+
+    public ParquetDoubleStatistics(Double minimum, Double maximum)
+    {
+        this.minimum = minimum;
+        this.maximum = maximum;
+    }
+
+    @Override
+    public Double getMin()
+    {
+        return minimum;
+    }
+
+    @Override
+    public Double getMax()
+    {
+        return maximum;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetIntegerStatistics.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetIntegerStatistics.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.predicate;
+
+public class ParquetIntegerStatistics
+        implements ParquetRangeStatistics<Long>
+{
+    private final Long minimum;
+    private final Long maximum;
+
+    public ParquetIntegerStatistics(Long minimum, Long maximum)
+    {
+        this.minimum = minimum;
+        this.maximum = maximum;
+    }
+
+    @Override
+    public Long getMin()
+    {
+        return minimum;
+    }
+
+    @Override
+    public Long getMax()
+    {
+        return maximum;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetPredicate.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetPredicate.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.predicate;
+
+import org.apache.parquet.column.statistics.Statistics;
+
+import java.util.Map;
+
+public interface ParquetPredicate
+{
+    ParquetPredicate TRUE = new ParquetPredicate()
+    {
+        @Override
+        public boolean matches(long numberOfRows, Map<Integer, Statistics<?>> statisticsByColumnIndex)
+        {
+            return true;
+        }
+
+        @Override
+        public boolean matches(Map<Integer, ParquetDictionaryDescriptor> dictionariesByColumnIndex)
+        {
+            return true;
+        }
+    };
+
+    /**
+     * Should the Parquet Reader process a file section with the specified statistics.
+     *
+     * @param numberOfRows the number of rows in the segment; this can be used with
+     * Statistics to determine if a column is only null
+     * @param statisticsByColumnIndex statistics for column by ordinal position
+     * in the file; this will match the field order from the hive metastore
+     */
+    boolean matches(long numberOfRows, Map<Integer, Statistics<?>> statisticsByColumnIndex);
+
+    /**
+     * Should the Parquet Reader process a file section with the specified dictionary.
+     *
+     * @param dictionariesByColumnIndex dictionaries for column by ordinal position
+     * in the file; this will match the field order from the hive metastore
+     */
+    boolean matches(Map<Integer, ParquetDictionaryDescriptor> dictionariesByColumnIndex);
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetPredicateUtils.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetPredicateUtils.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.predicate;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.iceberg.parquet.ParquetDataSource;
+import com.facebook.presto.iceberg.parquet.ParquetDictionaryPage;
+import com.facebook.presto.iceberg.parquet.ParquetEncoding;
+import com.facebook.presto.iceberg.parquet.predicate.TupleDomainParquetPredicate.ColumnReference;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.airlift.slice.Slice;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.format.DictionaryPageHeader;
+import org.apache.parquet.format.PageHeader;
+import org.apache.parquet.format.PageType;
+import org.apache.parquet.format.Util;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.MessageType;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.iceberg.parquet.ParquetCompressionUtils.decompress;
+import static com.facebook.presto.iceberg.parquet.ParquetEncoding.BIT_PACKED;
+import static com.facebook.presto.iceberg.parquet.ParquetEncoding.PLAIN_DICTIONARY;
+import static com.facebook.presto.iceberg.parquet.ParquetEncoding.RLE;
+import static com.facebook.presto.iceberg.parquet.ParquetTypeUtils.getParquetEncoding;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.lang.Math.toIntExact;
+
+public final class ParquetPredicateUtils
+{
+    private ParquetPredicateUtils()
+    {
+    }
+
+    public static boolean isStatisticsOverflow(Type type, ParquetIntegerStatistics parquetIntegerStatistics)
+    {
+        long min = parquetIntegerStatistics.getMin();
+        long max = parquetIntegerStatistics.getMax();
+        return (type.equals(TINYINT) && (min < Byte.MIN_VALUE || max > Byte.MAX_VALUE)) ||
+                (type.equals(SMALLINT) && (min < Short.MIN_VALUE || max > Short.MAX_VALUE)) ||
+                (type.equals(INTEGER) && (min < Integer.MIN_VALUE || max > Integer.MAX_VALUE));
+    }
+
+    public static ParquetPredicate buildParquetPredicate(
+            List<HiveColumnHandle> columns,
+            TupleDomain<HiveColumnHandle> effectivePredicate,
+            MessageType fileSchema,
+            TypeManager typeManager)
+    {
+        ImmutableList.Builder<ColumnReference<HiveColumnHandle>> columnReferences = ImmutableList.builder();
+        for (HiveColumnHandle column : columns) {
+            if (!column.isPartitionKey()) {
+                int parquetFieldIndex = lookupParquetColumn(column, fileSchema);
+                Type type = typeManager.getType(column.getTypeSignature());
+                columnReferences.add(new ColumnReference<>(column, parquetFieldIndex, type));
+            }
+        }
+
+        return new TupleDomainParquetPredicate<>(effectivePredicate, columnReferences.build());
+    }
+
+    private static int lookupParquetColumn(HiveColumnHandle column, MessageType fileSchema)
+    {
+        int parquetFieldIndex = 0;
+        for (; parquetFieldIndex < fileSchema.getColumns().size(); parquetFieldIndex++) {
+            final String[] path = fileSchema.getColumns().get(parquetFieldIndex).getPath();
+            // Parquet does not support predicate pushdown for complex types.
+            // The path should have only one element for primitive types and for complex types it will have
+            // a longer path tree, like [column_name, map, key] and [column_name, map, value], so we
+            // want to not even attempt to push down those aggregates.
+            if (path.length == 1) {
+                String columnName = fileSchema.getColumns().get(parquetFieldIndex).getPath()[0];
+                if (column.getName().equals(columnName)) {
+                    break;
+                }
+            }
+        }
+        return parquetFieldIndex;
+    }
+
+    public static boolean predicateMatches(ParquetPredicate parquetPredicate,
+            BlockMetaData block,
+            ParquetDataSource dataSource,
+            MessageType requestedSchema,
+            TupleDomain<HiveColumnHandle> effectivePredicate)
+    {
+        Map<Integer, Statistics<?>> columnStatistics = getStatisticsByColumnOrdinal(block);
+        if (!parquetPredicate.matches(block.getRowCount(), columnStatistics)) {
+            return false;
+        }
+
+        Map<Integer, ParquetDictionaryDescriptor> dictionaries = getDictionariesByColumnOrdinal(block, dataSource, requestedSchema, effectivePredicate);
+        return parquetPredicate.matches(dictionaries);
+    }
+
+    private static Map<Integer, Statistics<?>> getStatisticsByColumnOrdinal(BlockMetaData blockMetadata)
+    {
+        ImmutableMap.Builder<Integer, Statistics<?>> statistics = ImmutableMap.builder();
+        for (int ordinal = 0; ordinal < blockMetadata.getColumns().size(); ordinal++) {
+            Statistics<?> columnStatistics = blockMetadata.getColumns().get(ordinal).getStatistics();
+            if (columnStatistics != null) {
+                statistics.put(ordinal, columnStatistics);
+            }
+        }
+        return statistics.build();
+    }
+
+    private static Map<Integer, ParquetDictionaryDescriptor> getDictionariesByColumnOrdinal(
+            BlockMetaData blockMetadata,
+            ParquetDataSource dataSource,
+            MessageType requestedSchema,
+            TupleDomain<HiveColumnHandle> effectivePredicate)
+    {
+        ImmutableMap.Builder<Integer, ParquetDictionaryDescriptor> dictionaries = ImmutableMap.builder();
+        for (int ordinal = 0; ordinal < blockMetadata.getColumns().size(); ordinal++) {
+            ColumnChunkMetaData columnChunkMetaData = blockMetadata.getColumns().get(ordinal);
+
+            for (int i = 0; i < requestedSchema.getColumns().size(); i++) {
+                ColumnDescriptor columnDescriptor = requestedSchema.getColumns().get(i);
+                if (isColumnPredicate(columnDescriptor, effectivePredicate) &&
+                        columnChunkMetaData.getPath().equals(ColumnPath.get(columnDescriptor.getPath())) &&
+                        isOnlyDictionaryEncodingPages(columnChunkMetaData.getEncodings())) {
+                    try {
+                        int totalSize = toIntExact(columnChunkMetaData.getTotalSize());
+                        byte[] buffer = new byte[totalSize];
+                        dataSource.readFully(columnChunkMetaData.getStartingPos(), buffer);
+                        Optional<ParquetDictionaryPage> dictionaryPage = readDictionaryPage(buffer, columnChunkMetaData.getCodec());
+                        dictionaries.put(ordinal, new ParquetDictionaryDescriptor(columnDescriptor, dictionaryPage));
+                    }
+                    catch (IOException ignored) {
+                    }
+                    break;
+                }
+            }
+        }
+        return dictionaries.build();
+    }
+
+    private static Optional<ParquetDictionaryPage> readDictionaryPage(byte[] data, CompressionCodecName codecName)
+    {
+        try {
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
+            PageHeader pageHeader = Util.readPageHeader(inputStream);
+
+            if (pageHeader.type != PageType.DICTIONARY_PAGE) {
+                return Optional.empty();
+            }
+
+            Slice compressedData = wrappedBuffer(data, data.length - inputStream.available(), pageHeader.getCompressed_page_size());
+            DictionaryPageHeader dicHeader = pageHeader.getDictionary_page_header();
+            ParquetEncoding encoding = getParquetEncoding(Encoding.valueOf(dicHeader.getEncoding().name()));
+            int dictionarySize = dicHeader.getNum_values();
+
+            return Optional.of(new ParquetDictionaryPage(decompress(codecName, compressedData, pageHeader.getUncompressed_page_size()), dictionarySize, encoding));
+        }
+        catch (IOException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private static boolean isColumnPredicate(ColumnDescriptor columnDescriptor, TupleDomain<HiveColumnHandle> effectivePredicate)
+    {
+        String[] columnPath = columnDescriptor.getPath();
+        String columnName = columnPath[columnPath.length - 1];
+        return effectivePredicate.getDomains().get().keySet().stream()
+                .map(HiveColumnHandle::getName)
+                .anyMatch(columnName::equals);
+    }
+
+    @VisibleForTesting
+    @SuppressWarnings("deprecation")
+    static boolean isOnlyDictionaryEncodingPages(Set<Encoding> encodings)
+    {
+        // TODO: update to use EncodingStats in ColumnChunkMetaData when available
+        if (encodings.contains(PLAIN_DICTIONARY)) {
+            // PLAIN_DICTIONARY was present, which means at least one page was
+            // dictionary-encoded and 1.0 encodings are used
+            // The only other allowed encodings are RLE and BIT_PACKED which are used for repetition or definition levels
+            return Sets.difference(encodings, ImmutableSet.of(PLAIN_DICTIONARY, RLE, BIT_PACKED)).isEmpty();
+        }
+
+        // if PLAIN_DICTIONARY wasn't present, then either the column is not
+        // dictionary-encoded, or the 2.0 encoding, RLE_DICTIONARY, was used.
+        // for 2.0, this cannot determine whether a page fell back without
+        // page encoding stats
+        return false;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetRangeStatistics.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetRangeStatistics.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.predicate;
+
+public interface ParquetRangeStatistics<T>
+{
+    T getMin();
+
+    T getMax();
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetStringStatistics.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/ParquetStringStatistics.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.predicate;
+
+import io.airlift.slice.Slice;
+
+public class ParquetStringStatistics
+        implements ParquetRangeStatistics<Slice>
+{
+    private final Slice minimum;
+    private final Slice maximum;
+
+    public ParquetStringStatistics(Slice minimum, Slice maximum)
+    {
+        this.minimum = minimum;
+        this.maximum = maximum;
+    }
+
+    @Override
+    public Slice getMin()
+    {
+        return minimum;
+    }
+
+    @Override
+    public Slice getMax()
+    {
+        return maximum;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/predicate/TupleDomainParquetPredicate.java
@@ -1,0 +1,335 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.predicate;
+
+import com.facebook.presto.iceberg.parquet.ParquetDictionaryPage;
+import com.facebook.presto.iceberg.parquet.dictionary.ParquetDictionary;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.Range;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.statistics.BinaryStatistics;
+import org.apache.parquet.column.statistics.BooleanStatistics;
+import org.apache.parquet.column.statistics.DoubleStatistics;
+import org.apache.parquet.column.statistics.FloatStatistics;
+import org.apache.parquet.column.statistics.IntStatistics;
+import org.apache.parquet.column.statistics.LongStatistics;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Float.floatToRawIntBits;
+import static java.util.Objects.requireNonNull;
+
+public class TupleDomainParquetPredicate<C>
+        implements ParquetPredicate
+{
+    private final TupleDomain<C> effectivePredicate;
+    private final List<ColumnReference<C>> columnReferences;
+
+    public TupleDomainParquetPredicate(TupleDomain<C> effectivePredicate, List<ColumnReference<C>> columnReferences)
+    {
+        this.effectivePredicate = requireNonNull(effectivePredicate, "effectivePredicate is null");
+        this.columnReferences = ImmutableList.copyOf(requireNonNull(columnReferences, "columnReferences is null"));
+    }
+
+    @Override
+    public boolean matches(long numberOfRows, Map<Integer, Statistics<?>> statisticsByColumnIndex)
+    {
+        if (numberOfRows == 0) {
+            return false;
+        }
+        ImmutableMap.Builder<C, Domain> domains = ImmutableMap.builder();
+
+        for (ColumnReference<C> columnReference : columnReferences) {
+            Statistics<?> statistics = statisticsByColumnIndex.get(columnReference.getOrdinal());
+
+            Domain domain;
+            if (statistics == null || statistics.isEmpty()) {
+                // no stats for column
+                domain = Domain.all(columnReference.getType());
+            }
+            else {
+                domain = getDomain(columnReference.getType(), numberOfRows, statistics);
+            }
+            domains.put(columnReference.getColumn(), domain);
+        }
+        TupleDomain<C> stripeDomain = TupleDomain.withColumnDomains(domains.build());
+
+        return effectivePredicate.overlaps(stripeDomain);
+    }
+
+    @Override
+    public boolean matches(Map<Integer, ParquetDictionaryDescriptor> dictionariesByColumnIndex)
+    {
+        ImmutableMap.Builder<C, Domain> domains = ImmutableMap.builder();
+
+        for (ColumnReference<C> columnReference : columnReferences) {
+            ParquetDictionaryDescriptor dictionaryDescriptor = dictionariesByColumnIndex.get(columnReference.getOrdinal());
+            Domain domain = getDomain(columnReference.getType(), dictionaryDescriptor);
+            if (domain != null) {
+                domains.put(columnReference.getColumn(), domain);
+            }
+        }
+        TupleDomain<C> stripeDomain = TupleDomain.withColumnDomains(domains.build());
+
+        return effectivePredicate.overlaps(stripeDomain);
+    }
+
+    @VisibleForTesting
+    public static Domain getDomain(Type type, long rowCount, Statistics<?> statistics)
+    {
+        if (statistics == null || statistics.isEmpty()) {
+            return Domain.all(type);
+        }
+
+        if (statistics.getNumNulls() == rowCount) {
+            return Domain.onlyNull(type);
+        }
+
+        boolean hasNullValue = statistics.getNumNulls() != 0L;
+
+        // ignore corrupted statistics
+        if (statistics.genericGetMin() == null || statistics.genericGetMax() == null) {
+            return Domain.create(ValueSet.all(type), hasNullValue);
+        }
+
+        if (type.equals(BOOLEAN) && statistics instanceof BooleanStatistics) {
+            BooleanStatistics booleanStatistics = (BooleanStatistics) statistics;
+
+            boolean hasTrueValues = !(booleanStatistics.getMax() == false && booleanStatistics.getMin() == false);
+            boolean hasFalseValues = !(booleanStatistics.getMax() == true && booleanStatistics.getMin() == true);
+            if (hasTrueValues && hasFalseValues) {
+                return Domain.all(type);
+            }
+            if (hasTrueValues) {
+                return Domain.create(ValueSet.of(type, true), hasNullValue);
+            }
+            if (hasFalseValues) {
+                return Domain.create(ValueSet.of(type, false), hasNullValue);
+            }
+        }
+        else if ((type.equals(BIGINT) || type.equals(TINYINT) || type.equals(SMALLINT) || type.equals(INTEGER)) && (statistics instanceof LongStatistics || statistics instanceof IntStatistics)) {
+            ParquetIntegerStatistics parquetIntegerStatistics;
+            if (statistics instanceof LongStatistics) {
+                LongStatistics longStatistics = (LongStatistics) statistics;
+                // ignore corrupted statistics
+                if (longStatistics.genericGetMin() > longStatistics.genericGetMax()) {
+                    return Domain.create(ValueSet.all(type), hasNullValue);
+                }
+                parquetIntegerStatistics = new ParquetIntegerStatistics(longStatistics.genericGetMin(), longStatistics.genericGetMax());
+            }
+            else {
+                IntStatistics intStatistics = (IntStatistics) statistics;
+                // ignore corrupted statistics
+                if (intStatistics.genericGetMin() > intStatistics.genericGetMax()) {
+                    return Domain.create(ValueSet.all(type), hasNullValue);
+                }
+                parquetIntegerStatistics = new ParquetIntegerStatistics((long) intStatistics.getMin(), (long) intStatistics.getMax());
+            }
+            if (ParquetPredicateUtils.isStatisticsOverflow(type, parquetIntegerStatistics)) {
+                return Domain.create(ValueSet.all(type), hasNullValue);
+            }
+            return createDomain(type, hasNullValue, parquetIntegerStatistics);
+        }
+        else if (type.equals(REAL) && statistics instanceof FloatStatistics) {
+            FloatStatistics floatStatistics = (FloatStatistics) statistics;
+            // ignore corrupted statistics
+            if (floatStatistics.genericGetMin() > floatStatistics.genericGetMax()) {
+                return Domain.create(ValueSet.all(type), hasNullValue);
+            }
+
+            ParquetIntegerStatistics parquetStatistics = new ParquetIntegerStatistics(
+                    (long) floatToRawIntBits(floatStatistics.getMin()),
+                    (long) floatToRawIntBits(floatStatistics.getMax()));
+
+            return createDomain(type, hasNullValue, parquetStatistics);
+        }
+        else if (type.equals(DOUBLE) && statistics instanceof DoubleStatistics) {
+            DoubleStatistics doubleStatistics = (DoubleStatistics) statistics;
+            // ignore corrupted statistics
+            if (doubleStatistics.genericGetMin() > doubleStatistics.genericGetMax()) {
+                return Domain.create(ValueSet.all(type), hasNullValue);
+            }
+            ParquetDoubleStatistics parquetDoubleStatistics = new ParquetDoubleStatistics(doubleStatistics.genericGetMin(), doubleStatistics.genericGetMax());
+            return createDomain(type, hasNullValue, parquetDoubleStatistics);
+        }
+        else if (isVarcharType(type) && statistics instanceof BinaryStatistics) {
+            BinaryStatistics binaryStatistics = (BinaryStatistics) statistics;
+            Slice minSlice = Slices.wrappedBuffer(binaryStatistics.getMin().getBytes());
+            Slice maxSlice = Slices.wrappedBuffer(binaryStatistics.getMax().getBytes());
+            // ignore corrupted statistics
+            if (minSlice.compareTo(maxSlice) > 0) {
+                return Domain.create(ValueSet.all(type), hasNullValue);
+            }
+            ParquetStringStatistics parquetStringStatistics = new ParquetStringStatistics(minSlice, maxSlice);
+            return createDomain(type, hasNullValue, parquetStringStatistics);
+        }
+        return Domain.create(ValueSet.all(type), hasNullValue);
+    }
+
+    @VisibleForTesting
+    public static Domain getDomain(Type type, ParquetDictionaryDescriptor dictionaryDescriptor)
+    {
+        if (dictionaryDescriptor == null) {
+            return null;
+        }
+
+        ColumnDescriptor columnDescriptor = dictionaryDescriptor.getColumnDescriptor();
+        Optional<ParquetDictionaryPage> dictionaryPage = dictionaryDescriptor.getDictionaryPage();
+        if (!dictionaryPage.isPresent()) {
+            return null;
+        }
+
+        ParquetDictionary dictionary;
+        try {
+            dictionary = dictionaryPage.get().getEncoding().initDictionary(columnDescriptor, dictionaryPage.get());
+        }
+        catch (Exception e) {
+            // In case of exception, just continue reading the data, not using dictionary page at all
+            // OK to ignore exception when reading dictionaries
+            return null;
+        }
+
+        int dictionarySize = dictionaryPage.get().getDictionarySize();
+        if (type.equals(BIGINT) && columnDescriptor.getType() == PrimitiveTypeName.INT64) {
+            List<Domain> domains = new ArrayList<>();
+            for (int i = 0; i < dictionarySize; i++) {
+                domains.add(Domain.singleValue(type, dictionary.decodeToLong(i)));
+            }
+            domains.add(Domain.onlyNull(type));
+            return Domain.union(domains);
+        }
+        else if (type.equals(BIGINT) && columnDescriptor.getType() == PrimitiveTypeName.INT32) {
+            List<Domain> domains = new ArrayList<>();
+            for (int i = 0; i < dictionarySize; i++) {
+                domains.add(Domain.singleValue(type, (long) dictionary.decodeToInt(i)));
+            }
+            domains.add(Domain.onlyNull(type));
+            return Domain.union(domains);
+        }
+        else if (type.equals(DOUBLE) && columnDescriptor.getType() == PrimitiveTypeName.DOUBLE) {
+            List<Domain> domains = new ArrayList<>();
+            for (int i = 0; i < dictionarySize; i++) {
+                domains.add(Domain.singleValue(type, dictionary.decodeToDouble(i)));
+            }
+            domains.add(Domain.onlyNull(type));
+            return Domain.union(domains);
+        }
+        else if (type.equals(DOUBLE) && columnDescriptor.getType() == PrimitiveTypeName.FLOAT) {
+            List<Domain> domains = new ArrayList<>();
+            for (int i = 0; i < dictionarySize; i++) {
+                domains.add(Domain.singleValue(type, (double) dictionary.decodeToFloat(i)));
+            }
+            domains.add(Domain.onlyNull(type));
+            return Domain.union(domains);
+        }
+        else if (isVarcharType(type) && columnDescriptor.getType() == PrimitiveTypeName.BINARY) {
+            List<Domain> domains = new ArrayList<>();
+            for (int i = 0; i < dictionarySize; i++) {
+                domains.add(Domain.singleValue(type, Slices.wrappedBuffer(dictionary.decodeToBinary(i).getBytes())));
+            }
+            domains.add(Domain.onlyNull(type));
+            return Domain.union(domains);
+        }
+        return null;
+    }
+
+    private static <T extends Comparable<T>> Domain createDomain(Type type, boolean hasNullValue, ParquetRangeStatistics<T> rangeStatistics)
+    {
+        return createDomain(type, hasNullValue, rangeStatistics, value -> value);
+    }
+
+    private static <F, T extends Comparable<T>> Domain createDomain(Type type,
+            boolean hasNullValue,
+            ParquetRangeStatistics<F> rangeStatistics,
+            Function<F, T> function)
+    {
+        F min = rangeStatistics.getMin();
+        F max = rangeStatistics.getMax();
+
+        if (min != null && max != null) {
+            return Domain.create(ValueSet.ofRanges(Range.range(type, function.apply(min), true, function.apply(max), true)), hasNullValue);
+        }
+        if (max != null) {
+            return Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(type, function.apply(max))), hasNullValue);
+        }
+        if (min != null) {
+            return Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(type, function.apply(min))), hasNullValue);
+        }
+        return Domain.create(ValueSet.all(type), hasNullValue);
+    }
+
+    public static class ColumnReference<C>
+    {
+        private final C column;
+        private final int ordinal;
+        private final Type type;
+
+        public ColumnReference(C column, int ordinal, Type type)
+        {
+            this.column = requireNonNull(column, "column is null");
+            checkArgument(ordinal >= 0, "ordinal is negative");
+            this.ordinal = ordinal;
+            this.type = requireNonNull(type, "type is null");
+        }
+
+        public C getColumn()
+        {
+            return column;
+        }
+
+        public int getOrdinal()
+        {
+            return ordinal;
+        }
+
+        public Type getType()
+        {
+            return type;
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("column", column)
+                    .add("ordinal", ordinal)
+                    .add("type", type)
+                    .toString();
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetBinaryColumnReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetBinaryColumnReader.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.RichColumnDescriptor;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.Slice;
+import org.apache.parquet.io.api.Binary;
+
+import static com.facebook.presto.spi.type.Chars.isCharType;
+import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
+import static com.facebook.presto.spi.type.Varchars.truncateToLength;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
+import static io.airlift.slice.Slices.wrappedBuffer;
+
+public class ParquetBinaryColumnReader
+        extends ParquetColumnReader
+{
+    public ParquetBinaryColumnReader(RichColumnDescriptor descriptor)
+    {
+        super(descriptor);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type type)
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            Binary binary = valuesReader.readBytes();
+            Slice value;
+            if (binary.length() == 0) {
+                value = EMPTY_SLICE;
+            }
+            else {
+                value = wrappedBuffer(binary.getBytes());
+            }
+            if (isVarcharType(type)) {
+                value = truncateToLength(value, type);
+            }
+            if (isCharType(type)) {
+                value = truncateToLengthAndTrimSpaces(value, type);
+            }
+            type.writeSlice(blockBuilder, value);
+        }
+        else if (isValueNull()) {
+            blockBuilder.appendNull();
+        }
+    }
+
+    @Override
+    protected void skipValue()
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            valuesReader.readBytes();
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetBooleanColumnReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetBooleanColumnReader.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.RichColumnDescriptor;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+
+public class ParquetBooleanColumnReader
+        extends ParquetColumnReader
+{
+    public ParquetBooleanColumnReader(RichColumnDescriptor descriptor)
+    {
+        super(descriptor);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type type)
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            type.writeBoolean(blockBuilder, valuesReader.readBoolean());
+        }
+        else if (isValueNull()) {
+            blockBuilder.appendNull();
+        }
+    }
+
+    @Override
+    protected void skipValue()
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            valuesReader.readBoolean();
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetColumnChunk.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetColumnChunk.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.ParquetCorruptionException;
+import com.facebook.presto.iceberg.parquet.ParquetDataPage;
+import com.facebook.presto.iceberg.parquet.ParquetDataPageV1;
+import com.facebook.presto.iceberg.parquet.ParquetDataPageV2;
+import com.facebook.presto.iceberg.parquet.ParquetDictionaryPage;
+import io.airlift.slice.Slice;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.format.DataPageHeader;
+import org.apache.parquet.format.DataPageHeaderV2;
+import org.apache.parquet.format.DictionaryPageHeader;
+import org.apache.parquet.format.PageHeader;
+import org.apache.parquet.format.Util;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.iceberg.parquet.ParquetTypeUtils.getParquetEncoding;
+import static io.airlift.slice.Slices.wrappedBuffer;
+
+public class ParquetColumnChunk
+        extends ByteArrayInputStream
+{
+    private final ParquetColumnChunkDescriptor descriptor;
+
+    public ParquetColumnChunk(
+            ParquetColumnChunkDescriptor descriptor,
+            byte[] data,
+            int offset)
+    {
+        super(data);
+        this.descriptor = descriptor;
+        this.pos = offset;
+    }
+
+    public ParquetColumnChunkDescriptor getDescriptor()
+    {
+        return descriptor;
+    }
+
+    protected PageHeader readPageHeader()
+            throws IOException
+    {
+        return Util.readPageHeader(this);
+    }
+
+    public ParquetPageReader readAllPages()
+            throws IOException
+    {
+        List<ParquetDataPage> pages = new ArrayList<>();
+        ParquetDictionaryPage dictionaryPage = null;
+        long valueCount = 0;
+        while (valueCount < descriptor.getColumnChunkMetaData().getValueCount()) {
+            PageHeader pageHeader = readPageHeader();
+            int uncompressedPageSize = pageHeader.getUncompressed_page_size();
+            int compressedPageSize = pageHeader.getCompressed_page_size();
+            switch (pageHeader.type) {
+                case DICTIONARY_PAGE:
+                    if (dictionaryPage != null) {
+                        throw new ParquetCorruptionException("%s has more than one dictionary page in column chunk", descriptor.getColumnDescriptor());
+                    }
+                    dictionaryPage = readDictionaryPage(pageHeader, uncompressedPageSize, compressedPageSize);
+                    break;
+                case DATA_PAGE:
+                    valueCount += readDataPageV1(pageHeader, uncompressedPageSize, compressedPageSize, pages);
+                    break;
+                case DATA_PAGE_V2:
+                    valueCount += readDataPageV2(pageHeader, uncompressedPageSize, compressedPageSize, pages);
+                    break;
+                default:
+                    skip(compressedPageSize);
+                    break;
+            }
+        }
+        return new ParquetPageReader(descriptor.getColumnChunkMetaData().getCodec(), pages, dictionaryPage);
+    }
+
+    public int getPosition()
+    {
+        return pos;
+    }
+
+    private Slice getSlice(int size)
+    {
+        Slice slice = wrappedBuffer(buf, pos, size);
+        pos += size;
+        return slice;
+    }
+
+    private ParquetDictionaryPage readDictionaryPage(PageHeader pageHeader, int uncompressedPageSize, int compressedPageSize)
+            throws IOException
+    {
+        DictionaryPageHeader dicHeader = pageHeader.getDictionary_page_header();
+        return new ParquetDictionaryPage(
+                getSlice(compressedPageSize),
+                uncompressedPageSize,
+                dicHeader.getNum_values(),
+                getParquetEncoding(Encoding.valueOf(dicHeader.getEncoding().name())));
+    }
+
+    private long readDataPageV1(PageHeader pageHeader,
+            int uncompressedPageSize,
+            int compressedPageSize,
+            List<ParquetDataPage> pages)
+            throws IOException
+    {
+        DataPageHeader dataHeaderV1 = pageHeader.getData_page_header();
+        pages.add(new ParquetDataPageV1(
+                getSlice(compressedPageSize),
+                dataHeaderV1.getNum_values(),
+                uncompressedPageSize,
+                ParquetMetadataReader.readStats(
+                        dataHeaderV1.getStatistics(),
+                        descriptor.getColumnDescriptor().getType()),
+                getParquetEncoding(Encoding.valueOf(dataHeaderV1.getRepetition_level_encoding().name())),
+                getParquetEncoding(Encoding.valueOf(dataHeaderV1.getDefinition_level_encoding().name())),
+                getParquetEncoding(Encoding.valueOf(dataHeaderV1.getEncoding().name()))));
+        return dataHeaderV1.getNum_values();
+    }
+
+    private long readDataPageV2(PageHeader pageHeader,
+            int uncompressedPageSize,
+            int compressedPageSize,
+            List<ParquetDataPage> pages)
+            throws IOException
+    {
+        DataPageHeaderV2 dataHeaderV2 = pageHeader.getData_page_header_v2();
+        int dataSize = compressedPageSize - dataHeaderV2.getRepetition_levels_byte_length() - dataHeaderV2.getDefinition_levels_byte_length();
+        pages.add(new ParquetDataPageV2(
+                dataHeaderV2.getNum_rows(),
+                dataHeaderV2.getNum_nulls(),
+                dataHeaderV2.getNum_values(),
+                getSlice(dataHeaderV2.getRepetition_levels_byte_length()),
+                getSlice(dataHeaderV2.getDefinition_levels_byte_length()),
+                getParquetEncoding(Encoding.valueOf(dataHeaderV2.getEncoding().name())),
+                getSlice(dataSize),
+                uncompressedPageSize,
+                ParquetMetadataReader.readStats(
+                        dataHeaderV2.getStatistics(),
+                        descriptor.getColumnDescriptor().getType()),
+                dataHeaderV2.isIs_compressed()));
+        return dataHeaderV2.getNum_values();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetColumnChunkDescriptor.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetColumnChunkDescriptor.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+
+public class ParquetColumnChunkDescriptor
+{
+    private final ColumnDescriptor columnDescriptor;
+    private final ColumnChunkMetaData columnChunkMetaData;
+    private final int size;
+
+    public ParquetColumnChunkDescriptor(
+            ColumnDescriptor columnDescriptor,
+            ColumnChunkMetaData columnChunkMetaData,
+            int size)
+    {
+        this.columnDescriptor = columnDescriptor;
+        this.columnChunkMetaData = columnChunkMetaData;
+        this.size = size;
+    }
+
+    public int getSize()
+    {
+        return size;
+    }
+
+    public ColumnDescriptor getColumnDescriptor()
+    {
+        return columnDescriptor;
+    }
+
+    public ColumnChunkMetaData getColumnChunkMetaData()
+    {
+        return columnChunkMetaData;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetColumnReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetColumnReader.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.ParquetDataPage;
+import com.facebook.presto.iceberg.parquet.ParquetDataPageV1;
+import com.facebook.presto.iceberg.parquet.ParquetDataPageV2;
+import com.facebook.presto.iceberg.parquet.ParquetDictionaryPage;
+import com.facebook.presto.iceberg.parquet.ParquetEncoding;
+import com.facebook.presto.iceberg.parquet.ParquetTypeUtils;
+import com.facebook.presto.iceberg.parquet.RichColumnDescriptor;
+import com.facebook.presto.iceberg.parquet.dictionary.ParquetDictionary;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.PageBuilderStatus;
+import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.Slice;
+import it.unimi.dsi.fastutil.ints.IntList;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
+import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.schema.DecimalMetadata;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static com.facebook.presto.iceberg.parquet.ParquetValidationUtils.validateParquet;
+import static com.facebook.presto.iceberg.parquet.ParquetValuesType.DEFINITION_LEVEL;
+import static com.facebook.presto.iceberg.parquet.ParquetValuesType.REPETITION_LEVEL;
+import static com.facebook.presto.iceberg.parquet.ParquetValuesType.VALUES;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.OriginalType.DECIMAL;
+
+public abstract class ParquetColumnReader
+{
+    private static final int EMPTY_LEVEL_VALUE = -1;
+    protected final RichColumnDescriptor columnDescriptor;
+    protected int definitionLevel = EMPTY_LEVEL_VALUE;
+    protected ValuesReader valuesReader;
+    protected int nextBatchSize;
+
+    private ParquetLevelReader repetitionReader;
+    private ParquetLevelReader definitionReader;
+    private int repetitionLevel = EMPTY_LEVEL_VALUE;
+    private long totalValueCount;
+    private ParquetPageReader pageReader;
+    private ParquetDictionary dictionary;
+    private int currentValueCount;
+    private ParquetDataPage page;
+    private int remainingValueCountInPage;
+    private int readOffset;
+
+    protected abstract void readValue(BlockBuilder blockBuilder, Type type);
+
+    protected abstract void skipValue();
+
+    protected boolean isValueNull()
+    {
+        return ParquetTypeUtils.isValueNull(columnDescriptor.isRequired(), definitionLevel, columnDescriptor.getMaxDefinitionLevel());
+    }
+
+    public static ParquetColumnReader createReader(RichColumnDescriptor descriptor)
+    {
+        switch (descriptor.getType()) {
+            case BOOLEAN:
+                return new ParquetBooleanColumnReader(descriptor);
+            case INT32:
+                return createDecimalColumnReader(descriptor).orElse(new ParquetIntColumnReader(descriptor));
+            case INT64:
+                return createDecimalColumnReader(descriptor).orElse(new ParquetLongColumnReader(descriptor));
+            case INT96:
+                return new ParquetTimestampColumnReader(descriptor);
+            case FLOAT:
+                return new ParquetFloatColumnReader(descriptor);
+            case DOUBLE:
+                return new ParquetDoubleColumnReader(descriptor);
+            case BINARY:
+                return createDecimalColumnReader(descriptor).orElse(new ParquetBinaryColumnReader(descriptor));
+            case FIXED_LEN_BYTE_ARRAY:
+                return createDecimalColumnReader(descriptor)
+                        .orElseThrow(() -> new PrestoException(NOT_SUPPORTED, "Parquet type FIXED_LEN_BYTE_ARRAY supported as DECIMAL; got " + descriptor.getPrimitiveType().getOriginalType()));
+            default:
+                throw new PrestoException(NOT_SUPPORTED, "Unsupported parquet type: " + descriptor.getType());
+        }
+    }
+
+    private static Optional<ParquetColumnReader> createDecimalColumnReader(RichColumnDescriptor descriptor)
+    {
+        if (descriptor.getPrimitiveType().getOriginalType() != DECIMAL) {
+            return Optional.empty();
+        }
+        DecimalMetadata decimalMetadata = descriptor.getPrimitiveType().getDecimalMetadata();
+        return Optional.of(ParquetDecimalColumnReaderFactory.createReader(descriptor, decimalMetadata.getPrecision(), decimalMetadata.getScale()));
+    }
+
+    public ParquetColumnReader(RichColumnDescriptor columnDescriptor)
+    {
+        this.columnDescriptor = requireNonNull(columnDescriptor, "columnDescriptor");
+        pageReader = null;
+    }
+
+    public ParquetPageReader getPageReader()
+    {
+        return pageReader;
+    }
+
+    public void setPageReader(ParquetPageReader pageReader)
+    {
+        this.pageReader = requireNonNull(pageReader, "pageReader");
+        ParquetDictionaryPage dictionaryPage = pageReader.readDictionaryPage();
+
+        if (dictionaryPage != null) {
+            try {
+                dictionary = dictionaryPage.getEncoding().initDictionary(columnDescriptor, dictionaryPage);
+            }
+            catch (IOException e) {
+                throw new ParquetDecodingException("could not decode the dictionary for " + columnDescriptor, e);
+            }
+        }
+        else {
+            dictionary = null;
+        }
+        checkArgument(pageReader.getTotalValueCount() > 0, "page is empty");
+        totalValueCount = pageReader.getTotalValueCount();
+    }
+
+    public void prepareNextRead(int batchSize)
+    {
+        readOffset = readOffset + nextBatchSize;
+        nextBatchSize = batchSize;
+    }
+
+    public ColumnDescriptor getDescriptor()
+    {
+        return columnDescriptor;
+    }
+
+    public Block readPrimitive(Type type, IntList definitionLevels, IntList repetitionLevels)
+            throws IOException
+    {
+        seek();
+        BlockBuilder blockBuilder = type.createBlockBuilder(new PageBuilderStatus().createBlockBuilderStatus(), nextBatchSize);
+        int valueCount = 0;
+        while (valueCount < nextBatchSize) {
+            if (page == null) {
+                readNextPage();
+            }
+            int valuesToRead = Math.min(remainingValueCountInPage, nextBatchSize - valueCount);
+            readValues(blockBuilder, valuesToRead, type, definitionLevels, repetitionLevels);
+            valueCount += valuesToRead;
+        }
+        checkArgument(valueCount == nextBatchSize, "valueCount " + valueCount + " not equals to batchSize " + nextBatchSize);
+
+        readOffset = 0;
+        nextBatchSize = 0;
+        return blockBuilder.build();
+    }
+
+    private void readValues(BlockBuilder blockBuilder, int valuesToRead, Type type, IntList definitionLevels, IntList repetitionLevels)
+            throws IOException
+    {
+        processValues(valuesToRead, ignored -> {
+            readValue(blockBuilder, type);
+            definitionLevels.add(definitionLevel);
+            repetitionLevels.add(repetitionLevel);
+        });
+    }
+
+    private void skipValues(int valuesToRead)
+            throws IOException
+    {
+        processValues(valuesToRead, ignored -> skipValue());
+    }
+
+    private void processValues(int valuesToRead, Consumer<Void> valueConsumer)
+            throws IOException
+    {
+        if (definitionLevel == EMPTY_LEVEL_VALUE && repetitionLevel == EMPTY_LEVEL_VALUE) {
+            definitionLevel = definitionReader.readLevel();
+            repetitionLevel = repetitionReader.readLevel();
+        }
+        int valueCount = 0;
+        for (int i = 0; i < valuesToRead; i++) {
+            do {
+                valueConsumer.accept(null);
+                valueCount++;
+                if (valueCount == remainingValueCountInPage) {
+                    updatePosition(valueCount);
+                    if (!pageReader.available()) {
+                        return;
+                    }
+                    valueCount = 0;
+                    readNextPage();
+                }
+                repetitionLevel = repetitionReader.readLevel();
+                definitionLevel = definitionReader.readLevel();
+            }
+            while (repetitionLevel != 0);
+        }
+        updatePosition(valueCount);
+    }
+
+    private void seek()
+            throws IOException
+    {
+        checkArgument(currentValueCount <= totalValueCount, "Already read all values in column chunk");
+        if (readOffset == 0) {
+            return;
+        }
+        int valuePosition = 0;
+        while (valuePosition < readOffset) {
+            if (page == null) {
+                readNextPage();
+            }
+            int offset = Math.min(remainingValueCountInPage, readOffset - valuePosition);
+            skipValues(offset);
+            valuePosition = valuePosition + offset;
+        }
+        checkArgument(valuePosition == readOffset, "valuePosition " + valuePosition + " must be equal to readOffset " + readOffset);
+    }
+
+    private void readNextPage()
+            throws IOException
+    {
+        page = pageReader.readPage();
+        validateParquet(page != null, "Not enough values to read in column chunk");
+        remainingValueCountInPage = page.getValueCount();
+
+        if (page instanceof ParquetDataPageV1) {
+            valuesReader = readPageV1((ParquetDataPageV1) page);
+        }
+        else {
+            valuesReader = readPageV2((ParquetDataPageV2) page);
+        }
+    }
+
+    private void updatePosition(int valuesToRead)
+    {
+        if (valuesToRead == remainingValueCountInPage) {
+            page = null;
+            valuesReader = null;
+        }
+        remainingValueCountInPage = remainingValueCountInPage - valuesToRead;
+        currentValueCount += valuesToRead;
+    }
+
+    private ValuesReader readPageV1(ParquetDataPageV1 page)
+    {
+        ValuesReader rlReader = page.getRepetitionLevelEncoding().getValuesReader(columnDescriptor, REPETITION_LEVEL);
+        ValuesReader dlReader = page.getDefinitionLevelEncoding().getValuesReader(columnDescriptor, DEFINITION_LEVEL);
+        repetitionReader = new ParquetLevelValuesReader(rlReader);
+        definitionReader = new ParquetLevelValuesReader(dlReader);
+        try {
+//            byte[] bytes = page.getSlice().getBytes();
+//            rlReader.initFromPage(page.getValueCount(), bytes, 0);
+//            int offset = rlReader.getNextOffset();
+//            dlReader.initFromPage(page.getValueCount(), bytes, offset);
+//            offset = dlReader.getNextOffset();
+//            return initDataReader(page.getValueEncoding(), bytes, offset, page.getValueCount());
+            byte[] bytes = page.getSlice().getBytes();
+            final ByteBufferInputStream bufferInputStream = ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes));
+            rlReader.initFromPage(page.getValueCount(), bufferInputStream);
+            int offset = bytes.length - bufferInputStream.available();
+            // Assumes ByteBufferInputStream.remainingStream makes a copy of the underlying bytebuffer.
+            final ByteBufferInputStream dlbyteBufferInputStream = ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes, offset, bytes.length - offset));
+            dlReader.initFromPage(page.getValueCount(), dlbyteBufferInputStream);
+            offset = bytes.length - dlbyteBufferInputStream.available();
+            return initDataReader(page.getValueEncoding(), ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes, offset, bytes.length - offset)), page.getValueCount());
+        }
+        catch (IOException e) {
+            throw new ParquetDecodingException("Error reading parquet page " + page + " in column " + columnDescriptor, e);
+        }
+    }
+
+    private ValuesReader readPageV2(ParquetDataPageV2 page)
+    {
+        repetitionReader = buildLevelRLEReader(columnDescriptor.getMaxRepetitionLevel(), page.getRepetitionLevels());
+        definitionReader = buildLevelRLEReader(columnDescriptor.getMaxDefinitionLevel(), page.getDefinitionLevels());
+        return initDataReader(page.getDataEncoding(), ByteBufferInputStream.wrap(ByteBuffer.wrap(page.getSlice().getBytes())), page.getValueCount());
+    }
+
+    private ParquetLevelReader buildLevelRLEReader(int maxLevel, Slice slice)
+    {
+        if (maxLevel == 0) {
+            return new ParquetLevelNullReader();
+        }
+        return new ParquetLevelRLEReader(new RunLengthBitPackingHybridDecoder(BytesUtils.getWidthFromMaxInt(maxLevel), new ByteArrayInputStream(slice.getBytes())));
+    }
+
+    private ValuesReader initDataReader(ParquetEncoding dataEncoding, ByteBufferInputStream bufferInputStream, int valueCount)
+    {
+        ValuesReader valuesReader;
+        if (dataEncoding.usesDictionary()) {
+            if (dictionary == null) {
+                throw new ParquetDecodingException("Dictionary is missing for Page");
+            }
+            valuesReader = dataEncoding.getDictionaryBasedValuesReader(columnDescriptor, VALUES, dictionary);
+        }
+        else {
+            valuesReader = dataEncoding.getValuesReader(columnDescriptor, VALUES);
+        }
+
+        try {
+            valuesReader.initFromPage(valueCount, bufferInputStream);
+            return valuesReader;
+        }
+        catch (IOException e) {
+            throw new ParquetDecodingException("Error reading parquet page in column " + columnDescriptor, e);
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetDecimalColumnReaderFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetDecimalColumnReaderFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.RichColumnDescriptor;
+import com.facebook.presto.spi.type.DecimalType;
+
+public final class ParquetDecimalColumnReaderFactory
+{
+    private ParquetDecimalColumnReaderFactory() {}
+
+    public static ParquetColumnReader createReader(RichColumnDescriptor descriptor, int precision, int scale)
+    {
+        DecimalType decimalType = DecimalType.createDecimalType(precision, scale);
+        if (decimalType.isShort()) {
+            return new ParquetShortDecimalColumnReader(descriptor);
+        }
+        else {
+            return new ParquetLongDecimalColumnReader(descriptor);
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetDoubleColumnReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetDoubleColumnReader.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.RichColumnDescriptor;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+
+public class ParquetDoubleColumnReader
+        extends ParquetColumnReader
+{
+    public ParquetDoubleColumnReader(RichColumnDescriptor descriptor)
+    {
+        super(descriptor);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type type)
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            type.writeDouble(blockBuilder, valuesReader.readDouble());
+        }
+        else if (isValueNull()) {
+            blockBuilder.appendNull();
+        }
+    }
+
+    @Override
+    protected void skipValue()
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            valuesReader.readDouble();
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetFloatColumnReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetFloatColumnReader.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.RichColumnDescriptor;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+
+import static java.lang.Float.floatToRawIntBits;
+
+public class ParquetFloatColumnReader
+        extends ParquetColumnReader
+{
+    public ParquetFloatColumnReader(RichColumnDescriptor descriptor)
+    {
+        super(descriptor);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type type)
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            type.writeLong(blockBuilder, floatToRawIntBits(valuesReader.readFloat()));
+        }
+        else if (isValueNull()) {
+            blockBuilder.appendNull();
+        }
+    }
+
+    @Override
+    protected void skipValue()
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            valuesReader.readFloat();
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetIntColumnReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetIntColumnReader.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.RichColumnDescriptor;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+
+public class ParquetIntColumnReader
+        extends ParquetColumnReader
+{
+    public ParquetIntColumnReader(RichColumnDescriptor descriptor)
+    {
+        super(descriptor);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type type)
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            type.writeLong(blockBuilder, valuesReader.readInteger());
+        }
+        else if (isValueNull()) {
+            blockBuilder.appendNull();
+        }
+    }
+
+    @Override
+    protected void skipValue()
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            valuesReader.readInteger();
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetLevelNullReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetLevelNullReader.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+public class ParquetLevelNullReader
+        implements ParquetLevelReader
+{
+    @Override
+    public int readLevel()
+    {
+        return 0;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetLevelRLEReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetLevelRLEReader.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
+import org.apache.parquet.io.ParquetDecodingException;
+
+import java.io.IOException;
+
+public class ParquetLevelRLEReader
+        implements ParquetLevelReader
+{
+    private final RunLengthBitPackingHybridDecoder delegate;
+
+    public ParquetLevelRLEReader(RunLengthBitPackingHybridDecoder delegate)
+    {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public int readLevel()
+    {
+        try {
+            return delegate.readInt();
+        }
+        catch (IOException e) {
+            throw new ParquetDecodingException(e);
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetLevelReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetLevelReader.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+public interface ParquetLevelReader
+{
+    int readLevel();
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetLevelValuesReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetLevelValuesReader.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import org.apache.parquet.column.values.ValuesReader;
+
+public class ParquetLevelValuesReader
+        implements ParquetLevelReader
+{
+    private final ValuesReader delegate;
+
+    public ParquetLevelValuesReader(ValuesReader delegate)
+    {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public int readLevel()
+    {
+        return delegate.readInteger();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetLongColumnReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetLongColumnReader.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.RichColumnDescriptor;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.DateTimeEncoding;
+import com.facebook.presto.spi.type.TimeType;
+import com.facebook.presto.spi.type.TimeWithTimeZoneType;
+import com.facebook.presto.spi.type.TimeZoneKey;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.TimestampWithTimeZoneType;
+import com.facebook.presto.spi.type.Type;
+
+public class ParquetLongColumnReader
+        extends ParquetColumnReader
+{
+    public ParquetLongColumnReader(RichColumnDescriptor descriptor)
+    {
+        super(descriptor);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type type)
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            if (type.equals(TimeType.TIME) || type.equals(TimestampType.TIMESTAMP)) {
+                type.writeLong(blockBuilder, valuesReader.readLong() / 1000);
+            }
+            else if (type.equals(TimeWithTimeZoneType.TIME_WITH_TIME_ZONE) || type.equals(TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE)) {
+                type.writeLong(blockBuilder, DateTimeEncoding.packDateTimeWithZone(valuesReader.readLong() / 1000, TimeZoneKey.UTC_KEY));
+            }
+            else {
+                type.writeLong(blockBuilder, valuesReader.readLong());
+            }
+        }
+        else if (isValueNull()) {
+            blockBuilder.appendNull();
+        }
+    }
+
+    @Override
+    protected void skipValue()
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            valuesReader.readLong();
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetLongDecimalColumnReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetLongDecimalColumnReader.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.RichColumnDescriptor;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Decimals;
+import com.facebook.presto.spi.type.Type;
+import org.apache.parquet.io.api.Binary;
+
+import java.math.BigInteger;
+
+public class ParquetLongDecimalColumnReader
+        extends ParquetColumnReader
+{
+    ParquetLongDecimalColumnReader(RichColumnDescriptor descriptor)
+    {
+        super(descriptor);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type type)
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            Binary value = valuesReader.readBytes();
+            type.writeSlice(blockBuilder, Decimals.encodeUnscaledValue(new BigInteger(value.getBytes())));
+        }
+        else if (isValueNull()) {
+            blockBuilder.appendNull();
+        }
+    }
+
+    @Override
+    protected void skipValue()
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            valuesReader.readBytes();
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetMetadataReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetMetadataReader.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.ParquetCompressionUtils;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.format.ColumnChunk;
+import org.apache.parquet.format.ColumnMetaData;
+import org.apache.parquet.format.ConvertedType;
+import org.apache.parquet.format.Encoding;
+import org.apache.parquet.format.FileMetaData;
+import org.apache.parquet.format.KeyValue;
+import org.apache.parquet.format.RowGroup;
+import org.apache.parquet.format.SchemaElement;
+import org.apache.parquet.format.Statistics;
+import org.apache.parquet.format.Type;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Type.Repetition;
+import org.apache.parquet.schema.Types;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.iceberg.parquet.ParquetValidationUtils.validateParquet;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.apache.parquet.format.Util.readFileMetaData;
+
+public final class ParquetMetadataReader
+{
+    private static final int PARQUET_METADATA_LENGTH = 4;
+    private static final byte[] MAGIC = "PAR1".getBytes(US_ASCII);
+
+    private ParquetMetadataReader() {}
+
+    public static ParquetMetadata readFooter(FileSystem fileSystem, Path file)
+            throws IOException
+    {
+        FileStatus fileStatus = fileSystem.getFileStatus(file);
+        try (FSDataInputStream inputStream = fileSystem.open(file)) {
+            // Parquet File Layout:
+            //
+            // MAGIC
+            // variable: Data
+            // variable: Metadata
+            // 4 bytes: MetadataLength
+
+            // MAGIC
+            long length = fileStatus.getLen();
+            validateParquet(length >= MAGIC.length + PARQUET_METADATA_LENGTH + MAGIC.length, "%s is not a valid Parquet File", file);
+            long metadataLengthIndex = length - PARQUET_METADATA_LENGTH - MAGIC.length;
+
+            inputStream.seek(metadataLengthIndex);
+            int metadataLength = readIntLittleEndian(inputStream);
+
+            byte[] magic = new byte[MAGIC.length];
+            inputStream.readFully(magic);
+            validateParquet(Arrays.equals(MAGIC, magic), "Not valid Parquet file: %s expected magic number: %s got: %s", file, Arrays.toString(MAGIC), Arrays.toString(magic));
+
+            long metadataIndex = metadataLengthIndex - metadataLength;
+            validateParquet(
+                    metadataIndex >= MAGIC.length && metadataIndex < metadataLengthIndex,
+                    "Corrupted Parquet file: %s metadata index: %s out of range",
+                    file,
+                    metadataIndex);
+            inputStream.seek(metadataIndex);
+            FileMetaData fileMetaData = readFileMetaData(inputStream);
+            List<SchemaElement> schema = fileMetaData.getSchema();
+            validateParquet(!schema.isEmpty(), "Empty Parquet schema in file: %s", file);
+
+            MessageType messageType = readParquetSchema(schema);
+            List<BlockMetaData> blocks = new ArrayList<>();
+            List<RowGroup> rowGroups = fileMetaData.getRow_groups();
+            if (rowGroups != null) {
+                for (RowGroup rowGroup : rowGroups) {
+                    BlockMetaData blockMetaData = new BlockMetaData();
+                    blockMetaData.setRowCount(rowGroup.getNum_rows());
+                    blockMetaData.setTotalByteSize(rowGroup.getTotal_byte_size());
+                    List<ColumnChunk> columns = rowGroup.getColumns();
+                    validateParquet(!columns.isEmpty(), "No columns in row group: %s", rowGroup);
+                    String filePath = columns.get(0).getFile_path();
+                    for (ColumnChunk columnChunk : columns) {
+                        validateParquet(
+                                (filePath == null && columnChunk.getFile_path() == null)
+                                        || (filePath != null && filePath.equals(columnChunk.getFile_path())),
+                                "all column chunks of the same row group must be in the same file");
+                        ColumnMetaData metaData = columnChunk.meta_data;
+                        String[] path = metaData.path_in_schema.toArray(new String[metaData.path_in_schema.size()]);
+                        ColumnPath columnPath = ColumnPath.get(path);
+                        ColumnChunkMetaData column = ColumnChunkMetaData.get(
+                                columnPath,
+                                messageType.getType(columnPath.toArray()).asPrimitiveType().getPrimitiveTypeName(),
+                                ParquetCompressionUtils.fromCompressionCodec(metaData.codec),
+                                readEncodings(metaData.encodings),
+                                readStats(metaData.statistics, messageType.getType(columnPath.toArray()).asPrimitiveType().getPrimitiveTypeName()),
+                                metaData.data_page_offset,
+                                metaData.dictionary_page_offset,
+                                metaData.num_values,
+                                metaData.total_compressed_size,
+                                metaData.total_uncompressed_size);
+                        blockMetaData.addColumn(column);
+                    }
+                    blockMetaData.setPath(filePath);
+                    blocks.add(blockMetaData);
+                }
+            }
+
+            Map<String, String> keyValueMetaData = new HashMap<>();
+            List<KeyValue> keyValueList = fileMetaData.getKey_value_metadata();
+            if (keyValueList != null) {
+                for (KeyValue keyValue : keyValueList) {
+                    keyValueMetaData.put(keyValue.key, keyValue.value);
+                }
+            }
+            return new ParquetMetadata(new org.apache.parquet.hadoop.metadata.FileMetaData(messageType, keyValueMetaData, fileMetaData.getCreated_by()), blocks);
+        }
+    }
+
+    private static MessageType readParquetSchema(List<SchemaElement> schema)
+    {
+        Iterator<SchemaElement> schemaIterator = schema.iterator();
+        SchemaElement rootSchema = schemaIterator.next();
+        Types.MessageTypeBuilder builder = Types.buildMessage();
+        readTypeSchema(builder, schemaIterator, rootSchema.getNum_children());
+        return builder.named(rootSchema.name);
+    }
+
+    private static void readTypeSchema(Types.GroupBuilder<?> builder, Iterator<SchemaElement> schemaIterator, int typeCount)
+    {
+        for (int i = 0; i < typeCount; i++) {
+            SchemaElement element = schemaIterator.next();
+            Types.Builder<?, ?> typeBuilder;
+            if (element.type == null) {
+                typeBuilder = builder.group(Repetition.valueOf(element.repetition_type.name()));
+                readTypeSchema((Types.GroupBuilder<?>) typeBuilder, schemaIterator, element.num_children);
+            }
+            else {
+                Types.PrimitiveBuilder<?> primitiveBuilder = builder.primitive(getTypeName(element.type), Repetition.valueOf(element.repetition_type.name()));
+                if (element.isSetType_length()) {
+                    primitiveBuilder.length(element.type_length);
+                }
+                if (element.isSetPrecision()) {
+                    primitiveBuilder.precision(element.precision);
+                }
+                if (element.isSetScale()) {
+                    primitiveBuilder.scale(element.scale);
+                }
+                typeBuilder = primitiveBuilder;
+            }
+
+            if (element.isSetConverted_type()) {
+                typeBuilder.as(getOriginalType(element.converted_type));
+            }
+            if (element.isSetField_id()) {
+                typeBuilder.id(element.field_id);
+            }
+            typeBuilder.named(element.name);
+        }
+    }
+
+    public static org.apache.parquet.column.statistics.Statistics<?> readStats(Statistics statistics, PrimitiveTypeName type)
+    {
+        org.apache.parquet.column.statistics.Statistics<?> stats = org.apache.parquet.column.statistics.Statistics.getStatsBasedOnType(type);
+        if (statistics != null) {
+            if (statistics.isSetMax() && statistics.isSetMin()) {
+                stats.setMinMaxFromBytes(statistics.min.array(), statistics.max.array());
+            }
+            stats.setNumNulls(statistics.null_count);
+        }
+        return stats;
+    }
+
+    private static Set<org.apache.parquet.column.Encoding> readEncodings(List<Encoding> encodings)
+    {
+        Set<org.apache.parquet.column.Encoding> columnEncodings = new HashSet<>();
+        for (Encoding encoding : encodings) {
+            columnEncodings.add(org.apache.parquet.column.Encoding.valueOf(encoding.name()));
+        }
+        return Collections.unmodifiableSet(columnEncodings);
+    }
+
+    private static PrimitiveTypeName getTypeName(Type type)
+    {
+        switch (type) {
+            case BYTE_ARRAY:
+                return PrimitiveTypeName.BINARY;
+            case INT64:
+                return PrimitiveTypeName.INT64;
+            case INT32:
+                return PrimitiveTypeName.INT32;
+            case BOOLEAN:
+                return PrimitiveTypeName.BOOLEAN;
+            case FLOAT:
+                return PrimitiveTypeName.FLOAT;
+            case DOUBLE:
+                return PrimitiveTypeName.DOUBLE;
+            case INT96:
+                return PrimitiveTypeName.INT96;
+            case FIXED_LEN_BYTE_ARRAY:
+                return PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+            default:
+                throw new IllegalArgumentException("Unknown type " + type);
+        }
+    }
+
+    private static OriginalType getOriginalType(ConvertedType type)
+    {
+        switch (type) {
+            case UTF8:
+                return OriginalType.UTF8;
+            case MAP:
+                return OriginalType.MAP;
+            case MAP_KEY_VALUE:
+                return OriginalType.MAP_KEY_VALUE;
+            case LIST:
+                return OriginalType.LIST;
+            case ENUM:
+                return OriginalType.ENUM;
+            case DECIMAL:
+                return OriginalType.DECIMAL;
+            case DATE:
+                return OriginalType.DATE;
+            case TIME_MILLIS:
+                return OriginalType.TIME_MILLIS;
+            case TIME_MICROS:
+                return OriginalType.TIME_MICROS;
+            case TIMESTAMP_MILLIS:
+                return OriginalType.TIMESTAMP_MILLIS;
+            case TIMESTAMP_MICROS:
+                return OriginalType.TIMESTAMP_MICROS;
+            case INTERVAL:
+                return OriginalType.INTERVAL;
+            case INT_8:
+                return OriginalType.INT_8;
+            case INT_16:
+                return OriginalType.INT_16;
+            case INT_32:
+                return OriginalType.INT_32;
+            case INT_64:
+                return OriginalType.INT_64;
+            case UINT_8:
+                return OriginalType.UINT_8;
+            case UINT_16:
+                return OriginalType.UINT_16;
+            case UINT_32:
+                return OriginalType.UINT_32;
+            case UINT_64:
+                return OriginalType.UINT_64;
+            case JSON:
+                return OriginalType.JSON;
+            case BSON:
+                return OriginalType.BSON;
+            default:
+                throw new IllegalArgumentException("Unknown converted type " + type);
+        }
+    }
+
+    private static int readIntLittleEndian(InputStream in)
+            throws IOException
+    {
+        int ch1 = in.read();
+        int ch2 = in.read();
+        int ch3 = in.read();
+        int ch4 = in.read();
+        if ((ch1 | ch2 | ch3 | ch4) < 0) {
+            throw new EOFException();
+        }
+        return ((ch4 << 24) + (ch3 << 16) + (ch2 << 8) + (ch1));
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetPageReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetPageReader.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.ParquetDataPage;
+import com.facebook.presto.iceberg.parquet.ParquetDataPageV1;
+import com.facebook.presto.iceberg.parquet.ParquetDataPageV2;
+import com.facebook.presto.iceberg.parquet.ParquetDictionaryPage;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.facebook.presto.iceberg.parquet.ParquetCompressionUtils.decompress;
+import static java.lang.Math.toIntExact;
+
+class ParquetPageReader
+{
+    private final CompressionCodecName codec;
+    private final long valueCount;
+    private final List<ParquetDataPage> compressedPages;
+    private final ParquetDictionaryPage compressedDictionaryPage;
+
+    public ParquetPageReader(CompressionCodecName codec,
+            List<ParquetDataPage> compressedPages,
+            ParquetDictionaryPage compressedDictionaryPage)
+    {
+        this.codec = codec;
+        this.compressedPages = new LinkedList<>(compressedPages);
+        this.compressedDictionaryPage = compressedDictionaryPage;
+        int count = 0;
+        for (ParquetDataPage page : compressedPages) {
+            count += page.getValueCount();
+        }
+        this.valueCount = count;
+    }
+
+    public long getTotalValueCount()
+    {
+        return valueCount;
+    }
+
+    public ParquetDataPage readPage()
+    {
+        if (compressedPages.isEmpty()) {
+            return null;
+        }
+        ParquetDataPage compressedPage = compressedPages.remove(0);
+        try {
+            if (compressedPage instanceof ParquetDataPageV1) {
+                ParquetDataPageV1 dataPageV1 = (ParquetDataPageV1) compressedPage;
+                return new ParquetDataPageV1(
+                        decompress(codec, dataPageV1.getSlice(), dataPageV1.getUncompressedSize()),
+                        dataPageV1.getValueCount(),
+                        dataPageV1.getUncompressedSize(),
+                        dataPageV1.getStatistics(),
+                        dataPageV1.getRepetitionLevelEncoding(),
+                        dataPageV1.getDefinitionLevelEncoding(),
+                        dataPageV1.getValueEncoding());
+            }
+            else {
+                ParquetDataPageV2 dataPageV2 = (ParquetDataPageV2) compressedPage;
+                if (!dataPageV2.isCompressed()) {
+                    return dataPageV2;
+                }
+                int uncompressedSize = toIntExact(dataPageV2.getUncompressedSize()
+                        - dataPageV2.getDefinitionLevels().length()
+                        - dataPageV2.getRepetitionLevels().length());
+                return new ParquetDataPageV2(
+                        dataPageV2.getRowCount(),
+                        dataPageV2.getNullCount(),
+                        dataPageV2.getValueCount(),
+                        dataPageV2.getRepetitionLevels(),
+                        dataPageV2.getDefinitionLevels(),
+                        dataPageV2.getDataEncoding(),
+                        decompress(codec, dataPageV2.getSlice(), uncompressedSize),
+                        dataPageV2.getUncompressedSize(),
+                        dataPageV2.getStatistics(),
+                        false);
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Could not decompress page", e);
+        }
+    }
+
+    public ParquetDictionaryPage readDictionaryPage()
+    {
+        if (compressedDictionaryPage == null) {
+            return null;
+        }
+        try {
+            return new ParquetDictionaryPage(
+                    decompress(codec, compressedDictionaryPage.getSlice(), compressedDictionaryPage.getUncompressedSize()),
+                    compressedDictionaryPage.getDictionarySize(),
+                    compressedDictionaryPage.getEncoding());
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Error reading dictionary page", e);
+        }
+    }
+
+    public boolean available()
+    {
+        return !compressedPages.isEmpty();
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetReader.java
@@ -1,0 +1,446 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.ParquetCorruptionException;
+import com.facebook.presto.iceberg.parquet.ParquetDataSource;
+import com.facebook.presto.iceberg.parquet.RichColumnDescriptor;
+import com.facebook.presto.iceberg.parquet.memory.AggregatedMemoryContext;
+import com.facebook.presto.iceberg.parquet.memory.LocalMemoryContext;
+import com.facebook.presto.spi.block.ArrayBlock;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.RowBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.NamedTypeSignature;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.TypeSignatureParameter;
+import it.unimi.dsi.fastutil.booleans.BooleanArrayList;
+import it.unimi.dsi.fastutil.booleans.BooleanList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.io.PrimitiveColumnIO;
+import org.apache.parquet.schema.MessageType;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.iceberg.parquet.ParquetTypeUtils.getColumns;
+import static com.facebook.presto.iceberg.parquet.ParquetTypeUtils.getDescriptor;
+import static com.facebook.presto.iceberg.parquet.ParquetTypeUtils.isValueNull;
+import static com.facebook.presto.iceberg.parquet.ParquetValidationUtils.validateParquet;
+import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
+import static com.facebook.presto.spi.type.StandardTypes.MAP;
+import static com.facebook.presto.spi.type.StandardTypes.ROW;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+
+public class ParquetReader
+        implements Closeable
+{
+    private static final int MAX_VECTOR_LENGTH = 1024;
+
+    private final MessageType fileSchema;
+    private final MessageType requestedSchema;
+    private final List<BlockMetaData> blocks;
+    private final ParquetDataSource dataSource;
+    private final TypeManager typeManager;
+
+    private int currentBlock;
+    private BlockMetaData currentBlockMetadata;
+    private long currentPosition;
+    private long currentGroupRowCount;
+    private long nextRowInGroup;
+    private int batchSize;
+    private final Map<ColumnDescriptor, ParquetColumnReader> columnReadersMap = new HashMap<>();
+
+    private AggregatedMemoryContext currentRowGroupMemoryContext;
+    private final AggregatedMemoryContext systemMemoryContext;
+
+    public ParquetReader(MessageType fileSchema,
+            MessageType requestedSchema,
+            List<BlockMetaData> blocks,
+            ParquetDataSource dataSource,
+            TypeManager typeManager,
+            AggregatedMemoryContext systemMemoryContext)
+    {
+        this.fileSchema = fileSchema;
+        this.requestedSchema = requestedSchema;
+        this.blocks = blocks;
+        this.dataSource = dataSource;
+        this.typeManager = typeManager;
+        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
+        this.currentRowGroupMemoryContext = systemMemoryContext.newAggregatedMemoryContext();
+        initializeColumnReaders();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        currentRowGroupMemoryContext.close();
+        dataSource.close();
+    }
+
+    public long getPosition()
+    {
+        return currentPosition;
+    }
+
+    public int nextBatch()
+    {
+        if (nextRowInGroup >= currentGroupRowCount && !advanceToNextRowGroup()) {
+            return -1;
+        }
+
+        batchSize = toIntExact(min(MAX_VECTOR_LENGTH, currentGroupRowCount - nextRowInGroup));
+
+        nextRowInGroup += batchSize;
+        currentPosition += batchSize;
+        for (PrimitiveColumnIO columnIO : getColumns(fileSchema, requestedSchema)) {
+            ColumnDescriptor descriptor = columnIO.getColumnDescriptor();
+            RichColumnDescriptor column = new RichColumnDescriptor(descriptor.getPath(), columnIO.getType().asPrimitiveType(), descriptor.getMaxRepetitionLevel(), descriptor.getMaxDefinitionLevel());
+            ParquetColumnReader columnReader = columnReadersMap.get(column);
+            columnReader.prepareNextRead(batchSize);
+        }
+        return batchSize;
+    }
+
+    private boolean advanceToNextRowGroup()
+    {
+        currentRowGroupMemoryContext.close();
+        currentRowGroupMemoryContext = systemMemoryContext.newAggregatedMemoryContext();
+
+        if (currentBlock == blocks.size()) {
+            return false;
+        }
+        currentBlockMetadata = blocks.get(currentBlock);
+        currentBlock = currentBlock + 1;
+
+        nextRowInGroup = 0L;
+        currentGroupRowCount = currentBlockMetadata.getRowCount();
+        columnReadersMap.clear();
+        initializeColumnReaders();
+        return true;
+    }
+
+    public Block readArray(Type type, List<String> path)
+            throws IOException
+    {
+        return readArray(type, path, new IntArrayList(), new IntArrayList());
+    }
+
+    private Block readArray(Type type, List<String> path, IntList definitionLevels, IntList repetitionLevels)
+            throws IOException
+    {
+        List<Type> parameters = type.getTypeParameters();
+        checkArgument(parameters.size() == 1, "Arrays must have a single type parameter, found %d", parameters.size());
+        final List<String[]> matchingPath = findMatchingPath(path);
+        checkArgument(matchingPath.size() >= 1, "Arrays must have at least one matching path, none found for path = %s, requestedSchema=%s", Arrays.toString(path.toArray()), requestedSchema);
+        final String arrayTypeName = matchingPath.get(0)[path.size()];
+        path.add(arrayTypeName);
+        Type elementType = parameters.get(0);
+        Block block = readBlock(matchingPath.get(0)[path.size()], elementType, path, definitionLevels, repetitionLevels);
+        path.remove(path.lastIndexOf(arrayTypeName));
+        IntList offsets = new IntArrayList();
+        BooleanList valueIsNull = new BooleanArrayList();
+        calculateCollectionOffsets(toArray(path), offsets, valueIsNull, definitionLevels, repetitionLevels);
+        return ArrayBlock.fromElementBlock(valueIsNull.size(), Optional.of(valueIsNull.toBooleanArray()), offsets.toIntArray(), block);
+    }
+
+    public List<String[]> findMatchingPath(List<String> processingPath)
+    {
+        final List<String[]> schemaPaths = requestedSchema.getPaths();
+        return schemaPaths.stream().filter(paths -> paths.length > processingPath.size() && Arrays.equals(Arrays.copyOf(paths, processingPath.size()), processingPath.toArray())).collect(Collectors.toList());
+    }
+
+    public Block readMap(Type type, List<String> path)
+            throws IOException
+    {
+        return readMap(type, path, new IntArrayList(), new IntArrayList());
+    }
+
+    private Block readMap(Type type, List<String> path, IntList definitionLevels, IntList repetitionLevels)
+            throws IOException
+    {
+        List<Type> parameters = type.getTypeParameters();
+        checkArgument(parameters.size() == 2, "Maps must have two type parameters, found %d", parameters.size());
+        Block[] blocks = new Block[parameters.size()];
+
+        IntList keyDefinitionLevels = new IntArrayList();
+        IntList keyRepetitionLevels = new IntArrayList();
+        final List<String[]> matchingPath = findMatchingPath(path);
+        checkArgument(matchingPath.size() >= 2, "Maps must have at least two matching paths, none found for path = %s, requestedSchema=%s", Arrays.toString(path.toArray()), requestedSchema);
+        final String mapTypeName = matchingPath.get(0)[path.size()];
+        path.add(mapTypeName);
+        final int size = path.size();
+        blocks[0] = readBlock(matchingPath.get(0)[size], parameters.get(0), path, keyDefinitionLevels, keyRepetitionLevels);
+        blocks[1] = readBlock(matchingPath.get(1)[size], parameters.get(1), path, new IntArrayList(), new IntArrayList());
+        path.remove(path.lastIndexOf(mapTypeName));
+        definitionLevels.addAll(keyDefinitionLevels);
+        repetitionLevels.addAll(keyRepetitionLevels);
+        IntList offsets = new IntArrayList();
+        BooleanList valueIsNull = new BooleanArrayList();
+        calculateCollectionOffsets(toArray(path), offsets, valueIsNull, keyDefinitionLevels, keyRepetitionLevels);
+        return ((MapType) type).createBlockFromKeyValue(Optional.of(valueIsNull.toBooleanArray()), offsets.toIntArray(), blocks[0], blocks[1]);
+    }
+
+    public Block readStruct(Type type, List<String> path)
+            throws IOException
+    {
+        return readStruct(type, path, new IntArrayList(), new IntArrayList());
+    }
+
+    private Block readStruct(Type type, List<String> path, IntList structDefinitionLevels, IntList structRepetitionLevels)
+            throws IOException
+    {
+        List<TypeSignatureParameter> fields = type.getTypeSignature().getParameters();
+        Block[] blocks = new Block[fields.size()];
+        IntList fieldDefinitionLevels = null;
+        IntList fieldRepetitionLevels = null;
+        for (int i = 0; i < fields.size(); i++) {
+            fieldDefinitionLevels = new IntArrayList();
+            fieldRepetitionLevels = new IntArrayList();
+            NamedTypeSignature namedTypeSignature = fields.get(i).getNamedTypeSignature();
+            Type fieldType = typeManager.getType(namedTypeSignature.getTypeSignature());
+            String name = namedTypeSignature.getName().get();
+            blocks[i] = readBlock(name, fieldType, path, fieldDefinitionLevels, fieldRepetitionLevels);
+        }
+        BooleanList structIsNull = new BooleanArrayList();
+        IntList structOffsets = new IntArrayList();
+        calculateStructOffsets(toArray(path), structOffsets, structIsNull, structDefinitionLevels, structRepetitionLevels, fieldDefinitionLevels, fieldRepetitionLevels);
+        return RowBlock.fromFieldBlocks(structIsNull.size(), Optional.of(structIsNull.toBooleanArray()), blocks);
+    }
+
+    /**
+     * Each struct has three variants of presence:
+     * 1) Struct is not defined, because one of it's optional parent fields is null
+     * 2) Struct is null
+     * 3) Struct is defined and not empty. In this case offset value is increased by one.
+     * <p>
+     * One of the struct's field repetition/definition levels are used to calculate offsets of the struct.
+     */
+    private void calculateStructOffsets(
+            String[] path,
+            IntList structOffsets,
+            BooleanList structIsNull,
+            IntList structDefinitionLevels,
+            IntList structRepetitionLevels,
+            IntList fieldDefinitionLevels,
+            IntList fieldRepetitionLevels)
+    {
+        int offset = 0;
+        structOffsets.add(offset);
+        if (fieldDefinitionLevels != null) {
+            int maxDefinitionLevel = getMaxDefinitionLevel(path);
+            int maxRepetitionLevel = getMaxRepetitionLevel(path);
+            for (int i = 0; i < fieldDefinitionLevels.size(); i++) {
+                if (fieldRepetitionLevels.get(i) <= maxRepetitionLevel) {
+                    if (isValueNull(isRequired(path), fieldDefinitionLevels.get(i), maxDefinitionLevel)) {
+                        // Struct is null
+                        structIsNull.add(true);
+                        structOffsets.add(offset);
+                    }
+                    else if (fieldDefinitionLevels.get(i) >= maxDefinitionLevel) {
+                        // Struct is defined and not empty
+                        structIsNull.add(false);
+                        offset++;
+                        structOffsets.add(offset);
+                    }
+                }
+            }
+            structDefinitionLevels.addAll(fieldDefinitionLevels);
+            structRepetitionLevels.addAll(fieldRepetitionLevels);
+        }
+    }
+
+    /**
+     * Each collection (Array or Map) has four variants of presence:
+     * 1) Collection is not defined, because one of it's optional parent fields is null
+     * 2) Collection is null
+     * 3) Collection is defined but empty
+     * 4) Collection is defined and not empty. In this case offset value is increased by the number of elements in that collection
+     */
+    private void calculateCollectionOffsets(String[] path, IntList offsets, BooleanList collectionIsNull, IntList definitionLevels, IntList repetitionLevels)
+    {
+        int maxDefinitionLevel = getMaxDefinitionLevel(path);
+        int maxElementRepetitionLevel = getMaxRepetitionLevel(path) + 1;
+        int offset = 0;
+        offsets.add(offset);
+        for (int i = 0; i < definitionLevels.size(); i = getNextCollectionStartIndex(repetitionLevels, maxElementRepetitionLevel, i)) {
+            if (isValueNull(isRequired(path), definitionLevels.get(i), maxDefinitionLevel)) {
+                //Collection is null
+                collectionIsNull.add(true);
+                offsets.add(offset);
+            }
+            else if (definitionLevels.get(i) == maxDefinitionLevel) {
+                // Collection is defined but empty
+                collectionIsNull.add(false);
+                offsets.add(offset);
+            }
+            else if (definitionLevels.get(i) > maxDefinitionLevel) {
+                //Collection is defined and not empty
+                collectionIsNull.add(false);
+                offset += getCollectionSize(repetitionLevels, maxElementRepetitionLevel, i + 1);
+                offsets.add(offset);
+            }
+        }
+    }
+
+    private int getNextCollectionStartIndex(IntList repetitionLevels, int maxRepetitionLevel, int elementIndex)
+    {
+        do {
+            elementIndex++;
+        }
+        while (hasMoreElements(repetitionLevels, elementIndex) && !isCollectionBeginningMarker(repetitionLevels, maxRepetitionLevel, elementIndex));
+        return elementIndex;
+    }
+
+    private int getCollectionSize(IntList repetitionLevels, int maxRepetitionLevel, int nextIndex)
+    {
+        int size = 1; // taking into account, that the method is called for not empty collections only
+        while (hasMoreElements(repetitionLevels, nextIndex) && !isCollectionBeginningMarker(repetitionLevels, maxRepetitionLevel, nextIndex)) {
+            //Collection elements can be not primitive.
+            //Counting only elements which belong to current collection, skipping inner elements of nested collections/structs
+            if (repetitionLevels.get(nextIndex) <= maxRepetitionLevel) {
+                size++;
+            }
+            nextIndex++;
+        }
+        return size;
+    }
+
+    private boolean isCollectionBeginningMarker(IntList repetitionLevels, int maxRepetitionLevel, int nextIndex)
+    {
+        return repetitionLevels.get(nextIndex) < maxRepetitionLevel;
+    }
+
+    private boolean hasMoreElements(IntList repetitionLevels, int nextIndex)
+    {
+        return nextIndex < repetitionLevels.size();
+    }
+
+    public Block readPrimitive(ColumnDescriptor columnDescriptor, Type type)
+            throws IOException
+    {
+        return readPrimitive(columnDescriptor, type, new IntArrayList(), new IntArrayList());
+    }
+
+    private Block readPrimitive(ColumnDescriptor columnDescriptor, Type type, IntList definitionLevels, IntList repetitionLevels)
+            throws IOException
+    {
+        ParquetColumnReader columnReader = columnReadersMap.get(columnDescriptor);
+        if (columnReader.getPageReader() == null) {
+            validateParquet(currentBlockMetadata.getRowCount() > 0, "Row group has 0 rows");
+            ColumnChunkMetaData metadata = getColumnChunkMetaData(columnDescriptor);
+            long startingPosition = metadata.getStartingPos();
+            int totalSize = toIntExact(metadata.getTotalSize());
+            byte[] buffer = allocateBlock(totalSize);
+            dataSource.readFully(startingPosition, buffer);
+            ParquetColumnChunkDescriptor descriptor = new ParquetColumnChunkDescriptor(columnDescriptor, metadata, totalSize);
+            ParquetColumnChunk columnChunk = new ParquetColumnChunk(descriptor, buffer, 0);
+            columnReader.setPageReader(columnChunk.readAllPages());
+        }
+        return columnReader.readPrimitive(type, definitionLevels, repetitionLevels);
+    }
+
+    private byte[] allocateBlock(int length)
+    {
+        byte[] buffer = new byte[length];
+        LocalMemoryContext blockMemoryContext = currentRowGroupMemoryContext.newLocalMemoryContext();
+        blockMemoryContext.setBytes(buffer.length);
+        return buffer;
+    }
+
+    private ColumnChunkMetaData getColumnChunkMetaData(ColumnDescriptor columnDescriptor)
+            throws IOException
+    {
+        for (ColumnChunkMetaData metadata : currentBlockMetadata.getColumns()) {
+            if (metadata.getPath().equals(ColumnPath.get(columnDescriptor.getPath()))) {
+                return metadata;
+            }
+        }
+        throw new ParquetCorruptionException("Metadata is missing for column: %s", columnDescriptor);
+    }
+
+    private void initializeColumnReaders()
+    {
+        for (PrimitiveColumnIO columnIO : getColumns(fileSchema, requestedSchema)) {
+            ColumnDescriptor descriptor = columnIO.getColumnDescriptor();
+            RichColumnDescriptor column = new RichColumnDescriptor(descriptor.getPath(), columnIO.getType().asPrimitiveType(), descriptor.getMaxRepetitionLevel(), descriptor.getMaxDefinitionLevel());
+            columnReadersMap.put(column, ParquetColumnReader.createReader(column));
+        }
+    }
+
+    private Block readBlock(String name, Type type, List<String> path, IntList definitionLevels, IntList repetitionLevels)
+            throws IOException
+    {
+        path.add(name);
+        Optional<RichColumnDescriptor> descriptor = getDescriptor(fileSchema, requestedSchema, path);
+        if (!descriptor.isPresent()) {
+            path.remove(path.lastIndexOf(name));
+            return RunLengthEncodedBlock.create(type, null, batchSize);
+        }
+
+        Block block;
+        if (ROW.equals(type.getTypeSignature().getBase())) {
+            block = readStruct(type, path, definitionLevels, repetitionLevels);
+        }
+        else if (MAP.equals(type.getTypeSignature().getBase())) {
+            block = readMap(type, path, definitionLevels, repetitionLevels);
+        }
+        else if (ARRAY.equals(type.getTypeSignature().getBase())) {
+            block = readArray(type, path, definitionLevels, repetitionLevels);
+        }
+        else {
+            block = readPrimitive(descriptor.get(), type, definitionLevels, repetitionLevels);
+        }
+        path.remove(path.lastIndexOf(name));
+        return block;
+    }
+
+    private String[] toArray(List<String> list)
+    {
+        return list.toArray(new String[list.size()]);
+    }
+
+    private int getMaxDefinitionLevel(String... path)
+    {
+        return requestedSchema.getMaxDefinitionLevel(path);
+    }
+
+    private int getMaxRepetitionLevel(String... path)
+    {
+        return requestedSchema.getMaxRepetitionLevel(path);
+    }
+
+    private boolean isRequired(String... path)
+    {
+        return requestedSchema.getType(path).getRepetition() == REQUIRED;
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetShortDecimalColumnReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetShortDecimalColumnReader.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.RichColumnDescriptor;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.Type;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+
+import static com.facebook.presto.hive.util.DecimalUtils.getShortDecimalValue;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+
+public class ParquetShortDecimalColumnReader
+        extends ParquetColumnReader
+{
+    ParquetShortDecimalColumnReader(RichColumnDescriptor descriptor)
+    {
+        super(descriptor);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type type)
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            long decimalValue;
+            if (columnDescriptor.getType().equals(INT32)) {
+                HiveDecimalWritable hiveDecimalWritable = new HiveDecimalWritable(HiveDecimal.create(valuesReader.readInteger()));
+                decimalValue = getShortDecimalValue(hiveDecimalWritable, ((DecimalType) type).getScale());
+            }
+            else if (columnDescriptor.getType().equals(INT64)) {
+                HiveDecimalWritable hiveDecimalWritable = new HiveDecimalWritable(HiveDecimal.create(valuesReader.readLong()));
+                decimalValue = getShortDecimalValue(hiveDecimalWritable, ((DecimalType) type).getScale());
+            }
+            else {
+                decimalValue = getShortDecimalValue(valuesReader.readBytes().getBytes());
+            }
+            type.writeLong(blockBuilder, decimalValue);
+        }
+        else if (isValueNull()) {
+            blockBuilder.appendNull();
+        }
+    }
+
+    @Override
+    protected void skipValue()
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            if (columnDescriptor.getType().equals(INT32)) {
+                valuesReader.readInteger();
+            }
+            else if (columnDescriptor.getType().equals(INT64)) {
+                valuesReader.readLong();
+            }
+            else {
+                valuesReader.readBytes();
+            }
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetTimestampColumnReader.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/reader/ParquetTimestampColumnReader.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.reader;
+
+import com.facebook.presto.iceberg.parquet.RichColumnDescriptor;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+import org.apache.parquet.io.api.Binary;
+
+import static com.facebook.presto.iceberg.parquet.ParquetTimestampUtils.getTimestampMillis;
+
+public class ParquetTimestampColumnReader
+        extends ParquetColumnReader
+{
+    public ParquetTimestampColumnReader(RichColumnDescriptor descriptor)
+    {
+        super(descriptor);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type type)
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            Binary binary = valuesReader.readBytes();
+            type.writeLong(blockBuilder, getTimestampMillis(binary));
+        }
+        else if (isValueNull()) {
+            blockBuilder.appendNull();
+        }
+    }
+
+    @Override
+    protected void skipValue()
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            valuesReader.readBytes();
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/writer/PrestoWriteSupport.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/parquet/writer/PrestoWriteSupport.java
@@ -1,0 +1,477 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.parquet.writer;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.iceberg.type.TypeConveter;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.type.DateType;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.Decimals;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.RealType;
+import com.facebook.presto.spi.type.RowType;
+import com.facebook.presto.spi.type.SqlDecimal;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.VarbinaryType;
+import com.facebook.presto.spi.type.VarcharType;
+import com.netflix.iceberg.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.hadoop.api.WriteSupport;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.RecordConsumer;
+import org.apache.parquet.schema.MessageType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.iceberg.type.TypeConveter.convert;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.toIntExact;
+import static java.util.Collections.EMPTY_MAP;
+import static java.util.stream.Collectors.toList;
+
+public class PrestoWriteSupport
+        extends WriteSupport<Page>
+{
+    // The page is ordered based on the hive column order.
+    private final List<HiveColumnHandle> columns;
+    private final MessageType schema;
+    private final TypeManager typeManager;
+    private final ConnectorSession session;
+    private final Schema icebergSchema;
+    private final List<ColumnWriter> writers;
+
+    private RecordConsumer recordConsumer;
+
+    public PrestoWriteSupport(List<HiveColumnHandle> columns, MessageType schema, Schema icebergSchema, TypeManager typeManager, ConnectorSession session)
+    {
+        this.columns = columns;
+        this.schema = schema;
+        this.typeManager = typeManager;
+        this.session = session;
+        this.icebergSchema = icebergSchema;
+        this.writers = getPrestoType(columns).stream().map(t -> getWriter(t)).collect(toList());
+    }
+
+    @Override
+    public WriteContext init(Configuration configuration)
+    {
+        return new WriteContext(schema, EMPTY_MAP);
+    }
+
+    @Override
+    public void prepareForWrite(RecordConsumer recordConsumer)
+    {
+        this.recordConsumer = recordConsumer;
+    }
+
+    @Override
+    public void write(Page page)
+    {
+        final int numRows = page.getPositionCount();
+        for (int rowNum = 0; rowNum < numRows; rowNum++) {
+            recordConsumer.startMessage();
+            for (int columnIndex = 0; columnIndex < page.getChannelCount(); columnIndex++) {
+                final Block block = page.getBlock(columnIndex);
+                if (!block.isNull(rowNum)) {
+                    consumeField(columns.get(columnIndex).getName(), columnIndex, writers.get(columnIndex), block, rowNum);
+                }
+            }
+            recordConsumer.endMessage();
+        }
+    }
+
+    public List<Type> getPrestoType(List<HiveColumnHandle> columns)
+    {
+        return columns.stream().map(col -> convert(icebergSchema.findType(col.getName()), typeManager)).collect(toList());
+    }
+
+    private interface ColumnWriter
+    {
+        void write(Block block, int rownum);
+
+        void write(Object obj);
+    }
+
+    // TODO instead of Type.get***() method we can use com.facebook.presto.spi.type.TypeUtils.readNativeValue
+    private class IntWriter
+            implements ColumnWriter
+    {
+        @Override
+        public void write(Block block, int rownum)
+        {
+            write(toIntExact(IntegerType.INTEGER.getLong(block, rownum)));
+        }
+
+        @Override
+        public void write(Object obj)
+        {
+            recordConsumer.addInteger((Integer) obj);
+        }
+    }
+
+    private class BooleanWriter
+            implements ColumnWriter
+    {
+        @Override
+        public void write(Block block, int rownum)
+        {
+            write(BooleanType.BOOLEAN.getBoolean(block, rownum));
+        }
+
+        @Override
+        public void write(Object obj)
+        {
+            recordConsumer.addBoolean((Boolean) obj);
+        }
+    }
+
+    private class LongWriter
+            implements ColumnWriter
+    {
+        @Override
+        public void write(Block block, int rownum)
+        {
+            write(BigintType.BIGINT.getLong(block, rownum));
+        }
+
+        @Override
+        public void write(Object obj)
+        {
+            recordConsumer.addLong((Long) obj);
+        }
+    }
+
+    private class BinaryWriter
+            implements ColumnWriter
+    {
+        @Override
+        public void write(Block block, int rownum)
+        {
+            write(VarbinaryType.VARBINARY.getSlice(block, rownum).getBytes());
+        }
+
+        @Override
+        public void write(Object obj)
+        {
+            recordConsumer.addBinary(Binary.fromConstantByteArray((byte[]) obj));
+        }
+    }
+
+    private class FloatWriter
+            implements ColumnWriter
+    {
+        @Override
+        public void write(Block block, int rownum)
+        {
+            write(intBitsToFloat((int) RealType.REAL.getLong(block, rownum)));
+        }
+
+        @Override
+        public void write(Object obj)
+        {
+            recordConsumer.addFloat((Float) obj);
+        }
+    }
+
+    private class DoubleWriter
+            implements ColumnWriter
+    {
+        @Override
+        public void write(Block block, int rownum)
+        {
+            write(DoubleType.DOUBLE.getDouble(block, rownum));
+        }
+
+        @Override
+        public void write(Object obj)
+        {
+            recordConsumer.addDouble((Double) obj);
+        }
+    }
+
+    private class StringWriter
+            implements ColumnWriter
+    {
+        @Override
+        public void write(Block block, int rownum)
+        {
+            write(VarcharType.VARCHAR.getObjectValue(session, block, rownum));
+        }
+
+        @Override
+        public void write(Object obj)
+        {
+            recordConsumer.addBinary(Binary.fromReusedByteArray(((String) obj).getBytes()));
+        }
+    }
+
+    private class DateWriter
+            implements ColumnWriter
+    {
+        @Override
+        public void write(Block block, int rownum)
+        {
+            write(DateType.DATE.getLong(block, rownum));
+        }
+
+        @Override
+        public void write(Object obj)
+        {
+            recordConsumer.addLong((Long) obj);
+        }
+    }
+
+    private class TimeStampWriter
+            implements ColumnWriter
+    {
+        @Override
+        public void write(Block block, int rownum)
+        {
+            write(TimestampType.TIMESTAMP.getLong(block, rownum));
+        }
+
+        @Override
+        public void write(Object obj)
+        {
+            recordConsumer.addLong((Long) obj);
+        }
+    }
+
+    private class DecimalWriter
+            implements ColumnWriter
+    {
+        private static final int MAX_INT_PRECISION = 8;
+        private final DecimalType decimalType;
+
+        public DecimalWriter(DecimalType decimalType)
+        {
+            this.decimalType = decimalType;
+        }
+
+        @Override
+        public void write(Block block, int rownum)
+        {
+            write(decimalType.getObjectValue(session, block, rownum));
+        }
+
+        @Override
+        public void write(Object obj)
+        {
+            final SqlDecimal sqlDecimal = (SqlDecimal) obj;
+            if (decimalType.getPrecision() <= MAX_INT_PRECISION) {
+                recordConsumer.addInteger(sqlDecimal.getUnscaledValue().intValueExact());
+            }
+            else if (decimalType.getPrecision() <= Decimals.MAX_SHORT_PRECISION) {
+                recordConsumer.addLong(sqlDecimal.getUnscaledValue().longValueExact());
+            }
+            else {
+                recordConsumer.addBinary(Binary.fromReusedByteArray(sqlDecimal.getUnscaledValue().toByteArray()));
+            }
+        }
+    }
+
+    private class ListWriter
+            implements ColumnWriter
+    {
+        private final ArrayType arrayType;
+        private final ColumnWriter baseTypeWriter;
+
+        private ListWriter(ArrayType arrayType)
+        {
+            this.arrayType = arrayType;
+            this.baseTypeWriter = getWriter(arrayType.getElementType());
+        }
+
+        @Override
+        public void write(Block block, int rownum)
+        {
+            final List<Object> elements = (List<Object>) arrayType.getObjectValue(session, block, rownum);
+            write(elements.toArray());
+        }
+
+        @Override
+        public void write(Object arr)
+        {
+            Object[] elements = (Object[]) arr;
+            recordConsumer.startGroup();
+            if (elements != null && elements.length != 0) {
+                recordConsumer.startField("list", 0);
+                for (int i = 0; i < elements.length; i++) {
+                    recordConsumer.startGroup();
+                    if (elements[i] != null) {
+                        consumeField("element", 0, baseTypeWriter, elements[i]);
+                    }
+                    recordConsumer.endGroup();
+                }
+                recordConsumer.endField("list", 0);
+            }
+            recordConsumer.endGroup();
+        }
+    }
+
+    private class MapWriter
+            implements ColumnWriter
+    {
+        private final MapType mapType;
+        private final ColumnWriter keyWriter;
+        private final ColumnWriter valueWriter;
+
+        private MapWriter(MapType mapType)
+        {
+            this.mapType = mapType;
+            this.keyWriter = getWriter(mapType.getKeyType());
+            this.valueWriter = getWriter(mapType.getValueType());
+        }
+
+        @Override
+        public void write(Block block, int rownum)
+        {
+            write(this.mapType.getObjectValue(session, block, rownum));
+        }
+
+        @Override
+        public void write(Object obj)
+        {
+            Map map = (Map) obj;
+            recordConsumer.startGroup();
+            if (map != null && map.size() != 0) {
+                recordConsumer.startField("key_value", 0);
+                int i = 0;
+                for (Object entry : map.entrySet()) {
+                    recordConsumer.startGroup();
+                    consumeField("key", 0, keyWriter, ((Map.Entry) entry).getKey());
+
+                    if (((Map.Entry) entry).getValue() != null) {
+                        consumeField("value", 1, valueWriter, ((Map.Entry) entry).getValue());
+                    }
+                    i++;
+                    recordConsumer.endGroup();
+                }
+                recordConsumer.endField("key_value", 0);
+            }
+            recordConsumer.endGroup();
+        }
+    }
+
+    private class RowWriter
+            implements ColumnWriter
+    {
+        private final List<ColumnWriter> columnWriters;
+        private final RowType rowType;
+
+        private RowWriter(RowType rowType)
+        {
+            this.rowType = rowType;
+            this.columnWriters = rowType.getFields().stream().map(f -> getWriter(f.getType())).collect(toList());
+        }
+
+        @Override
+        public void write(Block block, int rownum)
+        {
+            write(rowType.getObjectValue(session, block, rownum));
+        }
+
+        @Override
+        public void write(Object obj)
+        {
+            List<Object> fields = (List<Object>) obj;
+            recordConsumer.startGroup();
+            for (int i = 0; i < fields.size(); i++) {
+                final String name = rowType.getFields().get(i).getName().orElseThrow(() -> new IllegalArgumentException("parquet requires row type fields to have names"));
+                if (fields.get(i) != null) {
+                    consumeField(name, i, columnWriters.get(i), fields.get(i));
+                }
+            }
+            recordConsumer.endGroup();
+        }
+    }
+
+    private void consumeGroup(ColumnWriter writer, Block block, int rowNum)
+    {
+        recordConsumer.startGroup();
+        writer.write(block, rowNum);
+        recordConsumer.endGroup();
+    }
+
+    private void consumeGroup(ColumnWriter writer, Object value)
+    {
+        recordConsumer.startGroup();
+        writer.write(value);
+        recordConsumer.endGroup();
+    }
+
+    private void consumeField(String fieldName, int index, ColumnWriter writer, Block block, int rowNum)
+    {
+        recordConsumer.startField(fieldName, index);
+        writer.write(block, rowNum);
+        recordConsumer.endField(fieldName, index);
+    }
+
+    private void consumeField(String fieldName, int index, ColumnWriter writer, Object value)
+    {
+        recordConsumer.startField(fieldName, index);
+        writer.write(value);
+        recordConsumer.endField(fieldName, index);
+    }
+
+    private Map<Type, ColumnWriter> writerMap = new HashMap()
+    {{
+            put(com.netflix.iceberg.types.Type.TypeID.BOOLEAN, new BooleanWriter());
+            put(com.netflix.iceberg.types.Type.TypeID.LONG, new LongWriter());
+            put(com.netflix.iceberg.types.Type.TypeID.FLOAT, new FloatWriter());
+            put(com.netflix.iceberg.types.Type.TypeID.DOUBLE, new DoubleWriter());
+            put(com.netflix.iceberg.types.Type.TypeID.INTEGER, new IntWriter());
+            put(com.netflix.iceberg.types.Type.TypeID.DATE, new DateWriter());
+            //TODO put(com.netflix.iceberg.types.Type.TypeID.TIME, new TimeWriter());
+            put(com.netflix.iceberg.types.Type.TypeID.TIMESTAMP, new TimeStampWriter());
+            put(com.netflix.iceberg.types.Type.TypeID.STRING, new StringWriter());
+            put(com.netflix.iceberg.types.Type.TypeID.UUID, new StringWriter());
+            put(com.netflix.iceberg.types.Type.TypeID.FIXED, new BinaryWriter());
+            put(com.netflix.iceberg.types.Type.TypeID.BINARY, new BinaryWriter());
+        }};
+
+    private final ColumnWriter getWriter(Type type)
+    {
+        final com.netflix.iceberg.types.Type icebergType = TypeConveter.convert(type);
+        if (writerMap.containsKey(icebergType.typeId())) {
+            return writerMap.get(icebergType.typeId());
+        }
+        else {
+            switch (icebergType.typeId()) {
+                case DECIMAL:
+                    return new DecimalWriter((DecimalType) type);
+                case LIST:
+                    return new ListWriter((ArrayType) type);
+                case MAP:
+                    return new MapWriter((MapType) type);
+                case STRUCT:
+                    return new RowWriter((RowType) type);
+                default:
+                    throw new UnsupportedOperationException(" presto does not support " + icebergType);
+            }
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/type/TypeConveter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/type/TypeConveter.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.type;
+
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.type.DateType;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.RealType;
+import com.facebook.presto.spi.type.RowType;
+import com.facebook.presto.spi.type.TimeType;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.TimestampWithTimeZoneType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.VarbinaryType;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.collect.ImmutableList;
+import com.netflix.iceberg.types.Types;
+
+import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.spi.block.MethodHandleUtil.compose;
+import static com.facebook.presto.spi.block.MethodHandleUtil.nativeValueGetter;
+
+public class TypeConveter
+{
+    private static Map<Class<Type>, com.netflix.iceberg.types.Type> prestoTypeToIcebergType = new HashMap()
+    {
+        {
+            put(BooleanType.class, Types.BooleanType.get());
+            put(VarbinaryType.class, Types.BinaryType.get());
+            put(DateType.class, Types.DateType.get());
+            put(DoubleType.class, Types.DoubleType.get());
+            put(BigintType.class, Types.LongType.get());
+            put(RealType.class, Types.FloatType.get());
+            put(IntegerType.class, Types.IntegerType.get());
+            put(TimeType.class, Types.TimeType.get());
+            put(TimestampType.class, Types.TimestampType.withoutZone());
+            put(TimestampWithTimeZoneType.class, Types.TimestampType.withZone());
+            put(VarcharType.class, Types.StringType.get());
+        }
+    };
+
+    private TypeConveter()
+    {
+    }
+
+    public static Type convert(com.netflix.iceberg.types.Type type, TypeManager typeManager)
+    {
+        switch (type.typeId()) {
+            case BOOLEAN:
+                return BooleanType.BOOLEAN;
+            case BINARY:
+            case FIXED:
+                return VarbinaryType.VARBINARY;
+            case DATE:
+                return DateType.DATE;
+            case DECIMAL:
+                com.netflix.iceberg.types.Types.DecimalType decimalType = (com.netflix.iceberg.types.Types.DecimalType) type;
+                return DecimalType.createDecimalType(decimalType.precision(), decimalType.scale());
+            case DOUBLE:
+                return DoubleType.DOUBLE;
+            case LONG:
+                return BigintType.BIGINT;
+            case FLOAT:
+                return RealType.REAL;
+            case INTEGER:
+                return IntegerType.INTEGER;
+            case TIME:
+                return TimeType.TIME;
+            case TIMESTAMP:
+                com.netflix.iceberg.types.Types.TimestampType timestampType = (com.netflix.iceberg.types.Types.TimestampType) type;
+                if (timestampType.shouldAdjustToUTC()) {
+                    return TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+                }
+                else {
+                    return TimestampType.TIMESTAMP;
+                }
+            case UUID:
+            case STRING:
+                return VarcharType.createUnboundedVarcharType();
+            case STRUCT:
+                com.netflix.iceberg.types.Types.StructType structType = (com.netflix.iceberg.types.Types.StructType) type;
+                List<com.netflix.iceberg.types.Types.NestedField> fields = structType.fields();
+                List<RowType.Field> fieldList = new ArrayList<>();
+                for (com.netflix.iceberg.types.Types.NestedField field : fields) {
+                    fieldList.add(new RowType.Field(Optional.of(field.name()), convert(field.type(), typeManager)));
+                }
+                return RowType.from(fieldList);
+            case LIST:
+                com.netflix.iceberg.types.Types.ListType listType = (com.netflix.iceberg.types.Types.ListType) type;
+                return new ArrayType(convert(listType.elementType(), typeManager));
+            case MAP:
+                com.netflix.iceberg.types.Types.MapType mapType = (com.netflix.iceberg.types.Types.MapType) type;
+                Type keyType = convert(mapType.keyType(), typeManager);
+                Type valType = convert(mapType.valueType(), typeManager);
+                MethodHandle keyNativeEquals = typeManager.resolveOperator(OperatorType.EQUAL, ImmutableList.of(keyType, keyType));
+                MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
+                MethodHandle keyBlockEquals = compose(keyNativeEquals, nativeValueGetter(keyType), nativeValueGetter(keyType));
+                MethodHandle keyNativeHashCode = typeManager.resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(keyType));
+                MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
+                return new MapType(
+                        keyType,
+                        valType,
+                        keyBlockNativeEquals,
+                        keyBlockEquals,
+                        keyNativeHashCode,
+                        keyBlockHashCode);
+            default:
+                throw new UnsupportedOperationException("can not fromIceberg type id = " + type.typeId() + " from iceberg to preto type, type = " + type);
+        }
+    }
+
+    public static com.netflix.iceberg.types.Type convert(Type type)
+    {
+        if (prestoTypeToIcebergType.containsKey(type.getClass())) {
+            return prestoTypeToIcebergType.get(type.getClass());
+        }
+        else if (type instanceof DecimalType) {
+            return handle((DecimalType) type);
+        }
+        else if (type instanceof RowType) {
+            return handle((RowType) type);
+        }
+        else if (type instanceof ArrayType) {
+            return handle((ArrayType) type);
+        }
+        else if (type instanceof MapType) {
+            return handle((MapType) type);
+        }
+        else {
+            throw new IllegalArgumentException("Iceberg does not support presto type " + type);
+        }
+    }
+
+    private static com.netflix.iceberg.types.Type handle(DecimalType type)
+    {
+        return Types.DecimalType.of(type.getPrecision(), type.getScale());
+    }
+
+    private static com.netflix.iceberg.types.Type handle(RowType type)
+    {
+        final List<RowType.Field> fields = type.getFields();
+        // TODO 1 needs to be an incremented ID and field.getName() is optional so we need to throw an exception if it has no value.
+        final List<Types.NestedField> icebergRowFields = fields.stream().map(field -> Types.NestedField.required(1, field.getName().get(), convert(field.getType()))).collect(Collectors.toList());
+        return Types.StructType.of(icebergRowFields);
+    }
+
+    private static com.netflix.iceberg.types.Type handle(ArrayType type)
+    {
+        return Types.ListType.ofRequired(1, convert(type.getElementType()));
+    }
+
+    private static com.netflix.iceberg.types.Type handle(MapType type)
+    {
+        return Types.MapType.ofRequired(1, 2, convert(type.getKeyType()), convert(type.getValueType()));
+    }
+}

--- a/presto-main/etc/catalog/iceberg.properties
+++ b/presto-main/etc/catalog/iceberg.properties
@@ -1,0 +1,32 @@
+#
+# WARNING
+# ^^^^^^^
+# This configuration file is for development only and should NOT be used be
+# used in production. For example configuration, see the Presto documentation.
+#
+connector.name=iceberg
+
+#Metastore properties
+hive.metastore-cache-ttl=1m
+hive.metastore-refresh-interval=1m
+hive.metastore.uri=thrift://localhost:9083
+hive.assume-canonical-partition-keys=true
+hive.metastore-timeout=20s
+hive.non-managed-table-writes-enabled=true
+
+#S3 properties
+hive.s3.staging-directory=/mnt/tmp/
+hive.s3.max-client-retries=25
+hive.s3.max-error-retries=50
+hive.s3.max-connections=500
+hive.s3.connect-timeout=5s
+hive.s3.socket-timeout=5s
+hive.s3.max-backoff-time=10s
+hive.s3.max-retry-time=1m
+hive.config.resources=etc/hive-site.xml
+hive.allow-drop-table=true
+hive.allow-rename-table=true
+hive.allow-add-column=true
+hive.allow-drop-column=true
+hive.allow-rename-column=true
+

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -27,6 +27,7 @@ query.client.timeout=5m
 query.min-expire-age=30m
 
 plugin.bundles=\
+  ../presto-iceberg/pom.xml,\
   ../presto-blackhole/pom.xml,\
   ../presto-memory/pom.xml,\
   ../presto-jmx/pom.xml,\

--- a/presto-main/etc/hive-site.xml
+++ b/presto-main/etc/hive-site.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>metastore.thrift.uris</name>
+    <value>thrift://localhost:9083</value>
+  </property>
+  <property>
+    <name>metastore.warehouse.dir</name>
+    <value>file:///tmp/</value>
+  </property>
+  <property>
+    <name>hive.metastore.warehouse.dir</name>
+    <value>file:///tmp/</value>
+  </property>
+</configuration>

--- a/presto-server/src/main/provisio/presto.xml
+++ b/presto-server/src/main/provisio/presto.xml
@@ -68,6 +68,12 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/presto-iceberg">
+        <artifact id="${project.groupId}:presto-iceberg:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/memory">
         <artifact id="${project.groupId}:presto-memory:zip:${project.version}">
             <unpack />

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorSplitSource.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorSplitSource.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.connector.classloader;
+
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
+
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.Objects.requireNonNull;
+
+public class ClassLoaderSafeConnectorSplitSource
+        implements ConnectorSplitSource
+{
+    private final ConnectorSplitSource delegate;
+    private final ClassLoader classLoader;
+
+    public ClassLoaderSafeConnectorSplitSource(ConnectorSplitSource delegate, ClassLoader classLoader)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public CompletableFuture<ConnectorSplitBatch> getNextBatch(ConnectorPartitionHandle partitionHandle, int maxSize)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getNextBatch(partitionHandle, maxSize);
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.close();
+        }
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.isFinished();
+        }
+    }
+}


### PR DESCRIPTION
Initial patch with Iceberg plugin (https://github.com/Netflix/iceberg). The current implementation allows create, CTAS, drop, Select with predicate pushdown and some schema manipulation like add/remove columns. There are still more operations that needs to be supported and some of them require extending the parser but I already have a pretty huge PR. 

Before anyone starts reviewing I would like to point out that one big flaw in the current implementation is that I had to copy the parquet package from presto-hive to presto-iceberg. Iceberg requires a newer version of parquet which has resulted in renaming of all parquet class as parquet was moved to apache. parquet code was recently moved to its own module in presto-parquet which is a step in the right direction and I can simplify this PR and remove all duplication if we can bump the parquet version. 