### PR TITLE
 Fix race condition in remote task final info visibility

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryTracker.java
@@ -248,24 +248,6 @@ public class QueryTracker<T extends TrackedQuery>
     {
         for (T query : queries.values()) {
             try {
-                // TODO: This fix is a workaround, and must be removed once the better fix is provided.
-                // Issue is tracked at https://github.com/prestodb/presto/issues/11844
-                //
-                // getQueryInfo has a side effect. It sets the final query info if all the stageInfo's are final.
-                //
-                // Setting final query info is required to have the finalQueryInfoListener triggered.
-                // The code that places the query into the eviction queue is the finalQueryInfoListener (see SqlQueryManager#createQueryInternal).
-                //
-                // If query is failed with SqlQueryExecution#fail or with SqlQueryExecution#cancelQuery the final query info must be
-                // set when all the query stages respond with the final stage info.
-                //
-                // Currently the callback registered on all the stages in the SqlQueryScheduler's constructor doesn't set the final query info,
-                // as due to the race, the stageInfo's in the moment of processing that callback are not final.
-                if (query instanceof QueryExecution) {
-                    QueryExecution execution = (QueryExecution) query;
-                    execution.getQueryInfo();
-                }
-
                 if (query.isDone()) {
                     continue;
                 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
@@ -42,6 +42,8 @@ public interface RemoteTask
 
     void addStateChangeListener(StateChangeListener<TaskStatus> stateChangeListener);
 
+    void addFinalTaskInfoListener(StateChangeListener<TaskInfo> stateChangeListener);
+
     ListenableFuture<?> whenSplitQueueHasSpace(int threshold);
 
     void cancel();

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -270,6 +270,11 @@ public class SqlQueryManager
         return queryTracker.getQuery(queryId).getQueryPlan();
     }
 
+    public void addFinalQueryInfoListener(QueryId queryId, StateChangeListener<QueryInfo> stateChangeListener)
+    {
+        queryTracker.getQuery(queryId).addFinalQueryInfoListener(stateChangeListener);
+    }
+
     @Override
     public QueryState getQueryState(QueryId queryId)
     {

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -408,6 +408,12 @@ public final class HttpRemoteTask
     }
 
     @Override
+    public void addFinalTaskInfoListener(StateChangeListener<TaskInfo> stateChangeListener)
+    {
+        taskInfoFetcher.addFinalTaskInfoListener(stateChangeListener);
+    }
+
+    @Override
     public synchronized ListenableFuture<?> whenSplitQueueHasSpace(int threshold)
     {
         if (whenSplitQueueHasSpaceThreshold.isPresent()) {

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -17,8 +17,10 @@ import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.eventlistener.EventListenerManager;
+import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.SqlQueryManager;
+import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.TaskManager;
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroupManager;
 import com.facebook.presto.memory.ClusterMemoryManager;
@@ -329,6 +331,11 @@ public class TestingPrestoServer
     public Plan getQueryPlan(QueryId queryId)
     {
         return queryManager.getQueryPlan(queryId);
+    }
+
+    public void addFinalQueryInfoListener(QueryId queryId, StateChangeListener<QueryInfo> stateChangeListener)
+    {
+        queryManager.addFinalQueryInfoListener(queryId, stateChangeListener);
     }
 
     public ConnectorId createCatalog(String catalogName, String connectorName)

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -68,6 +68,7 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
@@ -369,6 +370,19 @@ public class MockRemoteTaskFactory
         public void addStateChangeListener(StateChangeListener<TaskStatus> stateChangeListener)
         {
             taskStateMachine.addStateChangeListener(newValue -> stateChangeListener.stateChanged(getTaskStatus()));
+        }
+
+        @Override
+        public void addFinalTaskInfoListener(StateChangeListener<TaskInfo> stateChangeListener)
+        {
+            AtomicBoolean done = new AtomicBoolean();
+            StateChangeListener<TaskState> fireOnceStateChangeListener = state -> {
+                if (state.isDone() && done.compareAndSet(false, true)) {
+                    stateChangeListener.stateChanged(getTaskInfo());
+                }
+            };
+            taskStateMachine.addStateChangeListener(fireOnceStateChangeListener);
+            fireOnceStateChangeListener.stateChanged(taskStateMachine.getState());
         }
 
         @Override

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestFinalQueryInfo.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestFinalQueryInfo.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.client.ClientSession;
+import com.facebook.presto.client.StatementClient;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.SettableFuture;
+import io.airlift.units.Duration;
+import okhttp3.OkHttpClient;
+import org.testng.annotations.Test;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.client.StatementClientFactory.newStatementClient;
+import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertTrue;
+
+public class TestFinalQueryInfo
+{
+    @Test(timeOut = 240_000)
+    public void testFinalQueryInfoSetOnAbort()
+            throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = createQueryRunner(TEST_SESSION)) {
+            QueryId queryId = startQuery("SELECT COUNT(*) FROM tpch.sf1000.lineitem", queryRunner);
+            SettableFuture<QueryInfo> finalQueryInfoFuture = SettableFuture.create();
+            queryRunner.getCoordinator().addFinalQueryInfoListener(queryId, finalQueryInfoFuture::set);
+
+            // wait 1s then kill query
+            Thread.sleep(1_000);
+            queryRunner.getCoordinator().getQueryManager().cancelQuery(queryId);
+
+            // wait for final query info
+            QueryInfo finalQueryInfo = tryGetFutureValue(finalQueryInfoFuture, 10, SECONDS)
+                    .orElseThrow(() -> new AssertionError("Final query info never set"));
+            assertTrue(finalQueryInfo.isFinalQueryInfo());
+        }
+    }
+
+    private static QueryId startQuery(String sql, DistributedQueryRunner queryRunner)
+    {
+        OkHttpClient httpClient = new OkHttpClient();
+        try {
+            ClientSession clientSession = new ClientSession(
+                    queryRunner.getCoordinator().getBaseUrl(),
+                    "user",
+                    "source",
+                    Optional.empty(),
+                    ImmutableSet.of(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    "America/Los_Angeles",
+                    Locale.ENGLISH,
+                    ImmutableMap.of(),
+                    ImmutableMap.of(),
+                    ImmutableMap.of(),
+                    null,
+                    new Duration(2, MINUTES));
+
+            // start query
+            StatementClient client = newStatementClient(httpClient, clientSession, sql);
+
+            // wait for query to be fully scheduled
+            while (client.isRunning() && !client.currentStatusInfo().getStats().isScheduled()) {
+                client.advance();
+            }
+
+            return new QueryId(client.currentStatusInfo().getId());
+        }
+        finally {
+            // close the client since, query is not managed by the client protocol
+            httpClient.dispatcher().executorService().shutdown();
+            httpClient.connectionPool().evictAll();
+        }
+    }
+
+    public static DistributedQueryRunner createQueryRunner(Session session)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                .setNodeCount(2)
+                .build();
+
+        try {
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
+            return queryRunner;
+        }
+        catch (Exception e) {
+            queryRunner.close();
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
This builds on #11843.  This adds "Fix race condition in remote task final info visibility` and reverts `Fix memory leak for failed queries`