### PR TITLE
Optimize ARRAY_UNION

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
@@ -118,6 +118,14 @@ public class TypedSet
         return blockPositionByHash.get(getHashPositionOfElement(block, position));
     }
 
+    public Block getBlock()
+    {
+        if (containsNullElement) {
+            elementBlock.appendNull();
+        }
+        return elementBlock.build();
+    }
+
     /**
      * Get slot position of element at {@code position} of {@code block}
      */

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -1131,11 +1131,17 @@ public class TestArrayOperators
     @Test
     public void testArrayUnion()
     {
+        assertFunction("ARRAY_UNION(ARRAY [], ARRAY [])", new ArrayType(UNKNOWN), asList());
+        assertFunction("ARRAY_UNION(ARRAY [NULL], ARRAY [])", new ArrayType(UNKNOWN), singletonList(null));
+        assertFunction("ARRAY_UNION(ARRAY [TRUE, NULL, TRUE], ARRAY [NULL, TRUE, NULL, NULL, FALSE])", new ArrayType(BOOLEAN), asList(null, true, false));
+        assertFunction("ARRAY_UNION(ARRAY [TRUE, NULL], ARRAY [])", new ArrayType(BOOLEAN), asList(null, true));
+        assertFunction("ARRAY_UNION(ARRAY [cast(0 as bigint), NULL, cast(12 as bigint), NULL], ARRAY [NULL, cast(10 as bigint), NULL, NULL])", new ArrayType(BIGINT), asList(0L, null, 12L, 10L));
+        assertFunction("ARRAY_UNION(ARRAY [cast(0 as bigint), cast(0 as bigint), NULL, cast(12 as bigint), NULL], ARRAY [NULL, cast(10 as bigint), NULL, NULL])", new ArrayType(BIGINT), asList(0L, null, 12L, 10L));
         assertFunction("ARRAY_UNION(ARRAY [cast(10 as bigint), NULL, cast(12 as bigint), NULL], ARRAY [NULL, cast(10 as bigint), NULL, NULL])", new ArrayType(BIGINT), asList(10L, null, 12L));
         assertFunction("ARRAY_UNION(ARRAY [12], ARRAY [10])", new ArrayType(INTEGER), ImmutableList.of(12, 10));
         assertFunction("ARRAY_UNION(ARRAY ['foo', 'bar', 'baz'], ARRAY ['foo', 'test', 'bar'])", new ArrayType(createVarcharType(4)), ImmutableList.of("foo", "bar", "baz", "test"));
         assertFunction("ARRAY_UNION(ARRAY [NULL], ARRAY [NULL, NULL])", new ArrayType(UNKNOWN), asList((Object) null));
-        assertFunction("ARRAY_UNION(ARRAY ['abc', NULL, 'xyz', NULL], ARRAY [NULL, 'abc', NULL, NULL])", new ArrayType(createVarcharType(3)), asList("abc", null, "xyz"));
+        assertFunction("ARRAY_UNION(ARRAY ['abc', NULL, 'xyz', NULL], ARRAY [NULL, 'abc', NULL, NULL])", new ArrayType(createVarcharType(3)), asList("abc", "xyz", null));
         assertFunction("ARRAY_UNION(ARRAY [1, 5], ARRAY [1])", new ArrayType(INTEGER), ImmutableList.of(1, 5));
         assertFunction("ARRAY_UNION(ARRAY [1, 1, 2, 4], ARRAY [1, 1, 4, 4])", new ArrayType(INTEGER), ImmutableList.of(1, 2, 4));
         assertFunction("ARRAY_UNION(ARRAY [2, 8], ARRAY [8, 3])", new ArrayType(INTEGER), ImmutableList.of(2, 8, 3));


### PR DESCRIPTION
ARRAY_UNION can directly use the elementBlock in TypedSet as result.
This will reduce GC pressure and also improve performance. We also
provided specialization for Boolean type.

JMH benchmark before the change:
Benchmark                            (type)  Mode  Cnt   Score   Error  Units
BenchmarkArrayUnion.arrayUnion   BIGINT  avgt   20   43.703 ± 5.171  ns/op
BenchmarkArrayUnion.arrayUnion  VARCHAR  avgt   20   85.907 ± 3.745  ns/op
BenchmarkArrayUnion.arrayUnion   DOUBLE  avgt   20  113.791 ± 7.881  ns/op
BenchmarkArrayUnion.arrayIntersect  BOOLEAN  avgt   20  16.238 ± 0.359  ns/op

After:
Benchmark                       (type)  Mode  Cnt   Score   Error  Units
BenchmarkArrayUnion.arrayUnion   BIGINT  avgt   20  44.041 ± 5.132  ns/op
BenchmarkArrayUnion.arrayUnion  VARCHAR  avgt   20  75.538 ± 1.896  ns/op
BenchmarkArrayUnion.arrayUnion   DOUBLE  avgt   20  67.694 ± 6.582  ns/op
BenchmarkArrayUnion.arrayUnion  BOOLEAN  avgt   20  3.717 ± 0.282  ns/op