### PR TITLE
Print only table name in AbstractCostBasedPlanTest

### DIFF
--- a/presto-benchto-benchmarks/src/test/java/com/facebook/presto/sql/planner/AbstractCostBasedPlanTest.java
+++ b/presto-benchto-benchmarks/src/test/java/com/facebook/presto/sql/planner/AbstractCostBasedPlanTest.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
@@ -21,6 +22,8 @@ import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.tpcds.TpcdsTableHandle;
+import com.facebook.presto.tpch.TpchTableHandle;
 import com.google.common.base.Strings;
 import com.google.common.base.VerifyException;
 import com.google.common.io.Resources;
@@ -202,7 +205,17 @@ public abstract class AbstractCostBasedPlanTest
         @Override
         public Void visitTableScan(TableScanNode node, Integer indent)
         {
-            output(indent, "scan %s", node.getTable().getConnectorHandle());
+            ConnectorTableHandle connectorTableHandle = node.getTable().getConnectorHandle();
+            if (connectorTableHandle instanceof TpcdsTableHandle) {
+                output(indent, "scan %s", ((TpcdsTableHandle) connectorTableHandle).getTableName());
+            }
+            else if (connectorTableHandle instanceof TpchTableHandle) {
+                output(indent, "scan %s", ((TpchTableHandle) connectorTableHandle).getTableName());
+            }
+            else {
+                throw new IllegalStateException(format("Unexpected ConnectorTableHandle: %s", connectorTableHandle.getClass()));
+            }
+
             return null;
         }
 

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q01.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q01.plan.txt
@@ -4,7 +4,7 @@ local exchange (GATHER, SINGLE, [])
             join (LEFT, REPLICATED):
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                        scan tpcds:customer:sf3000.0
+                        scan customer
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["sr_customer_sk"])
                             join (INNER, REPLICATED):
@@ -13,13 +13,13 @@ local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["sr_customer_sk", "sr_store_sk"])
                                             partial aggregation over (sr_customer_sk, sr_store_sk)
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_returns:sf3000.0
+                                                    scan store_returns
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:store:sf3000.0
+                                        scan store
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over (sr_store_sk_24)
@@ -31,10 +31,10 @@ local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["sr_customer_sk_20", "sr_store_sk_24"])
                                                     partial aggregation over (sr_customer_sk_20, sr_store_sk_24)
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:store_returns:sf3000.0
+                                                            scan store_returns
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPLICATE, BROADCAST, [])
                     single aggregation over ()

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q02.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q02.plan.txt
@@ -10,15 +10,15 @@ remote exchange (GATHER, SINGLE, [])
                                     join (INNER, PARTITIONED):
                                         local exchange (REPARTITION, ROUND_ROBIN, [])
                                             remote exchange (REPARTITION, HASH, ["ws_sold_date_sk"])
-                                                scan tpcds:web_sales:sf3000.0
+                                                scan web_sales
                                             remote exchange (REPARTITION, HASH, ["cs_sold_date_sk"])
-                                                scan tpcds:catalog_sales:sf3000.0
+                                                scan catalog_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["d_date_sk"])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["d_week_seq_83"])
-                            scan tpcds:date_dim:sf3000.0
+                            scan date_dim
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["expr_395"])
                         join (INNER, PARTITIONED):
@@ -29,12 +29,12 @@ remote exchange (GATHER, SINGLE, [])
                                             join (INNER, PARTITIONED):
                                                 local exchange (REPARTITION, ROUND_ROBIN, [])
                                                     remote exchange (REPARTITION, HASH, ["ws_sold_date_sk_132"])
-                                                        scan tpcds:web_sales:sf3000.0
+                                                        scan web_sales
                                                     remote exchange (REPARTITION, HASH, ["cs_sold_date_sk_178"])
-                                                        scan tpcds:catalog_sales:sf3000.0
+                                                        scan catalog_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["d_date_sk_228"])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq_316"])
-                                    scan tpcds:date_dim:sf3000.0
+                                    scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q03.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q03.plan.txt
@@ -6,10 +6,10 @@ local exchange (GATHER, SINGLE, [])
                     partial aggregation over (d_year, i_brand, i_brand_id)
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
-                                scan tpcds:store_sales:sf3000.0
+                                scan store_sales
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:item:sf3000.0
+                                        scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:date_dim:sf3000.0
+                                    scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q04.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q04.plan.txt
@@ -15,13 +15,13 @@ local exchange (GATHER, SINGLE, [])
                                                         partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
                                                             join (INNER, REPLICATED):
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:store_sales:sf3000.0
+                                                                    scan store_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:date_dim:sf3000.0
+                                                                            scan date_dim
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:customer:sf3000.0
+                                                                        scan customer
                                         single aggregation over (c_birth_country_42, c_customer_id_29, c_email_address_44, c_first_name_36, c_last_name_37, c_login_43, c_preferred_cust_flag_38, d_year_52)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
@@ -44,13 +44,13 @@ local exchange (GATHER, SINGLE, [])
                                                             partial aggregation over (c_birth_country_260, c_customer_id_247, c_email_address_262, c_first_name_254, c_last_name_255, c_login_261, c_preferred_cust_flag_256, d_year_293)
                                                                 join (INNER, REPLICATED):
                                                                     join (INNER, REPLICATED):
-                                                                        scan tpcds:store_sales:sf3000.0
+                                                                        scan store_sales
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                scan date_dim
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:customer:sf3000.0
+                                                                            scan customer
                                             single aggregation over (c_birth_country_367, c_customer_id_354, c_email_address_369, c_first_name_361, c_last_name_362, c_login_368, c_preferred_cust_flag_363, d_year_411)
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
@@ -78,13 +78,13 @@ local exchange (GATHER, SINGLE, [])
                                                 partial aggregation over (c_birth_country_760, c_customer_id_747, c_email_address_762, c_first_name_754, c_last_name_755, c_login_761, c_preferred_cust_flag_756, d_year_804)
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:catalog_sales:sf3000.0
+                                                            scan catalog_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:customer:sf3000.0
+                                                                scan customer
                                 remote exchange (REPARTITION, HASH, ["c_customer_id_875"])
                                     single aggregation over (c_birth_country_888, c_customer_id_875, c_email_address_890, c_first_name_882, c_last_name_883, c_login_889, c_preferred_cust_flag_884, d_year_932)
                                         join (INNER, REPLICATED):
@@ -107,13 +107,13 @@ local exchange (GATHER, SINGLE, [])
                                             partial aggregation over (c_birth_country_1153, c_customer_id_1140, c_email_address_1155, c_first_name_1147, c_last_name_1148, c_login_1154, c_preferred_cust_flag_1149, d_year_1197)
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:catalog_sales:sf3000.0
+                                                        scan catalog_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:customer:sf3000.0
+                                                            scan customer
                             remote exchange (REPARTITION, HASH, ["c_customer_id_1268"])
                                 single aggregation over (c_birth_country_1281, c_customer_id_1268, c_email_address_1283, c_first_name_1275, c_last_name_1276, c_login_1282, c_preferred_cust_flag_1277, d_year_1325)
                                     join (INNER, REPLICATED):
@@ -144,13 +144,13 @@ local exchange (GATHER, SINGLE, [])
                                                 join (INNER, PARTITIONED):
                                                     remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_1682"])
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:web_sales:sf3000.0
+                                                            scan web_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["c_customer_sk_1660"])
-                                                            scan tpcds:customer:sf3000.0
+                                                            scan customer
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["c_customer_id_1819"])
                     single aggregation over (c_birth_country_1832, c_customer_id_1819, c_email_address_1834, c_first_name_1826, c_last_name_1827, c_login_1833, c_preferred_cust_flag_1828, d_year_1865)
@@ -174,10 +174,10 @@ local exchange (GATHER, SINGLE, [])
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_2075"])
                                             join (INNER, REPLICATED):
-                                                scan tpcds:web_sales:sf3000.0
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["c_customer_sk_2053"])
-                                                scan tpcds:customer:sf3000.0
+                                                scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q05.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q05.plan.txt
@@ -14,15 +14,15 @@ local exchange (GATHER, SINGLE, [])
                                                     join (INNER, PARTITIONED):
                                                         local exchange (REPARTITION, ROUND_ROBIN, [])
                                                             remote exchange (REPARTITION, HASH, ["ss_sold_date_sk"])
-                                                                scan tpcds:store_sales:sf3000.0
+                                                                scan store_sales
                                                             remote exchange (REPARTITION, HASH, ["sr_returned_date_sk"])
-                                                                scan tpcds:store_returns:sf3000.0
+                                                                scan store_returns
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPARTITION, HASH, ["d_date_sk"])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["s_store_sk"])
-                                                        scan tpcds:store:sf3000.0
+                                                        scan store
                             final aggregation over (cp_catalog_page_id)
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["cp_catalog_page_id"])
@@ -32,15 +32,15 @@ local exchange (GATHER, SINGLE, [])
                                                     join (INNER, PARTITIONED):
                                                         local exchange (REPARTITION, ROUND_ROBIN, [])
                                                             remote exchange (REPARTITION, HASH, ["cs_sold_date_sk"])
-                                                                scan tpcds:catalog_sales:sf3000.0
+                                                                scan catalog_sales
                                                             remote exchange (REPARTITION, HASH, ["cr_returned_date_sk"])
-                                                                scan tpcds:catalog_returns:sf3000.0
+                                                                scan catalog_returns
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPARTITION, HASH, ["d_date_sk_124"])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["cp_catalog_page_sk"])
-                                                        scan tpcds:catalog_page:sf3000.0
+                                                        scan catalog_page
                             final aggregation over (web_site_id)
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["web_site_id"])
@@ -50,17 +50,17 @@ local exchange (GATHER, SINGLE, [])
                                                     join (INNER, PARTITIONED):
                                                         local exchange (REPARTITION, ROUND_ROBIN, [])
                                                             remote exchange (REPARTITION, HASH, ["ws_sold_date_sk"])
-                                                                scan tpcds:web_sales:sf3000.0
+                                                                scan web_sales
                                                             remote exchange (REPARTITION, HASH, ["wr_returned_date_sk"])
                                                                 join (RIGHT, PARTITIONED):
                                                                     remote exchange (REPARTITION, HASH, ["ws_item_sk_216", "ws_order_number_230"])
-                                                                        scan tpcds:web_sales:sf3000.0
+                                                                        scan web_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
-                                                                            scan tpcds:web_returns:sf3000.0
+                                                                            scan web_returns
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPARTITION, HASH, ["d_date_sk_281"])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["web_site_sk"])
-                                                        scan tpcds:web_site:sf3000.0
+                                                        scan web_site

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q06.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q06.plan.txt
@@ -10,11 +10,11 @@ local exchange (GATHER, SINGLE, [])
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                             join (INNER, REPLICATED):
-                                                scan tpcds:store_sales:sf3000.0
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                     local exchange (GATHER, SINGLE, [])
@@ -23,25 +23,25 @@ local exchange (GATHER, SINGLE, [])
                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                     remote exchange (REPARTITION, HASH, ["d_month_seq_3"])
                                                                                         partial aggregation over (d_month_seq_3)
-                                                                                            scan tpcds:date_dim:sf3000.0
+                                                                                            scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                                 join (INNER, PARTITIONED):
                                                     remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                                        scan tpcds:customer:sf3000.0
+                                                        scan customer
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                            scan tpcds:customer_address:sf3000.0
+                                                            scan customer_address
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
                                         final aggregation over (i_category_43)
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["i_category_43"])
                                                     partial aggregation over (i_category_43)
-                                                        scan tpcds:item:sf3000.0
+                                                        scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
                                     single aggregation over ()

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q07.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q07.plan.txt
@@ -8,16 +8,16 @@ local exchange (GATHER, SINGLE, [])
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:store_sales:sf3000.0
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:customer_demographics:sf3000.0
+                                                scan customer_demographics
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:date_dim:sf3000.0
+                                            scan date_dim
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:promotion:sf3000.0
+                                        scan promotion
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:item:sf3000.0
+                                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q08.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q08.plan.txt
@@ -8,20 +8,20 @@ local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["substr_55"])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:store_sales:sf3000.0
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:store:sf3000.0
+                                            scan store
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["substr_56"])
                                     final aggregation over (expr_29)
                                         local exchange (REPARTITION, HASH, ["expr_29"])
                                             remote exchange (REPARTITION, HASH, ["expr_47"])
                                                 partial aggregation over (expr_47)
-                                                    scan tpcds:customer_address:sf3000.0
+                                                    scan customer_address
                                             remote exchange (REPARTITION, HASH, ["expr_50"])
                                                 partial aggregation over (expr_50)
                                                     final aggregation over (ca_zip_11)
@@ -30,7 +30,7 @@ local exchange (GATHER, SINGLE, [])
                                                                 partial aggregation over (ca_zip_11)
                                                                     join (INNER, PARTITIONED):
                                                                         remote exchange (REPARTITION, HASH, ["ca_address_sk_2"])
-                                                                            scan tpcds:customer_address:sf3000.0
+                                                                            scan customer_address
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                                                                scan tpcds:customer:sf3000.0
+                                                                                scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q09.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q09.plan.txt
@@ -14,109 +14,109 @@ remote exchange (GATHER, SINGLE, [])
                                                     cross join:
                                                         cross join:
                                                             cross join:
-                                                                scan tpcds:reason:sf3000.0
+                                                                scan reason
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                                         final aggregation over ()
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (GATHER, SINGLE, [])
                                                                                     partial aggregation over ()
-                                                                                        scan tpcds:store_sales:sf3000.0
+                                                                                        scan store_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                     final aggregation over ()
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (GATHER, SINGLE, [])
                                                                                 partial aggregation over ()
-                                                                                    scan tpcds:store_sales:sf3000.0
+                                                                                    scan store_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 final aggregation over ()
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (GATHER, SINGLE, [])
                                                                             partial aggregation over ()
-                                                                                scan tpcds:store_sales:sf3000.0
+                                                                                scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                             final aggregation over ()
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (GATHER, SINGLE, [])
                                                                         partial aggregation over ()
-                                                                            scan tpcds:store_sales:sf3000.0
+                                                                            scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         final aggregation over ()
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (GATHER, SINGLE, [])
                                                                     partial aggregation over ()
-                                                                        scan tpcds:store_sales:sf3000.0
+                                                                        scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     final aggregation over ()
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (GATHER, SINGLE, [])
                                                                 partial aggregation over ()
-                                                                    scan tpcds:store_sales:sf3000.0
+                                                                    scan store_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 final aggregation over ()
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (GATHER, SINGLE, [])
                                                             partial aggregation over ()
-                                                                scan tpcds:store_sales:sf3000.0
+                                                                scan store_sales
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             final aggregation over ()
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (GATHER, SINGLE, [])
                                                         partial aggregation over ()
-                                                            scan tpcds:store_sales:sf3000.0
+                                                            scan store_sales
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
                                         final aggregation over ()
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (GATHER, SINGLE, [])
                                                     partial aggregation over ()
-                                                        scan tpcds:store_sales:sf3000.0
+                                                        scan store_sales
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
                                     final aggregation over ()
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (GATHER, SINGLE, [])
                                                 partial aggregation over ()
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPLICATE, BROADCAST, [])
                                 final aggregation over ()
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (GATHER, SINGLE, [])
                                             partial aggregation over ()
-                                                scan tpcds:store_sales:sf3000.0
+                                                scan store_sales
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
                             final aggregation over ()
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (GATHER, SINGLE, [])
                                         partial aggregation over ()
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over ()
-                                        scan tpcds:store_sales:sf3000.0
+                                        scan store_sales
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPLICATE, BROADCAST, [])
                     final aggregation over ()
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (GATHER, SINGLE, [])
                                 partial aggregation over ()
-                                    scan tpcds:store_sales:sf3000.0
+                                    scan store_sales
         local exchange (GATHER, SINGLE, [])
             remote exchange (REPLICATE, BROADCAST, [])
                 final aggregation over ()
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (GATHER, SINGLE, [])
                             partial aggregation over ()
-                                scan tpcds:store_sales:sf3000.0
+                                scan store_sales

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q10.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q10.plan.txt
@@ -10,10 +10,10 @@ local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["cs_ship_customer_sk"])
                                         partial aggregation over (cs_ship_customer_sk)
                                             join (INNER, REPLICATED):
-                                                scan tpcds:catalog_sales:sf3000.0
+                                                scan catalog_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 join (RIGHT, PARTITIONED):
                                     final aggregation over (ws_bill_customer_sk)
@@ -21,14 +21,14 @@ local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                                                 partial aggregation over (ws_bill_customer_sk)
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:web_sales:sf3000.0
+                                                        scan web_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                             join (INNER, REPLICATED):
-                                                scan tpcds:customer_demographics:sf3000.0
+                                                scan customer_demographics
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         join (INNER, PARTITIONED):
@@ -37,14 +37,14 @@ local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                                                         partial aggregation over (ss_customer_sk)
                                                                             join (INNER, REPLICATED):
-                                                                                scan tpcds:store_sales:sf3000.0
+                                                                                scan store_sales
                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                                        scan tpcds:date_dim:sf3000.0
+                                                                                        scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                                                     join (INNER, REPLICATED):
-                                                                        scan tpcds:customer:sf3000.0
+                                                                        scan customer
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:customer_address:sf3000.0
+                                                                                scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q11.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q11.plan.txt
@@ -12,13 +12,13 @@ local exchange (GATHER, SINGLE, [])
                                             partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:store_sales:sf3000.0
+                                                        scan store_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:customer:sf3000.0
+                                                            scan customer
                             single aggregation over (c_birth_country_42, c_customer_id_29, c_email_address_44, c_first_name_36, c_last_name_37, c_login_43, c_preferred_cust_flag_38, d_year_52)
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
@@ -35,13 +35,13 @@ local exchange (GATHER, SINGLE, [])
                                                 partial aggregation over (c_birth_country_166, c_customer_id_153, c_email_address_168, c_first_name_160, c_last_name_161, c_login_167, c_preferred_cust_flag_162, d_year_199)
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:store_sales:sf3000.0
+                                                            scan store_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:customer:sf3000.0
+                                                                scan customer
                                 single aggregation over (c_birth_country_273, c_customer_id_260, c_email_address_275, c_first_name_267, c_last_name_268, c_login_274, c_preferred_cust_flag_269, d_year_317)
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
@@ -64,13 +64,13 @@ local exchange (GATHER, SINGLE, [])
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_546"])
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:web_sales:sf3000.0
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["c_customer_sk_524"])
-                                                    scan tpcds:customer:sf3000.0
+                                                    scan customer
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["c_customer_id_683"])
                     single aggregation over (c_birth_country_696, c_customer_id_683, c_email_address_698, c_first_name_690, c_last_name_691, c_login_697, c_preferred_cust_flag_692, d_year_729)
@@ -87,10 +87,10 @@ local exchange (GATHER, SINGLE, [])
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_811"])
                                             join (INNER, REPLICATED):
-                                                scan tpcds:web_sales:sf3000.0
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["c_customer_sk_789"])
-                                                scan tpcds:customer:sf3000.0
+                                                scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q12.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q12.plan.txt
@@ -8,10 +8,10 @@ local exchange (GATHER, SINGLE, [])
                             partial aggregation over (i_category, i_class, i_current_price, i_item_desc, i_item_id)
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:web_sales:sf3000.0
+                                        scan web_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:item:sf3000.0
+                                            scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q13.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q13.plan.txt
@@ -7,19 +7,19 @@ final aggregation over ()
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    scan tpcds:store_sales:sf3000.0
+                                    scan store_sales
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:customer_address:sf3000.0
+                                            scan customer_address
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:date_dim:sf3000.0
+                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:household_demographics:sf3000.0
+                                    scan household_demographics
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPLICATE, BROADCAST, [])
-                                scan tpcds:customer_demographics:sf3000.0
+                                scan customer_demographics
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
-                            scan tpcds:store:sf3000.0
+                            scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q14_1.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q14_1.plan.txt
@@ -14,53 +14,53 @@ local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["ss_item_sk"])
                                                         join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                scan tpcds:store_sales:sf3000.0
+                                                                scan store_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:date_dim:sf3000.0
+                                                                        scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:item:sf3000.0
+                                                                    scan item
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["i_item_sk_1"])
                                                             join (INNER, PARTITIONED):
                                                                 remote exchange (REPARTITION, HASH, ["i_brand_id_8", "i_category_id_12", "i_class_id_10"])
-                                                                    scan tpcds:item:sf3000.0
+                                                                    scan item
                                                                 final aggregation over (expr_216, expr_217, expr_218)
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPARTITION, HASH, ["i_brand_id_53", "i_category_id_57", "i_class_id_55"])
                                                                             partial aggregation over (i_brand_id_53, i_category_id_57, i_class_id_55)
                                                                                 join (INNER, REPLICATED):
                                                                                     join (INNER, REPLICATED):
-                                                                                        scan tpcds:store_sales:sf3000.0
+                                                                                        scan store_sales
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                scan date_dim
                                                                                     local exchange (GATHER, SINGLE, [])
                                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan tpcds:item:sf3000.0
+                                                                                            scan item
                                                                         remote exchange (REPARTITION, HASH, ["i_brand_id_108", "i_category_id_112", "i_class_id_110"])
                                                                             partial aggregation over (i_brand_id_108, i_category_id_112, i_class_id_110)
                                                                                 join (INNER, REPLICATED):
                                                                                     join (INNER, REPLICATED):
-                                                                                        scan tpcds:catalog_sales:sf3000.0
+                                                                                        scan catalog_sales
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                scan date_dim
                                                                                     local exchange (GATHER, SINGLE, [])
                                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan tpcds:item:sf3000.0
+                                                                                            scan item
                                                                         remote exchange (REPARTITION, HASH, ["i_brand_id_167", "i_category_id_171", "i_class_id_169"])
                                                                             partial aggregation over (i_brand_id_167, i_category_id_171, i_class_id_169)
                                                                                 join (INNER, REPLICATED):
                                                                                     join (INNER, REPLICATED):
-                                                                                        scan tpcds:web_sales:sf3000.0
+                                                                                        scan web_sales
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                scan date_dim
                                                                                     local exchange (GATHER, SINGLE, [])
                                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan tpcds:item:sf3000.0
+                                                                                            scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
                                         final aggregation over ()
@@ -68,22 +68,22 @@ local exchange (GATHER, SINGLE, [])
                                                 remote exchange (GATHER, SINGLE, [])
                                                     partial aggregation over ()
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:store_sales:sf3000.0
+                                                            scan store_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                     partial aggregation over ()
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:catalog_sales:sf3000.0
+                                                            scan catalog_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                     partial aggregation over ()
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:web_sales:sf3000.0
+                                                            scan web_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                             cross join:
                                 final aggregation over (i_brand_id_508, i_category_id_512, i_class_id_510)
                                     local exchange (GATHER, SINGLE, [])
@@ -93,53 +93,53 @@ local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["cs_item_sk_482"])
                                                         join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                scan tpcds:catalog_sales:sf3000.0
+                                                                scan catalog_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:date_dim:sf3000.0
+                                                                        scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:item:sf3000.0
+                                                                    scan item
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["i_item_sk_552"])
                                                             join (INNER, PARTITIONED):
                                                                 remote exchange (REPARTITION, HASH, ["i_brand_id_559", "i_category_id_563", "i_class_id_561"])
-                                                                    scan tpcds:item:sf3000.0
+                                                                    scan item
                                                                 final aggregation over (expr_836, expr_837, expr_838)
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPARTITION, HASH, ["i_brand_id_604", "i_category_id_608", "i_class_id_606"])
                                                                             partial aggregation over (i_brand_id_604, i_category_id_608, i_class_id_606)
                                                                                 join (INNER, REPLICATED):
                                                                                     join (INNER, REPLICATED):
-                                                                                        scan tpcds:store_sales:sf3000.0
+                                                                                        scan store_sales
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                scan date_dim
                                                                                     local exchange (GATHER, SINGLE, [])
                                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan tpcds:item:sf3000.0
+                                                                                            scan item
                                                                         remote exchange (REPARTITION, HASH, ["i_brand_id_694", "i_category_id_698", "i_class_id_696"])
                                                                             partial aggregation over (i_brand_id_694, i_category_id_698, i_class_id_696)
                                                                                 join (INNER, REPLICATED):
                                                                                     join (INNER, REPLICATED):
-                                                                                        scan tpcds:catalog_sales:sf3000.0
+                                                                                        scan catalog_sales
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                scan date_dim
                                                                                     local exchange (GATHER, SINGLE, [])
                                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan tpcds:item:sf3000.0
+                                                                                            scan item
                                                                         remote exchange (REPARTITION, HASH, ["i_brand_id_787", "i_category_id_791", "i_class_id_789"])
                                                                             partial aggregation over (i_brand_id_787, i_category_id_791, i_class_id_789)
                                                                                 join (INNER, REPLICATED):
                                                                                     join (INNER, REPLICATED):
-                                                                                        scan tpcds:web_sales:sf3000.0
+                                                                                        scan web_sales
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                scan date_dim
                                                                                     local exchange (GATHER, SINGLE, [])
                                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan tpcds:item:sf3000.0
+                                                                                            scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
                                         final aggregation over ()
@@ -147,22 +147,22 @@ local exchange (GATHER, SINGLE, [])
                                                 remote exchange (GATHER, SINGLE, [])
                                                     partial aggregation over ()
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:store_sales:sf3000.0
+                                                            scan store_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                     partial aggregation over ()
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:catalog_sales:sf3000.0
+                                                            scan catalog_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                     partial aggregation over ()
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:web_sales:sf3000.0
+                                                            scan web_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                             cross join:
                                 final aggregation over (i_brand_id_1135, i_category_id_1139, i_class_id_1137)
                                     local exchange (GATHER, SINGLE, [])
@@ -172,53 +172,53 @@ local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["ws_item_sk_1097"])
                                                         join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                scan tpcds:web_sales:sf3000.0
+                                                                scan web_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:date_dim:sf3000.0
+                                                                        scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:item:sf3000.0
+                                                                    scan item
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["i_item_sk_1179"])
                                                             join (INNER, PARTITIONED):
                                                                 remote exchange (REPARTITION, HASH, ["i_brand_id_1186", "i_category_id_1190", "i_class_id_1188"])
-                                                                    scan tpcds:item:sf3000.0
+                                                                    scan item
                                                                 final aggregation over (expr_1463, expr_1464, expr_1465)
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPARTITION, HASH, ["i_brand_id_1231", "i_category_id_1235", "i_class_id_1233"])
                                                                             partial aggregation over (i_brand_id_1231, i_category_id_1235, i_class_id_1233)
                                                                                 join (INNER, REPLICATED):
                                                                                     join (INNER, REPLICATED):
-                                                                                        scan tpcds:store_sales:sf3000.0
+                                                                                        scan store_sales
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                scan date_dim
                                                                                     local exchange (GATHER, SINGLE, [])
                                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan tpcds:item:sf3000.0
+                                                                                            scan item
                                                                         remote exchange (REPARTITION, HASH, ["i_brand_id_1321", "i_category_id_1325", "i_class_id_1323"])
                                                                             partial aggregation over (i_brand_id_1321, i_category_id_1325, i_class_id_1323)
                                                                                 join (INNER, REPLICATED):
                                                                                     join (INNER, REPLICATED):
-                                                                                        scan tpcds:catalog_sales:sf3000.0
+                                                                                        scan catalog_sales
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                scan date_dim
                                                                                     local exchange (GATHER, SINGLE, [])
                                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan tpcds:item:sf3000.0
+                                                                                            scan item
                                                                         remote exchange (REPARTITION, HASH, ["i_brand_id_1414", "i_category_id_1418", "i_class_id_1416"])
                                                                             partial aggregation over (i_brand_id_1414, i_category_id_1418, i_class_id_1416)
                                                                                 join (INNER, REPLICATED):
                                                                                     join (INNER, REPLICATED):
-                                                                                        scan tpcds:web_sales:sf3000.0
+                                                                                        scan web_sales
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                scan date_dim
                                                                                     local exchange (GATHER, SINGLE, [])
                                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan tpcds:item:sf3000.0
+                                                                                            scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
                                         final aggregation over ()
@@ -226,19 +226,19 @@ local exchange (GATHER, SINGLE, [])
                                                 remote exchange (GATHER, SINGLE, [])
                                                     partial aggregation over ()
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:store_sales:sf3000.0
+                                                            scan store_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                     partial aggregation over ()
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:catalog_sales:sf3000.0
+                                                            scan catalog_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                     partial aggregation over ()
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:web_sales:sf3000.0
+                                                            scan web_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q14_2.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q14_2.plan.txt
@@ -11,58 +11,58 @@ local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ss_item_sk"])
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:item:sf3000.0
+                                                        scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["i_item_sk_1"])
                                                 join (INNER, PARTITIONED):
                                                     remote exchange (REPARTITION, HASH, ["i_brand_id_8", "i_category_id_12", "i_class_id_10"])
-                                                        scan tpcds:item:sf3000.0
+                                                        scan item
                                                     final aggregation over (expr_216, expr_217, expr_218)
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPARTITION, HASH, ["i_brand_id_53", "i_category_id_57", "i_class_id_55"])
                                                                 partial aggregation over (i_brand_id_53, i_category_id_57, i_class_id_55)
                                                                     join (INNER, REPLICATED):
                                                                         join (INNER, REPLICATED):
-                                                                            scan tpcds:store_sales:sf3000.0
+                                                                            scan store_sales
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:date_dim:sf3000.0
+                                                                                    scan date_dim
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:item:sf3000.0
+                                                                                scan item
                                                             remote exchange (REPARTITION, HASH, ["i_brand_id_108", "i_category_id_112", "i_class_id_110"])
                                                                 partial aggregation over (i_brand_id_108, i_category_id_112, i_class_id_110)
                                                                     join (INNER, REPLICATED):
                                                                         join (INNER, REPLICATED):
-                                                                            scan tpcds:catalog_sales:sf3000.0
+                                                                            scan catalog_sales
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:date_dim:sf3000.0
+                                                                                    scan date_dim
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:item:sf3000.0
+                                                                                scan item
                                                             remote exchange (REPARTITION, HASH, ["i_brand_id_167", "i_category_id_171", "i_class_id_169"])
                                                                 partial aggregation over (i_brand_id_167, i_category_id_171, i_class_id_169)
                                                                     join (INNER, REPLICATED):
                                                                         join (INNER, REPLICATED):
-                                                                            scan tpcds:web_sales:sf3000.0
+                                                                            scan web_sales
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:date_dim:sf3000.0
+                                                                                    scan date_dim
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:item:sf3000.0
+                                                                                scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (GATHER, SINGLE, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
@@ -70,22 +70,22 @@ local exchange (GATHER, SINGLE, [])
                                 remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over ()
                                         join (INNER, REPLICATED):
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                     partial aggregation over ()
                                         join (INNER, REPLICATED):
-                                            scan tpcds:catalog_sales:sf3000.0
+                                            scan catalog_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                     partial aggregation over ()
                                         join (INNER, REPLICATED):
-                                            scan tpcds:web_sales:sf3000.0
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
             cross join:
                 final aggregation over (i_brand_id_534, i_category_id_538, i_class_id_536)
                     local exchange (GATHER, SINGLE, [])
@@ -96,58 +96,58 @@ local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ss_item_sk_506"])
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:item:sf3000.0
+                                                        scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["i_item_sk_578"])
                                                 join (INNER, PARTITIONED):
                                                     remote exchange (REPARTITION, HASH, ["i_brand_id_585", "i_category_id_589", "i_class_id_587"])
-                                                        scan tpcds:item:sf3000.0
+                                                        scan item
                                                     final aggregation over (expr_862, expr_863, expr_864)
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPARTITION, HASH, ["i_brand_id_630", "i_category_id_634", "i_class_id_632"])
                                                                 partial aggregation over (i_brand_id_630, i_category_id_634, i_class_id_632)
                                                                     join (INNER, REPLICATED):
                                                                         join (INNER, REPLICATED):
-                                                                            scan tpcds:store_sales:sf3000.0
+                                                                            scan store_sales
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:date_dim:sf3000.0
+                                                                                    scan date_dim
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:item:sf3000.0
+                                                                                scan item
                                                             remote exchange (REPARTITION, HASH, ["i_brand_id_720", "i_category_id_724", "i_class_id_722"])
                                                                 partial aggregation over (i_brand_id_720, i_category_id_724, i_class_id_722)
                                                                     join (INNER, REPLICATED):
                                                                         join (INNER, REPLICATED):
-                                                                            scan tpcds:catalog_sales:sf3000.0
+                                                                            scan catalog_sales
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:date_dim:sf3000.0
+                                                                                    scan date_dim
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:item:sf3000.0
+                                                                                scan item
                                                             remote exchange (REPARTITION, HASH, ["i_brand_id_813", "i_category_id_817", "i_class_id_815"])
                                                                 partial aggregation over (i_brand_id_813, i_category_id_817, i_class_id_815)
                                                                     join (INNER, REPLICATED):
                                                                         join (INNER, REPLICATED):
-                                                                            scan tpcds:web_sales:sf3000.0
+                                                                            scan web_sales
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:date_dim:sf3000.0
+                                                                                    scan date_dim
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:item:sf3000.0
+                                                                                scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (GATHER, SINGLE, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
@@ -155,19 +155,19 @@ local exchange (GATHER, SINGLE, [])
                                 remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over ()
                                         join (INNER, REPLICATED):
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                     partial aggregation over ()
                                         join (INNER, REPLICATED):
-                                            scan tpcds:catalog_sales:sf3000.0
+                                            scan catalog_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                     partial aggregation over ()
                                         join (INNER, REPLICATED):
-                                            scan tpcds:web_sales:sf3000.0
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q15.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q15.plan.txt
@@ -7,15 +7,15 @@ local exchange (GATHER, SINGLE, [])
                         join (INNER, PARTITIONED):
                             remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
                                 join (INNER, REPLICATED):
-                                    scan tpcds:catalog_sales:sf3000.0
+                                    scan catalog_sales
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:date_dim:sf3000.0
+                                            scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                            scan tpcds:customer:sf3000.0
+                                            scan customer
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                scan tpcds:customer_address:sf3000.0
+                                                scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q16.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q16.plan.txt
@@ -8,24 +8,24 @@ final aggregation over ()
                             partial aggregation over (ca_state, cc_county, cs_call_center_sk, cs_ext_ship_cost, cs_net_profit, cs_order_number, cs_ship_addr_sk, cs_ship_date_sk, cs_warehouse_sk, d_date, unique)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["cs_order_number_17"])
-                                        scan tpcds:catalog_sales:sf3000.0
+                                        scan catalog_sales
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["cs_order_number"])
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:catalog_sales:sf3000.0
+                                                        scan catalog_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:customer_address:sf3000.0
+                                                                scan customer_address
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:call_center:sf3000.0
+                                                        scan call_center
                     final aggregation over (cr_order_number)
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["cr_order_number"])
                                 partial aggregation over (cr_order_number)
-                                    scan tpcds:catalog_returns:sf3000.0
+                                    scan catalog_returns

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q17.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q17.plan.txt
@@ -11,27 +11,27 @@ local exchange (GATHER, SINGLE, [])
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_item_sk", "ss_ticket_number"])
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["sr_customer_sk", "sr_item_sk", "sr_ticket_number"])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:store_returns:sf3000.0
+                                                        scan store_returns
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:store:sf3000.0
+                                                scan store
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk", "cs_item_sk"])
                                     join (INNER, REPLICATED):
-                                        scan tpcds:catalog_sales:sf3000.0
+                                        scan catalog_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q18.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q18.plan.txt
@@ -8,26 +8,26 @@ local exchange (GATHER, SINGLE, [])
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:catalog_sales:sf3000.0
+                                        scan catalog_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:customer_demographics:sf3000.0
+                                                scan customer_demographics
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             join (INNER, PARTITIONED):
                                                 remote exchange (REPARTITION, HASH, ["c_current_cdemo_sk"])
                                                     join (INNER, PARTITIONED):
                                                         remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                                            scan tpcds:customer:sf3000.0
+                                                            scan customer
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                                scan tpcds:customer_address:sf3000.0
+                                                                scan customer_address
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["cd_demo_sk_0"])
-                                                        scan tpcds:customer_demographics:sf3000.0
+                                                        scan customer_demographics
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:date_dim:sf3000.0
+                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:item:sf3000.0
+                                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q19.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q19.plan.txt
@@ -7,23 +7,23 @@ local exchange (GATHER, SINGLE, [])
                         join (INNER, REPLICATED):
                             join (INNER, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                    scan tpcds:customer_address:sf3000.0
+                                    scan customer_address
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                scan tpcds:customer:sf3000.0
+                                                scan customer
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:store_sales:sf3000.0
+                                                            scan store_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:item:sf3000.0
+                                                                scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:store:sf3000.0
+                                    scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q20.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q20.plan.txt
@@ -8,10 +8,10 @@ local exchange (GATHER, SINGLE, [])
                             partial aggregation over (i_category, i_class, i_current_price, i_item_desc, i_item_id)
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:catalog_sales:sf3000.0
+                                        scan catalog_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:item:sf3000.0
+                                            scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q21.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q21.plan.txt
@@ -7,13 +7,13 @@ local exchange (GATHER, SINGLE, [])
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    scan tpcds:inventory:sf3000.0
+                                    scan inventory
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:date_dim:sf3000.0
+                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:warehouse:sf3000.0
+                                    scan warehouse

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q22.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q22.plan.txt
@@ -6,10 +6,10 @@ local exchange (GATHER, SINGLE, [])
                     partial aggregation over (groupid, i_brand$gid, i_category$gid, i_class$gid, i_product_name$gid)
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
-                                scan tpcds:inventory:sf3000.0
+                                scan inventory
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:date_dim:sf3000.0
+                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:item:sf3000.0
+                                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q23_1.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q23_1.plan.txt
@@ -7,10 +7,10 @@ final aggregation over ()
                         semijoin (PARTITIONED):
                             remote exchange (REPARTITION, HASH, ["cs_item_sk"])
                                 join (INNER, REPLICATED):
-                                    scan tpcds:catalog_sales:sf3000.0
+                                    scan catalog_sales
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:date_dim:sf3000.0
+                                            scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["i_item_sk"])
                                     final aggregation over (d_date_3, i_item_sk, substr)
@@ -19,13 +19,13 @@ final aggregation over ()
                                                 partial aggregation over (d_date_3, i_item_sk, substr)
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:store_sales:sf3000.0
+                                                            scan store_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:item:sf3000.0
+                                                                scan item
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                             cross join:
@@ -34,10 +34,10 @@ final aggregation over ()
                                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                             partial aggregation over (c_customer_sk)
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:customer:sf3000.0
+                                                            scan customer
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
                                         final aggregation over ()
@@ -50,23 +50,23 @@ final aggregation over ()
                                                                     partial aggregation over (c_customer_sk_110)
                                                                         join (INNER, REPLICATED):
                                                                             join (INNER, REPLICATED):
-                                                                                scan tpcds:store_sales:sf3000.0
+                                                                                scan store_sales
                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                                        scan tpcds:date_dim:sf3000.0
+                                                                                        scan date_dim
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:customer:sf3000.0
+                                                                                    scan customer
             partial aggregation over ()
                 semijoin (PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                         semijoin (PARTITIONED):
                             remote exchange (REPARTITION, HASH, ["ws_item_sk"])
                                 join (INNER, REPLICATED):
-                                    scan tpcds:web_sales:sf3000.0
+                                    scan web_sales
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:date_dim:sf3000.0
+                                            scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["i_item_sk_275"])
                                     final aggregation over (d_date_249, i_item_sk_275, substr_297)
@@ -75,13 +75,13 @@ final aggregation over ()
                                                 partial aggregation over (d_date_249, i_item_sk_275, substr_297)
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:store_sales:sf3000.0
+                                                            scan store_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:item:sf3000.0
+                                                                scan item
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["c_customer_sk_355"])
                             cross join:
@@ -90,10 +90,10 @@ final aggregation over ()
                                         remote exchange (REPARTITION, HASH, ["c_customer_sk_355"])
                                             partial aggregation over (c_customer_sk_355)
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:customer:sf3000.0
+                                                            scan customer
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
                                         final aggregation over ()
@@ -106,10 +106,10 @@ final aggregation over ()
                                                                     partial aggregation over (c_customer_sk_405)
                                                                         join (INNER, REPLICATED):
                                                                             join (INNER, REPLICATED):
-                                                                                scan tpcds:store_sales:sf3000.0
+                                                                                scan store_sales
                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                                        scan tpcds:date_dim:sf3000.0
+                                                                                        scan date_dim
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:customer:sf3000.0
+                                                                                    scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q23_2.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q23_2.plan.txt
@@ -11,13 +11,13 @@ local exchange (GATHER, SINGLE, [])
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:catalog_sales:sf3000.0
+                                                    scan catalog_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                    scan tpcds:customer:sf3000.0
+                                                    scan customer
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["i_item_sk"])
                                             final aggregation over (d_date_3, i_item_sk, substr)
@@ -26,13 +26,13 @@ local exchange (GATHER, SINGLE, [])
                                                         partial aggregation over (d_date_3, i_item_sk, substr)
                                                             join (INNER, REPLICATED):
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:store_sales:sf3000.0
+                                                                    scan store_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:date_dim:sf3000.0
+                                                                            scan date_dim
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:item:sf3000.0
+                                                                        scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["c_customer_sk_80"])
                                     cross join:
@@ -41,10 +41,10 @@ local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["c_customer_sk_80"])
                                                     partial aggregation over (c_customer_sk_80)
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:store_sales:sf3000.0
+                                                            scan store_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:customer:sf3000.0
+                                                                    scan customer
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 final aggregation over ()
@@ -57,13 +57,13 @@ local exchange (GATHER, SINGLE, [])
                                                                             partial aggregation over (c_customer_sk_128)
                                                                                 join (INNER, REPLICATED):
                                                                                     join (INNER, REPLICATED):
-                                                                                        scan tpcds:store_sales:sf3000.0
+                                                                                        scan store_sales
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                scan date_dim
                                                                                     local exchange (GATHER, SINGLE, [])
                                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan tpcds:customer:sf3000.0
+                                                                                            scan customer
         final aggregation over (c_first_name_229, c_last_name_230)
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["c_first_name_229", "c_last_name_230"])
@@ -75,13 +75,13 @@ local exchange (GATHER, SINGLE, [])
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:web_sales:sf3000.0
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["c_customer_sk_221"])
-                                                    scan tpcds:customer:sf3000.0
+                                                    scan customer
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["i_item_sk_319"])
                                             final aggregation over (d_date_293, i_item_sk_319, substr_341)
@@ -90,13 +90,13 @@ local exchange (GATHER, SINGLE, [])
                                                         partial aggregation over (d_date_293, i_item_sk_319, substr_341)
                                                             join (INNER, REPLICATED):
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:store_sales:sf3000.0
+                                                                    scan store_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:date_dim:sf3000.0
+                                                                            scan date_dim
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:item:sf3000.0
+                                                                        scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["c_customer_sk_399"])
                                     cross join:
@@ -105,10 +105,10 @@ local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["c_customer_sk_399"])
                                                     partial aggregation over (c_customer_sk_399)
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:store_sales:sf3000.0
+                                                            scan store_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:customer:sf3000.0
+                                                                    scan customer
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 final aggregation over ()
@@ -121,10 +121,10 @@ local exchange (GATHER, SINGLE, [])
                                                                             partial aggregation over (c_customer_sk_449)
                                                                                 join (INNER, REPLICATED):
                                                                                     join (INNER, REPLICATED):
-                                                                                        scan tpcds:store_sales:sf3000.0
+                                                                                        scan store_sales
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                scan date_dim
                                                                                     local exchange (GATHER, SINGLE, [])
                                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan tpcds:customer:sf3000.0
+                                                                                            scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q24_1.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q24_1.plan.txt
@@ -14,23 +14,23 @@ remote exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                                         join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                scan tpcds:store_sales:sf3000.0
+                                                                scan store_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                                         join (INNER, REPLICATED):
-                                                                            scan tpcds:store_returns:sf3000.0
+                                                                            scan store_returns
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:item:sf3000.0
+                                                                                    scan item
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:store:sf3000.0
+                                                                    scan store
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                            scan tpcds:customer:sf3000.0
+                                                            scan customer
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ca_zip", "upper"])
-                                                    scan tpcds:customer_address:sf3000.0
+                                                    scan customer_address
         local exchange (GATHER, SINGLE, [])
             remote exchange (REPLICATE, BROADCAST, [])
                 final aggregation over ()
@@ -47,19 +47,19 @@ remote exchange (GATHER, SINGLE, [])
                                                             join (INNER, PARTITIONED):
                                                                 remote exchange (REPARTITION, HASH, ["ss_item_sk_81", "ss_ticket_number_88"])
                                                                     join (INNER, REPLICATED):
-                                                                        scan tpcds:store_sales:sf3000.0
+                                                                        scan store_sales
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:store:sf3000.0
+                                                                                scan store
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPARTITION, HASH, ["sr_item_sk_104", "sr_ticket_number_111"])
-                                                                        scan tpcds:store_returns:sf3000.0
+                                                                        scan store_returns
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:customer:sf3000.0
+                                                                    scan customer
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:item:sf3000.0
+                                                                scan item
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:customer_address:sf3000.0
+                                                            scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q24_2.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q24_2.plan.txt
@@ -14,23 +14,23 @@ remote exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                                         join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                scan tpcds:store_sales:sf3000.0
+                                                                scan store_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                                         join (INNER, REPLICATED):
-                                                                            scan tpcds:store_returns:sf3000.0
+                                                                            scan store_returns
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:item:sf3000.0
+                                                                                    scan item
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:store:sf3000.0
+                                                                    scan store
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                            scan tpcds:customer:sf3000.0
+                                                            scan customer
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ca_zip", "upper"])
-                                                    scan tpcds:customer_address:sf3000.0
+                                                    scan customer_address
         local exchange (GATHER, SINGLE, [])
             remote exchange (REPLICATE, BROADCAST, [])
                 final aggregation over ()
@@ -47,19 +47,19 @@ remote exchange (GATHER, SINGLE, [])
                                                             join (INNER, PARTITIONED):
                                                                 remote exchange (REPARTITION, HASH, ["ss_item_sk_81", "ss_ticket_number_88"])
                                                                     join (INNER, REPLICATED):
-                                                                        scan tpcds:store_sales:sf3000.0
+                                                                        scan store_sales
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpcds:store:sf3000.0
+                                                                                scan store
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPARTITION, HASH, ["sr_item_sk_104", "sr_ticket_number_111"])
-                                                                        scan tpcds:store_returns:sf3000.0
+                                                                        scan store_returns
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:customer:sf3000.0
+                                                                    scan customer
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:item:sf3000.0
+                                                                scan item
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:customer_address:sf3000.0
+                                                            scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q25.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q25.plan.txt
@@ -11,27 +11,27 @@ local exchange (GATHER, SINGLE, [])
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_item_sk", "ss_ticket_number"])
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["sr_customer_sk", "sr_item_sk", "sr_ticket_number"])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:store_returns:sf3000.0
+                                                        scan store_returns
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:store:sf3000.0
+                                                scan store
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk", "cs_item_sk"])
                                     join (INNER, REPLICATED):
-                                        scan tpcds:catalog_sales:sf3000.0
+                                        scan catalog_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q26.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q26.plan.txt
@@ -8,16 +8,16 @@ local exchange (GATHER, SINGLE, [])
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:catalog_sales:sf3000.0
+                                        scan catalog_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:customer_demographics:sf3000.0
+                                                scan customer_demographics
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:date_dim:sf3000.0
+                                            scan date_dim
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:promotion:sf3000.0
+                                        scan promotion
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:item:sf3000.0
+                                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q27.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q27.plan.txt
@@ -9,16 +9,16 @@ local exchange (GATHER, SINGLE, [])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:customer_demographics:sf3000.0
+                                                    scan customer_demographics
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:store:sf3000.0
+                                                scan store
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:date_dim:sf3000.0
+                                            scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["i_item_sk"])
-                                    scan tpcds:item:sf3000.0
+                                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q28.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q28.plan.txt
@@ -9,39 +9,39 @@ cross join:
                                 partial aggregation over ()
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ss_list_price"])
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                     final aggregation over ()
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (GATHER, SINGLE, [])
                                 partial aggregation over ()
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ss_list_price_27"])
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                 final aggregation over ()
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (GATHER, SINGLE, [])
                             partial aggregation over ()
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["ss_list_price_68"])
-                                        scan tpcds:store_sales:sf3000.0
+                                        scan store_sales
             final aggregation over ()
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (GATHER, SINGLE, [])
                         partial aggregation over ()
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ss_list_price_109"])
-                                    scan tpcds:store_sales:sf3000.0
+                                    scan store_sales
         final aggregation over ()
             local exchange (GATHER, SINGLE, [])
                 remote exchange (GATHER, SINGLE, [])
                     partial aggregation over ()
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["ss_list_price_150"])
-                                scan tpcds:store_sales:sf3000.0
+                                scan store_sales
     final aggregation over ()
         local exchange (GATHER, SINGLE, [])
             remote exchange (GATHER, SINGLE, [])
                 partial aggregation over ()
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["ss_list_price_191"])
-                            scan tpcds:store_sales:sf3000.0
+                            scan store_sales

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q29.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q29.plan.txt
@@ -7,10 +7,10 @@ local exchange (GATHER, SINGLE, [])
                         join (INNER, PARTITIONED):
                             remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk", "cs_item_sk"])
                                 join (INNER, REPLICATED):
-                                    scan tpcds:catalog_sales:sf3000.0
+                                    scan catalog_sales
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:date_dim:sf3000.0
+                                            scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["i_item_sk", "sr_customer_sk"])
                                     join (INNER, REPLICATED):
@@ -18,20 +18,20 @@ local exchange (GATHER, SINGLE, [])
                                             join (INNER, PARTITIONED):
                                                 remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_item_sk", "ss_ticket_number"])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:store_sales:sf3000.0
+                                                        scan store_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["sr_customer_sk", "sr_item_sk", "sr_ticket_number"])
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:store_returns:sf3000.0
+                                                            scan store_returns
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:store:sf3000.0
+                                                    scan store
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:item:sf3000.0
+                                                scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q30.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q30.plan.txt
@@ -10,20 +10,20 @@ local exchange (GATHER, SINGLE, [])
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk"])
                                             join (INNER, REPLICATED):
-                                                scan tpcds:web_returns:sf3000.0
+                                                scan web_returns
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                scan tpcds:customer_address:sf3000.0
+                                                scan customer_address
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
                             join (INNER, REPLICATED):
-                                scan tpcds:customer:sf3000.0
+                                scan customer
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:customer_address:sf3000.0
+                                        scan customer_address
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over (ca_state_90)
@@ -37,13 +37,13 @@ local exchange (GATHER, SINGLE, [])
                                                         join (INNER, PARTITIONED):
                                                             remote exchange (REPARTITION, HASH, ["wr_returning_addr_sk_40"])
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:web_returns:sf3000.0
+                                                                    scan web_returns
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:date_dim:sf3000.0
+                                                                            scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPARTITION, HASH, ["ca_address_sk_82"])
-                                                                    scan tpcds:customer_address:sf3000.0
+                                                                    scan customer_address
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPLICATE, BROADCAST, [])
                     single aggregation over ()

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q31.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q31.plan.txt
@@ -10,26 +10,26 @@ remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over (ca_county_81, d_qoy_56, d_year_52)
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:store_sales:sf3000.0
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:customer_address:sf3000.0
+                                                    scan customer_address
                         final aggregation over (ca_county_345, d_qoy_320, d_year_316)
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ca_county_345", "d_qoy_320", "d_year_316"])
                                     partial aggregation over (ca_county_345, d_qoy_320, d_year_316)
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:web_sales:sf3000.0
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:customer_address:sf3000.0
+                                                    scan customer_address
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["ca_county_173", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
                             join (INNER, PARTITIONED):
@@ -39,26 +39,26 @@ remote exchange (GATHER, SINGLE, [])
                                             partial aggregation over (ca_county_173, d_qoy_148, d_year_144)
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:store_sales:sf3000.0
+                                                        scan store_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:customer_address:sf3000.0
+                                                            scan customer_address
                                 final aggregation over (ca_county_448, d_qoy_423, d_year_419)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ca_county_448", "d_qoy_423", "d_year_419"])
                                             partial aggregation over (ca_county_448, d_qoy_423, d_year_419)
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:web_sales:sf3000.0
+                                                        scan web_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:customer_address:sf3000.0
+                                                            scan customer_address
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["ca_county", NullableValue{type=integer, value=2000}, NullableValue{type=integer, value=2}])
                         join (INNER, PARTITIONED):
@@ -68,23 +68,23 @@ remote exchange (GATHER, SINGLE, [])
                                         partial aggregation over (ca_county, d_qoy, d_year)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:customer_address:sf3000.0
+                                                        scan customer_address
                             final aggregation over (ca_county_242, d_qoy_217, d_year_213)
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["ca_county_242", "d_qoy_217", "d_year_213"])
                                         partial aggregation over (ca_county_242, d_qoy_217, d_year_213)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:web_sales:sf3000.0
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:customer_address:sf3000.0
+                                                        scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q32.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q32.plan.txt
@@ -9,21 +9,21 @@ final aggregation over ()
                                 remote exchange (REPARTITION, HASH, ["cs_item_sk_15"])
                                     partial aggregation over (cs_item_sk_15)
                                         join (INNER, REPLICATED):
-                                            scan tpcds:catalog_sales:sf3000.0
+                                            scan catalog_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["cs_item_sk"])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:catalog_sales:sf3000.0
+                                        scan catalog_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:item:sf3000.0
+                                                scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:date_dim:sf3000.0
+                                            scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
                             single aggregation over ()

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q33.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q33.plan.txt
@@ -9,21 +9,21 @@ local exchange (GATHER, SINGLE, [])
                                 semijoin (PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["i_manufact_id"])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:store_sales:sf3000.0
+                                                                    scan store_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:customer_address:sf3000.0
+                                                                            scan customer_address
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["i_manufact_id_14"])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                 partial aggregation over (i_manufact_id_98)
                     final aggregation over (i_manufact_id_98)
                         local exchange (GATHER, SINGLE, [])
@@ -31,21 +31,21 @@ local exchange (GATHER, SINGLE, [])
                                 semijoin (PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["i_manufact_id_98"])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:catalog_sales:sf3000.0
+                                                                    scan catalog_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:customer_address:sf3000.0
+                                                                            scan customer_address
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["i_manufact_id_121"])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                 partial aggregation over (i_manufact_id_210)
                     final aggregation over (i_manufact_id_210)
                         local exchange (GATHER, SINGLE, [])
@@ -53,18 +53,18 @@ local exchange (GATHER, SINGLE, [])
                                 semijoin (PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["i_manufact_id_210"])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:web_sales:sf3000.0
+                                                                    scan web_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:customer_address:sf3000.0
+                                                                            scan customer_address
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["i_manufact_id_233"])
-                                            scan tpcds:item:sf3000.0
+                                            scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q34.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q34.plan.txt
@@ -10,16 +10,16 @@ remote exchange (GATHER, SINGLE, [])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:store_sales:sf3000.0
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:store:sf3000.0
+                                                        scan store
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:household_demographics:sf3000.0
+                                                scan household_demographics
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                        scan tpcds:customer:sf3000.0
+                        scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q35.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q35.plan.txt
@@ -13,37 +13,37 @@ local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                                     join (INNER, PARTITIONED):
                                                         remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                                            scan tpcds:customer:sf3000.0
+                                                            scan customer
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                                scan tpcds:customer_address:sf3000.0
+                                                                scan customer_address
                                                 final aggregation over (ss_customer_sk)
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                                             partial aggregation over (ss_customer_sk)
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:store_sales:sf3000.0
+                                                                    scan store_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:date_dim:sf3000.0
+                                                                            scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
-                                                scan tpcds:customer_demographics:sf3000.0
+                                                scan customer_demographics
                                 final aggregation over (ws_bill_customer_sk)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                                             partial aggregation over (ws_bill_customer_sk)
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:web_sales:sf3000.0
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                             final aggregation over (cs_ship_customer_sk)
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["cs_ship_customer_sk"])
                                         partial aggregation over (cs_ship_customer_sk)
                                             join (INNER, REPLICATED):
-                                                scan tpcds:catalog_sales:sf3000.0
+                                                scan catalog_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q36.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q36.plan.txt
@@ -9,13 +9,13 @@ local exchange (GATHER, SINGLE, [])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:store:sf3000.0
+                                                    scan store
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:item:sf3000.0
+                                            scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q37.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q37.plan.txt
@@ -5,15 +5,15 @@ local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["i_current_price", "i_item_desc", "i_item_id"])
                     partial aggregation over (i_current_price, i_item_desc, i_item_id)
                         join (INNER, REPLICATED):
-                            scan tpcds:catalog_sales:sf3000.0
+                            scan catalog_sales
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:inventory:sf3000.0
+                                            scan inventory
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q38.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q38.plan.txt
@@ -11,13 +11,13 @@ final aggregation over ()
                                         partial aggregation over (c_first_name, c_last_name, d_date)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:customer:sf3000.0
+                                                        scan customer
                         partial aggregation over (c_first_name_42, c_last_name_43, d_date_8)
                             final aggregation over (c_first_name_42, c_last_name_43, d_date_8)
                                 local exchange (GATHER, SINGLE, [])
@@ -26,13 +26,13 @@ final aggregation over ()
                                             join (INNER, PARTITIONED):
                                                 remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:catalog_sales:sf3000.0
+                                                        scan catalog_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["c_customer_sk_34"])
-                                                        scan tpcds:customer:sf3000.0
+                                                        scan customer
                         partial aggregation over (c_first_name_97, c_last_name_98, d_date_63)
                             final aggregation over (c_first_name_97, c_last_name_98, d_date_63)
                                 local exchange (GATHER, SINGLE, [])
@@ -41,10 +41,10 @@ final aggregation over ()
                                             join (INNER, PARTITIONED):
                                                 remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:web_sales:sf3000.0
+                                                        scan web_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["c_customer_sk_89"])
-                                                        scan tpcds:customer:sf3000.0
+                                                        scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q39_1.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q39_1.plan.txt
@@ -10,16 +10,16 @@ remote exchange (GATHER, SINGLE, [])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:inventory:sf3000.0
+                                                scan inventory
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:warehouse:sf3000.0
+                                                scan warehouse
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["i_item_sk_66", "w_warehouse_sk_88"])
                         final aggregation over (d_moy_110, i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88)
@@ -29,13 +29,13 @@ remote exchange (GATHER, SINGLE, [])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:inventory:sf3000.0
+                                                    scan inventory
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:item:sf3000.0
+                                                        scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:warehouse:sf3000.0
+                                                    scan warehouse

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q39_2.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q39_2.plan.txt
@@ -10,16 +10,16 @@ remote exchange (GATHER, SINGLE, [])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:inventory:sf3000.0
+                                                scan inventory
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:warehouse:sf3000.0
+                                                scan warehouse
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["i_item_sk_66", "w_warehouse_sk_88"])
                         final aggregation over (d_moy_110, i_item_sk_66, w_warehouse_name_90, w_warehouse_sk_88)
@@ -29,13 +29,13 @@ remote exchange (GATHER, SINGLE, [])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:inventory:sf3000.0
+                                                    scan inventory
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:item:sf3000.0
+                                                        scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:warehouse:sf3000.0
+                                                    scan warehouse

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q40.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q40.plan.txt
@@ -8,16 +8,16 @@ local exchange (GATHER, SINGLE, [])
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (LEFT, REPLICATED):
-                                        scan tpcds:catalog_sales:sf3000.0
+                                        scan catalog_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:catalog_returns:sf3000.0
+                                                scan catalog_returns
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:date_dim:sf3000.0
+                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:warehouse:sf3000.0
+                                    scan warehouse

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q41.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q41.plan.txt
@@ -6,14 +6,14 @@ local exchange (GATHER, SINGLE, [])
                     partial aggregation over (i_product_name)
                         cross join:
                             join (LEFT, REPLICATED):
-                                scan tpcds:item:sf3000.0
+                                scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
                                         final aggregation over (i_manufact_14)
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["i_manufact_14"])
                                                     partial aggregation over (i_manufact_14)
-                                                        scan tpcds:item:sf3000.0
+                                                        scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
                                     single aggregation over ()

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q42.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q42.plan.txt
@@ -6,10 +6,10 @@ local exchange (GATHER, SINGLE, [])
                     partial aggregation over (d_year, i_category, i_category_id)
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
-                                scan tpcds:store_sales:sf3000.0
+                                scan store_sales
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:item:sf3000.0
+                                        scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:date_dim:sf3000.0
+                                    scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q43.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q43.plan.txt
@@ -5,11 +5,11 @@ local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["s_store_id", "s_store_name"])
                     partial aggregation over (s_store_id, s_store_name)
                         join (INNER, REPLICATED):
-                            scan tpcds:date_dim:sf3000.0
+                            scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
                                     join (INNER, REPLICATED):
-                                        scan tpcds:store_sales:sf3000.0
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:store:sf3000.0
+                                                scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q44.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q44.plan.txt
@@ -13,7 +13,7 @@ local exchange (GATHER, SINGLE, [])
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["ss_item_sk"])
                                                         partial aggregation over (ss_item_sk)
-                                                            scan tpcds:store_sales:sf3000.0
+                                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     local exchange (GATHER, SINGLE, [])
@@ -22,7 +22,7 @@ local exchange (GATHER, SINGLE, [])
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPARTITION, HASH, ["ss_store_sk_13"])
                                                                         partial aggregation over (ss_store_sk_13)
-                                                                            scan tpcds:store_sales:sf3000.0
+                                                                            scan store_sales
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["rank_131"])
                                     local exchange (GATHER, SINGLE, [])
@@ -32,7 +32,7 @@ local exchange (GATHER, SINGLE, [])
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["ss_item_sk_61"])
                                                             partial aggregation over (ss_item_sk_61)
-                                                                scan tpcds:store_sales:sf3000.0
+                                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         local exchange (GATHER, SINGLE, [])
@@ -41,10 +41,10 @@ local exchange (GATHER, SINGLE, [])
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPARTITION, HASH, ["ss_store_sk_98"])
                                                                             partial aggregation over (ss_store_sk_98)
-                                                                                scan tpcds:store_sales:sf3000.0
+                                                                                scan store_sales
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["i_item_sk"])
-                            scan tpcds:item:sf3000.0
+                            scan item
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["i_item_sk_148"])
-                    scan tpcds:item:sf3000.0
+                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q45.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q45.plan.txt
@@ -10,21 +10,21 @@ local exchange (GATHER, SINGLE, [])
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                                             join (INNER, REPLICATED):
-                                                scan tpcds:web_sales:sf3000.0
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                                 join (INNER, PARTITIONED):
                                                     remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                                                        scan tpcds:customer:sf3000.0
+                                                        scan customer
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                            scan tpcds:customer_address:sf3000.0
+                                                            scan customer_address
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["i_item_id_2"])
-                                    scan tpcds:item:sf3000.0
+                                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q46.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q46.plan.txt
@@ -10,24 +10,24 @@ local exchange (GATHER, SINGLE, [])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:store_sales:sf3000.0
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:store:sf3000.0
+                                                        scan store
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:household_demographics:sf3000.0
+                                                    scan household_demographics
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                        scan tpcds:customer_address:sf3000.0
+                                        scan customer_address
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                     join (INNER, PARTITIONED):
                         remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
-                            scan tpcds:customer:sf3000.0
+                            scan customer
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["ca_address_sk_26"])
-                                scan tpcds:customer_address:sf3000.0
+                                scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q47.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q47.plan.txt
@@ -11,16 +11,16 @@ local exchange (GATHER, SINGLE, [])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:store:sf3000.0
+                                                        scan store
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["i_brand_73", "i_category_77", "s_company_name_155", "s_store_name_143"])
                         final aggregation over (d_moy_118, d_year_116, i_brand_73, i_category_77, s_company_name_155, s_store_name_143)
@@ -30,16 +30,16 @@ local exchange (GATHER, SINGLE, [])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:store:sf3000.0
+                                                        scan store
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["i_brand_250", "i_category_254", "s_company_name_332", "s_store_name_320"])
                     final aggregation over (d_moy_295, d_year_293, i_brand_250, i_category_254, s_company_name_332, s_store_name_320)
@@ -49,13 +49,13 @@ local exchange (GATHER, SINGLE, [])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:store_sales:sf3000.0
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:store:sf3000.0
+                                                    scan store
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:item:sf3000.0
+                                                scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q48.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q48.plan.txt
@@ -7,16 +7,16 @@ final aggregation over ()
                         remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    scan tpcds:store_sales:sf3000.0
+                                    scan store_sales
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:customer_demographics:sf3000.0
+                                            scan customer_demographics
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:date_dim:sf3000.0
+                                        scan date_dim
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                scan tpcds:customer_address:sf3000.0
+                                scan customer_address
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
-                            scan tpcds:store:sf3000.0
+                            scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q49.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q49.plan.txt
@@ -10,14 +10,14 @@ local exchange (GATHER, SINGLE, [])
                                     partial aggregation over (ws_item_sk)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
-                                                scan tpcds:web_returns:sf3000.0
+                                                scan web_returns
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ws_item_sk", "ws_order_number"])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:web_sales:sf3000.0
+                                                        scan web_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
             partial aggregation over (cs_item_sk, expr_101, expr_136, rank_113, rank_115)
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (GATHER, SINGLE, [])
@@ -27,14 +27,14 @@ local exchange (GATHER, SINGLE, [])
                                     partial aggregation over (cs_item_sk)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
-                                                scan tpcds:catalog_returns:sf3000.0
+                                                scan catalog_returns
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:catalog_sales:sf3000.0
+                                                        scan catalog_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
             partial aggregation over (expr_194, expr_239, rank_206, rank_208, ss_item_sk)
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (GATHER, SINGLE, [])
@@ -44,11 +44,11 @@ local exchange (GATHER, SINGLE, [])
                                     partial aggregation over (ss_item_sk)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["sr_item_sk", "sr_ticket_number"])
-                                                scan tpcds:store_returns:sf3000.0
+                                                scan store_returns
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ss_item_sk", "ss_ticket_number"])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:store_sales:sf3000.0
+                                                        scan store_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q50.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q50.plan.txt
@@ -7,17 +7,17 @@ local exchange (GATHER, SINGLE, [])
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    scan tpcds:store_sales:sf3000.0
+                                    scan store_sales
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             join (INNER, REPLICATED):
-                                                scan tpcds:store_returns:sf3000.0
+                                                scan store_returns
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:date_dim:sf3000.0
+                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:store:sf3000.0
+                                    scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q51.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q51.plan.txt
@@ -10,10 +10,10 @@ local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["d_date", "ws_item_sk"])
                                         partial aggregation over (d_date, ws_item_sk)
                                             join (INNER, REPLICATED):
-                                                scan tpcds:web_sales:sf3000.0
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["ss_item_sk"])
                             final aggregation over (d_date_23, ss_item_sk)
@@ -21,7 +21,7 @@ local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["d_date_23", "ss_item_sk"])
                                         partial aggregation over (d_date_23, ss_item_sk)
                                             join (INNER, REPLICATED):
-                                                scan tpcds:store_sales:sf3000.0
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q52.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q52.plan.txt
@@ -6,10 +6,10 @@ local exchange (GATHER, SINGLE, [])
                     partial aggregation over (d_year, i_brand, i_brand_id)
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
-                                scan tpcds:store_sales:sf3000.0
+                                scan store_sales
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:date_dim:sf3000.0
+                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:item:sf3000.0
+                                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q53.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q53.plan.txt
@@ -9,13 +9,13 @@ local exchange (GATHER, SINGLE, [])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:store:sf3000.0
+                                            scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q54.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q54.plan.txt
@@ -27,30 +27,30 @@ local exchange (GATHER, SINGLE, [])
                                                                                                         join (INNER, PARTITIONED):
                                                                                                             local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                                                                 remote exchange (REPARTITION, HASH, ["cs_item_sk"])
-                                                                                                                    scan tpcds:catalog_sales:sf3000.0
+                                                                                                                    scan catalog_sales
                                                                                                                 remote exchange (REPARTITION, HASH, ["ws_item_sk"])
-                                                                                                                    scan tpcds:web_sales:sf3000.0
+                                                                                                                    scan web_sales
                                                                                                             local exchange (GATHER, SINGLE, [])
                                                                                                                 remote exchange (REPARTITION, HASH, ["i_item_sk"])
-                                                                                                                    scan tpcds:item:sf3000.0
+                                                                                                                    scan item
                                                                                                     local exchange (GATHER, SINGLE, [])
                                                                                                         remote exchange (REPARTITION, HASH, ["d_date_sk"])
-                                                                                                            scan tpcds:date_dim:sf3000.0
+                                                                                                            scan date_dim
                                                                                             local exchange (GATHER, SINGLE, [])
                                                                                                 remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                                                                    scan tpcds:customer:sf3000.0
+                                                                                                    scan customer
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
-                                                                                    scan tpcds:store_sales:sf3000.0
+                                                                                    scan store_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                                            scan tpcds:customer_address:sf3000.0
+                                                                            scan customer_address
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPARTITION, HASH, ["s_county", "s_state"])
-                                                                    scan tpcds:store:sf3000.0
+                                                                    scan store
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["d_date_sk_30"])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         local exchange (GATHER, SINGLE, [])
@@ -59,7 +59,7 @@ local exchange (GATHER, SINGLE, [])
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPARTITION, HASH, ["expr_86"])
                                                                             partial aggregation over (expr_86)
-                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     local exchange (GATHER, SINGLE, [])
@@ -68,4 +68,4 @@ local exchange (GATHER, SINGLE, [])
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPARTITION, HASH, ["expr_118"])
                                                                         partial aggregation over (expr_118)
-                                                                            scan tpcds:date_dim:sf3000.0
+                                                                            scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q55.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q55.plan.txt
@@ -6,10 +6,10 @@ local exchange (GATHER, SINGLE, [])
                     partial aggregation over (i_brand, i_brand_id)
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
-                                scan tpcds:store_sales:sf3000.0
+                                scan store_sales
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:date_dim:sf3000.0
+                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:item:sf3000.0
+                                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q56.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q56.plan.txt
@@ -9,21 +9,21 @@ local exchange (GATHER, SINGLE, [])
                                 semijoin (PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["i_item_id"])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:store_sales:sf3000.0
+                                                                    scan store_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:customer_address:sf3000.0
+                                                                            scan customer_address
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["i_item_id_2"])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                 partial aggregation over (i_item_id_86)
                     final aggregation over (i_item_id_86)
                         local exchange (GATHER, SINGLE, [])
@@ -31,21 +31,21 @@ local exchange (GATHER, SINGLE, [])
                                 semijoin (PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["i_item_id_86"])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:catalog_sales:sf3000.0
+                                                                    scan catalog_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:customer_address:sf3000.0
+                                                                            scan customer_address
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["i_item_id_109"])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                 partial aggregation over (i_item_id_198)
                     final aggregation over (i_item_id_198)
                         local exchange (GATHER, SINGLE, [])
@@ -53,18 +53,18 @@ local exchange (GATHER, SINGLE, [])
                                 semijoin (PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["i_item_id_198"])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:web_sales:sf3000.0
+                                                                    scan web_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:customer_address:sf3000.0
+                                                                            scan customer_address
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["i_item_id_221"])
-                                            scan tpcds:item:sf3000.0
+                                            scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q57.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q57.plan.txt
@@ -11,16 +11,16 @@ local exchange (GATHER, SINGLE, [])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:catalog_sales:sf3000.0
+                                                    scan catalog_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:item:sf3000.0
+                                                        scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:call_center:sf3000.0
+                                                    scan call_center
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["cc_name_147", "i_brand_65", "i_category_69"])
                         final aggregation over (cc_name_147, d_moy_121, d_year_119, i_brand_65, i_category_69)
@@ -30,16 +30,16 @@ local exchange (GATHER, SINGLE, [])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:catalog_sales:sf3000.0
+                                                    scan catalog_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:item:sf3000.0
+                                                        scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:call_center:sf3000.0
+                                                    scan call_center
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["cc_name_328", "i_brand_246", "i_category_250"])
                     final aggregation over (cc_name_328, d_moy_302, d_year_300, i_brand_246, i_category_250)
@@ -49,13 +49,13 @@ local exchange (GATHER, SINGLE, [])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:catalog_sales:sf3000.0
+                                                scan catalog_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:call_center:sf3000.0
+                                                scan call_center

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q58.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q58.plan.txt
@@ -10,22 +10,22 @@ local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["d_date"])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:store_sales:sf3000.0
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["d_date_3"])
                                             join (INNER, REPLICATED):
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (GATHER, SINGLE, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                 final aggregation over (i_item_id_79)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["i_item_id_79"])
@@ -34,22 +34,22 @@ local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["d_date_102"])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:catalog_sales:sf3000.0
+                                                scan catalog_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["d_date_131"])
                                             join (INNER, REPLICATED):
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (GATHER, SINGLE, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
             final aggregation over (i_item_id_210)
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["i_item_id_210"])
@@ -58,19 +58,19 @@ local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_date_233"])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:web_sales:sf3000.0
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:item:sf3000.0
+                                                scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["d_date_262"])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:date_dim:sf3000.0
+                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (GATHER, SINGLE, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q59.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q59.plan.txt
@@ -9,16 +9,16 @@ local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq", "ss_store_sk"])
                                     partial aggregation over (d_week_seq, ss_store_sk)
                                         join (INNER, REPLICATED):
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPLICATE, BROADCAST, [])
-                                scan tpcds:date_dim:sf3000.0
+                                scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
-                            scan tpcds:store:sf3000.0
+                            scan store
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["expr_361", "s_store_id_235"])
                     join (INNER, REPLICATED):
@@ -28,13 +28,13 @@ local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["d_week_seq_147", "ss_store_sk_127"])
                                         partial aggregation over (d_week_seq_147, ss_store_sk_127)
                                             join (INNER, REPLICATED):
-                                                scan tpcds:store_sales:sf3000.0
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:date_dim:sf3000.0
+                                    scan date_dim
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPLICATE, BROADCAST, [])
-                                scan tpcds:store:sf3000.0
+                                scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q60.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q60.plan.txt
@@ -9,21 +9,21 @@ local exchange (GATHER, SINGLE, [])
                                 semijoin (PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["i_item_id"])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:store_sales:sf3000.0
+                                                                    scan store_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:customer_address:sf3000.0
+                                                                            scan customer_address
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["i_item_id_2"])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                 partial aggregation over (i_item_id_86)
                     final aggregation over (i_item_id_86)
                         local exchange (GATHER, SINGLE, [])
@@ -31,21 +31,21 @@ local exchange (GATHER, SINGLE, [])
                                 semijoin (PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["i_item_id_86"])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:catalog_sales:sf3000.0
+                                                                    scan catalog_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:customer_address:sf3000.0
+                                                                            scan customer_address
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["i_item_id_109"])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                 partial aggregation over (i_item_id_198)
                     final aggregation over (i_item_id_198)
                         local exchange (GATHER, SINGLE, [])
@@ -53,18 +53,18 @@ local exchange (GATHER, SINGLE, [])
                                 semijoin (PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["i_item_id_198"])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:web_sales:sf3000.0
+                                                                    scan web_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:customer_address:sf3000.0
+                                                                            scan customer_address
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["i_item_id_221"])
-                                            scan tpcds:item:sf3000.0
+                                            scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q61.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q61.plan.txt
@@ -4,54 +4,54 @@ cross join:
             remote exchange (GATHER, SINGLE, [])
                 partial aggregation over ()
                     join (INNER, REPLICATED):
-                        scan tpcds:item:sf3000.0
+                        scan item
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPLICATE, BROADCAST, [])
                                 join (INNER, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:date_dim:sf3000.0
+                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:promotion:sf3000.0
+                                                        scan promotion
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:store_sales:sf3000.0
+                                                                    scan store_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:store:sf3000.0
+                                                                            scan store
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                             join (INNER, REPLICATED):
-                                                scan tpcds:customer:sf3000.0
+                                                scan customer
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:customer_address:sf3000.0
+                                                        scan customer_address
     final aggregation over ()
         local exchange (GATHER, SINGLE, [])
             remote exchange (GATHER, SINGLE, [])
                 partial aggregation over ()
                     join (INNER, REPLICATED):
-                        scan tpcds:item:sf3000.0
+                        scan item
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPLICATE, BROADCAST, [])
                                 join (INNER, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["ss_customer_sk_7"])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:date_dim:sf3000.0
+                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:store_sales:sf3000.0
+                                                        scan store_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:store:sf3000.0
+                                                                scan store
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["c_customer_sk_84"])
                                             join (INNER, REPLICATED):
-                                                scan tpcds:customer:sf3000.0
+                                                scan customer
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:customer_address:sf3000.0
+                                                        scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q62.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q62.plan.txt
@@ -8,16 +8,16 @@ local exchange (GATHER, SINGLE, [])
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:web_sales:sf3000.0
+                                        scan web_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:ship_mode:sf3000.0
+                                            scan ship_mode
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:warehouse:sf3000.0
+                                        scan warehouse
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:web_site:sf3000.0
+                                    scan web_site

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q63.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q63.plan.txt
@@ -9,13 +9,13 @@ local exchange (GATHER, SINGLE, [])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:store:sf3000.0
+                                            scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q64.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q64.plan.txt
@@ -38,65 +38,65 @@ remote exchange (GATHER, SINGLE, [])
                                                                                                                                                     join (INNER, PARTITIONED):
                                                                                                                                                         remote exchange (REPARTITION, HASH, ["sr_item_sk"])
                                                                                                                                                             join (INNER, REPLICATED):
-                                                                                                                                                                scan tpcds:store_sales:sf3000.0
+                                                                                                                                                                scan store_sales
                                                                                                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                                                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                                                                        scan tpcds:store_returns:sf3000.0
+                                                                                                                                                                        scan store_returns
                                                                                                                                                         final aggregation over (cs_item_sk)
                                                                                                                                                             local exchange (GATHER, SINGLE, [])
                                                                                                                                                                 remote exchange (REPARTITION, HASH, ["cs_item_sk"])
                                                                                                                                                                     partial aggregation over (cs_item_sk)
                                                                                                                                                                         join (INNER, PARTITIONED):
                                                                                                                                                                             remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
-                                                                                                                                                                                scan tpcds:catalog_sales:sf3000.0
+                                                                                                                                                                                scan catalog_sales
                                                                                                                                                                             local exchange (GATHER, SINGLE, [])
                                                                                                                                                                                 remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
-                                                                                                                                                                                    scan tpcds:catalog_returns:sf3000.0
+                                                                                                                                                                                    scan catalog_returns
                                                                                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                                                                                     remote exchange (REPARTITION, HASH, ["d_date_sk"])
-                                                                                                                                                        scan tpcds:date_dim:sf3000.0
+                                                                                                                                                        scan date_dim
                                                                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                                                                             remote exchange (REPARTITION, HASH, ["s_store_sk"])
-                                                                                                                                                scan tpcds:store:sf3000.0
+                                                                                                                                                scan store
                                                                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                                                                     remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                                                                                                                                        scan tpcds:customer:sf3000.0
+                                                                                                                                        scan customer
                                                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                                                             remote exchange (REPARTITION, HASH, ["d_date_sk_22"])
-                                                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                                                scan date_dim
                                                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                                                     remote exchange (REPARTITION, HASH, ["d_date_sk_50"])
-                                                                                                                        scan tpcds:date_dim:sf3000.0
+                                                                                                                        scan date_dim
                                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                                             remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
-                                                                                                                scan tpcds:customer_demographics:sf3000.0
+                                                                                                                scan customer_demographics
                                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                                     remote exchange (REPARTITION, HASH, ["cd_demo_sk_78"])
-                                                                                                        scan tpcds:customer_demographics:sf3000.0
+                                                                                                        scan customer_demographics
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPARTITION, HASH, ["p_promo_sk"])
-                                                                                                scan tpcds:promotion:sf3000.0
+                                                                                                scan promotion
                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                     remote exchange (REPARTITION, HASH, ["hd_demo_sk"])
-                                                                                        scan tpcds:household_demographics:sf3000.0
+                                                                                        scan household_demographics
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPARTITION, HASH, ["hd_demo_sk_87"])
-                                                                                scan tpcds:household_demographics:sf3000.0
+                                                                                scan household_demographics
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                                        scan tpcds:customer_address:sf3000.0
+                                                                        scan customer_address
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPARTITION, HASH, ["ca_address_sk_92"])
-                                                                scan tpcds:customer_address:sf3000.0
+                                                                scan customer_address
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["ib_income_band_sk"])
-                                                        scan tpcds:income_band:sf3000.0
+                                                        scan income_band
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["ib_income_band_sk_105"])
-                                                scan tpcds:income_band:sf3000.0
+                                                scan income_band
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["i_item_sk"])
-                                        scan tpcds:item:sf3000.0
+                                        scan item
                 final aggregation over (ca_city_547, ca_city_560, ca_street_name_544, ca_street_name_557, ca_street_number_543, ca_street_number_556, ca_zip_550, ca_zip_563, d_year_369, d_year_397, d_year_425, i_item_sk_573, i_product_name_594, s_store_name_452, s_zip_472)
                     local exchange (GATHER, SINGLE, [])
                         partial aggregation over (ca_city_547, ca_city_560, ca_street_name_544, ca_street_name_557, ca_street_number_543, ca_street_number_556, ca_zip_550, ca_zip_563, d_year_369, d_year_397, d_year_425, i_item_sk_573, i_product_name_594, s_store_name_452, s_zip_472)
@@ -133,62 +133,62 @@ remote exchange (GATHER, SINGLE, [])
                                                                                                                                                     join (INNER, PARTITIONED):
                                                                                                                                                         remote exchange (REPARTITION, HASH, ["sr_item_sk_259"])
                                                                                                                                                             join (INNER, REPLICATED):
-                                                                                                                                                                scan tpcds:store_sales:sf3000.0
+                                                                                                                                                                scan store_sales
                                                                                                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                                                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                                                                        scan tpcds:store_returns:sf3000.0
+                                                                                                                                                                        scan store_returns
                                                                                                                                                         final aggregation over (cs_item_sk_292)
                                                                                                                                                             local exchange (GATHER, SINGLE, [])
                                                                                                                                                                 remote exchange (REPARTITION, HASH, ["cs_item_sk_292"])
                                                                                                                                                                     partial aggregation over (cs_item_sk_292)
                                                                                                                                                                         join (INNER, PARTITIONED):
                                                                                                                                                                             remote exchange (REPARTITION, HASH, ["cs_item_sk_292", "cs_order_number_294"])
-                                                                                                                                                                                scan tpcds:catalog_sales:sf3000.0
+                                                                                                                                                                                scan catalog_sales
                                                                                                                                                                             local exchange (GATHER, SINGLE, [])
                                                                                                                                                                                 remote exchange (REPARTITION, HASH, ["cr_item_sk_313", "cr_order_number_327"])
-                                                                                                                                                                                    scan tpcds:catalog_returns:sf3000.0
+                                                                                                                                                                                    scan catalog_returns
                                                                                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                                                                                     remote exchange (REPARTITION, HASH, ["d_date_sk_363"])
-                                                                                                                                                        scan tpcds:date_dim:sf3000.0
+                                                                                                                                                        scan date_dim
                                                                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                                                                             remote exchange (REPARTITION, HASH, ["s_store_sk_447"])
-                                                                                                                                                scan tpcds:store:sf3000.0
+                                                                                                                                                scan store
                                                                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                                                                     remote exchange (REPARTITION, HASH, ["c_customer_sk_476"])
-                                                                                                                                        scan tpcds:customer:sf3000.0
+                                                                                                                                        scan customer
                                                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                                                             remote exchange (REPARTITION, HASH, ["d_date_sk_391"])
-                                                                                                                                scan tpcds:date_dim:sf3000.0
+                                                                                                                                scan date_dim
                                                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                                                     remote exchange (REPARTITION, HASH, ["d_date_sk_419"])
-                                                                                                                        scan tpcds:date_dim:sf3000.0
+                                                                                                                        scan date_dim
                                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                                             remote exchange (REPARTITION, HASH, ["cd_demo_sk_494"])
-                                                                                                                scan tpcds:customer_demographics:sf3000.0
+                                                                                                                scan customer_demographics
                                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                                     remote exchange (REPARTITION, HASH, ["cd_demo_sk_503"])
-                                                                                                        scan tpcds:customer_demographics:sf3000.0
+                                                                                                        scan customer_demographics
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPARTITION, HASH, ["p_promo_sk_512"])
-                                                                                                scan tpcds:promotion:sf3000.0
+                                                                                                scan promotion
                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                     remote exchange (REPARTITION, HASH, ["hd_demo_sk_531"])
-                                                                                        scan tpcds:household_demographics:sf3000.0
+                                                                                        scan household_demographics
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPARTITION, HASH, ["hd_demo_sk_536"])
-                                                                                scan tpcds:household_demographics:sf3000.0
+                                                                                scan household_demographics
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPARTITION, HASH, ["ca_address_sk_541"])
-                                                                        scan tpcds:customer_address:sf3000.0
+                                                                        scan customer_address
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPARTITION, HASH, ["ca_address_sk_554"])
-                                                                scan tpcds:customer_address:sf3000.0
+                                                                scan customer_address
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["ib_income_band_sk_567"])
-                                                        scan tpcds:income_band:sf3000.0
+                                                        scan income_band
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["ib_income_band_sk_570"])
-                                                scan tpcds:income_band:sf3000.0
+                                                scan income_band
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["i_item_sk_573"])
-                                        scan tpcds:item:sf3000.0
+                                        scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q65.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q65.plan.txt
@@ -7,15 +7,15 @@ local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["ss_item_sk_26", "ss_store_sk_31"])
                             partial aggregation over (ss_item_sk_26, ss_store_sk_31)
                                 join (INNER, REPLICATED):
-                                    scan tpcds:store_sales:sf3000.0
+                                    scan store_sales
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:date_dim:sf3000.0
+                                            scan date_dim
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         join (INNER, PARTITIONED):
                             remote exchange (REPARTITION, HASH, ["s_store_sk"])
-                                scan tpcds:store:sf3000.0
+                                scan store
                             final aggregation over (ss_store_sk)
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["ss_store_sk"])
@@ -25,10 +25,10 @@ local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["ss_item_sk", "ss_store_sk"])
                                                         partial aggregation over (ss_item_sk, ss_store_sk)
                                                             join (INNER, REPLICATED):
-                                                                scan tpcds:store_sales:sf3000.0
+                                                                scan store_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:date_dim:sf3000.0
+                                                                        scan date_dim
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPLICATE, BROADCAST, [])
-                    scan tpcds:item:sf3000.0
+                    scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q66.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q66.plan.txt
@@ -11,19 +11,19 @@ local exchange (GATHER, SINGLE, [])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:web_sales:sf3000.0
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:ship_mode:sf3000.0
+                                                            scan ship_mode
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:time_dim:sf3000.0
+                                                        scan time_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:warehouse:sf3000.0
+                                                scan warehouse
                 partial aggregation over (concat_242, d_year_136, w_city_124, w_country_128, w_county_125, w_state_126, w_warehouse_name_118, w_warehouse_sq_ft_119)
                     final aggregation over (d_year_136, w_city_124, w_country_128, w_county_125, w_state_126, w_warehouse_name_118, w_warehouse_sq_ft_119)
                         local exchange (GATHER, SINGLE, [])
@@ -33,16 +33,16 @@ local exchange (GATHER, SINGLE, [])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:catalog_sales:sf3000.0
+                                                    scan catalog_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:ship_mode:sf3000.0
+                                                            scan ship_mode
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:time_dim:sf3000.0
+                                                        scan time_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:warehouse:sf3000.0
+                                                scan warehouse

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q67.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q67.plan.txt
@@ -9,13 +9,13 @@ local exchange (GATHER, SINGLE, [])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:store:sf3000.0
+                                                scan store
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:item:sf3000.0
+                                            scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q68.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q68.plan.txt
@@ -4,7 +4,7 @@ local exchange (GATHER, SINGLE, [])
             remote exchange (REPARTITION, HASH, ["c_current_addr_sk"])
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                        scan tpcds:customer:sf3000.0
+                        scan customer
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                             final aggregation over (ca_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
@@ -12,22 +12,22 @@ local exchange (GATHER, SINGLE, [])
                                     partial aggregation over (ca_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ca_address_sk"])
-                                                scan tpcds:customer_address:sf3000.0
+                                                scan customer_address
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["ss_addr_sk"])
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                scan tpcds:store_sales:sf3000.0
+                                                                scan store_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:date_dim:sf3000.0
+                                                                        scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:store:sf3000.0
+                                                                    scan store
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:household_demographics:sf3000.0
+                                                                scan household_demographics
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["ca_address_sk_32"])
-                    scan tpcds:customer_address:sf3000.0
+                    scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q69.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q69.plan.txt
@@ -11,15 +11,15 @@ local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                                             partial aggregation over (ws_bill_customer_sk)
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:web_sales:sf3000.0
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["cd_demo_sk"])
-                                                scan tpcds:customer_demographics:sf3000.0
+                                                scan customer_demographics
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["c_current_cdemo_sk"])
                                                     join (INNER, PARTITIONED):
@@ -28,23 +28,23 @@ local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                                                     partial aggregation over (ss_customer_sk)
                                                                         join (INNER, REPLICATED):
-                                                                            scan tpcds:store_sales:sf3000.0
+                                                                            scan store_sales
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan tpcds:date_dim:sf3000.0
+                                                                                    scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPARTITION, HASH, ["c_customer_sk"])
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:customer:sf3000.0
+                                                                    scan customer
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:customer_address:sf3000.0
+                                                                            scan customer_address
                             final aggregation over (cs_ship_customer_sk)
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["cs_ship_customer_sk"])
                                         partial aggregation over (cs_ship_customer_sk)
                                             join (INNER, REPLICATED):
-                                                scan tpcds:catalog_sales:sf3000.0
+                                                scan catalog_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q70.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q70.plan.txt
@@ -10,13 +10,13 @@ local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["s_state"])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:store_sales:sf3000.0
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:store:sf3000.0
+                                                    scan store
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["s_state_48"])
                                             final aggregation over (s_state_48)
@@ -25,10 +25,10 @@ local exchange (GATHER, SINGLE, [])
                                                         partial aggregation over (s_state_48)
                                                             join (INNER, REPLICATED):
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:store_sales:sf3000.0
+                                                                    scan store_sales
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                                            scan tpcds:date_dim:sf3000.0
+                                                                            scan date_dim
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:store:sf3000.0
+                                                                        scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q71.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q71.plan.txt
@@ -9,26 +9,26 @@ remote exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ws_sold_time_sk_87"])
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, ["i_item_sk"])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["ws_item_sk"])
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:web_sales:sf3000.0
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                             remote exchange (REPARTITION, HASH, ["cs_item_sk"])
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:catalog_sales:sf3000.0
+                                                    scan catalog_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                             remote exchange (REPARTITION, HASH, ["ss_item_sk"])
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["t_time_sk"])
-                                        scan tpcds:time_dim:sf3000.0
+                                        scan time_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q72.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q72.plan.txt
@@ -10,13 +10,13 @@ local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["d_week_seq_15", "inv_item_sk"])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:inventory:sf3000.0
+                                                scan inventory
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:warehouse:sf3000.0
+                                                    scan warehouse
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["cs_item_sk", "d_week_seq"])
                                             join (INNER, REPLICATED):
@@ -24,25 +24,25 @@ local exchange (GATHER, SINGLE, [])
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                scan tpcds:catalog_sales:sf3000.0
+                                                                scan catalog_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:customer_demographics:sf3000.0
+                                                                        scan customer_demographics
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:household_demographics:sf3000.0
+                                                                    scan household_demographics
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:item:sf3000.0
+                                                        scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:promotion:sf3000.0
+                                        scan promotion
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:catalog_returns:sf3000.0
+                                    scan catalog_returns

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q73.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q73.plan.txt
@@ -10,16 +10,16 @@ remote exchange (GATHER, SINGLE, [])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:store_sales:sf3000.0
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:store:sf3000.0
+                                                    scan store
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:household_demographics:sf3000.0
+                                                scan household_demographics
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["c_customer_sk"])
-                        scan tpcds:customer:sf3000.0
+                        scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q74.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q74.plan.txt
@@ -12,13 +12,13 @@ local exchange (GATHER, SINGLE, [])
                                             partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:store_sales:sf3000.0
+                                                        scan store_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:customer:sf3000.0
+                                                            scan customer
                             single aggregation over (c_customer_id_17, c_first_name_24, c_last_name_25, d_year_40)
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
@@ -35,13 +35,13 @@ local exchange (GATHER, SINGLE, [])
                                                 partial aggregation over (c_customer_id_109, c_first_name_116, c_last_name_117, d_year_155)
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:store_sales:sf3000.0
+                                                            scan store_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:customer:sf3000.0
+                                                                scan customer
                                 single aggregation over (c_customer_id_200, c_first_name_207, c_last_name_208, d_year_257)
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
@@ -64,13 +64,13 @@ local exchange (GATHER, SINGLE, [])
                                         join (INNER, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_438"])
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:web_sales:sf3000.0
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["c_customer_sk_416"])
-                                                    scan tpcds:customer:sf3000.0
+                                                    scan customer
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["c_customer_id_543"])
                     single aggregation over (c_customer_id_543, c_first_name_550, c_last_name_551, d_year_589)
@@ -87,10 +87,10 @@ local exchange (GATHER, SINGLE, [])
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk_655"])
                                             join (INNER, REPLICATED):
-                                                scan tpcds:web_sales:sf3000.0
+                                                scan web_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["c_customer_sk_633"])
-                                                scan tpcds:customer:sf3000.0
+                                                scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q75.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q75.plan.txt
@@ -8,50 +8,50 @@ local exchange (GATHER, SINGLE, [])
                             partial aggregation over (d_year, expr, expr_13, i_brand_id, i_category_id, i_class_id, i_manufact_id)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["cr_item_sk", "cr_order_number"])
-                                        scan tpcds:catalog_returns:sf3000.0
+                                        scan catalog_returns
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["cs_item_sk", "cs_order_number"])
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:catalog_sales:sf3000.0
+                                                    scan catalog_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:item:sf3000.0
+                                                            scan item
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                         remote exchange (REPARTITION, HASH, ["i_brand_id_28", "i_category_id_32", "i_class_id_30", "i_manufact_id_34"])
                             partial aggregation over (d_year_51, expr_84, expr_85, i_brand_id_28, i_category_id_32, i_class_id_30, i_manufact_id_34)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["sr_item_sk", "sr_ticket_number"])
-                                        scan tpcds:store_returns:sf3000.0
+                                        scan store_returns
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ss_item_sk", "ss_ticket_number"])
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:item:sf3000.0
+                                                            scan item
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                         remote exchange (REPARTITION, HASH, ["i_brand_id_107", "i_category_id_111", "i_class_id_109", "i_manufact_id_113"])
                             partial aggregation over (d_year_130, expr_163, expr_164, i_brand_id_107, i_category_id_111, i_class_id_109, i_manufact_id_113)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
-                                        scan tpcds:web_returns:sf3000.0
+                                        scan web_returns
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ws_item_sk", "ws_order_number"])
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:web_sales:sf3000.0
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:item:sf3000.0
+                                                            scan item
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
             single aggregation over (d_year_619, i_brand_id_620, i_category_id_622, i_class_id_621, i_manufact_id_623)
                 final aggregation over (d_year_619, expr_624, expr_625, i_brand_id_620, i_category_id_622, i_class_id_621, i_manufact_id_623)
                     local exchange (GATHER, SINGLE, [])
@@ -59,47 +59,47 @@ local exchange (GATHER, SINGLE, [])
                             partial aggregation over (d_year_298, expr_358, expr_359, i_brand_id_275, i_category_id_279, i_class_id_277, i_manufact_id_281)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["cr_item_sk_324", "cr_order_number_338"])
-                                        scan tpcds:catalog_returns:sf3000.0
+                                        scan catalog_returns
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["cs_item_sk_249", "cs_order_number_251"])
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:catalog_sales:sf3000.0
+                                                    scan catalog_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:item:sf3000.0
+                                                            scan item
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                         remote exchange (REPARTITION, HASH, ["i_brand_id_397", "i_category_id_401", "i_class_id_399", "i_manufact_id_403"])
                             partial aggregation over (d_year_420, expr_473, expr_474, i_brand_id_397, i_category_id_401, i_class_id_399, i_manufact_id_403)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["sr_item_sk_446", "sr_ticket_number_453"])
-                                        scan tpcds:store_returns:sf3000.0
+                                        scan store_returns
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ss_item_sk_369", "ss_ticket_number_376"])
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:item:sf3000.0
+                                                            scan item
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                         remote exchange (REPARTITION, HASH, ["i_brand_id_530", "i_category_id_534", "i_class_id_532", "i_manufact_id_536"])
                             partial aggregation over (d_year_553, expr_610, expr_611, i_brand_id_530, i_category_id_534, i_class_id_532, i_manufact_id_536)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["wr_item_sk_579", "wr_order_number_590"])
-                                        scan tpcds:web_returns:sf3000.0
+                                        scan web_returns
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ws_item_sk_492", "ws_order_number_506"])
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:web_sales:sf3000.0
+                                                    scan web_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:item:sf3000.0
+                                                            scan item
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q76.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q76.plan.txt
@@ -7,34 +7,34 @@ local exchange (GATHER, SINGLE, [])
                         partial aggregation over (d_qoy, d_year, expr_12, expr_217, i_category)
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    scan tpcds:store_sales:sf3000.0
+                                    scan store_sales
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:item:sf3000.0
+                                            scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:date_dim:sf3000.0
+                                        scan date_dim
                     remote exchange (REPARTITION, HASH, ["d_qoy_49", "d_year_45", "expr_223", "expr_68", "i_category_29"])
                         partial aggregation over (d_qoy_49, d_year_45, expr_223, expr_68, i_category_29)
                             join (INNER, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, ["ws_sold_date_sk"])
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, ["ws_item_sk"])
-                                            scan tpcds:web_sales:sf3000.0
+                                            scan web_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["i_item_sk_17"])
-                                                scan tpcds:item:sf3000.0
+                                                scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["d_date_sk_39"])
-                                        scan tpcds:date_dim:sf3000.0
+                                        scan date_dim
                 remote exchange (REPARTITION, HASH, ["d_qoy_129", "d_year_125", "expr_147", "expr_160", "i_category_109"])
                     partial aggregation over (d_qoy_129, d_year_125, expr_147, expr_160, i_category_109)
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
-                                scan tpcds:catalog_sales:sf3000.0
+                                scan catalog_sales
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:item:sf3000.0
+                                        scan item
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:date_dim:sf3000.0
+                                    scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q77.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q77.plan.txt
@@ -12,36 +12,36 @@ local exchange (GATHER, SINGLE, [])
                                             partial aggregation over (s_store_sk)
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:store_sales:sf3000.0
+                                                        scan store_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:store:sf3000.0
+                                                            scan store
                                 final aggregation over (s_store_sk_46)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["s_store_sk_46"])
                                             partial aggregation over (s_store_sk_46)
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:store_returns:sf3000.0
+                                                        scan store_returns
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:store:sf3000.0
+                                                            scan store
                             cross join:
                                 final aggregation over (cs_call_center_sk)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["cs_call_center_sk"])
                                             partial aggregation over (cs_call_center_sk)
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:catalog_sales:sf3000.0
+                                                    scan catalog_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
                                         final aggregation over (cr_call_center_sk)
@@ -49,10 +49,10 @@ local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["cr_call_center_sk"])
                                                     partial aggregation over (cr_call_center_sk)
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:catalog_returns:sf3000.0
+                                                            scan catalog_returns
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                             join (LEFT, PARTITIONED):
                                 final aggregation over (wp_web_page_sk)
                                     local exchange (GATHER, SINGLE, [])
@@ -60,23 +60,23 @@ local exchange (GATHER, SINGLE, [])
                                             partial aggregation over (wp_web_page_sk)
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:web_sales:sf3000.0
+                                                        scan web_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:web_page:sf3000.0
+                                                            scan web_page
                                 final aggregation over (wp_web_page_sk_298)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["wp_web_page_sk_298"])
                                             partial aggregation over (wp_web_page_sk_298)
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:web_returns:sf3000.0
+                                                        scan web_returns
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:web_page:sf3000.0
+                                                            scan web_page

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q78.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q78.plan.txt
@@ -9,26 +9,26 @@ local exchange (GATHER, SINGLE, [])
                                 partial aggregation over (d_year, ss_customer_sk, ss_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, REPLICATED):
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:store_returns:sf3000.0
+                                                    scan store_returns
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                     final aggregation over (d_year_53, ws_bill_customer_sk, ws_item_sk)
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["d_year_53", "ws_bill_customer_sk", "ws_item_sk"])
                                 partial aggregation over (d_year_53, ws_bill_customer_sk, ws_item_sk)
                                     join (INNER, REPLICATED):
                                         join (LEFT, REPLICATED):
-                                            scan tpcds:web_sales:sf3000.0
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:web_returns:sf3000.0
+                                                    scan web_returns
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
                     final aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_130)
@@ -37,10 +37,10 @@ local exchange (GATHER, SINGLE, [])
                                 partial aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_130)
                                     join (INNER, REPLICATED):
                                         join (LEFT, REPLICATED):
-                                            scan tpcds:catalog_sales:sf3000.0
+                                            scan catalog_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:catalog_returns:sf3000.0
+                                                    scan catalog_returns
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q79.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q79.plan.txt
@@ -8,16 +8,16 @@ local exchange (GATHER, SINGLE, [])
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:store_sales:sf3000.0
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:household_demographics:sf3000.0
+                                            scan household_demographics
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:store:sf3000.0
+                                        scan store
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPLICATE, BROADCAST, [])
-                    scan tpcds:customer:sf3000.0
+                    scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q80.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q80.plan.txt
@@ -14,22 +14,22 @@ local exchange (GATHER, SINGLE, [])
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
                                                             join (LEFT, REPLICATED):
-                                                                scan tpcds:store_sales:sf3000.0
+                                                                scan store_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:store_returns:sf3000.0
+                                                                        scan store_returns
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:item:sf3000.0
+                                                                scan item
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:promotion:sf3000.0
+                                                            scan promotion
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:store:sf3000.0
+                                                        scan store
                             final aggregation over (cp_catalog_page_id)
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["cp_catalog_page_id"])
@@ -39,22 +39,22 @@ local exchange (GATHER, SINGLE, [])
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
                                                             join (LEFT, REPLICATED):
-                                                                scan tpcds:catalog_sales:sf3000.0
+                                                                scan catalog_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:catalog_returns:sf3000.0
+                                                                        scan catalog_returns
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:item:sf3000.0
+                                                                scan item
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:promotion:sf3000.0
+                                                            scan promotion
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:catalog_page:sf3000.0
+                                                        scan catalog_page
                             final aggregation over (web_site_id)
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["web_site_id"])
@@ -64,19 +64,19 @@ local exchange (GATHER, SINGLE, [])
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
                                                             join (LEFT, REPLICATED):
-                                                                scan tpcds:web_sales:sf3000.0
+                                                                scan web_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:web_returns:sf3000.0
+                                                                        scan web_returns
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:item:sf3000.0
+                                                                scan item
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:promotion:sf3000.0
+                                                            scan promotion
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:web_site:sf3000.0
+                                                        scan web_site

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q81.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q81.plan.txt
@@ -9,20 +9,20 @@ local exchange (GATHER, SINGLE, [])
                                 partial aggregation over (ca_state, cr_returning_customer_sk)
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:catalog_returns:sf3000.0
+                                            scan catalog_returns
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:customer_address:sf3000.0
+                                                scan customer_address
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
                             join (INNER, REPLICATED):
-                                scan tpcds:customer:sf3000.0
+                                scan customer
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:customer_address:sf3000.0
+                                        scan customer_address
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over (ca_state_93)
@@ -35,13 +35,13 @@ local exchange (GATHER, SINGLE, [])
                                                     partial aggregation over (ca_state_93, cr_returning_customer_sk_37)
                                                         join (INNER, REPLICATED):
                                                             join (INNER, REPLICATED):
-                                                                scan tpcds:catalog_returns:sf3000.0
+                                                                scan catalog_returns
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:date_dim:sf3000.0
+                                                                        scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:customer_address:sf3000.0
+                                                                    scan customer_address
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPLICATE, BROADCAST, [])
                     single aggregation over ()

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q82.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q82.plan.txt
@@ -5,15 +5,15 @@ local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["i_current_price", "i_item_desc", "i_item_id"])
                     partial aggregation over (i_current_price, i_item_desc, i_item_id)
                         join (INNER, REPLICATED):
-                            scan tpcds:store_sales:sf3000.0
+                            scan store_sales
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:inventory:sf3000.0
+                                            scan inventory
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q83.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q83.plan.txt
@@ -9,21 +9,21 @@ local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_date"])
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:store_returns:sf3000.0
+                                            scan store_returns
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:item:sf3000.0
+                                                scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["d_date_3"])
                                         semijoin (PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["d_week_seq_5"])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["d_week_seq_34"])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
             join (INNER, PARTITIONED):
                 final aggregation over (i_item_id_82)
                     local exchange (GATHER, SINGLE, [])
@@ -33,21 +33,21 @@ local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["d_date_105"])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:catalog_returns:sf3000.0
+                                                scan catalog_returns
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["d_date_134"])
                                             semijoin (PARTITIONED):
                                                 remote exchange (REPARTITION, HASH, ["d_week_seq_136"])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["d_week_seq_165"])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                 final aggregation over (i_item_id_216)
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["i_item_id_216"])
@@ -56,18 +56,18 @@ local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["d_date_239"])
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:web_returns:sf3000.0
+                                                scan web_returns
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["d_date_268"])
                                             semijoin (PARTITIONED):
                                                 remote exchange (REPARTITION, HASH, ["d_week_seq_270"])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["d_week_seq_299"])
-                                                        scan tpcds:date_dim:sf3000.0
+                                                        scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q84.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q84.plan.txt
@@ -1,23 +1,23 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, REPLICATED):
-            scan tpcds:store_returns:sf3000.0
+            scan store_returns
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPLICATE, BROADCAST, [])
                     join (INNER, REPLICATED):
-                        scan tpcds:customer_demographics:sf3000.0
+                        scan customer_demographics
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPLICATE, BROADCAST, [])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:customer:sf3000.0
+                                        scan customer
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:customer_address:sf3000.0
+                                                scan customer_address
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             join (INNER, REPLICATED):
-                                                scan tpcds:household_demographics:sf3000.0
+                                                scan household_demographics
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:income_band:sf3000.0
+                                                        scan income_band

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q85.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q85.plan.txt
@@ -8,30 +8,30 @@ local exchange (GATHER, SINGLE, [])
                             join (INNER, REPLICATED):
                                 join (INNER, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["cd_demo_sk_0", "cd_education_status_3", "cd_marital_status_2"])
-                                        scan tpcds:customer_demographics:sf3000.0
+                                        scan customer_demographics
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["cd_education_status", "cd_marital_status", "wr_returning_cdemo_sk"])
                                             join (INNER, REPLICATED):
                                                 join (INNER, PARTITIONED):
                                                     remote exchange (REPARTITION, HASH, ["ws_item_sk", "ws_order_number"])
                                                         join (INNER, REPLICATED):
-                                                            scan tpcds:web_sales:sf3000.0
+                                                            scan web_sales
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["wr_item_sk", "wr_order_number"])
                                                             join (INNER, REPLICATED):
-                                                                scan tpcds:web_returns:sf3000.0
+                                                                scan web_returns
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpcds:customer_address:sf3000.0
+                                                                        scan customer_address
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:customer_demographics:sf3000.0
+                                                        scan customer_demographics
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:web_page:sf3000.0
+                                        scan web_page
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:reason:sf3000.0
+                                    scan reason

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q86.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q86.plan.txt
@@ -8,10 +8,10 @@ local exchange (GATHER, SINGLE, [])
                             partial aggregation over (groupid, i_category$gid, i_class$gid)
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:web_sales:sf3000.0
+                                        scan web_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:item:sf3000.0
+                                            scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q87.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q87.plan.txt
@@ -11,13 +11,13 @@ final aggregation over ()
                                         partial aggregation over (c_first_name, c_last_name, d_date)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:customer:sf3000.0
+                                                        scan customer
                         partial aggregation over (c_first_name_47, c_last_name_48, d_date_13)
                             final aggregation over (c_first_name_47, c_last_name_48, d_date_13)
                                 local exchange (GATHER, SINGLE, [])
@@ -26,13 +26,13 @@ final aggregation over ()
                                             join (INNER, PARTITIONED):
                                                 remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk"])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:catalog_sales:sf3000.0
+                                                        scan catalog_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["c_customer_sk_39"])
-                                                        scan tpcds:customer:sf3000.0
+                                                        scan customer
                         partial aggregation over (c_first_name_108, c_last_name_109, d_date_74)
                             final aggregation over (c_first_name_108, c_last_name_109, d_date_74)
                                 local exchange (GATHER, SINGLE, [])
@@ -41,10 +41,10 @@ final aggregation over ()
                                             join (INNER, PARTITIONED):
                                                 remote exchange (REPARTITION, HASH, ["ws_bill_customer_sk"])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:web_sales:sf3000.0
+                                                        scan web_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:date_dim:sf3000.0
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["c_customer_sk_100"])
-                                                        scan tpcds:customer:sf3000.0
+                                                        scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q88.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q88.plan.txt
@@ -12,16 +12,16 @@ cross join:
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:store_sales:sf3000.0
+                                                        scan store_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:time_dim:sf3000.0
+                                                                scan time_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:store:sf3000.0
+                                                            scan store
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:household_demographics:sf3000.0
+                                                        scan household_demographics
                             final aggregation over ()
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (GATHER, SINGLE, [])
@@ -29,16 +29,16 @@ cross join:
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:store_sales:sf3000.0
+                                                        scan store_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:time_dim:sf3000.0
+                                                                scan time_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:store:sf3000.0
+                                                            scan store
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:household_demographics:sf3000.0
+                                                        scan household_demographics
                         final aggregation over ()
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (GATHER, SINGLE, [])
@@ -46,16 +46,16 @@ cross join:
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    scan tpcds:store_sales:sf3000.0
+                                                    scan store_sales
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:time_dim:sf3000.0
+                                                            scan time_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:store:sf3000.0
+                                                        scan store
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:household_demographics:sf3000.0
+                                                    scan household_demographics
                     final aggregation over ()
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (GATHER, SINGLE, [])
@@ -63,16 +63,16 @@ cross join:
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
                                             join (INNER, REPLICATED):
-                                                scan tpcds:store_sales:sf3000.0
+                                                scan store_sales
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:time_dim:sf3000.0
+                                                        scan time_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:store:sf3000.0
+                                                    scan store
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:household_demographics:sf3000.0
+                                                scan household_demographics
                 final aggregation over ()
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (GATHER, SINGLE, [])
@@ -80,16 +80,16 @@ cross join:
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:time_dim:sf3000.0
+                                                    scan time_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:store:sf3000.0
+                                                scan store
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:household_demographics:sf3000.0
+                                            scan household_demographics
             final aggregation over ()
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (GATHER, SINGLE, [])
@@ -97,16 +97,16 @@ cross join:
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:store_sales:sf3000.0
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:time_dim:sf3000.0
+                                                scan time_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:store:sf3000.0
+                                            scan store
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:household_demographics:sf3000.0
+                                        scan household_demographics
         final aggregation over ()
             local exchange (GATHER, SINGLE, [])
                 remote exchange (GATHER, SINGLE, [])
@@ -114,16 +114,16 @@ cross join:
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    scan tpcds:store_sales:sf3000.0
+                                    scan store_sales
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:time_dim:sf3000.0
+                                            scan time_dim
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:store:sf3000.0
+                                        scan store
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:household_demographics:sf3000.0
+                                    scan household_demographics
     final aggregation over ()
         local exchange (GATHER, SINGLE, [])
             remote exchange (GATHER, SINGLE, [])
@@ -131,13 +131,13 @@ cross join:
                     join (INNER, REPLICATED):
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
-                                scan tpcds:store_sales:sf3000.0
+                                scan store_sales
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:time_dim:sf3000.0
+                                        scan time_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:store:sf3000.0
+                                    scan store
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPLICATE, BROADCAST, [])
-                                scan tpcds:household_demographics:sf3000.0
+                                scan household_demographics

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q89.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q89.plan.txt
@@ -9,13 +9,13 @@ local exchange (GATHER, SINGLE, [])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:item:sf3000.0
+                                                    scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:store:sf3000.0
+                                            scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q90.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q90.plan.txt
@@ -6,16 +6,16 @@ cross join:
                     join (INNER, REPLICATED):
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
-                                scan tpcds:web_sales:sf3000.0
+                                scan web_sales
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:web_page:sf3000.0
+                                        scan web_page
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:time_dim:sf3000.0
+                                    scan time_dim
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPLICATE, BROADCAST, [])
-                                scan tpcds:household_demographics:sf3000.0
+                                scan household_demographics
     final aggregation over ()
         local exchange (GATHER, SINGLE, [])
             remote exchange (GATHER, SINGLE, [])
@@ -23,13 +23,13 @@ cross join:
                     join (INNER, REPLICATED):
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
-                                scan tpcds:web_sales:sf3000.0
+                                scan web_sales
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:web_page:sf3000.0
+                                        scan web_page
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:time_dim:sf3000.0
+                                    scan time_dim
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPLICATE, BROADCAST, [])
-                                scan tpcds:household_demographics:sf3000.0
+                                scan household_demographics

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q91.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q91.plan.txt
@@ -6,27 +6,27 @@ remote exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["cc_call_center_id", "cc_manager", "cc_name", "cd_education_status", "cd_marital_status"])
                         partial aggregation over (cc_call_center_id, cc_manager, cc_name, cd_education_status, cd_marital_status)
                             join (INNER, REPLICATED):
-                                scan tpcds:call_center:sf3000.0
+                                scan call_center
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:household_demographics:sf3000.0
+                                            scan household_demographics
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:customer_demographics:sf3000.0
+                                                        scan customer_demographics
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                 join (INNER, REPLICATED):
-                                                                    scan tpcds:date_dim:sf3000.0
+                                                                    scan date_dim
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                                             join (INNER, REPLICATED):
-                                                                                scan tpcds:catalog_returns:sf3000.0
+                                                                                scan catalog_returns
                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                                                         join (INNER, REPLICATED):
-                                                                                            scan tpcds:customer:sf3000.0
+                                                                                            scan customer
                                                                                             local exchange (GATHER, SINGLE, [])
                                                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                    scan tpcds:customer_address:sf3000.0
+                                                                                                    scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q92.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q92.plan.txt
@@ -9,21 +9,21 @@ final aggregation over ()
                                 remote exchange (REPARTITION, HASH, ["ws_item_sk_3"])
                                     partial aggregation over (ws_item_sk_3)
                                         join (INNER, REPLICATED):
-                                            scan tpcds:web_sales:sf3000.0
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["ws_item_sk"])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:web_sales:sf3000.0
+                                        scan web_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:item:sf3000.0
+                                                scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:date_dim:sf3000.0
+                                            scan date_dim
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
                             single aggregation over ()

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q93.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q93.plan.txt
@@ -7,10 +7,10 @@ local exchange (GATHER, SINGLE, [])
                         join (INNER, REPLICATED):
                             join (LEFT, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, ["ss_item_sk", "ss_ticket_number"])
-                                    scan tpcds:store_sales:sf3000.0
+                                    scan store_sales
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["sr_item_sk", "sr_ticket_number"])
-                                        scan tpcds:store_returns:sf3000.0
+                                        scan store_returns
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:reason:sf3000.0
+                                    scan reason

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q94.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q94.plan.txt
@@ -8,24 +8,24 @@ final aggregation over ()
                             partial aggregation over (ca_state, d_date, unique, web_company_name, ws_ext_ship_cost, ws_net_profit, ws_order_number, ws_ship_addr_sk, ws_ship_date_sk, ws_warehouse_sk, ws_web_site_sk)
                                 join (RIGHT, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["ws_order_number_17"])
-                                        scan tpcds:web_sales:sf3000.0
+                                        scan web_sales
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ws_order_number"])
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
-                                                        scan tpcds:web_sales:sf3000.0
+                                                        scan web_sales
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpcds:customer_address:sf3000.0
+                                                                scan customer_address
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpcds:date_dim:sf3000.0
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpcds:web_site:sf3000.0
+                                                        scan web_site
                     final aggregation over (wr_order_number)
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["wr_order_number"])
                                 partial aggregation over (wr_order_number)
-                                    scan tpcds:web_returns:sf3000.0
+                                    scan web_returns

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q95.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q95.plan.txt
@@ -9,33 +9,33 @@ final aggregation over ()
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:web_sales:sf3000.0
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:customer_address:sf3000.0
+                                                    scan customer_address
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:web_site:sf3000.0
+                                            scan web_site
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ws_order_number_17"])
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, ["ws_order_number_17"])
-                                            scan tpcds:web_sales:sf3000.0
+                                            scan web_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["ws_order_number_51"])
-                                                scan tpcds:web_sales:sf3000.0
+                                                scan web_sales
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["wr_order_number"])
                                 join (INNER, PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["wr_order_number"])
                                         join (INNER, REPLICATED):
-                                            scan tpcds:web_sales:sf3000.0
+                                            scan web_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:web_returns:sf3000.0
+                                                    scan web_returns
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["ws_order_number_141"])
-                                            scan tpcds:web_sales:sf3000.0
+                                            scan web_sales

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q96.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q96.plan.txt
@@ -5,13 +5,13 @@ final aggregation over ()
                 join (INNER, REPLICATED):
                     join (INNER, REPLICATED):
                         join (INNER, REPLICATED):
-                            scan tpcds:store_sales:sf3000.0
+                            scan store_sales
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:time_dim:sf3000.0
+                                    scan time_dim
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPLICATE, BROADCAST, [])
-                                scan tpcds:household_demographics:sf3000.0
+                                scan household_demographics
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
-                            scan tpcds:store:sf3000.0
+                            scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q97.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q97.plan.txt
@@ -8,16 +8,16 @@ final aggregation over ()
                             remote exchange (REPARTITION, HASH, ["ss_customer_sk", "ss_item_sk"])
                                 partial aggregation over (ss_customer_sk, ss_item_sk)
                                     join (INNER, REPLICATED):
-                                        scan tpcds:store_sales:sf3000.0
+                                        scan store_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                     final aggregation over (cs_bill_customer_sk, cs_item_sk)
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["cs_bill_customer_sk", "cs_item_sk"])
                                 partial aggregation over (cs_bill_customer_sk, cs_item_sk)
                                     join (INNER, REPLICATED):
-                                        scan tpcds:catalog_sales:sf3000.0
+                                        scan catalog_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q98.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q98.plan.txt
@@ -9,10 +9,10 @@ remote exchange (GATHER, SINGLE, [])
                                 partial aggregation over (i_category, i_class, i_current_price, i_item_desc, i_item_id)
                                     join (INNER, REPLICATED):
                                         join (INNER, REPLICATED):
-                                            scan tpcds:store_sales:sf3000.0
+                                            scan store_sales
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpcds:date_dim:sf3000.0
+                                                    scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:item:sf3000.0
+                                                scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q99.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q99.plan.txt
@@ -8,16 +8,16 @@ local exchange (GATHER, SINGLE, [])
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan tpcds:catalog_sales:sf3000.0
+                                        scan catalog_sales
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpcds:date_dim:sf3000.0
+                                                scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpcds:ship_mode:sf3000.0
+                                            scan ship_mode
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpcds:warehouse:sf3000.0
+                                        scan warehouse
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
-                                    scan tpcds:call_center:sf3000.0
+                                    scan call_center

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q01.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q01.plan.txt
@@ -5,4 +5,4 @@ remote exchange (GATHER, SINGLE, [])
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["linestatus", "returnflag"])
                         partial aggregation over (linestatus, returnflag)
-                            scan tpch:lineitem:sf3000.0
+                            scan lineitem

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q02.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q02.plan.txt
@@ -8,38 +8,38 @@ remote exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["partkey_15"])
                                 partial aggregation over (partkey_15)
                                     join (INNER, REPLICATED):
-                                        scan tpch:partsupp:sf3000.0
+                                        scan partsupp
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 join (INNER, REPLICATED):
-                                                    scan tpch:supplier:sf3000.0
+                                                    scan supplier
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                             join (INNER, REPLICATED):
-                                                                scan tpch:nation:sf3000.0
+                                                                scan nation
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan tpch:region:sf3000.0
+                                                                        scan region
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["partkey"])
                             join (INNER, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, ["suppkey_4"])
                                     join (INNER, REPLICATED):
-                                        scan tpch:partsupp:sf3000.0
+                                        scan partsupp
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpch:part:sf3000.0
+                                                scan part
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["suppkey"])
                                         join (INNER, REPLICATED):
-                                            scan tpch:supplier:sf3000.0
+                                            scan supplier
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpch:nation:sf3000.0
+                                                        scan nation
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpch:region:sf3000.0
+                                                                scan region
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         single aggregation over ()

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q03.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q03.plan.txt
@@ -5,11 +5,11 @@ local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["orderdate", "orderkey_3", "shippriority"])
                     partial aggregation over (orderdate, orderkey_3, shippriority)
                         join (INNER, REPLICATED):
-                            scan tpch:lineitem:sf3000.0
+                            scan lineitem
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
                                     join (INNER, REPLICATED):
-                                        scan tpch:orders:sf3000.0
+                                        scan orders
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan tpch:customer:sf3000.0
+                                                scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q04.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q04.plan.txt
@@ -7,9 +7,9 @@ remote exchange (GATHER, SINGLE, [])
                         partial aggregation over (orderpriority)
                             join (INNER, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, ["orderkey"])
-                                    scan tpch:orders:sf3000.0
+                                    scan orders
                                 final aggregation over (orderkey_0)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["orderkey_0"])
                                             partial aggregation over (orderkey_0)
-                                                scan tpch:lineitem:sf3000.0
+                                                scan lineitem

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q05.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q05.plan.txt
@@ -7,23 +7,23 @@ remote exchange (GATHER, SINGLE, [])
                         partial aggregation over (name_15)
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    scan tpch:lineitem:sf3000.0
+                                    scan lineitem
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             join (INNER, PARTITIONED):
                                                 remote exchange (REPARTITION, HASH, ["custkey_0"])
-                                                    scan tpch:orders:sf3000.0
+                                                    scan orders
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["custkey"])
                                                         join (INNER, REPLICATED):
-                                                            scan tpch:customer:sf3000.0
+                                                            scan customer
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                     join (INNER, REPLICATED):
-                                                                        scan tpch:nation:sf3000.0
+                                                                        scan nation
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpch:region:sf3000.0
+                                                                                scan region
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpch:supplier:sf3000.0
+                                        scan supplier

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q06.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q06.plan.txt
@@ -2,4 +2,4 @@ final aggregation over ()
     local exchange (GATHER, SINGLE, [])
         remote exchange (GATHER, SINGLE, [])
             partial aggregation over ()
-                scan tpch:lineitem:sf3000.0
+                scan lineitem

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q07.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q07.plan.txt
@@ -8,22 +8,22 @@ remote exchange (GATHER, SINGLE, [])
                             join (INNER, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, ["orderkey"])
                                     join (INNER, REPLICATED):
-                                        scan tpch:lineitem:sf3000.0
+                                        scan lineitem
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 join (INNER, REPLICATED):
-                                                    scan tpch:supplier:sf3000.0
+                                                    scan supplier
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpch:nation:sf3000.0
+                                                            scan nation
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["orderkey_3"])
                                         join (INNER, REPLICATED):
-                                            scan tpch:orders:sf3000.0
+                                            scan orders
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpch:customer:sf3000.0
+                                                        scan customer
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpch:nation:sf3000.0
+                                                                scan nation

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q08.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q08.plan.txt
@@ -10,29 +10,29 @@ remote exchange (GATHER, SINGLE, [])
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, ["orderkey_7"])
                                             join (INNER, REPLICATED):
-                                                scan tpch:orders:sf3000.0
+                                                scan orders
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         join (INNER, REPLICATED):
-                                                            scan tpch:customer:sf3000.0
+                                                            scan customer
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                     join (INNER, REPLICATED):
-                                                                        scan tpch:nation:sf3000.0
+                                                                        scan nation
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan tpch:region:sf3000.0
+                                                                                scan region
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["orderkey"])
                                                 join (INNER, REPLICATED):
-                                                    scan tpch:lineitem:sf3000.0
+                                                    scan lineitem
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan tpch:part:sf3000.0
+                                                            scan part
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["suppkey"])
                                         join (INNER, REPLICATED):
-                                            scan tpch:supplier:sf3000.0
+                                            scan supplier
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan tpch:nation:sf3000.0
+                                                    scan nation

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q09.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q09.plan.txt
@@ -14,19 +14,19 @@ remote exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["suppkey_4"])
                                                         join (INNER, PARTITIONED):
                                                             remote exchange (REPARTITION, HASH, ["partkey"])
-                                                                scan tpch:part:sf3000.0
+                                                                scan part
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPARTITION, HASH, ["partkey_3"])
-                                                                    scan tpch:lineitem:sf3000.0
+                                                                    scan lineitem
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["suppkey"])
-                                                            scan tpch:supplier:sf3000.0
+                                                            scan supplier
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["suppkey_8"])
-                                                        scan tpch:partsupp:sf3000.0
+                                                        scan partsupp
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["orderkey_11"])
-                                                scan tpch:orders:sf3000.0
+                                                scan orders
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["nationkey_14"])
-                                        scan tpch:nation:sf3000.0
+                                        scan nation

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q10.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q10.plan.txt
@@ -6,14 +6,14 @@ local exchange (GATHER, SINGLE, [])
                     join (INNER, PARTITIONED):
                         remote exchange (REPARTITION, HASH, ["custkey_3"])
                             join (INNER, REPLICATED):
-                                scan tpch:customer:sf3000.0
+                                scan customer
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
-                                        scan tpch:nation:sf3000.0
+                                        scan nation
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["custkey"])
                                 join (INNER, REPLICATED):
-                                    scan tpch:lineitem:sf3000.0
+                                    scan lineitem
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpch:orders:sf3000.0
+                                            scan orders

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q11.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q11.plan.txt
@@ -7,14 +7,14 @@ remote exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["partkey"])
                             partial aggregation over (partkey)
                                 join (INNER, REPLICATED):
-                                    scan tpch:partsupp:sf3000.0
+                                    scan partsupp
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             join (INNER, REPLICATED):
-                                                scan tpch:supplier:sf3000.0
+                                                scan supplier
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan tpch:nation:sf3000.0
+                                                        scan nation
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
@@ -22,11 +22,11 @@ remote exchange (GATHER, SINGLE, [])
                                 remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over ()
                                         join (INNER, REPLICATED):
-                                            scan tpch:partsupp:sf3000.0
+                                            scan partsupp
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     join (INNER, REPLICATED):
-                                                        scan tpch:supplier:sf3000.0
+                                                        scan supplier
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan tpch:nation:sf3000.0
+                                                                scan nation

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q12.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q12.plan.txt
@@ -7,7 +7,7 @@ remote exchange (GATHER, SINGLE, [])
                         partial aggregation over (shipmode)
                             join (INNER, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, ["orderkey"])
-                                    scan tpch:orders:sf3000.0
+                                    scan orders
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["orderkey_0"])
-                                        scan tpch:lineitem:sf3000.0
+                                        scan lineitem

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q13.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q13.plan.txt
@@ -10,7 +10,7 @@ remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over (custkey)
                                         join (LEFT, PARTITIONED):
                                             remote exchange (REPARTITION, HASH, ["custkey"])
-                                                scan tpch:customer:sf3000.0
+                                                scan customer
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["custkey_0"])
-                                                    scan tpch:orders:sf3000.0
+                                                    scan orders

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q14.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q14.plan.txt
@@ -4,7 +4,7 @@ final aggregation over ()
             partial aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["partkey_0"])
-                        scan tpch:part:sf3000.0
+                        scan part
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["partkey"])
-                            scan tpch:lineitem:sf3000.0
+                            scan lineitem

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q15.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q15.plan.txt
@@ -4,12 +4,12 @@ remote exchange (GATHER, SINGLE, [])
             join (INNER, REPLICATED):
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["suppkey"])
-                        scan tpch:supplier:sf3000.0
+                        scan supplier
                     final aggregation over (suppkey_0)
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["suppkey_0"])
                                 partial aggregation over (suppkey_0)
-                                    scan tpch:lineitem:sf3000.0
+                                    scan lineitem
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
@@ -20,4 +20,4 @@ remote exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["suppkey_16"])
                                                     partial aggregation over (suppkey_16)
-                                                        scan tpch:lineitem:sf3000.0
+                                                        scan lineitem

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q16.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q16.plan.txt
@@ -12,10 +12,10 @@ remote exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["suppkey"])
                                                 join (INNER, PARTITIONED):
                                                     remote exchange (REPARTITION, HASH, ["partkey"])
-                                                        scan tpch:partsupp:sf3000.0
+                                                        scan partsupp
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, ["partkey_0"])
-                                                            scan tpch:part:sf3000.0
+                                                            scan part
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["suppkey_3"])
-                                                    scan tpch:supplier:sf3000.0
+                                                    scan supplier

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q17.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q17.plan.txt
@@ -8,14 +8,14 @@ final aggregation over ()
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["partkey_4"])
                                     partial aggregation over (partkey_4)
-                                        scan tpch:lineitem:sf3000.0
+                                        scan lineitem
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["partkey"])
                                 join (INNER, REPLICATED):
-                                    scan tpch:lineitem:sf3000.0
+                                    scan lineitem
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan tpch:part:sf3000.0
+                                            scan part
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPLICATE, BROADCAST, [])
                             single aggregation over ()

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q18.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q18.plan.txt
@@ -6,19 +6,19 @@ local exchange (GATHER, SINGLE, [])
                     semijoin (PARTITIONED):
                         join (INNER, PARTITIONED):
                             remote exchange (REPARTITION, HASH, ["orderkey_3"])
-                                scan tpch:lineitem:sf3000.0
+                                scan lineitem
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["orderkey"])
                                     join (INNER, PARTITIONED):
                                         remote exchange (REPARTITION, HASH, ["custkey_0"])
-                                            scan tpch:orders:sf3000.0
+                                            scan orders
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["custkey"])
-                                                scan tpch:customer:sf3000.0
+                                                scan customer
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, ["orderkey_6"])
                                 final aggregation over (orderkey_6)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["orderkey_6"])
                                             partial aggregation over (orderkey_6)
-                                                scan tpch:lineitem:sf3000.0
+                                                scan lineitem

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q19.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q19.plan.txt
@@ -4,7 +4,7 @@ final aggregation over ()
             partial aggregation over ()
                 join (INNER, PARTITIONED):
                     remote exchange (REPARTITION, HASH, ["partkey"])
-                        scan tpch:lineitem:sf3000.0
+                        scan lineitem
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, ["partkey_0"])
-                            scan tpch:part:sf3000.0
+                            scan part

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q20.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q20.plan.txt
@@ -4,27 +4,27 @@ remote exchange (GATHER, SINGLE, [])
             semijoin (PARTITIONED):
                 remote exchange (REPARTITION, HASH, ["suppkey"])
                     join (INNER, REPLICATED):
-                        scan tpch:supplier:sf3000.0
+                        scan supplier
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPLICATE, BROADCAST, [])
-                                scan tpch:nation:sf3000.0
+                                scan nation
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, ["suppkey_4"])
                         cross join:
                             join (LEFT, PARTITIONED):
                                 semijoin (PARTITIONED):
                                     remote exchange (REPARTITION, HASH, ["partkey"])
-                                        scan tpch:partsupp:sf3000.0
+                                        scan partsupp
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["partkey_8"])
-                                            scan tpch:part:sf3000.0
+                                            scan part
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["partkey_18"])
                                         final aggregation over (partkey_18, suppkey_19)
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, ["partkey_18", "suppkey_19"])
                                                     partial aggregation over (partkey_18, suppkey_19)
-                                                        scan tpch:lineitem:sf3000.0
+                                                        scan lineitem
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
                                     single aggregation over ()

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q21.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q21.plan.txt
@@ -17,19 +17,19 @@ local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPARTITION, HASH, ["orderkey"])
                                                                     join (INNER, PARTITIONED):
                                                                         remote exchange (REPARTITION, HASH, ["suppkey"])
-                                                                            scan tpch:supplier:sf3000.0
+                                                                            scan supplier
                                                                         local exchange (GATHER, SINGLE, [])
                                                                             remote exchange (REPARTITION, HASH, ["suppkey_0"])
-                                                                                scan tpch:lineitem:sf3000.0
+                                                                                scan lineitem
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPARTITION, HASH, ["orderkey_3"])
-                                                                        scan tpch:orders:sf3000.0
+                                                                        scan orders
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (REPARTITION, HASH, ["nationkey_6"])
-                                                                scan tpch:nation:sf3000.0
+                                                                scan nation
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["orderkey_10"])
-                                                        scan tpch:lineitem:sf3000.0
+                                                        scan lineitem
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, ["orderkey_92"])
-                                        scan tpch:lineitem:sf3000.0
+                                        scan lineitem

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q22.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q22.plan.txt
@@ -8,16 +8,16 @@ remote exchange (GATHER, SINGLE, [])
                             join (LEFT, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, ["custkey"])
                                     cross join:
-                                        scan tpch:customer:sf3000.0
+                                        scan customer
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 final aggregation over ()
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (GATHER, SINGLE, [])
                                                             partial aggregation over ()
-                                                                scan tpch:customer:sf3000.0
+                                                                scan customer
                                 final aggregation over (custkey_13)
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["custkey_13"])
                                             partial aggregation over (custkey_13)
-                                                scan tpch:orders:sf3000.0
+                                                scan orders


### PR DESCRIPTION
This makes query plans more abstract which allows
to test them againt non TPCH/TPCDS metadata sources
(e.g: Hive)