### PR TITLE
Fix Count(*) on empty relation return NULL when optimize_mixed_distinct_aggregation is turned on.

### DIFF
--- a/presto-main/etc/catalog/hive.properties
+++ b/presto-main/etc/catalog/hive.properties
@@ -6,4 +6,5 @@
 #
 
 connector.name=hive-hadoop2
-hive.metastore.uri=thrift://localhost:9083
+hive.metastore.uri=thrift://qabb-qa-metastore0:9083,thrift://qabb-qa-metastore1:9083
+hive.config.resources=/Users/chenqi/Programs/hdfs-site.xml,/Users/chenqi/Programs/core-site.xml

--- a/presto-main/etc/catalog/hive.properties
+++ b/presto-main/etc/catalog/hive.properties
@@ -6,5 +6,4 @@
 #
 
 connector.name=hive-hadoop2
-hive.metastore.uri=thrift://qabb-qa-metastore0:9083,thrift://qabb-qa-metastore1:9083
-hive.config.resources=/Users/chenqi/Programs/hdfs-site.xml,/Users/chenqi/Programs/core-site.xml
+hive.metastore.uri=thrift://localhost:9083

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -33,6 +33,7 @@ import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
@@ -151,6 +152,9 @@ public class OptimizeMixedDistinctAggregations
             // Change aggregate node to do second aggregation, handles this part of optimized plan mentioned above:
             //          SELECT a1, a2,..., an, arbitrary(if(group = 0, f1)),...., arbitrary(if(group = 0, fm)), F(if(group = 1, c))
             ImmutableMap.Builder<Symbol, Aggregation> aggregations = ImmutableMap.builder();
+            // Add coalesce projection node to handle count(), count_if(), approx_distinct() functions return a
+            // non-null result without any input
+            ImmutableMap.Builder<Symbol, Symbol> coalesceSymbolsBuilder = ImmutableMap.builder();
             for (Map.Entry<Symbol, Aggregation> entry : node.getAggregations().entrySet()) {
                 FunctionCall functionCall = entry.getValue().getCall();
                 if (entry.getValue().getMask().isPresent()) {
@@ -167,14 +171,27 @@ public class OptimizeMixedDistinctAggregations
                     // Aggregations on non-distinct are already done by new node, just extract the non-null value
                     Symbol argument = aggregateInfo.getNewNonDistinctAggregateSymbols().get(entry.getKey());
                     QualifiedName functionName = QualifiedName.of("arbitrary");
-                    aggregations.put(entry.getKey(), new Aggregation(
-                            new FunctionCall(functionName, functionCall.getWindow(), false, ImmutableList.of(argument.toSymbolReference())),
-                            getFunctionSignature(functionName, argument),
-                            Optional.empty()));
+                    String signatureName = entry.getValue().getSignature().getName();
+                    if (signatureName.equals("count")
+                            || signatureName.equals("count_if") || signatureName.equals("approx_distinct")) {
+                        Symbol newSymbol = symbolAllocator.newSymbol("expr", symbolAllocator.getTypes().get(entry.getKey()));
+                        aggregations.put(newSymbol, new Aggregation(
+                                new FunctionCall(functionName, functionCall.getWindow(), false, ImmutableList.of(argument.toSymbolReference())),
+                                getFunctionSignature(functionName, argument),
+                                Optional.empty()));
+                        coalesceSymbolsBuilder.put(newSymbol, entry.getKey());
+                    }
+                    else {
+                        aggregations.put(entry.getKey(), new Aggregation(
+                                new FunctionCall(functionName, functionCall.getWindow(), false, ImmutableList.of(argument.toSymbolReference())),
+                                getFunctionSignature(functionName, argument),
+                                Optional.empty()));
+                    }
                 }
             }
+            Map<Symbol, Symbol> coalesceSymbols = coalesceSymbolsBuilder.build();
 
-            return new AggregationNode(
+            AggregationNode aggregationNode = new AggregationNode(
                     idAllocator.getNextId(),
                     source,
                     aggregations.build(),
@@ -183,6 +200,23 @@ public class OptimizeMixedDistinctAggregations
                     node.getStep(),
                     Optional.empty(),
                     node.getGroupIdSymbol());
+
+            if (coalesceSymbols.isEmpty()) {
+                return aggregationNode;
+            }
+
+            Assignments.Builder outputSymbols = Assignments.builder();
+            for (Symbol symbol : aggregationNode.getOutputSymbols()) {
+                if (coalesceSymbols.get(symbol) != null) {
+                    Expression expression = new CoalesceExpression(symbol.toSymbolReference(), new Cast(new LongLiteral("0"), "bigint"));
+                    outputSymbols.put(coalesceSymbols.get(symbol), expression);
+                }
+                else {
+                    outputSymbols.put(symbol, symbol.toSymbolReference());
+                }
+            }
+
+            return new ProjectNode(idAllocator.getNextId(), aggregationNode, outputSymbols.build());
         }
 
         @Override

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestOptimizeMixedDistinctAggregations.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestOptimizeMixedDistinctAggregations.java
@@ -28,10 +28,8 @@ public class TestOptimizeMixedDistinctAggregations
     @Override
     public void testCountDistinct()
     {
-        // TODO https://github.com/prestodb/presto/issues/8894 . Once fixed, remove test override.
-
         assertQuery("SELECT COUNT(DISTINCT custkey + 1) FROM orders", "SELECT COUNT(*) FROM (SELECT DISTINCT custkey + 1 FROM orders) t");
-        // assertQuery("SELECT COUNT(DISTINCT linenumber), COUNT(*) from lineitem where linenumber < 0");
+        assertQuery("SELECT COUNT(DISTINCT linenumber), COUNT(*) from lineitem where linenumber < 0");
     }
 
     // TODO add dedicated test cases and remove `extends AbstractTestAggregation`


### PR DESCRIPTION
Use a coalesce projection node to fix Count(*) on empty relation return NULL when optimize_mixed_distinct_aggregation is turned on.