### PR TITLE
Implement parallel partition pruning in Glue Hive adapter

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestHiveClientGlueMetastore.java
@@ -48,7 +48,7 @@ public class TestHiveClientGlueMetastore
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
         GlueHiveMetastoreConfig glueConfig = new GlueHiveMetastoreConfig();
         glueConfig.setDefaultWarehouseDir(tempDir.toURI().toString());
-
+        glueConfig.setMaxGlueConnections(10);
         return new GlueHiveMetastore(hdfsEnvironment, glueConfig);
     }
 


### PR DESCRIPTION
Glue supports the splitting the partition into non-overlapping buckets
called segments. This commit uses segments to make parallel partition 
fetches.