### PR TITLE
Add a comment about ColumnStatistics' "unknown" estimates semantics

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
@@ -114,6 +114,12 @@ public final class ColumnStatistics
         return new Builder();
     }
 
+    /**
+     * If one of the estimates below is unspecified, the default "unknown" estimate value
+     * (represented by floating point NaN) may cause the resulting symbol statistics
+     * to be "unknown" as well.
+     * @see SymbolStatsEstimate
+     */
     public static final class Builder
     {
         private Estimate nullsFraction = Estimate.unknown();


### PR DESCRIPTION
Recently, we have implemented column statistics estimation for our SPI connector [1].

One (a bit surprising) issue was that we had to return a not-NaN estimate for `nullsFraction` [2] even if we had an estimate of the row count of the table (initially we assumed that Presto will assume 0 NULLs if it isn’t specified, so we specified only the `dataSize` of each column statistic).

Since “unknown” values are marked by NaN, the resulting costs became NaN as well [3], so the CBO was ignoring our queries (until we fixed that by returning a not-NaN values for each column statistic).

[1] https://github.com/prestodb/presto/blob/57c70aee95fe6c00666f13ba5dc2f930fae87d84/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java#L102

[2] https://github.com/prestodb/presto/blob/b6addd420c5bec97e675eb5f4c238301cf80c083/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java#L22

[3] https://github.com/prestodb/presto/blob/f112441aa3f4e6c485f5333bd4f38901c0f96433/presto-main/src/main/java/com/facebook/presto/cost/TableScanStatsRule.java#L75