### PR TITLE
Fix Count(*) on empty relation returns NULL when optimize_mixed_distinct_aggregation is turned on.

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestOptimizeMixedDistinctAggregations.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestOptimizeMixedDistinctAggregations.java
@@ -28,10 +28,8 @@ public class TestOptimizeMixedDistinctAggregations
     @Override
     public void testCountDistinct()
     {
-        // TODO https://github.com/prestodb/presto/issues/8894 . Once fixed, remove test override.
-
         assertQuery("SELECT COUNT(DISTINCT custkey + 1) FROM orders", "SELECT COUNT(*) FROM (SELECT DISTINCT custkey + 1 FROM orders) t");
-        // assertQuery("SELECT COUNT(DISTINCT linenumber), COUNT(*) from lineitem where linenumber < 0");
+        assertQuery("SELECT COUNT(DISTINCT linenumber), COUNT(*) from lineitem where linenumber < 0");
     }
 
     // TODO add dedicated test cases and remove `extends AbstractTestAggregation`


### PR DESCRIPTION
Introduce coalesce(x, 0) on a projection node to fix Count(*) on empty relation returns NULL when optimize_mixed_distinct_aggregation is turned on.