### PR TITLE
Add suppressed exceptions to tear down exceptions in verifier

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/QueryResult.java
@@ -18,6 +18,8 @@ import io.airlift.units.Duration;
 
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public class QueryResult
@@ -72,5 +74,12 @@ public class QueryResult
     public List<List<Object>> getResults()
     {
         return results;
+    }
+
+    public void addSuppressed(Throwable throwable)
+    {
+        checkState(exception != null, "exception is null");
+        checkArgument(throwable != null, "throwable is null");
+        exception.addSuppressed(throwable);
     }
 }


### PR DESCRIPTION
Otherwise, when we have failures in setup or query run, tear down
failures will hide them. This change makes sure that we retain that
information in those cases.