### PR TITLE
Remove hive_connector test group

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -22,7 +22,6 @@ public final class TestGroups
     public static final String QUARANTINE = "quarantine";
     public static final String FUNCTIONS = "functions";
     public static final String CLI = "cli";
-    public static final String HIVE_CONNECTOR = "hive_connector";
     public static final String SYSTEM_CONNECTOR = "system";
     public static final String JMX_CONNECTOR = "jmx";
     public static final String BLACKHOLE_CONNECTOR = "blackhole";

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestAllDatatypesFromHiveConnector.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestAllDatatypesFromHiveConnector.java
@@ -33,7 +33,6 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 import static com.facebook.presto.tests.TestGroups.AVRO;
-import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.JDBC;
 import static com.facebook.presto.tests.TestGroups.POST_HIVE_1_0_1;
 import static com.facebook.presto.tests.TestGroups.SKIP_ON_CDH;
@@ -127,7 +126,7 @@ public class TestAllDatatypesFromHiveConnector
     }
 
     @Requires(TextRequirements.class)
-    @Test(groups = {HIVE_CONNECTOR, SMOKE})
+    @Test(groups = {SMOKE})
     public void testSelectAllDatatypesTextFile()
     {
         String tableName = ALL_HIVE_SIMPLE_TYPES_TEXTFILE.getName();
@@ -156,7 +155,7 @@ public class TestAllDatatypesFromHiveConnector
     }
 
     @Requires(OrcRequirements.class)
-    @Test(groups = {HIVE_CONNECTOR, JDBC})
+    @Test(groups = {JDBC})
     public void testSelectAllDatatypesOrc()
     {
         String tableName = mutableTableInstanceOf(ALL_HIVE_SIMPLE_TYPES_ORC).getNameInDatabase();
@@ -187,7 +186,7 @@ public class TestAllDatatypesFromHiveConnector
     }
 
     @Requires(RcfileRequirements.class)
-    @Test(groups = {HIVE_CONNECTOR, JDBC})
+    @Test(groups = {JDBC})
     public void testSelectAllDatatypesRcfile()
     {
         String tableName = mutableTableInstanceOf(ALL_HIVE_SIMPLE_TYPES_RCFILE).getNameInDatabase();
@@ -218,7 +217,7 @@ public class TestAllDatatypesFromHiveConnector
     }
 
     @Requires(AvroRequirements.class)
-    @Test(groups = {HIVE_CONNECTOR, JDBC, SKIP_ON_CDH, AVRO})
+    @Test(groups = {JDBC, SKIP_ON_CDH, AVRO})
     public void testSelectAllDatatypesAvro()
     {
         String tableName = mutableTableInstanceOf(ALL_HIVE_SIMPLE_TYPES_AVRO).getNameInDatabase();
@@ -348,7 +347,7 @@ public class TestAllDatatypesFromHiveConnector
     }
 
     @Requires(ParquetRequirements.class)
-    @Test(groups = {HIVE_CONNECTOR, POST_HIVE_1_0_1})
+    @Test(groups = {POST_HIVE_1_0_1})
     public void testSelectAllDatatypesParquetFile()
     {
         String tableName = mutableTableInstanceOf(ALL_HIVE_SIMPLE_TYPES_PARQUET).getNameInDatabase();

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestAvroSchemaEvolution.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestAvroSchemaEvolution.java
@@ -20,7 +20,6 @@ import io.prestodb.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.tests.TestGroups.AVRO;
-import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static io.prestodb.tempto.assertions.QueryAssert.Row.row;
 import static io.prestodb.tempto.assertions.QueryAssert.assertThat;
 import static io.prestodb.tempto.context.ThreadLocalTestContextHolder.testContext;
@@ -61,14 +60,14 @@ public class TestAvroSchemaEvolution
         query(format("DROP TABLE IF EXISTS %s", TABLE_NAME));
     }
 
-    @Test(groups = {AVRO, HIVE_CONNECTOR})
+    @Test(groups = {AVRO})
     public void testSelectTable()
     {
         assertThat(query(format("SELECT string_col FROM %s", TABLE_NAME)))
                 .containsExactly(row("string0"));
     }
 
-    @Test(groups = {AVRO, HIVE_CONNECTOR})
+    @Test(groups = {AVRO})
     public void testInsertAfterSchemaEvolution()
     {
         assertThat(query(SELECT_STAR))
@@ -82,7 +81,7 @@ public class TestAvroSchemaEvolution
                         row("string1", 1, 101));
     }
 
-    @Test(groups = {AVRO, HIVE_CONNECTOR})
+    @Test(groups = {AVRO})
     public void testSchemaEvolutionWithIncompatibleType()
     {
         assertThat(query(COLUMNS_IN_TABLE))
@@ -97,7 +96,7 @@ public class TestAvroSchemaEvolution
                 .failsWithMessage("Found int, expecting string");
     }
 
-    @Test(groups = {AVRO, HIVE_CONNECTOR})
+    @Test(groups = {AVRO})
     public void testSchemaEvolution()
     {
         assertThat(query(COLUMNS_IN_TABLE))
@@ -139,7 +138,7 @@ public class TestAvroSchemaEvolution
                 .containsExactly(row("string0", null));
     }
 
-    @Test(groups = {AVRO, HIVE_CONNECTOR})
+    @Test(groups = {AVRO})
     public void testSchemaWhenUrlIsUnset()
     {
         assertThat(query(COLUMNS_IN_TABLE))
@@ -155,7 +154,7 @@ public class TestAvroSchemaEvolution
                         row("dummy_col", "varchar", "", ""));
     }
 
-    @Test(groups = {AVRO, HIVE_CONNECTOR})
+    @Test(groups = {AVRO})
     public void testCreateTableLike()
     {
         String createTableLikeName = "test_avro_like";

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestAvroSchemaUrl.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestAvroSchemaUrl.java
@@ -25,7 +25,6 @@ import org.testng.annotations.Test;
 import java.io.InputStream;
 
 import static com.facebook.presto.tests.TestGroups.AVRO;
-import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.utils.QueryExecutors.onHive;
 import static com.facebook.presto.tests.utils.QueryExecutors.onPresto;
 import static io.prestodb.tempto.assertions.QueryAssert.Row.row;
@@ -65,7 +64,7 @@ public class TestAvroSchemaUrl
         };
     }
 
-    @Test(dataProvider = "avroSchemaLocations", groups = {AVRO, HIVE_CONNECTOR})
+    @Test(dataProvider = "avroSchemaLocations", groups = {AVRO})
     public void testHiveCreatedTable(String schemaLocation)
     {
         onHive().executeQuery("DROP TABLE IF EXISTS test_avro_schema_url_hive");
@@ -85,7 +84,7 @@ public class TestAvroSchemaUrl
         onHive().executeQuery("DROP TABLE test_avro_schema_url_hive");
     }
 
-    @Test(dataProvider = "avroSchemaLocations", groups = {AVRO, HIVE_CONNECTOR})
+    @Test(dataProvider = "avroSchemaLocations", groups = {AVRO})
     public void testPrestoCreatedTable(String schemaLocation)
     {
         onPresto().executeQuery("DROP TABLE IF EXISTS test_avro_schema_url_presto");

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestExternalHiveTable.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestExternalHiveTable.java
@@ -20,7 +20,6 @@ import io.prestodb.tempto.configuration.Configuration;
 import io.prestodb.tempto.fulfillment.table.TableInstance;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.hive.HiveTableDefinitions.NATION_PARTITIONED_BY_BIGINT_REGIONKEY;
 import static com.facebook.presto.tests.hive.HiveTableDefinitions.NATION_PARTITIONED_BY_REGIONKEY_NUMBER_OF_LINES_PER_SPLIT;
 import static com.facebook.presto.tests.utils.QueryExecutors.onHive;
@@ -44,7 +43,7 @@ public class TestExternalHiveTable
                 mutableTable(NATION_PARTITIONED_BY_BIGINT_REGIONKEY));
     }
 
-    @Test(groups = {HIVE_CONNECTOR})
+    @Test
     public void testInsertIntoExternalTable()
     {
         TableInstance nation = mutableTablesState().get(NATION.getName());
@@ -55,7 +54,7 @@ public class TestExternalHiveTable
                 .failsWithMessage("Cannot write to non-managed Hive table");
     }
 
-    @Test(groups = {HIVE_CONNECTOR})
+    @Test
     public void testDeleteFromExternalTable()
     {
         TableInstance nation = mutableTablesState().get(NATION.getName());
@@ -65,7 +64,7 @@ public class TestExternalHiveTable
                 .failsWithMessage("Cannot delete from non-managed Hive table");
     }
 
-    @Test(groups = {HIVE_CONNECTOR})
+    @Test
     public void testDeleteFromExternalPartitionedTableTable()
     {
         TableInstance nation = mutableTablesState().get(NATION_PARTITIONED_BY_BIGINT_REGIONKEY.getName());

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestGrantRevoke.java
@@ -22,7 +22,6 @@ import io.prestodb.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.tests.TestGroups.AUTHORIZATION;
-import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static com.facebook.presto.tests.utils.QueryExecutors.connectToPresto;
 import static com.facebook.presto.tests.utils.QueryExecutors.onHive;
@@ -49,7 +48,7 @@ public class TestGrantRevoke
      *          - "alice@presto" that has "jdbc_user: alice"
      *          - "bob@presto" that has "jdbc_user: bob"
      *     (all other values of the connection are same as that of the default "presto" connection).
-    */
+     */
 
     @BeforeTestWithContext
     public void setup()
@@ -77,7 +76,7 @@ public class TestGrantRevoke
         }
     }
 
-    @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testGrantRevoke()
     {
         // test GRANT
@@ -99,7 +98,7 @@ public class TestGrantRevoke
                 .failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
     }
 
-    @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testShowGrants()
     {
         assertThat(aliceExecutor.executeQuery(format("SHOW GRANTS ON %s", tableName)))
@@ -118,7 +117,7 @@ public class TestGrantRevoke
                         row("bob", "hive", "default", tableName, "INSERT", Boolean.FALSE)));
     }
 
-    @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAll()
     {
         aliceExecutor.executeQuery(format("GRANT ALL PRIVILEGES ON %s TO bob", tableName));
@@ -133,7 +132,7 @@ public class TestGrantRevoke
         assertThat(bobExecutor.executeQuery(format("SHOW GRANTS ON %s", tableName))).hasNoRows();
     }
 
-    @Test(groups = {HIVE_CONNECTOR, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testPublic()
     {
         aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO PUBLIC", tableName));
@@ -144,7 +143,7 @@ public class TestGrantRevoke
         assertThat(aliceExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
     }
 
-    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testTableOwnerPrivileges()
     {
         onHive().executeQuery("set role admin;");
@@ -153,7 +152,7 @@ public class TestGrantRevoke
                 .containsOnly(ownerGrants());
     }
 
-    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testViewOwnerPrivileges()
     {
         onHive().executeQuery("set role admin;");

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBasicTableStatistics.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBasicTableStatistics.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.HIVE_TABLE_STATISTICS;
 import static com.facebook.presto.tests.utils.QueryExecutors.onHive;
 import static com.facebook.presto.tests.utils.QueryExecutors.onPresto;
@@ -39,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestHiveBasicTableStatistics
         extends ProductTest
 {
-    @Test(groups = {HIVE_CONNECTOR, HIVE_TABLE_STATISTICS})
+    @Test(groups = {HIVE_TABLE_STATISTICS})
     public void testCreateUnpartitioned()
     {
         String tableName = "test_basic_statistics_unpartitioned_ctas_presto";
@@ -57,7 +56,7 @@ public class TestHiveBasicTableStatistics
         }
     }
 
-    @Test(groups = {HIVE_CONNECTOR, HIVE_TABLE_STATISTICS})
+    @Test(groups = {HIVE_TABLE_STATISTICS})
     public void testCreateTableWithNoData()
     {
         String tableName = "test_basic_statistics_unpartitioned_ctas_presto_with_no_data";
@@ -74,7 +73,7 @@ public class TestHiveBasicTableStatistics
         }
     }
 
-    @Test(groups = {HIVE_CONNECTOR, HIVE_TABLE_STATISTICS})
+    @Test(groups = {HIVE_TABLE_STATISTICS})
     public void testInsertUnpartitioned()
     {
         String tableName = "test_basic_statistics_unpartitioned_insert_presto";
@@ -110,7 +109,7 @@ public class TestHiveBasicTableStatistics
         }
     }
 
-    @Test(groups = {HIVE_CONNECTOR, HIVE_TABLE_STATISTICS})
+    @Test(groups = {HIVE_TABLE_STATISTICS})
     public void testCreatePartitioned()
     {
         String tableName = "test_basic_statistics_partitioned_ctas_presto";
@@ -145,7 +144,7 @@ public class TestHiveBasicTableStatistics
         }
     }
 
-    @Test(groups = {HIVE_CONNECTOR, HIVE_TABLE_STATISTICS})
+    @Test(groups = {HIVE_TABLE_STATISTICS})
     public void testInsertPartitioned()
     {
         String tableName = "test_basic_statistics_partitioned_insert_presto";
@@ -183,7 +182,7 @@ public class TestHiveBasicTableStatistics
         }
     }
 
-    @Test(groups = {HIVE_CONNECTOR, HIVE_TABLE_STATISTICS})
+    @Test(groups = {HIVE_TABLE_STATISTICS})
     public void testInsertBucketed()
     {
         String tableName = "test_basic_statistics_bucketed_insert_presto";
@@ -218,7 +217,7 @@ public class TestHiveBasicTableStatistics
         }
     }
 
-    @Test(groups = {HIVE_CONNECTOR, HIVE_TABLE_STATISTICS})
+    @Test(groups = {HIVE_TABLE_STATISTICS})
     public void testInsertBucketedPartitioned()
     {
         String tableName = "test_basic_statistics_bucketed_partitioned_insert_presto";

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBucketedTables.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBucketedTables.java
@@ -24,7 +24,6 @@ import io.prestodb.tempto.fulfillment.table.hive.HiveTableDefinition;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.tests.TestGroups.BIG_QUERY;
-import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.utils.QueryExecutors.onHive;
 import static io.prestodb.tempto.assertions.QueryAssert.Row.row;
 import static io.prestodb.tempto.assertions.QueryAssert.assertThat;
@@ -61,7 +60,7 @@ public class TestHiveBucketedTables
                 immutableTable(NATION));
     }
 
-    @Test(groups = {HIVE_CONNECTOR, BIG_QUERY})
+    @Test(groups = {BIG_QUERY})
     public void testIgnorePartitionBucketingIfNotBucketed()
     {
         String tableName = mutableTablesState().get(BUCKETED_PARTITIONED_NATION).getNameInDatabase();

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveCoercion.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveCoercion.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.tests.TestGroups.HIVE_COERCION;
-import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.JDBC;
 import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingPrestoJdbcDriver;
 import static com.facebook.presto.tests.utils.JdbcDriverUtils.usingTeradataJdbcDriver;
@@ -190,42 +189,42 @@ public class TestHiveCoercion
     }
 
     @Requires(TextRequirements.class)
-    @Test(groups = {HIVE_COERCION, HIVE_CONNECTOR, JDBC})
+    @Test(groups = {HIVE_COERCION, JDBC})
     public void testHiveCoercionTextFile()
     {
         doTestHiveCoercion(HIVE_COERCION_TEXTFILE);
     }
 
     @Requires(OrcRequirements.class)
-    @Test(groups = {HIVE_COERCION, HIVE_CONNECTOR, JDBC})
+    @Test(groups = {HIVE_COERCION, JDBC})
     public void testHiveCoercionOrc()
     {
         doTestHiveCoercion(HIVE_COERCION_ORC);
     }
 
     @Requires(RcTextRequirements.class)
-    @Test(groups = {HIVE_COERCION, HIVE_CONNECTOR, JDBC})
+    @Test(groups = {HIVE_COERCION, JDBC})
     public void testHiveCoercionRcText()
     {
         doTestHiveCoercion(HIVE_COERCION_RCTEXT);
     }
 
     @Requires(RcBinaryRequirements.class)
-    @Test(groups = {HIVE_COERCION, HIVE_CONNECTOR, JDBC})
+    @Test(groups = {HIVE_COERCION, JDBC})
     public void testHiveCoercionRcBinary()
     {
         doTestHiveCoercion(HIVE_COERCION_RCBINARY);
     }
 
     @Requires(ParquetRequirements.class)
-    @Test(groups = {HIVE_COERCION, HIVE_CONNECTOR, JDBC})
+    @Test(groups = {HIVE_COERCION, JDBC})
     public void testHiveCoercionParquet()
     {
         doTestHiveCoercion(HIVE_COERCION_PARQUET);
     }
 
     @Requires(AvroRequirements.class)
-    @Test(groups = {HIVE_COERCION, HIVE_CONNECTOR, JDBC})
+    @Test(groups = {HIVE_COERCION, JDBC})
     public void testHiveCoercionAvro()
     {
         String tableName = mutableTableInstanceOf(HIVE_COERCION_AVRO).getNameInDatabase();
@@ -283,32 +282,32 @@ public class TestHiveCoercion
         Connection connection = defaultQueryExecutor().getConnection();
         if (usingPrestoJdbcDriver(connection)) {
             expectedRows = ImmutableList.of(
-                        row(
-                                -1,
-                                2,
-                                -3L,
-                                100,
-                                -101L,
-                                2323L,
-                                "12345",
-                                0.5,
-                                asMap("keep", "as is", "ti2si", (short) -1, "si2int", 100, "int2bi", 2323L, "bi2vc", "12345"),
-                                ImmutableList.of(asMap("ti2int", 2, "si2bi", -101L, "bi2vc", "12345")),
-                                asMap(2, asMap("ti2bi", -3L, "int2bi", 2323L, "float2double", 0.5, "add", null)),
-                                1),
-                        row(
-                                1,
-                                -2,
-                                null,
-                                -100,
-                                101L,
-                                -2323L,
-                                "-12345",
-                                -1.5,
-                                asMap("keep", null, "ti2si", (short) 1, "si2int", -100, "int2bi", -2323L, "bi2vc", "-12345"),
-                                ImmutableList.of(asMap("ti2int", -2, "si2bi", 101L, "bi2vc", "-12345")),
-                                ImmutableMap.of(-2, asMap("ti2bi", null, "int2bi", -2323L, "float2double", -1.5, "add", null)),
-                                1));
+                    row(
+                            -1,
+                            2,
+                            -3L,
+                            100,
+                            -101L,
+                            2323L,
+                            "12345",
+                            0.5,
+                            asMap("keep", "as is", "ti2si", (short) -1, "si2int", 100, "int2bi", 2323L, "bi2vc", "12345"),
+                            ImmutableList.of(asMap("ti2int", 2, "si2bi", -101L, "bi2vc", "12345")),
+                            asMap(2, asMap("ti2bi", -3L, "int2bi", 2323L, "float2double", 0.5, "add", null)),
+                            1),
+                    row(
+                            1,
+                            -2,
+                            null,
+                            -100,
+                            101L,
+                            -2323L,
+                            "-12345",
+                            -1.5,
+                            asMap("keep", null, "ti2si", (short) 1, "si2int", -100, "int2bi", -2323L, "bi2vc", "-12345"),
+                            ImmutableList.of(asMap("ti2int", -2, "si2bi", 101L, "bi2vc", "-12345")),
+                            ImmutableMap.of(-2, asMap("ti2bi", null, "int2bi", -2323L, "float2double", -1.5, "add", null)),
+                            1));
         }
         else if (usingTeradataJdbcDriver(connection)) {
             expectedRows = ImmutableList.of(

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
@@ -28,7 +28,6 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
-import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.SKIP_ON_CDH;
 import static com.facebook.presto.tests.hive.AllSimpleTypesTableDefinitions.ALL_HIVE_SIMPLE_TYPES_TEXTFILE;
 import static com.facebook.presto.tests.hive.HiveTableDefinitions.NATION_PARTITIONED_BY_BIGINT_REGIONKEY;
@@ -171,7 +170,7 @@ public class TestHiveTableStatistics
         }
     }
 
-    @Test(groups = {HIVE_CONNECTOR})
+    @Test
     @Requires(UnpartitionedNationTable.class)
     public void testStatisticsForUnpartitionedTable()
     {
@@ -211,7 +210,7 @@ public class TestHiveTableStatistics
                 row(null, null, null, null, 25.0, null, null));
     }
 
-    @Test(groups = {HIVE_CONNECTOR})
+    @Test
     @Requires(NationPartitionedByBigintTable.class)
     public void testStatisticsForTablePartitionedByBigint()
     {
@@ -338,7 +337,7 @@ public class TestHiveTableStatistics
                 row(null, null, null, null, 5.0, null, null));
     }
 
-    @Test(groups = {HIVE_CONNECTOR})
+    @Test
     @Requires(NationPartitionedByVarcharTable.class)
     public void testStatisticsForTablePartitionedByVarchar()
     {
@@ -466,7 +465,7 @@ public class TestHiveTableStatistics
     }
 
     // This covers also stats calculation for unpartitioned table
-    @Test(groups = {HIVE_CONNECTOR, SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats
+    @Test(groups = {SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats
     @Requires(AllTypesTable.class)
     public void testStatisticsForAllDataTypes()
     {
@@ -514,7 +513,7 @@ public class TestHiveTableStatistics
                 row(null, null, null, null, 2.0, null, null));
     }
 
-    @Test(groups = {HIVE_CONNECTOR, SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats
+    @Test(groups = {SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats
     @Requires(AllTypesTable.class)
     public void testStatisticsForAllDataTypesNoData()
     {
@@ -561,7 +560,7 @@ public class TestHiveTableStatistics
                 row(null, null, null, null, 0.0, null, null));
     }
 
-    @Test(groups = {HIVE_CONNECTOR, SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats
+    @Test(groups = {SKIP_ON_CDH}) // skip on cdh due to no support for date column and stats
     @Requires(AllTypesTable.class)
     public void testStatisticsForAllDataTypesOnlyNulls()
     {

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestInsertIntoHiveTable.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestInsertIntoHiveTable.java
@@ -26,7 +26,6 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
-import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.POST_HIVE_1_0_1;
 import static com.facebook.presto.tests.hive.AllSimpleTypesTableDefinitions.ALL_HIVE_SIMPLE_TYPES_TEXTFILE;
 import static io.prestodb.tempto.Requirements.compose;
@@ -74,7 +73,7 @@ public class TestInsertIntoHiveTable
                 .build();
     }
 
-    @Test(groups = {HIVE_CONNECTOR, POST_HIVE_1_0_1})
+    @Test(groups = {POST_HIVE_1_0_1})
     public void testInsertIntoValuesToHiveTableAllHiveSimpleTypes()
     {
         String tableNameInDatabase = mutableTablesState().get(TABLE_NAME).getNameInDatabase();
@@ -116,7 +115,7 @@ public class TestInsertIntoHiveTable
                         "kot binarny".getBytes()));
     }
 
-    @Test(groups = {HIVE_CONNECTOR, POST_HIVE_1_0_1})
+    @Test(groups = {POST_HIVE_1_0_1})
     public void testInsertIntoSelectToHiveTableAllHiveSimpleTypes()
     {
         String tableNameInDatabase = mutableTablesState().get(TABLE_NAME).getNameInDatabase();
@@ -141,7 +140,7 @@ public class TestInsertIntoHiveTable
                         "kot binarny".getBytes()));
     }
 
-    @Test(groups = {HIVE_CONNECTOR, POST_HIVE_1_0_1})
+    @Test(groups = {POST_HIVE_1_0_1})
     public void testInsertIntoPartitionedWithSerdePropety()
     {
         String tableNameInDatabase = mutableTablesState().get(PARTITIONED_TABLE_WITH_SERDE).getNameInDatabase();

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestSqlStandardAccessControlChecks.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestSqlStandardAccessControlChecks.java
@@ -19,7 +19,6 @@ import io.prestodb.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.tests.TestGroups.AUTHORIZATION;
-import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static com.facebook.presto.tests.utils.QueryExecutors.connectToPresto;
 import static io.prestodb.tempto.assertions.QueryAssert.assertThat;
@@ -48,7 +47,7 @@ public class TestSqlStandardAccessControlChecks
         aliceExecutor.executeQuery(format("CREATE VIEW %s AS SELECT month, day FROM %s", viewName, tableName));
     }
 
-    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlSelect()
     {
         assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
@@ -63,7 +62,7 @@ public class TestSqlStandardAccessControlChecks
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", viewName))).hasNoRows();
     }
 
-    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlSelectFromPartitions()
     {
         assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM \"%s$partitions\"", tableName)))
@@ -73,7 +72,7 @@ public class TestSqlStandardAccessControlChecks
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM \"%s$partitions\"", tableName))).hasNoRows();
     }
 
-    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlInsert()
     {
         assertThat(() -> bobExecutor.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName)))
@@ -84,7 +83,7 @@ public class TestSqlStandardAccessControlChecks
         assertThat(aliceExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
     }
 
-    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlDelete()
     {
         aliceExecutor.executeQuery(format("INSERT INTO %s VALUES (4, 13)", tableName));
@@ -97,7 +96,7 @@ public class TestSqlStandardAccessControlChecks
         assertThat(aliceExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
     }
 
-    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlCreateTableAsSelect()
     {
         String createTableAsSelect = "bob_create_table_as_select";
@@ -112,7 +111,7 @@ public class TestSqlStandardAccessControlChecks
         bobExecutor.executeQuery("DROP TABLE " + createTableAsSelect);
     }
 
-    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlDropTable()
     {
         assertThat(() -> bobExecutor.executeQuery(format("DROP TABLE %s", tableName)))
@@ -123,7 +122,7 @@ public class TestSqlStandardAccessControlChecks
                 .failsWithMessage("does not exist");
     }
 
-    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlAlterTable()
     {
         assertThat(aliceExecutor.executeQuery(format("SHOW COLUMNS FROM %s", tableName))).hasRowsCount(2);
@@ -134,7 +133,7 @@ public class TestSqlStandardAccessControlChecks
         assertThat(aliceExecutor.executeQuery(format("SHOW COLUMNS FROM %s", tableName))).hasRowsCount(3);
     }
 
-    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlCreateView()
     {
         String viewName = "bob_view";
@@ -173,7 +172,7 @@ public class TestSqlStandardAccessControlChecks
         bobExecutor.executeQuery("DROP VIEW " + viewName);
     }
 
-    @Test(groups = {AUTHORIZATION, HIVE_CONNECTOR, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlDropView()
     {
         String viewName = "alice_view_for_drop";

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestTablePartitioningInsertInto.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestTablePartitioningInsertInto.java
@@ -19,7 +19,6 @@ import io.prestodb.tempto.configuration.Configuration;
 import io.prestodb.tempto.query.QueryResult;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static com.facebook.presto.tests.TestGroups.SMOKE;
 import static com.facebook.presto.tests.hive.HiveTableDefinitions.NATION_PARTITIONED_BY_BIGINT_REGIONKEY;
 import static com.facebook.presto.tests.hive.HiveTableDefinitions.NATION_PARTITIONED_BY_REGIONKEY_NUMBER_OF_LINES_PER_SPLIT;
@@ -45,7 +44,7 @@ public class TestTablePartitioningInsertInto
                 mutableTable(NATION, TARGET_NATION_NAME, CREATED));
     }
 
-    @Test(groups = {HIVE_CONNECTOR, SMOKE})
+    @Test(groups = {SMOKE})
     public void selectFromPartitionedNation()
             throws Exception
     {

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestTablePartitioningSelect.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestTablePartitioningSelect.java
@@ -29,7 +29,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static com.facebook.presto.tests.TestGroups.HIVE_CONNECTOR;
 import static io.prestodb.tempto.Requirements.allOf;
 import static io.prestodb.tempto.assertions.QueryAssert.Row.row;
 import static io.prestodb.tempto.assertions.QueryAssert.assertThat;
@@ -90,7 +89,7 @@ public class TestTablePartitioningSelect
                 mutableTable(SINGLE_INT_COLUMN_PARTITIONED_AVRO, TABLE_NAME, LOADED));
     }
 
-    @Test(groups = {HIVE_CONNECTOR})
+    @Test
     public void testSelectPartitionedHiveTableDifferentFormats()
     {
         String tableNameInDatabase = tablesState.get(TABLE_NAME).getNameInDatabase();


### PR DESCRIPTION
It's not used for composing test runs.
It's not applied uniformly (some Hive tests lack it), so it cannot be
used for composing test runs reliably.