### PR TITLE
Count max code point once per batch for slice readers

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
@@ -45,7 +45,9 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.ROW_GROUP_DICTIONARY;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.ROW_GROUP_DICTIONARY_LENGTH;
 import static com.facebook.presto.orc.reader.SliceStreamReader.computeTruncatedLength;
+import static com.facebook.presto.orc.reader.SliceStreamReader.getMaxCodePointCount;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -311,12 +313,14 @@ public class SliceDictionaryStreamReader
             int length = dictionaryLengthVector[i];
 
             int truncatedLength;
+            int maxCodePointCount = getMaxCodePointCount(type);
+            boolean isCharType = isCharType(type);
             if (length > 0) {
                 // read data without truncation
                 dictionaryDataStream.next(data, offset, offset + length);
 
                 // adjust offsets with truncated length
-                truncatedLength = computeTruncatedLength(slice, offset, length, type);
+                truncatedLength = computeTruncatedLength(slice, offset, length, maxCodePointCount, isCharType);
                 verify(truncatedLength >= 0);
             }
             else {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectStreamReader.java
@@ -40,8 +40,10 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.SliceStreamReader.computeTruncatedLength;
+import static com.facebook.presto.orc.reader.SliceStreamReader.getMaxCodePointCount;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -178,6 +180,8 @@ public class SliceDirectStreamReader
         // * convert original length values in offsetVector into truncated offset values
         int currentLength = offsetVector[0];
         offsetVector[0] = 0;
+        int maxCodePointCount = getMaxCodePointCount(type);
+        boolean isCharType = isCharType(type);
         for (int i = 1; i <= currentBatchSize; i++) {
             int nextLength = offsetVector[i];
             if (isNullVector != null && isNullVector[i - 1]) {
@@ -192,7 +196,7 @@ public class SliceDirectStreamReader
             dataStream.next(data, offset, offset + currentLength);
 
             // adjust offsetVector with truncated length
-            int truncatedLength = computeTruncatedLength(slice, offset, currentLength, type);
+            int truncatedLength = computeTruncatedLength(slice, offset, currentLength, maxCodePointCount, isCharType);
             verify(truncatedLength >= 0);
             offsetVector[i] = offset + truncatedLength;
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
@@ -83,7 +83,7 @@ public class TestOrcReaderMemoryUsage
                     break;
                 }
 
-                Block block = reader.readBlock(BIGINT, 0);
+                Block block = reader.readBlock(VARCHAR, 0);
                 assertEquals(block.getPositionCount(), batchSize);
 
                 // We only verify the memory usage when the batchSize reaches MAX_BATCH_SIZE as batchSize may be

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/VarbinaryType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/VarbinaryType.java
@@ -30,6 +30,11 @@ public final class VarbinaryType
         super(parseTypeSignature(StandardTypes.VARBINARY), Slice.class);
     }
 
+    public static boolean isVarbinaryType(Type type)
+    {
+        return type instanceof VarbinaryType;
+    }
+
     @Override
     public boolean isComparable()
     {


### PR DESCRIPTION
SliceStreamReader::computeTruncatedLength computes truncated length for
a slice. Type length is calculated per function call, even it is
redundant for slice reader reading every row given the type is fixed.
This patch moves the type length calculation outside the batch loop and
only computes the truncated length within the loop.

Resolves #11694 