### PR TITLE
[hotfix]numFalse in columnStatistic should marked as not present when…

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -415,9 +415,8 @@ public final class ThriftMetastoreUtil
     }
 
     /**
-     * Impala 'COMPUTE STATS' will write -1 as the numFalse
-     * @param numFalse
-     * @return
+     * Impala 'COMPUTE STATS' write 1 as the numTrue and -1 as the numFalse
+     * @see <a href="https://github.com/apache/impala/blob/0cbe37afc8f77fd8e0aef7e710e2d1b214c1c5b1/fe/src/main/java/org/apache/impala/catalog/ColumnStats.java#L269">Impala ColumnStats.java#L269</>
      */
     public static OptionalLong fromMetastoreNumFalse(long numFalse)
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -363,7 +363,7 @@ public final class ThriftMetastoreUtil
             BooleanColumnStatsData booleanStatsData = columnStatistics.getStatsData().getBooleanStats();
             return createBooleanColumnStatistics(
                     booleanStatsData.isSetNumTrues() ? OptionalLong.of(booleanStatsData.getNumTrues()) : OptionalLong.empty(),
-                    booleanStatsData.isSetNumFalses() ? OptionalLong.of(booleanStatsData.getNumFalses()) : OptionalLong.empty(),
+                    booleanStatsData.isSetNumFalses() ? fromMetastoreNumFalse(booleanStatsData.getNumFalses()) : OptionalLong.empty(),
                     booleanStatsData.isSetNumNulls() ? fromMetastoreNullsCount(booleanStatsData.getNumNulls()) : OptionalLong.empty());
         }
         if (columnStatistics.getStatsData().isSetStringStats()) {
@@ -412,6 +412,19 @@ public final class ThriftMetastoreUtil
             return OptionalLong.empty();
         }
         return OptionalLong.of(nullsCount);
+    }
+
+    /**
+     * Impala 'COMPUTE STATS' will write -1 as the numFalse
+     * @param numFalse
+     * @return
+     */
+    public static OptionalLong fromMetastoreNumFalse(long numFalse)
+    {
+        if (numFalse == -1L) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(numFalse);
     }
 
     public static Optional<BigDecimal> fromMetastoreDecimal(@Nullable Decimal decimal)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -361,9 +361,11 @@ public final class ThriftMetastoreUtil
         }
         if (columnStatistics.getStatsData().isSetBooleanStats()) {
             BooleanColumnStatsData booleanStatsData = columnStatistics.getStatsData().getBooleanStats();
+            OptionalLong numFalse = fromMetastoreNumFalse(booleanStatsData.getNumFalses());
+            OptionalLong numTrue = (booleanStatsData.getNumFalses() == -1 ? OptionalLong.empty() : OptionalLong.of(booleanStatsData.getNumTrues()));
             return createBooleanColumnStatistics(
-                    booleanStatsData.isSetNumTrues() ? OptionalLong.of(booleanStatsData.getNumTrues()) : OptionalLong.empty(),
-                    booleanStatsData.isSetNumFalses() ? fromMetastoreNumFalse(booleanStatsData.getNumFalses()) : OptionalLong.empty(),
+                    booleanStatsData.isSetNumTrues() ? numTrue : OptionalLong.empty(),
+                    booleanStatsData.isSetNumFalses() ? numFalse : OptionalLong.empty(),
                     booleanStatsData.isSetNumNulls() ? fromMetastoreNullsCount(booleanStatsData.getNumNulls()) : OptionalLong.empty());
         }
         if (columnStatistics.getStatsData().isSetStringStats()) {


### PR DESCRIPTION
The same as https://github.com/prestodb/presto/pull/11549
I have already meet the numFalse = -1 and our query corrupted;
I believe it is also necessary to resolve this -1 which is generated by impala;