### PR TITLE
Enable char predicates to be pushed down.

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/QueryBuilder.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.predicate.Range;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DateType;
 import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.IntegerType;
@@ -169,6 +170,9 @@ public class QueryBuilder
             else if (typeAndValue.getType() instanceof VarcharType) {
                 statement.setString(i + 1, ((Slice) typeAndValue.getValue()).toStringUtf8());
             }
+            else if (typeAndValue.getType() instanceof CharType) {
+                statement.setString(i + 1, ((Slice) typeAndValue.getValue()).toStringUtf8());
+            }
             else {
                 throw new UnsupportedOperationException("Can't handle type: " + typeAndValue.getType());
             }
@@ -192,7 +196,8 @@ public class QueryBuilder
                 validType.equals(TimeWithTimeZoneType.TIME_WITH_TIME_ZONE) ||
                 validType.equals(TimestampType.TIMESTAMP) ||
                 validType.equals(TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE) ||
-                validType instanceof VarcharType;
+                validType instanceof VarcharType ||
+                validType instanceof CharType;
     }
 
     private List<String> toConjuncts(List<JdbcColumnHandle> columns, TupleDomain<ColumnHandle> tupleDomain, List<TypeAndValue> accumulator)

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcQueryBuilder.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcQueryBuilder.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.Range;
 import com.facebook.presto.spi.predicate.SortedRangeSet;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.CharType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -39,6 +40,7 @@ import java.util.Locale;
 
 import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
 import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BOOLEAN;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_CHAR;
 import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_DATE;
 import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_DOUBLE;
 import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_INTEGER;
@@ -80,6 +82,7 @@ public class TestJdbcQueryBuilder
     {
         database = new TestingDatabase();
         jdbcClient = database.getJdbcClient();
+        CharType charType = CharType.createCharType(0);
 
         columns = ImmutableList.of(
                 new JdbcColumnHandle("test_id", "col_0", JDBC_BIGINT, BIGINT),
@@ -92,7 +95,8 @@ public class TestJdbcQueryBuilder
                 new JdbcColumnHandle("test_id", "col_7", JDBC_TINYINT, TINYINT),
                 new JdbcColumnHandle("test_id", "col_8", JDBC_SMALLINT, SMALLINT),
                 new JdbcColumnHandle("test_id", "col_9", JDBC_INTEGER, INTEGER),
-                new JdbcColumnHandle("test_id", "col_10", JDBC_REAL, REAL));
+                new JdbcColumnHandle("test_id", "col_10", JDBC_REAL, REAL),
+                new JdbcColumnHandle("test_id", "col_11", JDBC_CHAR, charType));
 
         Connection connection = database.getConnection();
         try (PreparedStatement preparedStatement = connection.prepareStatement("create table \"test_table\" (" + "" +
@@ -106,7 +110,8 @@ public class TestJdbcQueryBuilder
                 "\"col_7\" TINYINT, " +
                 "\"col_8\" SMALLINT, " +
                 "\"col_9\" INTEGER, " +
-                "\"col_10\" REAL " +
+                "\"col_10\" REAL, " +
+                "\"col_11\" CHAR(128) " +
                 ")")) {
             preparedStatement.execute();
             StringBuilder stringBuilder = new StringBuilder("insert into \"test_table\" values ");
@@ -115,7 +120,7 @@ public class TestJdbcQueryBuilder
             for (int i = 0; i < len; i++) {
                 stringBuilder.append(format(
                         Locale.ENGLISH,
-                        "(%d, %f, %b, 'test_str_%d', '%s', '%s', '%s', %d, %d, %d, %f)",
+                        "(%d, %f, %b, 'test_str_%d', '%s', '%s', '%s', %d, %d, %d, %f, 'test_str_%d')",
                         i,
                         200000.0 + i / 2.0,
                         i % 2 == 0,
@@ -126,7 +131,8 @@ public class TestJdbcQueryBuilder
                         i % 128,
                         -i,
                         i - 100,
-                        100.0f + i));
+                        100.0f + i,
+                        i));
                 dateTime = dateTime.plusHours(26);
                 if (i != len - 1) {
                     stringBuilder.append(",");
@@ -227,7 +233,7 @@ public class TestJdbcQueryBuilder
     }
 
     @Test
-    public void testBuildSqlWithString()
+    public void testBuildSqlWithVarchar()
             throws SQLException
     {
         TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
@@ -250,6 +256,34 @@ public class TestJdbcQueryBuilder
             assertContains(preparedStatement.toString(), "\"col_3\" >= ?");
             assertContains(preparedStatement.toString(), "\"col_3\" < ?");
             assertContains(preparedStatement.toString(), "\"col_3\" IN (?,?)");
+        }
+    }
+
+    @Test
+    public void testBuildSqlWithChar()
+            throws SQLException
+    {
+        CharType charType = CharType.createCharType(0);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                columns.get(11), Domain.create(SortedRangeSet.copyOf(charType,
+                        ImmutableList.of(
+                                Range.range(charType, utf8Slice("test_str_700"), true, utf8Slice("test_str_702"), false),
+                                Range.equal(charType, utf8Slice("test_str_180")),
+                                Range.equal(charType, utf8Slice("test_str_196")))),
+                        false)));
+
+        Connection connection = database.getConnection();
+        try (PreparedStatement preparedStatement = new QueryBuilder("\"").buildSql(jdbcClient, connection, "", "", "test_table", columns, tupleDomain);
+                ResultSet resultSet = preparedStatement.executeQuery()) {
+            ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+            while (resultSet.next()) {
+                builder.add((String) resultSet.getObject("col_11"));
+            }
+            assertEquals(builder.build(), ImmutableSet.of("test_str_700", "test_str_701", "test_str_180", "test_str_196"));
+
+            assertContains(preparedStatement.toString(), "\"col_11\" >= ?");
+            assertContains(preparedStatement.toString(), "\"col_11\" < ?");
+            assertContains(preparedStatement.toString(), "\"col_11\" IN (?,?)");
         }
     }
 

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingJdbcTypeHandle.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingJdbcTypeHandle.java
@@ -29,6 +29,7 @@ public final class TestingJdbcTypeHandle
     public static final JdbcTypeHandle JDBC_REAL = new JdbcTypeHandle(Types.REAL, 8, 0);
     public static final JdbcTypeHandle JDBC_DOUBLE = new JdbcTypeHandle(Types.DOUBLE, 8, 0);
 
+    public static final JdbcTypeHandle JDBC_CHAR = new JdbcTypeHandle(Types.CHAR, 10, 0);
     public static final JdbcTypeHandle JDBC_VARCHAR = new JdbcTypeHandle(Types.VARCHAR, 10, 0);
 
     public static final JdbcTypeHandle JDBC_DATE = new JdbcTypeHandle(Types.DATE, 8, 0);

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -16,7 +16,10 @@ package com.facebook.presto.plugin.mysql;
 import com.facebook.presto.Session;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.testing.mysql.TestingMySqlServer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -25,6 +28,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Map;
 
 import static com.facebook.presto.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
@@ -149,6 +153,38 @@ public class TestMySqlIntegrationSmokeTest
         assertEquals(row.getField(0), (byte) 127);
 
         assertUpdate("DROP TABLE mysql_test_tinyint1");
+    }
+
+    @Test
+    public void testCharTrailingSpace()
+            throws Exception
+    {
+        execute("CREATE TABLE tpch.char_trailing_space (x char(10))");
+        assertUpdate("INSERT INTO char_trailing_space VALUES ('test')", 1);
+
+        assertQuery("SELECT * FROM char_trailing_space WHERE x = char 'test'", "VALUES 'test'");
+        assertQuery("SELECT * FROM char_trailing_space WHERE x = char 'test  '", "VALUES 'test'");
+        assertQuery("SELECT * FROM char_trailing_space WHERE x = char 'test        '", "VALUES 'test'");
+
+        assertEquals(getQueryRunner().execute("SELECT * FROM char_trailing_space WHERE x = char ' test'").getRowCount(), 0);
+
+        Map<String, String> properties = ImmutableMap.of("deprecated.legacy-char-to-varchar-coercion", "true");
+        Map<String, String> connectorProperties = ImmutableMap.of("connection-url", mysqlServer.getJdbcUrl());
+
+        try (QueryRunner queryRunner = new DistributedQueryRunner(getSession(), 3, properties);) {
+            queryRunner.installPlugin(new MySqlPlugin());
+            queryRunner.createCatalog("mysql", "mysql", connectorProperties);
+
+            assertEquals(queryRunner.execute("SELECT * FROM char_trailing_space WHERE x = char 'test'").getRowCount(), 0);
+            assertEquals(queryRunner.execute("SELECT * FROM char_trailing_space WHERE x = char 'test  '").getRowCount(), 0);
+            assertEquals(queryRunner.execute("SELECT * FROM char_trailing_space WHERE x = char 'test       '").getRowCount(), 0);
+
+            MaterializedResult result = queryRunner.execute("SELECT * FROM char_trailing_space WHERE x = char 'test      '");
+            assertEquals(result.getRowCount(), 1);
+            assertEquals(result.getMaterializedRows().get(0).getField(0), "test      ");
+        }
+
+        assertUpdate("DROP TABLE char_trailing_space");
     }
 
     private void execute(String sql)

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -13,7 +13,11 @@
  */
 package com.facebook.presto.plugin.postgresql;
 
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.testing.postgresql.TestingPostgreSqlServer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -23,11 +27,13 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.airlift.tpch.TpchTable.ORDERS;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -165,6 +171,38 @@ public class TestPostgreSqlIntegrationSmokeTest
             assertQueryFails(format("INSERT INTO %s.test_cleanup (x) VALUES (0)", schemaName), "ERROR: new row .* violates check constraint [\\s\\S]*");
             assertQuery(format("SELECT table_name FROM information_schema.tables WHERE table_schema = '%s'", schemaName), "VALUES 'test_cleanup'");
         }
+    }
+
+    @Test
+    public void testCharTrailingSpace()
+            throws Exception
+    {
+        execute("CREATE TABLE tpch.char_trailing_space (x char(10))");
+        assertUpdate("INSERT INTO char_trailing_space VALUES ('test')", 1);
+
+        assertQuery("SELECT * FROM char_trailing_space WHERE x = char 'test'", "VALUES 'test'");
+        assertQuery("SELECT * FROM char_trailing_space WHERE x = char 'test  '", "VALUES 'test'");
+        assertQuery("SELECT * FROM char_trailing_space WHERE x = char 'test        '", "VALUES 'test'");
+
+        assertEquals(getQueryRunner().execute("SELECT * FROM char_trailing_space WHERE x = char ' test'").getRowCount(), 0);
+
+        Map<String, String> properties = ImmutableMap.of("deprecated.legacy-char-to-varchar-coercion", "true");
+        Map<String, String> connectorProperties = ImmutableMap.of("connection-url", postgreSqlServer.getJdbcUrl());
+
+        try (QueryRunner queryRunner = new DistributedQueryRunner(getSession(), 3, properties);) {
+            queryRunner.installPlugin(new PostgreSqlPlugin());
+            queryRunner.createCatalog("postgresql", "postgresql", connectorProperties);
+
+            assertEquals(queryRunner.execute("SELECT * FROM char_trailing_space WHERE x = char 'test'").getRowCount(), 0);
+            assertEquals(queryRunner.execute("SELECT * FROM char_trailing_space WHERE x = char 'test  '").getRowCount(), 0);
+            assertEquals(queryRunner.execute("SELECT * FROM char_trailing_space WHERE x = char 'test       '").getRowCount(), 0);
+
+            MaterializedResult result = queryRunner.execute("SELECT * FROM char_trailing_space WHERE x = char 'test      '");
+            assertEquals(result.getRowCount(), 1);
+            assertEquals(result.getMaterializedRows().get(0).getField(0), "test      ");
+        }
+
+        assertUpdate("DROP TABLE char_trailing_space");
     }
 
     private AutoCloseable withSchema(String schema)


### PR DESCRIPTION
When running queries with presto, if the underlying
table is of type varchar, the predicate gets pushed.

If it's of type char, it will NOT get pushed, which
causes presto to get the whole table, and then filter
locally, which is a big pain (and bad performance).

Using Presto PR #4842 as a guide, I've added support
for char types to also be passed down.  Unit tests
also updated for the type following the pattern.
Also integration tested against a mysql-like backend.