### PR TITLE
Treat other SQL types as varchar

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/StandardReadMappings.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/StandardReadMappings.java
@@ -231,6 +231,12 @@ public final class StandardReadMappings
 
             case Types.TIMESTAMP:
                 return Optional.of(timestampReadMapping());
+
+            case Types.OTHER:
+                if (columnSize > VarcharType.MAX_LENGTH) {
+                    return Optional.of(varcharReadMapping(createUnboundedVarcharType()));
+                }
+                return Optional.of(varcharReadMapping(createVarcharType(columnSize)));
         }
         return Optional.empty();
     }


### PR DESCRIPTION
Continuation of https://github.com/prestodb/presto/pull/7506
Fixes https://github.com/prestodb/presto/issues/5649 . Fixes #11821
Also mentioned in https://github.com/prestodb/presto/issues/5989 https://github.com/prestodb/presto/issues/6614

As discussed in the previously closed PR, I think this can serve as a decent quick first step. want to continue the work needed for this. But unfortunately as is, as @electrum predicted in the other PR, `INSERT` doesn't work. Not sure how we want to proceed from here. Is creating a new type(UUID, etc) that extends `AbstractType` the way to go?