### PR TITLE
Make exception handling in SqlQueryManager more resilient

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -38,8 +38,6 @@ import com.facebook.presto.spi.resourceGroups.SelectionContext;
 import com.facebook.presto.spi.resourceGroups.SelectionCriteria;
 import com.facebook.presto.sql.SqlEnvironmentConfig;
 import com.facebook.presto.sql.SqlPath;
-import com.facebook.presto.sql.analyzer.SemanticException;
-import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.transaction.TransactionManager;
@@ -402,7 +400,7 @@ public class SqlQueryManager
                 }
             });
         }
-        catch (ParsingException | PrestoException | SemanticException e) {
+        catch (RuntimeException e) {
             // This is intentionally not a method, since after the state change listener is registered
             // it's not safe to do any of this, and we had bugs before where people reused this code in a method
 


### PR DESCRIPTION
Today, there are many places where `RuntimeException` can be thrown and not wrapped in
proper `PrestoException`. One such example is `ConnectorMetadata#getTableHandle`.
When a connector throws `RuntimeException`, no valid response is send back to the client
and CLI displays "Query is gone(server restarted?)".

This change fixes exception propagation to the client. Fixing all the places where `RuntimeException`
is not wrapped into `PrestoException` is a next step, but is beyond scope of this PR (and of any single
PR for that matter).