### PR TITLE
Extend system properties functionality

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
@@ -129,6 +129,12 @@ public class FullConnectorSession
     }
 
     @Override
+    public <T> T getSystemProperty(String name, Class<T> type)
+    {
+        return getSession().getSystemProperty(name, type);
+    }
+
+    @Override
     public String toString()
     {
         return toStringHelper(this)

--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -16,6 +16,7 @@ package com.facebook.presto.event;
 import com.facebook.presto.SessionRepresentation;
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.connector.ConnectorId;
+import com.facebook.presto.eventlistener.DefaultQueryContext;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.Column;
 import com.facebook.presto.execution.ExecutionFailureInfo;
@@ -231,7 +232,7 @@ public class QueryMonitor
 
     private QueryContext createQueryContext(SessionRepresentation session, Optional<ResourceGroupId> resourceGroup)
     {
-        return new QueryContext(
+        return new DefaultQueryContext(
                 session.getUser(),
                 session.getPrincipal(),
                 session.getRemoteUserAddress(),
@@ -247,7 +248,8 @@ public class QueryMonitor
                 session.getResourceEstimates(),
                 serverAddress,
                 serverVersion,
-                environment);
+                environment,
+                sessionPropertyManager);
     }
 
     private Optional<String> createTextQueryPlan(QueryInfo queryInfo)

--- a/presto-main/src/main/java/com/facebook/presto/eventlistener/DefaultQueryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/eventlistener/DefaultQueryContext.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.eventlistener;
+
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.spi.eventlistener.QueryContext;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.spi.session.ResourceEstimates;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class DefaultQueryContext
+        implements QueryContext
+{
+    private final String user;
+    private final Optional<String> principal;
+    private final Optional<String> remoteClientAddress;
+    private final Optional<String> userAgent;
+    private final Optional<String> clientInfo;
+    private final Set<String> clientTags;
+    private final Set<String> clientCapabilities;
+    private final Optional<String> source;
+
+    private final Optional<String> catalog;
+    private final Optional<String> schema;
+
+    private final Optional<ResourceGroupId> resourceGroupId;
+
+    private final Map<String, String> sessionProperties;
+    private final ResourceEstimates resourceEstimates;
+
+    private final String serverAddress;
+    private final String serverVersion;
+    private final String environment;
+
+    private final SessionPropertyManager sessionPropertyManager;
+
+    public DefaultQueryContext(
+            String user,
+            Optional<String> principal,
+            Optional<String> remoteClientAddress,
+            Optional<String> userAgent,
+            Optional<String> clientInfo,
+            Set<String> clientTags,
+            Set<String> clientCapabilities,
+            Optional<String> source,
+            Optional<String> catalog,
+            Optional<String> schema,
+            Optional<ResourceGroupId> resourceGroupId,
+            Map<String, String> sessionProperties,
+            ResourceEstimates resourceEstimates,
+            String serverAddress,
+            String serverVersion,
+            String environment,
+            SessionPropertyManager sessionPropertyManager)
+    {
+        this.user = requireNonNull(user, "user is null");
+        this.principal = requireNonNull(principal, "principal is null");
+        this.remoteClientAddress = requireNonNull(remoteClientAddress, "remoteClientAddress is null");
+        this.userAgent = requireNonNull(userAgent, "userAgent is null");
+        this.clientInfo = requireNonNull(clientInfo, "clientInfo is null");
+        this.clientTags = requireNonNull(clientTags, "clientTags is null");
+        this.clientCapabilities = requireNonNull(clientCapabilities, "clientCapabilities is null");
+        this.source = requireNonNull(source, "source is null");
+        this.catalog = requireNonNull(catalog, "catalog is null");
+        this.schema = requireNonNull(schema, "schema is null");
+        this.resourceGroupId = requireNonNull(resourceGroupId, "resourceGroupId is null");
+        this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
+        this.resourceEstimates = requireNonNull(resourceEstimates, "resourceEstimates is null");
+        this.serverAddress = requireNonNull(serverAddress, "serverAddress is null");
+        this.serverVersion = requireNonNull(serverVersion, "serverVersion is null");
+        this.environment = requireNonNull(environment, "environment is null");
+        this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
+    }
+
+    @JsonProperty
+    @Override
+    public String getUser()
+    {
+        return user;
+    }
+
+    @JsonProperty
+    @Override
+    public Optional<String> getPrincipal()
+    {
+        return principal;
+    }
+
+    @JsonProperty
+    @Override
+    public Optional<String> getRemoteClientAddress()
+    {
+        return remoteClientAddress;
+    }
+
+    @JsonProperty
+    @Override
+    public Optional<String> getUserAgent()
+    {
+        return userAgent;
+    }
+
+    @JsonProperty
+    @Override
+    public Optional<String> getClientInfo()
+    {
+        return clientInfo;
+    }
+
+    @JsonProperty
+    @Override
+    public Set<String> getClientTags()
+    {
+        return clientTags;
+    }
+
+    @JsonProperty
+    @Override
+    public Set<String> getClientCapabilities()
+    {
+        return clientCapabilities;
+    }
+
+    @JsonProperty
+    @Override
+    public Optional<String> getSource()
+    {
+        return source;
+    }
+
+    @JsonProperty
+    @Override
+    public Optional<String> getCatalog()
+    {
+        return catalog;
+    }
+
+    @JsonProperty
+    @Override
+    public Optional<String> getSchema()
+    {
+        return schema;
+    }
+
+    @JsonProperty
+    @Override
+    public Optional<ResourceGroupId> getResourceGroupId()
+    {
+        return resourceGroupId;
+    }
+
+    @JsonProperty
+    @Override
+    public Map<String, String> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    @JsonProperty
+    @Override
+    public ResourceEstimates getResourceEstimates()
+    {
+        return resourceEstimates;
+    }
+
+    @JsonProperty
+    @Override
+    public String getServerAddress()
+    {
+        return serverAddress;
+    }
+
+    @JsonProperty
+    @Override
+    public String getServerVersion()
+    {
+        return serverVersion;
+    }
+
+    @JsonProperty
+    @Override
+    public String getEnvironment()
+    {
+        return environment;
+    }
+
+    @JsonIgnore
+    @Override
+    public <T> T getSystemProperty(String name, Class<T> type)
+    {
+        return sessionPropertyManager.decodeSystemPropertyValue(name, sessionProperties.get(name), type);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -354,7 +354,8 @@ public class LocalQueryRunner
                 new EventListenerManager(),
                 blockEncodingManager,
                 new SessionPropertyDefaults(nodeInfo),
-                typeRegistry);
+                typeRegistry,
+                new SessionPropertyManager());
 
         connectorManager.addConnectorFactory(globalSystemConnectorFactory);
         connectorManager.createConnection(GlobalSystemConnector.NAME, GlobalSystemConnector.NAME, ImmutableMap.of());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
@@ -44,4 +44,9 @@ public interface ConnectorSession
     boolean isLegacyTimestamp();
 
     <T> T getProperty(String name, Class<T> type);
+
+    default <T> T getSystemProperty(String name, Class<T> type)
+    {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
@@ -19,10 +19,12 @@ import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupConfigurationManagerFactory;
 import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
+import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
 import com.facebook.presto.spi.type.ParametricType;
 import com.facebook.presto.spi.type.Type;
 
+import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.emptyList;
@@ -76,6 +78,14 @@ public interface Plugin
     }
 
     default Iterable<SessionPropertyConfigurationManagerFactory> getSessionPropertyConfigurationManagerFactories()
+    {
+        return emptyList();
+    }
+
+    /**
+     * @return the system properties for this plugin
+     */
+    default List<PropertyMetadata<?>> getPluginSessionProperties()
     {
         return emptyList();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryContext.java
@@ -11,170 +11,71 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.facebook.presto.spi.eventlistener;
 
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.session.ResourceEstimates;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static java.util.Objects.requireNonNull;
-
-public class QueryContext
+public interface QueryContext
 {
-    private final String user;
-    private final Optional<String> principal;
-    private final Optional<String> remoteClientAddress;
-    private final Optional<String> userAgent;
-    private final Optional<String> clientInfo;
-    private final Set<String> clientTags;
-    private final Set<String> clientCapabilities;
-    private final Optional<String> source;
-
-    private final Optional<String> catalog;
-    private final Optional<String> schema;
-
-    private final Optional<ResourceGroupId> resourceGroupId;
-
-    private final Map<String, String> sessionProperties;
-    private final ResourceEstimates resourceEstimates;
-
-    private final String serverAddress;
-    private final String serverVersion;
-    private final String environment;
-
-    public QueryContext(
-            String user,
-            Optional<String> principal,
-            Optional<String> remoteClientAddress,
-            Optional<String> userAgent,
-            Optional<String> clientInfo,
-            Set<String> clientTags,
-            Set<String> clientCapabilities,
-            Optional<String> source,
-            Optional<String> catalog,
-            Optional<String> schema,
-            Optional<ResourceGroupId> resourceGroupId,
-            Map<String, String> sessionProperties,
-            ResourceEstimates resourceEstimates,
-            String serverAddress,
-            String serverVersion,
-            String environment)
-    {
-        this.user = requireNonNull(user, "user is null");
-        this.principal = requireNonNull(principal, "principal is null");
-        this.remoteClientAddress = requireNonNull(remoteClientAddress, "remoteClientAddress is null");
-        this.userAgent = requireNonNull(userAgent, "userAgent is null");
-        this.clientInfo = requireNonNull(clientInfo, "clientInfo is null");
-        this.clientTags = requireNonNull(clientTags, "clientTags is null");
-        this.clientCapabilities = requireNonNull(clientCapabilities, "clientCapabilities is null");
-        this.source = requireNonNull(source, "source is null");
-        this.catalog = requireNonNull(catalog, "catalog is null");
-        this.schema = requireNonNull(schema, "schema is null");
-        this.resourceGroupId = requireNonNull(resourceGroupId, "resourceGroupId is null");
-        this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
-        this.resourceEstimates = requireNonNull(resourceEstimates, "resourceEstimates is null");
-        this.serverAddress = requireNonNull(serverAddress, "serverAddress is null");
-        this.serverVersion = requireNonNull(serverVersion, "serverVersion is null");
-        this.environment = requireNonNull(environment, "environment is null");
-    }
+    @JsonProperty
+    public String getUser();
 
     @JsonProperty
-    public String getUser()
-    {
-        return user;
-    }
+    public Optional<String> getPrincipal();
 
     @JsonProperty
-    public Optional<String> getPrincipal()
-    {
-        return principal;
-    }
+    public Optional<String> getRemoteClientAddress();
 
     @JsonProperty
-    public Optional<String> getRemoteClientAddress()
-    {
-        return remoteClientAddress;
-    }
+    public Optional<String> getUserAgent();
 
     @JsonProperty
-    public Optional<String> getUserAgent()
-    {
-        return userAgent;
-    }
+    public Optional<String> getClientInfo();
 
     @JsonProperty
-    public Optional<String> getClientInfo()
-    {
-        return clientInfo;
-    }
+    public Set<String> getClientTags();
 
     @JsonProperty
-    public Set<String> getClientTags()
-    {
-        return clientTags;
-    }
+    public Set<String> getClientCapabilities();
 
     @JsonProperty
-    public Set<String> getClientCapabilities()
-    {
-        return clientCapabilities;
-    }
+    public Optional<String> getSource();
 
     @JsonProperty
-    public Optional<String> getSource()
-    {
-        return source;
-    }
+    public Optional<String> getCatalog();
 
     @JsonProperty
-    public Optional<String> getCatalog()
-    {
-        return catalog;
-    }
+    public Optional<String> getSchema();
 
     @JsonProperty
-    public Optional<String> getSchema()
-    {
-        return schema;
-    }
+    public Optional<ResourceGroupId> getResourceGroupId();
 
     @JsonProperty
-    public Optional<ResourceGroupId> getResourceGroupId()
-    {
-        return resourceGroupId;
-    }
+    public Map<String, String> getSessionProperties();
 
     @JsonProperty
-    public Map<String, String> getSessionProperties()
-    {
-        return sessionProperties;
-    }
+    public ResourceEstimates getResourceEstimates();
 
     @JsonProperty
-    public ResourceEstimates getResourceEstimates()
-    {
-        return resourceEstimates;
-    }
+    String getServerAddress();
 
     @JsonProperty
-    public String getServerAddress()
-    {
-        return serverAddress;
-    }
+    String getServerVersion();
 
     @JsonProperty
-    public String getServerVersion()
-    {
-        return serverVersion;
-    }
+    String getEnvironment();
 
-    @JsonProperty
-    public String getEnvironment()
+    @JsonIgnore
+    default <T> T getSystemProperty(String name, Class<T> type)
     {
-        return environment;
+        throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
These patches 

- give access to all system properties from the ConnectorSession
- give access to all system properties from the QueryContext (for event listeners)
- allow plugins to define system properties

this makes it possible to e.g. have session specific values to move through the system. We use this to manage internal access control for a multi tenant data store.

This is still a very basic set of patches that need tests etc. I'd like a review whether this is a desirable pattern to have or there are better ways to do this. 