### PR TITLE
Improve the performance of generated projection loop

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/project/ConstantPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/ConstantPageProjection.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.ExpressionProfiler;
 import com.google.common.collect.ImmutableList;
 
 import static com.facebook.presto.spi.type.TypeUtils.writeNativeValue;
@@ -61,7 +62,7 @@ public class ConstantPageProjection
     }
 
     @Override
-    public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+    public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions, ExpressionProfiler expressionProfiler)
     {
         return new CompletedWork<>(new RunLengthEncodedBlock(value, selectedPositions.size()));
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.ExpressionProfiler;
 import com.facebook.presto.sql.relational.RowExpression;
 
 import java.lang.invoke.MethodHandle;
@@ -65,11 +66,11 @@ public class GeneratedPageProjection
     }
 
     @Override
-    public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+    public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions, ExpressionProfiler expressionProfiler)
     {
         blockBuilder = blockBuilder.newBlockBuilderLike(null);
         try {
-            return (Work<Block>) pageProjectionWorkFactory.invoke(blockBuilder, session, yieldSignal, page, selectedPositions);
+            return (Work<Block>) pageProjectionWorkFactory.invoke(blockBuilder, session, yieldSignal, page, selectedPositions, expressionProfiler);
         }
         catch (Throwable e) {
             throw new RuntimeException(e);

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/InputPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/InputPageProjection.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.ExpressionProfiler;
 
 import static java.util.Objects.requireNonNull;
 
@@ -54,7 +55,7 @@ public class InputPageProjection
     }
 
     @Override
-    public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+    public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions, ExpressionProfiler expressionProfiler)
     {
         Block block = requireNonNull(page, "page is null").getBlock(0);
         requireNonNull(selectedPositions, "selectedPositions is null");

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/InterpretedPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/InterpretedPageProjection.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.ExpressionProfiler;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.DeterminismEvaluator;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
@@ -95,7 +96,7 @@ public class InterpretedPageProjection
     }
 
     @Override
-    public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+    public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions, ExpressionProfiler expressionProfiler)
     {
         return new InterpretedPageProjectionWork(yieldSignal, page, selectedPositions);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProjection.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.ExpressionProfiler;
 
 public interface PageProjection
 {
@@ -28,5 +29,5 @@ public interface PageProjection
 
     InputChannels getInputChannels();
 
-    Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions);
+    Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions, ExpressionProfiler expressionProfiler);
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/ExpressionProfiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/ExpressionProfiler.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.gen;
+
+import com.facebook.presto.annotation.UsedByGeneratedCode;
+import com.google.common.annotations.VisibleForTesting;
+
+import static com.google.common.base.Verify.verify;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * This class can be called from generated projection classes to profile a single
+ * expression over many rows, and determines whether the profiled expression is expensive.
+ * That information is used by the projection class to determine whether it should check
+ * the yield signal in the projection tight loop. Please see {@link PageFunctionCompiler} for how to
+ * use this class in generated code.
+ */
+@UsedByGeneratedCode
+public class ExpressionProfiler
+{
+    private static final int NUMBER_OF_ROWS_TO_PROFILE = 1024;
+    private static final int EXPENSIVE_FUNCTION_THRESHOLD_MILLIS = 1_000;
+
+    private final int rowsToProfile;
+    private final int expensiveFunctionThresholdMillis;
+    private double meanExecutionTime;
+    private int samples;
+    private long previousTimestamp = -1;
+    private boolean isExpressionExpensive = true;
+    private boolean isProfiling = true;
+
+    public ExpressionProfiler()
+    {
+        this.rowsToProfile = NUMBER_OF_ROWS_TO_PROFILE;
+        this.expensiveFunctionThresholdMillis = EXPENSIVE_FUNCTION_THRESHOLD_MILLIS;
+    }
+
+    @VisibleForTesting
+    public ExpressionProfiler(int rowsToProfile, int expensiveFunctionThresholdMillis)
+    {
+        verify(rowsToProfile >= 0, "rowsToProfile is negative");
+        verify(expensiveFunctionThresholdMillis >= 0, "expensiveFunctionThresholdMillis is negative");
+        this.rowsToProfile = rowsToProfile;
+        this.expensiveFunctionThresholdMillis = expensiveFunctionThresholdMillis;
+    }
+
+    /**
+     * This method keeps track of the timings between subsequent calls (until it collects enough samples)
+     * to determine how long the expression evaluation takes.
+     */
+    public void profile()
+    {
+        if (!isProfiling) {
+            return;
+        }
+
+        // just update the previous timestamp and continue for the initial call
+        if (previousTimestamp == -1) {
+            previousTimestamp = System.nanoTime();
+            return;
+        }
+
+        long now = System.nanoTime();
+        long delta = NANOSECONDS.toMillis(now - previousTimestamp);
+        meanExecutionTime = (meanExecutionTime * samples + delta) / (samples + 1);
+        if (samples++ >= rowsToProfile) {
+            isProfiling = false;
+            if (meanExecutionTime < expensiveFunctionThresholdMillis) {
+                isExpressionExpensive = false;
+            }
+            return;
+        }
+        previousTimestamp = now;
+    }
+
+    public boolean isDoneProfiling()
+    {
+        return !isProfiling;
+    }
+
+    public boolean isExpressionExpensive()
+    {
+        return isExpressionExpensive;
+    }
+
+    public void reset()
+    {
+        previousTimestamp = -1;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -55,6 +55,7 @@ import io.airlift.bytecode.Scope;
 import io.airlift.bytecode.Variable;
 import io.airlift.bytecode.control.ForLoop;
 import io.airlift.bytecode.control.IfStatement;
+import io.airlift.bytecode.expression.BytecodeExpression;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
@@ -202,7 +203,7 @@ public class PageFunctionCompiler
                 result.getRewrittenExpression(),
                 determinismEvaluator.isDeterministic(result.getRewrittenExpression()),
                 result.getInputChannels(),
-                constructorMethodHandle(pageProjectionWorkClass, BlockBuilder.class, ConnectorSession.class, DriverYieldSignal.class, Page.class, SelectedPositions.class));
+                constructorMethodHandle(pageProjectionWorkClass, BlockBuilder.class, ConnectorSession.class, DriverYieldSignal.class, Page.class, SelectedPositions.class, ExpressionProfiler.class));
     }
 
     private static ParameterizedType generateProjectionWorkClassName(Optional<String> classNameSuffix)
@@ -218,6 +219,7 @@ public class PageFunctionCompiler
                 type(Object.class),
                 type(Work.class));
 
+        FieldDefinition expressionProfilerField = classDefinition.declareField(a(PRIVATE), "expressionProfiler", ExpressionProfiler.class);
         FieldDefinition blockBuilderField = classDefinition.declareField(a(PRIVATE), "blockBuilder", BlockBuilder.class);
         FieldDefinition sessionField = classDefinition.declareField(a(PRIVATE), "session", ConnectorSession.class);
         FieldDefinition yieldSignalField = classDefinition.declareField(a(PRIVATE), "yieldSignal", DriverYieldSignal.class);
@@ -229,7 +231,31 @@ public class PageFunctionCompiler
         CachedInstanceBinder cachedInstanceBinder = new CachedInstanceBinder(classDefinition, callSiteBinder);
 
         // process
-        generateProcessMethod(classDefinition, blockBuilderField, sessionField, yieldSignalField, pageField, selectedPositionsField, nextIndexOrPositionField, resultField);
+        generateProcessMethod(
+                classDefinition,
+                blockBuilderField,
+                selectedPositionsField,
+                resultField);
+
+        // processPositions
+        generateProcessPositionsMethod(
+                classDefinition,
+                expressionProfilerField,
+                sessionField,
+                yieldSignalField,
+                pageField,
+                selectedPositionsField,
+                nextIndexOrPositionField);
+
+        // processRange
+        generateProcessRangeMethod(
+                classDefinition,
+                expressionProfilerField,
+                sessionField,
+                yieldSignalField,
+                pageField,
+                selectedPositionsField,
+                nextIndexOrPositionField);
 
         // getResult
         MethodDefinition method = classDefinition.declareMethod(a(PUBLIC), "getResult", type(Object.class), ImmutableList.of());
@@ -245,8 +271,9 @@ public class PageFunctionCompiler
         Parameter yieldSignal = arg("yieldSignal", DriverYieldSignal.class);
         Parameter page = arg("page", Page.class);
         Parameter selectedPositions = arg("selectedPositions", SelectedPositions.class);
+        Parameter expressionProfiler = arg("expressionProfiler", ExpressionProfiler.class);
 
-        MethodDefinition constructorDefinition = classDefinition.declareConstructor(a(PUBLIC), blockBuilder, session, yieldSignal, page, selectedPositions);
+        MethodDefinition constructorDefinition = classDefinition.declareConstructor(a(PUBLIC), blockBuilder, session, yieldSignal, page, selectedPositions, expressionProfiler);
 
         BytecodeBlock body = constructorDefinition.getBody();
         Variable thisVariable = constructorDefinition.getThis();
@@ -260,7 +287,9 @@ public class PageFunctionCompiler
                 .append(thisVariable.setField(pageField, page))
                 .append(thisVariable.setField(selectedPositionsField, selectedPositions))
                 .append(thisVariable.setField(nextIndexOrPositionField, selectedPositions.invoke("getOffset", int.class)))
-                .append(thisVariable.setField(resultField, constantNull(Block.class)));
+                .append(thisVariable.setField(resultField, constantNull(Block.class)))
+                .append(thisVariable.setField(expressionProfilerField, expressionProfiler))
+                .append(thisVariable.getField(expressionProfilerField).invoke("reset", void.class));
 
         cachedInstanceBinder.generateInitializations(thisVariable, body);
         body.ret();
@@ -271,45 +300,22 @@ public class PageFunctionCompiler
     private static MethodDefinition generateProcessMethod(
             ClassDefinition classDefinition,
             FieldDefinition blockBuilder,
-            FieldDefinition session,
-            FieldDefinition yieldSignal,
-            FieldDefinition page,
             FieldDefinition selectedPositions,
-            FieldDefinition nextIndexOrPosition,
             FieldDefinition result)
     {
         MethodDefinition method = classDefinition.declareMethod(a(PUBLIC), "process", type(boolean.class), ImmutableList.of());
-
-        Scope scope = method.getScope();
-        Variable thisVariable = method.getThis();
         BytecodeBlock body = method.getBody();
+        Variable thisVariable = method.getThis();
 
-        Variable from = scope.declareVariable("from", body, thisVariable.getField(nextIndexOrPosition));
-        Variable to = scope.declareVariable("to", body, add(thisVariable.getField(selectedPositions).invoke("getOffset", int.class), thisVariable.getField(selectedPositions).invoke("size", int.class)));
-        Variable positions = scope.declareVariable(int[].class, "positions");
-        Variable index = scope.declareVariable(int.class, "index");
-
-        IfStatement ifStatement = new IfStatement()
-                .condition(thisVariable.getField(selectedPositions).invoke("isList", boolean.class));
-        body.append(ifStatement);
-
-        ifStatement.ifTrue(new BytecodeBlock()
-                .append(positions.set(thisVariable.getField(selectedPositions).invoke("getPositions", int[].class)))
-                .append(new ForLoop("positions loop")
-                        .initialize(index.set(from))
-                        .condition(lessThan(index, to))
-                        .update(index.increment())
-                        .body(new BytecodeBlock()
-                                .append(thisVariable.invoke("evaluate", void.class, thisVariable.getField(session), thisVariable.getField(page), positions.getElement(index)))
-                                .append(generateCheckYieldBlock(thisVariable, index, yieldSignal, nextIndexOrPosition)))));
-
-        ifStatement.ifFalse(new ForLoop("range based loop")
-                .initialize(index.set(from))
-                .condition(lessThan(index, to))
-                .update(index.increment())
-                .body(new BytecodeBlock()
-                        .append(thisVariable.invoke("evaluate", void.class, thisVariable.getField(session), thisVariable.getField(page), index))
-                        .append(generateCheckYieldBlock(thisVariable, index, yieldSignal, nextIndexOrPosition))));
+        body.append(new IfStatement()
+                .condition(thisVariable.getField(selectedPositions).invoke("isList", boolean.class))
+                .ifTrue(new BytecodeBlock()
+                        .append(new IfStatement()
+                                .condition(not(thisVariable.invoke("processPositions", boolean.class)))
+                                .ifTrue(new BytecodeBlock().push(false).retBoolean())))
+                .ifFalse(new IfStatement()
+                        .condition(not(thisVariable.invoke("processRange", boolean.class)))
+                        .ifTrue(new BytecodeBlock().push(false).retBoolean())));
 
         body.comment("result = this.blockBuilder.build(); return true;")
                 .append(thisVariable.setField(result, thisVariable.getField(blockBuilder).invoke("build", Block.class)))
@@ -317,6 +323,139 @@ public class PageFunctionCompiler
                 .retBoolean();
 
         return method;
+    }
+
+    private void generateProcessRangeMethod(
+            ClassDefinition classDefinition,
+            FieldDefinition expressionProfiler,
+            FieldDefinition session,
+            FieldDefinition yieldSignal,
+            FieldDefinition page,
+            FieldDefinition selectedPositions,
+            FieldDefinition nextIndexOrPosition)
+    {
+        MethodDefinition method = classDefinition.declareMethod(a(PUBLIC), "processRange", type(boolean.class), ImmutableList.of());
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        Variable thisVariable = method.getThis();
+        Variable from = scope.declareVariable("from", body, thisVariable.getField(nextIndexOrPosition));
+        Variable to = scope.declareVariable("to", body, add(thisVariable.getField(selectedPositions).invoke("getOffset", int.class), thisVariable.getField(selectedPositions).invoke("size", int.class)));
+        Variable index = scope.declareVariable(int.class, "index");
+
+        body.append(new IfStatement()
+                .condition(thisVariable.getField(expressionProfiler).invoke("isDoneProfiling", boolean.class))
+                .ifTrue(generateDoneProfilingBody(
+                        thisVariable,
+                        expressionProfiler,
+                        page,
+                        session,
+                        yieldSignal,
+                        nextIndexOrPosition,
+                        from,
+                        to,
+                        Optional.empty(),
+                        index))
+                .ifFalse(new BytecodeBlock()
+                        .append(new ForLoop("range loop")
+                                .initialize(index.set(from))
+                                .condition(lessThan(index, to))
+                                .update(index.increment())
+                                .body(new BytecodeBlock()
+                                        .comment("evaluate()")
+                                        .append(thisVariable.invoke("evaluate", void.class, thisVariable.getField(session), thisVariable.getField(page), index))
+                                        .comment("expressionProfiler.profile()")
+                                        .append(thisVariable.getField(expressionProfiler).invoke("profile", void.class))
+                                        .comment("check yield")
+                                        .append(generateCheckYieldBlock(thisVariable, index, yieldSignal, nextIndexOrPosition))))));
+
+        body.comment("return true;")
+                .push(true)
+                .retBoolean();
+    }
+
+    private void generateProcessPositionsMethod(
+            ClassDefinition classDefinition,
+            FieldDefinition expressionProfiler,
+            FieldDefinition session,
+            FieldDefinition yieldSignal,
+            FieldDefinition page,
+            FieldDefinition selectedPositions,
+            FieldDefinition nextIndexOrPosition)
+    {
+        MethodDefinition method = classDefinition.declareMethod(a(PUBLIC), "processPositions", type(boolean.class), ImmutableList.of());
+
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        Variable thisVariable = method.getThis();
+        Variable positions = scope.declareVariable(int[].class, "positions");
+        Variable index = scope.declareVariable(int.class, "index");
+        Variable from = scope.declareVariable("from", body, thisVariable.getField(nextIndexOrPosition));
+        Variable to = scope.declareVariable("to", body, add(thisVariable.getField(selectedPositions).invoke("getOffset", int.class), thisVariable.getField(selectedPositions).invoke("size", int.class)));
+
+        BytecodeExpression invokeEvaluate = thisVariable.invoke("evaluate", void.class, thisVariable.getField(session), thisVariable.getField(page), positions.getElement(index));
+
+        body.append((positions.set(thisVariable.getField(selectedPositions).invoke("getPositions", int[].class))));
+
+        body.append(new IfStatement()
+                .condition(thisVariable.getField(expressionProfiler).invoke("isDoneProfiling", boolean.class))
+                .ifTrue(generateDoneProfilingBody(
+                        thisVariable,
+                        expressionProfiler,
+                        page,
+                        session,
+                        yieldSignal,
+                        nextIndexOrPosition,
+                        from,
+                        to,
+                        Optional.of(positions),
+                        index))
+                .ifFalse(new BytecodeBlock()
+                        .append(new ForLoop("positions loop")
+                                .initialize(index.set(from))
+                                .condition(lessThan(index, to))
+                                .update(index.increment())
+                                .body(new BytecodeBlock()
+                                        .comment("evaluate()")
+                                        .append(invokeEvaluate)
+                                        .comment("expressionProfiler.profiler()")
+                                        .append(thisVariable.getField(expressionProfiler).invoke("profile", void.class))
+                                        .comment("check for yield")
+                                        .append(generateCheckYieldBlock(thisVariable, index, yieldSignal, nextIndexOrPosition))))));
+
+        body.comment("return true;")
+            .push(true)
+            .retBoolean();
+    }
+
+    private static BytecodeNode generateDoneProfilingBody(
+            Variable thisVariable,
+            FieldDefinition expressionProfiler,
+            FieldDefinition page,
+            FieldDefinition session,
+            FieldDefinition yieldSignal,
+            FieldDefinition nextIndexOrPosition,
+            Variable from,
+            Variable to,
+            Optional<Variable> positions,
+            Variable index)
+    {
+        return new IfStatement()
+                .condition(thisVariable.getField(expressionProfiler).invoke("isExpressionExpensive", boolean.class))
+                .ifTrue(new ForLoop("loop checking the yield signal")
+                .initialize(index.set(from))
+                .condition(lessThan(index, to))
+                .update(index.increment())
+                .body(new BytecodeBlock()
+                        .append(thisVariable.invoke("evaluate", void.class, thisVariable.getField(session), thisVariable.getField(page), positions.map(positionsArray -> positionsArray.getElement(index)).orElse(index)))
+                        .append(generateCheckYieldBlock(thisVariable, index, yieldSignal, nextIndexOrPosition))))
+                .ifFalse(new ForLoop("loop that doesn't check the yield signal")
+                .initialize(index.set(from))
+                .condition(lessThan(index, to))
+                .update(index.increment())
+                .body(new BytecodeBlock()
+                        .append(thisVariable.invoke("evaluate", void.class, thisVariable.getField(session), thisVariable.getField(page), positions.map(positionsArray -> positionsArray.getElement(index)).orElse(index)))));
     }
 
     private static BytecodeBlock generateCheckYieldBlock(Variable thisVariable, Variable index, FieldDefinition yieldSignal, FieldDefinition nextIndexOrPosition)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
@@ -34,6 +34,7 @@ import com.facebook.presto.spi.RecordPageSource;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
+import com.facebook.presto.sql.gen.ExpressionProfiler;
 import com.facebook.presto.sql.gen.PageFunctionCompiler;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.relational.RowExpression;
@@ -267,7 +268,9 @@ public class TestScanFilterAndProjectOperator
             projections.add(call(internalScalarFunction("generic_long_page_col" + i, BIGINT.getTypeSignature(), ImmutableList.of(BIGINT.getTypeSignature())), BIGINT, field(0, BIGINT)));
         }
         Supplier<CursorProcessor> cursorProcessor = expressionCompiler.compileCursorProcessor(Optional.empty(), projections.build(), "key");
-        Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(Optional.empty(), projections.build());
+        // configure the ExpressionProfiler to check for yield every row
+        ExpressionProfiler profiler = new ExpressionProfiler(10, 0);
+        Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(Optional.empty(), projections.build(), Optional.empty(), Optional.of(profiler));
 
         ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
                 0,

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.spi.block.LongArrayBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.ExpressionProfiler;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -219,7 +220,7 @@ public class TestDictionaryAwarePageProjection
     private static void testProjectRange(Block block, Class<? extends Block> expectedResultType, DictionaryAwarePageProjection projection, boolean forceYield)
     {
         DriverYieldSignal yieldSignal = new DriverYieldSignal();
-        Work<Block> work = projection.project(null, yieldSignal, new Page(block), SelectedPositions.positionsRange(5, 10));
+        Work<Block> work = projection.project(null, yieldSignal, new Page(block), SelectedPositions.positionsRange(5, 10), new ExpressionProfiler());
         Block result;
         if (forceYield) {
             result = projectWithYield(work, yieldSignal);
@@ -239,7 +240,7 @@ public class TestDictionaryAwarePageProjection
     {
         DriverYieldSignal yieldSignal = new DriverYieldSignal();
         int[] positions = {0, 2, 4, 6, 8, 10};
-        Work<Block> work = projection.project(null, yieldSignal, new Page(block), SelectedPositions.positionsList(positions, 0, positions.length));
+        Work<Block> work = projection.project(null, yieldSignal, new Page(block), SelectedPositions.positionsList(positions, 0, positions.length), new ExpressionProfiler());
         Block result;
         if (forceYield) {
             result = projectWithYield(work, yieldSignal);
@@ -258,7 +259,7 @@ public class TestDictionaryAwarePageProjection
     private static void testProjectFastReturnIgnoreYield(Block block, DictionaryAwarePageProjection projection)
     {
         DriverYieldSignal yieldSignal = new DriverYieldSignal();
-        Work<Block> work = projection.project(null, yieldSignal, new Page(block), SelectedPositions.positionsRange(5, 10));
+        Work<Block> work = projection.project(null, yieldSignal, new Page(block), SelectedPositions.positionsRange(5, 10), new ExpressionProfiler());
         yieldSignal.setWithDelay(1, executor);
         yieldSignal.forceYieldForTesting();
 
@@ -308,7 +309,7 @@ public class TestDictionaryAwarePageProjection
         }
 
         @Override
-        public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+        public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions, ExpressionProfiler expressionProfiler)
         {
             return new TestPageProjectionWork(yieldSignal, page, selectedPositions);
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.spi.block.VariableWidthBlock;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.ExpressionProfiler;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -385,10 +386,10 @@ public class TestPageProcessor
         }
 
         @Override
-        public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+        public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions, ExpressionProfiler expressionProfiler)
         {
             setInvocationCount(getInvocationCount() + 1);
-            return delegate.project(session, yieldSignal, page, selectedPositions);
+            return delegate.project(session, yieldSignal, page, selectedPositions, expressionProfiler);
         }
 
         public int getInvocationCount()
@@ -411,9 +412,9 @@ public class TestPageProcessor
         }
 
         @Override
-        public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+        public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions, ExpressionProfiler expressionProfiler)
         {
-            return new YieldPageProjectionWork(session, yieldSignal, page, selectedPositions);
+            return new YieldPageProjectionWork(session, yieldSignal, page, selectedPositions, expressionProfiler);
         }
 
         private class YieldPageProjectionWork
@@ -422,10 +423,10 @@ public class TestPageProcessor
             private final DriverYieldSignal yieldSignal;
             private final Work<Block> work;
 
-            public YieldPageProjectionWork(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+            public YieldPageProjectionWork(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions, ExpressionProfiler expressionProfiler)
             {
                 this.yieldSignal = yieldSignal;
-                this.work = delegate.project(session, yieldSignal, page, selectedPositions);
+                this.work = delegate.project(session, yieldSignal, page, selectedPositions, expressionProfiler);
             }
 
             @Override
@@ -467,7 +468,7 @@ public class TestPageProcessor
         }
 
         @Override
-        public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+        public Work<Block> project(ConnectorSession session, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions, ExpressionProfiler expressionProfiler)
         {
             return new CompletedWork<>(page.getBlock(0).getLoadedBlock());
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestInterpretedPageProjectionFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestInterpretedPageProjectionFunction.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.ExpressionProfiler;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.google.common.collect.ImmutableMap;
@@ -218,7 +219,8 @@ public class TestInterpretedPageProjectionFunction
                 TEST_SESSION.toConnectorSession(),
                 yieldSignal,
                 new Page(positions.length, blocks),
-                positionsList(positions, 0, positions.length));
+                positionsList(positions, 0, positions.length),
+                new ExpressionProfiler());
 
         Block block;
         // Get nothing for the first position.length compute due to yield
@@ -248,7 +250,8 @@ public class TestInterpretedPageProjectionFunction
                 TEST_SESSION.toConnectorSession(),
                 new DriverYieldSignal(),
                 new Page(positions.length, blocks),
-                positionsList(positions, 0, positions.length));
+                positionsList(positions, 0, positions.length),
+                new ExpressionProfiler());
         assertTrue(work.process());
         block = work.getResult();
 


### PR DESCRIPTION
The yield check in the generated projection tight loop may have negative
impact on the performance. The yield check was introduced for expensive
projections so that the engine can yield those. However, that check is
not really necessary for cheap projections and having a branch in the
tight for loop seems to hurt the performance.

This change introduces an ExpressionProfiler to determine whether a
projection is cheap/expensive, and as a result, in the best case where
the projection is cheap the generated projection code can execute a
simple tight loop for expression evaluation, and get rid of the yield
check entirely.

This change has been benchmarked with various production queries and
microbenchmarks and it results in up to ~5% improvement in performance.

```
Benchmark                                   (expressionProfilerEnabled)  Mode  Cnt      Score      Error  Units
ExpressionProfilerBenchmark.pageProjection                        false  avgt   15  25176.150 ± 2187.975  ns/op
ExpressionProfilerBenchmark.pageProjection                         true  avgt   15  23767.123 ± 1480.502  ns/op
```

#### Other notes:

- The performance is on-par or slightly better (seen improvements up to 3-4%) for several production queries, and [ubenchmarks](https://gist.github.com/nezihyigitbasi/e7c0f6e0df3e1a22cd0ac777c337351c) show around ~5.5% improvement.
- An approach I tried initially was to use the check `if (profiler.shouldCheckYield() && yield.isSet())` in the tight loop instead of  `if (yield.isSet())` to hopefully eliminate atomic boolean reads. However, it turns out that the cost is similar. So, it's not the atomic variable reads in the loop that hurts the performance, it's the branches in the tight loop hurting the performance. Therefore, I took the current approach where I get rid of the branches in the tight loop entirely if possible (when the expression is cheap).
- `ExpressionProfiler` samples 1024 rows right now before it stops profiling. Depending on the file format that may be multiple pages (ORC starts with pages of size 1 and exponentially increases the page size, Parquet reader is probably producing fixed size pages). I haven't experimented with this sample size so far.
- `ExpressionProfiler` estimates the mean execution time for the `evaluate` calls over these 1024 samples and claim the expression as expensive if the mean execution time is greater than `1s`. I didn't experiment with different values for this threshold, so not sure this is a good value or not.
- Here is the decompiled version of the new generated projection class: https://gist.github.com/nezihyigitbasi/2015d78e7c24d51e896428f139926b64
- Here is the decompiled version of the **old** generated projection class for comparison: https://gist.github.com/nezihyigitbasi/622365e7f9701fa74e22acac1c28fbc4