### PR TITLE
Make sure stats are finite and rounded

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/JoinStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/JoinStatsRule.java
@@ -37,6 +37,7 @@ import static com.facebook.presto.cost.FilterStatsCalculator.UNKNOWN_FILTER_COEF
 import static com.facebook.presto.cost.SymbolStatsEstimate.buildFrom;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.EQUAL;
+import static com.facebook.presto.util.MoreMath.roundToDouble;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Sets.difference;
@@ -313,7 +314,7 @@ public class JoinStatsRule
 
         // TODO: use range methods when they have defined (and consistent) semantics
         double leftNDV = leftColumnStats.getDistinctValuesCount();
-        double matchingRightNDV = rightColumnStats.getDistinctValuesCount() * unmatchedJoinComplementNdvsCoefficient;
+        double matchingRightNDV = roundToDouble(rightColumnStats.getDistinctValuesCount() * unmatchedJoinComplementNdvsCoefficient);
 
         if (leftNDV > matchingRightNDV) {
             // Assume "excessive" left NDVs and left null rows are unmatched.

--- a/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
@@ -31,9 +31,11 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static com.facebook.presto.util.MoreMath.firstNonNaN;
+import static com.facebook.presto.util.MoreMath.roundToDouble;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Double.NaN;
+import static java.lang.Double.isFinite;
 import static java.lang.Double.isNaN;
 import static java.util.Objects.requireNonNull;
 
@@ -60,8 +62,8 @@ public class PlanNodeStatsEstimate
 
     private PlanNodeStatsEstimate(double outputRowCount, PMap<Symbol, SymbolStatsEstimate> symbolStatistics)
     {
-        checkArgument(isNaN(outputRowCount) || outputRowCount >= 0, "outputRowCount cannot be negative");
-        this.outputRowCount = outputRowCount;
+        checkArgument((isFinite(outputRowCount) && outputRowCount >= 0) || isNaN(outputRowCount), "outputRowCount must be finite and non-negative or NaN, got: %s", outputRowCount);
+        this.outputRowCount = roundToDouble(outputRowCount);
         this.symbolStatistics = symbolStatistics;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatisticRange.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatisticRange.java
@@ -15,6 +15,7 @@ package com.facebook.presto.cost;
 
 import java.util.Objects;
 
+import static com.facebook.presto.util.MoreMath.roundToDouble;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Double.NaN;
@@ -53,8 +54,8 @@ public class StatisticRange
         this.low = low;
         this.high = high;
 
-        checkArgument(distinctValues >= 0 || isNaN(distinctValues), "Distinct values count should be non-negative, got: %s", distinctValues);
-        this.distinctValues = distinctValues;
+        checkArgument((isFinite(distinctValues) && distinctValues >= 0) || isNaN(distinctValues), "distinctValues must be a finite non-negative or NaN, got: %s", distinctValues);
+        this.distinctValues = roundToDouble(distinctValues);
     }
 
     public static StatisticRange empty()

--- a/presto-main/src/main/java/com/facebook/presto/cost/SymbolStatsEstimate.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/SymbolStatsEstimate.java
@@ -19,11 +19,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import java.util.function.Function;
 
+import static com.facebook.presto.util.MoreMath.roundToDouble;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+import static java.lang.Double.isFinite;
 import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
 import static java.lang.String.format;
@@ -73,12 +75,12 @@ public class SymbolStatsEstimate
         boolean isEmptyRange = isNaN(lowValue) && isNaN(highValue);
         this.nullsFraction = isEmptyRange ? 1.0 : nullsFraction;
 
-        checkArgument(averageRowSize >= 0 || isNaN(averageRowSize), "Average row size should be non-negative or NaN, got: %s", averageRowSize);
+        checkArgument((isFinite(averageRowSize) && averageRowSize >= 0) || isNaN(averageRowSize), "averageRowSize must be finite and non-negative or NaN, got: %s", averageRowSize);
         this.averageRowSize = averageRowSize;
 
-        checkArgument(distinctValuesCount >= 0 || isNaN(distinctValuesCount), "Distinct values count should be non-negative, got: %s", distinctValuesCount);
+        checkArgument((isFinite(distinctValuesCount) && distinctValuesCount >= 0) || isNaN(distinctValuesCount), "distinctValuesCount must be finite and non-negative or NaN, got: %s", distinctValuesCount);
         // TODO normalize distinctValuesCount for an empty range (or validate it is already normalized)
-        this.distinctValuesCount = distinctValuesCount;
+        this.distinctValuesCount = roundToDouble(distinctValuesCount);
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/util/MoreMath.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/MoreMath.java
@@ -15,7 +15,11 @@ package com.facebook.presto.util;
 
 import java.util.stream.DoubleStream;
 
+import static com.google.common.base.Verify.verify;
+import static com.google.common.math.DoubleMath.isMathematicalInteger;
+import static com.google.common.math.DoubleMath.roundToBigInteger;
 import static java.lang.Double.isNaN;
+import static java.math.RoundingMode.HALF_UP;
 
 public final class MoreMath
 {
@@ -109,5 +113,15 @@ public final class MoreMath
             }
         }
         throw new IllegalArgumentException("All values are NaN");
+    }
+
+    public static double roundToDouble(double value)
+    {
+        if (isNaN(value) || isMathematicalInteger(value)) {
+            return value;
+        }
+        double result = roundToBigInteger(value, HALF_UP).doubleValue();
+        verify(isMathematicalInteger(result));
+        return result;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestComparisonStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestComparisonStatsCalculator.java
@@ -243,7 +243,7 @@ public class TestComparisonStatsCalculator
 
         // Literal on the edge of symbol range
         assertCalculate(new ComparisonExpression(EQUAL, new SymbolReference("x"), new DoubleLiteral("10.0")))
-                .outputRowsCount(18.75) // all rows minus nulls divided by distinct values count
+                .outputRowsCount(19) // all rows minus nulls divided by distinct values count
                 .symbolStats("x", symbolAssert -> {
                     symbolAssert.averageRowSize(4.0)
                             .distinctValuesCount(1.0)
@@ -328,7 +328,7 @@ public class TestComparisonStatsCalculator
 
         // Literal on the edge of symbol range
         assertCalculate(new ComparisonExpression(NOT_EQUAL, new SymbolReference("x"), new DoubleLiteral("10.0")))
-                .outputRowsCount(731.25) // all rows minus nulls multiplied by ((distinct values - 1) / distinct values)
+                .outputRowsCount(731) // all rows minus nulls multiplied by ((distinct values - 1) / distinct values)
                 .symbolStats("x", symbolAssert -> {
                     symbolAssert.averageRowSize(4.0)
                             .distinctValuesCount(39.0)
@@ -425,7 +425,7 @@ public class TestComparisonStatsCalculator
 
         // Literal on the edge of symbol range (whole range excluded)
         assertCalculate(new ComparisonExpression(LESS_THAN, new SymbolReference("x"), new DoubleLiteral("-10.0")))
-                .outputRowsCount(18.75) // all rows minus nulls divided by NDV (one value from edge is included as approximation)
+                .outputRowsCount(19) // all rows minus nulls divided by NDV (one value from edge is included as approximation)
                 .symbolStats("x", symbolAssert -> {
                     symbolAssert.averageRowSize(4.0)
                             .distinctValuesCount(1.0)
@@ -460,7 +460,7 @@ public class TestComparisonStatsCalculator
                 .outputRowsCount(225.0) // all rows minus nulls times range coverage (25% - heuristic)
                 .symbolStats("rightOpen", symbolAssert -> {
                     symbolAssert.averageRowSize(4.0)
-                            .distinctValuesCount(12.5) //(25% heuristic)
+                            .distinctValuesCount(13) //(25% heuristic)
                             .lowValue(-15.0)
                             .highValue(0.0)
                             .nullsFraction(0.0);
@@ -510,7 +510,7 @@ public class TestComparisonStatsCalculator
 
         // Literal on the edge of symbol range (whole range excluded)
         assertCalculate(new ComparisonExpression(GREATER_THAN, new SymbolReference("x"), new DoubleLiteral("10.0")))
-                .outputRowsCount(18.75) // all rows minus nulls divided by NDV (one value from edge is included as approximation)
+                .outputRowsCount(19) // all rows minus nulls divided by NDV (one value from edge is included as approximation)
                 .symbolStats("x", symbolAssert -> {
                     symbolAssert.averageRowSize(4.0)
                             .distinctValuesCount(1.0)
@@ -534,7 +534,7 @@ public class TestComparisonStatsCalculator
                 .outputRowsCount(225.0) // all rows minus nulls times range coverage (25% - heuristic)
                 .symbolStats("leftOpen", symbolAssert -> {
                     symbolAssert.averageRowSize(4.0)
-                            .distinctValuesCount(12.5) //(25% heuristic)
+                            .distinctValuesCount(13) //(25% heuristic)
                             .lowValue(0.0)
                             .highValue(15.0)
                             .nullsFraction(0.0);
@@ -573,7 +573,7 @@ public class TestComparisonStatsCalculator
     {
         // z's stats should be unchanged when not involved, except NDV capping to row count
         // Equal ranges
-        double rowCount = 2.7;
+        double rowCount = 3;
         assertCalculate(new ComparisonExpression(EQUAL, new SymbolReference("u"), new SymbolReference("w")))
                 .outputRowsCount(rowCount)
                 .symbolStats("u", equalTo(capNDV(zeroNullsFraction(uStats), rowCount)))
@@ -581,61 +581,61 @@ public class TestComparisonStatsCalculator
                 .symbolStats("z", equalTo(capNDV(zStats, rowCount)));
 
         // One symbol's range is within the other's
-        rowCount = 9.375;
+        rowCount = 9;
         assertCalculate(new ComparisonExpression(EQUAL, new SymbolReference("x"), new SymbolReference("y")))
                 .outputRowsCount(rowCount)
                 .symbolStats("x", symbolAssert -> {
                     symbolAssert.averageRowSize(4)
                             .lowValue(0)
                             .highValue(5)
-                            .distinctValuesCount(9.375 /* min(rowCount, ndv in intersection */)
+                            .distinctValuesCount(9 /* min(rowCount, ndv in intersection */)
                             .nullsFraction(0);
                 })
                 .symbolStats("y", symbolAssert -> {
                     symbolAssert.averageRowSize(4)
                             .lowValue(0)
                             .highValue(5)
-                            .distinctValuesCount(9.375 /* min(rowCount, ndv in intersection */)
+                            .distinctValuesCount(9 /* min(rowCount, ndv in intersection */)
                             .nullsFraction(0);
                 })
                 .symbolStats("z", equalTo(capNDV(zStats, rowCount)));
 
         // Partially overlapping ranges
-        rowCount = 16.875;
+        rowCount = 17;
         assertCalculate(new ComparisonExpression(EQUAL, new SymbolReference("x"), new SymbolReference("w")))
                 .outputRowsCount(rowCount)
                 .symbolStats("x", symbolAssert -> {
                     symbolAssert.averageRowSize(6)
                             .lowValue(0)
                             .highValue(10)
-                            .distinctValuesCount(16.875 /* min(rowCount, ndv in intersection */)
+                            .distinctValuesCount(17 /* min(rowCount, ndv in intersection */)
                             .nullsFraction(0);
                 })
                 .symbolStats("w", symbolAssert -> {
                     symbolAssert.averageRowSize(6)
                             .lowValue(0)
                             .highValue(10)
-                            .distinctValuesCount(16.875 /* min(rowCount, ndv in intersection */)
+                            .distinctValuesCount(17 /* min(rowCount, ndv in intersection */)
                             .nullsFraction(0);
                 })
                 .symbolStats("z", equalTo(capNDV(zStats, rowCount)));
 
         // None of the ranges is included in the other, and one symbol has much higher cardinality, so that it has bigger NDV in intersect than the other in total
-        rowCount = 2.25;
+        rowCount = 2;
         assertCalculate(new ComparisonExpression(EQUAL, new SymbolReference("x"), new SymbolReference("u")))
                 .outputRowsCount(rowCount)
                 .symbolStats("x", symbolAssert -> {
                     symbolAssert.averageRowSize(6)
                             .lowValue(0)
                             .highValue(10)
-                            .distinctValuesCount(2.25 /* min(rowCount, ndv in intersection */)
+                            .distinctValuesCount(2 /* min(rowCount, ndv in intersection */)
                             .nullsFraction(0);
                 })
                 .symbolStats("u", symbolAssert -> {
                     symbolAssert.averageRowSize(6)
                             .lowValue(0)
                             .highValue(10)
-                            .distinctValuesCount(2.25 /* min(rowCount, ndv in intersection */)
+                            .distinctValuesCount(2 /* min(rowCount, ndv in intersection */)
                             .nullsFraction(0);
                 })
                 .symbolStats("z", equalTo(capNDV(zStats, rowCount)));
@@ -645,7 +645,7 @@ public class TestComparisonStatsCalculator
     public void symbolToSymbolNotEqual()
     {
         // Equal ranges
-        double rowCount = 807.3;
+        double rowCount = 807;
         assertCalculate(new ComparisonExpression(NOT_EQUAL, new SymbolReference("u"), new SymbolReference("w")))
                 .outputRowsCount(rowCount)
                 .symbolStats("u", equalTo(capNDV(zeroNullsFraction(uStats), rowCount)))
@@ -653,7 +653,7 @@ public class TestComparisonStatsCalculator
                 .symbolStats("z", equalTo(capNDV(zStats, rowCount)));
 
         // One symbol's range is within the other's
-        rowCount = 365.625;
+        rowCount = 366;
         assertCalculate(new ComparisonExpression(NOT_EQUAL, new SymbolReference("x"), new SymbolReference("y")))
                 .outputRowsCount(rowCount)
                 .symbolStats("x", equalTo(capNDV(zeroNullsFraction(xStats), rowCount)))
@@ -661,7 +661,7 @@ public class TestComparisonStatsCalculator
                 .symbolStats("z", equalTo(capNDV(zStats, rowCount)));
 
         // Partially overlapping ranges
-        rowCount = 658.125;
+        rowCount = 658;
         assertCalculate(new ComparisonExpression(NOT_EQUAL, new SymbolReference("x"), new SymbolReference("w")))
                 .outputRowsCount(rowCount)
                 .symbolStats("x", equalTo(capNDV(zeroNullsFraction(xStats), rowCount)))
@@ -669,7 +669,7 @@ public class TestComparisonStatsCalculator
                 .symbolStats("z", equalTo(capNDV(zStats, rowCount)));
 
         // None of the ranges is included in the other, and one symbol has much higher cardinality, so that it has bigger NDV in intersect than the other in total
-        rowCount = 672.75;
+        rowCount = 673;
         assertCalculate(new ComparisonExpression(NOT_EQUAL, new SymbolReference("x"), new SymbolReference("u")))
                 .outputRowsCount(rowCount)
                 .symbolStats("x", equalTo(capNDV(zeroNullsFraction(xStats), rowCount)))
@@ -680,14 +680,14 @@ public class TestComparisonStatsCalculator
     @Test
     public void symbolToCastExpressionNotEqual()
     {
-        double rowCount = 807.3;
+        double rowCount = 807;
         assertCalculate(new ComparisonExpression(NOT_EQUAL, new SymbolReference("u"), new Cast(new SymbolReference("w"), BIGINT)))
                 .outputRowsCount(rowCount)
                 .symbolStats("u", equalTo(capNDV(zeroNullsFraction(uStats), rowCount)))
                 .symbolStats("w", equalTo(capNDV(wStats, rowCount)))
                 .symbolStats("z", equalTo(capNDV(zStats, rowCount)));
 
-        rowCount = 897.0;
+        rowCount = 897;
         assertCalculate(new ComparisonExpression(NOT_EQUAL, new SymbolReference("u"), new Cast(new LongLiteral("10"), BIGINT)))
                 .outputRowsCount(rowCount)
                 .symbolStats("u", equalTo(capNDV(updateNDV(zeroNullsFraction(uStats), -1), rowCount)))

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -305,17 +305,17 @@ public class TestCostCalculator
 
         assertCost(aggregation, costs, stats, types)
                 .cpu(6000 * IS_NULL_OVERHEAD + 6000)
-                .memory(13 * IS_NULL_OVERHEAD)
+                .memory(16 * IS_NULL_OVERHEAD)
                 .network(0);
 
         assertCostEstimatedExchanges(aggregation, costs, stats, types)
                 .cpu((6000 + 6000 + 6000) * IS_NULL_OVERHEAD + 6000)
-                .memory(13 * IS_NULL_OVERHEAD)
+                .memory(16 * IS_NULL_OVERHEAD)
                 .network(6000 * IS_NULL_OVERHEAD);
 
         assertCostFragmentedPlan(aggregation, costs, stats, types)
                 .cpu(6000 + 6000 * IS_NULL_OVERHEAD)
-                .memory(13 * IS_NULL_OVERHEAD)
+                .memory(16 * IS_NULL_OVERHEAD)
                 .network(0 * IS_NULL_OVERHEAD);
 
         assertCostHasUnknownComponentsForUnknownStats(aggregation, types);

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsCalculator.java
@@ -158,7 +158,7 @@ public class TestFilterStatsCalculator
     @Test
     public void testComparison()
     {
-        double lessThan3Rows = 487.5;
+        double lessThan3Rows = 488;
         assertExpression("x < 3e0")
                 .outputRowsCount(lessThan3Rows)
                 .symbolStats(new Symbol("x"), symbolAssert ->
@@ -174,7 +174,7 @@ public class TestFilterStatsCalculator
         for (String minusThree : ImmutableList.of("DECIMAL '-3'", "-3e0", "(4e0-7e0)", "CAST(-3 AS DECIMAL(7,3))"/*, "CAST('1' AS BIGINT) - 4"*/)) {
             for (String xEquals : ImmutableList.of("x = %s", "%s = x", "COALESCE(x * CAST(NULL AS BIGINT), x) = %s", "%s = CAST(x AS DOUBLE)")) {
                 assertExpression(format(xEquals, minusThree))
-                        .outputRowsCount(18.75)
+                        .outputRowsCount(19)
                         .symbolStats(new Symbol("x"), symbolAssert ->
                                 symbolAssert.averageRowSize(4.0)
                                         .lowValue(-3)
@@ -185,7 +185,7 @@ public class TestFilterStatsCalculator
 
             for (String xLessThan : ImmutableList.of("x < %s", "%s > x", "%s > CAST(x AS DOUBLE)")) {
                 assertExpression(format(xLessThan, minusThree))
-                        .outputRowsCount(262.5)
+                        .outputRowsCount(262)
                         .symbolStats(new Symbol("x"), symbolAssert ->
                                 symbolAssert.averageRowSize(4.0)
                                         .lowValue(-10)
@@ -209,7 +209,7 @@ public class TestFilterStatsCalculator
                                 .nullsFraction(0.0));
 
         assertExpression("x = 0e0 OR x = DOUBLE '-7.5'")
-                .outputRowsCount(37.5)
+                .outputRowsCount(38)
                 .symbolStats(new Symbol("x"), symbolAssert ->
                         symbolAssert.averageRowSize(4.0)
                                 .lowValue(-7.5)
@@ -218,7 +218,7 @@ public class TestFilterStatsCalculator
                                 .nullsFraction(0.0));
 
         assertExpression("x = 1e0 OR x = 3e0")
-                .outputRowsCount(37.5)
+                .outputRowsCount(38)
                 .symbolStats(new Symbol("x"), symbolAssert ->
                         symbolAssert.averageRowSize(4.0)
                                 .lowValue(1)
@@ -227,7 +227,7 @@ public class TestFilterStatsCalculator
                                 .nullsFraction(0));
 
         assertExpression("x = 1e0 OR 'a' = 'b' OR x = 3e0")
-                .outputRowsCount(37.5)
+                .outputRowsCount(38)
                 .symbolStats(new Symbol("x"), symbolAssert ->
                         symbolAssert.averageRowSize(4.0)
                                 .lowValue(1)
@@ -252,7 +252,7 @@ public class TestFilterStatsCalculator
     public void testAndStats()
     {
         assertExpression("x < 0e0 AND x > DOUBLE '-7.5'")
-                .outputRowsCount(281.25)
+                .outputRowsCount(281)
                 .symbolStats(new Symbol("x"), symbolAssert ->
                         symbolAssert.averageRowSize(4.0)
                                 .lowValue(-7.5)
@@ -268,7 +268,7 @@ public class TestFilterStatsCalculator
 
         // first argument unknown
         assertExpression("json_array_contains(JSON '[]', x) AND x < 0e0")
-                .outputRowsCount(337.5)
+                .outputRowsCount(338)
                 .symbolStats(new Symbol("x"), symbolAssert ->
                         symbolAssert.lowValue(-10)
                                 .highValue(0)
@@ -277,7 +277,7 @@ public class TestFilterStatsCalculator
 
         // second argument unknown
         assertExpression("x < 0e0 AND json_array_contains(JSON '[]', x)")
-                .outputRowsCount(337.5)
+                .outputRowsCount(338)
                 .symbolStats(new Symbol("x"), symbolAssert ->
                         symbolAssert.lowValue(-10)
                                 .highValue(0)
@@ -355,7 +355,7 @@ public class TestFilterStatsCalculator
     {
         // Only right side cut
         assertExpression("x BETWEEN 7.5e0 AND 12e0")
-                .outputRowsCount(93.75)
+                .outputRowsCount(94)
                 .symbolStats("x", symbolStats ->
                         symbolStats.distinctValuesCount(5.0)
                                 .lowValue(7.5)
@@ -364,14 +364,14 @@ public class TestFilterStatsCalculator
 
         // Only left side cut
         assertExpression("x BETWEEN DOUBLE '-12' AND DOUBLE '-7.5'")
-                .outputRowsCount(93.75)
+                .outputRowsCount(94)
                 .symbolStats("x", symbolStats ->
                         symbolStats.distinctValuesCount(5.0)
                                 .lowValue(-10)
                                 .highValue(-7.5)
                                 .nullsFraction(0.0));
         assertExpression("x BETWEEN -12e0 AND -7.5e0")
-                .outputRowsCount(93.75)
+                .outputRowsCount(94)
                 .symbolStats("x", symbolStats ->
                         symbolStats.distinctValuesCount(5.0)
                                 .lowValue(-10)
@@ -380,7 +380,7 @@ public class TestFilterStatsCalculator
 
         // Both sides cut
         assertExpression("x BETWEEN DOUBLE '-2.5' AND 2.5e0")
-                .outputRowsCount(187.5)
+                .outputRowsCount(188)
                 .symbolStats("x", symbolStats ->
                         symbolStats.distinctValuesCount(10.0)
                                 .lowValue(-2.5)
@@ -389,9 +389,9 @@ public class TestFilterStatsCalculator
 
         // Both sides cut unknownRange
         assertExpression("unknownRange BETWEEN 2.72e0 AND 3.14e0")
-                .outputRowsCount(112.5)
+                .outputRowsCount(113)
                 .symbolStats("unknownRange", symbolStats ->
-                        symbolStats.distinctValuesCount(6.25)
+                        symbolStats.distinctValuesCount(6)
                                 .lowValue(2.72)
                                 .highValue(3.14)
                                 .nullsFraction(0.0));
@@ -462,28 +462,28 @@ public class TestFilterStatsCalculator
     {
         // One value in range
         assertExpression("x IN (7.5e0)")
-                .outputRowsCount(18.75)
+                .outputRowsCount(19)
                 .symbolStats("x", symbolStats ->
                         symbolStats.distinctValuesCount(1.0)
                                 .lowValue(7.5)
                                 .highValue(7.5)
                                 .nullsFraction(0.0));
         assertExpression("x IN (DOUBLE '-7.5')")
-                .outputRowsCount(18.75)
+                .outputRowsCount(19)
                 .symbolStats("x", symbolStats ->
                         symbolStats.distinctValuesCount(1.0)
                                 .lowValue(-7.5)
                                 .highValue(-7.5)
                                 .nullsFraction(0.0));
         assertExpression("x IN (BIGINT '2' + 5.5e0)")
-                .outputRowsCount(18.75)
+                .outputRowsCount(19)
                 .symbolStats("x", symbolStats ->
                         symbolStats.distinctValuesCount(1.0)
                                 .lowValue(7.5)
                                 .highValue(7.5)
                                 .nullsFraction(0.0));
         assertExpression("x IN (-7.5e0)")
-                .outputRowsCount(18.75)
+                .outputRowsCount(19)
                 .symbolStats("x", symbolStats ->
                         symbolStats.distinctValuesCount(1.0)
                                 .lowValue(-7.5)
@@ -492,7 +492,7 @@ public class TestFilterStatsCalculator
 
         // Multiple values in range
         assertExpression("x IN (1.5e0, 2.5e0, 7.5e0)")
-                .outputRowsCount(56.25)
+                .outputRowsCount(57)
                 .symbolStats("x", symbolStats ->
                         symbolStats.distinctValuesCount(3.0)
                                 .lowValue(1.5)
@@ -507,7 +507,7 @@ public class TestFilterStatsCalculator
 
         // Multiple values some in some out of range
         assertExpression("x IN (DOUBLE '-42', 1.5e0, 2.5e0, 7.5e0, 314e0)")
-                .outputRowsCount(56.25)
+                .outputRowsCount(57)
                 .symbolStats("x", symbolStats ->
                         symbolStats.distinctValuesCount(3.0)
                                 .lowValue(1.5)

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
@@ -34,6 +34,7 @@ import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
 import static java.lang.Double.NaN;
+import static java.lang.Math.round;
 
 public class TestJoinStatsRule
         extends BaseStatsCalculatorTest
@@ -230,8 +231,8 @@ public class TestJoinStatsRule
     @Test
     public void testStatsForLeftAndRightJoin()
     {
-        double innerJoinRowCount = LEFT_ROWS_COUNT * RIGHT_ROWS_COUNT / LEFT_JOIN_COLUMN_NDV * LEFT_JOIN_COLUMN_NON_NULLS * RIGHT_JOIN_COLUMN_NON_NULLS;
-        double joinComplementRowCount = LEFT_ROWS_COUNT * (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4);
+        double innerJoinRowCount = round(LEFT_ROWS_COUNT * RIGHT_ROWS_COUNT / LEFT_JOIN_COLUMN_NDV * LEFT_JOIN_COLUMN_NON_NULLS * RIGHT_JOIN_COLUMN_NON_NULLS);
+        double joinComplementRowCount = round(LEFT_ROWS_COUNT * (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4));
         double joinComplementColumnNulls = LEFT_JOIN_COLUMN_NULLS / (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4);
         double totalRowCount = innerJoinRowCount + joinComplementRowCount;
 
@@ -263,10 +264,10 @@ public class TestJoinStatsRule
     @Test
     public void testStatsForFullJoin()
     {
-        double innerJoinRowCount = LEFT_ROWS_COUNT * RIGHT_ROWS_COUNT / LEFT_JOIN_COLUMN_NDV * LEFT_JOIN_COLUMN_NON_NULLS * RIGHT_JOIN_COLUMN_NON_NULLS;
-        double leftJoinComplementRowCount = LEFT_ROWS_COUNT * (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4);
+        double innerJoinRowCount = round(LEFT_ROWS_COUNT * RIGHT_ROWS_COUNT / LEFT_JOIN_COLUMN_NDV * LEFT_JOIN_COLUMN_NON_NULLS * RIGHT_JOIN_COLUMN_NON_NULLS);
+        double leftJoinComplementRowCount = round(LEFT_ROWS_COUNT * (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4));
         double leftJoinComplementColumnNulls = LEFT_JOIN_COLUMN_NULLS / (LEFT_JOIN_COLUMN_NULLS + LEFT_JOIN_COLUMN_NON_NULLS / 4);
-        double rightJoinComplementRowCount = RIGHT_ROWS_COUNT * RIGHT_JOIN_COLUMN_NULLS;
+        double rightJoinComplementRowCount = round(RIGHT_ROWS_COUNT * RIGHT_JOIN_COLUMN_NULLS);
         double rightJoinComplementColumnNulls = 1.0;
         double totalRowCount = innerJoinRowCount + leftJoinComplementRowCount + rightJoinComplementRowCount;
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestSemiJoinStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestSemiJoinStatsCalculator.java
@@ -24,6 +24,7 @@ import static com.facebook.presto.cost.SemiJoinStatsCalculator.computeSemiJoin;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
+import static java.lang.Math.round;
 
 public class TestSemiJoinStatsCalculator
 {
@@ -143,7 +144,7 @@ public class TestSemiJoinStatsCalculator
                         .distinctValuesCount(wStats.getDistinctValuesCount()))
                 .symbolStats(w, stats -> stats.isEqualTo(wStats))
                 .symbolStats(z, stats -> stats.isEqualTo(zStats))
-                .outputRowsCount(inputStatistics.getOutputRowCount() * xStats.getValuesFraction() * (wStats.getDistinctValuesCount() / xStats.getDistinctValuesCount()));
+                .outputRowsCount(round(inputStatistics.getOutputRowCount() * xStats.getValuesFraction() * (wStats.getDistinctValuesCount() / xStats.getDistinctValuesCount())));
 
         // overlapping ranges, nothing filtered out
         assertThat(computeSemiJoin(inputStatistics, inputStatistics, x, u))

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestUnionStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestUnionStatsRule.java
@@ -117,12 +117,12 @@ public class TestUnionStatsRule
                         .symbolStats("o2", assertion -> assertion
                                 .lowValue(0)
                                 .highValue(7)
-                                .distinctValuesCount(6.4)
+                                .distinctValuesCount(6)
                                 .nullsFractionUnknown())
                         .symbolStats("o3", assertion -> assertion
                                 .lowValueUnknown()
                                 .highValueUnknown()
-                                .distinctValuesCount(8.5)
+                                .distinctValuesCount(9)
                                 .nullsFraction(0.1666667))
                         .symbolStats("o4", assertion -> assertion
                                 .lowValue(10)

--- a/presto-main/src/test/java/com/facebook/presto/util/TestMoreMath.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestMoreMath.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.util.MoreMath.roundToDouble;
+import static java.lang.Double.NaN;
+import static java.lang.Math.nextUp;
+import static org.testng.Assert.assertEquals;
+
+public class TestMoreMath
+{
+    @Test
+    public void testRoundToDouble()
+    {
+        assertEquals(roundToDouble(NaN), NaN);
+        assertEquals(roundToDouble(0.0), 0.0);
+        assertEquals(roundToDouble(nextUp(0.0)), 0.0);
+        assertEquals(roundToDouble(0.1), 0.0);
+        assertEquals(roundToDouble(0.4), 0.0);
+        assertEquals(roundToDouble(0.5), 1.0);
+        assertEquals(roundToDouble(0.99), 1.0);
+        assertEquals(roundToDouble(1.09), 1.0);
+        assertEquals(roundToDouble(nextUp(1.0)), 1.0);
+    }
+}

--- a/presto-main/src/test/resources/sql/presto/tpcds/q31.plan.txt
+++ b/presto-main/src/test/resources/sql/presto/tpcds/q31.plan.txt
@@ -17,22 +17,8 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     scan tpcds:customer_address:sf3000.0
-                        final aggregation over (ca_county_345, d_qoy_320, d_year_316)
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["ca_county_345", "d_qoy_320", "d_year_316"])
-                                    partial aggregation over (ca_county_345, d_qoy_320, d_year_316)
-                                        join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                scan tpcds:web_sales:sf3000.0
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:customer_address:sf3000.0
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, ["ca_county_173", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
-                            join (INNER, PARTITIONED):
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county_173", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
                                 final aggregation over (ca_county_173, d_qoy_148, d_year_144)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ca_county_173", "d_qoy_148", "d_year_144"])
@@ -46,6 +32,22 @@ remote exchange (GATHER, SINGLE, [])
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                             scan tpcds:customer_address:sf3000.0
+                    join (INNER, PARTITIONED):
+                        final aggregation over (ca_county_345, d_qoy_320, d_year_316)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, ["ca_county_345", "d_qoy_320", "d_year_316"])
+                                    partial aggregation over (ca_county_345, d_qoy_320, d_year_316)
+                                        join (INNER, REPLICATED):
+                                            join (INNER, REPLICATED):
+                                                scan tpcds:web_sales:sf3000.0
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan tpcds:date_dim:sf3000.0
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan tpcds:customer_address:sf3000.0
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, ["ca_county_448", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
                                 final aggregation over (ca_county_448, d_qoy_423, d_year_419)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ca_county_448", "d_qoy_423", "d_year_419"])


### PR DESCRIPTION
PlanNodeStatsEstimate, SymbolStatsEstimate should check that outputRowCount,
distinctValuesCount are finite and rounded. Also averageRowSize must be finite.