### PR TITLE
Report top memory consumers when local memory limit is exceeded

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/ExceededMemoryLimitException.java
+++ b/presto-main/src/main/java/com/facebook/presto/ExceededMemoryLimitException.java
@@ -34,22 +34,16 @@ public class ExceededMemoryLimitException
         return new ExceededMemoryLimitException(EXCEEDED_GLOBAL_MEMORY_LIMIT, format("Query exceeded distributed total memory limit of %s", maxMemory));
     }
 
-    public static ExceededMemoryLimitException exceededLocalUserMemoryLimit(DataSize maxMemory, DataSize allocated, DataSize delta)
+    public static ExceededMemoryLimitException exceededLocalUserMemoryLimit(DataSize maxMemory, String additionalFailureInfo)
     {
-        return new ExceededMemoryLimitException(EXCEEDED_LOCAL_MEMORY_LIMIT, format(
-                "Query exceeded per-node user memory limit of %s when increasing allocation of %s by %s",
-                maxMemory,
-                allocated,
-                delta));
+        return new ExceededMemoryLimitException(EXCEEDED_LOCAL_MEMORY_LIMIT,
+                format("Query exceeded per-node user memory limit of %s [%s]", maxMemory, additionalFailureInfo));
     }
 
-    public static ExceededMemoryLimitException exceededLocalTotalMemoryLimit(DataSize maxMemory, DataSize allocated, DataSize delta)
+    public static ExceededMemoryLimitException exceededLocalTotalMemoryLimit(DataSize maxMemory, String additionalFailureInfo)
     {
-        return new ExceededMemoryLimitException(EXCEEDED_LOCAL_MEMORY_LIMIT, format(
-                "Query exceeded per-node total memory limit of %s when increasing allocation of %s by %s",
-                maxMemory,
-                allocated,
-                delta));
+        return new ExceededMemoryLimitException(EXCEEDED_LOCAL_MEMORY_LIMIT,
+                format("Query exceeded per-node total memory limit of %s [%s]", maxMemory, additionalFailureInfo));
     }
 
     private ExceededMemoryLimitException(StandardErrorCode errorCode, String message)

--- a/presto-main/src/main/java/com/facebook/presto/memory/DefaultQueryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/DefaultQueryContext.java
@@ -29,8 +29,10 @@ import io.airlift.units.DataSize;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.OptionalInt;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -45,9 +47,12 @@ import static com.facebook.presto.memory.context.AggregatedMemoryContext.newRoot
 import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.airlift.units.DataSize.succinctBytes;
+import static java.lang.String.format;
+import static java.util.Map.Entry.comparingByValue;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -320,17 +325,41 @@ public class DefaultQueryContext
         throw new UnsupportedOperationException("tryReserveMemory is not supported");
     }
 
-    private static void enforceUserMemoryLimit(long allocated, long delta, long maxMemory)
+    @GuardedBy("this")
+    private void enforceUserMemoryLimit(long allocated, long delta, long maxMemory)
     {
         if (allocated + delta > maxMemory) {
-            throw exceededLocalUserMemoryLimit(succinctBytes(maxMemory), succinctBytes(allocated), succinctBytes(delta));
+            throw exceededLocalUserMemoryLimit(succinctBytes(maxMemory), getAdditionalFailureInfo(allocated, delta));
         }
     }
 
-    private static void enforceTotalMemoryLimit(long allocated, long delta, long maxMemory)
+    @GuardedBy("this")
+    private void enforceTotalMemoryLimit(long allocated, long delta, long maxMemory)
     {
         if (allocated + delta > maxMemory) {
-            throw exceededLocalTotalMemoryLimit(succinctBytes(maxMemory), succinctBytes(allocated), succinctBytes(delta));
+            throw exceededLocalTotalMemoryLimit(succinctBytes(maxMemory), getAdditionalFailureInfo(allocated, delta));
         }
+    }
+
+    @GuardedBy("this")
+    private String getAdditionalFailureInfo(long allocated, long delta)
+    {
+        Map<String, Long> queryAllocations = memoryPool.getTaggedMemoryAllocations().get(queryId);
+
+        String additionalInfo = format("Allocated: %s, Delta: %s", succinctBytes(allocated), succinctBytes(delta));
+
+        // It's possible that a query tries allocating more than the available memory
+        // failing immediately before any allocation of that query is tagged
+        if (queryAllocations == null) {
+            return additionalInfo;
+        }
+
+        String topConsumers = queryAllocations.entrySet().stream()
+                .sorted(comparingByValue(Comparator.reverseOrder()))
+                .limit(3)
+                .collect(toImmutableMap(Entry::getKey, e -> succinctBytes(e.getValue())))
+                .toString();
+
+        return format("%s, Top Consumers: %s", additionalInfo, topConsumers);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
@@ -155,7 +155,7 @@ public class TestMemoryTracking
             fail("allocation should hit the per-node total memory limit");
         }
         catch (ExceededMemoryLimitException e) {
-            assertEquals(e.getMessage(), format("Query exceeded per-node total memory limit of %1$s when increasing allocation of %1$s by 1B", queryMaxTotalMemory));
+            assertEquals(e.getMessage(), format("Query exceeded per-node total memory limit of %1$s [Allocated: %1$s, Delta: 1B, Top Consumers: {test=%1$s}]", queryMaxTotalMemory));
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -308,7 +308,7 @@ public class TestHashAggregationOperator
         assertEquals(operator.getOperatorContext().getOperatorStats().getUserMemoryReservation().toBytes(), 0);
     }
 
-    @Test(dataProvider = "hashEnabled", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded per-node user memory limit of 10B when increasing allocation of 0B by .*")
+    @Test(dataProvider = "hashEnabled", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded per-node user memory limit of 10B.*")
     public void testMemoryLimit(boolean hashEnabled)
     {
         MetadataManager metadata = MetadataManager.createTestMetadataManager();
@@ -425,7 +425,7 @@ public class TestHashAggregationOperator
         assertEquals(count, 6_000 * 600);
     }
 
-    @Test(dataProvider = "hashEnabled", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded per-node user memory limit of 3MB when increasing allocation of 0B by .*")
+    @Test(dataProvider = "hashEnabled", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded per-node user memory limit of 3MB.*")
     public void testHashBuilderResizeLimit(boolean hashEnabled)
     {
         BlockBuilder builder = VARCHAR.createBlockBuilder(null, 1, MAX_BLOCK_SIZE_IN_BYTES);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOrderByOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOrderByOperator.java
@@ -161,7 +161,7 @@ public class TestOrderByOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test(expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded per-node user memory limit of 10B when increasing allocation of 0B by .*")
+    @Test(expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded per-node user memory limit of 10B.*")
     public void testMemoryLimit()
     {
         List<Page> input = rowPagesBuilder(BIGINT, DOUBLE)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestWindowOperator.java
@@ -204,7 +204,7 @@ public class TestWindowOperator
         assertOperatorEquals(operatorFactory, driverContext, input, expected);
     }
 
-    @Test(expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded per-node user memory limit of 10B when increasing allocation of 0B by .*")
+    @Test(expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded per-node user memory limit of 10B.*")
     public void testMemoryLimit()
     {
         List<Page> input = rowPagesBuilder(BIGINT, DOUBLE)


### PR DESCRIPTION
Sample exception message:

```
com.facebook.presto.ExceededMemoryLimitException: Query exceeded per-node user memory limit of 1MB [Allocated: 754.36kB, Delta: 377.18kB, Top Consumers: {HashAggregationOperator=754.36kB, PartitionedOutputOperator=147.32kB, FilterAndProjectOperator=25.00kB}]
```