### PR TITLE
Patch JsonType equal operator - the default equals operator will fail…

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/JsonType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/JsonType.java
@@ -99,4 +99,15 @@ public class JsonType
     {
         blockBuilder.writeBytes(value, offset, length).closeEntry();
     }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (this == other) {
+            return true;
+        }
+        else {
+            return (other != null) && getTypeSignature().equals(((Type) other).getTypeSignature());
+        }
+    }
 }


### PR DESCRIPTION
… if the classes are loaded from different loaders. This can lead to inserting rows with json type to fail. ie StatementAnalyzer->visitInsert->typesMatchForInsert fail to validate the json column.

Query 20181219_064256_00000_tjzb7 failed: Insert query has mismatched column types: Table: [integer, integer, integer, bigint, double, timestamp, timestamp, bigint, varchar, varchar(256), json, varchar(4), varchar(2), varchar(2), varchar(2)], Query: [integer, integer, integer, bigint, double, timestamp, timestamp, bigint, varchar, varchar(256), json, varchar(4), varchar(2), varchar(2), varchar(2)]

