### PR TITLE
Fix TestColumnarPageProcessor

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/TestColumnarPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestColumnarPageProcessor.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.PageFunctionCompiler;
 import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -41,8 +42,14 @@ public class TestColumnarPageProcessor
     private static final int POSITIONS = 100;
     private final List<Type> types = ImmutableList.of(BIGINT, VARCHAR);
     private final MetadataManager metadata = createTestMetadataManager();
-    private final PageProcessor processor = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0))
-            .compilePageProcessor(Optional.empty(), ImmutableList.of(field(0, types.get(0)), field(1, types.get(1))), MAX_BATCH_SIZE).get();
+    private PageProcessor processor;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        processor = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0))
+                .compilePageProcessor(Optional.empty(), ImmutableList.of(field(0, types.get(0)), field(1, types.get(1))), MAX_BATCH_SIZE).get();
+    }
 
     @Test
     public void testProcess()


### PR DESCRIPTION
When TestColumnarPageProcessor test methods run concurrently it's
possible to see test failures due to the exception below as multiple
threads will be sharing the PageProcessor instance (hence the
ExpressionProfiler instance). This change fixes that by creating a new
PageProcessor for each test method.

com.google.common.base.VerifyException: start() is not called
	at com.google.common.base.Verify.verify(Verify.java:123)
	at com.facebook.presto.sql.gen.ExpressionProfiler.stop(ExpressionProfiler.java:59)