### PR TITLE
Change representation of EnforceSingleRowNode in EXPLAIN

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -1247,7 +1247,7 @@ public class PlanPrinter
         @Override
         public Void visitEnforceSingleRow(EnforceSingleRowNode node, Integer indent)
         {
-            print(indent, "- Scalar => [%s]", formatOutputs(node.getOutputSymbols()));
+            print(indent, "- EnforceSingleRow => [%s]", formatOutputs(node.getOutputSymbols()));
             printPlanNodesStatsAndCost(indent + 2, node);
             printStats(indent + 2, node.getId());
 


### PR DESCRIPTION
In my opinion, 
```
...
   - Scalar
      - ....
```
is not self-explanatory. I think the following is:
```
...
   - EnforceSingleRow
      - ....
```