### PR TITLE
Tag all modules when releasing at once

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1206,6 +1206,7 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <configuration>
                         <preparationGoals>clean verify -DskipTests</preparationGoals>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
When running release:prepare, presto will build the tree for every
module and query all versions for each submodule. With this change,
the build asks only once.