### PR TITLE
Add joda-to-java-time-bridge to plugins

### DIFF
--- a/presto-atop/pom.xml
+++ b/presto-atop/pom.xml
@@ -78,6 +78,12 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>joda-to-java-time-bridge</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>io.airlift</groupId>

--- a/presto-resource-group-managers/pom.xml
+++ b/presto-resource-group-managers/pom.xml
@@ -108,6 +108,12 @@
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>joda-to-java-time-bridge</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>com.facebook.presto</groupId>


### PR DESCRIPTION
Build will break if joda-to-java-time-bridge is not added to plugins.
This is due to a recent change in presto: 8ac4b8 "Use JVM time zone rules in Joda"