### PR TITLE
Accelerate geometries for Spatial Join

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1013,7 +1013,7 @@
             <dependency>
                 <groupId>com.esri.geometry</groupId>
                 <artifactId>esri-geometry-api</artifactId>
-                <version>2.2.1</version>
+                <version>2.2.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Build gemetries are often used repeated for spatial relation checks in a
spatial join.  Accelerating a geometry is a one-time cost which reduces
the complexity of these checks from `O(n)` to `O(lg n)` or even `O(1)`,
where n is the number of vertices.  When a geometry is accessed for the
join, accelerate it (an idempotent operation).

In a real world example of joining ~400k polygons with ~1B points, wall time
went from 1.5h to 4m after acceleration.

Fixes #11953