### PR TITLE
[WIP] Allow connectors receive only columns specified in insert list

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloMetadata.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloMetadata.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.connector.ConnectorFeature;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.statistics.ComputedStatistics;
@@ -55,8 +56,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.facebook.presto.accumulo.AccumuloErrorCode.ACCUMULO_TABLE_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.connector.ConnectorFeature.INSERT_NEED_ALL_COLUMNS;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Sets.immutableEnumSet;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -78,6 +81,12 @@ public class AccumuloMetadata
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
         this.client = requireNonNull(client, "client is null");
+    }
+
+    @Override
+    public Set<ConnectorFeature> listFeatures()
+    {
+        return immutableEnumSet(INSERT_NEED_ALL_COLUMNS);
     }
 
     @Override
@@ -204,7 +213,7 @@ public class AccumuloMetadata
     }
 
     @Override
-    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> inputColumns)
     {
         checkNoRollback();
         AccumuloTableHandle handle = (AccumuloTableHandle) tableHandle;

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloIntegrationSmokeTest.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/TestAccumuloIntegrationSmokeTest.java
@@ -16,6 +16,7 @@ package com.facebook.presto.accumulo;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 
@@ -50,5 +51,16 @@ public class TestAccumuloIntegrationSmokeTest
         assertEquals(actual.getMaterializedRows().get(7).getField(1), "integer");
         assertEquals(actual.getMaterializedRows().get(8).getField(0), "comment");
         assertEquals(actual.getMaterializedRows().get(8).getField(1), "varchar(79)");
+    }
+
+    @Test
+    public void testInsertPartial()
+    {
+        assertUpdate("CREATE TABLE test_insert_partial (c1 BIGINT, c2 VARCHAR)");
+        assertUpdate("INSERT INTO test_insert_partial (c1) VALUES (1)", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c1, c2) VALUES (2, NULL)", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c1, c2) VALUES (3, 'test')", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c2, c1) VALUES ('test2', 4)", "VALUES(1)");
+        assertQuery("SELECT * FROM test_insert_partial", "VALUES (1, NULL), (2, NULL), (3, 'test'), (4, 'test2')");
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -63,7 +63,7 @@ public interface JdbcClient
 
     void commitCreateTable(JdbcOutputTableHandle handle);
 
-    JdbcOutputTableHandle beginInsertTable(ConnectorTableMetadata tableMetadata);
+    JdbcOutputTableHandle beginInsertTable(ConnectorTableMetadata tableMetadata, List<JdbcColumnHandle> inputColumnHandles);
 
     void finishInsertTable(JdbcOutputTableHandle handle);
 

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaNotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.connector.ConnectorFeature;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.statistics.ComputedStatistics;
@@ -55,6 +56,7 @@ import static com.facebook.presto.plugin.blackhole.BlackHoleConnector.SPLIT_COUN
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static java.lang.String.format;
+import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
@@ -70,6 +72,12 @@ public class BlackHoleMetadata
     public BlackHoleMetadata()
     {
         schemas.add(SCHEMA_NAME);
+    }
+
+    @Override
+    public Set<ConnectorFeature> listFeatures()
+    {
+        return emptySet();
     }
 
     @Override
@@ -230,7 +238,7 @@ public class BlackHoleMetadata
     }
 
     @Override
-    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> inputColumns)
     {
         BlackHoleTableHandle handle = (BlackHoleTableHandle) tableHandle;
         return new BlackHoleInsertTableHandle(handle.getPageProcessingDelay());

--- a/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleSmoke.java
+++ b/presto-blackhole/src/test/java/com/facebook/presto/plugin/blackhole/TestBlackHoleSmoke.java
@@ -189,6 +189,19 @@ public class TestBlackHoleSmoke
     }
 
     @Test
+    public void testInsertPartial()
+    {
+        queryRunner.execute("CREATE TABLE test_insert_partial (c1 BIGINT, c2 VARCHAR)");
+        assertThatQueryReturnsValue("INSERT INTO test_insert_partial (c1) VALUES (1)", 1L);
+        assertThatQueryReturnsValue("INSERT INTO test_insert_partial (c1, c2) VALUES (2, NULL)", 1L);
+        assertThatQueryReturnsValue("INSERT INTO test_insert_partial (c1, c2) VALUES (3, 'test')", 1L);
+        assertThatQueryReturnsValue("INSERT INTO test_insert_partial (c2, c1) VALUES ('test2', 4)", 1L);
+        assertThatQueryReturnsValue("SELECT count(*) FROM test_insert_partial",  0L);
+        assertThatQueryReturnsValue("DROP TABLE test_insert_partial", true);
+    }
+
+
+    @Test
     public void fieldLength()
     {
         Session session = testSessionBuilder()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/CreateEmptyPartitionProcedure.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/CreateEmptyPartitionProcedure.java
@@ -86,7 +86,7 @@ public class CreateEmptyPartitionProcedure
     {
         TransactionalMetadata hiveMetadata = hiveMetadataFactory.get();
 
-        HiveInsertTableHandle hiveInsertTableHandle = (HiveInsertTableHandle) hiveMetadata.beginInsert(session, new HiveTableHandle(schema, table));
+        HiveInsertTableHandle hiveInsertTableHandle = (HiveInsertTableHandle) hiveMetadata.beginInsert(session, new HiveTableHandle(schema, table), ImmutableList.of());
 
         List<String> actualPartitionColumnNames = hiveInsertTableHandle.getInputColumns().stream()
                 .filter(HiveColumnHandle::isPartitionKey)

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduMetadata.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduMetadata.java
@@ -30,6 +30,7 @@ import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.NotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.connector.ConnectorFeature;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.statistics.ComputedStatistics;
@@ -55,6 +56,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Sets.immutableEnumSet;
 import static java.util.Objects.requireNonNull;
 
 public class KuduMetadata
@@ -68,6 +70,12 @@ public class KuduMetadata
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
         this.clientSession = requireNonNull(clientSession, "clientSession is null");
+    }
+
+    @Override
+    public Set<ConnectorFeature> listFeatures()
+    {
+        return immutableEnumSet(ConnectorFeature.INSERT_NEED_ALL_COLUMNS);
     }
 
     @Override
@@ -273,7 +281,7 @@ public class KuduMetadata
     }
 
     @Override
-    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle connectorTableHandle)
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle connectorTableHandle, List<ColumnHandle> inputColumns)
     {
         KuduTableHandle tableHandle = (KuduTableHandle) connectorTableHandle;
 

--- a/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationSmoke.java
+++ b/presto-kudu/src/test/java/com/facebook/presto/kudu/TestKuduIntegrationSmoke.java
@@ -70,6 +70,17 @@ public class TestKuduIntegrationSmoke
         assertEquals(filteredActual, expectedColumns, String.format("%s != %s", filteredActual, expectedColumns));
     }
 
+    @Test
+    public void testInsertPartial()
+    {
+        assertUpdate("CREATE TABLE test_insert_partial (c1 BIGINT, c2 VARCHAR)");
+        assertUpdate("INSERT INTO test_insert_partial (c1) VALUES (1)", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c1, c2) VALUES (2, NULL)", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c1, c2) VALUES (3, 'test')", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c2, c1) VALUES ('test2', 4)", "VALUES(1)");
+        assertQuery("SELECT * FROM test_insert_partial", "VALUES (1, NULL), (2, NULL), (3, 'test'), (4, 'test2')");
+    }
+
     @AfterClass(alwaysRun = true)
     public final void destroy()
     {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.connector.ConnectorFeature;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
@@ -58,6 +59,8 @@ public interface Metadata
     boolean schemaExists(Session session, CatalogSchemaName schema);
 
     boolean catalogExists(Session session, String catalogName);
+
+    Set<ConnectorFeature> getConnectorFeatures(Session session, ConnectorId connectorId);
 
     List<String> listSchemaNames(Session session, String catalogName);
 
@@ -192,7 +195,7 @@ public interface Metadata
     /**
      * Begin insert query
      */
-    InsertTableHandle beginInsert(Session session, TableHandle tableHandle);
+    InsertTableHandle beginInsert(Session session, TableHandle tableHandle, List<ColumnHandle> columnHandles);
 
     /**
      * Finish insert query

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginTableWrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/BeginTableWrite.java
@@ -163,7 +163,7 @@ public class BeginTableWrite
             }
             if (target instanceof TableWriterNode.InsertReference) {
                 TableWriterNode.InsertReference insert = (TableWriterNode.InsertReference) target;
-                return new TableWriterNode.InsertHandle(metadata.beginInsert(session, insert.getHandle()), metadata.getTableMetadata(session, insert.getHandle()).getTable());
+                return new TableWriterNode.InsertHandle(metadata.beginInsert(session, insert.getHandle(), insert.getColumnHandles()), metadata.getTableMetadata(session, insert.getHandle()).getTable());
             }
             if (target instanceof TableWriterNode.DeleteHandle) {
                 TableWriterNode.DeleteHandle delete = (TableWriterNode.DeleteHandle) target;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/TableWriterNode.java
@@ -17,6 +17,7 @@ import com.facebook.presto.metadata.InsertTableHandle;
 import com.facebook.presto.metadata.NewTableLayout;
 import com.facebook.presto.metadata.OutputTableHandle;
 import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.sql.planner.PartitioningScheme;
@@ -257,15 +258,22 @@ public class TableWriterNode
             extends WriterTarget
     {
         private final TableHandle handle;
+        private final List<ColumnHandle> columnHandles;
 
-        public InsertReference(TableHandle handle)
+        public InsertReference(TableHandle handle, List<ColumnHandle> columnHandles)
         {
             this.handle = requireNonNull(handle, "handle is null");
+            this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
         }
 
         public TableHandle getHandle()
         {
             return handle;
+        }
+
+        public List<ColumnHandle> getColumnHandles()
+        {
+            return columnHandles;
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingMetadata.java
@@ -238,7 +238,7 @@ public class TestingMetadata
     }
 
     @Override
-    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> inputColumns)
     {
         return TestingHandle.INSTANCE;
     }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.connector.ConnectorFeature;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
@@ -42,12 +43,20 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 
+import static java.util.Collections.emptySet;
+
 public abstract class AbstractMockMetadata
         implements Metadata
 {
     public static Metadata dummyMetadata()
     {
         return new AbstractMockMetadata() {};
+    }
+
+    @Override
+    public Set<ConnectorFeature> getConnectorFeatures(Session session, ConnectorId connectorId)
+    {
+        return emptySet();
     }
 
     @Override
@@ -249,7 +258,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
+    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle, List<ColumnHandle> inputColumnHandles)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryMetadata.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryMetadata.java
@@ -34,6 +34,7 @@ import com.facebook.presto.spi.SchemaNotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.ViewNotFoundException;
+import com.facebook.presto.spi.connector.ConnectorFeature;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.predicate.TupleDomain;
@@ -63,6 +64,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Sets.immutableEnumSet;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -89,6 +91,12 @@ public class MemoryMetadata
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
         this.schemas.add(SCHEMA_NAME);
+    }
+
+    @Override
+    public Set<ConnectorFeature> listFeatures()
+    {
+        return immutableEnumSet(ConnectorFeature.INSERT_NEED_ALL_COLUMNS);
     }
 
     @Override
@@ -258,7 +266,7 @@ public class MemoryMetadata
     }
 
     @Override
-    public synchronized MemoryInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public synchronized MemoryInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> inputColumns)
     {
         MemoryTableHandle memoryTableHandle = (MemoryTableHandle) tableHandle;
         return new MemoryInsertTableHandle(memoryTableHandle, ImmutableSet.copyOf(tableIds.values()));

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryMetadata.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryMetadata.java
@@ -118,7 +118,7 @@ public class TestMemoryMetadata
         MemoryTableHandle firstTableHandle = (MemoryTableHandle) metadata.getTableHandle(SESSION, firstTableName);
         Long firstTableId = firstTableHandle.getTableId();
 
-        assertTrue(metadata.beginInsert(SESSION, firstTableHandle).getActiveTableIds().contains(firstTableId));
+        assertTrue(metadata.beginInsert(SESSION, firstTableHandle, ImmutableList.of()).getActiveTableIds().contains(firstTableId));
 
         SchemaTableName secondTableName = new SchemaTableName("default", "second_table");
         metadata.createTable(SESSION, new ConnectorTableMetadata(secondTableName, ImmutableList.of(), ImmutableMap.of()), false);
@@ -127,8 +127,8 @@ public class TestMemoryMetadata
         Long secondTableId = secondTableHandle.getTableId();
 
         assertNotEquals(firstTableId, secondTableId);
-        assertTrue(metadata.beginInsert(SESSION, secondTableHandle).getActiveTableIds().contains(firstTableId));
-        assertTrue(metadata.beginInsert(SESSION, secondTableHandle).getActiveTableIds().contains(secondTableId));
+        assertTrue(metadata.beginInsert(SESSION, secondTableHandle, ImmutableList.of()).getActiveTableIds().contains(firstTableId));
+        assertTrue(metadata.beginInsert(SESSION, secondTableHandle, ImmutableList.of()).getActiveTableIds().contains(secondTableId));
     }
 
     @Test

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemorySmoke.java
@@ -69,6 +69,17 @@ public class TestMemorySmoke
     }
 
     @Test
+    public void testInsertPartial()
+    {
+        assertUpdate("CREATE TABLE test_insert_partial (c1 BIGINT, c2 VARCHAR)");
+        assertUpdate("INSERT INTO test_insert_partial (c1) VALUES (1)", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c1, c2) VALUES (2, NULL)", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c1, c2) VALUES (3, 'test')", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c2, c1) VALUES ('test2', 4)", "VALUES(1)");
+        assertQuery("SELECT * FROM test_insert_partial", "VALUES (1, NULL), (2, NULL), (3, 'test'), (4, 'test2')");
+    }
+
+    @Test
     public void testCreateTableWithNoData()
     {
         assertUpdate("CREATE TABLE test_empty (a BIGINT)");

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -136,6 +136,17 @@ public class TestMongoIntegrationSmokeTest
     }
 
     @Test
+    public void testInsertPartial()
+    {
+        assertUpdate("CREATE TABLE test_insert_partial (c1 BIGINT, c2 VARCHAR)");
+        assertUpdate("INSERT INTO test_insert_partial (c1) VALUES (1)", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c1, c2) VALUES (2, NULL)", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c1, c2) VALUES (3, 'test')", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c2, c1) VALUES ('test2', 4)", "VALUES(1)");
+        assertQuery("SELECT * FROM test_insert_partial", "VALUES (1, NULL), (2, NULL), (3, 'test'), (4, 'test2')");
+    }
+
+    @Test
     public void testArrays()
     {
         assertUpdate("CREATE TABLE tmp_array1 AS SELECT ARRAY[1, 2, NULL] AS col", 1);

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.mysql;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
@@ -106,6 +107,19 @@ public class TestMySqlIntegrationSmokeTest
         assertUpdate("INSERT INTO test_insert VALUES (123, 'test')", 1);
         assertQuery("SELECT * FROM test_insert", "SELECT 123 x, 'test' y");
         assertUpdate("DROP TABLE test_insert");
+    }
+
+    @Test
+    public void testInsertPartial()
+            throws SQLException
+    {
+        execute("CREATE TABLE tpch.test_insert_partial (c1 BIGINT, c2 VARCHAR(100))");
+        assertUpdate("INSERT INTO test_insert_partial (c1) VALUES (1)", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c1, c2) VALUES (2, NULL)", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c1, c2) VALUES (3, 'test')", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c2, c1) VALUES ('test2', 4)", "VALUES(1)");
+        assertQuery("SELECT * FROM test_insert_partial", "VALUES (1, NULL), (2, NULL), (3, 'test'), (4, 'test2')");
+        assertUpdate("DROP TABLE test_insert_partial");
     }
 
     @Test

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
@@ -43,6 +43,7 @@ import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.ViewNotFoundException;
+import com.facebook.presto.spi.connector.ConnectorFeature;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
@@ -115,6 +116,7 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.Sets.immutableEnumSet;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static java.lang.String.format;
 import static java.util.Collections.nCopies;
@@ -154,6 +156,12 @@ public class RaptorMetadata
         this.dao = onDemandDao(dbi, MetadataDao.class);
         this.shardManager = requireNonNull(shardManager, "shardManager is null");
         this.beginDeleteForTableId = requireNonNull(beginDeleteForTableId, "beginDeleteForTableId is null");
+    }
+
+    @Override
+    public Set<ConnectorFeature> listFeatures()
+    {
+        return immutableEnumSet(ConnectorFeature.INSERT_NEED_ALL_COLUMNS);
     }
 
     @Override
@@ -687,7 +695,7 @@ public class RaptorMetadata
     }
 
     @Override
-    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> inputColumns)
     {
         RaptorTableHandle handle = (RaptorTableHandle) tableHandle;
         long tableId = handle.getTableId();

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTest.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorIntegrationSmokeTest.java
@@ -118,6 +118,17 @@ public class TestRaptorIntegrationSmokeTest
     }
 
     @Test
+    public void testInsertPartial()
+    {
+        assertUpdate("CREATE TABLE test_insert_partial (c1 BIGINT, c2 VARCHAR)");
+        assertUpdate("INSERT INTO test_insert_partial (c1) VALUES (1)", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c1, c2) VALUES (2, NULL)", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c1, c2) VALUES (3, 'test')", "VALUES(1)");
+        assertUpdate("INSERT INTO test_insert_partial (c2, c1) VALUES ('test2', 4)", "VALUES(1)");
+        assertQuery("SELECT * FROM test_insert_partial", "VALUES (1, NULL), (2, NULL), (3, 'test'), (4, 'test2')");
+    }
+
+    @Test
     public void testShardUuidHiddenColumn()
     {
         assertUpdate("CREATE TABLE test_shard_uuid AS SELECT orderdate, orderkey FROM orders", "SELECT count(*) FROM orders");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorFeature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorFeature.java
@@ -1,0 +1,6 @@
+package com.facebook.presto.spi.connector;
+
+public enum ConnectorFeature
+{
+    INSERT_NEED_ALL_COLUMNS,
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -51,10 +51,16 @@ import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
 
 public interface ConnectorMetadata
 {
+    default Set<ConnectorFeature> listFeatures()
+    {
+        return emptySet();
+    }
+
     /**
      * Checks if a schema exists. The connector may have schemas that exist
      * but are not enumerable via {@link #listSchemaNames}.
@@ -117,6 +123,7 @@ public interface ConnectorMetadata
 
     /**
      * List table names, possibly filtered by schema. An empty list is returned if none match.
+     *
      * @deprecated replaced by {@link ConnectorMetadata#listTables(ConnectorSession, Optional)}
      */
     @Deprecated
@@ -314,6 +321,12 @@ public interface ConnectorMetadata
     /**
      * Begin insert query
      */
+    default ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> inputColumns)
+    {
+        return beginInsert(session, tableHandle);
+    }
+
+    @Deprecated
     default ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support inserts");
@@ -373,6 +386,7 @@ public interface ConnectorMetadata
 
     /**
      * List view names, possibly filtered by schema. An empty list is returned if none match.
+     *
      * @deprecated replaced by {@link ConnectorMetadata#listViews(ConnectorSession, Optional)}
      */
     @Deprecated

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -307,10 +307,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> inputColumns)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.beginInsert(session, tableHandle);
+            return delegate.beginInsert(session, tableHandle, inputColumns);
         }
     }
 


### PR DESCRIPTION
To address issue #11766, basically, engine will check if connector needs full list of columns from table ( uses features provided by #11561 ). If yes, engine will fill in nulls for missing columns. Engine will provide list of insert columnHandles to connector in beginInsert method and it is up to connector how to fill missing columns. 