### PR TITLE
Change the default location of request log when rpm is used

### DIFF
--- a/presto-server-rpm/pom.xml
+++ b/presto-server-rpm/pom.xml
@@ -171,6 +171,14 @@
                                 </rule>
 
                                 <rule>
+                                    <destination>/etc/presto/catalog</destination>
+                                    <base>dist/config/catalog</base>
+                                    <includes>
+                                        <include>*</include>
+                                    </includes>
+                                </rule>
+
+                                <rule>
                                     <destination>/usr/shared/doc/presto</destination>
                                     <base>${server.tar.package}</base>
                                     <includes>

--- a/presto-server-rpm/src/main/resources/dist/config/catalog/localfile.properties
+++ b/presto-server-rpm/src/main/resources/dist/config/catalog/localfile.properties
@@ -1,0 +1,10 @@
+#
+# WARNING
+# ^^^^^^^
+# This configuration file is for development only and should NOT be used be
+# used in production. For example configuration, see the Presto documentation.
+#
+
+connector.name=localfile
+presto-logs.http-request-log.location=/var/log/presto
+presto-logs.http-request-log.pattern=http-request.log*


### PR DESCRIPTION
I'm trying to contribute to resolve this issue.
https://github.com/prestodb/presto/issues/12030

I confirmed the file structure in rpm generated by this commit.
```
[/Users/satoshi.hirose/.ghq/github.com/satoshihirose/presto/presto-server-rpm/tmp]tree etc
etc
├── init.d
│   └── presto
└── presto
    ├── catalog
    │   └── localfile.properties
    ├── config.properties
    ├── jvm.config
    ├── log.properties
    └── node.properties

3 directories, 6 files
```