### PR TITLE
Lazily build hashtable for MapBlock

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
@@ -64,8 +64,15 @@ public class MapBlockEncoding
         blockEncodingSerde.writeBlock(sliceOutput, mapBlock.getRawKeyBlock().getRegion(entriesStartOffset, entriesEndOffset - entriesStartOffset));
         blockEncodingSerde.writeBlock(sliceOutput, mapBlock.getRawValueBlock().getRegion(entriesStartOffset, entriesEndOffset - entriesStartOffset));
 
-        sliceOutput.appendInt((entriesEndOffset - entriesStartOffset) * HASH_MULTIPLIER);
-        sliceOutput.writeBytes(wrappedIntArray(hashTable, entriesStartOffset * HASH_MULTIPLIER, (entriesEndOffset - entriesStartOffset) * HASH_MULTIPLIER));
+        if (hashTable != null) {
+            int hashTableLength = (entriesEndOffset - entriesStartOffset) * HASH_MULTIPLIER;
+            sliceOutput.appendInt(hashTableLength); // hashtable length
+            sliceOutput.writeBytes(wrappedIntArray(hashTable, entriesStartOffset * HASH_MULTIPLIER, hashTableLength));
+        }
+        else {
+            // if the hashTable is null, we write the length -1
+            sliceOutput.appendInt(-1);  // hashtable length
+        }
 
         sliceOutput.appendInt(positionCount);
         for (int position = 0; position < positionCount + 1; position++) {
@@ -82,18 +89,27 @@ public class MapBlockEncoding
         Block keyBlock = blockEncodingSerde.readBlock(sliceInput);
         Block valueBlock = blockEncodingSerde.readBlock(sliceInput);
 
-        int[] hashTable = new int[sliceInput.readInt()];
-        sliceInput.readBytes(wrappedIntArray(hashTable));
+        int hashTableLength = sliceInput.readInt();
+        int[] hashTable = null;
+        if (hashTableLength >= 0) {
+            hashTable = new int[hashTableLength];
+            sliceInput.readBytes(wrappedIntArray(hashTable));
+        }
 
-        if (keyBlock.getPositionCount() != valueBlock.getPositionCount() || keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
+        if (keyBlock.getPositionCount() != valueBlock.getPositionCount()) {
             throw new IllegalArgumentException(
-                    format("Deserialized MapBlock violates invariants: key %d, value %d, hash %d", keyBlock.getPositionCount(), valueBlock.getPositionCount(), hashTable.length));
+                    format("Deserialized MapBlock violates invariants: key %d, value %d", keyBlock.getPositionCount(), valueBlock.getPositionCount()));
+        }
+
+        if (hashTable != null && keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
+            throw new IllegalArgumentException(
+                    format("Deserialized MapBlock violates invariants: expected hashtable size %d, actual hashtable size %d", keyBlock.getPositionCount() * HASH_MULTIPLIER, hashTable.length));
         }
 
         int positionCount = sliceInput.readInt();
         int[] offsets = new int[positionCount + 1];
         sliceInput.readBytes(wrappedIntArray(offsets));
         Optional<boolean[]> mapIsNull = EncoderUtil.decodeNullBits(sliceInput, positionCount);
-        return MapType.createMapBlockInternal(typeManager, keyType, 0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, hashTable);
+        return MapType.createMapBlockInternal(typeManager, keyType, 0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, Optional.ofNullable(hashTable));
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
-import java.lang.invoke.MethodHandle;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -35,24 +34,14 @@ public class SingleMapBlock
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleMapBlock.class).instanceSize();
 
     private final int offset;
-    private final int positionCount;
-    private final Block keyBlock;
-    private final Block valueBlock;
-    private final int[] hashTable;
-    final Type keyType;
-    private final MethodHandle keyNativeHashCode;
-    private final MethodHandle keyBlockNativeEquals;
+    private final int positionCount;  // The number of keys in this single map * 2
+    private final AbstractMapBlock mapBlock;
 
-    SingleMapBlock(int offset, int positionCount, Block keyBlock, Block valueBlock, int[] hashTable, Type keyType, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals)
+    SingleMapBlock(int offset, int positionCount, AbstractMapBlock mapBlock)
     {
         this.offset = offset;
         this.positionCount = positionCount;
-        this.keyBlock = keyBlock;
-        this.valueBlock = valueBlock;
-        this.hashTable = hashTable;
-        this.keyType = keyType;
-        this.keyNativeHashCode = keyNativeHashCode;
-        this.keyBlockNativeEquals = keyBlockNativeEquals;
+        this.mapBlock = mapBlock;
     }
 
     @Override
@@ -64,23 +53,23 @@ public class SingleMapBlock
     @Override
     public long getSizeInBytes()
     {
-        return keyBlock.getRegionSizeInBytes(offset / 2, positionCount / 2) +
-                valueBlock.getRegionSizeInBytes(offset / 2, positionCount / 2) +
+        return mapBlock.getRawKeyBlock().getRegionSizeInBytes(offset / 2, positionCount / 2) +
+                mapBlock.getRawValueBlock().getRegionSizeInBytes(offset / 2, positionCount / 2) +
                 sizeOfIntArray(positionCount / 2 * HASH_MULTIPLIER);
     }
 
     @Override
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE + keyBlock.getRetainedSizeInBytes() + valueBlock.getRetainedSizeInBytes() + sizeOf(hashTable);
+        return INSTANCE_SIZE + mapBlock.getRawKeyBlock().getRetainedSizeInBytes() + mapBlock.getRawValueBlock().getRetainedSizeInBytes() + sizeOf(mapBlock.getHashTables());
     }
 
     @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
-        consumer.accept(keyBlock, keyBlock.getRetainedSizeInBytes());
-        consumer.accept(valueBlock, valueBlock.getRetainedSizeInBytes());
-        consumer.accept(hashTable, sizeOf(hashTable));
+        consumer.accept(mapBlock.getRawKeyBlock(), mapBlock.getRawKeyBlock().getRetainedSizeInBytes());
+        consumer.accept(mapBlock.getRawValueBlock(), mapBlock.getRawValueBlock().getRetainedSizeInBytes());
+        consumer.accept(mapBlock.getHashTables(), sizeOf(mapBlock.getHashTables()));
         consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
@@ -99,13 +88,13 @@ public class SingleMapBlock
     @Override
     Block getRawKeyBlock()
     {
-        return keyBlock;
+        return mapBlock.getRawKeyBlock();
     }
 
     @Override
     Block getRawValueBlock()
     {
-        return valueBlock;
+        return mapBlock.getRawValueBlock();
     }
 
     @Override
@@ -117,29 +106,29 @@ public class SingleMapBlock
     @Override
     public Block getLoadedBlock()
     {
-        if (keyBlock != keyBlock.getLoadedBlock()) {
+        if (mapBlock.getRawKeyBlock() != mapBlock.getRawKeyBlock().getLoadedBlock()) {
             // keyBlock has to be loaded since MapBlock constructs hash table eagerly.
             throw new IllegalStateException();
         }
 
-        Block loadedValueBlock = valueBlock.getLoadedBlock();
-        if (loadedValueBlock == valueBlock) {
+        Block loadedValueBlock = mapBlock.getRawValueBlock().getLoadedBlock();
+        if (loadedValueBlock == mapBlock.getRawValueBlock()) {
             return this;
         }
         return new SingleMapBlock(
                 offset,
                 positionCount,
-                keyBlock,
-                loadedValueBlock,
-                hashTable,
-                keyType,
-                keyNativeHashCode,
-                keyBlockNativeEquals);
+                mapBlock);
     }
 
     int[] getHashTable()
     {
-        return hashTable;
+        return mapBlock.getHashTables();
+    }
+
+    Type getKeyType()
+    {
+        return mapBlock.keyType;
     }
 
     /**
@@ -151,9 +140,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables();
+
         long hashCode;
         try {
-            hashCode = (long) keyNativeHashCode.invoke(nativeValue);
+            hashCode = (long) mapBlock.keyNativeHashCode.invoke(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -170,7 +162,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) keyBlockNativeEquals.invoke(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.keyBlockNativeEquals.invoke(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -195,9 +187,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables();
+
         long hashCode;
         try {
-            hashCode = (long) keyNativeHashCode.invokeExact(nativeValue);
+            hashCode = (long) mapBlock.keyNativeHashCode.invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -214,7 +209,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) keyBlockNativeEquals.invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -236,9 +231,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables();
+
         long hashCode;
         try {
-            hashCode = (long) keyNativeHashCode.invokeExact(nativeValue);
+            hashCode = (long) mapBlock.keyNativeHashCode.invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -255,7 +253,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) keyBlockNativeEquals.invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -277,9 +275,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables();
+
         long hashCode;
         try {
-            hashCode = (long) keyNativeHashCode.invokeExact(nativeValue);
+            hashCode = (long) mapBlock.keyNativeHashCode.invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -296,7 +297,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) keyBlockNativeEquals.invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -318,9 +319,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables();
+
         long hashCode;
         try {
-            hashCode = (long) keyNativeHashCode.invokeExact(nativeValue);
+            hashCode = (long) mapBlock.keyNativeHashCode.invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -337,7 +341,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) keyBlockNativeEquals.invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -359,9 +363,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables();
+
         long hashCode;
         try {
-            hashCode = (long) keyNativeHashCode.invokeExact(nativeValue);
+            hashCode = (long) mapBlock.keyNativeHashCode.invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -378,7 +385,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) keyBlockNativeEquals.invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
@@ -22,6 +22,7 @@ import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
 import java.lang.invoke.MethodHandle;
+import java.util.Optional;
 
 import static com.facebook.presto.spi.block.AbstractMapBlock.HASH_MULTIPLIER;
 import static com.facebook.presto.spi.block.MethodHandleUtil.compose;
@@ -54,15 +55,23 @@ public class SingleMapBlockEncoding
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         SingleMapBlock singleMapBlock = (SingleMapBlock) block;
-        TypeSerde.writeType(sliceOutput, singleMapBlock.keyType);
+        TypeSerde.writeType(sliceOutput, singleMapBlock.getKeyType());
 
         int offset = singleMapBlock.getOffset();
         int positionCount = singleMapBlock.getPositionCount();
         blockEncodingSerde.writeBlock(sliceOutput, singleMapBlock.getRawKeyBlock().getRegion(offset / 2, positionCount / 2));
         blockEncodingSerde.writeBlock(sliceOutput, singleMapBlock.getRawValueBlock().getRegion(offset / 2, positionCount / 2));
         int[] hashTable = singleMapBlock.getHashTable();
-        sliceOutput.appendInt(positionCount / 2 * HASH_MULTIPLIER);
-        sliceOutput.writeBytes(wrappedIntArray(hashTable, offset / 2 * HASH_MULTIPLIER, positionCount / 2 * HASH_MULTIPLIER));
+
+        if (hashTable != null) {
+            int hashTableLength = positionCount / 2 * HASH_MULTIPLIER;
+            sliceOutput.appendInt(hashTableLength);  // hashtable length
+            sliceOutput.writeBytes(wrappedIntArray(hashTable, offset / 2 * HASH_MULTIPLIER, hashTableLength));
+        }
+        else {
+            // if the hashTable is null, we write the length -1
+            sliceOutput.appendInt(-1);
+        }
     }
 
     @Override
@@ -72,18 +81,41 @@ public class SingleMapBlockEncoding
         MethodHandle keyNativeEquals = typeManager.resolveOperator(OperatorType.EQUAL, asList(keyType, keyType));
         MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
         MethodHandle keyNativeHashCode = typeManager.resolveOperator(OperatorType.HASH_CODE, singletonList(keyType));
+        MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
 
         Block keyBlock = blockEncodingSerde.readBlock(sliceInput);
         Block valueBlock = blockEncodingSerde.readBlock(sliceInput);
 
-        int[] hashTable = new int[sliceInput.readInt()];
-        sliceInput.readBytes(wrappedIntArray(hashTable));
-
-        if (keyBlock.getPositionCount() != valueBlock.getPositionCount() || keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
-            throw new IllegalArgumentException(
-                    format("Deserialized SingleMapBlock violates invariants: key %d, value %d, hash %d", keyBlock.getPositionCount(), valueBlock.getPositionCount(), hashTable.length));
+        int hashTableLength = sliceInput.readInt();
+        int[] hashTable = null;
+        if (hashTableLength >= 0) {
+            hashTable = new int[hashTableLength];
+            sliceInput.readBytes(wrappedIntArray(hashTable));
         }
 
-        return new SingleMapBlock(0, keyBlock.getPositionCount() * 2, keyBlock, valueBlock, hashTable, keyType, keyNativeHashCode, keyBlockNativeEquals);
+        if (keyBlock.getPositionCount() != valueBlock.getPositionCount()) {
+            throw new IllegalArgumentException(
+                    format("Deserialized SingleMapBlock violates invariants: key %d, value %d", keyBlock.getPositionCount(), valueBlock.getPositionCount()));
+        }
+
+        if (hashTable != null && keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
+            throw new IllegalArgumentException(
+                    format("Deserialized SingleMapBlock violates invariants: expected hashtable size %d, actual hashtable size %d", keyBlock.getPositionCount() * HASH_MULTIPLIER, hashTable.length));
+        }
+
+        MapBlock mapBlock = MapBlock.createMapBlockInternal(
+                0,
+                1,
+                Optional.empty(),
+                new int[] {0, keyBlock.getPositionCount()},
+                keyBlock,
+                valueBlock,
+                Optional.ofNullable(hashTable),
+                keyType,
+                keyBlockNativeEquals,
+                keyNativeHashCode,
+                keyBlockHashCode);
+
+        return new SingleMapBlock(0, keyBlock.getPositionCount() * 2, mapBlock);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
@@ -278,11 +278,11 @@ public class MapType
             int[] offsets,
             Block keyBlock,
             Block valueBlock,
-            int[] hashTables)
+            Optional<int[]> hashTables)
     {
         // TypeManager caches types. Therefore, it is important that we go through it instead of coming up with the MethodHandles directly.
         // BIGINT is chosen arbitrarily here. Any type will do.
         MapType mapType = (MapType) typeManager.getType(new TypeSignature(StandardTypes.MAP, TypeSignatureParameter.of(keyType.getTypeSignature()), TypeSignatureParameter.of(BIGINT.getTypeSignature())));
-        return MapBlock.createMapBlockInternal(startOffset, positionCount, mapIsNull, offsets, keyBlock, valueBlock, hashTables, keyType, mapType.keyBlockNativeEquals, mapType.keyNativeHashCode);
+        return MapBlock.createMapBlockInternal(startOffset, positionCount, mapIsNull, offsets, keyBlock, valueBlock, hashTables, keyType, mapType.keyBlockNativeEquals, mapType.keyNativeHashCode, mapType.keyBlockHashCode);
     }
 }


### PR DESCRIPTION
Fix for #11808
Presto builds hashtable for MapBlocks eagerly when constructing the
MapBlock even it's not needed in the query. Building a hashtable could
take up to 30% CPU of the scan cost on a map column. This commit defers
the hashtable build to the time it's needed in SeekKey(). Note that we
only do this to the MapBlock, not the MapBlockBuilder to avoid complex
synchronization problems. The MapBlockBuilder will always build the
hashtable. As the result MergingPageOutput and PartitionOutputOperator
will still rebuild the hashtables when needed. The measurements shows
there will be less than 10% pages for MergingPageOutput to build the
hashtables. We will have a seperate PR to improve PartitionOutput
and avoid rebuilding the pages so as to avoid hashtable rebuilding.

Simple select checsum queries show over 40% CPU gain:
```
Test                          | After  | Before | Improvement
select 2 map columns checksum | 11.69d | 20.06d | 42%
Select 1 map column checksum  |  9.67d | 17.73d | 45%
```