### PR TITLE
Propagate partition properties for full outer join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -119,7 +119,6 @@ import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunction
 import com.facebook.presto.sql.gen.OrderingCompiler;
 import com.facebook.presto.sql.gen.PageFunctionCompiler;
 import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.Partitioning.ArgumentBinding;
 import com.facebook.presto.sql.planner.optimizations.IndexJoinOptimizer;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
@@ -391,8 +390,12 @@ public class LocalExecutionPlanner
         }
         else {
             partitionChannels = partitioningScheme.getPartitioning().getArguments().stream()
-                    .map(ArgumentBinding::getColumn)
-                    .map(outputLayout::indexOf)
+                    .map(argument -> {
+                        if (argument.isConstant()) {
+                            return -1;
+                        }
+                        return outputLayout.indexOf(argument.getColumn());
+                    })
                     .collect(toImmutableList());
             partitionConstants = partitioningScheme.getPartitioning().getArguments().stream()
                     .map(argument -> {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
@@ -16,6 +16,8 @@ package com.facebook.presto.sql.planner;
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.predicate.NullableValue;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -32,6 +34,7 @@ import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
@@ -51,7 +54,15 @@ public final class Partitioning
     public static Partitioning create(PartitioningHandle handle, List<Symbol> columns)
     {
         return new Partitioning(handle, columns.stream()
-                .map(ArgumentBinding::columnBinding)
+                .map(Symbol::toSymbolReference)
+                .map(ArgumentBinding::expressionBinding)
+                .collect(toImmutableList()));
+    }
+
+    public static Partitioning createWithExpressions(PartitioningHandle handle, List<Expression> expressions)
+    {
+        return new Partitioning(handle, expressions.stream()
+                .map(ArgumentBinding::expressionBinding)
                 .collect(toImmutableList()));
     }
 
@@ -160,13 +171,20 @@ public final class Partitioning
 
     public boolean isPartitionedOn(Collection<Symbol> columns, Set<Symbol> knownConstants)
     {
-        // partitioned on (k_1, k_2, ..., k_n) => partitioned on (k_1, k_2, ..., k_n, k_n+1, ...)
-        // can safely ignore all constant columns when comparing partition properties
-        return arguments.stream()
-                .filter(ArgumentBinding::isVariable)
-                .map(ArgumentBinding::getColumn)
-                .filter(symbol -> !knownConstants.contains(symbol))
-                .allMatch(columns::contains);
+        for (ArgumentBinding argument : arguments) {
+            // partitioned on (k_1, k_2, ..., k_n) => partitioned on (k_1, k_2, ..., k_n, k_n+1, ...)
+            // can safely ignore all constant columns when comparing partition properties
+            if (argument.isConstant()) {
+                continue;
+            }
+            if (!argument.isVariable()) {
+                return false;
+            }
+            if (!knownConstants.contains(argument.getColumn()) && !columns.contains(argument.getColumn())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public boolean isEffectivelySinglePartition(Set<Symbol> knownConstants)
@@ -194,11 +212,11 @@ public final class Partitioning
                 .collect(toImmutableList()));
     }
 
-    public Optional<Partitioning> translate(Function<Symbol, Optional<Symbol>> translator, Function<Symbol, Optional<NullableValue>> constants)
+    public Optional<Partitioning> translate(Translator translator)
     {
         ImmutableList.Builder<ArgumentBinding> newArguments = ImmutableList.builder();
         for (ArgumentBinding argument : arguments) {
-            Optional<ArgumentBinding> newArgument = argument.translate(translator, constants);
+            Optional<ArgumentBinding> newArgument = argument.translate(translator);
             if (!newArgument.isPresent()) {
                 return Optional.empty();
             }
@@ -243,24 +261,42 @@ public final class Partitioning
     }
 
     @Immutable
+    public static final class Translator
+    {
+        private final Function<Symbol, Optional<Symbol>> columnTranslator;
+        private final Function<Symbol, Optional<NullableValue>> constantTranslator;
+        private final Function<Expression, Optional<Symbol>> expressionTranslator;
+
+        public Translator(
+                Function<Symbol, Optional<Symbol>> columnTranslator,
+                Function<Symbol, Optional<NullableValue>> constantTranslator,
+                Function<Expression, Optional<Symbol>> expressionTranslator)
+        {
+            this.columnTranslator = requireNonNull(columnTranslator, "columnTranslator is null");
+            this.constantTranslator = requireNonNull(constantTranslator, "constantTranslator is null");
+            this.expressionTranslator = requireNonNull(expressionTranslator, "expressionTranslator is null");
+        }
+    }
+
+    @Immutable
     public static final class ArgumentBinding
     {
-        private final Symbol column;
+        private final Expression expression;
         private final NullableValue constant;
 
         @JsonCreator
         public ArgumentBinding(
-                @JsonProperty("column") Symbol column,
+                @JsonProperty("expression") Expression expression,
                 @JsonProperty("constant") NullableValue constant)
         {
-            this.column = column;
+            this.expression = expression;
             this.constant = constant;
-            checkArgument((column == null) != (constant == null), "Either column or constant must be set");
+            checkArgument((expression == null) != (constant == null), "Either expression or constant must be set");
         }
 
-        public static ArgumentBinding columnBinding(Symbol column)
+        public static ArgumentBinding expressionBinding(Expression expression)
         {
-            return new ArgumentBinding(requireNonNull(column, "column is null"), null);
+            return new ArgumentBinding(requireNonNull(expression, "expression is null"), null);
         }
 
         public static ArgumentBinding constantBinding(NullableValue constant)
@@ -275,13 +311,19 @@ public final class Partitioning
 
         public boolean isVariable()
         {
-            return column != null;
+            return expression instanceof SymbolReference;
+        }
+
+        public Symbol getColumn()
+        {
+            verify(expression instanceof SymbolReference, "Expect the expression to be a SymbolReference");
+            return Symbol.from(expression);
         }
 
         @JsonProperty
-        public Symbol getColumn()
+        public Expression getExpression()
         {
-            return column;
+            return expression;
         }
 
         @JsonProperty
@@ -295,25 +337,31 @@ public final class Partitioning
             if (isConstant()) {
                 return this;
             }
-            return columnBinding(translator.apply(column));
+            return expressionBinding(translator.apply(Symbol.from(expression)).toSymbolReference());
         }
 
-        public Optional<ArgumentBinding> translate(Function<Symbol, Optional<Symbol>> translator, Function<Symbol, Optional<NullableValue>> constants)
+        public Optional<ArgumentBinding> translate(Translator translator)
         {
             if (isConstant()) {
                 return Optional.of(this);
             }
 
-            Optional<ArgumentBinding> newColumn = translator.apply(column)
-                    .map(ArgumentBinding::columnBinding);
+            if (!isVariable()) {
+                return translator.expressionTranslator.apply(expression)
+                        .map(Symbol::toSymbolReference)
+                        .map(ArgumentBinding::expressionBinding);
+            }
+
+            Optional<ArgumentBinding> newColumn = translator.columnTranslator.apply(Symbol.from(expression))
+                    .map(Symbol::toSymbolReference)
+                    .map(ArgumentBinding::expressionBinding);
             if (newColumn.isPresent()) {
                 return newColumn;
             }
-
             // As a last resort, check for a constant mapping for the symbol
             // Note: this MUST be last because we want to favor the symbol representation
             // as it makes further optimizations possible.
-            return constants.apply(column)
+            return translator.constantTranslator.apply(Symbol.from(expression))
                     .map(ArgumentBinding::constantBinding);
         }
 
@@ -323,7 +371,8 @@ public final class Partitioning
             if (constant != null) {
                 return constant.toString();
             }
-            return "\"" + column + "\"";
+
+            return expression.toString();
         }
 
         @Override
@@ -336,14 +385,14 @@ public final class Partitioning
                 return false;
             }
             ArgumentBinding that = (ArgumentBinding) o;
-            return Objects.equals(column, that.column) &&
+            return Objects.equals(expression, that.expression) &&
                     Objects.equals(constant, that.constant);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(column, constant);
+            return Objects.hash(expression, constant);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PreferredProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PreferredProperties.java
@@ -391,7 +391,7 @@ class PreferredProperties
                 return Optional.of(new PartitioningProperties(newPartitioningColumns, Optional.empty(), nullsAndAnyReplicated));
             }
 
-            Optional<Partitioning> newPartitioning = partitioning.get().translate(translator, symbol -> Optional.empty());
+            Optional<Partitioning> newPartitioning = partitioning.get().translate(new Partitioning.Translator(translator, symbol -> Optional.empty(), coalesceSymbols -> Optional.empty()));
             if (!newPartitioning.isPresent()) {
                 return Optional.empty();
             }

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -309,7 +309,8 @@ public final class GraphvizPrinter
         public Void visitExchange(ExchangeNode node, Void context)
         {
             List<ArgumentBinding> symbols = node.getOutputSymbols().stream()
-                    .map(ArgumentBinding::columnBinding)
+                    .map(Symbol::toSymbolReference)
+                    .map(ArgumentBinding::expressionBinding)
                     .collect(toImmutableList());
             if (node.getType() == REPARTITION) {
                 symbols = node.getPartitioningScheme().getPartitioning().getArguments();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestFullOuterJoinWithCoalesce.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestFullOuterJoinWithCoalesce.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
+
+public class TestFullOuterJoinWithCoalesce
+        extends BasePlanTest
+{
+    @Test
+    public void testFullOuterJoinWithCoalesce()
+    {
+        assertDistributedPlan("SELECT coalesce(ts.a, r.a) " +
+                "FROM (" +
+                "   SELECT coalesce(t.a, s.a) AS a " +
+                "   FROM (VALUES (1), (2), (3)) t(a) " +
+                "   FULL OUTER JOIN (VALUES (1), (4)) s(a)" +
+                "   ON t.a = s.a) ts " +
+                "FULL OUTER JOIN (VALUES (2), (5)) r(a) on ts.a = r.a",
+                anyTree(
+                        project(
+                                ImmutableMap.of("expr", expression("coalesce(ts, r)")),
+                                join(
+                                        FULL,
+                                        ImmutableList.of(equiJoinClause("ts", "r")),
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("ts", expression("coalesce(t, s)")),
+                                                        join(
+                                                                FULL,
+                                                                ImmutableList.of(equiJoinClause("t", "s")),
+                                                                exchange(REMOTE, REPARTITION, anyTree(values(ImmutableList.of("t")))),
+                                                                exchange(LOCAL, GATHER, anyTree(values(ImmutableList.of("s"))))))),
+                                        exchange(LOCAL, GATHER, anyTree(values(ImmutableList.of("r"))))))));
+    }
+}


### PR DESCRIPTION
For full outer join, if both sides of the equi-join contains all partitioning columns,
the output of the join would be partitioned on coalesce of these columns.