### PR TITLE
Fix assertion in tryUpdateUserMemory method

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/DefaultQueryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/DefaultQueryContext.java
@@ -196,7 +196,11 @@ public class DefaultQueryContext
     {
         if (delta <= 0) {
             ListenableFuture<?> future = updateUserMemory(allocationTag, delta);
-            verify(future.isDone(), "future should be done");
+            // When delta == 0 and the pool is full the future can still not be done,
+            // but, for negative deltas it must always be done.
+            if (delta < 0) {
+                verify(future.isDone(), "future should be done");
+            }
             return true;
         }
         if (queryMemoryContext.getUserMemory() + delta > maxUserMemory) {

--- a/presto-main/src/main/java/com/facebook/presto/memory/LegacyQueryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/LegacyQueryContext.java
@@ -164,7 +164,11 @@ public class LegacyQueryContext
     {
         if (delta <= 0) {
             ListenableFuture<?> future = updateUserMemory(allocationTag, delta);
-            verify(future.isDone(), "future should be done");
+            // When delta == 0 and the pool is full the future can still not be done,
+            // but, for negative deltas it must always be done.
+            if (delta < 0) {
+                verify(future.isDone(), "future should be done");
+            }
             return true;
         }
         if (queryMemoryContext.getUserMemory() + delta > maxMemory) {

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
@@ -329,6 +329,16 @@ public class TestMemoryTracking
     }
 
     @Test
+    public void testTrySetZeroBytesFullPool()
+    {
+        LocalMemoryContext localMemoryContext = operatorContext.localUserMemoryContext();
+        // fill up the pool
+        memoryPool.reserve(new QueryId("test_query"), "test", memoryPool.getFreeBytes());
+        // try to reserve 0 bytes in the full pool
+        assertTrue(localMemoryContext.trySetBytes(localMemoryContext.getBytes()));
+    }
+
+    @Test
     public void testDestroy()
     {
         LocalMemoryContext newLocalSystemMemoryContext = operatorContext.newLocalSystemMemoryContext("test");


### PR DESCRIPTION
When DefaultQueryContext::tryUpdateUserMemory() is called with a delta
of 0 and when the general pool is full, the updateUserMemory call will
return a future that's not done. However, tryUpdateUserMemory was simply
assuming that for that case the future must be done and asserting on
that, which causes query failures. This change fixes that.

It makes sense for updateUserMemory to return a future that's not done
when we reserve 0 bytes and the pool is full, so that the caller knows
that the pool is full and waits on that future to make the next
reservation. Therefore, for the delta == 0 case it's not correct to
simply assume that future returned from updateUserMemory is done.

Fixes #12040