### PR TITLE
Drop snappy test table in the same way as it was created

### DIFF
--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
@@ -196,7 +196,7 @@ public class TestHiveStorageFormats
     {
         String tableName = "table_created_in_hive_parquet";
 
-        query("DROP TABLE IF EXISTS " + tableName);
+        onHive().executeQuery("DROP TABLE IF EXISTS " + tableName);
 
         onHive().executeQuery(format(
                 "CREATE TABLE %s (" +
@@ -210,7 +210,7 @@ public class TestHiveStorageFormats
 
         assertThat(query("SELECT * FROM " + tableName)).containsExactly(row(1, "test data"));
 
-        query("DROP TABLE " + tableName);
+        onHive().executeQuery("DROP TABLE " + tableName);
     }
 
     private static void assertSelect(String query, String tableName)


### PR DESCRIPTION
Drop snappy test table in the same way as it was created

That way this test is less vulnerable on test environment in which it
is executed.
