### PR TITLE
Fix typo in json property in ThreadResource

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/ThreadResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ThreadResource.java
@@ -94,7 +94,7 @@ public class ThreadResource
                 @JsonProperty("id") long id,
                 @JsonProperty("name") String name,
                 @JsonProperty("state") String state,
-                @JsonProperty("lockOwner") Long lockOwnerId,
+                @JsonProperty("lockOwnerId") Long lockOwnerId,
                 @JsonProperty("stackTrace") List<StackLine> stackTrace)
         {
             this.id = id;
@@ -158,7 +158,7 @@ public class ThreadResource
         public StackLine(
                 @JsonProperty("file") String file,
                 @JsonProperty("line") int line,
-                @JsonProperty("class") String className,
+                @JsonProperty("className") String className,
                 @JsonProperty("method") String method)
         {
             this.file = file;


### PR DESCRIPTION
I found that `JsonProperty`s are not compatible between ser-de at ThreadResource classes. 