### PR TITLE
Replace floorMod with faster reduction function

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -504,6 +504,13 @@ public class MapBlockBuilder
             throw new RuntimeException(throwable);
         }
 
-        return (int) Math.floorMod(hashCode, hashTableSize);
+        return computePosition(hashCode, hashTableSize);
+    }
+
+    // This function reduces the 64 bit hashcode to [0, hashTableSize) uniformly. It first reduces the hashcode to 32 bit
+    // integer x then normalize it to x / 2^32 * hashSize to reduce the range of x from [0, 2^32) to [0, hashTableSize)
+    static int computePosition(long hashcode, int hashTableSize)
+    {
+        return (int) ((Integer.toUnsignedLong(Long.hashCode(hashcode)) * hashTableSize) >> 32);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
@@ -25,6 +25,7 @@ import java.util.function.BiConsumer;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.block.AbstractMapBlock.HASH_MULTIPLIER;
+import static com.facebook.presto.spi.block.MapBlockBuilder.computePosition;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
 import static java.lang.String.format;
@@ -161,9 +162,9 @@ public class SingleMapBlock
 
         int hashTableOffset = offset / 2 * HASH_MULTIPLIER;
         int hashTableSize = positionCount / 2 * HASH_MULTIPLIER;
-        int hash = (int) Math.floorMod(hashCode, hashTableSize);
+        int position = computePosition(hashCode, hashTableSize);
         while (true) {
-            int keyPosition = hashTable[hashTableOffset + hash];
+            int keyPosition = hashTable[hashTableOffset + position];
             if (keyPosition == -1) {
                 return -1;
             }
@@ -179,9 +180,9 @@ public class SingleMapBlock
             if (match) {
                 return keyPosition * 2 + 1;
             }
-            hash++;
-            if (hash == hashTableSize) {
-                hash = 0;
+            position++;
+            if (position == hashTableSize) {
+                position = 0;
             }
         }
     }
@@ -205,9 +206,9 @@ public class SingleMapBlock
 
         int hashTableOffset = offset / 2 * HASH_MULTIPLIER;
         int hashTableSize = positionCount / 2 * HASH_MULTIPLIER;
-        int hash = (int) Math.floorMod(hashCode, hashTableSize);
+        int position = computePosition(hashCode, hashTableSize);
         while (true) {
-            int keyPosition = hashTable[hashTableOffset + hash];
+            int keyPosition = hashTable[hashTableOffset + position];
             if (keyPosition == -1) {
                 return -1;
             }
@@ -223,9 +224,9 @@ public class SingleMapBlock
             if (match) {
                 return keyPosition * 2 + 1;
             }
-            hash++;
-            if (hash == hashTableSize) {
-                hash = 0;
+            position++;
+            if (position == hashTableSize) {
+                position = 0;
             }
         }
     }
@@ -246,9 +247,9 @@ public class SingleMapBlock
 
         int hashTableOffset = offset / 2 * HASH_MULTIPLIER;
         int hashTableSize = positionCount / 2 * HASH_MULTIPLIER;
-        int hash = (int) Math.floorMod(hashCode, hashTableSize);
+        int position = computePosition(hashCode, hashTableSize);
         while (true) {
-            int keyPosition = hashTable[hashTableOffset + hash];
+            int keyPosition = hashTable[hashTableOffset + position];
             if (keyPosition == -1) {
                 return -1;
             }
@@ -264,9 +265,9 @@ public class SingleMapBlock
             if (match) {
                 return keyPosition * 2 + 1;
             }
-            hash++;
-            if (hash == hashTableSize) {
-                hash = 0;
+            position++;
+            if (position == hashTableSize) {
+                position = 0;
             }
         }
     }
@@ -287,9 +288,9 @@ public class SingleMapBlock
 
         int hashTableOffset = offset / 2 * HASH_MULTIPLIER;
         int hashTableSize = positionCount / 2 * HASH_MULTIPLIER;
-        int hash = (int) Math.floorMod(hashCode, hashTableSize);
+        int position = computePosition(hashCode, hashTableSize);
         while (true) {
-            int keyPosition = hashTable[hashTableOffset + hash];
+            int keyPosition = hashTable[hashTableOffset + position];
             if (keyPosition == -1) {
                 return -1;
             }
@@ -305,9 +306,9 @@ public class SingleMapBlock
             if (match) {
                 return keyPosition * 2 + 1;
             }
-            hash++;
-            if (hash == hashTableSize) {
-                hash = 0;
+            position++;
+            if (position == hashTableSize) {
+                position = 0;
             }
         }
     }
@@ -328,9 +329,9 @@ public class SingleMapBlock
 
         int hashTableOffset = offset / 2 * HASH_MULTIPLIER;
         int hashTableSize = positionCount / 2 * HASH_MULTIPLIER;
-        int hash = (int) Math.floorMod(hashCode, hashTableSize);
+        int position = computePosition(hashCode, hashTableSize);
         while (true) {
-            int keyPosition = hashTable[hashTableOffset + hash];
+            int keyPosition = hashTable[hashTableOffset + position];
             if (keyPosition == -1) {
                 return -1;
             }
@@ -346,9 +347,9 @@ public class SingleMapBlock
             if (match) {
                 return keyPosition * 2 + 1;
             }
-            hash++;
-            if (hash == hashTableSize) {
-                hash = 0;
+            position++;
+            if (position == hashTableSize) {
+                position = 0;
             }
         }
     }
@@ -369,9 +370,9 @@ public class SingleMapBlock
 
         int hashTableOffset = offset / 2 * HASH_MULTIPLIER;
         int hashTableSize = positionCount / 2 * HASH_MULTIPLIER;
-        int hash = (int) Math.floorMod(hashCode, hashTableSize);
+        int position = computePosition(hashCode, hashTableSize);
         while (true) {
-            int keyPosition = hashTable[hashTableOffset + hash];
+            int keyPosition = hashTable[hashTableOffset + position];
             if (keyPosition == -1) {
                 return -1;
             }
@@ -387,9 +388,9 @@ public class SingleMapBlock
             if (match) {
                 return keyPosition * 2 + 1;
             }
-            hash++;
-            if (hash == hashTableSize) {
-                hash = 0;
+            position++;
+            if (position == hashTableSize) {
+                position = 0;
             }
         }
     }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/BenchmarkComputePosition.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/BenchmarkComputePosition.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(NANOSECONDS)
+@Fork(3)
+@Warmup(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkComputePosition
+{
+    private int hashTableSize = ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);
+    private long hashcode = ThreadLocalRandom.current().nextLong();
+
+    // This is the baseline.
+    @Benchmark
+    public long computePositionWithFloorMod()
+    {
+        return Math.floorMod(hashcode, hashTableSize);
+    }
+
+    @Benchmark
+    public long computePositionWithMod()
+    {
+        return (int) (hashcode & 0x7fff_ffff_ffff_ffffL) % hashTableSize;
+    }
+
+    // This reduction function requires the hashTableSize to be power of 2.
+    @Benchmark
+    public long computePositionWithMask()
+    {
+        return (int) hashcode & (hashTableSize - 1);
+    }
+
+    // This function reduces the 64 bit hashcode to [0, hashTableSize) uniformly if the hashcode has uniform distribution.
+    // It first reduces the hashcode to 32 bit integer x then normalizes it to x / 2^32 * hashSize to reduce the range of x
+    // from [0, 2^32) to [0, hashTableSize).
+    @Benchmark
+    public long computePositionWithBitShifting()
+    {
+        return (int) ((Integer.toUnsignedLong(Long.hashCode(hashcode)) * hashTableSize) >> 32);
+    }
+
+    // This function used division instead of bit shifting. JVM would compile it to bit shifting instructions thus it
+    // has similar performance to computePositionWithBitShifting()
+    @Benchmark
+    public long computePositionWithDivision()
+    {
+        return (int) ((Integer.toUnsignedLong(Long.hashCode(hashcode)) * hashTableSize) / (1 << 32));
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkComputePosition.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}


### PR DESCRIPTION
Building hashtable in map column uses 30% of CPU out of the scan cost
on that column, and Math.floorMod() uses 60% CPU out of building
hashtable. We tested 5 custom range reduction functions and chose
computePositionWithBitShifting(), which is one of the top 3 implementations
 in performance and does not require the hash table size to be power of 2. 
After the change buildHashTable improved 31% and the total CPU for the 
test select map query improved 14%.

The following table shows the CPU percentage for the Mod,
getHashPosition and buildHashTable and the total CPU hours for the
select checksum query on a map column. The numbers are the average
of 3 runs on a verifier cluster.

The following table shows the CPU percentage for computePosition,
getHashPosition and buildHashTable and the total CPU hours for a
select checksum query on a map column.

```
 			computePosition% getHashPosition% buildHashTable% Total CPU Hours
computePositionWithMod		16.62		21.89		28.04	          14.37
computePositionWithMask		0.51		9.53		14.44	          12.24
computePositionWithBitShifting	4.61		11.66		18.97	          12.32
computePositionWithFloorMod	16.22		22.03		27.33	          14.21
```

The JMH benchmark results on JDK 10:
```
Benchmark                                                Mode  Cnt   Score   Error  Units
BenchmarkComputePosition.computePositionWithBitShifting  avgt   30   2.954 ± 0.122  ns/op
BenchmarkComputePosition.computePositionWithDivision     avgt   30   2.852 ± 0.145  ns/op
BenchmarkComputePosition.computePositionWithFloorMod     avgt   30  11.212 ± 0.215  ns/op
BenchmarkComputePosition.computePositionWithMask         avgt   30   2.455 ± 0.054  ns/op
BenchmarkComputePosition.computePositionWithMod          avgt   30   4.490 ± 0.113  ns/op
```

The benchmark shows similar performance on JDK 8 and 11 for all methods.

computePositionWithBitShifting() and computePositionWithDivision() can reduce the 64 bit hashcode to range [0, 2^32) then to [0, hashTableSize) uniformly if the hashcode is uniformly distributed.

The plotted the distribution of these functions and floorMod() show similarly good uniform distributions.
<img width="1107" alt="screen shot 2018-11-01 at 4 54 56 pm" src="https://user-images.githubusercontent.com/33299678/47893351-cf674380-de19-11e8-99f8-6af2458f0f04.png">

<img width="1198" alt="screen shot 2018-11-01 at 4 54 23 pm" src="https://user-images.githubusercontent.com/33299678/47893363-da21d880-de19-11e8-8e30-dc574dd8ec80.png">

