### PR TITLE
Add missing @Nullable annotations

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.spi.block;
 
+import javax.annotation.Nullable;
+
 import static com.facebook.presto.spi.block.ArrayBlock.createArrayBlockInternal;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
@@ -29,6 +31,7 @@ public abstract class AbstractArrayBlock
 
     protected abstract int getOffsetBase();
 
+    @Nullable
     protected abstract boolean[] getValueIsNull();
 
     int getOffset(int position)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
@@ -70,6 +70,7 @@ public abstract class AbstractMapBlock
      */
     protected abstract int getOffsetBase();
 
+    @Nullable
     protected abstract boolean[] getMapIsNull();
 
     protected abstract void ensureHashTableLoaded();


### PR DESCRIPTION
`ArrayBlock#getValueIsNull()` is `@Nullable`, so
`AbstractArrayBlock#getValueIsNull()` should also be annotated as such.
Same for `AbstractMapBlock#getMapIsNull()` and
`MapBlock#getMapIsNull()`.