### PR TITLE
Optimize the documentation of presto

### DIFF
--- a/presto-docs/src/main/sphinx/sql/show-grants.rst
+++ b/presto-docs/src/main/sphinx/sql/show-grants.rst
@@ -27,7 +27,7 @@ Examples
 
 List the grants for the current user on table ``orders``::
 
-    SHOW GRANTS ON TABLE ``orders``;
+    SHOW GRANTS ON TABLE orders;
 
 List the grants for the current user on all the tables in all schemas of the current catalog::
 


### PR DESCRIPTION
Optimize the documentation of presto
There are some errors when I run the code that copy from https://prestodb.io/docs/0.210/sql/show-grants.html:

```
presto:default> SHOW GRANTS ON TABLE ``orders``;
Query 20181222_084346_00033_8emcn failed: line 1:22: backquoted identifiers are not supported; use double quotes to quote identifiers
SHOW GRANTS ON TABLE ``orders``

presto:default> SHOW GRANTS ON TABLE `orders`;
Query 20181222_084356_00034_8emcn failed: line 1:22: backquoted identifiers are not supported; use double quotes to quote identifiers
SHOW GRANTS ON TABLE `orders`
```
It's better to remove `` before and after orders
After optimize it :
```presto:default> SHOW GRANTS ON TABLE orders;
 Grantee | Catalog | Schema | Table | Privilege | Grantable
---------+---------+--------+-------+-----------+-----------
(0 rows)

Query 20181222_084401_00035_8emcn, FINISHED, 1 node
Splits: 19 total, 19 done (100.00%)
0:02 [0 rows, 0B] [0 rows/s, 0B/s]```
