### PR TITLE
WIP - Change TypedSet to HashTable for array functions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/HashTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/HashTable.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.base.Verify;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
+import static com.facebook.presto.type.TypeUtils.hashPosition;
+import static com.facebook.presto.type.TypeUtils.positionEqualsPosition;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static it.unimi.dsi.fastutil.HashCommon.arraySize;
+import static java.util.Objects.isNull;
+import static java.util.Objects.requireNonNull;
+
+public class HashTable
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(TypedSet.class).instanceSize();
+    private static final float FILL_RATIO = 0.75f;
+    private static final int EMPTY_SLOT = -1;
+
+    private final Type type;
+    private final Block block;
+
+    private int[] positionByHash;
+    private int hashCapacity;
+    private int maxFill;
+    private int hashMask;
+    private int size;
+
+    public HashTable(Type type, Block block, int expectedSize)
+    {
+        this.type = requireNonNull(type, "type is null");
+        this.block = requireNonNull(block, "block is null");
+        checkArgument(expectedSize >= 0, "expectedSize is negative");
+
+        hashCapacity = arraySize(expectedSize, FILL_RATIO);
+
+        maxFill = calculateMaxFill(hashCapacity);
+        hashMask = hashCapacity - 1;
+        positionByHash = new int[hashCapacity];
+        Arrays.fill(positionByHash, EMPTY_SLOT);
+    }
+
+    public boolean contains(Block block, int position)
+    {
+        checkArgument(!isNull(block), "block is null");
+        checkArgument(position >= 0, "position is negative");
+        return positionByHash[getHashPosition(block, position)] != EMPTY_SLOT;
+    }
+
+    public boolean addIfAbsent(Block block, int position)
+    {
+        checkArgument(!isNull(block), "block is null");
+        checkArgument(position >= 0, "position is negative");
+        int hashPosition = getHashPosition(block, position);
+        if (positionByHash[hashPosition] == EMPTY_SLOT) {
+            if (this.block instanceof BlockBuilder) {
+                BlockBuilder blockBuilder = (BlockBuilder) this.block;
+                type.appendTo(block, position, blockBuilder);
+                int positionInBuilder = blockBuilder.getPositionCount() - 1;
+                positionByHash[hashPosition] = positionInBuilder;
+            }
+            else {
+                Verify.verify(block == this.block);
+                positionByHash[hashPosition] = position;
+            }
+
+            size++;
+            if (size >= maxFill) {
+                rehash();
+            }
+
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+    public Block getBlock()
+    {
+        if (block instanceof BlockBuilder) {
+            return ((BlockBuilder) block).build();
+        }
+
+        int[] positions = new int[size];
+        int j = 0;
+        for (int i = 0; i < positionByHash.length; i++) {
+            int blockPosition = positionByHash[i];
+            if (blockPosition != EMPTY_SLOT) {
+                positions[j++] = blockPosition;
+            }
+        }
+
+        return block.getPositions(positions, 0, size);
+    }
+
+    public int size()
+    {
+        return size;
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(positionByHash) + block.getRetainedSizeInBytes();
+    }
+
+    private int getHashPosition(Block block, int position)
+    {
+        int hashPosition = getMaskedHash(hashPosition(type, block, position));
+        while (true) {
+            if (positionByHash[hashPosition] == EMPTY_SLOT) {
+                return hashPosition;
+            }
+            // TODO: replace positionEqualsPosition to isDistinctFrom operator
+            else if (positionEqualsPosition(type, this.block, positionByHash[hashPosition], block, position)) {
+                return hashPosition;
+            }
+            hashPosition = getMaskedHash(hashPosition + 1);
+        }
+    }
+
+    private void rehash()
+    {
+        long newCapacityLong = hashCapacity * 2L;
+        if (newCapacityLong > Integer.MAX_VALUE) {
+            throw new PrestoException(GENERIC_INSUFFICIENT_RESOURCES, "Size of hash table cannot exceed 1 billion entries");
+        }
+        int newCapacity = (int) newCapacityLong;
+        hashCapacity = newCapacity;
+        hashMask = newCapacity - 1;
+        maxFill = calculateMaxFill(newCapacity);
+        int[] oldPositionByHash = positionByHash;
+        positionByHash = new int[newCapacity];
+        Arrays.fill(positionByHash, EMPTY_SLOT);
+        for (int position : oldPositionByHash) {
+            if (position != EMPTY_SLOT) {
+                positionByHash[getHashPosition(this.block, position)] = position;
+            }
+        }
+    }
+
+    private static int calculateMaxFill(int hashSize)
+    {
+        checkArgument(hashSize > 0, "hashSize must be greater than 0");
+        int maxFill = (int) Math.ceil(hashSize * FILL_RATIO);
+        if (maxFill == hashSize) {
+            maxFill--;
+        }
+        checkArgument(hashSize > maxFill, "hashSize must be larger than maxFill");
+        return maxFill;
+    }
+
+    private int getMaskedHash(long rawHash)
+    {
+        return (int) (rawHash & hashMask);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayIntersectFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayIntersectFunction.java
@@ -13,33 +13,21 @@
  */
 package com.facebook.presto.operator.scalar;
 
+import com.facebook.presto.operator.aggregation.HashTable;
 import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.Description;
-import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
-import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
-import it.unimi.dsi.fastutil.ints.AbstractIntComparator;
-import it.unimi.dsi.fastutil.ints.IntArrays;
-import it.unimi.dsi.fastutil.ints.IntComparator;
-
-import java.lang.invoke.MethodHandle;
-
-import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 
 @ScalarFunction("array_intersect")
 @Description("Intersects elements of the two given arrays")
 public final class ArrayIntersectFunction
 {
-    private static final int INITIAL_SIZE = 128;
-
-    private int[] leftPositions = new int[INITIAL_SIZE];
-    private int[] rightPositions = new int[INITIAL_SIZE];
     private final PageBuilder pageBuilder;
 
     @TypeParameter("E")
@@ -48,98 +36,48 @@ public final class ArrayIntersectFunction
         pageBuilder = new PageBuilder(ImmutableList.of(elementType));
     }
 
-    private static IntComparator intBlockCompare(Type type, Block block)
-    {
-        return new AbstractIntComparator()
-        {
-            @Override
-            public int compare(int left, int right)
-            {
-                if (block.isNull(left) && block.isNull(right)) {
-                    return 0;
-                }
-                if (block.isNull(left)) {
-                    return -1;
-                }
-                if (block.isNull(right)) {
-                    return 1;
-                }
-                return type.compareTo(block, left, block, right);
-            }
-        };
-    }
-
     @TypeParameter("E")
     @SqlType("array(E)")
     public Block intersect(
-            @OperatorDependency(operator = LESS_THAN, returnType = StandardTypes.BOOLEAN, argumentTypes = {"E", "E"}) MethodHandle lessThanFunction,
             @TypeParameter("E") Type type,
             @SqlType("array(E)") Block leftArray,
             @SqlType("array(E)") Block rightArray)
     {
-        int leftPositionCount = leftArray.getPositionCount();
+        if (leftArray.getPositionCount() < rightArray.getPositionCount()) {
+            Block tempArray = leftArray;
+            leftArray = rightArray;
+            rightArray = tempArray;
+        }
+
         int rightPositionCount = rightArray.getPositionCount();
 
-        if (leftPositionCount == 0) {
-            return leftArray;
-        }
         if (rightPositionCount == 0) {
             return rightArray;
-        }
-
-        if (leftPositions.length < leftPositionCount) {
-            leftPositions = new int[leftPositionCount];
-        }
-
-        if (rightPositions.length < rightPositionCount) {
-            rightPositions = new int[rightPositionCount];
         }
 
         if (pageBuilder.isFull()) {
             pageBuilder.reset();
         }
 
-        for (int i = 0; i < leftPositionCount; i++) {
-            leftPositions[i] = i;
-        }
+        HashTable rightHashTable = new HashTable(type, rightArray, rightPositionCount);
         for (int i = 0; i < rightPositionCount; i++) {
-            rightPositions[i] = i;
+            rightHashTable.addIfAbsent(rightArray, i);
         }
-        IntArrays.quickSort(leftPositions, 0, leftPositionCount, intBlockCompare(type, leftArray));
-        IntArrays.quickSort(rightPositions, 0, rightPositionCount, intBlockCompare(type, rightArray));
 
-        BlockBuilder resultBlockBuilder = pageBuilder.getBlockBuilder(0);
+        BlockBuilder leftBlockBuilder = pageBuilder.getBlockBuilder(0);
+        int positionCountBefore = leftBlockBuilder.getPositionCount();
 
-        int leftCurrentPosition = 0;
-        int rightCurrentPosition = 0;
-        int leftBasePosition;
-        int rightBasePosition;
-        int totalCount = 0;
-
-        while (leftCurrentPosition < leftPositionCount && rightCurrentPosition < rightPositionCount) {
-            leftBasePosition = leftCurrentPosition;
-            rightBasePosition = rightCurrentPosition;
-            int compareValue = type.compareTo(leftArray, leftPositions[leftCurrentPosition], rightArray, rightPositions[rightCurrentPosition]);
-            if (compareValue > 0) {
-                rightCurrentPosition++;
-            }
-            else if (compareValue < 0) {
-                leftCurrentPosition++;
-            }
-            else {
-                type.appendTo(leftArray, leftPositions[leftCurrentPosition], resultBlockBuilder);
-                leftCurrentPosition++;
-                rightCurrentPosition++;
-                totalCount++;
-                while (leftCurrentPosition < leftPositionCount && type.equalTo(leftArray, leftPositions[leftBasePosition], leftArray, leftPositions[leftCurrentPosition])) {
-                    leftCurrentPosition++;
-                }
-                while (rightCurrentPosition < rightPositionCount && type.equalTo(rightArray, rightPositions[rightBasePosition], rightArray, rightPositions[rightCurrentPosition])) {
-                    rightCurrentPosition++;
-                }
+        // The intersected set can have at most rightPositionCount elements
+        HashTable leftHashTable = new HashTable(type, leftBlockBuilder, rightPositionCount);
+        for (int i = 0; i < leftArray.getPositionCount(); i++) {
+            if (rightHashTable.contains(leftArray, i)) {
+                leftHashTable.addIfAbsent(leftArray, i);
             }
         }
-        pageBuilder.declarePositions(totalCount);
-        return resultBlockBuilder.getRegion(resultBlockBuilder.getPositionCount() - totalCount, totalCount);
+
+        int positionCountAfter = leftBlockBuilder.getPositionCount();
+        pageBuilder.declarePositions(positionCountAfter - positionCountBefore);
+
+        return leftHashTable.getBlock();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestHashTable.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestHashTable.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.block.BlockAssertions.createEmptyLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongSequenceBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static java.util.Collections.nCopies;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestHashTable
+{
+    private static final String FUNCTION_NAME = "typed_set_test";
+
+    @Test
+    public void testConstructor()
+    {
+        try {
+            //noinspection ResultOfObjectAllocationIgnored
+            BlockBuilder blockBuilder = BIGINT.createFixedSizeBlockBuilder(1);
+            new HashTable(null, blockBuilder, 1);
+            fail("Should throw exception if type is null");
+        }
+        catch (NullPointerException | IllegalArgumentException e) {
+            // ignored
+        }
+
+        try {
+            //noinspection ResultOfObjectAllocationIgnored
+            new HashTable(BIGINT, null, 1);
+            fail("Should throw exception if block is null");
+        }
+        catch (NullPointerException | IllegalArgumentException e) {
+            // ignored
+        }
+
+        BlockBuilder keys = VARCHAR.createBlockBuilder(null, 5);
+
+        for (int i = -2; i <= -1; i++) {
+            try {
+                //noinspection ResultOfObjectAllocationIgnored
+                BlockBuilder blockBuilder = BIGINT.createFixedSizeBlockBuilder(1);
+                new HashTable(BIGINT, blockBuilder, i);
+                fail("Should throw exception if expectedSize < 0");
+            }
+            catch (IllegalArgumentException e) {
+                // ignored
+            }
+        }
+    }
+
+    @Test
+    public void testBigintSimpleHashTable()
+    {
+        List<Integer> expectedSetSizes = ImmutableList.of(1, 10, 100, 1000);
+        List<Block> longBlocks =
+                ImmutableList.of(
+                        createEmptyLongsBlock(),
+                        createLongsBlock(1L),
+                        createLongsBlock(1L, 2L, 3L),
+                        createLongsBlock(1L, 2L, 3L, 1L, 2L, 3L),
+                        createLongsBlock(1L, null, 3L),
+                        createLongsBlock(null, null, null),
+                        createLongSequenceBlock(0, 100),
+                        createLongSequenceBlock(-100, 100),
+                        createLongsBlock(nCopies(1, null)),
+                        createLongsBlock(nCopies(100, null)),
+                        createLongsBlock(nCopies(expectedSetSizes.get(expectedSetSizes.size() - 1) * 2, null)),
+                        createLongsBlock(nCopies(expectedSetSizes.get(expectedSetSizes.size() - 1) * 2, 0L)));
+
+        for (int expectedSetSize : expectedSetSizes) {
+            for (Block block : longBlocks) {
+                testBigintBlock(block, expectedSetSize);
+                testBigintBlockBuilder(block, expectedSetSize);
+            }
+        }
+    }
+
+    private static void testBigintBlock(Block longBlock, int expectedSetSize)
+    {
+        HashTable hashTable = new HashTable(BIGINT, longBlock, longBlock.getPositionCount());
+        Set<Long> set = new HashSet<>();
+        for (int blockPosition = 0; blockPosition < longBlock.getPositionCount(); blockPosition++) {
+            long number = BIGINT.getLong(longBlock, blockPosition);
+            assertEquals(hashTable.contains(longBlock, blockPosition), set.contains(number));
+            assertEquals(hashTable.size(), set.size());
+
+            set.add(number);
+            hashTable.addIfAbsent(longBlock, blockPosition);
+
+            assertEquals(hashTable.contains(longBlock, blockPosition), set.contains(number));
+            assertEquals(hashTable.size(), set.size());
+        }
+    }
+
+    private static void testBigintBlockBuilder(Block longBlock, int expectedSetSize)
+    {
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, longBlock.getPositionCount());
+        HashTable hashTable = new HashTable(BIGINT, blockBuilder, longBlock.getPositionCount());
+        Set<Long> set = new HashSet<>();
+        for (int blockPosition = 0; blockPosition < longBlock.getPositionCount(); blockPosition++) {
+            long number = BIGINT.getLong(longBlock, blockPosition);
+            assertEquals(hashTable.contains(longBlock, blockPosition), set.contains(number));
+            assertEquals(hashTable.size(), set.size());
+
+            set.add(number);
+            hashTable.addIfAbsent(longBlock, blockPosition);
+
+            assertEquals(hashTable.contains(longBlock, blockPosition), set.contains(number));
+            assertEquals(hashTable.size(), set.size());
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -35,6 +35,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 import java.math.BigInteger;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -94,6 +95,16 @@ public abstract class AbstractTestFunctions
     protected void assertFunction(String projection, Type expectedType, Object expected)
     {
         functionAssertions.assertFunction(projection, expectedType, expected);
+    }
+
+    protected void assertFunctionWithSortedResults(String projection, Type expectedType, Object expected)
+    {
+        functionAssertions.assertFunctionWithSortedResults(projection, expectedType, expected);
+    }
+
+    protected void assertFunctionWithSortedResults(String projection, Type expectedType, Object expected, Comparator comparator)
+    {
+        functionAssertions.assertFunctionWithSortedResults(projection, expectedType, expected, comparator);
     }
 
     protected void assertOperator(OperatorType operator, String value, Type expectedType, Object expected)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayUnion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayUnion.java
@@ -65,13 +65,13 @@ import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 @Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.AverageTime)
-public class BenchmarkArrayDistinct
+public class BenchmarkArrayUnion
 {
-    private static final int POSITIONS = 1000;
+    private static final int POSITIONS = 1_000;
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS)
-    public List<Optional<Page>> arrayDistinct(BenchmarkData data)
+    public List<Optional<Page>> arrayUnion(BenchmarkData data)
     {
         return ImmutableList.copyOf(data.getPageProcessor().process(SESSION, new DriverYieldSignal(), data.getPage()));
     }
@@ -80,12 +80,12 @@ public class BenchmarkArrayDistinct
     @State(Scope.Thread)
     public static class BenchmarkData
     {
-        private String name = "array_distinct";
+        private String name = "array_union";
 
         @Param({"BIGINT", "VARCHAR", "DOUBLE", "BOOLEAN"})
         private String type = "BIGINT";
 
-        @Param({"10", "100", "1000"})
+        @Param({"10", "100", "1000", "10000"})
         private String arraySizeString = "100";
 
         private Page page;
@@ -97,7 +97,7 @@ public class BenchmarkArrayDistinct
             MetadataManager metadata = MetadataManager.createTestMetadataManager();
             ExpressionCompiler compiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
             ImmutableList.Builder<RowExpression> projectionsBuilder = ImmutableList.builder();
-            Block[] blocks = new Block[1];
+            Block[] blocks = new Block[2]; // create two blocks for each type
 
             Type elementType;
             switch (type) {
@@ -118,9 +118,11 @@ public class BenchmarkArrayDistinct
             }
 
             ArrayType arrayType = new ArrayType(elementType);
-            Signature signature = new Signature(name, FunctionKind.SCALAR, arrayType.getTypeSignature(), arrayType.getTypeSignature());
-            projectionsBuilder.add(new CallExpression(signature, arrayType, ImmutableList.of(field(0, arrayType))));
-            blocks[0] = createChannel(POSITIONS, Integer.parseInt(arraySizeString), elementType);
+            Signature signature = new Signature(name, FunctionKind.SCALAR, arrayType.getTypeSignature(), arrayType.getTypeSignature(), arrayType.getTypeSignature());
+            projectionsBuilder.add(new CallExpression(signature, arrayType, ImmutableList.of(field(0, arrayType), field(1, arrayType))));
+            int arraySize = Integer.parseInt(arraySizeString);
+            blocks[0] = createChannel(POSITIONS, arraySize, elementType);
+            blocks[1] = createChannel(POSITIONS, arraySize, elementType);
 
             ImmutableList<RowExpression> projections = projectionsBuilder.build();
             pageProcessor = compiler.compilePageProcessor(Optional.empty(), projections).get();
@@ -172,11 +174,11 @@ public class BenchmarkArrayDistinct
         // assure the benchmarks are valid before running
         BenchmarkData data = new BenchmarkData();
         data.setup();
-        new BenchmarkArrayDistinct().arrayDistinct(data);
+        new BenchmarkArrayUnion().arrayUnion(data);
 
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .include(".*" + BenchmarkArrayDistinct.class.getSimpleName() + ".*")
+                .include(".*" + BenchmarkArrayUnion.class.getSimpleName() + ".*")
                 .build();
         new Runner(options).run();
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -92,6 +92,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -261,6 +263,38 @@ public final class FunctionAssertions
         }
 
         Object actual = selectSingleValue(projection, expectedType, compiler);
+        assertEquals(actual, expected);
+    }
+
+    public void assertFunctionWithSortedResults(String projection, Type expectedType, Object expected)
+    {
+        if (expected instanceof Slice) {
+            expected = ((Slice) expected).toStringUtf8();
+        }
+
+        Object actual = selectSingleValue(projection, expectedType, compiler);
+        if (actual instanceof List) {
+            Collections.sort((List) actual);
+        }
+        else {
+            throw new AssertionError("Actual is supposed to be a List, but it's " + actual.getClass());
+        }
+        assertEquals(actual, expected);
+    }
+
+    public void assertFunctionWithSortedResults(String projection, Type expectedType, Object expected, Comparator comparator)
+    {
+        if (expected instanceof Slice) {
+            expected = ((Slice) expected).toStringUtf8();
+        }
+
+        Object actual = selectSingleValue(projection, expectedType, compiler);
+        if (actual instanceof List) {
+            Collections.sort((List) actual, comparator);
+        }
+        else {
+            throw new AssertionError("Actual is supposed to be a List, but it's " + actual.getClass());
+        }
         assertEquals(actual, expected);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -277,6 +277,7 @@ public class VariableWidthBlockBuilder
     private void growCapacity()
     {
         int newSize = BlockUtil.calculateNewArraySize(valueIsNull.length);
+        //System.out.println("newSize " + newSize + " current retained size " + getSizeInBytes());
         valueIsNull = Arrays.copyOf(valueIsNull, newSize);
         offsets = Arrays.copyOf(offsets, newSize + 1);
         updateArraysDataSize();


### PR DESCRIPTION
Resolves:
https://github.com/prestodb/presto/issues/11493
https://github.com/prestodb/presto/issues/11978
https://github.com/prestodb/presto/issues/11977

This commit rewrites ARRAY_INTERSECT, ARRAY_DISTINCT, ARRAY_UNION using
a new class HashTable to:
1) Improve performance and reduce memory consumption;
2) Fix the wrong results bug #11978 and #11977.

The HashTable class was adapted from JsonUtil#HashTable and TypedSet
with the following design considerations:

1) The HashTable can be created from an immutable Block or an empty
BlockBuilder. If the input is a Block, addIfAbsent() would only need to
update the hash table to add a new value. No additional memory copy is
needed. If the input if an empty BlockBuilder, addIfAbsent() would also
add the new input value to the BlockBuilder in addtion to updating the
hashtable. In either way, we avoided an extra memory copy. Note that the
check of the Block class type does introduce about 10%-30% performance
regression than using two seperate classes, but it is still showing gain
over TypedSet.

The class can return the result Block from the input Block or
BlockBuilder. If the input is BlockBuilder then a Block directly built
from it is returned. Otherwise the values for the positions present in
the hashtable is built and returned.

2) We tried to avoid hash recomputation from callers for contains and
add.

3) We allow the caller to pass in an estimated hashtable size to avoid
rehashing.

The JMH benchmarks were ran on Blocks of 1000 rows with 10, 100, 1000
array entries in each row. BIGINT, VARCHAR, DOUBLE, and BOOLEAN were
tested. Note that all numbers were not using type specialized code
even if they're present. This is to examine the effect of using the
new HashTable class only.

ARRAY_INTERSECT, Using sort (original):
Benchmark                               (arraySizeString)   (type)  Mode  Cnt        Score        Error  Units
BenchmarkArrayIntersect.arrayIntersect                 10   BIGINT  avgt   20      816.963 ±     19.150  ns/op
BenchmarkArrayIntersect.arrayIntersect                 10  VARCHAR  avgt   20     1437.385 ±     32.980  ns/op
BenchmarkArrayIntersect.arrayIntersect                 10   DOUBLE  avgt   20      741.172 ±     13.893  ns/op
BenchmarkArrayIntersect.arrayIntersect                 10  BOOLEAN  avgt   20      451.989 ±     12.216  ns/op
BenchmarkArrayIntersect.arrayIntersect                100   BIGINT  avgt   20    15009.721 ±    576.803  ns/op
BenchmarkArrayIntersect.arrayIntersect                100  VARCHAR  avgt   20    30356.848 ±    607.700  ns/op
BenchmarkArrayIntersect.arrayIntersect                100   DOUBLE  avgt   20    14211.824 ±    269.999  ns/op
BenchmarkArrayIntersect.arrayIntersect                100  BOOLEAN  avgt   20     2698.627 ±    152.828  ns/op
BenchmarkArrayIntersect.arrayIntersect               1000   BIGINT  avgt   20   192445.860 ±   2278.683  ns/op
BenchmarkArrayIntersect.arrayIntersect               1000  VARCHAR  avgt   20   321142.819 ±   7050.989  ns/op
BenchmarkArrayIntersect.arrayIntersect               1000   DOUBLE  avgt   20   203028.772 ±   4898.172  ns/op
BenchmarkArrayIntersect.arrayIntersect               1000  BOOLEAN  avgt   20    22854.985 ±    445.286  ns/op
BenchmarkArrayIntersect.arrayIntersect              10000   BIGINT  avgt   20  2548819.023 ±  50089.751  ns/op
BenchmarkArrayIntersect.arrayIntersect              10000  VARCHAR  avgt   20  2392899.264 ±  47861.656  ns/op
BenchmarkArrayIntersect.arrayIntersect              10000   DOUBLE  avgt   20  2703042.454 ± 104176.133  ns/op
BenchmarkArrayIntersect.arrayIntersect              10000  BOOLEAN  avgt   20   213666.313 ±   1954.165  ns/op

ARRAY_INTERSECT, Using TypedSet (As shown in PR #11984:
Benchmark                               (arraySizeString)   (type)  Mode  Cnt       Score      Error  Units
BenchmarkArrayIntersect.arrayIntersect                 10   BIGINT  avgt   20     744.993 ±   26.434  ns/op
BenchmarkArrayIntersect.arrayIntersect                 10  VARCHAR  avgt   20    1626.876 ±   80.488  ns/op
BenchmarkArrayIntersect.arrayIntersect                 10   DOUBLE  avgt   20     762.618 ±   18.264  ns/op
BenchmarkArrayIntersect.arrayIntersect                 10  BOOLEAN  avgt   20     563.116 ±   14.056  ns/op
BenchmarkArrayIntersect.arrayIntersect                100   BIGINT  avgt   20    5307.227 ±  176.027  ns/op
BenchmarkArrayIntersect.arrayIntersect                100  VARCHAR  avgt   20   12503.550 ±  930.792  ns/op
BenchmarkArrayIntersect.arrayIntersect                100   DOUBLE  avgt   20    4960.093 ±  218.068  ns/op
BenchmarkArrayIntersect.arrayIntersect                100  BOOLEAN  avgt   20    3506.155 ±   89.350  ns/op
BenchmarkArrayIntersect.arrayIntersect               1000   BIGINT  avgt   20   54011.841 ± 1157.535  ns/op
BenchmarkArrayIntersect.arrayIntersect               1000  VARCHAR  avgt   20  138138.117 ± 2312.833  ns/op
BenchmarkArrayIntersect.arrayIntersect               1000   DOUBLE  avgt   20   52353.568 ± 1500.466  ns/op
BenchmarkArrayIntersect.arrayIntersect               1000  BOOLEAN  avgt   20   27390.156 ±  538.806  ns/op

ARRAY_INTERSECT, Using HashTable, not using PageBuilder (See note1 below)
Benchmark                               (arraySizeString)   (type)  Mode  Cnt       Score       Error  Units
BenchmarkArrayIntersect.arrayIntersect                 10   BIGINT  avgt   20     588.884 ±    23.353  ns/op
BenchmarkArrayIntersect.arrayIntersect                 10  VARCHAR  avgt   20    1209.353 ±    25.677  ns/op
BenchmarkArrayIntersect.arrayIntersect                 10   DOUBLE  avgt   20     394.150 ±     9.150  ns/op
BenchmarkArrayIntersect.arrayIntersect                 10  BOOLEAN  avgt   20     454.669 ±     8.582  ns/op
BenchmarkArrayIntersect.arrayIntersect                100   BIGINT  avgt   20    4619.287 ±   152.689  ns/op
BenchmarkArrayIntersect.arrayIntersect                100  VARCHAR  avgt   20   10578.612 ±   243.154  ns/op
BenchmarkArrayIntersect.arrayIntersect                100   DOUBLE  avgt   20    2330.880 ±    67.917  ns/op
BenchmarkArrayIntersect.arrayIntersect                100  BOOLEAN  avgt   20    2879.377 ±    59.567  ns/op
BenchmarkArrayIntersect.arrayIntersect               1000   BIGINT  avgt   20   46797.957 ±  1540.572  ns/op
BenchmarkArrayIntersect.arrayIntersect               1000  VARCHAR  avgt   20  106199.153 ±  3875.884  ns/op
BenchmarkArrayIntersect.arrayIntersect               1000   DOUBLE  avgt   20   24430.349 ±   558.838  ns/op
BenchmarkArrayIntersect.arrayIntersect               1000  BOOLEAN  avgt   20   27448.122 ±   767.058  ns/op
BenchmarkArrayIntersect.arrayIntersect              10000   BIGINT  avgt   20  517433.121 ± 17836.669  ns/op
BenchmarkArrayIntersect.arrayIntersect              10000  VARCHAR  avgt   20  891996.441 ± 16470.239  ns/op
BenchmarkArrayIntersect.arrayIntersect              10000   DOUBLE  avgt   20  332203.796 ±  7918.177  ns/op
BenchmarkArrayIntersect.arrayIntersect              10000  BOOLEAN  avgt   20  202184.853 ± 51445.059  ns/op

ARRAY_UNION, Using TypedSet (original)
Benchmark                       (arraySizeString)   (type)  Mode  Cnt      Score      Error  Units
BenchmarkArrayUnion.arrayUnion                 10   BIGINT  avgt   20   1106.702 ±  125.186  ns/op
BenchmarkArrayUnion.arrayUnion                 10  VARCHAR  avgt   20   2936.697 ±   75.938  ns/op
BenchmarkArrayUnion.arrayUnion                 10   DOUBLE  avgt   20   1069.611 ±   30.923  ns/op
BenchmarkArrayUnion.arrayUnion                 10  BOOLEAN  avgt   20    442.312 ±   12.642  ns/op
BenchmarkArrayUnion.arrayUnion                100   BIGINT  avgt   20   7565.756 ±  476.906  ns/op
BenchmarkArrayUnion.arrayUnion                100  VARCHAR  avgt   20  19746.303 ±  637.598  ns/op
BenchmarkArrayUnion.arrayUnion                100   DOUBLE  avgt   20   7990.463 ±  315.215  ns/op
BenchmarkArrayUnion.arrayUnion                100  BOOLEAN  avgt   20   2821.322 ±  126.267  ns/op
BenchmarkArrayUnion.arrayUnion               1000   BIGINT  avgt   20  78448.551 ± 1799.462  ns/op
BenchmarkArrayUnion.arrayUnion               1000  VARCHAR  avgt   20  98506.432 ± 2350.677  ns/op
BenchmarkArrayUnion.arrayUnion               1000   DOUBLE  avgt   20  82625.185 ± 3147.564  ns/op

ARRAY_UNION, Using HashTable, not using PageBuilder (See note1 below)
Benchmark                       (arraySizeString)   (type)  Mode  Cnt      Score      Error  Units
BenchmarkArrayUnion.arrayUnion                 10   BIGINT  avgt   20    552.578 ±   25.674  ns/op
BenchmarkArrayUnion.arrayUnion                 10  VARCHAR  avgt   20   1785.893 ±   57.115  ns/op
BenchmarkArrayUnion.arrayUnion                 10   DOUBLE  avgt   20    554.432 ±   19.863  ns/op
BenchmarkArrayUnion.arrayUnion                 10  BOOLEAN  avgt   20    219.533 ±    5.263  ns/op
BenchmarkArrayUnion.arrayUnion                100   BIGINT  avgt   20   3893.698 ±  228.846  ns/op
BenchmarkArrayUnion.arrayUnion                100  VARCHAR  avgt   20  12585.958 ±  327.471  ns/op
BenchmarkArrayUnion.arrayUnion                100   DOUBLE  avgt   20   3843.612 ±  166.522  ns/op
BenchmarkArrayUnion.arrayUnion                100  BOOLEAN  avgt   20   1583.191 ±  386.227  ns/op
BenchmarkArrayUnion.arrayUnion               1000   BIGINT  avgt   20  39900.585 ±  842.960  ns/op
BenchmarkArrayUnion.arrayUnion               1000  VARCHAR  avgt   20  70375.042 ± 1793.881  ns/op
BenchmarkArrayUnion.arrayUnion               1000   DOUBLE  avgt   20  39905.696 ± 1911.857  ns/op
BenchmarkArrayUnion.arrayUnion               1000  BOOLEAN  avgt   20  11147.282 ±  678.497  ns/op

ARRAY_DISTINCT, Using TypedSet (original)
Benchmark                       (arraySizeString)   (type)  Mode  Cnt      Score      Error  Units
BenchmarkArrayUnion.arrayUnion                 10   BIGINT  avgt   20    551.480 ±   17.743  ns/op
BenchmarkArrayUnion.arrayUnion                 10  VARCHAR  avgt   20   1846.533 ±   85.912  ns/op
BenchmarkArrayUnion.arrayUnion                 10   DOUBLE  avgt   20    573.547 ±   35.368  ns/op
BenchmarkArrayUnion.arrayUnion                 10  BOOLEAN  avgt   20    232.252 ±   19.261  ns/op
BenchmarkArrayUnion.arrayUnion                100   BIGINT  avgt   20   4403.410 ±  631.545  ns/op
BenchmarkArrayUnion.arrayUnion                100  VARCHAR  avgt   20  12964.978 ±  707.499  ns/op
BenchmarkArrayUnion.arrayUnion                100   DOUBLE  avgt   20   3841.738 ±  155.047  ns/op
BenchmarkArrayUnion.arrayUnion                100  BOOLEAN  avgt   20   1197.182 ±   63.073  ns/op
BenchmarkArrayUnion.arrayUnion               1000   BIGINT  avgt   20  40894.698 ± 1356.368  ns/op
BenchmarkArrayUnion.arrayUnion               1000  VARCHAR  avgt   20  68847.286 ± 1380.070  ns/op
BenchmarkArrayUnion.arrayUnion               1000   DOUBLE  avgt   20  40348.384 ±  920.434  ns/op
BenchmarkArrayUnion.arrayUnion               1000  BOOLEAN  avgt   20   8892.462 ±  292.235  ns/op

ARRAY_DISTINCT, Using HashTable
Benchmark                              (arraySizeString)   (type)  Mode  Cnt      Score      Error  Units
BenchmarkArrayDistinct.arrayDistinct                  10   BIGINT  avgt   20    422.732 ±   14.037  ns/op
BenchmarkArrayDistinct.arrayDistinct                  10  VARCHAR  avgt   20    889.063 ±   18.377  ns/op
BenchmarkArrayDistinct.arrayDistinct                  10   DOUBLE  avgt   20    328.964 ±    7.290  ns/op
BenchmarkArrayDistinct.arrayDistinct                  10  BOOLEAN  avgt   20    185.788 ±    4.915  ns/op
BenchmarkArrayDistinct.arrayDistinct                 100   BIGINT  avgt   20   3249.734 ±  112.246  ns/op
BenchmarkArrayDistinct.arrayDistinct                 100  VARCHAR  avgt   20   6774.174 ±  129.837  ns/op
BenchmarkArrayDistinct.arrayDistinct                 100   DOUBLE  avgt   20   2137.946 ±   40.572  ns/op
BenchmarkArrayDistinct.arrayDistinct                 100  BOOLEAN  avgt   20    558.567 ±   31.567  ns/op
BenchmarkArrayDistinct.arrayDistinct                1000   BIGINT  avgt   20  32042.905 ±  637.472  ns/op
BenchmarkArrayDistinct.arrayDistinct                1000  VARCHAR  avgt   20  37180.367 ± 1000.611  ns/op
BenchmarkArrayDistinct.arrayDistinct                1000   DOUBLE  avgt   20  21234.565 ±  707.286  ns/op
BenchmarkArrayDistinct.arrayDistinct                1000  BOOLEAN  avgt   20   3887.345 ±  214.052  ns/op

Note 1:
We used pageBuilder in the implementations, but due to an issue on
CachedInstance being created for every batch, this approach is around
2x-6x worse than just creating a new BlockBuilder for each Block being
processed. The JMH benchmarks above were not using PageBuilder. We
will keep the PageBuilder logic in this commit, and will fix the issue
shortly.

TODO:
HashTable is still using the equal to logic. Once PR #11983 is merged,
we will change it to use the isDistinctFrom operator.