### PR TITLE
Fix 'Capture Snapshot' button for showing threads

### DIFF
--- a/presto-main/src/main/resources/webapp/src/components/WorkerThreadList.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/WorkerThreadList.jsx
@@ -75,13 +75,11 @@ export class WorkerThreadList extends React.Component {
             }
 
             const match = THREAD_GROUP_REGEXP.exec(thread.name);
-            if (!match) {
-                result[thread.name].push(thread);
+            const threadGroup = match ? match[1] : thread.name;
+            if (!result[threadGroup]) {
+                result[threadGroup] = [];
             }
-            else {
-                const [, namePrefix, ...ignored] = match;
-                result[namePrefix].push(thread);
-            }
+            result[threadGroup].push(thread);
         }
 
         return result


### PR DESCRIPTION
Before the change, the code was attempting `result[...].push(...)`
without first adding lists as `result` map values.

Following was being logged:
```
WorkerThreadList.jsx:472 Uncaught TypeError: Cannot read property 'push' of undefined
    at Function.processThreads (WorkerThreadList.jsx:472)
    at WorkerThreadList.eval (WorkerThreadList.jsx:75)
    at i (jquery-2.2.3.min.js:2)
    at Object.fireWith [as resolveWith] (jquery-2.2.3.min.js:2)
    at z (jquery-2.2.3.min.js:4)
    at XMLHttpRequest.<anonymous> (jquery-2.2.3.min.js:4)
```