### PR TITLE
Remove extra remote exchange in window function

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -299,7 +299,8 @@ public class AddExchanges
                     PreferredProperties.partitionedWithLocal(ImmutableSet.copyOf(node.getPartitionBy()), desiredProperties)
                             .mergeWithParent(preferredProperties));
 
-            if (!child.getProperties().isStreamPartitionedOn(node.getPartitionBy())) {
+            if (!child.getProperties().isStreamPartitionedOn(node.getPartitionBy()) &&
+                    !child.getProperties().isNodePartitionedOn(node.getPartitionBy())) {
                 if (node.getPartitionBy().isEmpty()) {
                     child = withDerivedProperties(
                             gatheringExchange(idAllocator.getNextId(), REMOTE, child.getNode()),
@@ -336,7 +337,8 @@ public class AddExchanges
                             .mergeWithParent(preferredProperties));
 
             // TODO: add config option/session property to force parallel plan if child is unpartitioned and window has a PARTITION BY clause
-            if (!child.getProperties().isStreamPartitionedOn(node.getPartitionBy())) {
+            if (!child.getProperties().isStreamPartitionedOn(node.getPartitionBy())
+                    && !child.getProperties().isNodePartitionedOn(node.getPartitionBy())) {
                 child = withDerivedProperties(
                         partitionedExchange(
                                 idAllocator.getNextId(),
@@ -369,7 +371,8 @@ public class AddExchanges
             }
 
             PlanWithProperties child = planChild(node, preferredChildProperties);
-            if (!child.getProperties().isStreamPartitionedOn(node.getPartitionBy())) {
+            if (!child.getProperties().isStreamPartitionedOn(node.getPartitionBy())
+                    && !child.getProperties().isNodePartitionedOn(node.getPartitionBy())) {
                 // add exchange + push function to child
                 child = withDerivedProperties(
                         new TopNRowNumberNode(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -50,6 +50,7 @@ import static com.facebook.presto.SystemSessionProperties.FORCE_SINGLE_NODE_OUTP
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_HASH_GENERATION;
 import static com.facebook.presto.spi.StandardErrorCode.SUBQUERY_MULTIPLE_ROWS;
+import static com.facebook.presto.spi.block.SortOrder.ASC_NULLS_LAST;
 import static com.facebook.presto.spi.predicate.Domain.singleValue;
 import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
@@ -70,12 +71,16 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.markDi
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.rowNumber;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.specification;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictTableScan;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.topNRowNumber;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.window;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.FINAL;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.PARTIAL;
@@ -101,6 +106,8 @@ import static org.testng.Assert.assertFalse;
 public class TestLogicalPlanner
         extends BasePlanTest
 {
+    // TODO: Use com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder#tableScan with required node/stream
+    // partitioning to properly test aggregation, window function and join.
     @Test
     public void testAggregation()
     {
@@ -129,6 +136,151 @@ public class TestLogicalPlanner
                                                         ImmutableMap.of("partial_sum", functionCall("sum", ImmutableList.of("totalprice"))),
                                                         PARTIAL,
                                                         anyTree(tableScan("orders", ImmutableMap.of("totalprice", "totalprice")))))))));
+    }
+
+    @Test
+    public void testWindow()
+    {
+        // Window partition key is pre-bucketed.
+        assertDistributedPlan("SELECT rank() OVER (PARTITION BY orderkey) FROM orders",
+                anyTree(
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specification(ImmutableList.of("orderkey"), ImmutableList.of(), ImmutableMap.of()))
+                                        .addFunction(functionCall("rank", Optional.empty(), ImmutableList.of())),
+                                project(tableScan("orders", ImmutableMap.of("orderkey", "orderkey"))))));
+
+        assertDistributedPlan("SELECT row_number() OVER (PARTITION BY orderkey) FROM orders",
+                anyTree(
+                        rowNumber(rowNumberMatcherBuilder -> rowNumberMatcherBuilder
+                                        .partitionBy(ImmutableList.of("orderkey")),
+                                project(tableScan("orders", ImmutableMap.of("orderkey", "orderkey"))))));
+
+        assertDistributedPlan("SELECT orderkey FROM (SELECT orderkey, row_number() OVER (PARTITION BY orderkey ORDER BY custkey) n FROM orders) WHERE n = 1",
+                anyTree(
+                        topNRowNumber(topNRowNumber -> topNRowNumber
+                                        .specification(
+                                                ImmutableList.of("orderkey"),
+                                                ImmutableList.of("custkey"),
+                                                ImmutableMap.of("custkey", ASC_NULLS_LAST)),
+                                project(tableScan("orders", ImmutableMap.of("orderkey", "orderkey", "custkey", "custkey"))))));
+
+        // Window partition key is not pre-bucketed.
+        assertDistributedPlan("SELECT rank() OVER (PARTITION BY orderstatus) FROM orders",
+                anyTree(
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specification(ImmutableList.of("orderstatus"), ImmutableList.of(), ImmutableMap.of()))
+                                        .addFunction(functionCall("rank", Optional.empty(), ImmutableList.of())),
+                                exchange(LOCAL, GATHER,
+                                        exchange(REMOTE, REPARTITION,
+                                                project(tableScan("orders", ImmutableMap.of("orderstatus", "orderstatus"))))))));
+
+        assertDistributedPlan("SELECT row_number() OVER (PARTITION BY orderstatus) FROM orders",
+                anyTree(
+                        rowNumber(rowNumberMatcherBuilder -> rowNumberMatcherBuilder
+                                        .partitionBy(ImmutableList.of("orderstatus")),
+                                exchange(LOCAL, GATHER,
+                                        exchange(REMOTE, REPARTITION,
+                                                project(tableScan("orders", ImmutableMap.of("orderstatus", "orderstatus"))))))));
+
+        assertDistributedPlan("SELECT orderstatus FROM (SELECT orderstatus, row_number() OVER (PARTITION BY orderstatus ORDER BY custkey) n FROM orders) WHERE n = 1",
+                anyTree(
+                        topNRowNumber(topNRowNumber -> topNRowNumber
+                                        .specification(
+                                                ImmutableList.of("orderstatus"),
+                                                ImmutableList.of("custkey"),
+                                                ImmutableMap.of("custkey", ASC_NULLS_LAST))
+                                        .partial(false),
+                                exchange(LOCAL, GATHER,
+                                        exchange(REMOTE, REPARTITION,
+                                                topNRowNumber(topNRowNumber -> topNRowNumber
+                                                                .specification(
+                                                                        ImmutableList.of("orderstatus"),
+                                                                        ImmutableList.of("custkey"),
+                                                                        ImmutableMap.of("custkey", ASC_NULLS_LAST))
+                                                                .partial(true),
+                                                        project(tableScan("orders", ImmutableMap.of("orderstatus", "orderstatus", "custkey", "custkey")))))))));
+    }
+
+    @Test
+    public void testWindowAfterJoin()
+    {
+        // Window partition key is a super set of join key.
+        assertDistributedPlan("SELECT rank() OVER (PARTITION BY o.orderstatus, o.orderkey) FROM orders o JOIN lineitem l ON o.orderstatus = l.linestatus",
+                anyTree(
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specification(ImmutableList.of("orderstatus", "orderkey"), ImmutableList.of(), ImmutableMap.of()))
+                                        .addFunction(functionCall("rank", Optional.empty(), ImmutableList.of())),
+                                exchange(LOCAL, GATHER,
+                                        project(
+                                                join(INNER, ImmutableList.of(equiJoinClause("orderstatus", "linestatus")), Optional.empty(), Optional.of(PARTITIONED),
+                                                        exchange(REMOTE, REPARTITION,
+                                                                anyTree(tableScan("orders", ImmutableMap.of("orderstatus", "orderstatus", "orderkey", "orderkey")))),
+                                                        exchange(LOCAL, GATHER,
+                                                                exchange(REMOTE, REPARTITION,
+                                                                        anyTree(tableScan("lineitem", ImmutableMap.of("linestatus", "linestatus")))))))))));
+
+        // Window partition key is not a super set of join key.
+        assertDistributedPlan("SELECT rank() OVER (PARTITION BY o.orderkey) FROM orders o JOIN lineitem l ON o.orderstatus = l.linestatus",
+                anyTree(
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specification(ImmutableList.of("orderkey"), ImmutableList.of(), ImmutableMap.of()))
+                                        .addFunction(functionCall("rank", Optional.empty(), ImmutableList.of())),
+                                exchange(LOCAL, GATHER,
+                                        exchange(REMOTE, REPARTITION,
+                                                anyTree(join(INNER, ImmutableList.of(equiJoinClause("orderstatus", "linestatus")), Optional.empty(), Optional.of(PARTITIONED),
+                                                        exchange(REMOTE, REPARTITION,
+                                                                anyTree(tableScan("orders", ImmutableMap.of("orderstatus", "orderstatus", "orderkey", "orderkey")))),
+                                                        exchange(LOCAL, GATHER,
+                                                                exchange(REMOTE, REPARTITION,
+                                                                        anyTree(tableScan("lineitem", ImmutableMap.of("linestatus", "linestatus"))))))))))));
+
+        // Test broadcast join
+        Session broadcastJoin = Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.BROADCAST.name())
+                .setSystemProperty(FORCE_SINGLE_NODE_OUTPUT, Boolean.toString(false))
+                .build();
+        assertDistributedPlan("SELECT rank() OVER (PARTITION BY o.custkey) FROM orders o JOIN lineitem l ON o.orderstatus = l.linestatus",
+                broadcastJoin,
+                anyTree(
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specification(ImmutableList.of("custkey"), ImmutableList.of(), ImmutableMap.of()))
+                                        .addFunction(functionCall("rank", Optional.empty(), ImmutableList.of())),
+                                exchange(LOCAL, GATHER,
+                                        exchange(REMOTE, REPARTITION,
+                                                project(
+                                                        join(INNER, ImmutableList.of(equiJoinClause("orderstatus", "linestatus")), Optional.empty(), Optional.of(REPLICATED),
+                                                                anyTree(tableScan("orders", ImmutableMap.of("orderstatus", "orderstatus", "custkey", "custkey"))),
+                                                                exchange(LOCAL, GATHER,
+                                                                        exchange(REMOTE, REPLICATE,
+                                                                                anyTree(tableScan("lineitem", ImmutableMap.of("linestatus", "linestatus"))))))))))));
+    }
+
+    @Test
+    public void testWindowAfterAggregation()
+    {
+        // Window partition key is a super set of group by key.
+        assertDistributedPlan("SELECT rank() OVER (PARTITION BY custkey) FROM orders GROUP BY custkey",
+                anyTree(
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specification(ImmutableList.of("custkey"), ImmutableList.of(), ImmutableMap.of()))
+                                        .addFunction(functionCall("rank", Optional.empty(), ImmutableList.of())),
+                                project(aggregation(singleGroupingSet("custkey"), ImmutableMap.of(), ImmutableMap.of(), Optional.empty(), FINAL,
+                                        exchange(LOCAL, GATHER,
+                                                project(exchange(REMOTE, REPARTITION,
+                                                        anyTree(tableScan("orders", ImmutableMap.of("custkey", "custkey")))))))))));
+
+        // Window partition key is not a super set of group by key.
+        assertDistributedPlan("SELECT rank() OVER (partition by custkey) FROM (SELECT shippriority, custkey, sum(totalprice) FROM orders GROUP BY shippriority, custkey)",
+                anyTree(
+                        window(windowMatcherBuilder -> windowMatcherBuilder
+                                        .specification(specification(ImmutableList.of("custkey"), ImmutableList.of(), ImmutableMap.of()))
+                                        .addFunction(functionCall("rank", Optional.empty(), ImmutableList.of())),
+                                exchange(LOCAL, GATHER,
+                                        exchange(REMOTE, REPARTITION,
+                                                project(aggregation(singleGroupingSet("shippriority", "custkey"), ImmutableMap.of(), ImmutableMap.of(), Optional.empty(), FINAL,
+                                                        exchange(LOCAL, GATHER,
+                                                                exchange(REMOTE, REPARTITION,
+                                                                        anyTree(tableScan("orders", ImmutableMap.of("custkey", "custkey", "shippriority", "shippriority"))))))))))));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -271,6 +271,20 @@ public final class PlanMatchPattern
         return windowMatcherBuilder.build();
     }
 
+    public static PlanMatchPattern rowNumber(Consumer<RowNumberMatcher.Builder> rowNumberMatcherBuilderConsumer, PlanMatchPattern source)
+    {
+        RowNumberMatcher.Builder rowNumberMatcherBuilder = new RowNumberMatcher.Builder(source);
+        rowNumberMatcherBuilderConsumer.accept(rowNumberMatcherBuilder);
+        return rowNumberMatcherBuilder.build();
+    }
+
+    public static PlanMatchPattern topNRowNumber(Consumer<TopNRowNumberMatcher.Builder> topNRowNumberMatcherBuilderComsumer, PlanMatchPattern source)
+    {
+        TopNRowNumberMatcher.Builder topNRowNumberMatcherBuilder = new TopNRowNumberMatcher.Builder(source);
+        topNRowNumberMatcherBuilderComsumer.accept(topNRowNumberMatcherBuilder);
+        return topNRowNumberMatcherBuilder.build();
+    }
+
     public static PlanMatchPattern sort(PlanMatchPattern source)
     {
         return node(SortNode.class, source);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowNumberMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowNumberMatcher.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.RowNumberNode;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class RowNumberMatcher
+        implements Matcher
+{
+    private final Optional<List<SymbolAlias>> partitionBy;
+    private final Optional<Optional<Integer>> maxRowCountPerPartition;
+    private final Optional<SymbolAlias> rowNumberSymbol;
+    private final Optional<Optional<SymbolAlias>> hashSymbol;
+
+    private RowNumberMatcher(
+            Optional<List<SymbolAlias>> partitionBy,
+            Optional<Optional<Integer>> maxRowCountPerPartition,
+            Optional<SymbolAlias> rowNumberSymbol,
+            Optional<Optional<SymbolAlias>> hashSymbol)
+    {
+        this.partitionBy = requireNonNull(partitionBy, "partitionBy is null");
+        this.maxRowCountPerPartition = requireNonNull(maxRowCountPerPartition, "maxRowCountPerPartition is null");
+        this.rowNumberSymbol = requireNonNull(rowNumberSymbol, "rowNumberSymbol is null");
+        this.hashSymbol = requireNonNull(hashSymbol, "hashSymbol is null");
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof RowNumberNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+
+        RowNumberNode rowNumberNode = (RowNumberNode) node;
+
+        if (!partitionBy
+                .map(expectedPartitionBy -> expectedPartitionBy.stream()
+                        .map(alias -> alias.toSymbol(symbolAliases))
+                        .collect(toImmutableList())
+                        .equals(rowNumberNode.getPartitionBy()))
+                .orElse(true)) {
+            return NO_MATCH;
+        }
+
+        if (!maxRowCountPerPartition
+                .map(expectedMaxRowCountPerPartition -> expectedMaxRowCountPerPartition.equals(rowNumberNode.getMaxRowCountPerPartition()))
+                .orElse(true)) {
+            return NO_MATCH;
+        }
+
+        if (!rowNumberSymbol
+                .map(expectedRowNumberSymbol ->
+                        expectedRowNumberSymbol.toSymbol(symbolAliases)
+                                .equals(rowNumberNode.getRowNumberSymbol()))
+                .orElse(true)) {
+            return NO_MATCH;
+        }
+
+        if (!hashSymbol
+                .map(expectedHashSymbol ->
+                        expectedHashSymbol
+                                .map(symbolAlias -> symbolAlias.toSymbol(symbolAliases))
+                                .equals(rowNumberNode.getHashSymbol()))
+                .orElse(true)) {
+            return NO_MATCH;
+        }
+
+        return match();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("partitionBy", partitionBy)
+                .add("maxRowCountPerPartition", maxRowCountPerPartition)
+                .add("rowNumberSymbol", rowNumberSymbol)
+                .add("hashSymbol", hashSymbol)
+                .toString();
+    }
+
+    /**
+     * By default, matches any RowNumberNode.  Users add additional constraints by
+     * calling the various member functions of the Builder, typically named according
+     * to the field names of RowNumberNode.
+     */
+    public static class Builder
+    {
+        private final PlanMatchPattern source;
+        private Optional<List<SymbolAlias>> partitionBy = Optional.empty();
+        private Optional<Optional<Integer>> maxRowCountPerPartition = Optional.empty();
+        private Optional<SymbolAlias> rowNumberSymbol = Optional.empty();
+        private Optional<Optional<SymbolAlias>> hashSymbol = Optional.empty();
+
+        Builder(PlanMatchPattern source)
+        {
+            this.source = requireNonNull(source, "source is null");
+        }
+
+        public Builder partitionBy(List<String> partitionBy)
+        {
+            requireNonNull(partitionBy, "partitionBy is null");
+            this.partitionBy = Optional.of(partitionBy.stream()
+                    .map(SymbolAlias::new)
+                    .collect(toImmutableList()));
+            return this;
+        }
+
+        public Builder maxRowCountPerPartition(Optional<Integer> maxRowCountPerPartition)
+        {
+            this.maxRowCountPerPartition = Optional.of(requireNonNull(maxRowCountPerPartition, "maxRowCountPerPartition is null"));
+            return this;
+        }
+
+        public Builder rowNumberSymbol(SymbolAlias rowNumberSymbol)
+        {
+            this.rowNumberSymbol = Optional.of(requireNonNull(rowNumberSymbol, "rowNumberSymbol is null"));
+            return this;
+        }
+
+        public Builder hashSymbol(Optional<SymbolAlias> hashSymbol)
+        {
+            this.hashSymbol = Optional.of(requireNonNull(hashSymbol, "hashSymbol is null"));
+            return this;
+        }
+
+        PlanMatchPattern build()
+        {
+            return node(RowNumberNode.class, source).with(
+                    new RowNumberMatcher(
+                            partitionBy,
+                            maxRowCountPerPartition,
+                            rowNumberSymbol,
+                            hashSymbol));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TopNRowNumberMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TopNRowNumberMatcher.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.block.SortOrder;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class TopNRowNumberMatcher
+        implements Matcher
+{
+    private final Optional<ExpectedValueProvider<WindowNode.Specification>> specification;
+    private final Optional<SymbolAlias> rowNumberSymbol;
+    private final Optional<Integer> maxRowCountPerPartition;
+    private final Optional<Boolean> partial;
+    private final Optional<Optional<SymbolAlias>> hashSymbol;
+
+    private TopNRowNumberMatcher(
+            Optional<ExpectedValueProvider<WindowNode.Specification>> specification,
+            Optional<SymbolAlias> rowNumberSymbol,
+            Optional<Integer> maxRowCountPerPartition,
+            Optional<Boolean> partial,
+            Optional<Optional<SymbolAlias>> hashSymbol)
+    {
+        this.specification = requireNonNull(specification, "specification is null");
+        this.rowNumberSymbol = requireNonNull(rowNumberSymbol, "rowNumberSymbol is null");
+        this.maxRowCountPerPartition = requireNonNull(maxRowCountPerPartition, "maxRowCountPerPartition is null");
+        this.partial = requireNonNull(partial, "partial is null");
+        this.hashSymbol = requireNonNull(hashSymbol, "hashSymbol is null");
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return node instanceof TopNRowNumberNode;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
+
+        TopNRowNumberNode topNRowNumberNode = (TopNRowNumberNode) node;
+
+        if (!specification
+                .map(expectedSpecification ->
+                        expectedSpecification.getExpectedValue(symbolAliases)
+                                .equals(topNRowNumberNode.getSpecification()))
+                .orElse(true)) {
+            return NO_MATCH;
+        }
+
+        if (!rowNumberSymbol
+                .map(expectedRowNumberSymbol ->
+                        expectedRowNumberSymbol.toSymbol(symbolAliases)
+                                .equals(topNRowNumberNode.getRowNumberSymbol()))
+                .orElse(true)) {
+            return NO_MATCH;
+        }
+
+        if (!maxRowCountPerPartition
+                .map(expectedMaxRowCountPerPartition -> expectedMaxRowCountPerPartition.equals(topNRowNumberNode.getMaxRowCountPerPartition()))
+                .orElse(true)) {
+            return NO_MATCH;
+        }
+
+        if (!partial
+                .map(expectedPartial -> expectedPartial.equals(topNRowNumberNode.isPartial()))
+                .orElse(true)) {
+            return NO_MATCH;
+        }
+
+        if (!hashSymbol
+                .map(expectedHashSymbol ->
+                        expectedHashSymbol
+                                .map(symbolAlias -> symbolAlias.toSymbol(symbolAliases))
+                                .equals(topNRowNumberNode.getHashSymbol()))
+                .orElse(true)) {
+            return NO_MATCH;
+        }
+
+        return match();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("specification", specification)
+                .add("rowNumberSymbol", rowNumberSymbol)
+                .add("maxRowCountPerPartition", maxRowCountPerPartition)
+                .add("partial", partial)
+                .add("hashSymbol", hashSymbol)
+                .toString();
+    }
+
+    public static class Builder
+    {
+        private final PlanMatchPattern source;
+        private Optional<ExpectedValueProvider<WindowNode.Specification>> specification = Optional.empty();
+        private Optional<SymbolAlias> rowNumberSymbol = Optional.empty();
+        private Optional<Integer> maxRowCountPerPartition = Optional.empty();
+        private Optional<Boolean> partial = Optional.empty();
+        private Optional<Optional<SymbolAlias>> hashSymbol = Optional.empty();
+
+        Builder(PlanMatchPattern source)
+        {
+            this.source = requireNonNull(source, "source is null");
+        }
+
+        public Builder specification(
+                List<String> partitionBy,
+                List<String> orderBy,
+                Map<String, SortOrder> orderings)
+        {
+            this.specification = Optional.of(PlanMatchPattern.specification(partitionBy, orderBy, orderings));
+            return this;
+        }
+
+        public Builder rowNumberSymbol(SymbolAlias rowNumberSymbol)
+        {
+            this.rowNumberSymbol = Optional.of(requireNonNull(rowNumberSymbol, "rowNumberSymbol is null"));
+            return this;
+        }
+
+        public Builder maxRowCountPerPartition(int maxRowCountPerPartition)
+        {
+            this.maxRowCountPerPartition = Optional.of(maxRowCountPerPartition);
+            return this;
+        }
+
+        public Builder partial(boolean partial)
+        {
+            this.partial = Optional.of(partial);
+            return this;
+        }
+
+        public Builder hashSymbol(Optional<SymbolAlias> hashSymbol)
+        {
+            this.hashSymbol = Optional.of(requireNonNull(hashSymbol, "hashSymbol is null"));
+            return this;
+        }
+
+        PlanMatchPattern build()
+        {
+            return node(TopNRowNumberNode.class, source).with(
+                    new TopNRowNumberMatcher(
+                            specification,
+                            rowNumberSymbol,
+                            maxRowCountPerPartition,
+                            partial,
+                            hashSymbol));
+        }
+    }
+}


### PR DESCRIPTION
When the node is partitioned on a subset of window function partition
key, the required data is available locally, so we don't need another
remote exchange before window function.

Addresses #12109 