### PR TITLE
Remove hashCode and equals from AccessControlInfo

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -56,7 +56,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -773,27 +772,6 @@ public class Analysis
         public Identity getIdentity()
         {
             return identity;
-        }
-
-        @Override
-        public boolean equals(Object o)
-        {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            AccessControlInfo that = (AccessControlInfo) o;
-            return Objects.equals(accessControl, that.accessControl) &&
-                    Objects.equals(identity, that.identity);
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(accessControl, identity);
         }
 
         @Override


### PR DESCRIPTION
Remove hashCode and equals from AccessControlInfo

AccessControlInfo does not look as value object and hence it should not
implement hashCode and equals methods.

Also it is used only in
Map<AccessControlInfo, Map<QualifiedObjectName, Set<String>>>.
It looks like  a bug, because if we would get two equal
AccessControlInfos, then we could lose one
Map<QualifiedObjectName, Set<String>> and so we would skip one
access check.
