### PR TITLE
Support virtual bucketing on $path for hive unbucketed table

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketHandle.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
+import static com.facebook.presto.hive.HiveColumnHandle.pathColumnHandle;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -62,11 +63,25 @@ public class HiveBucketHandle
 
     public HiveBucketProperty toTableBucketProperty()
     {
+        if (isVirtuallyBucketed(columns)) {
+            return null;
+        }
+
         return new HiveBucketProperty(
                 columns.stream()
                         .map(HiveColumnHandle::getName)
                         .collect(toList()),
                 tableBucketCount,
                 ImmutableList.of());
+    }
+
+    public static HiveBucketHandle createVirtualBucketHandle(int virtualBucketCount)
+    {
+        return new HiveBucketHandle(ImmutableList.of(pathColumnHandle()), virtualBucketCount, virtualBucketCount);
+    }
+
+    public static boolean isVirtuallyBucketed(List<HiveColumnHandle> bucketColumns)
+    {
+        return bucketColumns.equals(ImmutableList.of(pathColumnHandle()));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
@@ -48,6 +49,7 @@ import static com.facebook.presto.hive.HiveColumnHandle.BUCKET_COLUMN_NAME;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static com.facebook.presto.hive.HiveUtil.getRegularColumnHandles;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -67,6 +69,12 @@ final class HiveBucketing
             HiveType.HIVE_STRING);
 
     private HiveBucketing() {}
+
+    public static int getVirtualBucket(int bucketCount, Path path)
+    {
+        // this is equivalent to bucketing the table on a VARCHAR column containing $path
+        return (hashBytes(0, utf8Slice(path.toString())) & Integer.MAX_VALUE) % bucketCount;
+    }
 
     public static int getHiveBucket(int bucketCount, List<TypeInfo> types, Page page, int position)
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -74,6 +74,7 @@ public final class HiveSessionProperties
     private static final String IGNORE_CORRUPTED_STATISTICS = "ignore_corrupted_statistics";
     private static final String COLLECT_COLUMN_STATISTICS_ON_WRITE = "collect_column_statistics_on_write";
     private static final String OPTIMIZE_MISMATCHED_BUCKET_COUNT = "optimize_mismatched_bucket_count";
+    private static final String VIRTUAL_BUCKET_COUNT = "virtual_bucket_count";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -284,6 +285,11 @@ public final class HiveSessionProperties
                         OPTIMIZE_MISMATCHED_BUCKET_COUNT,
                         "Experimenal: Enable optimization to avoid shuffle when bucket count is compatible but not the same",
                         hiveClientConfig.isOptimizeMismatchedBucketCount(),
+                        false),
+                integerProperty(
+                        VIRTUAL_BUCKET_COUNT,
+                        "Number of virtual bucket assigned for unbucketed tables",
+                        1,
                         false));
     }
 
@@ -471,6 +477,15 @@ public final class HiveSessionProperties
     public static boolean isOptimizedMismatchedBucketCount(ConnectorSession session)
     {
         return session.getProperty(OPTIMIZE_MISMATCHED_BUCKET_COUNT, Boolean.class);
+    }
+
+    public static int getVirtualBucketCount(ConnectorSession session)
+    {
+        int virtualBucketCount = session.getProperty(VIRTUAL_BUCKET_COUNT, Integer.class);
+        if (virtualBucketCount < 1) {
+            throw new PrestoException(INVALID_SESSION_PROPERTY, format("%s must be greater than 0: %s", VIRTUAL_BUCKET_COUNT, virtualBucketCount));
+        }
+        return virtualBucketCount;
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -2342,6 +2342,29 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testVirtualBucketing()
+    {
+        try {
+            assertUpdate(
+                    "CREATE TABLE test_virtual_bucket AS\n" +
+                            "SELECT orderkey key, comment value FROM orders",
+                    15000);
+            Session virtualBucketEnabled = Session.builder(getSession())
+                    .setCatalogSessionProperty(HIVE_CATALOG, "virtual_bucket_count", "2")
+                    .build();
+            @Language("SQL") String groupedByPath =
+                    "SELECT COUNT(DISTINCT(\"$path\")) FROM test_virtual_bucket";
+            @Language("SQL") String expectedGroupByPath = "SELECT 4";
+
+            assertQuery(getSession(), groupedByPath, expectedGroupByPath, assertRemoteExchangesCount(2));
+            assertQuery(virtualBucketEnabled, groupedByPath, expectedGroupByPath, assertRemoteExchangesCount(1));
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS test_virtual_bucket");
+        }
+    }
+
+    @Test
     public void testGroupedExecution()
     {
         try {


### PR DESCRIPTION
For unbucketed table, providing an option to virtually bucketing them
give us the ability to have addressable splits. This will be useful
when we introduce partial failure recovery in the future. User can
use hive connector session property "virtual_bucket_count" to control
this behavior.