### PR TITLE
Use list instead of map for bucket-to-node

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedBucketNodeMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedBucketNodeMap.java
@@ -15,47 +15,36 @@ package com.facebook.presto.execution.scheduler;
 
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.Node;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 
-import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.ToIntFunction;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 // the bucket to node mapping is fixed and pre-assigned
 public class FixedBucketNodeMap
         extends BucketNodeMap
 {
-    private final Map<Integer, Node> bucketToNode;
-    private final int bucketCount;
+    private final List<Node> bucketToNode;
 
-    public FixedBucketNodeMap(ToIntFunction<Split> splitToBucket, Map<Integer, Node> bucketToNode)
+    public FixedBucketNodeMap(ToIntFunction<Split> splitToBucket, List<Node> bucketToNode)
     {
         super(splitToBucket);
-        requireNonNull(bucketToNode, "bucketToNode is null");
-        this.bucketToNode = ImmutableMap.copyOf(bucketToNode);
-        bucketCount = bucketToNode.keySet().stream()
-                .mapToInt(Integer::intValue)
-                .max()
-                .getAsInt() + 1;
+        this.bucketToNode = ImmutableList.copyOf(requireNonNull(bucketToNode, "bucketToNode is null"));
     }
 
     @Override
     public Optional<Node> getAssignedNode(int bucketedId)
     {
-        checkArgument(bucketedId >= 0 && bucketedId < bucketCount);
-        Node node = bucketToNode.get(bucketedId);
-        verify(node != null);
-        return Optional.of(node);
+        return Optional.of(bucketToNode.get(bucketedId));
     }
 
     @Override
     public int getBucketCount()
     {
-        return bucketCount;
+        return bucketToNode.size();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedCountScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedCountScheduler.java
@@ -19,8 +19,8 @@ import com.facebook.presto.spi.Node;
 import com.google.common.annotations.VisibleForTesting;
 
 import java.util.List;
-import java.util.Map;
 import java.util.OptionalInt;
+import java.util.stream.IntStream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
@@ -34,9 +34,9 @@ public class FixedCountScheduler
     }
 
     private final TaskScheduler taskScheduler;
-    private final Map<Integer, Node> partitionToNode;
+    private final List<Node> partitionToNode;
 
-    public FixedCountScheduler(SqlStageExecution stage, Map<Integer, Node> partitionToNode)
+    public FixedCountScheduler(SqlStageExecution stage, List<Node> partitionToNode)
     {
         requireNonNull(stage, "stage is null");
         this.taskScheduler = stage::scheduleTask;
@@ -44,7 +44,7 @@ public class FixedCountScheduler
     }
 
     @VisibleForTesting
-    public FixedCountScheduler(TaskScheduler taskScheduler, Map<Integer, Node> partitionToNode)
+    public FixedCountScheduler(TaskScheduler taskScheduler, List<Node> partitionToNode)
     {
         this.taskScheduler = requireNonNull(taskScheduler, "taskScheduler is null");
         this.partitionToNode = requireNonNull(partitionToNode, "partitionToNode is null");
@@ -54,8 +54,8 @@ public class FixedCountScheduler
     public ScheduleResult schedule()
     {
         OptionalInt totalPartitions = OptionalInt.of(partitionToNode.size());
-        List<RemoteTask> newTasks = partitionToNode.entrySet().stream()
-                .map(entry -> taskScheduler.scheduleTask(entry.getValue(), entry.getKey(), totalPartitions))
+        List<RemoteTask> newTasks = IntStream.range(0, partitionToNode.size())
+                .mapToObj(partition -> taskScheduler.scheduleTask(partitionToNode.get(partition), partition, totalPartitions))
                 .collect(toImmutableList());
 
         return new ScheduleResult(true, newTasks, 0);

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -69,7 +69,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.stream.IntStream;
 
 import static com.facebook.presto.SystemSessionProperties.getConcurrentLifespansPerNode;
 import static com.facebook.presto.SystemSessionProperties.getWriterMinSize;
@@ -325,14 +324,7 @@ public class SqlQueryScheduler
                     if (groupedExecutionForStage) {
                         checkState(connectorPartitionHandles.size() == nodePartitionMap.getBucketToPartition().length);
                     }
-                    Map<Integer, Node> partitionToNode = nodePartitionMap.getPartitionToNode();
-                    stageNodeList = IntStream.range(0, partitionToNode.size())
-                            .mapToObj(id -> {
-                                Node node = partitionToNode.get(id);
-                                verify(node != null);
-                                return node;
-                            })
-                            .collect(toImmutableList());
+                    stageNodeList = nodePartitionMap.getPartitionToNode();
                     bucketNodeMap = nodePartitionMap.asBucketNodeMap();
                     bucketToPartition = Optional.of(nodePartitionMap.getBucketToPartition());
                 }
@@ -352,7 +344,7 @@ public class SqlQueryScheduler
             else {
                 // all sources are remote
                 NodePartitionMap nodePartitionMap = partitioningCache.apply(plan.getFragment().getPartitioning());
-                Map<Integer, Node> partitionToNode = nodePartitionMap.getPartitionToNode();
+                List<Node> partitionToNode = nodePartitionMap.getPartitionToNode();
                 // todo this should asynchronously wait a standard timeout period before failing
                 checkCondition(!partitionToNode.isEmpty(), NO_NODES_AVAILABLE, "No worker nodes available");
                 stageSchedulers.put(stageId, new FixedCountScheduler(stage, partitionToNode));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SystemPartitioningHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SystemPartitioningHandle.java
@@ -29,7 +29,6 @@ import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
 import java.util.Objects;
@@ -154,12 +153,7 @@ public final class SystemPartitioningHandle
 
         checkCondition(!nodes.isEmpty(), NO_NODES_AVAILABLE, "No worker nodes available");
 
-        ImmutableMap.Builder<Integer, Node> partitionToNode = ImmutableMap.builder();
-        for (int i = 0; i < nodes.size(); i++) {
-            Node node = nodes.get(i);
-            partitionToNode.put(i, node);
-        }
-        return new NodePartitionMap(partitionToNode.build(), split -> {
+        return new NodePartitionMap(nodes, split -> {
             throw new UnsupportedOperationException("System distribution does not support source splits");
         });
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
@@ -21,15 +21,16 @@ import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.metadata.PrestoNode;
 import com.facebook.presto.spi.Node;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
-import java.util.Map;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.IntStream;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -89,12 +90,10 @@ public class TestFixedCountScheduler
         assertEquals(result.getNewTasks().stream().map(RemoteTask::getNodeId).collect(toImmutableSet()).size(), 5);
     }
 
-    private static Map<Integer, Node> generateRandomNodes(int count)
+    private static List<Node> generateRandomNodes(int count)
     {
-        ImmutableMap.Builder<Integer, Node> nodes = ImmutableMap.builder();
-        for (int i = 0; i < count; i++) {
-            nodes.put(i, new PrestoNode("other " + i, URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN, false));
-        }
-        return nodes.build();
+        return IntStream.range(0, count)
+                .mapToObj(i -> new PrestoNode("other " + i, URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN, false))
+                .collect(toImmutableList());
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorNodePartitioningProvider.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorNodePartitioningProvider.java
@@ -23,13 +23,12 @@ import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 
 import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.function.ToIntFunction;
 
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
@@ -55,13 +54,13 @@ public class RaptorNodePartitioningProvider
 
         Map<String, Node> nodesById = uniqueIndex(nodeSupplier.getWorkerNodes(), Node::getNodeIdentifier);
 
-        ImmutableMap.Builder<Integer, Node> bucketToNode = ImmutableMap.builder();
-        for (Entry<Integer, String> entry : handle.getBucketToNode().entrySet()) {
-            Node node = nodesById.get(entry.getValue());
+        ImmutableList.Builder<Node> bucketToNode = ImmutableList.builder();
+        for (String nodeIdentifier : handle.getBucketToNode()) {
+            Node node = nodesById.get(nodeIdentifier);
             if (node == null) {
-                throw new PrestoException(NO_NODES_AVAILABLE, "Node for bucket is offline: " + entry.getValue());
+                throw new PrestoException(NO_NODES_AVAILABLE, "Node for bucket is offline: " + nodeIdentifier);
             }
-            bucketToNode.put(entry.getKey(), node);
+            bucketToNode.add(node);
         }
         return createBucketNodeMap(bucketToNode.build());
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorPartitioningHandle.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorPartitioningHandle.java
@@ -16,9 +16,9 @@ package com.facebook.presto.raptor;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 
-import java.util.Map;
+import java.util.List;
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
@@ -27,15 +27,15 @@ public class RaptorPartitioningHandle
         implements ConnectorPartitioningHandle
 {
     private final long distributionId;
-    private final Map<Integer, String> bucketToNode;
+    private final List<String> bucketToNode;
 
     @JsonCreator
     public RaptorPartitioningHandle(
             @JsonProperty("distributionId") long distributionId,
-            @JsonProperty("bucketToNode") Map<Integer, String> bucketToNode)
+            @JsonProperty("bucketToNode") List<String> bucketToNode)
     {
         this.distributionId = distributionId;
-        this.bucketToNode = ImmutableMap.copyOf(requireNonNull(bucketToNode, "bucketToNode is null"));
+        this.bucketToNode = ImmutableList.copyOf(requireNonNull(bucketToNode, "bucketToNode is null"));
     }
 
     @JsonProperty
@@ -45,7 +45,7 @@ public class RaptorPartitioningHandle
     }
 
     @JsonProperty
-    public Map<Integer, String> getBucketToNode()
+    public List<String> getBucketToNode()
     {
         return bucketToNode;
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplitManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplitManager.java
@@ -102,7 +102,7 @@ public class RaptorSplitManager
         boolean bucketed = table.getBucketCount().isPresent();
         boolean merged = bucketed && !table.isDelete() && (table.getBucketCount().getAsInt() >= getOneSplitPerBucketThreshold(session));
         OptionalLong transactionId = table.getTransactionId();
-        Optional<Map<Integer, String>> bucketToNode = handle.getPartitioning().map(RaptorPartitioningHandle::getBucketToNode);
+        Optional<List<String>> bucketToNode = handle.getPartitioning().map(RaptorPartitioningHandle::getBucketToNode);
         verify(bucketed == bucketToNode.isPresent(), "mismatched bucketCount and bucketToNode presence");
         return new RaptorSplitSource(tableId, merged, effectivePredicate, transactionId, bucketToNode);
     }
@@ -138,7 +138,7 @@ public class RaptorSplitManager
         private final long tableId;
         private final TupleDomain<RaptorColumnHandle> effectivePredicate;
         private final OptionalLong transactionId;
-        private final Optional<Map<Integer, String>> bucketToNode;
+        private final Optional<List<String>> bucketToNode;
         private final ResultIterator<BucketShards> iterator;
 
         @GuardedBy("this")
@@ -149,7 +149,7 @@ public class RaptorSplitManager
                 boolean merged,
                 TupleDomain<RaptorColumnHandle> effectivePredicate,
                 OptionalLong transactionId,
-                Optional<Map<Integer, String>> bucketToNode)
+                Optional<List<String>> bucketToNode)
         {
             this.tableId = tableId;
             this.effectivePredicate = requireNonNull(effectivePredicate, "effectivePredicate is null");

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
@@ -27,7 +27,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
@@ -82,6 +81,7 @@ import static com.facebook.presto.spi.StandardErrorCode.SERVER_STARTING_UP;
 import static com.facebook.presto.spi.StandardErrorCode.TRANSACTION_CONFLICT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.partition;
 import static java.lang.Boolean.TRUE;
 import static java.lang.Math.multiplyExact;
@@ -116,7 +116,7 @@ public class DatabaseShardManager
             .maximumSize(10_000)
             .build(CacheLoader.from(this::loadNodeId));
 
-    private final LoadingCache<Long, Map<Integer, String>> bucketAssignmentsCache = CacheBuilder.newBuilder()
+    private final LoadingCache<Long, List<String>> bucketAssignmentsCache = CacheBuilder.newBuilder()
             .expireAfterWrite(1, SECONDS)
             .build(CacheLoader.from(this::loadBucketAssignments));
 
@@ -543,7 +543,7 @@ public class DatabaseShardManager
     }
 
     @Override
-    public ResultIterator<BucketShards> getShardNodesBucketed(long tableId, boolean merged, Map<Integer, String> bucketToNode, TupleDomain<RaptorColumnHandle> effectivePredicate)
+    public ResultIterator<BucketShards> getShardNodesBucketed(long tableId, boolean merged, List<String> bucketToNode, TupleDomain<RaptorColumnHandle> effectivePredicate)
     {
         return new ShardIterator(tableId, merged, Optional.of(bucketToNode), effectivePredicate, dbi);
     }
@@ -604,7 +604,7 @@ public class DatabaseShardManager
     }
 
     @Override
-    public Map<Integer, String> getBucketAssignments(long distributionId)
+    public List<String> getBucketAssignments(long distributionId)
     {
         try {
             return bucketAssignmentsCache.getUnchecked(distributionId);
@@ -669,13 +669,13 @@ public class DatabaseShardManager
         return dao.getBucketNodes(distributionId);
     }
 
-    private Map<Integer, String> loadBucketAssignments(long distributionId)
+    private List<String> loadBucketAssignments(long distributionId)
     {
         Set<String> nodeIds = getNodeIdentifiers();
         List<BucketNode> bucketNodes = getBuckets(distributionId);
         BucketReassigner reassigner = new BucketReassigner(nodeIds, bucketNodes);
 
-        ImmutableMap.Builder<Integer, String> assignments = ImmutableMap.builder();
+        List<String> assignments = new ArrayList<>(nCopies(bucketNodes.size(), null));
         PrestoException limiterException = null;
         Set<String> offlineNodes = new HashSet<>();
 
@@ -706,14 +706,14 @@ public class DatabaseShardManager
                 log.info("Reassigned bucket %s for distribution ID %s from %s to %s", bucket, distributionId, oldNodeId, nodeId);
             }
 
-            assignments.put(bucket, nodeId);
+            verify(assignments.set(bucket, nodeId) == null, "Duplicate bucket");
         }
 
         if (limiterException != null) {
             throw limiterException;
         }
 
-        return assignments.build();
+        return ImmutableList.copyOf(assignments);
     }
 
     private Set<String> getNodeIdentifiers()

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardIterator.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardIterator.java
@@ -54,7 +54,7 @@ final class ShardIterator
     private final Map<Integer, String> nodeMap = new HashMap<>();
 
     private final boolean merged;
-    private final Map<Integer, String> bucketToNode;
+    private final List<String> bucketToNode;
     private final ShardDao dao;
     private final Connection connection;
     private final PreparedStatement statement;
@@ -64,7 +64,7 @@ final class ShardIterator
     public ShardIterator(
             long tableId,
             boolean merged,
-            Optional<Map<Integer, String>> bucketToNode,
+            Optional<List<String>> bucketToNode,
             TupleDomain<RaptorColumnHandle> effectivePredicate,
             IDBI dbi)
     {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
@@ -75,7 +75,7 @@ public interface ShardManager
     /**
      * Return the shard nodes for a bucketed table.
      */
-    ResultIterator<BucketShards> getShardNodesBucketed(long tableId, boolean merged, Map<Integer, String> bucketToNode, TupleDomain<RaptorColumnHandle> effectivePredicate);
+    ResultIterator<BucketShards> getShardNodesBucketed(long tableId, boolean merged, List<String> bucketToNode, TupleDomain<RaptorColumnHandle> effectivePredicate);
 
     /**
      * Remove all old shard assignments and assign a shard to a node
@@ -107,7 +107,7 @@ public interface ShardManager
     /**
      * Get map of buckets to node identifiers for a distribution.
      */
-    Map<Integer, String> getBucketAssignments(long distributionId);
+    List<String> getBucketAssignments(long distributionId);
 
     /**
      * Change the node a bucket is assigned to.

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
@@ -384,9 +384,9 @@ public class TestDatabaseShardManager
 
         shardManager.createBuckets(distributionId, bucketCount);
 
-        Map<Integer, String> assignments = shardManager.getBucketAssignments(distributionId);
+        List<String> assignments = shardManager.getBucketAssignments(distributionId);
         assertEquals(assignments.size(), bucketCount);
-        assertEquals(ImmutableSet.copyOf(assignments.values()), nodeIds(originalNodes));
+        assertEquals(ImmutableSet.copyOf(assignments), nodeIds(originalNodes));
 
         Set<Node> newNodes = ImmutableSet.of(node1, node3);
         shardManager = createShardManager(dbi, () -> newNodes, ticker);
@@ -402,14 +402,14 @@ public class TestDatabaseShardManager
         ticker.increment(2, DAYS);
         assignments = shardManager.getBucketAssignments(distributionId);
         assertEquals(assignments.size(), bucketCount);
-        assertEquals(ImmutableSet.copyOf(assignments.values()), nodeIds(newNodes));
+        assertEquals(ImmutableSet.copyOf(assignments), nodeIds(newNodes));
 
         Set<Node> singleNode = ImmutableSet.of(node1);
         shardManager = createShardManager(dbi, () -> singleNode, ticker);
         ticker.increment(2, DAYS);
         assignments = shardManager.getBucketAssignments(distributionId);
         assertEquals(assignments.size(), bucketCount);
-        assertEquals(ImmutableSet.copyOf(assignments.values()), nodeIds(singleNode));
+        assertEquals(ImmutableSet.copyOf(assignments), nodeIds(singleNode));
     }
 
     @Test
@@ -431,7 +431,7 @@ public class TestDatabaseShardManager
         List<ColumnInfo> columns = ImmutableList.of(new ColumnInfo(1, BIGINT));
         shardManager.createTable(tableId, columns, true, OptionalLong.empty());
 
-        try (ResultIterator<BucketShards> iterator = shardManager.getShardNodesBucketed(tableId, true, ImmutableMap.of(), TupleDomain.all())) {
+        try (ResultIterator<BucketShards> iterator = shardManager.getShardNodesBucketed(tableId, true, ImmutableList.of(), TupleDomain.all())) {
             assertFalse(iterator.hasNext());
         }
     }


### PR DESCRIPTION
A list is better because the mapping is contiguous.