### PR TITLE
Move tests out of big_query test group

### DIFF
--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q05.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q05.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: big_query, tpch; tables: customer,orders,lineitem,supplier,nation,region
+-- database: presto; groups: tpch; tables: customer,orders,lineitem,supplier,nation,region
 SELECT
   n_name,
   sum(l_extendedprice * (1 - l_discount)) AS revenue

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q08.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q08.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch, big_query; tables: part,supplier,lineitem,orders,customer,nation
+-- database: presto; groups: tpch; tables: part,supplier,lineitem,orders,customer,nation
 SELECT
   o_year,
   sum(CASE

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q17.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q17.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch, big_query; tables: lineitem,part
+-- database: presto; groups: tpch; tables: lineitem,part
 SELECT sum(l_extendedprice) / 7.0 AS avg_yearly
 FROM
   lineitem,

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q18.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q18.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch, big_query; tables: customer,orders,lineitem
+-- database: presto; groups: tpch; tables: customer,orders,lineitem
 SELECT
   c_name,
   c_custkey,

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/tpcds/q06.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/tpcds/q06.sql
@@ -1,4 +1,4 @@
--- database: presto_tpcds; groups: tpcds, big_query; requires: io.prestodb.tempto.fulfillment.table.hive.tpcds.ImmutableTpcdsTablesRequirements
+-- database: presto_tpcds; groups: tpcds; requires: io.prestodb.tempto.fulfillment.table.hive.tpcds.ImmutableTpcdsTablesRequirements
 --- takes over 30 minutes on travis to complete
 SELECT
   "a"."ca_state" "STATE"


### PR DESCRIPTION
Move tests out of big_query test group

These tests used to not pass on travis due to low amount of (memory)
resources. Now it looks they are fine.
