### PR TITLE
Fix integer overflow when turning dictionary into direct

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.airlift.units.DataSize;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -29,8 +30,12 @@ public class OrcWriterOptions
     private static final int DEFAULT_STRIPE_MAX_ROW_COUNT = 10_000_000;
     private static final int DEFAULT_ROW_GROUP_MAX_ROW_COUNT = 10_000;
     private static final DataSize DEFAULT_DICTIONARY_MAX_MEMORY = new DataSize(16, MEGABYTE);
-    public static final DataSize DEFAULT_MAX_STRING_STATISTICS_LIMIT = new DataSize(64, BYTE);
-    private static final DataSize DEFAULT_MAX_COMPRESSION_BUFFER_SIZE = new DataSize(256, KILOBYTE);
+
+    @VisibleForTesting
+    static final DataSize DEFAULT_MAX_STRING_STATISTICS_LIMIT = new DataSize(64, BYTE);
+
+    @VisibleForTesting
+    static final DataSize DEFAULT_MAX_COMPRESSION_BUFFER_SIZE = new DataSize(256, KILOBYTE);
 
     private final DataSize stripeMinSize;
     private final DataSize stripeMaxSize;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSliceDictionaryColumnWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSliceDictionaryColumnWriter.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.writer.SliceDictionaryColumnWriter;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_MAX_COMPRESSION_BUFFER_SIZE;
+import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_MAX_STRING_STATISTICS_LIMIT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.Math.toIntExact;
+import static org.testng.Assert.assertFalse;
+
+public class TestSliceDictionaryColumnWriter
+{
+    @Test
+    public void testDirectConversion()
+    {
+        SliceDictionaryColumnWriter writer = new SliceDictionaryColumnWriter(
+                0,
+                VARCHAR,
+                CompressionKind.NONE,
+                toIntExact(DEFAULT_MAX_COMPRESSION_BUFFER_SIZE.toBytes()),
+                OrcEncoding.ORC,
+                DEFAULT_MAX_STRING_STATISTICS_LIMIT);
+
+        // a single row group exceeds 2G after direct conversion
+        byte[] value = new byte[megabytes(1)];
+        ThreadLocalRandom.current().nextBytes(value);
+        Block data = RunLengthEncodedBlock.create(VARCHAR, Slices.wrappedBuffer(value), 3000);
+        writer.beginRowGroup();
+        writer.writeBlock(data);
+        writer.finishRowGroup();
+
+        assertFalse(writer.tryConvertToDirect(megabytes(64)).isPresent());
+    }
+
+    private static int megabytes(int size)
+    {
+        return toIntExact(new DataSize(size, MEGABYTE).toBytes());
+    }
+}


### PR DESCRIPTION
Turning dictionary into direct in ORC writer can end up with writing
huge data.
eb6028d8a8e3758cfc5f66cecf237eb1fa750643 tries to fix this by
checking the written size after converting each row group. However,
in certain cases a single row group already exceed 2G after converting
into direct. For example, a varchar column repeated with a single
value with length around 500k.

This commit fixed this by checking the written size after each batch of
write.

Fixes https://github.com/prestodb/presto/issues/11930