### PR TITLE
Fix typo in the regexp_like documentation

### DIFF
--- a/presto-docs/src/main/sphinx/functions/regexp.rst
+++ b/presto-docs/src/main/sphinx/functions/regexp.rst
@@ -74,7 +74,7 @@ with a few notable exceptions:
     Evaluates the regular expression ``pattern`` and determines if it is
     contained within ``string``.
 
-    This function is similar to the ``LIKE`` operator, expect that the
+    This function is similar to the ``LIKE`` operator, except that the
     pattern only needs to be contained within ``string``, rather than
     needing to match all of ``string``. In other words, this performs a
     *contains* operation rather than a *match* operation. You can match


### PR DESCRIPTION
Noticed this small typo.