### PR TITLE
 map special jdbc (presto 'unsupported') column types to unbounded varchar type

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/StandardReadMappings.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/StandardReadMappings.java
@@ -199,7 +199,7 @@ public final class StandardReadMappings
                 int decimalDigits = type.getDecimalDigits();
                 int precision = columnSize + max(-decimalDigits, 0); // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
                 if (precision > Decimals.MAX_PRECISION) {
-                    return Optional.empty();
+                    return Optional.of(varcharReadMapping(createUnboundedVarcharType()));
                 }
                 return Optional.of(decimalReadMapping(createDecimalType(precision, max(decimalDigits, 0))));
 
@@ -232,6 +232,6 @@ public final class StandardReadMappings
             case Types.TIMESTAMP:
                 return Optional.of(timestampReadMapping());
         }
-        return Optional.empty();
+        return Optional.of(varcharReadMapping(createUnboundedVarcharType()));
     }
 }

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlTypeMapping.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlTypeMapping.java
@@ -266,8 +266,8 @@ public class TestMySqlTypeMapping
         jdbcSqlExecutor.execute(format("CREATE TABLE tpch.test_unsupported_data_type(supported_column varchar(5), unsupported_column %s)", databaseDataType));
         try {
             assertQuery(
-                    "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'tpch' AND TABLE_NAME = 'test_unsupported_data_type'",
-                    "VALUES 'supported_column'"); // no 'unsupported_column'
+                    "SELECT COLUMN_NAME,DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'tpch' AND TABLE_NAME = 'test_unsupported_data_type'",
+                    "VALUES ('supported_column','varchar(5)'),('unsupported_column','varchar')"); // 'unsupported_column' is mapped to an unbounded varchar
         }
         finally {
             jdbcSqlExecutor.execute("DROP TABLE tpch.test_unsupported_data_type");

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -128,10 +128,6 @@ public class TestPostgreSqlIntegrationSmokeTest
                 AutoCloseable ignore3 = withTable("tpch.no_columns", "()")) {
             assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains("orders", "no_supported_columns", "supported_columns", "no_columns");
 
-            assertQueryFails("SELECT c FROM no_supported_columns", "Table 'tpch.no_supported_columns' not found");
-            assertQueryFails("SELECT * FROM no_supported_columns", "Table 'tpch.no_supported_columns' not found");
-            assertQueryFails("SELECT 'a' FROM no_supported_columns", "Table 'tpch.no_supported_columns' not found");
-
             assertQueryFails("SELECT c FROM no_columns", "Table 'tpch.no_columns' not found");
             assertQueryFails("SELECT * FROM no_columns", "Table 'tpch.no_columns' not found");
             assertQueryFails("SELECT 'a' FROM no_columns", "Table 'tpch.no_columns' not found");
@@ -140,7 +136,6 @@ public class TestPostgreSqlIntegrationSmokeTest
             assertQueryFails("SELECT * FROM non_existent", ".* Table .*tpch.non_existent.* does not exist");
             assertQueryFails("SELECT 'a' FROM non_existent", ".* Table .*tpch.non_existent.* does not exist");
 
-            assertQuery("SHOW COLUMNS FROM no_supported_columns", "SELECT 'nothing' WHERE false");
             assertQuery("SHOW COLUMNS FROM no_columns", "SELECT 'nothing' WHERE false");
 
             // Other tables should be visible in SHOW TABLES (the no_supported_columns might be included or might be not) and information_schema.tables
@@ -151,6 +146,7 @@ public class TestPostgreSqlIntegrationSmokeTest
 
             // Other tables should be introspectable with SHOW COLUMNS and information_schema.columns
             assertQuery("SHOW COLUMNS FROM supported_columns", "VALUES ('good', 'varchar(5)', '', '')");
+            assertQuery("SHOW COLUMNS FROM no_supported_columns", "VALUES ('c', 'varchar', '', '')");
 
             // Listing columns in all tables should not fail due to tables with no columns
             computeActual("SELECT column_name FROM information_schema.columns WHERE table_schema = 'tpch'");

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -274,7 +274,7 @@ public class TestPostgreSqlTypeMapping
         try {
             assertQuery(
                     "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'tpch' AND TABLE_NAME = 'test_unsupported_data_type'",
-                    "VALUES 'key'"); // no 'unsupported_column'
+                    "VALUES ('key'),('unsupported_column')"); // 'unsupported_column' is mapped to an unbounded varchar
         }
         finally {
             jdbcSqlExecutor.execute("DROP TABLE tpch.test_unsupported_data_type");


### PR DESCRIPTION
resolves issue https://github.com/prestodb/presto/issues/11821

By mapping special jdbc columns to an unbounded varchar type,  we avoid the need to skip those columns and make them visible for further analysis