### PR TITLE
[WIP] Adding support for case sensitive table names

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -62,6 +62,12 @@ public class JdbcMetadata
     }
 
     @Override
+    public boolean supportsCaseSensitiveIdentifier(ConnectorSession connectorSession)
+    {
+        return true;
+    }
+
+    @Override
     public boolean schemaExists(ConnectorSession session, String schemaName)
     {
         return jdbcClient.schemaExists(schemaName);
@@ -129,10 +135,11 @@ public class JdbcMetadata
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
         List<SchemaTableName> tables;
         if (prefix.getTableName() != null) {
-            tables = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+            tables = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName(),
+                    prefix.getOriginalSchemaName(), prefix.getOriginalTableName()));
         }
         else {
-            tables = listTables(session, prefix.getSchemaName());
+            tables = listTables(session, prefix.getOriginalSchemaName());
         }
         for (SchemaTableName tableName : tables) {
             try {

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraTableHandle.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraTableHandle.java
@@ -60,7 +60,7 @@ public class CassandraTableHandle
 
     public SchemaTableName getSchemaTableName()
     {
-        return new SchemaTableName(schemaName, tableName);
+        return new SchemaTableName(schemaName, tableName, schemaName, tableName);
     }
 
     @Override

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxMetadata.java
@@ -86,6 +86,12 @@ public class JmxMetadata
     }
 
     @Override
+    public boolean supportsCaseSensitiveIdentifier(ConnectorSession session)
+    {
+        return true;
+    }
+
+    @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {
         return ImmutableList.of(JMX_SCHEMA_NAME, HISTORY_SCHEMA_NAME);
@@ -124,9 +130,9 @@ public class JmxMetadata
     private JmxTableHandle getJmxTableHandle(SchemaTableName tableName)
     {
         try {
-            String objectNamePattern = toPattern(tableName.getTableName().toLowerCase(ENGLISH));
+            String objectNamePattern = toPattern(tableName.getOriginalTableName());
             List<ObjectName> objectNames = mbeanServer.queryNames(WILDCARD, null).stream()
-                    .filter(name -> name.getCanonicalName().toLowerCase(ENGLISH).matches(objectNamePattern))
+                    .filter(name -> name.getCanonicalName().matches(objectNamePattern))
                     .collect(toImmutableList());
             if (objectNames.isEmpty()) {
                 return null;
@@ -195,7 +201,10 @@ public class JmxMetadata
             }
             else if (HISTORY_SCHEMA_NAME.equals(schema)) {
                 return jmxHistoricalData.getTables().stream()
-                        .map(tableName -> new SchemaTableName(JmxMetadata.HISTORY_SCHEMA_NAME, tableName))
+                        .map(tableName -> new SchemaTableName(JmxMetadata.HISTORY_SCHEMA_NAME,
+                                tableName,
+                                JmxMetadata.HISTORY_SCHEMA_NAME,
+                                tableName))
                         .collect(toList());
             }
         }
@@ -207,7 +216,10 @@ public class JmxMetadata
         Builder<SchemaTableName> tableNames = ImmutableList.builder();
         for (ObjectName objectName : mbeanServer.queryNames(WILDCARD, null)) {
             // todo remove lower case when presto supports mixed case names
-            tableNames.add(new SchemaTableName(JMX_SCHEMA_NAME, objectName.getCanonicalName().toLowerCase(ENGLISH)));
+            tableNames.add(new SchemaTableName(JMX_SCHEMA_NAME,
+                    objectName.getCanonicalName().toLowerCase(ENGLISH),
+                    JMX_SCHEMA_NAME,
+                    objectName.getCanonicalName()));
         }
         return tableNames.build();
     }

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxPeriodicSampler.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxPeriodicSampler.java
@@ -59,7 +59,10 @@ public class JmxPeriodicSampler
 
         for (String tableName : jmxHistoricalData.getTables()) {
             tableHandleBuilder.add(requireNonNull(
-                    jmxMetadata.getTableHandle(new SchemaTableName(JmxMetadata.HISTORY_SCHEMA_NAME, tableName)),
+                    jmxMetadata.getTableHandle(new SchemaTableName(JmxMetadata.HISTORY_SCHEMA_NAME,
+                            tableName,
+                            JmxMetadata.HISTORY_SCHEMA_NAME,
+                            tableName)),
                     format("tableHandle is null for table [%s]", tableName)));
         }
 
@@ -121,7 +124,7 @@ public class JmxPeriodicSampler
                             objectName,
                             tableHandle.getColumnHandles(),
                             dumpTimestamp);
-                    jmxHistoricalData.addRow(tableHandle.getTableName().getTableName(), row);
+                    jmxHistoricalData.addRow(tableHandle.getTableName().getOriginalTableName(), row);
                 }
             }
             catch (Exception exception) {

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxHistoricalData.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxHistoricalData.java
@@ -46,22 +46,4 @@ public class TestJmxHistoricalData
         jmxHistoricalData.addRow(TABLE_NAME, ImmutableList.of(42, "ala"));
         assertEquals(jmxHistoricalData.getRows(TABLE_NAME, bothColumns).size(), MAX_ENTRIES);
     }
-
-    @Test
-    public void testCaseInsensitive()
-    {
-        JmxHistoricalData jmxHistoricalData = new JmxHistoricalData(MAX_ENTRIES, ImmutableSet.of(TABLE_NAME.toUpperCase()));
-
-        List<Integer> columns = ImmutableList.of(0);
-        assertEquals(jmxHistoricalData.getRows(TABLE_NAME, columns), ImmutableList.of());
-        assertEquals(jmxHistoricalData.getRows(TABLE_NAME.toUpperCase(), columns), ImmutableList.of());
-
-        jmxHistoricalData.addRow(TABLE_NAME, ImmutableList.of(42));
-        jmxHistoricalData.addRow(TABLE_NAME.toUpperCase(), ImmutableList.of(44));
-
-        assertEquals(jmxHistoricalData.getRows(TABLE_NAME, columns), ImmutableList.of(
-                ImmutableList.<Object>of(42), ImmutableList.<Object>of(44)));
-        assertEquals(jmxHistoricalData.getRows(TABLE_NAME.toUpperCase(), columns), ImmutableList.of(
-                ImmutableList.<Object>of(42), ImmutableList.<Object>of(44)));
-    }
 }

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxMetadata.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxMetadata.java
@@ -27,17 +27,16 @@ import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
-import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestJmxMetadata
 {
     private static final String RUNTIME_OBJECT = "java.lang:type=Runtime";
-    private static final SchemaTableName RUNTIME_TABLE = new SchemaTableName(JMX_SCHEMA_NAME, RUNTIME_OBJECT.toLowerCase(ENGLISH));
-    private static final SchemaTableName RUNTIME_HISTORY_TABLE = new SchemaTableName(HISTORY_SCHEMA_NAME, RUNTIME_OBJECT.toLowerCase(ENGLISH));
+    private static final SchemaTableName RUNTIME_TABLE = new SchemaTableName(JMX_SCHEMA_NAME, RUNTIME_OBJECT, JMX_SCHEMA_NAME, RUNTIME_OBJECT);
+    private static final SchemaTableName RUNTIME_HISTORY_TABLE = new SchemaTableName(HISTORY_SCHEMA_NAME, RUNTIME_OBJECT, HISTORY_SCHEMA_NAME, RUNTIME_OBJECT);
 
-    private final JmxMetadata metadata = new JmxMetadata(getPlatformMBeanServer(), new JmxHistoricalData(1000, ImmutableSet.of(RUNTIME_OBJECT.toLowerCase(ENGLISH))));
+    private final JmxMetadata metadata = new JmxMetadata(getPlatformMBeanServer(), new JmxHistoricalData(1000, ImmutableSet.of(RUNTIME_OBJECT)));
 
     @Test
     public void testListSchemas()
@@ -48,6 +47,7 @@ public class TestJmxMetadata
     @Test
     public void testListTables()
     {
+        System.out.println(metadata.listTables(SESSION, JMX_SCHEMA_NAME) + " " + RUNTIME_TABLE.getOriginalTableName());
         assertTrue(metadata.listTables(SESSION, JMX_SCHEMA_NAME).contains(RUNTIME_TABLE));
         assertTrue(metadata.listTables(SESSION, HISTORY_SCHEMA_NAME).contains(RUNTIME_HISTORY_TABLE));
     }
@@ -90,9 +90,13 @@ public class TestJmxMetadata
         assertTrue(columns.contains(new JmxColumnHandle("Name", createUnboundedVarcharType())));
         assertTrue(columns.contains(new JmxColumnHandle("StartTime", BIGINT)));
 
-        assertTrue(metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "*java.lang:type=Runtime*")).getObjectNames().contains(RUNTIME_OBJECT));
-        assertTrue(metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "java.lang:*=Runtime")).getObjectNames().contains(RUNTIME_OBJECT));
-        assertTrue(metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "*")).getObjectNames().contains(RUNTIME_OBJECT));
-        assertTrue(metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "*:*")).getObjectNames().contains(RUNTIME_OBJECT));
+        assertTrue(metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "*java.lang:type=Runtime*",
+                JMX_SCHEMA_NAME, "*java.lang:type=Runtime*")).getObjectNames().contains(RUNTIME_OBJECT));
+        assertTrue(metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "java.lang:*=Runtime",
+                JMX_SCHEMA_NAME, "java.lang:*=Runtime")).getObjectNames().contains(RUNTIME_OBJECT));
+        assertTrue(metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "*",
+                JMX_SCHEMA_NAME, "*")).getObjectNames().contains(RUNTIME_OBJECT));
+        assertTrue(metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "*:*",
+                JMX_SCHEMA_NAME, "*:*")).getObjectNames().contains(RUNTIME_OBJECT));
     }
 }

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxQueries.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxQueries.java
@@ -18,14 +18,12 @@ import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
-import java.util.Locale;
 import java.util.Set;
 
 import static com.facebook.presto.connector.informationSchema.InformationSchemaMetadata.INFORMATION_SCHEMA;
 import static com.facebook.presto.connector.jmx.JmxMetadata.HISTORY_SCHEMA_NAME;
 import static com.facebook.presto.connector.jmx.JmxMetadata.JMX_SCHEMA_NAME;
 import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -57,9 +55,7 @@ public class TestJmxQueries
     @Test
     public void testShowTables()
     {
-        Set<String> standardNamesLower = STANDARD_NAMES.stream()
-                .map(name -> name.toLowerCase(Locale.ENGLISH))
-                .collect(toImmutableSet());
+        Set<String> standardNamesLower = ImmutableSet.copyOf(STANDARD_NAMES);
         MaterializedResult result = computeActual("SHOW TABLES");
         assertTrue(result.getOnlyColumnAsSet().containsAll(standardNamesLower));
     }
@@ -85,8 +81,8 @@ public class TestJmxQueries
     public void testOrderOfParametersIsIgnored()
     {
         assertEqualsIgnoreOrder(
-                computeActual("SELECT node FROM \"java.nio:type=bufferpool,name=direct\""),
-                computeActual("SELECT node FROM \"java.nio:name=direct,type=bufferpool\""));
+                computeActual("SELECT node FROM \"java.nio:type=BufferPool,name=direct\""),
+                computeActual("SELECT node FROM \"java.nio:name=direct,type=BufferPool\""));
     }
 
     @Test
@@ -95,6 +91,7 @@ public class TestJmxQueries
         computeActual("SELECT * FROM \"*:*\"");
         computeActual("SELECT * FROM \"java.util.logging:*\"");
         assertTrue(computeActual("SELECT * FROM \"java.lang:*\"").getRowCount() > 1);
-        assertTrue(computeActual("SELECT * FROM \"jAVA.LANg:*\"").getRowCount() > 1);
+        assertQueryFails("SELECT * FROM \"jAVA.LANg:*\"",
+                "line 1:15: Table jmx.current.java.lang:\\* does not exist");
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaPageSourceProvider.java
@@ -138,8 +138,8 @@ public class InformationSchemaPageSourceProvider
                     }
                     table.add(
                             prefix.getCatalogName(),
-                            tableName.getSchemaName(),
-                            tableName.getTableName(),
+                            tableName.getOriginalSchemaName(),
+                            tableName.getOriginalTableName(),
                             column.getName(),
                             ordinalPosition,
                             null,
@@ -166,8 +166,8 @@ public class InformationSchemaPageSourceProvider
                 String type = views.contains(name) ? "VIEW" : "BASE TABLE";
                 table.add(
                         prefix.getCatalogName(),
-                        name.getSchemaName(),
-                        name.getTableName(),
+                        name.getOriginalSchemaName(),
+                        name.getOriginalTableName(),
                         type);
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/QualifiedObjectName.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/QualifiedObjectName.java
@@ -46,6 +46,9 @@ public class QualifiedObjectName
     private final String catalogName;
     private final String schemaName;
     private final String objectName;
+    private final String originalSchemaName;
+    private final String originalObjectName;
+    private final boolean isCaseSensitive;
 
     public QualifiedObjectName(String catalogName, String schemaName, String objectName)
     {
@@ -53,6 +56,23 @@ public class QualifiedObjectName
         this.catalogName = catalogName;
         this.schemaName = schemaName;
         this.objectName = objectName;
+        this.originalSchemaName = schemaName;
+        this.originalObjectName = objectName;
+        this.isCaseSensitive = false;
+    }
+
+    public QualifiedObjectName(String catalogName,
+            String schemaName, String objectName,
+            String originalSchemaName, String originalObjectName)
+    {
+        checkObjectName(catalogName, schemaName, objectName);
+        this.catalogName = catalogName;
+        this.schemaName = schemaName;
+        this.objectName = objectName;
+        this.originalSchemaName = originalSchemaName;
+        this.originalObjectName = originalObjectName;
+        this.isCaseSensitive = !(this.schemaName.equals(originalSchemaName) &&
+                this.objectName.equals(originalObjectName));
     }
 
     public String getCatalogName()
@@ -70,19 +90,34 @@ public class QualifiedObjectName
         return objectName;
     }
 
+    public String getOriginalSchemaName()
+    {
+        return originalSchemaName;
+    }
+
+    public String getOriginalObjectName()
+    {
+        return originalObjectName;
+    }
+
+    public boolean isCaseSensitive()
+    {
+        return isCaseSensitive;
+    }
+
     public SchemaTableName asSchemaTableName()
     {
-        return new SchemaTableName(schemaName, objectName);
+        return new SchemaTableName(schemaName, objectName, originalSchemaName, originalObjectName);
     }
 
     public CatalogSchemaTableName asCatalogSchemaTableName()
     {
-        return new CatalogSchemaTableName(catalogName, schemaName, objectName);
+        return new CatalogSchemaTableName(catalogName, asSchemaTableName());
     }
 
     public QualifiedTablePrefix asQualifiedTablePrefix()
     {
-        return new QualifiedTablePrefix(catalogName, schemaName, objectName);
+        return new QualifiedTablePrefix(catalogName, schemaName, objectName, originalSchemaName, originalObjectName);
     }
 
     @Override
@@ -97,13 +132,15 @@ public class QualifiedObjectName
         QualifiedObjectName o = (QualifiedObjectName) obj;
         return Objects.equals(catalogName, o.catalogName) &&
                 Objects.equals(schemaName, o.schemaName) &&
-                Objects.equals(objectName, o.objectName);
+                Objects.equals(objectName, o.objectName) &&
+                Objects.equals(originalSchemaName, o.originalSchemaName) &&
+                Objects.equals(originalObjectName, o.originalObjectName);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(catalogName, schemaName, objectName);
+        return Objects.hash(catalogName, schemaName, objectName, originalSchemaName, originalObjectName);
     }
 
     @JsonValue
@@ -115,6 +152,6 @@ public class QualifiedObjectName
 
     public static Function<SchemaTableName, QualifiedObjectName> convertFromSchemaTableName(String catalogName)
     {
-        return input -> new QualifiedObjectName(catalogName, input.getSchemaName(), input.getTableName());
+        return input -> new QualifiedObjectName(catalogName, input.getSchemaName(), input.getTableName(), input.getOriginalSchemaName(), input.getOriginalTableName());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
@@ -476,8 +476,7 @@ public class IOPlanPrinter
             context.addInputTableColumnInfo(new IOPlan.TableColumnInfo(
                     new CatalogSchemaTableName(
                             tableMetadata.getConnectorId().getCatalogName(),
-                            tableMetadata.getTable().getSchemaName(),
-                            tableMetadata.getTable().getTableName()),
+                            tableMetadata.getTable()),
                     parseConstraints(node.getTable(), node.getCurrentConstraint())));
             return null;
         }
@@ -490,22 +489,19 @@ public class IOPlanPrinter
                 CreateHandle createHandle = (CreateHandle) writerTarget;
                 context.setOutputTable(new CatalogSchemaTableName(
                         createHandle.getHandle().getConnectorId().getCatalogName(),
-                        createHandle.getSchemaTableName().getSchemaName(),
-                        createHandle.getSchemaTableName().getTableName()));
+                        createHandle.getSchemaTableName()));
             }
             else if (writerTarget instanceof InsertHandle) {
                 InsertHandle insertHandle = (InsertHandle) writerTarget;
                 context.setOutputTable(new CatalogSchemaTableName(
                         insertHandle.getHandle().getConnectorId().getCatalogName(),
-                        insertHandle.getSchemaTableName().getSchemaName(),
-                        insertHandle.getSchemaTableName().getTableName()));
+                        insertHandle.getSchemaTableName()));
             }
             else if (writerTarget instanceof DeleteHandle) {
                 DeleteHandle deleteHandle = (DeleteHandle) writerTarget;
                 context.setOutputTable(new CatalogSchemaTableName(
                         deleteHandle.getHandle().getConnectorId().getCatalogName(),
-                        deleteHandle.getSchemaTableName().getSchemaName(),
-                        deleteHandle.getSchemaTableName().getTableName()));
+                        deleteHandle.getSchemaTableName()));
             }
             else if (writerTarget instanceof CreateName || writerTarget instanceof InsertReference) {
                 throw new IllegalStateException(format("%s should not appear in final plan", writerTarget.getClass().getSimpleName()));

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -1830,11 +1830,15 @@ class AstBuilder
 
     private QualifiedName getQualifiedName(SqlBaseParser.QualifiedNameContext context)
     {
-        List<String> parts = visit(context.identifier(), Identifier.class).stream()
+        List<Identifier> identifierList = visit(context.identifier(), Identifier.class);
+        List<String> parts = identifierList.stream()
                 .map(Identifier::getValue) // TODO: preserve quotedness
                 .collect(Collectors.toList());
+        List<Boolean> isCaseSensitive = identifierList.stream()
+                .map(Identifier::isDelimited)
+                .collect(toList());
 
-        return QualifiedName.of(parts);
+        return QualifiedName.of(parts, isCaseSensitive);
     }
 
     private static boolean isDistinct(SqlBaseParser.SetQuantifierContext setQuantifier)

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/JmxConnectorTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/JmxConnectorTests.java
@@ -29,7 +29,7 @@ public class JmxConnectorTests
     @Test(groups = {JMX_CONNECTOR, JDBC})
     public void selectFromJavaRuntimeJmxMBean()
     {
-        String sql = "SELECT node, vmname, vmversion FROM jmx.current.\"java.lang:type=runtime\"";
+        String sql = "SELECT node, vmname, vmversion FROM jmx.current.\"java.lang:type=Runtime\"";
         assertThat(query(sql))
                 .hasColumns(VARCHAR, VARCHAR, VARCHAR)
                 .hasAnyRows();
@@ -39,7 +39,7 @@ public class JmxConnectorTests
     public void selectFromJavaOperatingSystemJmxMBean()
     {
         assertThat(query("SELECT openfiledescriptorcount, maxfiledescriptorcount " +
-                "FROM jmx.current.\"java.lang:type=operatingsystem\""))
+                "FROM jmx.current.\"java.lang:type=OperatingSystem\""))
                 .hasColumns(BIGINT, BIGINT)
                 .hasAnyRows();
     }

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/catalog/showTables.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/catalog/showTables.result
@@ -1,7 +1,7 @@
 -- delimiter: |; ignoreOrder: true; ignoreExcessRows:true;
-java.lang:type=classloading|
-java.lang:type=compilation|
-java.lang:type=memory|
-java.lang:type=operatingsystem|
-java.lang:type=runtime|
-java.lang:type=threading|
+java.lang:type=Classloading|
+java.lang:type=Compilation|
+java.lang:type=Memory|
+java.lang:type=OperatingSystem|
+java.lang:type=Runtime|
+java.lang:type=Threading|

--- a/presto-spi/src/main/java/com/facebook/presto/spi/CatalogSchemaName.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/CatalogSchemaName.java
@@ -22,11 +22,23 @@ public final class CatalogSchemaName
 {
     private final String catalogName;
     private final String schemaName;
+    private final String originalSchemaName;
+    private final boolean isSchemaCaseSensitive;
 
     public CatalogSchemaName(String catalogName, String schemaName)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null").toLowerCase(ENGLISH);
         this.schemaName = requireNonNull(schemaName, "schemaName is null").toLowerCase(ENGLISH);
+        this.originalSchemaName = this.schemaName;
+        this.isSchemaCaseSensitive = false;
+    }
+
+    public CatalogSchemaName(String catalogName, String schemaName, String originalSchemaName)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null").toLowerCase(ENGLISH);
+        this.schemaName = requireNonNull(schemaName, "schemaName is null").toLowerCase(ENGLISH);
+        this.originalSchemaName = requireNonNull(originalSchemaName, "originalSchemaName is null");
+        this.isSchemaCaseSensitive = !this.schemaName.equals(this.originalSchemaName);
     }
 
     public String getCatalogName()
@@ -37,6 +49,16 @@ public final class CatalogSchemaName
     public String getSchemaName()
     {
         return schemaName;
+    }
+
+    public String getOriginalSchemaName()
+    {
+        return originalSchemaName;
+    }
+
+    public boolean isSchemaCaseSensitive()
+    {
+        return isSchemaCaseSensitive;
     }
 
     @Override
@@ -50,13 +72,14 @@ public final class CatalogSchemaName
         }
         CatalogSchemaName that = (CatalogSchemaName) obj;
         return Objects.equals(catalogName, that.catalogName) &&
-                Objects.equals(schemaName, that.schemaName);
+                Objects.equals(schemaName, that.schemaName) &&
+                Objects.equals(originalSchemaName, that.originalSchemaName);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(catalogName, schemaName);
+        return Objects.hash(catalogName, schemaName, originalSchemaName);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/SchemaTableName.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SchemaTableName.java
@@ -25,12 +25,25 @@ public class SchemaTableName
 {
     private final String schemaName;
     private final String tableName;
+    private final String originalSchemaName;
+    private final String originalTableName;
 
     @JsonCreator
-    public SchemaTableName(@JsonProperty("schema") String schemaName, @JsonProperty("table") String tableName)
+    public SchemaTableName(@JsonProperty("schema") String schemaName, @JsonProperty("table") String tableName,
+            @JsonProperty("originalSchema") String originalSchemaName, @JsonProperty("originalTable") String originalTableName)
     {
         this.schemaName = checkNotEmpty(schemaName, "schemaName").toLowerCase(ENGLISH);
         this.tableName = checkNotEmpty(tableName, "tableName").toLowerCase(ENGLISH);
+        this.originalSchemaName = checkNotEmpty(originalSchemaName, "actualSchemaName");
+        this.originalTableName = checkNotEmpty(originalTableName, "actualTableName");
+    }
+
+    public SchemaTableName(String schemaName, String tableName)
+    {
+        this.schemaName = checkNotEmpty(schemaName, "schemaName").toLowerCase(ENGLISH);
+        this.tableName = checkNotEmpty(tableName, "tableName").toLowerCase(ENGLISH);
+        this.originalSchemaName = this.schemaName;
+        this.originalTableName = this.tableName;
     }
 
     @JsonProperty("schema")
@@ -45,10 +58,22 @@ public class SchemaTableName
         return tableName;
     }
 
+    @JsonProperty("originalSchema")
+    public String getOriginalSchemaName()
+    {
+        return originalSchemaName;
+    }
+
+    @JsonProperty("originalTable")
+    public String getOriginalTableName()
+    {
+        return originalTableName;
+    }
+
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName);
+        return Objects.hash(schemaName, tableName, originalSchemaName, originalTableName);
     }
 
     @Override
@@ -62,7 +87,9 @@ public class SchemaTableName
         }
         final SchemaTableName other = (SchemaTableName) obj;
         return Objects.equals(this.schemaName, other.schemaName) &&
-                Objects.equals(this.tableName, other.tableName);
+                Objects.equals(this.tableName, other.tableName) &&
+                Objects.equals(this.originalSchemaName, other.originalSchemaName) &&
+                Objects.equals(this.originalTableName, other.originalTableName);
     }
 
     @Override
@@ -73,6 +100,6 @@ public class SchemaTableName
 
     public SchemaTablePrefix toSchemaTablePrefix()
     {
-        return new SchemaTablePrefix(schemaName, tableName);
+        return new SchemaTablePrefix(schemaName, tableName, originalSchemaName, originalTableName);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/SchemaTablePrefix.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SchemaTablePrefix.java
@@ -23,23 +23,41 @@ public class SchemaTablePrefix
     private final String schemaName;
     /* nullable */
     private final String tableName;
+    /* nullable */
+    private final String originalSchemaName;
+    /* nullable */
+    private final String orignialTableName;
 
     public SchemaTablePrefix()
     {
         this.schemaName = null;
         this.tableName = null;
+        this.originalSchemaName = null;
+        this.orignialTableName = null;
     }
 
     public SchemaTablePrefix(String schemaName)
     {
         this.schemaName = checkNotEmpty(schemaName, "schemaName");
         this.tableName = null;
+        this.originalSchemaName = this.schemaName;
+        this.orignialTableName = null;
     }
 
     public SchemaTablePrefix(String schemaName, String tableName)
     {
         this.schemaName = checkNotEmpty(schemaName, "schemaName");
         this.tableName = checkNotEmpty(tableName, "tableName");
+        this.originalSchemaName = schemaName;
+        this.orignialTableName = tableName;
+    }
+
+    public SchemaTablePrefix(String schemaName, String tableName, String originalSchemaName, String orignialTableName)
+    {
+        this.schemaName = checkNotEmpty(schemaName, "schemaName");
+        this.tableName = checkNotEmpty(tableName, "tableName");
+        this.originalSchemaName = checkNotEmpty(originalSchemaName, "actualSchemaName");
+        this.orignialTableName = checkNotEmpty(orignialTableName, "actualTableName");
     }
 
     public String getSchemaName()
@@ -52,6 +70,16 @@ public class SchemaTablePrefix
         return tableName;
     }
 
+    public String getOriginalSchemaName()
+    {
+        return originalSchemaName;
+    }
+
+    public String getOriginalTableName()
+    {
+        return orignialTableName;
+    }
+
     public boolean matches(SchemaTableName schemaTableName)
     {
         // null schema name matches everything
@@ -59,11 +87,13 @@ public class SchemaTablePrefix
             return true;
         }
 
-        if (!schemaName.equals(schemaTableName.getSchemaName())) {
+        if (!(schemaName.equals(schemaTableName.getSchemaName())
+                && originalSchemaName.equals(schemaTableName.getOriginalSchemaName()))) {
             return false;
         }
 
-        return tableName == null || tableName.equals(schemaTableName.getTableName());
+        return tableName == null || tableName.equals(schemaTableName.getTableName()) &&
+                orignialTableName == null || orignialTableName.equals(schemaTableName.getOriginalTableName());
     }
 
     public SchemaTableName toSchemaTableName()
@@ -71,13 +101,13 @@ public class SchemaTablePrefix
         if (schemaName == null || tableName == null) {
             throw new IllegalStateException("both schemaName and tableName must be set");
         }
-        return new SchemaTableName(schemaName, tableName);
+        return new SchemaTableName(schemaName, tableName, originalSchemaName, orignialTableName);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName);
+        return Objects.hash(schemaName, tableName, originalSchemaName, orignialTableName);
     }
 
     @Override
@@ -91,7 +121,9 @@ public class SchemaTablePrefix
         }
         final SchemaTablePrefix other = (SchemaTablePrefix) obj;
         return Objects.equals(this.schemaName, other.schemaName) &&
-                Objects.equals(this.tableName, other.tableName);
+                Objects.equals(this.tableName, other.tableName) &&
+                Objects.equals(this.originalSchemaName, other.originalSchemaName) &&
+                Objects.equals(this.orignialTableName, other.orignialTableName);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -56,6 +56,15 @@ import static java.util.stream.Collectors.toList;
 public interface ConnectorMetadata
 {
     /**
+     * Checks whether the connector supports querying case sensitive
+     * tables
+     */
+    default boolean supportsCaseSensitiveIdentifier(ConnectorSession session)
+    {
+        return false;
+    }
+
+    /**
      * Checks if a schema exists. The connector may have schemas that exist
      * but are not enumerable via {@link #listSchemaNames}.
      */

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -64,6 +64,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public boolean supportsCaseSensitiveIdentifier(ConnectorSession session)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.supportsCaseSensitiveIdentifier(session);
+        }
+    }
+
+    @Override
     public List<ConnectorTableLayoutResult> getTableLayouts(
             ConnectorSession session,
             ConnectorTableHandle table,

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4057,7 +4057,8 @@ public abstract class AbstractTestQueries
     @Test
     public void testQuotedIdentifiers()
     {
-        assertQuery("SELECT \"TOTALPRICE\" \"my price\" FROM \"ORDERS\"");
+        assertQueryFails("SELECT \"TOTALPRICE\" \"my price\" FROM \"ORDERS\"",
+                "line 1:[0-9]+: Table [a-z]+.[a-zA-Z]+.orders does not exist");
     }
 
     @Test

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
@@ -22,15 +22,12 @@ import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder;
-import com.facebook.presto.transaction.TransactionBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.util.List;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.execution.QueryState.FAILED;
@@ -137,18 +134,5 @@ public class TestMetadataManager
         // cancel query
         queryManager.cancelQuery(queryId);
         assertEquals(metadataManager.getCatalogsByQueryId().size(), 0);
-    }
-
-    @Test
-    public void testUpperCaseSchemaIsChangedToLowerCase()
-    {
-        TransactionBuilder.transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())
-                .execute(
-                        TEST_SESSION,
-                        transactionSession -> {
-                            List<String> expectedSchemas = ImmutableList.of("information_schema", "upper_case_schema");
-                            assertEquals(queryRunner.getMetadata().listSchemaNames(transactionSession, "upper_case_schema_catalog"), expectedSchemas);
-                            return null;
-                        });
     }
 }


### PR DESCRIPTION
Work in Progress.
Currently Presto doesn't have support for case-sensitive table names (#2863). Here we try to add support for the same by passing the actual schema/table name which is obtained from `QualifiedName` where we maintain both the  actual table/schema name and also the transformed one(transformed to lower case). We just need to pass it to the connector over `SchemaTableName` so now the Connector will have access both to the actual schema/table name and also to the transformed one and it can decide accordingly. Here we have added support only for `Select` queries if this approach looks good then we can add support for the other kind of queries and will update the test suite for the same. 