### PR TITLE
Add minor state check to PartitionedLookupSourceFactory

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSourceFactory.java
@@ -151,6 +151,7 @@ public final class PartitionedLookupSourceFactory
     {
         lock.writeLock().lock();
         try {
+            checkState(!destroyed.isDone(), "already destroyed");
             if (lookupSourceSupplier != null) {
                 return immediateFuture(new SpillAwareLookupSourceProvider());
             }


### PR DESCRIPTION
PartitionedLookupSourceFactory#createLookupSourceProvider() should be
called before the factory is destroyed. Otherwise, the returned future
will never complete.