### PR TITLE
Optionally use default filter factor to estimate filter node

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -114,6 +114,7 @@ public final class SystemSessionProperties
     public static final String ENABLE_STATS_CALCULATOR = "enable_stats_calculator";
     public static final String IGNORE_STATS_CALCULATOR_FAILURES = "ignore_stats_calculator_failures";
     public static final String MAX_DRIVERS_PER_TASK = "max_drivers_per_task";
+    public static final String DEFAULT_FILTER_FACTOR_ENABLED = "default_filter_factor_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -531,6 +532,11 @@ public final class SystemSessionProperties
                         IGNORE_STATS_CALCULATOR_FAILURES,
                         "Ignore statistics calculator failures",
                         featuresConfig.isIgnoreStatsCalculatorFailures(),
+                        false),
+                booleanProperty(
+                        DEFAULT_FILTER_FACTOR_ENABLED,
+                        "use a default filter factor for unknown filters in a filter node",
+                        featuresConfig.isDefaultFilterFactorEnabled(),
                         false));
     }
 
@@ -902,5 +908,10 @@ public final class SystemSessionProperties
     public static boolean isIgnoreStatsCalculatorFailures(Session session)
     {
         return session.getSystemProperty(IGNORE_STATS_CALCULATOR_FAILURES, Boolean.class);
+    }
+
+    public static boolean isDefaultFilterFactorEnabled(Session session)
+    {
+        return session.getSystemProperty(DEFAULT_FILTER_FACTOR_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
@@ -41,7 +41,7 @@ public class StatsCalculatorModule
         rules.add(new OutputStatsRule());
         rules.add(new TableScanStatsRule(metadata, normalizer));
         rules.add(new SimpleFilterProjectSemiJoinStatsRule(normalizer, filterStatsCalculator)); // this must be before FilterStatsRule
-        rules.add(new FilterStatsRule(filterStatsCalculator));
+        rules.add(new FilterStatsRule(normalizer, filterStatsCalculator));
         rules.add(new ValuesStatsRule(metadata));
         rules.add(new LimitStatsRule(normalizer));
         rules.add(new EnforceSingleRowStatsRule(normalizer));

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -108,6 +108,7 @@ public class FeaturesConfig
     private boolean iterativeOptimizerEnabled = true;
     private boolean enableStatsCalculator = true;
     private boolean ignoreStatsCalculatorFailures = true;
+    private boolean defaultFilterFactorEnabled;
     private boolean pushAggregationThroughJoin = true;
     private double memoryRevokingTarget = 0.5;
     private double memoryRevokingThreshold = 0.9;
@@ -616,6 +617,18 @@ public class FeaturesConfig
     {
         this.ignoreStatsCalculatorFailures = ignoreStatsCalculatorFailures;
         return this;
+    }
+
+    @Config("optimizer.default-filter-factor-enabled")
+    public FeaturesConfig setDefaultFilterFactorEnabled(boolean defaultFilterFactorEnabled)
+    {
+        this.defaultFilterFactorEnabled = defaultFilterFactorEnabled;
+        return this;
+    }
+
+    public boolean isDefaultFilterFactorEnabled()
+    {
+        return defaultFilterFactorEnabled;
     }
 
     public DataSize getAggregationOperatorUnspillMemoryLimit()

--- a/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorTester.java
@@ -36,7 +36,12 @@ public class StatsCalculatorTester
 
     public StatsCalculatorTester()
     {
-        this(createQueryRunner());
+        this(testSessionBuilder().build());
+    }
+
+    public StatsCalculatorTester(Session session)
+    {
+        this(createQueryRunner(session));
     }
 
     private StatsCalculatorTester(LocalQueryRunner queryRunner)
@@ -47,10 +52,8 @@ public class StatsCalculatorTester
         this.queryRunner = queryRunner;
     }
 
-    private static LocalQueryRunner createQueryRunner()
+    private static LocalQueryRunner createQueryRunner(Session session)
     {
-        Session session = testSessionBuilder().build();
-
         LocalQueryRunner queryRunner = new LocalQueryRunner(session);
         queryRunner.createCatalog(session.getCatalog().get(),
                 new TpchConnectorFactory(1),

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsRule.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.sql.planner.Symbol;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public class TestFilterStatsRule
+        extends BaseStatsCalculatorTest
+{
+    public StatsCalculatorTester defaultFilterTester;
+
+    @BeforeClass
+    public void setupClass()
+    {
+        defaultFilterTester = new StatsCalculatorTester(
+                testSessionBuilder()
+                        .setSystemProperty("default_filter_factor_enabled", "true")
+                        .build());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDownClass()
+    {
+        defaultFilterTester.close();
+        defaultFilterTester = null;
+    }
+
+    @Test
+    public void testEstimatableFilter()
+    {
+        tester().assertStatsFor(pb -> pb
+                .filter(expression("i1 = 5"),
+                        pb.values(pb.symbol("i1"), pb.symbol("i2"), pb.symbol("i3"))))
+                .withSourceStats(0, PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(10)
+                        .addSymbolStatistics(new Symbol("i1"), SymbolStatsEstimate.builder()
+                                .setLowValue(1)
+                                .setHighValue(10)
+                                .setDistinctValuesCount(5)
+                                .setNullsFraction(0)
+                                .build())
+                        .addSymbolStatistics(new Symbol("i2"), SymbolStatsEstimate.builder()
+                                .setLowValue(0)
+                                .setHighValue(3)
+                                .setDistinctValuesCount(4)
+                                .setNullsFraction(0)
+                                .build())
+                        .addSymbolStatistics(new Symbol("i3"), SymbolStatsEstimate.builder()
+                                .setLowValue(10)
+                                .setHighValue(15)
+                                .setDistinctValuesCount(4)
+                                .setNullsFraction(0.1)
+                                .build())
+                        .build())
+                .check(check -> check
+                        .outputRowsCount(2)
+                        .symbolStats("i1", assertion -> assertion
+                                .lowValue(5)
+                                .highValue(5)
+                                .distinctValuesCount(1)
+                                .dataSizeUnknown()
+                                .nullsFraction(0))
+                        .symbolStats("i2", assertion -> assertion
+                                .lowValue(0)
+                                .highValue(3)
+                                .dataSizeUnknown()
+                                .distinctValuesCount(2)
+                                .nullsFraction(0))
+                        .symbolStats("i3", assertion -> assertion
+                                .lowValue(10)
+                                .highValue(15)
+                                .dataSizeUnknown()
+                                .distinctValuesCount(1.9)
+                                .nullsFraction(0.05)));
+
+        defaultFilterTester.assertStatsFor(pb -> pb
+                .filter(expression("i1 = 5"),
+                        pb.values(pb.symbol("i1"), pb.symbol("i2"), pb.symbol("i3"))))
+                .withSourceStats(0, PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(10)
+                        .addSymbolStatistics(new Symbol("i1"), SymbolStatsEstimate.builder()
+                                .setLowValue(1)
+                                .setHighValue(10)
+                                .setDistinctValuesCount(5)
+                                .setNullsFraction(0)
+                                .build())
+                        .addSymbolStatistics(new Symbol("i2"), SymbolStatsEstimate.builder()
+                                .setLowValue(0)
+                                .setHighValue(3)
+                                .setDistinctValuesCount(4)
+                                .setNullsFraction(0)
+                                .build())
+                        .addSymbolStatistics(new Symbol("i3"), SymbolStatsEstimate.builder()
+                                .setLowValue(10)
+                                .setHighValue(15)
+                                .setDistinctValuesCount(4)
+                                .setNullsFraction(0.1)
+                                .build())
+                        .build())
+                .check(check -> check
+                        .outputRowsCount(2)
+                        .symbolStats("i1", assertion -> assertion
+                                .lowValue(5)
+                                .highValue(5)
+                                .distinctValuesCount(1)
+                                .dataSizeUnknown()
+                                .nullsFraction(0))
+                        .symbolStats("i2", assertion -> assertion
+                                .lowValue(0)
+                                .highValue(3)
+                                .dataSizeUnknown()
+                                .distinctValuesCount(2)
+                                .nullsFraction(0))
+                        .symbolStats("i3", assertion -> assertion
+                                .lowValue(10)
+                                .highValue(15)
+                                .dataSizeUnknown()
+                                .distinctValuesCount(1.9)
+                                .nullsFraction(0.05)));
+    }
+
+    @Test
+    public void testUnestimatableFunction()
+    {
+        // can't estimate function and default filter factor is turned off
+        tester()
+                .assertStatsFor(pb -> pb
+                        .filter(expression("sin(i1) = 1"),
+                                pb.values(pb.symbol("i1"), pb.symbol("i2"), pb.symbol("i3"))))
+                .withSourceStats(0, PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(10)
+                        .addSymbolStatistics(new Symbol("i1"), SymbolStatsEstimate.builder()
+                                .setLowValue(1)
+                                .setHighValue(10)
+                                .setDistinctValuesCount(5)
+                                .setNullsFraction(0)
+                                .build())
+                        .addSymbolStatistics(new Symbol("i2"), SymbolStatsEstimate.builder()
+                                .setLowValue(0)
+                                .setHighValue(3)
+                                .setDistinctValuesCount(4)
+                                .setNullsFraction(0)
+                                .build())
+                        .addSymbolStatistics(new Symbol("i3"), SymbolStatsEstimate.builder()
+                                .setLowValue(10)
+                                .setHighValue(15)
+                                .setDistinctValuesCount(4)
+                                .setNullsFraction(0.1)
+                                .build())
+                        .build())
+                .check(check -> check.outputRowsCountUnknown());
+
+        // can't estimate function, but default filter factor is turned on
+        defaultFilterTester.assertStatsFor(pb -> pb
+                .filter(expression("sin(i1) = 1"),
+                        pb.values(pb.symbol("i1"), pb.symbol("i2"), pb.symbol("i3"))))
+                .withSourceStats(0, PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(10)
+                        .addSymbolStatistics(new Symbol("i1"), SymbolStatsEstimate.builder()
+                                .setLowValue(1)
+                                .setHighValue(10)
+                                .setDistinctValuesCount(5)
+                                .setNullsFraction(0)
+                                .build())
+                        .addSymbolStatistics(new Symbol("i2"), SymbolStatsEstimate.builder()
+                                .setLowValue(0)
+                                .setHighValue(3)
+                                .setDistinctValuesCount(4)
+                                .setNullsFraction(0)
+                                .build())
+                        .addSymbolStatistics(new Symbol("i3"), SymbolStatsEstimate.builder()
+                                .setLowValue(10)
+                                .setHighValue(15)
+                                .setDistinctValuesCount(4)
+                                .setNullsFraction(0.1)
+                                .build())
+                        .build())
+                .check(check -> check
+                        .outputRowsCount(9)
+                        .symbolStats("i1", assertion -> assertion
+                                .lowValue(1)
+                                .highValue(10)
+                                .dataSizeUnknown()
+                                .distinctValuesCount(5)
+                                .nullsFraction(0))
+                        .symbolStats("i2", assertion -> assertion
+                                .lowValue(0)
+                                .highValue(3)
+                                .dataSizeUnknown()
+                                .distinctValuesCount(4)
+                                .nullsFraction(0))
+                        .symbolStats("i3", assertion -> assertion
+                                .lowValue(10)
+                                .highValue(15)
+                                .dataSizeUnknown()
+                                .distinctValuesCount(4)
+                                .nullsFraction(0.1)));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -86,6 +86,7 @@ public class TestFeaturesConfig
                 .setIterativeOptimizerTimeout(new Duration(3, MINUTES))
                 .setEnableStatsCalculator(true)
                 .setIgnoreStatsCalculatorFailures(true)
+                .setDefaultFilterFactorEnabled(false)
                 .setExchangeCompressionEnabled(false)
                 .setLegacyTimestamp(true)
                 .setLegacyRowFieldOrdinalAccess(false)
@@ -119,6 +120,7 @@ public class TestFeaturesConfig
                 .put("experimental.iterative-optimizer-timeout", "10s")
                 .put("experimental.enable-stats-calculator", "false")
                 .put("optimizer.ignore-stats-calculator-failures", "false")
+                .put("optimizer.default-filter-factor-enabled", "true")
                 .put("deprecated.legacy-array-agg", "true")
                 .put("deprecated.legacy-log-function", "true")
                 .put("deprecated.group-by-uses-equal", "true")
@@ -232,7 +234,8 @@ public class TestFeaturesConfig
                 .setMultimapAggGroupImplementation(MultimapAggGroupImplementation.LEGACY)
                 .setDistributedSortEnabled(false)
                 .setMaxGroupingSets(2047)
-                .setLegacyUnnestArrayRows(true);
+                .setLegacyUnnestArrayRows(true)
+                .setDefaultFilterFactorEnabled(true);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
Using the default filter factor to estimate joins can be very off base,
but using it for filter nodes means we will still behave well for small
tables joined to large ones, but not accidentally broadcast huge tables.
Therefore, we suspect this heuristic is lower risk.  Nevertheless, we
gate it with the session property default_filter_factor_enabled.  