### PR TITLE
Update to Aircompressor 0.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>aircompressor</artifactId>
-                <version>0.12</version>
+                <version>0.13</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This fixes a potential out-of-bounds read for ZSTD on corrupted input.