### PR TITLE
Build Blocks directly instead of using BlockBuilder in OrcRecordReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BlockSupplier.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BlockSupplier.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.orc.OrcDataSourceId;
+import com.facebook.presto.orc.stream.BooleanInputStream;
+import com.facebook.presto.orc.stream.LongInputStream;
+import com.facebook.presto.spi.block.Block;
+
+import java.io.IOException;
+
+public interface BlockSupplier
+{
+    Block provideFromDirectStream(OrcDataSourceId dataSourceId, int batchSize, BooleanInputStream presentStream, LongInputStream dataInputStream)
+            throws IOException;
+
+    Block provideFromDictionaryStream(OrcDataSourceId dataSourceId, int batchSize, BooleanInputStream presentStream, LongInputStream dataInputStream,
+            long[] dictionary, BooleanInputStream inDictionary)
+            throws IOException;
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
@@ -22,7 +22,8 @@ import com.facebook.presto.orc.stream.ByteInputStream;
 import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.ByteArrayBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -30,6 +31,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
@@ -97,29 +99,35 @@ public class ByteStreamReader
             }
         }
 
-        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
+        Block block;
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
             }
-            dataStream.nextVector(type, nextBatchSize, builder);
+            block = populateNonNullBlock();
         }
         else {
-            for (int i = 0; i < nextBatchSize; i++) {
-                if (presentStream.nextBit()) {
-                    verify(dataStream != null);
-                    type.writeLong(builder, dataStream.next());
-                }
-                else {
-                    builder.appendNull();
-                }
+            boolean[] isNull = new boolean[nextBatchSize];
+            int nullCount = presentStream.getUnsetBits(nextBatchSize, isNull);
+            if (nullCount == 0) {
+                verify(dataStream != null);
+                block = populateNonNullBlock();
+            }
+            else if (nullCount != nextBatchSize) {
+                verify(dataStream != null);
+                block = populateBlockWithNull(isNull);
+            }
+            else {
+                block = new RunLengthEncodedBlock(
+                        new ByteArrayBlock(1,
+                                Optional.of(new boolean[] {true}),
+                                new byte[] {0}),
+                        nextBatchSize);
             }
         }
-
         readOffset = 0;
         nextBatchSize = 0;
-
-        return builder.build();
+        return block;
     }
 
     private void openRowGroup()
@@ -129,6 +137,22 @@ public class ByteStreamReader
         dataStream = dataStreamSource.openStream();
 
         rowGroupOpen = true;
+    }
+
+    private Block populateNonNullBlock()
+            throws IOException
+    {
+        byte[] vector = new byte[nextBatchSize];
+        dataStream.nextVector(nextBatchSize, vector);
+        return new ByteArrayBlock(nextBatchSize, Optional.empty(), vector);
+    }
+
+    private Block populateBlockWithNull(boolean[] isNull)
+            throws IOException
+    {
+        byte[] vector = new byte[nextBatchSize];
+        dataStream.nextVector(nextBatchSize, vector, isNull);
+        return new ByteArrayBlock(nextBatchSize, Optional.of(isNull), vector);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
@@ -22,7 +22,8 @@ import com.facebook.presto.orc.stream.DoubleInputStream;
 import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.LongArrayBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -30,6 +31,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
@@ -97,29 +99,35 @@ public class DoubleStreamReader
             }
         }
 
-        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
+        Block block;
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
             }
-            dataStream.nextVector(type, nextBatchSize, builder);
+            block = populateNonNullBlock();
         }
         else {
-            for (int i = 0; i < nextBatchSize; i++) {
-                if (presentStream.nextBit()) {
-                    verify(dataStream != null);
-                    type.writeDouble(builder, dataStream.next());
-                }
-                else {
-                    builder.appendNull();
-                }
+            boolean[] isNull = new boolean[nextBatchSize];
+            int nullCount = presentStream.getUnsetBits(nextBatchSize, isNull);
+            if (nullCount == 0) {
+                verify(dataStream != null);
+                block = populateNonNullBlock();
+            }
+            else if (nullCount != nextBatchSize) {
+                verify(dataStream != null);
+                block = populateBlockWithNull(isNull);
+            }
+            else {
+                block = new RunLengthEncodedBlock(
+                        new LongArrayBlock(1,
+                                Optional.of(new boolean[] {true}),
+                                new long[] {0}),
+                        nextBatchSize);
             }
         }
-
         readOffset = 0;
         nextBatchSize = 0;
-
-        return builder.build();
+        return block;
     }
 
     private void openRowGroup()
@@ -129,6 +137,22 @@ public class DoubleStreamReader
         dataStream = dataStreamSource.openStream();
 
         rowGroupOpen = true;
+    }
+
+    private Block populateNonNullBlock()
+            throws IOException
+    {
+        long[] vector = new long[nextBatchSize];
+        dataStream.nextVector(nextBatchSize, vector);
+        return new LongArrayBlock(nextBatchSize, Optional.empty(), vector);
+    }
+
+    private Block populateBlockWithNull(boolean[] isNull)
+            throws IOException
+    {
+        long[] vector = new long[nextBatchSize];
+        dataStream.nextVector(nextBatchSize, vector, isNull);
+        return new LongArrayBlock(nextBatchSize, Optional.of(isNull), vector);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatStreamReader.java
@@ -22,7 +22,8 @@ import com.facebook.presto.orc.stream.FloatInputStream;
 import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.IntArrayBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -30,6 +31,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
@@ -37,7 +39,6 @@ import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStr
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOf;
-import static java.lang.Float.floatToRawIntBits;
 import static java.util.Objects.requireNonNull;
 
 public class FloatStreamReader
@@ -98,29 +99,51 @@ public class FloatStreamReader
             }
         }
 
-        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
+        Block block;
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
             }
-            dataStream.nextVector(type, nextBatchSize, builder);
+            block = populateNonNullBlock();
         }
         else {
-            for (int i = 0; i < nextBatchSize; i++) {
-                if (presentStream.nextBit()) {
-                    verify(dataStream != null);
-                    type.writeLong(builder, floatToRawIntBits(dataStream.next()));
-                }
-                else {
-                    builder.appendNull();
-                }
+            boolean[] isNull = new boolean[nextBatchSize];
+            int nullCount = presentStream.getUnsetBits(nextBatchSize, isNull);
+            if (nullCount == 0) {
+                verify(dataStream != null);
+                block = populateNonNullBlock();
+            }
+            else if (nullCount != nextBatchSize) {
+                verify(dataStream != null);
+                block = populateBlockWithNull(isNull);
+            }
+            else {
+                block = new RunLengthEncodedBlock(
+                        new IntArrayBlock(1,
+                                Optional.of(new boolean[] {true}),
+                                new int[] {0}),
+                        nextBatchSize);
             }
         }
-
         readOffset = 0;
         nextBatchSize = 0;
+        return block;
+    }
 
-        return builder.build();
+    private Block populateNonNullBlock()
+            throws IOException
+    {
+        int[] vector = new int[nextBatchSize];
+        dataStream.nextVector(nextBatchSize, vector);
+        return new IntArrayBlock(nextBatchSize, Optional.empty(), vector);
+    }
+
+    private Block populateBlockWithNull(boolean[] isNull)
+            throws IOException
+    {
+        int[] vector = new int[nextBatchSize];
+        dataStream.nextVector(nextBatchSize, vector, isNull);
+        return new IntArrayBlock(nextBatchSize, Optional.of(isNull), vector);
     }
 
     private void openRowGroup()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/IntArrayBlockSupplier.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/IntArrayBlockSupplier.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.OrcDataSourceId;
+import com.facebook.presto.orc.stream.BooleanInputStream;
+import com.facebook.presto.orc.stream.LongInputStream;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.IntArrayBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static java.lang.Math.toIntExact;
+
+public class IntArrayBlockSupplier
+        implements BlockSupplier
+{
+    @Override
+    public Block provideFromDirectStream(OrcDataSourceId dataSourceId, int batchSize, BooleanInputStream presentStream, LongInputStream dataStream)
+            throws IOException
+    {
+        if (presentStream == null) {
+            if (dataStream == null) {
+                throw new OrcCorruptionException(dataSourceId, "Value is not null but data stream is not present");
+            }
+            return populateNonNullBlock(batchSize, dataStream);
+        }
+        boolean[] isNull = new boolean[batchSize];
+        int nullCount = presentStream.getUnsetBits(batchSize, isNull);
+        if (nullCount == 0) {
+            verify(dataStream != null);
+            return populateNonNullBlock(batchSize, dataStream);
+        }
+        if (nullCount != batchSize) {
+            verify(dataStream != null);
+            return populateBlockWithNull(batchSize, dataStream, isNull);
+        }
+        return new RunLengthEncodedBlock(
+                new IntArrayBlock(1,
+                        Optional.of(new boolean[] {true}),
+                        new int[] {0}), batchSize);
+    }
+
+    private Block populateNonNullBlock(int batchSize, LongInputStream dataStream)
+            throws IOException
+    {
+        int[] vector = new int[batchSize];
+        dataStream.nextIntVector(batchSize, vector, 0);
+        return new IntArrayBlock(batchSize, Optional.empty(), vector);
+    }
+
+    private Block populateBlockWithNull(int batchSize, LongInputStream dataStream, boolean[] isNull)
+            throws IOException
+    {
+        int[] vector = new int[batchSize];
+        verify(dataStream != null);
+        dataStream.nextIntVector(batchSize, vector, 0, isNull);
+        return new IntArrayBlock(batchSize, Optional.of(isNull), vector);
+    }
+
+    @Override
+    public Block provideFromDictionaryStream(OrcDataSourceId dataSourceId, int batchSize, BooleanInputStream presentStream, LongInputStream dataStream, long[] dictionary, BooleanInputStream inDictionaryStream)
+            throws IOException
+    {
+        if (presentStream == null) {
+            // Data doesn't have nulls
+            if (dataStream == null) {
+                throw new OrcCorruptionException(dataSourceId, "Value is not null but data stream is not present");
+            }
+            return populateNonNullBlock(batchSize, dataStream, dictionary, inDictionaryStream);
+        }
+        boolean[] isNull = new boolean[batchSize];
+        int nullValues = presentStream.getUnsetBits(batchSize, isNull);
+        // Data has nulls
+        if (dataStream == null) {
+            // The only valid case for dataStream is null when data has nulls is that all values are nulls.
+            if (nullValues != batchSize) {
+                throw new OrcCorruptionException(dataSourceId, "Value is not null but data stream is not present");
+            }
+            return new RunLengthEncodedBlock(new IntArrayBlock(1, Optional.of(new boolean[] {true}),
+                    new int[] {0}), batchSize);
+        }
+        if (nullValues == 0) {
+            return populateNonNullBlock(batchSize, dataStream, dictionary, inDictionaryStream);
+        }
+        return populateBlockWithNull(batchSize, isNull, dataStream, dictionary, inDictionaryStream);
+    }
+
+    private Block populateNonNullBlock(int batchSize, LongInputStream dataStream, long[] dictionary, BooleanInputStream inDictionaryStream)
+            throws IOException
+    {
+        int[] vector = new int[batchSize];
+        if (inDictionaryStream == null) {
+            for (int i = 0; i < batchSize; i++) {
+                vector[i] = toIntExact(dictionary[((int) dataStream.next())]);
+            }
+        }
+        else {
+            boolean[] inDictionary = new boolean[batchSize];
+            int inCount = inDictionaryStream.getSetBits(batchSize, inDictionary);
+            if (inCount == 0) {
+                dataStream.nextIntVector(batchSize, vector, 0);
+            }
+            for (int i = 0; i < batchSize; i++) {
+                long id = dataStream.next();
+                if (inDictionary[i]) {
+                    vector[i] = toIntExact(dictionary[(int) id]);
+                }
+                else {
+                    vector[i] = toIntExact(id);
+                }
+            }
+        }
+        return new IntArrayBlock(batchSize, Optional.empty(), vector);
+    }
+
+    private Block populateBlockWithNull(int batchSize, boolean[] isNull, LongInputStream dataStream, long[] dictionary, BooleanInputStream inDictionaryStream)
+            throws IOException
+    {
+        int[] vector = new int[batchSize];
+        if (inDictionaryStream == null) {
+            for (int i = 0; i < batchSize; i++) {
+                if (!isNull[i]) {
+                    vector[i] = toIntExact(dictionary[((int) dataStream.next())]);
+                }
+            }
+        }
+        else {
+            boolean[] inDictionary = new boolean[batchSize];
+            int inCount = inDictionaryStream.getSetBits(batchSize, inDictionary);
+            if (inCount == 0) {
+                dataStream.nextIntVector(batchSize, vector, 0, isNull);
+            }
+            for (int i = 0; i < batchSize; i++) {
+                long id = dataStream.next();
+                if (inDictionary[i]) {
+                    vector[i] = toIntExact(dictionary[(int) id]);
+                }
+                else {
+                    vector[i] = toIntExact(id);
+                }
+            }
+        }
+        return new IntArrayBlock(batchSize, Optional.of(isNull), vector);
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongArrayBlockSupplier.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongArrayBlockSupplier.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.OrcDataSourceId;
+import com.facebook.presto.orc.stream.BooleanInputStream;
+import com.facebook.presto.orc.stream.LongInputStream;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.LongArrayBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+
+public class LongArrayBlockSupplier
+        implements BlockSupplier
+{
+    @Override
+    public Block provideFromDirectStream(OrcDataSourceId dataSourceId, int batchSize, BooleanInputStream presentStream, LongInputStream dataStream)
+            throws IOException
+    {
+        if (presentStream == null) {
+            if (dataStream == null) {
+                throw new OrcCorruptionException(dataSourceId, "Value is not null but data stream is not present");
+            }
+            return populateNonNullBlock(batchSize, dataStream);
+        }
+        boolean[] isNull = new boolean[batchSize];
+        int nullCount = presentStream.getUnsetBits(batchSize, isNull);
+        if (nullCount == 0) {
+            verify(dataStream != null);
+            return populateNonNullBlock(batchSize, dataStream);
+        }
+        if (nullCount != batchSize) {
+            verify(dataStream != null);
+            return populateBlockWithNull(batchSize, dataStream, isNull);
+        }
+        return new RunLengthEncodedBlock(
+                new LongArrayBlock(1,
+                        Optional.of(new boolean[] {true}),
+                        new long[] {0}), batchSize);
+    }
+
+    private Block populateNonNullBlock(int batchSize, LongInputStream dataStream)
+            throws IOException
+    {
+        long[] vector = new long[batchSize];
+        dataStream.nextLongVector(batchSize, vector);
+        return new LongArrayBlock(batchSize, Optional.empty(), vector);
+    }
+
+    private Block populateBlockWithNull(int batchSize, LongInputStream dataStream, boolean[] isNull)
+            throws IOException
+    {
+        long[] vector = new long[batchSize];
+        verify(dataStream != null);
+        dataStream.nextLongVector(batchSize, vector, isNull);
+        return new LongArrayBlock(batchSize, Optional.of(isNull), vector);
+    }
+
+    @Override
+    public Block provideFromDictionaryStream(OrcDataSourceId dataSourceId, int batchSize, BooleanInputStream presentStream, LongInputStream dataStream, long[] dictionary, BooleanInputStream inDictionaryStream)
+            throws IOException
+    {
+        if (presentStream == null) {
+            // Data doesn't have nulls
+            if (dataStream == null) {
+                throw new OrcCorruptionException(dataSourceId, "Value is not null but data stream is not present");
+            }
+            return populateNonNullBlock(batchSize, dataStream, dictionary, inDictionaryStream);
+        }
+        boolean[] isNull = new boolean[batchSize];
+        int nullValues = presentStream.getUnsetBits(batchSize, isNull);
+        // Data has nulls
+        if (dataStream == null) {
+            // The only valid case for dataStream is null when data has nulls is that all values are nulls.
+            if (nullValues != batchSize) {
+                throw new OrcCorruptionException(dataSourceId, "Value is not null but data stream is not present");
+            }
+            return new RunLengthEncodedBlock(new LongArrayBlock(1, Optional.of(new boolean[] {true}),
+                    new long[] {0}), batchSize);
+        }
+        if (nullValues == 0) {
+            return populateNonNullBlock(batchSize, dataStream, dictionary, inDictionaryStream);
+        }
+        return populateBlockWithNull(batchSize, isNull, dataStream, dictionary, inDictionaryStream);
+    }
+
+    private Block populateNonNullBlock(int batchSize, LongInputStream dataStream, long[] dictionary, BooleanInputStream inDictionaryStream)
+            throws IOException
+    {
+        long[] vector = new long[batchSize];
+        if (inDictionaryStream == null) {
+            for (int i = 0; i < batchSize; i++) {
+                vector[i] = dictionary[((int) dataStream.next())];
+            }
+        }
+        else {
+            boolean[] inDictionary = new boolean[batchSize];
+            int inCount = inDictionaryStream.getSetBits(batchSize, inDictionary);
+            if (inCount == 0) {
+                dataStream.nextLongVector(batchSize, vector);
+            }
+            for (int i = 0; i < batchSize; i++) {
+                long id = dataStream.next();
+                if (inDictionary[i]) {
+                    vector[i] = dictionary[(int) id];
+                }
+                else {
+                    vector[i] = id;
+                }
+            }
+        }
+        return new LongArrayBlock(batchSize, Optional.empty(), vector);
+    }
+
+    private Block populateBlockWithNull(int batchSize, boolean[] isNull, LongInputStream dataStream, long[] dictionary, BooleanInputStream inDictionaryStream)
+            throws IOException
+    {
+        long[] vector = new long[batchSize];
+        if (inDictionaryStream == null) {
+            for (int i = 0; i < batchSize; i++) {
+                if (!isNull[i]) {
+                    vector[i] = dictionary[((int) dataStream.next())];
+                }
+            }
+        }
+        else {
+            boolean[] inDictionary = new boolean[batchSize];
+            int inCount = inDictionaryStream.getSetBits(batchSize, inDictionary);
+            if (inCount == 0) {
+                dataStream.nextLongVector(batchSize, vector, isNull);
+            }
+            for (int i = 0; i < batchSize; i++) {
+                long id = dataStream.next();
+                if (inDictionary[i]) {
+                    vector[i] = dictionary[(int) id];
+                }
+                else {
+                    vector[i] = id;
+                }
+            }
+        }
+        return new LongArrayBlock(batchSize, Optional.of(isNull), vector);
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongStreamReader.java
@@ -44,11 +44,11 @@ public class LongStreamReader
     private final LongDictionaryStreamReader dictionaryReader;
     private StreamReader currentReader;
 
-    public LongStreamReader(StreamDescriptor streamDescriptor, AggregatedMemoryContext systemMemoryContext)
+    public LongStreamReader(BlockSupplier blockSupplier, StreamDescriptor streamDescriptor, AggregatedMemoryContext systemMemoryContext)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        directReader = new LongDirectStreamReader(streamDescriptor, systemMemoryContext.newLocalMemoryContext(LongStreamReader.class.getSimpleName()));
-        dictionaryReader = new LongDictionaryStreamReader(streamDescriptor, systemMemoryContext.newLocalMemoryContext(LongStreamReader.class.getSimpleName()));
+        directReader = new LongDirectStreamReader(blockSupplier, streamDescriptor, systemMemoryContext.newLocalMemoryContext(LongStreamReader.class.getSimpleName()));
+        dictionaryReader = new LongDictionaryStreamReader(blockSupplier, streamDescriptor, systemMemoryContext.newLocalMemoryContext(LongStreamReader.class.getSimpleName()));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ShortArrayBlockSupplier.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ShortArrayBlockSupplier.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.OrcDataSourceId;
+import com.facebook.presto.orc.stream.BooleanInputStream;
+import com.facebook.presto.orc.stream.LongInputStream;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.block.ShortArrayBlock;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+
+public class ShortArrayBlockSupplier
+        implements BlockSupplier
+{
+    @Override
+    public Block provideFromDirectStream(OrcDataSourceId dataSourceId, int batchSize, BooleanInputStream presentStream, LongInputStream dataStream)
+            throws IOException
+    {
+        if (presentStream == null) {
+            if (dataStream == null) {
+                throw new OrcCorruptionException(dataSourceId, "Value is not null but data stream is not present");
+            }
+            return populateNonNullBlock(batchSize, dataStream);
+        }
+        boolean[] isNull = new boolean[batchSize];
+        int nullCount = presentStream.getUnsetBits(batchSize, isNull);
+        if (nullCount == 0) {
+            verify(dataStream != null);
+            return populateNonNullBlock(batchSize, dataStream);
+        }
+        if (nullCount != batchSize) {
+            verify(dataStream != null);
+            return populateBlockWithNull(batchSize, dataStream, isNull);
+        }
+        return new RunLengthEncodedBlock(
+                new ShortArrayBlock(1,
+                        Optional.of(new boolean[] {true}),
+                        new short[] {0}),
+                batchSize);
+    }
+
+    private Block populateNonNullBlock(int batchSize, LongInputStream dataStream)
+            throws IOException
+    {
+        short[] vector = new short[batchSize];
+        dataStream.nextShortVector(batchSize, vector);
+        return new ShortArrayBlock(batchSize, Optional.empty(), vector);
+    }
+
+    private Block populateBlockWithNull(int batchSize, LongInputStream dataStream, boolean[] isNull)
+            throws IOException
+    {
+        short[] vector = new short[batchSize];
+        verify(dataStream != null);
+        dataStream.nextShortVector(batchSize, vector, isNull);
+        return new ShortArrayBlock(batchSize, Optional.of(isNull), vector);
+    }
+
+    @Override
+    public Block provideFromDictionaryStream(OrcDataSourceId dataSourceId, int batchSize, BooleanInputStream presentStream, LongInputStream dataStream, long[] dictionary, BooleanInputStream inDictionaryStream)
+            throws IOException
+    {
+        if (presentStream == null) {
+            // Data doesn't have nulls
+            if (dataStream == null) {
+                throw new OrcCorruptionException(dataSourceId, "Value is not null but data stream is not present");
+            }
+            return populateNonNullBlock(batchSize, dataStream, dictionary, inDictionaryStream);
+        }
+        boolean[] isNull = new boolean[batchSize];
+        int nullValues = presentStream.getUnsetBits(batchSize, isNull);
+        // Data has nulls
+        if (dataStream == null) {
+            // The only valid case for dataStream is null when data has nulls is that all values are nulls.
+            if (nullValues != batchSize) {
+                throw new OrcCorruptionException(dataSourceId, "Value is not null but data stream is not present");
+            }
+            return new RunLengthEncodedBlock(new ShortArrayBlock(1, Optional.of(new boolean[] {true}),
+                    new short[] {0}), batchSize);
+        }
+        if (nullValues == 0) {
+            return populateNonNullBlock(batchSize, dataStream, dictionary, inDictionaryStream);
+        }
+        return populateBlockWithNull(batchSize, isNull, dataStream, dictionary, inDictionaryStream);
+    }
+
+    private Block populateNonNullBlock(int batchSize, LongInputStream dataStream, long[] dictionary, BooleanInputStream inDictionaryStream)
+            throws IOException
+    {
+        short[] vector = new short[batchSize];
+        if (inDictionaryStream == null) {
+            for (int i = 0; i < batchSize; i++) {
+                vector[i] = (short) dictionary[((int) dataStream.next())];
+            }
+        }
+        else {
+            boolean[] inDictionary = new boolean[batchSize];
+            int inCount = inDictionaryStream.getSetBits(batchSize, inDictionary);
+            if (inCount == 0) {
+                dataStream.nextShortVector(batchSize, vector);
+            }
+            for (int i = 0; i < batchSize; i++) {
+                long id = dataStream.next();
+                if (inDictionary[i]) {
+                    vector[i] = (short) dictionary[(int) id];
+                }
+                else {
+                    vector[i] = (short) id;
+                }
+            }
+        }
+        return new ShortArrayBlock(batchSize, Optional.empty(), vector);
+    }
+
+    private Block populateBlockWithNull(int batchSize, boolean[] isNull, LongInputStream dataStream, long[] dictionary, BooleanInputStream inDictionaryStream)
+            throws IOException
+    {
+        short[] vector = new short[batchSize];
+        if (inDictionaryStream == null) {
+            for (int i = 0; i < batchSize; i++) {
+                if (!isNull[i]) {
+                    vector[i] = (short) dictionary[((int) dataStream.next())];
+                }
+            }
+        }
+        else {
+            boolean[] inDictionary = new boolean[batchSize];
+            int inCount = inDictionaryStream.getSetBits(batchSize, inDictionary);
+            if (inCount == 0) {
+                dataStream.nextShortVector(batchSize, vector, isNull);
+            }
+            for (int i = 0; i < batchSize; i++) {
+                long id = dataStream.next();
+                if (inDictionary[i]) {
+                    vector[i] = (short) dictionary[(int) id];
+                }
+                else {
+                    vector[i] = (short) id;
+                }
+            }
+        }
+        return new ShortArrayBlock(batchSize, Optional.of(isNull), vector);
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StreamReaders.java
@@ -34,10 +34,12 @@ public final class StreamReaders
             case BYTE:
                 return new ByteStreamReader(streamDescriptor, systemMemoryContext.newLocalMemoryContext(StreamReaders.class.getSimpleName()));
             case SHORT:
-            case INT:
-            case LONG:
+                return new LongStreamReader(new ShortArrayBlockSupplier(), streamDescriptor, systemMemoryContext);
             case DATE:
-                return new LongStreamReader(streamDescriptor, systemMemoryContext);
+            case INT:
+                return new LongStreamReader(new IntArrayBlockSupplier(), streamDescriptor, systemMemoryContext);
+            case LONG:
+                return new LongStreamReader(new LongArrayBlockSupplier(), streamDescriptor, systemMemoryContext);
             case FLOAT:
                 return new FloatStreamReader(streamDescriptor, systemMemoryContext.newLocalMemoryContext(StreamReaders.class.getSimpleName()));
             case DOUBLE:

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanInputStream.java
@@ -167,6 +167,28 @@ public class BooleanInputStream
     }
 
     /**
+     * Sets the vector element to 1 if the bit is set.
+     */
+    public void getSetBits(int batchSize, byte[] vector)
+            throws IOException
+    {
+        for (int i = 0; i < batchSize; i++) {
+            vector[i] = (byte) (nextBit() ? 1 : 0);
+        }
+    }
+
+    /**
+     * Sets the vector element to 1 if the bit is set and it is not null
+     */
+    public void getSetBits(int batchSize, byte[] vector, boolean[] isNull)
+            throws IOException
+    {
+        for (int i = 0; i < batchSize; i++) {
+            vector[i] = (byte) (!isNull[i] && nextBit() ? 1 : 0);
+        }
+    }
+
+    /**
      * Sets the vector element to true if the bit is not set.
      */
     public int getUnsetBits(int batchSize, boolean[] vector)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleInputStream.java
@@ -22,6 +22,7 @@ import io.airlift.slice.Slices;
 import java.io.IOException;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+import static java.lang.Double.doubleToLongBits;
 
 public class DoubleInputStream
         implements ValueInputStream<DoubleStreamCheckpoint>
@@ -68,6 +69,24 @@ public class DoubleInputStream
     {
         for (int i = 0; i < items; i++) {
             type.writeDouble(builder, next());
+        }
+    }
+
+    public void nextVector(int items, long[] vector, boolean[] isNull)
+            throws IOException
+    {
+        for (int i = 0; i < items; i++) {
+            if (!isNull[i]) {
+                vector[i] = doubleToLongBits(next());
+            }
+        }
+    }
+
+    public void nextVector(int items, long[] vector)
+            throws IOException
+    {
+        for (int i = 0; i < items; i++) {
+            vector[i] = doubleToLongBits(next());
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatInputStream.java
@@ -71,4 +71,22 @@ public class FloatInputStream
             type.writeLong(builder, floatToRawIntBits(next()));
         }
     }
+
+    public void nextVector(int items, int[] vector)
+            throws IOException
+    {
+        for (int i = 0; i < items; i++) {
+            vector[i] = floatToRawIntBits(next());
+        }
+    }
+
+    public void nextVector(int items, int[] vector, boolean[] isNull)
+            throws IOException
+    {
+        for (int i = 0; i < items; i++) {
+            if (!isNull[i]) {
+                vector[i] = floatToRawIntBits(next());
+            }
+        }
+    }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStream.java
@@ -69,6 +69,18 @@ public interface LongInputStream
         }
     }
 
+    default void nextLongVector(int items, long[] vector, boolean[] isNull)
+            throws IOException
+    {
+        checkPositionIndex(items, vector.length);
+
+        for (int i = 0; i < items; i++) {
+            if (!isNull[i]) {
+                vector[i] = next();
+            }
+        }
+    }
+
     default long sum(int items)
             throws IOException
     {
@@ -77,5 +89,27 @@ public interface LongInputStream
             sum += next();
         }
         return sum;
+    }
+
+    default void nextShortVector(int items, short[] vector)
+            throws IOException
+    {
+        checkPositionIndex(items, vector.length);
+
+        for (int i = 0; i < items; i++) {
+            vector[i] = (short) toIntExact(next());
+        }
+    }
+
+    default void nextShortVector(int items, short[] vector, boolean[] isNull)
+            throws IOException
+    {
+        checkPositionIndex(items, vector.length);
+
+        for (int i = 0; i < items; i++) {
+            if (!isNull[i]) {
+                vector[i] = (short) toIntExact(next());
+            }
+        }
     }
 }


### PR DESCRIPTION
In the above proposal (#12000) it was inferred that we can get some better performance when we try to populate the blocks directly (by populating the result on a native array and wrap a  corresponding `Block` on top of it) instead of going via `BlockBuilder` (provided the `DataType` and `Block` kind is known before hand). We try to implement the same model when we are creating `Block` from a orc file. These are the benchmark numbers that we obtained

```
NORMAL IMPL
Benchmark                                   Mode  Cnt  Score   Error  Units
BenchmarkStreamReaders.readBooleanNoNull    avgt   60  0.029 ± 0.004   s/op
BenchmarkStreamReaders.readBooleanWithNull  avgt   60  0.103 ± 0.014   s/op
BenchmarkStreamReaders.readByteNoNull       avgt   60  0.033 ± 0.003   s/op
BenchmarkStreamReaders.readByteWithNull     avgt   60  0.090 ± 0.009   s/op
BenchmarkStreamReaders.readDoubleNoNull     avgt   60  0.214 ± 0.002   s/op
BenchmarkStreamReaders.readDoubleWithNull   avgt   60  0.183 ± 0.002   s/op
BenchmarkStreamReaders.readFloatNoNull      avgt   60  0.175 ± 0.003   s/op
BenchmarkStreamReaders.readFloatWithNull    avgt   60  0.170 ± 0.001   s/op

OUR IMPL
Benchmark                                   Mode  Cnt  Score    Error  Units
BenchmarkStreamReaders.readBooleanNoNull    avgt   60  0.020 ±  0.001   s/op
BenchmarkStreamReaders.readBooleanWithNull  avgt   60  0.082 ±  0.002   s/op
BenchmarkStreamReaders.readByteNoNull       avgt   60  0.009 ±  0.001   s/op
BenchmarkStreamReaders.readByteWithNull     avgt   60  0.074 ±  0.003   s/op
BenchmarkStreamReaders.readDoubleNoNull     avgt   60  0.197 ±  0.002   s/op
BenchmarkStreamReaders.readDoubleWithNull   avgt   60  0.166 ±  0.003   s/op
BenchmarkStreamReaders.readFloatNoNull      avgt   60  0.160 ±  0.002   s/op
BenchmarkStreamReaders.readFloatWithNull    avgt   60  0.144 ±  0.001   s/op
```