### PR TITLE
Provide workaround for: Count(*) on empty relation return NULL when optimize_mixed_distinct_aggregations = true

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionRegistry.java
@@ -219,6 +219,7 @@ import static com.facebook.presto.metadata.FunctionKind.WINDOW;
 import static com.facebook.presto.metadata.Signature.internalOperator;
 import static com.facebook.presto.metadata.SignatureBinder.applyBoundVariables;
 import static com.facebook.presto.operator.aggregation.ArbitraryAggregationFunction.ARBITRARY_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.ArbitraryExtAggregationFunction.ARBITRARY_EXT_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.ChecksumAggregationFunction.CHECKSUM_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.CountColumn.COUNT_COLUMN;
 import static com.facebook.presto.operator.aggregation.DecimalAverageAggregation.DECIMAL_AVERAGE_AGGREGATION;
@@ -604,6 +605,7 @@ public class FunctionRegistry
                 .function(CHECKSUM_AGGREGATION)
                 .function(IDENTITY_CAST)
                 .function(ARBITRARY_AGGREGATION)
+                .function(ARBITRARY_EXT_AGGREGATION)
                 .functions(GREATEST, LEAST)
                 .functions(MAX_BY, MIN_BY, MAX_BY_N_AGGREGATION, MIN_BY_N_AGGREGATION)
                 .functions(MAX_AGGREGATION, MIN_AGGREGATION, MAX_N_AGGREGATION, MIN_N_AGGREGATION)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryExtAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryExtAggregationFunction.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.operator.aggregation.AggregationMetadata.AccumulatorStateDescriptor;
+import com.facebook.presto.operator.aggregation.state.BlockPositionState;
+import com.facebook.presto.operator.aggregation.state.BlockPositionStateSerializer;
+import com.facebook.presto.operator.aggregation.state.NullableBooleanState;
+import com.facebook.presto.operator.aggregation.state.NullableDoubleState;
+import com.facebook.presto.operator.aggregation.state.NullableLongState;
+import com.facebook.presto.operator.aggregation.state.StateCompiler;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.ImmutableList;
+import io.airlift.bytecode.DynamicClassLoader;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.metadata.Signature.typeVariable;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INPUT_CHANNEL;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class ArbitraryExtAggregationFunction
+        extends SqlAggregationFunction
+{
+    public static final ArbitraryExtAggregationFunction ARBITRARY_EXT_AGGREGATION = new ArbitraryExtAggregationFunction();
+    private static final String NAME = "arbitrary_ext";
+
+    private static final MethodHandle LONG_INPUT_FUNCTION = methodHandle(ArbitraryExtAggregationFunction.class, "input", Type.class, NullableLongState.class, Block.class, int.class);
+    private static final MethodHandle DOUBLE_INPUT_FUNCTION = methodHandle(ArbitraryExtAggregationFunction.class, "input", Type.class, NullableDoubleState.class, Block.class, int.class);
+    private static final MethodHandle BOOLEAN_INPUT_FUNCTION = methodHandle(ArbitraryExtAggregationFunction.class, "input", Type.class, NullableBooleanState.class, Block.class, int.class);
+    private static final MethodHandle BLOCK_POSITION_INPUT_FUNCTION = methodHandle(ArbitraryExtAggregationFunction.class, "input", Type.class, BlockPositionState.class, Block.class, int.class);
+
+    private static final MethodHandle LONG_OUTPUT_FUNCTION = methodHandle(ArbitraryExtAggregationFunction.class, "write", Type.class, NullableLongState.class, BlockBuilder.class);
+    private static final MethodHandle DOUBLE_OUTPUT_FUNCTION = methodHandle(ArbitraryExtAggregationFunction.class, "write", Type.class, NullableDoubleState.class, BlockBuilder.class);
+    private static final MethodHandle BOOLEAN_OUTPUT_FUNCTION = methodHandle(ArbitraryExtAggregationFunction.class, "write", Type.class, NullableBooleanState.class, BlockBuilder.class);
+    private static final MethodHandle BLOCK_POSITION_OUTPUT_FUNCTION = methodHandle(ArbitraryExtAggregationFunction.class, "write", Type.class, BlockPositionState.class, BlockBuilder.class);
+
+    private static final MethodHandle LONG_COMBINE_FUNCTION = methodHandle(ArbitraryExtAggregationFunction.class, "combine", NullableLongState.class, NullableLongState.class);
+    private static final MethodHandle DOUBLE_COMBINE_FUNCTION = methodHandle(ArbitraryExtAggregationFunction.class, "combine", NullableDoubleState.class, NullableDoubleState.class);
+    private static final MethodHandle BOOLEAN_COMBINE_FUNCTION = methodHandle(ArbitraryExtAggregationFunction.class, "combine", NullableBooleanState.class, NullableBooleanState.class);
+    private static final MethodHandle BLOCK_POSITION_COMBINE_FUNCTION = methodHandle(ArbitraryExtAggregationFunction.class, "combine", BlockPositionState.class, BlockPositionState.class);
+
+    protected ArbitraryExtAggregationFunction()
+    {
+        super(NAME,
+                ImmutableList.of(typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature("T"),
+                ImmutableList.of(parseTypeSignature("T")));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "return an arbitrary non-null input value";
+    }
+
+    @Override
+    public InternalAggregationFunction specialize(BoundVariables boundVariables, int arity, TypeManager typeManager, FunctionRegistry functionRegistry)
+    {
+        Type valueType = boundVariables.getTypeVariable("T");
+        return generateAggregation(valueType);
+    }
+
+    private static InternalAggregationFunction generateAggregation(Type type)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(ArbitraryExtAggregationFunction.class.getClassLoader());
+
+        List<Type> inputTypes = ImmutableList.of(type);
+
+        MethodHandle inputFunction;
+        MethodHandle combineFunction;
+        MethodHandle outputFunction;
+        Class<? extends AccumulatorState> stateInterface;
+        AccumulatorStateSerializer<?> stateSerializer;
+
+        if (type.getJavaType() == long.class) {
+            stateInterface = NullableLongState.class;
+            stateSerializer = StateCompiler.generateStateSerializer(stateInterface, classLoader);
+            inputFunction = LONG_INPUT_FUNCTION;
+            combineFunction = LONG_COMBINE_FUNCTION;
+            outputFunction = LONG_OUTPUT_FUNCTION;
+        }
+        else if (type.getJavaType() == double.class) {
+            stateInterface = NullableDoubleState.class;
+            stateSerializer = StateCompiler.generateStateSerializer(stateInterface, classLoader);
+            inputFunction = DOUBLE_INPUT_FUNCTION;
+            combineFunction = DOUBLE_COMBINE_FUNCTION;
+            outputFunction = DOUBLE_OUTPUT_FUNCTION;
+        }
+        else if (type.getJavaType() == boolean.class) {
+            stateInterface = NullableBooleanState.class;
+            stateSerializer = StateCompiler.generateStateSerializer(stateInterface, classLoader);
+            inputFunction = BOOLEAN_INPUT_FUNCTION;
+            combineFunction = BOOLEAN_COMBINE_FUNCTION;
+            outputFunction = BOOLEAN_OUTPUT_FUNCTION;
+        }
+        else {
+            //  native container type is Slice or Block
+            stateInterface = BlockPositionState.class;
+            stateSerializer = new BlockPositionStateSerializer(type);
+            inputFunction = BLOCK_POSITION_INPUT_FUNCTION;
+            combineFunction = BLOCK_POSITION_COMBINE_FUNCTION;
+            outputFunction = BLOCK_POSITION_OUTPUT_FUNCTION;
+        }
+        inputFunction = inputFunction.bindTo(type);
+
+        Type intermediateType = stateSerializer.getSerializedType();
+        List<ParameterMetadata> inputParameterMetadata = createInputParameterMetadata(type);
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, type.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
+                inputParameterMetadata,
+                inputFunction,
+                combineFunction,
+                outputFunction.bindTo(type),
+                ImmutableList.of(new AccumulatorStateDescriptor(
+                        stateInterface,
+                        stateSerializer,
+                        StateCompiler.generateStateFactory(stateInterface, classLoader))),
+                type);
+
+        GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
+        return new InternalAggregationFunction(NAME, inputTypes, ImmutableList.of(intermediateType), type, true, false, factory);
+    }
+
+    private static List<ParameterMetadata> createInputParameterMetadata(Type value)
+    {
+        return ImmutableList.of(new ParameterMetadata(STATE), new ParameterMetadata(BLOCK_INPUT_CHANNEL, value), new ParameterMetadata(BLOCK_INDEX));
+    }
+
+    public static void input(Type type, NullableDoubleState state, Block block, int position)
+    {
+        if (!state.isNull()) {
+            return;
+        }
+        state.setNull(false);
+        state.setDouble(type.getDouble(block, position));
+    }
+
+    public static void input(Type type, NullableLongState state, Block block, int position)
+    {
+        if (!state.isNull()) {
+            return;
+        }
+        state.setNull(false);
+        state.setLong(type.getLong(block, position));
+    }
+
+    public static void input(Type type, NullableBooleanState state, Block block, int position)
+    {
+        if (!state.isNull()) {
+            return;
+        }
+        state.setNull(false);
+        state.setBoolean(type.getBoolean(block, position));
+    }
+
+    public static void input(Type type, BlockPositionState state, Block block, int position)
+    {
+        if (state.getBlock() != null) {
+            return;
+        }
+        state.setBlock(block);
+        state.setPosition(position);
+    }
+
+    public static void combine(NullableLongState state, NullableLongState otherState)
+    {
+        if (!state.isNull()) {
+            return;
+        }
+        state.setNull(false);
+        state.setLong(otherState.getLong());
+    }
+
+    public static void combine(NullableDoubleState state, NullableDoubleState otherState)
+    {
+        if (!state.isNull()) {
+            return;
+        }
+        state.setNull(false);
+        state.setDouble(otherState.getDouble());
+    }
+
+    public static void combine(NullableBooleanState state, NullableBooleanState otherState)
+    {
+        if (!state.isNull()) {
+            return;
+        }
+        state.setNull(false);
+        state.setBoolean(otherState.getBoolean());
+    }
+
+    public static void combine(BlockPositionState state, BlockPositionState otherState)
+    {
+        if (state.getBlock() != null) {
+            return;
+        }
+        state.setBlock(otherState.getBlock());
+        state.setPosition(otherState.getPosition());
+    }
+
+    public static void write(Type type, NullableLongState state, BlockBuilder out)
+    {
+        type.writeLong(out, state.getLong());
+    }
+
+    public static void write(Type type, NullableDoubleState state, BlockBuilder out)
+    {
+        if (state.isNull()) {
+            out.appendNull();
+        }
+        else {
+            type.writeDouble(out, state.getDouble());
+        }
+    }
+
+    public static void write(Type type, NullableBooleanState state, BlockBuilder out)
+    {
+        if (state.isNull()) {
+            out.appendNull();
+        }
+        else {
+            type.writeBoolean(out, state.getBoolean());
+        }
+    }
+
+    public static void write(Type type, BlockPositionState state, BlockBuilder out)
+    {
+        if (state.getBlock() == null) {
+            out.appendNull();
+        }
+        else {
+            type.appendTo(state.getBlock(), state.getPosition(), out);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -166,7 +166,9 @@ public class OptimizeMixedDistinctAggregations
                 else {
                     // Aggregations on non-distinct are already done by new node, just extract the non-null value
                     Symbol argument = aggregateInfo.getNewNonDistinctAggregateSymbols().get(entry.getKey());
-                    QualifiedName functionName = QualifiedName.of("arbitrary");
+                    String signatureName = entry.getValue().getSignature().getName();
+                    QualifiedName functionName = QualifiedName.of((signatureName.equals("count")
+                            || signatureName.equals("count_if") || signatureName.equals("approx_distinct")) ? "arbitrary_ext" : "arbitrary");
                     aggregations.put(entry.getKey(), new Aggregation(
                             new FunctionCall(functionName, functionCall.getWindow(), false, ImmutableList.of(argument.toSymbolReference())),
                             getFunctionSignature(functionName, argument),

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArbitraryExtAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArbitraryExtAggregation.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.Signature;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import static com.facebook.presto.block.BlockAssertions.createArrayBigintBlock;
+import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createIntsBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
+import static com.facebook.presto.metadata.FunctionKind.AGGREGATE;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static org.testng.Assert.assertNotNull;
+
+public class TestArbitraryExtAggregation
+{
+    private static final MetadataManager metadata = MetadataManager.createTestMetadataManager();
+
+    @Test
+    public void testAllRegistered()
+    {
+        Set<Type> allTypes = metadata.getTypeManager().getTypes().stream().collect(toImmutableSet());
+
+        for (Type valueType : allTypes) {
+            assertNotNull(metadata.getFunctionRegistry().getAggregateFunctionImplementation(new Signature("arbitrary_ext", AGGREGATE, valueType.getTypeSignature(), valueType.getTypeSignature())));
+        }
+    }
+
+    @Test
+    public void testNullBoolean()
+    {
+        InternalAggregationFunction booleanAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary_ext", AGGREGATE, parseTypeSignature(StandardTypes.BOOLEAN), parseTypeSignature(StandardTypes.BOOLEAN)));
+        assertAggregation(
+                booleanAgg,
+                null,
+                createBooleansBlock((Boolean) null));
+    }
+
+    @Test
+    public void testValidBoolean()
+    {
+        InternalAggregationFunction booleanAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary_ext", AGGREGATE, parseTypeSignature(StandardTypes.BOOLEAN), parseTypeSignature(StandardTypes.BOOLEAN)));
+        assertAggregation(
+                booleanAgg,
+                true,
+                createBooleansBlock(true, true));
+    }
+
+    @Test
+    public void testNullLong()
+    {
+        InternalAggregationFunction longAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary_ext", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BIGINT)));
+        assertAggregation(
+                longAgg,
+                0L,
+                createLongsBlock(null, null));
+    }
+
+    @Test
+    public void testValidLong()
+    {
+        InternalAggregationFunction longAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary_ext", AGGREGATE, parseTypeSignature(StandardTypes.BIGINT), parseTypeSignature(StandardTypes.BIGINT)));
+        assertAggregation(
+                longAgg,
+                1L,
+                createLongsBlock(1L, null));
+    }
+
+    @Test
+    public void testNullDouble()
+    {
+        InternalAggregationFunction doubleAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary_ext", AGGREGATE, parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE)));
+        assertAggregation(
+                doubleAgg,
+                null,
+                createDoublesBlock(null, null));
+    }
+
+    @Test
+    public void testValidDouble()
+    {
+        InternalAggregationFunction doubleAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary_ext", AGGREGATE, parseTypeSignature(StandardTypes.DOUBLE), parseTypeSignature(StandardTypes.DOUBLE)));
+        assertAggregation(
+                doubleAgg,
+                2.0,
+                createDoublesBlock(null, 2.0));
+    }
+
+    @Test
+    public void testNullString()
+    {
+        InternalAggregationFunction stringAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary_ext", AGGREGATE, parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR)));
+        assertAggregation(
+                stringAgg,
+                null,
+                createStringsBlock(null, null));
+    }
+
+    @Test
+    public void testValidString()
+    {
+        InternalAggregationFunction stringAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary_ext", AGGREGATE, parseTypeSignature(StandardTypes.VARCHAR), parseTypeSignature(StandardTypes.VARCHAR)));
+        assertAggregation(
+                stringAgg,
+                "a",
+                createStringsBlock("a", "a"));
+    }
+
+    @Test
+    public void testNullArray()
+    {
+        InternalAggregationFunction arrayAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary_ext", AGGREGATE, parseTypeSignature("array(bigint)"), parseTypeSignature("array(bigint)")));
+        assertAggregation(
+                arrayAgg,
+                null,
+                createArrayBigintBlock(Arrays.asList(null, null, null, null)));
+    }
+
+    @Test
+    public void testValidArray()
+    {
+        InternalAggregationFunction arrayAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary_ext", AGGREGATE, parseTypeSignature("array(bigint)"), parseTypeSignature("array(bigint)")));
+        assertAggregation(
+                arrayAgg,
+                ImmutableList.of(23L, 45L),
+                createArrayBigintBlock(ImmutableList.of(ImmutableList.of(23L, 45L), ImmutableList.of(23L, 45L), ImmutableList.of(23L, 45L), ImmutableList.of(23L, 45L))));
+    }
+
+    @Test
+    public void testValidInt()
+    {
+        InternalAggregationFunction arrayAgg = metadata.getFunctionRegistry().getAggregateFunctionImplementation(
+                new Signature("arbitrary_ext", AGGREGATE, parseTypeSignature("integer"), parseTypeSignature("integer")));
+        assertAggregation(
+                arrayAgg,
+                3,
+                createIntsBlock(3, 3, null));
+    }
+}


### PR DESCRIPTION
Workaround for #8894
Introduce an arbitrary_ext() function to resolve this issue when use count(), count_if(), approx_distinct() functions.