### PR TITLE
Rename nodePartitioning variables to tablePartitioning

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1509,9 +1509,9 @@ public class HiveMetadata
             discretePredicates = Optional.of(new DiscretePredicates(partitionColumns, partitionDomains));
         }
 
-        Optional<ConnectorTablePartitioning> nodePartitioning = Optional.empty();
+        Optional<ConnectorTablePartitioning> tablePartitioning = Optional.empty();
         if (isBucketExecutionEnabled(session) && hiveLayoutHandle.getBucketHandle().isPresent()) {
-            nodePartitioning = hiveLayoutHandle.getBucketHandle().map(hiveBucketHandle -> new ConnectorTablePartitioning(
+            tablePartitioning = hiveLayoutHandle.getBucketHandle().map(hiveBucketHandle -> new ConnectorTablePartitioning(
                     new HivePartitioningHandle(
                             hiveBucketHandle.getReadBucketCount(),
                             hiveBucketHandle.getColumns().stream()
@@ -1527,7 +1527,7 @@ public class HiveMetadata
                 hiveLayoutHandle,
                 Optional.empty(),
                 predicate,
-                nodePartitioning,
+                tablePartitioning,
                 Optional.empty(),
                 discretePredicates,
                 ImmutableList.of());

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
@@ -181,7 +181,7 @@ public class TpchMetadata
     {
         TpchTableHandle tableHandle = (TpchTableHandle) table;
 
-        Optional<ConnectorTablePartitioning> nodePartition = Optional.empty();
+        Optional<ConnectorTablePartitioning> tablePartitioning = Optional.empty();
         Optional<Set<ColumnHandle>> partitioningColumns = Optional.empty();
         List<LocalProperty<ColumnHandle>> localProperties = ImmutableList.of();
 
@@ -191,7 +191,7 @@ public class TpchMetadata
         if (tableHandle.getTableName().equals(TpchTable.ORDERS.getTableName())) {
             if (partitioningEnabled) {
                 ColumnHandle orderKeyColumn = columns.get(columnNaming.getName(OrderColumn.ORDER_KEY));
-                nodePartition = Optional.of(new ConnectorTablePartitioning(
+                tablePartitioning = Optional.of(new ConnectorTablePartitioning(
                         new TpchPartitioningHandle(
                                 TpchTable.ORDERS.getTableName(),
                                 calculateTotalRows(OrderGenerator.SCALE_BASE, tableHandle.getScaleFactor())),
@@ -218,7 +218,7 @@ public class TpchMetadata
         else if (tableHandle.getTableName().equals(TpchTable.LINE_ITEM.getTableName())) {
             if (partitioningEnabled) {
                 ColumnHandle orderKeyColumn = columns.get(columnNaming.getName(LineItemColumn.ORDER_KEY));
-                nodePartition = Optional.of(new ConnectorTablePartitioning(
+                tablePartitioning = Optional.of(new ConnectorTablePartitioning(
                         new TpchPartitioningHandle(
                                 TpchTable.ORDERS.getTableName(),
                                 calculateTotalRows(OrderGenerator.SCALE_BASE, tableHandle.getScaleFactor())),
@@ -234,7 +234,7 @@ public class TpchMetadata
                 new TpchTableLayoutHandle(tableHandle, predicate),
                 Optional.empty(),
                 predicate, // TODO: conditionally return well-known properties (e.g., orderkey > 0, etc)
-                nodePartition,
+                tablePartitioning,
                 partitioningColumns,
                 Optional.empty(),
                 localProperties);


### PR DESCRIPTION
Clean-up after https://github.com/prestodb/presto/commit/8385a700c701a234315a52a15f3c94ef4f402eea, which renamed NodePartitioning to TablePartitioning.