### PR TITLE
Change ARRAY_INTERSECT to use TypedSet

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayIntersectFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayIntersectFunction.java
@@ -13,34 +13,21 @@
  */
 package com.facebook.presto.operator.scalar;
 
+import com.facebook.presto.operator.aggregation.TypedSet;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.Description;
-import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
-import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.type.TypeUtils;
 import com.google.common.collect.ImmutableList;
-import it.unimi.dsi.fastutil.ints.AbstractIntComparator;
-import it.unimi.dsi.fastutil.ints.IntArrays;
-import it.unimi.dsi.fastutil.ints.IntComparator;
-
-import java.lang.invoke.MethodHandle;
-
-import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 
 @ScalarFunction("array_intersect")
 @Description("Intersects elements of the two given arrays")
 public final class ArrayIntersectFunction
 {
-    private static final int INITIAL_SIZE = 128;
-
-    private int[] leftPositions = new int[INITIAL_SIZE];
-    private int[] rightPositions = new int[INITIAL_SIZE];
     private final PageBuilder pageBuilder;
 
     @TypeParameter("E")
@@ -49,103 +36,47 @@ public final class ArrayIntersectFunction
         pageBuilder = new PageBuilder(ImmutableList.of(elementType));
     }
 
-    private static int compareBlockValue(Type type, Block leftBlock, int left, Block rightBlock, int right)
-    {
-        if (leftBlock.isNull(left) && rightBlock.isNull(right)) {
-            return 0;
-        }
-        if (leftBlock.isNull(left)) {
-            return -1;
-        }
-        if (rightBlock.isNull(right)) {
-            return 1;
-        }
-        return type.compareTo(leftBlock, left, rightBlock, right);
-    }
-
-    private static IntComparator intBlockCompare(Type type, Block block)
-    {
-        return new AbstractIntComparator()
-        {
-            @Override
-            public int compare(int left, int right)
-            {
-                return compareBlockValue(type, block, left, block, right);
-            }
-        };
-    }
-
     @TypeParameter("E")
     @SqlType("array(E)")
     public Block intersect(
-            @OperatorDependency(operator = LESS_THAN, returnType = StandardTypes.BOOLEAN, argumentTypes = {"E", "E"}) MethodHandle lessThanFunction,
             @TypeParameter("E") Type type,
             @SqlType("array(E)") Block leftArray,
             @SqlType("array(E)") Block rightArray)
     {
+        if (leftArray.getPositionCount() < rightArray.getPositionCount()) {
+            Block tempArray = leftArray;
+            leftArray = rightArray;
+            rightArray = tempArray;
+        }
+
         int leftPositionCount = leftArray.getPositionCount();
         int rightPositionCount = rightArray.getPositionCount();
 
-        if (leftPositionCount == 0) {
-            return leftArray;
-        }
         if (rightPositionCount == 0) {
             return rightArray;
-        }
-
-        if (leftPositions.length < leftPositionCount) {
-            leftPositions = new int[leftPositionCount];
-        }
-
-        if (rightPositions.length < rightPositionCount) {
-            rightPositions = new int[rightPositionCount];
         }
 
         if (pageBuilder.isFull()) {
             pageBuilder.reset();
         }
 
-        for (int i = 0; i < leftPositionCount; i++) {
-            leftPositions[i] = i;
-        }
+        TypedSet rightTypedSet = new TypedSet(type, rightPositionCount, "array_intersect");
         for (int i = 0; i < rightPositionCount; i++) {
-            rightPositions[i] = i;
+            rightTypedSet.add(rightArray, i);
         }
-        IntArrays.quickSort(leftPositions, 0, leftPositionCount, intBlockCompare(type, leftArray));
-        IntArrays.quickSort(rightPositions, 0, rightPositionCount, intBlockCompare(type, rightArray));
 
-        BlockBuilder resultBlockBuilder = pageBuilder.getBlockBuilder(0);
+        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
 
-        int leftCurrentPosition = 0;
-        int rightCurrentPosition = 0;
-        int leftBasePosition;
-        int rightBasePosition;
-        int totalCount = 0;
-
-        while (leftCurrentPosition < leftPositionCount && rightCurrentPosition < rightPositionCount) {
-            leftBasePosition = leftCurrentPosition;
-            rightBasePosition = rightCurrentPosition;
-            int compareValue = compareBlockValue(type, leftArray, leftPositions[leftCurrentPosition], rightArray, rightPositions[rightCurrentPosition]);
-            if (compareValue > 0) {
-                rightCurrentPosition++;
-            }
-            else if (compareValue < 0) {
-                leftCurrentPosition++;
-            }
-            else {
-                type.appendTo(leftArray, leftPositions[leftCurrentPosition], resultBlockBuilder);
-                leftCurrentPosition++;
-                rightCurrentPosition++;
-                totalCount++;
-                while (leftCurrentPosition < leftPositionCount && TypeUtils.positionEqualsPosition(type, leftArray, leftPositions[leftBasePosition], leftArray, leftPositions[leftCurrentPosition])) {
-                    leftCurrentPosition++;
-                }
-                while (rightCurrentPosition < rightPositionCount && TypeUtils.positionEqualsPosition(type, rightArray, rightPositions[rightBasePosition], rightArray, rightPositions[rightCurrentPosition])) {
-                    rightCurrentPosition++;
-                }
+        // The intersected set can have at most rightPositionCount elements
+        TypedSet intersectTypedSet = new TypedSet(type, blockBuilder, rightPositionCount, "array_intersect");
+        for (int i = 0; i < leftPositionCount; i++) {
+            if (rightTypedSet.contains(leftArray, i)) {
+                intersectTypedSet.add(leftArray, i);
             }
         }
-        pageBuilder.declarePositions(totalCount);
-        return resultBlockBuilder.getRegion(resultBlockBuilder.getPositionCount() - totalCount, totalCount);
+
+        pageBuilder.declarePositions(intersectTypedSet.size());
+
+        return blockBuilder.getRegion(blockBuilder.getPositionCount() - intersectTypedSet.size(), intersectTypedSet.size());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedSet.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedSet.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.aggregation;
 
+import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
@@ -33,6 +34,7 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static java.util.Collections.nCopies;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestTypedSet
@@ -67,40 +69,134 @@ public class TestTypedSet
     public void testGetElementPosition()
     {
         int elementCount = 100;
-        TypedSet typedSet = new TypedSet(BIGINT, elementCount, FUNCTION_NAME);
+        // Set initialTypedSetEntryCount to a small number to trigger rehash()
+        int initialTypedSetEntryCount = 10;
+        TypedSet typedSet = new TypedSet(BIGINT, initialTypedSetEntryCount, FUNCTION_NAME);
         BlockBuilder blockBuilder = BIGINT.createFixedSizeBlockBuilder(elementCount);
         for (int i = 0; i < elementCount; i++) {
             BIGINT.writeLong(blockBuilder, i);
             typedSet.add(blockBuilder, i);
         }
+
+        assertEquals(typedSet.size(), elementCount);
+
         for (int j = 0; j < blockBuilder.getPositionCount(); j++) {
             assertEquals(typedSet.positionOf(blockBuilder, j), j);
         }
     }
 
     @Test
-    public void testGetElementPositionRandom()
+    public void testGetElementPositionWithNull()
     {
-        BlockBuilder keys = VARCHAR.createBlockBuilder(null, 5);
-        VARCHAR.writeSlice(keys, utf8Slice("hello"));
-        VARCHAR.writeSlice(keys, utf8Slice("bye"));
-        VARCHAR.writeSlice(keys, utf8Slice("abc"));
-
-        TypedSet set = new TypedSet(VARCHAR, keys.getPositionCount(), FUNCTION_NAME);
-        for (int i = 0; i < keys.getPositionCount(); i++) {
-            set.add(keys, i);
+        int elementCount = 100;
+        // Set initialTypedSetEntryCount to a small number to trigger rehash()
+        int initialTypedSetEntryCount = 10;
+        TypedSet typedSet = new TypedSet(BIGINT, initialTypedSetEntryCount, FUNCTION_NAME);
+        BlockBuilder blockBuilder = BIGINT.createFixedSizeBlockBuilder(elementCount);
+        for (int i = 0; i < elementCount; i++) {
+            if (i % 10 == 0) {
+                blockBuilder.appendNull();
+            }
+            else {
+                BIGINT.writeLong(blockBuilder, i);
+            }
+            typedSet.add(blockBuilder, i);
         }
 
-        BlockBuilder values = VARCHAR.createBlockBuilder(null, 5);
-        VARCHAR.writeSlice(values, utf8Slice("bye"));
-        VARCHAR.writeSlice(values, utf8Slice("abc"));
-        VARCHAR.writeSlice(values, utf8Slice("hello"));
-        VARCHAR.writeSlice(values, utf8Slice("bad"));
+        // The internal elementBlock and hashtable of the typedSet should contain
+        // all distinct non-null elements plus one null
+        assertEquals(typedSet.size(), elementCount - elementCount / 10 + 1);
 
-        assertEquals(set.positionOf(values, 2), 0);
-        assertEquals(set.positionOf(values, 1), 2);
-        assertEquals(set.positionOf(values, 0), 1);
-        assertFalse(set.contains(values, 3));
+        int nullCount = 0;
+        for (int j = 0; j < blockBuilder.getPositionCount(); j++) {
+            // The null is only added to typedSet once, so the internal elementBlock subscript is shifted by nullCountMinusOne
+            if (!blockBuilder.isNull(j)) {
+                assertEquals(typedSet.positionOf(blockBuilder, j), j - nullCount + 1);
+            }
+            else {
+                // The first null added to typedSet is at position 0
+                assertEquals(typedSet.positionOf(blockBuilder, j), 0);
+                nullCount++;
+            }
+        }
+    }
+
+    @Test
+    public void testGetElementPositionWithProvidedEmptyBlockBuilder()
+    {
+        int elementCount = 100;
+        // Set initialTypedSetEntryCount to a small number to trigger rehash()
+        int initialTypedSetEntryCount = 10;
+
+        BlockBuilder emptyBlockBuilder = BIGINT.createFixedSizeBlockBuilder(elementCount);
+        TypedSet typedSet = new TypedSet(BIGINT, emptyBlockBuilder, initialTypedSetEntryCount, FUNCTION_NAME);
+        BlockBuilder externalBlockBuilder = BIGINT.createFixedSizeBlockBuilder(elementCount);
+        for (int i = 0; i < elementCount; i++) {
+            if (i % 10 == 0) {
+                externalBlockBuilder.appendNull();
+            }
+            else {
+                BIGINT.writeLong(externalBlockBuilder, i);
+            }
+            typedSet.add(externalBlockBuilder, i);
+        }
+
+        assertEquals(typedSet.size(), emptyBlockBuilder.getPositionCount());
+        assertEquals(typedSet.size(), elementCount - elementCount / 10 + 1);
+
+        for (int j = 0; j < typedSet.size(); j++) {
+            assertEquals(typedSet.positionOf(emptyBlockBuilder, j), j);
+        }
+    }
+
+    @Test
+    public void testGetElementPositionWithProvidedNonEmptyBlockBuilder()
+    {
+        int elementCount = 100;
+        // Set initialTypedSetEntryCount to a small number to trigger rehash()
+        int initialTypedSetEntryCount = 10;
+
+        PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(BIGINT));
+        BlockBuilder firstBlockBuilder = pageBuilder.getBlockBuilder(0);
+
+        for (int i = 0; i < elementCount; i++) {
+            BIGINT.writeLong(firstBlockBuilder, i);
+        }
+        pageBuilder.declarePositions(elementCount);
+
+        // The secondBlockBuilder should already have elementCount rows.
+        BlockBuilder secondBlockBuilder = pageBuilder.getBlockBuilder(0);
+
+        TypedSet typedSet = new TypedSet(BIGINT, secondBlockBuilder, initialTypedSetEntryCount, FUNCTION_NAME);
+        BlockBuilder externalBlockBuilder = BIGINT.createFixedSizeBlockBuilder(elementCount);
+        for (int i = 0; i < elementCount; i++) {
+            if (i % 10 == 0) {
+                externalBlockBuilder.appendNull();
+            }
+            else {
+                BIGINT.writeLong(externalBlockBuilder, i);
+            }
+            typedSet.add(externalBlockBuilder, i);
+        }
+
+        assertEquals(typedSet.size(), secondBlockBuilder.getPositionCount() - elementCount);
+        assertEquals(typedSet.size(), elementCount - elementCount / 10 + 1);
+
+        for (int i = 0; i < typedSet.size(); i++) {
+            int expectedPositionInSecondBlockBuilder = i + elementCount;
+            assertEquals(typedSet.positionOf(secondBlockBuilder, expectedPositionInSecondBlockBuilder), expectedPositionInSecondBlockBuilder);
+        }
+    }
+
+    @Test
+    public void testGetElementPositionRandom()
+    {
+        TypedSet set = new TypedSet(VARCHAR, 1, FUNCTION_NAME);
+        testGetElementPositionRandomFor(set);
+
+        BlockBuilder emptyBlockBuilder = VARCHAR.createBlockBuilder(null, 3);
+        TypedSet setWithPassedInBuilder = new TypedSet(VARCHAR, emptyBlockBuilder, 1, FUNCTION_NAME);
+        testGetElementPositionRandomFor(setWithPassedInBuilder);
     }
 
     @Test
@@ -145,9 +241,46 @@ public class TestTypedSet
         }
     }
 
+    private void testGetElementPositionRandomFor(TypedSet set)
+    {
+        BlockBuilder keys = VARCHAR.createBlockBuilder(null, 5);
+        VARCHAR.writeSlice(keys, utf8Slice("hello"));
+        VARCHAR.writeSlice(keys, utf8Slice("bye"));
+        VARCHAR.writeSlice(keys, utf8Slice("abc"));
+
+        for (int i = 0; i < keys.getPositionCount(); i++) {
+            set.add(keys, i);
+        }
+
+        BlockBuilder values = VARCHAR.createBlockBuilder(null, 5);
+        VARCHAR.writeSlice(values, utf8Slice("bye"));
+        VARCHAR.writeSlice(values, utf8Slice("abc"));
+        VARCHAR.writeSlice(values, utf8Slice("hello"));
+        VARCHAR.writeSlice(values, utf8Slice("bad"));
+        values.appendNull();
+
+        assertEquals(set.positionOf(values, 4), -1);
+        assertEquals(set.positionOf(values, 2), 0);
+        assertEquals(set.positionOf(values, 1), 2);
+        assertEquals(set.positionOf(values, 0), 1);
+        assertFalse(set.contains(values, 3));
+
+        set.add(values, 4);
+        assertTrue(set.contains(values, 4));
+    }
+
     private static void testBigint(Block longBlock, int expectedSetSize)
     {
         TypedSet typedSet = new TypedSet(BIGINT, expectedSetSize, FUNCTION_NAME);
+        testBigintFor(typedSet, longBlock);
+
+        BlockBuilder emptyBlockBuilder = BIGINT.createBlockBuilder(null, expectedSetSize);
+        TypedSet typedSetWithPassedInBuilder = new TypedSet(BIGINT, emptyBlockBuilder, expectedSetSize, FUNCTION_NAME);
+        testBigintFor(typedSetWithPassedInBuilder, longBlock);
+    }
+
+    private static void testBigintFor(TypedSet typedSet, Block longBlock)
+    {
         Set<Long> set = new HashSet<>();
         for (int blockPosition = 0; blockPosition < longBlock.getPositionCount(); blockPosition++) {
             long number = BIGINT.getLong(longBlock, blockPosition);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayIntersect.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayIntersect.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.metadata.FunctionKind;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.operator.DriverYieldSignal;
+import com.facebook.presto.operator.project.PageProcessor;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.gen.ExpressionCompiler;
+import com.facebook.presto.sql.gen.PageFunctionCompiler;
+import com.facebook.presto.sql.relational.CallExpression;
+import com.facebook.presto.sql.relational.RowExpression;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.relational.Expressions.field;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkArrayIntersect
+{
+    private static final int POSITIONS = 1_000;
+
+    @Benchmark
+    @OperationsPerInvocation(POSITIONS)
+    public List<Optional<Page>> arrayIntersect(BenchmarkData data)
+    {
+        return ImmutableList.copyOf(data.getPageProcessor().process(
+                SESSION,
+                new DriverYieldSignal(),
+                newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
+                data.getPage()));
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private String name = "array_intersect";
+
+        @Param({"BIGINT", "VARCHAR", "DOUBLE", "BOOLEAN"})
+        private String type = "BIGINT";
+
+        @Param({"10", "100", "1000"})
+        private int arraySize = 10;
+
+        private Page page;
+        private PageProcessor pageProcessor;
+
+        @Setup
+        public void setup()
+        {
+            Type elementType;
+            switch (type) {
+                case "BIGINT":
+                    elementType = BIGINT;
+                    break;
+                case "VARCHAR":
+                    elementType = VARCHAR;
+                    break;
+                case "DOUBLE":
+                    elementType = DOUBLE;
+                    break;
+                case "BOOLEAN":
+                    elementType = BOOLEAN;
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+
+            ArrayType arrayType = new ArrayType(elementType);
+            Signature signature = new Signature(name, FunctionKind.SCALAR, arrayType.getTypeSignature(), arrayType.getTypeSignature(), arrayType.getTypeSignature());
+            ImmutableList<RowExpression> projections = ImmutableList.of(
+                    new CallExpression(signature, arrayType, ImmutableList.of(field(0, arrayType), field(1, arrayType))));
+
+            MetadataManager metadata = MetadataManager.createTestMetadataManager();
+            ExpressionCompiler compiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
+            pageProcessor = compiler.compilePageProcessor(Optional.empty(), projections).get();
+
+            page = new Page(createChannel(POSITIONS, arraySize, elementType), createChannel(POSITIONS, arraySize, elementType));
+        }
+
+        private static Block createChannel(int positionCount, int arraySize, Type elementType)
+        {
+            ArrayType arrayType = new ArrayType(elementType);
+            BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, positionCount);
+            for (int position = 0; position < positionCount; position++) {
+                BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+                for (int i = 0; i < arraySize; i++) {
+                    if (elementType.getJavaType() == long.class) {
+                        elementType.writeLong(entryBuilder, ThreadLocalRandom.current().nextLong() % arraySize);
+                    }
+                    else if (elementType.getJavaType() == double.class) {
+                        elementType.writeDouble(entryBuilder, ThreadLocalRandom.current().nextDouble() % arraySize);
+                    }
+                    else if (elementType.getJavaType() == boolean.class) {
+                        elementType.writeBoolean(entryBuilder, ThreadLocalRandom.current().nextBoolean());
+                    }
+                    else if (elementType.equals(VARCHAR)) {
+                        // make sure the size of a varchar is rather small; otherwise the aggregated slice may overflow
+                        elementType.writeSlice(entryBuilder, Slices.utf8Slice(Long.toString(ThreadLocalRandom.current().nextLong() % arraySize)));
+                    }
+                    else {
+                        throw new UnsupportedOperationException();
+                    }
+                }
+                blockBuilder.closeEntry();
+            }
+            return blockBuilder.build();
+        }
+
+        public PageProcessor getPageProcessor()
+        {
+            return pageProcessor;
+        }
+
+        public Page getPage()
+        {
+            return page;
+        }
+    }
+
+    @Test
+    public void verify()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkArrayIntersect().arrayIntersect(data);
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkArrayIntersect().arrayIntersect(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkArrayIntersect.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -1108,40 +1108,99 @@ public class TestArrayOperators
     @Test
     public void testArrayIntersect()
     {
-        assertFunction("ARRAY_INTERSECT(ARRAY [12], ARRAY [10])", new ArrayType(INTEGER), ImmutableList.of());
-        assertFunction("ARRAY_INTERSECT(ARRAY ['foo', 'bar', 'baz'], ARRAY ['foo', 'test', 'bar'])", new ArrayType(createVarcharType(4)), ImmutableList.of("bar", "foo"));
-        assertFunction("ARRAY_INTERSECT(ARRAY [NULL], ARRAY [NULL, NULL])", new ArrayType(UNKNOWN), asList((Object) null));
-        assertFunction("ARRAY_INTERSECT(ARRAY ['abc', NULL, 'xyz', NULL], ARRAY [NULL, 'abc', NULL, NULL])", new ArrayType(createVarcharType(3)), asList(null, "abc"));
-        assertFunction("ARRAY_INTERSECT(ARRAY [1, 5], ARRAY [1])", new ArrayType(INTEGER), ImmutableList.of(1));
-        assertFunction("ARRAY_INTERSECT(ARRAY [1, 1, 2, 4], ARRAY [1, 1, 4, 4])", new ArrayType(INTEGER), ImmutableList.of(1, 4));
-        assertFunction("ARRAY_INTERSECT(ARRAY [2, 8], ARRAY [8, 3])", new ArrayType(INTEGER), ImmutableList.of(8));
+        // test basic
+        assertFunction("ARRAY_INTERSECT(ARRAY [5], ARRAY [5])", new ArrayType(INTEGER), ImmutableList.of(5));
+        assertFunction("ARRAY_INTERSECT(ARRAY [1, 2, 5, 5, 6], ARRAY [5, 5, 6, 6, 7, 8])", new ArrayType(INTEGER), ImmutableList.of(5, 6));
         assertFunction("ARRAY_INTERSECT(ARRAY [IF (RAND() < 1.0E0, 7, 1) , 2], ARRAY [7])", new ArrayType(INTEGER), ImmutableList.of(7));
+        assertFunction("ARRAY_INTERSECT(ARRAY [CAST(5 AS BIGINT), CAST(5 AS BIGINT)], ARRAY [CAST(1 AS BIGINT), CAST(5 AS BIGINT)])", new ArrayType(BIGINT), ImmutableList.of(5L));
         assertFunction("ARRAY_INTERSECT(ARRAY [1, 5], ARRAY [1.0E0])", new ArrayType(DOUBLE), ImmutableList.of(1.0));
+        assertFunction("ARRAY_INTERSECT(ARRAY [1.0E0, 5.0E0], ARRAY [5.0E0, 5.0E0, 6.0E0])", new ArrayType(DOUBLE), ImmutableList.of(5.0));
         assertFunction("ARRAY_INTERSECT(ARRAY [8.3E0, 1.6E0, 4.1E0, 5.2E0], ARRAY [4.0E0, 5.2E0, 8.3E0, 9.7E0, 3.5E0])", new ArrayType(DOUBLE), ImmutableList.of(5.2, 8.3));
-        assertFunction("ARRAY_INTERSECT(ARRAY [5.1E0, 7, 3.0E0, 4.8E0, 10], ARRAY [6.5E0, 10.0E0, 1.9E0, 5.1E0, 3.9E0, 4.8E0])", new ArrayType(DOUBLE), ImmutableList.of(4.8, 5.1, 10.0));
-        assertFunction("ARRAY_INTERSECT(ARRAY [ARRAY [4, 5], ARRAY [6, 7]], ARRAY [ARRAY [4, 5], ARRAY [6, 8]])", new ArrayType(new ArrayType(INTEGER)), ImmutableList.of(ImmutableList.of(4, 5)));
-
-        assertFunction("ARRAY_INTERSECT(ARRAY [0, 1, NULL], ARRAY [0, 1, NULL])", new ArrayType(INTEGER), asList(null, 0, 1));
-        assertFunction("ARRAY_INTERSECT(ARRAY [0, 0, 1, NULL], ARRAY [0, 0, 1, NULL, NULL])", new ArrayType(INTEGER), asList(null, 0, 1));
-        assertFunction("ARRAY_INTERSECT(ARRAY [0], ARRAY [0, NULL])", new ArrayType(INTEGER), ImmutableList.of(0));
-        assertFunction("ARRAY_INTERSECT(ARRAY [0.0E0], ARRAY [NULL])", new ArrayType(DOUBLE), ImmutableList.of());
-        assertFunction("ARRAY_INTERSECT(ARRAY [0.0E0, NULL, NULL], ARRAY [0.0E0, 0.0E0, NULL])", new ArrayType(DOUBLE), asList(null, 0.0));
-        assertFunction("ARRAY_INTERSECT(ARRAY [false, NULL], ARRAY [false, NULL])", new ArrayType(BOOLEAN), asList(null, false));
-        assertFunction("ARRAY_INTERSECT(ARRAY [true, true, false, false, NULL, NULL], ARRAY [true, false, false, NULL])", new ArrayType(BOOLEAN), asList(null, false, true));
-        assertFunction("ARRAY_INTERSECT(ARRAY [''], ARRAY [NULL])", new ArrayType(createVarcharType(0)), ImmutableList.of());
-        assertFunction("ARRAY_INTERSECT(ARRAY [''], ARRAY ['', NULL])", new ArrayType(createVarcharType(0)), ImmutableList.of(""));
-        assertFunction("ARRAY_INTERSECT(ARRAY [], ARRAY [NULL])", new ArrayType(UNKNOWN), ImmutableList.of());
-
-        assertCachedInstanceHasBoundedRetainedSize("ARRAY_INTERSECT(ARRAY ['foo', 'bar', 'baz'], ARRAY ['foo', 'test', 'bar'])");
-
+        assertFunction("ARRAY_INTERSECT(ARRAY [5.1E0, 7, 3.0E0, 4.8E0, 10], ARRAY [6.5E0, 10.0E0, 1.9E0, 5.1E0, 3.9E0, 4.8E0])", new ArrayType(DOUBLE), ImmutableList.of(10.0, 5.1, 4.8));
         assertFunction(
                 "ARRAY_INTERSECT(ARRAY [2.3, 2.3, 2.2], ARRAY[2.2, 2.3])",
                 new ArrayType(createDecimalType(2, 1)),
-                ImmutableList.of(decimal("2.2"), decimal("2.3")));
+                ImmutableList.of(decimal("2.3"), decimal("2.2")));
         assertFunction("ARRAY_INTERSECT(ARRAY [2.330, 1.900, 2.330], ARRAY [2.3300, 1.9000])", new ArrayType(createDecimalType(5, 4)),
-                ImmutableList.of(decimal("1.9000"), decimal("2.3300")));
+                ImmutableList.of(decimal("2.3300"), decimal("1.9000")));
         assertFunction("ARRAY_INTERSECT(ARRAY [2, 3], ARRAY[2.0, 3.0])", new ArrayType(createDecimalType(11, 1)),
                 ImmutableList.of(decimal("00000000002.0"), decimal("00000000003.0")));
+        assertFunction("ARRAY_INTERSECT(ARRAY [true], ARRAY [true])", new ArrayType(BOOLEAN), ImmutableList.of(true));
+        assertFunction("ARRAY_INTERSECT(ARRAY [true, false], ARRAY [true])", new ArrayType(BOOLEAN), ImmutableList.of(true));
+        assertFunction("ARRAY_INTERSECT(ARRAY [true, true], ARRAY [true, true])", new ArrayType(BOOLEAN), ImmutableList.of(true));
+        assertFunction("ARRAY_INTERSECT(ARRAY ['abc'], ARRAY ['abc', 'bcd'])", new ArrayType(createVarcharType(3)), ImmutableList.of("abc"));
+        assertFunction("ARRAY_INTERSECT(ARRAY ['abc', 'abc'], ARRAY ['abc', 'abc'])", new ArrayType(createVarcharType(3)), ImmutableList.of("abc"));
+        assertFunction("ARRAY_INTERSECT(ARRAY ['foo', 'bar', 'baz'], ARRAY ['foo', 'test', 'bar'])", new ArrayType(createVarcharType(4)), ImmutableList.of("foo", "bar"));
+
+        // test empty results
+        assertFunction("ARRAY_INTERSECT(ARRAY [], ARRAY [5])", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("ARRAY_INTERSECT(ARRAY [5, 6], ARRAY [])", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("ARRAY_INTERSECT(ARRAY [1], ARRAY [5])", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("ARRAY_INTERSECT(ARRAY [CAST(1 AS BIGINT)], ARRAY [CAST(5 AS BIGINT)])", new ArrayType(BIGINT), ImmutableList.of());
+        assertFunction("ARRAY_INTERSECT(ARRAY [true, true], ARRAY [false])", new ArrayType(BOOLEAN), ImmutableList.of());
+        assertFunction("ARRAY_INTERSECT(ARRAY [], ARRAY [false])", new ArrayType(BOOLEAN), ImmutableList.of());
+        assertFunction("ARRAY_INTERSECT(ARRAY [5], ARRAY [1.0E0])", new ArrayType(DOUBLE), ImmutableList.of());
+        assertFunction("ARRAY_INTERSECT(ARRAY ['abc'], ARRAY [])", new ArrayType(createVarcharType(3)), ImmutableList.of());
+        assertFunction("ARRAY_INTERSECT(ARRAY [], ARRAY ['abc', 'bcd'])", new ArrayType(createVarcharType(3)), ImmutableList.of());
+        assertFunction("ARRAY_INTERSECT(ARRAY [], ARRAY [])", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("ARRAY_INTERSECT(ARRAY [], ARRAY [NULL])", new ArrayType(UNKNOWN), ImmutableList.of());
+
+        // test nulls
+        assertFunction("ARRAY_INTERSECT(ARRAY [NULL], ARRAY [NULL, NULL])", new ArrayType(UNKNOWN), asList((Object) null));
+        assertFunction("ARRAY_INTERSECT(ARRAY [0, 0, 1, NULL], ARRAY [0, 0, 1, NULL])", new ArrayType(INTEGER), asList(0, 1, null));
+        assertFunction("ARRAY_INTERSECT(ARRAY [0, 0], ARRAY [0, 0, NULL])", new ArrayType(INTEGER), ImmutableList.of(0));
+        assertFunction("ARRAY_INTERSECT(ARRAY [CAST(0 AS BIGINT), CAST(0 AS BIGINT)], ARRAY [CAST(0 AS BIGINT), NULL])", new ArrayType(BIGINT), ImmutableList.of(0L));
+        assertFunction("ARRAY_INTERSECT(ARRAY [0.0E0], ARRAY [NULL])", new ArrayType(DOUBLE), ImmutableList.of());
+        assertFunction("ARRAY_INTERSECT(ARRAY [0.0E0, NULL], ARRAY [0.0E0, NULL])", new ArrayType(DOUBLE), asList(0.0, null));
+        assertFunction("ARRAY_INTERSECT(ARRAY [true, true, false, false, NULL], ARRAY [true, false, false, NULL])", new ArrayType(BOOLEAN), asList(true, false, null));
+        assertFunction("ARRAY_INTERSECT(ARRAY [false, false], ARRAY [false, false, NULL])", new ArrayType(BOOLEAN), ImmutableList.of(false));
+        assertFunction("ARRAY_INTERSECT(ARRAY ['abc'], ARRAY [NULL])", new ArrayType(createVarcharType(3)), ImmutableList.of());
+        assertFunction("ARRAY_INTERSECT(ARRAY [''], ARRAY ['', NULL])", new ArrayType(createVarcharType(0)), ImmutableList.of(""));
+        assertFunction("ARRAY_INTERSECT(ARRAY ['', NULL], ARRAY ['', NULL])", new ArrayType(createVarcharType(0)), asList("", null));
+        assertFunction("ARRAY_INTERSECT(ARRAY [NULL], ARRAY ['abc', NULL])", new ArrayType(createVarcharType(3)), singletonList(null));
+        assertFunction("ARRAY_INTERSECT(ARRAY ['abc', NULL, 'xyz', NULL], ARRAY [NULL, 'abc', NULL, NULL])", new ArrayType(createVarcharType(3)), asList("abc", null));
+        assertFunction("ARRAY_INTERSECT(ARRAY [], ARRAY [NULL])", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("ARRAY_INTERSECT(ARRAY [NULL], ARRAY [NULL])", new ArrayType(UNKNOWN), singletonList(null));
+
+        // test composite types
+        assertFunction(
+                "ARRAY_INTERSECT(ARRAY[(123, 456), (123, 789)], ARRAY[(123, 456), (123, 456), (123, 789)])",
+                new ArrayType(RowType.anonymous(ImmutableList.of(INTEGER, INTEGER))),
+                ImmutableList.of(asList(123, 456), asList(123, 789)));
+        assertFunction(
+                "ARRAY_INTERSECT(ARRAY[ARRAY[123, 456], ARRAY[123, 789]], ARRAY[ARRAY[123, 456], ARRAY[123, 456], ARRAY[123, 789]])",
+                new ArrayType(new ArrayType((INTEGER))),
+                ImmutableList.of(asList(123, 456), asList(123, 789)));
+        assertFunction(
+                "ARRAY_INTERSECT(ARRAY[(123, 'abc'), (123, 'cde')], ARRAY[(123, 'abc'), (123, 'cde')])",
+                new ArrayType(RowType.anonymous(ImmutableList.of(INTEGER, createVarcharType(3)))),
+                ImmutableList.of(asList(123, "abc"), asList(123, "cde")));
+        assertFunction(
+                "ARRAY_INTERSECT(ARRAY[(123, 'abc'), (123, 'cde'), NULL], ARRAY[(123, 'abc'), (123, 'cde')])",
+                new ArrayType(RowType.anonymous(ImmutableList.of(INTEGER, createVarcharType(3)))),
+                ImmutableList.of(asList(123, "abc"), asList(123, "cde")));
+        assertFunction(
+                "ARRAY_INTERSECT(ARRAY[(123, 'abc'), (123, 'cde'), NULL, NULL], ARRAY[(123, 'abc'), (123, 'cde'), NULL])",
+                new ArrayType(RowType.anonymous(ImmutableList.of(INTEGER, createVarcharType(3)))),
+                asList(asList(123, "abc"), asList(123, "cde"), null));
+        assertFunction(
+                "ARRAY_INTERSECT(ARRAY[(123, 'abc'), (123, 'abc')], ARRAY[(123, 'abc'), (123, NULL)])",
+                new ArrayType(RowType.anonymous(ImmutableList.of(INTEGER, createVarcharType(3)))),
+                ImmutableList.of(asList(123, "abc")));
+        assertFunction(
+                "ARRAY_INTERSECT(ARRAY[(123, 'abc')], ARRAY[(123, NULL)])",
+                new ArrayType(RowType.anonymous(ImmutableList.of(INTEGER, createVarcharType(3)))),
+                ImmutableList.of());
+
+        // test unsupported
+        assertNotSupported(
+                "ARRAY_INTERSECT(ARRAY[(123, 'abc'), (123, NULL)], ARRAY[(123, 'abc'), (123, NULL)])",
+                "ROW comparison not supported for fields with null elements");
+        assertNotSupported(
+                "ARRAY_INTERSECT(ARRAY[(NULL, 'abc'), (123, 'abc')], ARRAY[(123, 'abc'),(NULL, 'abc')])",
+                "ROW comparison not supported for fields with null elements");
+
+        assertCachedInstanceHasBoundedRetainedSize("ARRAY_INTERSECT(ARRAY ['foo', 'bar', 'baz'], ARRAY ['foo', 'test', 'bar'])");
     }
 
     @Test


### PR DESCRIPTION
Resolves:
https://github.com/prestodb/presto/issues/11493

This commit improves the performance comparing to the original sort-merge
solution. The gain is from 2.3x to 11x for different data types.

before

```
Benchmark                                        (name)   (type)  Mode  Cnt    Score   Error  Units
BenchmarkArrayIntersect.arrayIntersect  array_intersect   BIGINT  avgt   20  193.023 ± 2.840  ns/op
BenchmarkArrayIntersect.arrayIntersect  array_intersect  VARCHAR  avgt   20  336.516 ± 5.301  ns/op
BenchmarkArrayIntersect.arrayIntersect  array_intersect   DOUBLE  avgt   20  219.812 ± 6.615  ns/op
BenchmarkArrayIntersect.arrayIntersect  array_intersect  BOOLEAN  avgt   20   23.913 ± 0.553  ns/op
```

After

```
Benchmark                                (type)  Mode  Cnt    Score   Error  Units
BenchmarkArrayIntersect.arrayIntersect   BIGINT  avgt   20   30.175 ± 5.077  ns/op
BenchmarkArrayIntersect.arrayIntersect  VARCHAR  avgt   20  146.365 ± 5.405  ns/op
BenchmarkArrayIntersect.arrayIntersect   DOUBLE  avgt   20   63.752 ± 5.329  ns/op
BenchmarkArrayIntersect.arrayIntersect  BOOLEAN  avgt   20    2.133 ± 0.243  ns/op
```