### PR TITLE
Update AWS SDK to version 1.11.445

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dep.airlift.version>0.174</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.36</dep.slice.version>
-        <dep.aws-sdk.version>1.11.293</dep.aws-sdk.version>
+        <dep.aws-sdk.version>1.11.445</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.drift.version>1.14</dep.drift.version>


### PR DESCRIPTION
Current AWS SDK version 1.11.293 does not support S3Select API, which is pre-requisite for https://github.com/prestodb/presto/pull/11033. Thus, updating AWS SDK to latest version, 1.11.445.