### PR TITLE
Allow StringStatistics with both min and max set to null

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -150,7 +150,7 @@ public class StringStatisticsBuilder
         for (ColumnStatistics columnStatistics : stats) {
             StringStatistics partialStatistics = columnStatistics.getStringStatistics();
             if (columnStatistics.getNumberOfValues() > 0) {
-                if (partialStatistics == null) {
+                if (partialStatistics == null || (partialStatistics.getMin() == null && partialStatistics.getMax() == null)) {
                     // there are non null values but no statistics, so we can not say anything about the data
                     return Optional.empty();
                 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatisticsBuilder.java
@@ -147,6 +147,16 @@ public class TestStringStatisticsBuilder
     }
 
     @Test
+    public void testMergeWithNullMinMaxValues()
+    {
+        List<ColumnStatistics> statisticsList = new ArrayList<>();
+        statisticsList.add(stringColumnStatistics(MEDIUM_BOTTOM_VALUE, MEDIUM_BOTTOM_VALUE));
+        assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), MEDIUM_BOTTOM_VALUE, MEDIUM_BOTTOM_VALUE);
+        statisticsList.add(stringColumnStatistics(null, null));
+        assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), null, null);
+    }
+
+    @Test
     public void testMixingAddValueAndMergeWithLimit()
     {
         // max merged to null


### PR DESCRIPTION
The ColumnStatistics#mergeColumnStatistics method is now used also for
merging stats from the ORC files written by other systems. Thus we
cannot enforce that there will be no StringStatistics with both min
and max set to null.