### PR TITLE
information_schema should not fail for illegal storage format

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -202,7 +202,7 @@ import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
 public class HiveMetadata
         implements TransactionalMetadata
 {
-    private static final Logger log = Logger.get(HiveMetadata.class);
+    private static final Logger LOG = Logger.get(HiveMetadata.class);
 
     public static final String PRESTO_VERSION_NAME = "presto_version";
     public static final String PRESTO_QUERY_ID_NAME = "presto_query_id";
@@ -410,7 +410,7 @@ public class HiveMetadata
             properties.put(STORAGE_FORMAT_PROPERTY, format);
         }
         catch (PrestoException ignored) {
-            log.warn("Storage Format Error: %s", ignored.getMessage());
+            LOG.warn("Storage Format Error: %s", ignored.getMessage());
             // todo fail if format is not known
         }
 


### PR DESCRIPTION
When I am running 
```
select table_schema, table_name, column_name, is_nullable, data_type from information_schema.columns
```
The whole query failed with error:
```
2018-11-02T21:19:39.156-0700	ERROR	remote-task-callback-2	com.facebook.presto.execution.StageStateMachine	Stage 20181103_041902_00000_wwji2.1 failed
java.lang.IllegalStateException: outputFormat should not be accessed from a null StorageFormat
	at com.facebook.presto.hive.metastore.StorageFormat.getOutputFormat(StorageFormat.java:61)
	at com.facebook.presto.hive.HiveMetadata.extractHiveStorageFormat(HiveMetadata.java:1730)
	at com.facebook.presto.hive.HiveMetadata.getTableMetadata(HiveMetadata.java:406)
	at com.facebook.presto.hive.HiveMetadata.listTableColumns(HiveMetadata.java:511)
	at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.listTableColumns(ClassLoaderSafeConnectorMetadata.java:193)
	at com.facebook.presto.metadata.MetadataManager.listTableColumns(MetadataManager.java:466)
	at com.facebook.presto.metadata.MetadataListing.listTableColumns(MetadataListing.java:93)
	at com.facebook.presto.connector.informationSchema.InformationSchemaPageSourceProvider.buildColumns(InformationSchemaPageSourceProvider.java:132)
	at com.facebook.presto.connector.informationSchema.InformationSchemaPageSourceProvider.getInformationSchemaTable(InformationSchemaPageSourceProvider.java:110)
	at com.facebook.presto.connector.informationSchema.InformationSchemaPageSourceProvider.getInternalTable(InformationSchemaPageSourceProvider.java:104)
	at com.facebook.presto.connector.informationSchema.InformationSchemaPageSourceProvider.createPageSource(InformationSchemaPageSourceProvider.java:74)
	at com.facebook.presto.split.PageSourceManager.createPageSource(PageSourceManager.java:56)
	at com.facebook.presto.operator.TableScanOperator.getOutput(TableScanOperator.java:239)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:379)
	at com.facebook.presto.operator.Driver.lambda$processFor$8(Driver.java:283)
	at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:675)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:276)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1053)
	at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:162)
	at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:456)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
I think in this circumstance, the exception should also be `PrestoException` , thus avoiding whole query failed for a single hive illegal table storage format;