### PR TITLE
TableFinishNode distribution properties should be derived from input

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -367,9 +367,7 @@ public class PropertyDerivations
         @Override
         public ActualProperties visitTableFinish(TableFinishNode node, List<ActualProperties> inputProperties)
         {
-            return ActualProperties.builder()
-                    .global(coordinatorSingleStreamPartition())
-                    .build();
+            return Iterables.getOnlyElement(inputProperties);
         }
 
         @Override


### PR DESCRIPTION
TableFinishNode does not enforce any distribution by itself.
It relies on ExchangeNode to stream data to coordinator.