### PR TITLE
FIx deployment of presto-jdbc artifact

### DIFF
--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -151,6 +151,27 @@
 
     <build>
         <plugins>
+            <!-- workaround for MSHADE-195 -->
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <!-- disable the default execution -->
+                    <execution>
+                        <id>attach-sources</id>
+                        <configuration>
+                            <skipSource>true</skipSource>
+                        </configuration>
+                    </execution>
+                    <!-- enable only the test jar, the sources jar is attached by the shade plugin -->
+                    <execution>
+                        <id>test-only</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>test-jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
The presto-jdbc artifact shades the resulting jar and creates a new
source jar. There is a bug in maven (MSHADE-195 and MSHADE-259) that
causes this source artifact to be deployed twice. This is not a problem
for SNAPSHOT or releases to a staging repo but it will fail for releases
to a regular repo where a non-SNAPSHOT version can not be overwritten.

This fixes the deployment to only deploy the source repository
once. With this fix, a deployment e.g. to an internal repo succeeds.