### PR TITLE
Separate hive integration test S3 prefixes

### DIFF
--- a/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
+++ b/presto-hive-hadoop2/bin/run_hive_s3_tests.sh
@@ -15,7 +15,7 @@ exec_in_hadoop_master_container sed -i \
   -e "s|%S3_BUCKET_ENDPOINT%|${S3_BUCKET_ENDPOINT}|g" \
  /etc/hadoop/conf/core-site.xml
 
-# create test table
+# create test tables
 table_path="s3a://${S3_BUCKET}/presto_test_external_fs/"
 exec_in_hadoop_master_container hadoop fs -mkdir -p "${table_path}"
 exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /tmp/test1.csv "${table_path}"
@@ -23,6 +23,14 @@ exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /tmp/test1.csv.gz "$
 exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /tmp/test1.csv.lz4 "${table_path}"
 exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /tmp/test1.csv.bz2 "${table_path}"
 exec_in_hadoop_master_container /usr/bin/hive -e "CREATE EXTERNAL TABLE presto_test_external_fs(t_bigint bigint) LOCATION '${table_path}'"
+
+table_path_s3_select_pushdown="s3a://${S3_BUCKET}/presto_test_external_fs_s3_select_pushdown/"
+exec_in_hadoop_master_container hadoop fs -mkdir -p "${table_path_s3_select_pushdown}"
+exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /tmp/test1.csv "${table_path_s3_select_pushdown}"
+exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /tmp/test1.csv.gz "${table_path_s3_select_pushdown}"
+exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /tmp/test1.csv.lz4 "${table_path_s3_select_pushdown}"
+exec_in_hadoop_master_container hadoop fs -copyFromLocal -f /tmp/test1.csv.bz2 "${table_path_s3_select_pushdown}"
+exec_in_hadoop_master_container /usr/bin/hive -e "CREATE EXTERNAL TABLE presto_test_external_fs_s3_select_pushdown(t_bigint bigint) LOCATION '${table_path_s3_select_pushdown}'"
 
 stop_unnecessary_hadoop_services
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -143,7 +143,7 @@ public abstract class AbstractTestHiveFileSystem
     protected void setup(String host, int port, String databaseName, Function<HiveClientConfig, HdfsConfiguration> hdfsConfigurationProvider, boolean s3SelectPushdownEnabled)
     {
         database = databaseName;
-        table = new SchemaTableName(database, "presto_test_external_fs");
+        table = s3SelectPushdownEnabled ? new SchemaTableName(database, "presto_test_external_fs_s3_select_pushdown") : new SchemaTableName(database, "presto_test_external_fs");
 
         String random = UUID.randomUUID().toString().toLowerCase(ENGLISH).replace("-", "");
         temporaryCreateTable = new SchemaTableName(database, "tmp_presto_test_create_" + random);


### PR DESCRIPTION
This change fixes flaky TestHiveFileSystemS3SelectPushdown and
TestHiveFileSystemS3 integration tests by separating the data
set S3 prefixes for the two tests. The tests are correct only when
the data set is idempotent, as concurrent test runs will try to
update the same location.

https://github.com/prestodb/presto/issues/12153