### PR TITLE
Add basic TupleDomain#toString

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/TupleDomain.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/TupleDomain.java
@@ -328,6 +328,18 @@ public final class TupleDomain<T>
         return Objects.hash(domains);
     }
 
+    @Override
+    public String toString()
+    {
+        if (isAll()) {
+            return "TupleDomain{ALL}";
+        }
+        if (isNone()) {
+            return "TupleDomain{NONE}";
+        }
+        return "TupleDomain{...}";
+    }
+
     public String toString(ConnectorSession session)
     {
         StringBuilder buffer = new StringBuilder();


### PR DESCRIPTION
While proper `toString` requires `ConnectorSession`, a basic `toString`
is still helpful when debugging.