### PR TITLE
Make presto server Kerberos service hostname component configurable.

### DIFF
--- a/presto-docs/src/main/sphinx/security/server.rst
+++ b/presto-docs/src/main/sphinx/security/server.rst
@@ -87,6 +87,7 @@ Kerberos authentication is configured in the coordinator node's
     http-server.authentication.type=KERBEROS
 
     http.server.authentication.krb5.service-name=presto
+    http.server.authentication.krb5.service-hostname=presto.example.com
     http.server.authentication.krb5.keytab=/etc/presto/presto.keytab
     http.authentication.krb5.config=/etc/krb5.conf
 
@@ -101,7 +102,10 @@ Property                                                Description
 ======================================================= ======================================================
 ``http-server.authentication.type``                     Authentication type for the Presto
                                                         coordinator. Must be set to ``KERBEROS``.
-``http.server.authentication.krb5.service-name``        The Kerberos server name for the Presto coordinator.
+``http.server.authentication.krb5.service-name``        The Kerberos service name for the Presto coordinator.
+                                                        Must match the Kerberos principal.
+``http.server.authentication.krb5.host-name``           Optional Kerberos service hostname for the Presto
+                                                        coordinator if different from server hostname.
                                                         Must match the Kerberos principal.
 ``http.server.authentication.krb5.keytab``              The location of the keytab that can be used to
                                                         authenticate the Kerberos principal specified in

--- a/presto-main/src/main/java/com/facebook/presto/server/security/KerberosAuthenticator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/KerberosAuthenticator.java
@@ -64,7 +64,9 @@ public class KerberosAuthenticator
         System.setProperty("java.security.krb5.conf", config.getKerberosConfig().getAbsolutePath());
 
         try {
-            String hostname = InetAddress.getLocalHost().getCanonicalHostName().toLowerCase(Locale.US);
+            String hostname = Optional.ofNullable(config.getServiceHostName())
+                    .orElseGet(() -> getLocalHost().getCanonicalHostName())
+                    .toLowerCase(Locale.US);
             String servicePrincipal = config.getServiceName() + "/" + hostname;
             loginContext = new LoginContext("", null, null, new Configuration()
             {
@@ -99,7 +101,7 @@ public class KerberosAuthenticator
                     },
                     ACCEPT_ONLY));
         }
-        catch (LoginException | UnknownHostException e) {
+        catch (LoginException e) {
             throw new RuntimeException(e);
         }
     }
@@ -193,5 +195,15 @@ public class KerberosAuthenticator
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    private static InetAddress getLocalHost()
+    {
+        try {
+            return InetAddress.getLocalHost();
+        }
+        catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/KerberosConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/KerberosConfig.java
@@ -23,6 +23,7 @@ public class KerberosConfig
 {
     private File kerberosConfig;
     private String serviceName;
+    private String serviceHostName;
     private File keytab;
 
     @NotNull
@@ -35,6 +36,18 @@ public class KerberosConfig
     public KerberosConfig setKerberosConfig(File kerberosConfig)
     {
         this.kerberosConfig = kerberosConfig;
+        return this;
+    }
+
+    public String getServiceHostName()
+    {
+        return serviceHostName;
+    }
+
+    @Config("http.server.authentication.krb5.host-name")
+    public KerberosConfig setServiceHostName(String serviceHostName)
+    {
+        this.serviceHostName = serviceHostName;
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestKerberosConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestKerberosConfig.java
@@ -28,6 +28,7 @@ public class TestKerberosConfig
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(KerberosConfig.class)
                 .setKerberosConfig(null)
                 .setServiceName(null)
+                .setServiceHostName(null)
                 .setKeytab(null));
     }
 
@@ -37,12 +38,14 @@ public class TestKerberosConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("http.authentication.krb5.config", "/etc/krb5.conf")
                 .put("http.server.authentication.krb5.service-name", "airlift")
+                .put("http.server.authentication.krb5.host-name", "presto.example.com")
                 .put("http.server.authentication.krb5.keytab", "/tmp/presto.keytab")
                 .build();
 
         KerberosConfig expected = new KerberosConfig()
                 .setKerberosConfig(new File("/etc/krb5.conf"))
                 .setServiceName("airlift")
+                .setServiceHostName("presto.example.com")
                 .setKeytab(new File("/tmp/presto.keytab"));
 
         ConfigAssertions.assertFullMapping(properties, expected);


### PR DESCRIPTION
Needed to make client-coordinator Kerberos authentication works with a proxy in the middle.

The setup where it's used:
* client have canonicalized hostname to false and target a proxy: `<virtual-host>`
* coordinator(s) uses a service keytab: `presto/<virtual-host>@<virtual-host-realm-infered-from-krb5.conf>`