### PR TITLE
Fix creating non-bucketed empty partition

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1220,6 +1220,13 @@ public class HiveMetadata
         Map<List<String>, ComputedStatistics> partitionComputedStatistics = createComputedStatisticsToPartitionMap(computedStatistics, partitionedBy, columnTypes);
 
         for (PartitionUpdate partitionUpdate : partitionUpdates) {
+            if (partitionUpdate.getFileNames().size() == 0) {
+                HiveWriteUtils.createDirectory(
+                        new HdfsContext(session, table.get().getDatabaseName(), table.get().getTableName()),
+                        hdfsEnvironment,
+                        partitionUpdate.getWritePath());
+            }
+
             if (partitionUpdate.getName().isEmpty()) {
                 // insert into unpartitioned table
                 metastore.finishInsertIntoExistingTable(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -938,6 +938,30 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testCreateEmptyPartition()
+    {
+        String tableName = "empty_partition_table";
+        assertUpdate(format("" +
+                "CREATE TABLE %s " +
+                "WITH ( " +
+                " FORMAT = 'ORC', " +
+                "   partitioned_by = ARRAY['p_varchar'] " +
+                ") " +
+                "AS " +
+                "SELECT c_bigint, p_varchar " +
+                "FROM ( " +
+                "  VALUES " +
+                "    (BIGINT '7', 'longlonglong')" +
+                ") AS x (c_bigint, p_varchar)", tableName), 1);
+        assertQuery(format("SELECT count(*) FROM \"%s$partitions\"", tableName), "SELECT 1");
+
+        // create an empty partition
+        assertUpdate(format("CALL system.create_empty_partition('%s', '%s', ARRAY['p_varchar'], ARRAY['%s'])", TPCH_SCHEMA, tableName, "empty"));
+        assertQuery(format("SELECT count(*) FROM \"%s$partitions\"", tableName), "SELECT 2");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
     public void testCreateEmptyBucketedPartition()
     {
         for (TestingHiveStorageFormat storageFormat : getAllTestingHiveStorageFormat()) {


### PR DESCRIPTION
Fix a bug where creating empty parition using CALL statement
throws exceptions when using file based metastore implementation.

#12002 