### PR TITLE
Don't record raw input for operators that don't really consume raw input

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ValuesOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ValuesOperator.java
@@ -113,7 +113,6 @@ public class ValuesOperator
         }
         Page page = pages.next();
         if (page != null) {
-            operatorContext.recordRawInput(page.getSizeInBytes());
             operatorContext.recordProcessedInput(page.getSizeInBytes(), page.getPositionCount());
         }
         return page;

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchangeSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchangeSourceOperator.java
@@ -123,7 +123,6 @@ public class LocalExchangeSourceOperator
     {
         Page page = source.removePage();
         if (page != null) {
-            operatorContext.recordRawInput(page.getSizeInBytes());
             operatorContext.recordProcessedInput(page.getSizeInBytes(), page.getPositionCount());
         }
         return page;

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalMergeSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalMergeSourceOperator.java
@@ -166,7 +166,6 @@ public class LocalMergeSourceOperator
         }
 
         Page page = mergedPages.getResult();
-        operatorContext.recordRawInput(page.getSizeInBytes());
         operatorContext.recordProcessedInput(page.getSizeInBytes(), page.getPositionCount());
         return page;
     }


### PR DESCRIPTION
This is a small follow up from: https://github.com/prestodb/presto/pull/11838

`Values, LocalExchange, LocalMerge` don't really consume raw input so it doesn't make sense to account their input as such