### PR TITLE
Do not change explicitly selected join distribution type

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
@@ -198,7 +198,7 @@ public class TestReorderJoins
     }
 
     @Test
-    public void testReplicatesWhenRequiredBySession()
+    public void testReplicatesUnrestrictedWhenRequiredBySession()
     {
         assertReorderJoins()
                 .on(p ->
@@ -209,6 +209,7 @@ public class TestReorderJoins
                                 ImmutableList.of(new EquiJoinClause(p.symbol("A1"), p.symbol("B1"))),
                                 ImmutableList.of(p.symbol("A1"), p.symbol("B1")),
                                 Optional.empty()))
+                .setSystemProperty(JOIN_MAX_BROADCAST_TABLE_SIZE, "1kB")
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, BROADCAST.name())
                 .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
                         .setOutputRowCount(10000)


### PR DESCRIPTION
ReorderJoin rule should not change distribution type if distribution
type is explicitly set as BROADCAST or REPLICATED.

This also fixes a failure when BROADCAST join type is selected explicitly,
but the broadcasted table size exceeds the broadcast table limit. In
such case ReorderJoin rule used to fail with the java.util.NoSuchElementException,
because no join options were added to the possibleJoinNodes list.
Example stack trace: https://gist.github.com/arhimondr/03770d751d3d19936c6c5885708659de