### PR TITLE
Fix time zone difference for GROUP BY over EXTRACT test

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestAggregations.java
@@ -638,14 +638,14 @@ public abstract class AbstractTestAggregations
     public void testGroupByExtract()
     {
         // whole expression in group by
-        assertQuery("SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY EXTRACT(YEAR FROM now())");
+        assertQuery("SELECT EXTRACT(YEAR FROM orderdate), count(*) FROM orders GROUP BY EXTRACT(YEAR FROM orderdate)");
 
         assertQuery(
-                "SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY 1",
-                "SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY EXTRACT(YEAR FROM now())");
+                "SELECT EXTRACT(YEAR FROM orderdate), count(*) FROM orders GROUP BY 1",
+                "SELECT EXTRACT(YEAR FROM orderdate), count(*) FROM orders GROUP BY EXTRACT(YEAR FROM orderdate)");
 
         // argument in group by
-        assertQuery("SELECT EXTRACT(YEAR FROM now()), count(*) FROM orders GROUP BY now()");
+        assertQuery("SELECT EXTRACT(YEAR FROM orderdate), count(*) FROM orders GROUP BY orderdate");
     }
 
     @Test


### PR DESCRIPTION
The Presto query uses the time zone from TestingSession, but H2 uses
the JVM time zone, which are different. This causes a query failure
during the new year period where the years are different. Changing to
use a date from the table fixes this and avoids the race condition
where the two queries run on different sides of the cutover.