### PR TITLE
Update joda to 2.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.drift.version>1.14</dep.drift.version>
+        <dep.joda.version>2.10</dep.joda.version>
         <dep.tempto.version>1.50</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>

--- a/presto-spi/src/main/resources/com/facebook/presto/spi/type/zone-index.properties
+++ b/presto-spi/src/main/resources/com/facebook/presto/spi/type/zone-index.properties
@@ -2046,7 +2046,7 @@
 2037 Brazil/West
 2038 Canada/Atlantic
 2039 Canada/Central
-2040 Canada/East-Saskatchewan
+# 2040 Canada/East-Saskatchewan # removed from tzdata since 2017c
 2041 Canada/Eastern
 2042 Canada/Mountain
 2043 Canada/Newfoundland

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTimeZoneKey.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTimeZoneKey.java
@@ -176,6 +176,10 @@ public class TestTimeZoneKey
             hasValue[key] = true;
         }
 
+        // previous spot for Canada/East-Saskatchewan
+        assertFalse(hasValue[2040]);
+        hasValue[2040] = true;
+
         for (int i = 0; i < hasValue.length; i++) {
             assertTrue(hasValue[i], "There is no time zone with key " + i);
         }
@@ -200,7 +204,7 @@ public class TestTimeZoneKey
             hasher.putString(timeZoneKey.getId(), StandardCharsets.UTF_8);
         }
         // Zone file should not (normally) be changed, so let's make this more difficult
-        assertEquals(hasher.hash().asLong(), -5839014144088293930L, "zone-index.properties file contents changed!");
+        assertEquals(hasher.hash().asLong(), 4694133082746267068L, "zone-index.properties file contents changed!");
     }
 
     public void assertTimeZoneNotSupported(String zoneId)


### PR DESCRIPTION
The tzdata in joda 2.10 matches that of Java 10.0.2 and 8u181