### PR TITLE
Allow HiveQueryRunner to persist data to a custom path

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileBasedSecurity.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileBasedSecurity.java
@@ -37,7 +37,7 @@ public class TestHiveFileBasedSecurity
             throws Exception
     {
         String path = this.getClass().getResource("security.json").getPath();
-        queryRunner = createQueryRunner(ImmutableList.of(NATION), ImmutableMap.of(), "file", ImmutableMap.of("security.config-file", path));
+        queryRunner = createQueryRunner(ImmutableList.of(NATION), ImmutableMap.of(), "file", ImmutableMap.of("security.config-file", path), Optional.empty());
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
    Add an optional argument to HiveQueryRunner to provide a path to read
    and write the data and metadata to. The path must point to a writable
    directory. On first run, HiveQueryRunner will create tpch and
    tpch_bucketed tables and store them in the specified directory. On
    subsequent runs using the same path, HiveQueryRunner will re-use the
    data created before.

    If no argument is provided, HiveQueryRunner will create a temporary
    directory to store data and delete it before exiting.