### PR TITLE
Add joda-to-java-time-bridge dependency in example connector

### DIFF
--- a/presto-example-http/pom.xml
+++ b/presto-example-http/pom.xml
@@ -27,6 +27,13 @@
         </dependency>
 
         <dependency>
+            <!-- airlift json has a dependency on joda -->
+            <groupId>io.airlift</groupId>
+            <artifactId>joda-to-java-time-bridge</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
         </dependency>


### PR DESCRIPTION
This commit fixes "server start" failure of presto-main with default trunk dev config. As a result, I believe it should be merged for now regardless of whether this is the right solution.

~~However, I think we should reevaluate our choice to have each connector declare this run-time dependency now that we noticed that people don't generally realize they have a dependency on joda. For one, I didn't realize that presto-example-http has a dependency on joda transitively when I walked through the dependency list. I had to resort to tools to find out how after the trunk failure is brought to my attention. I propose adding joda-to-java-time-bridge to SPI_PACKAGES (in the context of PluginClassLoader).~~