### PR TITLE
Fix issues with final stage info

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -275,18 +275,19 @@ public final class SqlStageExecution
 
     public BasicStageStats getBasicStageStats()
     {
-        return stateMachine.getBasicStageStats(
-                () -> getAllTasks().stream()
-                        .map(RemoteTask::getTaskInfo)
-                        .collect(toImmutableList()));
+        return stateMachine.getBasicStageStats(this::getAllTaskInfo);
     }
 
     public StageInfo getStageInfo()
     {
-        return stateMachine.getStageInfo(
-                () -> getAllTasks().stream()
-                        .map(RemoteTask::getTaskInfo)
-                        .collect(toImmutableList()));
+        return stateMachine.getStageInfo(this::getAllTaskInfo);
+    }
+
+    private Iterable<TaskInfo> getAllTaskInfo()
+    {
+        return getAllTasks().stream()
+                .map(RemoteTask::getTaskInfo)
+                .collect(toImmutableList());
     }
 
     public synchronized void addExchangeLocations(PlanFragmentId fragmentId, Set<RemoteTask> sourceTasks, boolean noMoreExchangeLocations)

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -28,7 +28,6 @@ import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -287,8 +286,7 @@ public final class SqlStageExecution
         return stateMachine.getStageInfo(
                 () -> getAllTasks().stream()
                         .map(RemoteTask::getTaskInfo)
-                        .collect(toImmutableList()),
-                ImmutableList::of);
+                        .collect(toImmutableList()));
     }
 
     public synchronized void addExchangeLocations(PlanFragmentId fragmentId, Set<RemoteTask> sourceTasks, boolean noMoreExchangeLocations)

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
@@ -82,8 +82,6 @@ public class StageStateMachine
 
     private final AtomicReference<DateTime> schedulingComplete = new AtomicReference<>();
     private final Distribution getSplitDistribution = new Distribution();
-    private final Distribution scheduleTaskDistribution = new Distribution();
-    private final Distribution addSplitDistribution = new Distribution();
 
     private final AtomicLong peakUserMemory = new AtomicLong();
     private final AtomicLong currentUserMemory = new AtomicLong();
@@ -442,8 +440,6 @@ public class StageStateMachine
         StageStats stageStats = new StageStats(
                 schedulingComplete.get(),
                 getSplitDistribution.snapshot(),
-                scheduleTaskDistribution.snapshot(),
-                addSplitDistribution.snapshot(),
 
                 totalTasks,
                 runningTasks,
@@ -505,16 +501,6 @@ public class StageStateMachine
         long elapsedNanos = System.nanoTime() - startNanos;
         getSplitDistribution.add(elapsedNanos);
         scheduledStats.getGetSplitTime().add(elapsedNanos, NANOSECONDS);
-    }
-
-    public void recordScheduleTaskTime(long startNanos)
-    {
-        scheduleTaskDistribution.add(System.nanoTime() - startNanos);
-    }
-
-    public void recordAddSplit(long startNanos)
-    {
-        addSplitDistribution.add(System.nanoTime() - startNanos);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
@@ -56,6 +56,7 @@ import static com.facebook.presto.execution.StageState.SCHEDULING;
 import static com.facebook.presto.execution.StageState.SCHEDULING_SPLITS;
 import static com.facebook.presto.execution.StageState.TERMINAL_STAGE_STATES;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.airlift.units.Duration.succinctDuration;
 import static java.lang.Math.max;
@@ -213,12 +214,8 @@ public class StageStateMachine
 
     public void setAllTasksFinal()
     {
-        StateChangeListener<StageState> stateChangeListener = state -> {
-            if (state.isDone()) {
-                finalStatusReady.set(true);
-            }
-        };
-        stageState.addStateChangeListener(stateChangeListener);
+        checkState(stageState.get().isDone());
+        finalStatusReady.set(true);
     }
 
     public long getUserMemoryReservation()

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
@@ -325,7 +325,7 @@ public class StageStateMachine
                 progressPercentage);
     }
 
-    public StageInfo getStageInfo(Supplier<Iterable<TaskInfo>> taskInfosSupplier, Supplier<Iterable<StageInfo>> subStageInfosSupplier)
+    public StageInfo getStageInfo(Supplier<Iterable<TaskInfo>> taskInfosSupplier)
     {
         // stage state must be captured first in order to provide a
         // consistent view of the stage. For example, building this
@@ -334,7 +334,6 @@ public class StageStateMachine
         StageState state = stageState.get();
 
         List<TaskInfo> taskInfos = ImmutableList.copyOf(taskInfosSupplier.get());
-        List<StageInfo> subStageInfos = ImmutableList.copyOf(subStageInfosSupplier.get());
 
         int totalTasks = taskInfos.size();
         int runningTasks = 0;
@@ -492,7 +491,7 @@ public class StageStateMachine
                 fragment.getTypes(),
                 stageStats,
                 taskInfos,
-                subStageInfos,
+                ImmutableList.of(),
                 failureInfo);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStateMachine.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.OptionalDouble;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -59,6 +58,7 @@ import static com.facebook.presto.execution.StageState.TERMINAL_STAGE_STATES;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.airlift.units.Duration.succinctDuration;
+import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -237,7 +237,7 @@ public class StageStateMachine
     {
         currentTotalMemory.addAndGet(deltaTotalMemoryInBytes);
         currentUserMemory.addAndGet(deltaUserMemoryInBytes);
-        peakUserMemory.updateAndGet(currentPeakValue -> Math.max(currentUserMemory.get(), currentPeakValue));
+        peakUserMemory.updateAndGet(currentPeakValue -> max(currentUserMemory.get(), currentPeakValue));
     }
 
     public BasicStageStats getBasicStageStats(Supplier<Iterable<TaskInfo>> taskInfosSupplier)
@@ -428,8 +428,8 @@ public class StageStateMachine
 
             int gcSec = toIntExact(taskStats.getFullGcTime().roundTo(SECONDS));
             totalFullGcSec += gcSec;
-            minFullGcSec = Math.min(minFullGcSec, gcSec);
-            maxFullGcSec = Math.max(maxFullGcSec, gcSec);
+            minFullGcSec = min(minFullGcSec, gcSec);
+            maxFullGcSec = max(maxFullGcSec, gcSec);
 
             for (PipelineStats pipeline : taskStats.getPipelines()) {
                 for (OperatorStats operatorStats : pipeline.getOperatorSummaries()) {
@@ -504,7 +504,7 @@ public class StageStateMachine
     {
         long elapsedNanos = System.nanoTime() - startNanos;
         getSplitDistribution.add(elapsedNanos);
-        scheduledStats.getGetSplitTime().add(elapsedNanos, TimeUnit.NANOSECONDS);
+        scheduledStats.getGetSplitTime().add(elapsedNanos, NANOSECONDS);
     }
 
     public void recordScheduleTaskTime(long startNanos)

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageStats.java
@@ -39,8 +39,6 @@ public class StageStats
     private final DateTime schedulingComplete;
 
     private final DistributionSnapshot getSplitDistribution;
-    private final DistributionSnapshot scheduleTaskDistribution;
-    private final DistributionSnapshot addSplitDistribution;
 
     private final int totalTasks;
     private final int runningTasks;
@@ -84,8 +82,6 @@ public class StageStats
             @JsonProperty("schedulingComplete") DateTime schedulingComplete,
 
             @JsonProperty("getSplitDistribution") DistributionSnapshot getSplitDistribution,
-            @JsonProperty("scheduleTaskDistribution") DistributionSnapshot scheduleTaskDistribution,
-            @JsonProperty("addSplitDistribution") DistributionSnapshot addSplitDistribution,
 
             @JsonProperty("totalTasks") int totalTasks,
             @JsonProperty("runningTasks") int runningTasks,
@@ -126,8 +122,6 @@ public class StageStats
     {
         this.schedulingComplete = schedulingComplete;
         this.getSplitDistribution = requireNonNull(getSplitDistribution, "getSplitDistribution is null");
-        this.scheduleTaskDistribution = requireNonNull(scheduleTaskDistribution, "scheduleTaskDistribution is null");
-        this.addSplitDistribution = requireNonNull(addSplitDistribution, "addSplitDistribution is null");
 
         checkArgument(totalTasks >= 0, "totalTasks is negative");
         this.totalTasks = totalTasks;
@@ -188,18 +182,6 @@ public class StageStats
     public DistributionSnapshot getGetSplitDistribution()
     {
         return getSplitDistribution;
-    }
-
-    @JsonProperty
-    public DistributionSnapshot getScheduleTaskDistribution()
-    {
-        return scheduleTaskDistribution;
-    }
-
-    @JsonProperty
-    public DistributionSnapshot getAddSplitDistribution()
-    {
-        return addSplitDistribution;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedCountScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedCountScheduler.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.Node;
 import com.google.common.annotations.VisibleForTesting;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.stream.IntStream;
 
@@ -30,7 +31,7 @@ public class FixedCountScheduler
 {
     public interface TaskScheduler
     {
-        RemoteTask scheduleTask(Node node, int partition, OptionalInt totalPartitions);
+        Optional<RemoteTask> scheduleTask(Node node, int partition, OptionalInt totalPartitions);
     }
 
     private final TaskScheduler taskScheduler;
@@ -56,6 +57,8 @@ public class FixedCountScheduler
         OptionalInt totalPartitions = OptionalInt.of(partitionToNode.size());
         List<RemoteTask> newTasks = IntStream.range(0, partitionToNode.size())
                 .mapToObj(partition -> taskScheduler.scheduleTask(partitionToNode.get(partition), partition, totalPartitions))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(toImmutableList());
 
         return new ScheduleResult(true, newTasks, 0);

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -168,6 +168,8 @@ public class FixedSourcePartitionedScheduler
             newTasks = Streams.mapWithIndex(
                     nodes.stream(),
                     (node, id) -> stage.scheduleTask(node, toIntExact(id), totalPartitions))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
                     .collect(toImmutableList());
             scheduledTasks = true;
         }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScaledWriterScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScaledWriterScheduler.java
@@ -24,6 +24,7 @@ import io.airlift.units.DataSize;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
@@ -119,8 +120,11 @@ public class ScaledWriterScheduler
 
         ImmutableList.Builder<RemoteTask> tasks = ImmutableList.builder();
         for (Node node : nodes) {
-            tasks.add(stage.scheduleTask(node, scheduledNodes.size(), OptionalInt.empty()));
-            scheduledNodes.add(node);
+            Optional<RemoteTask> remoteTask = stage.scheduleTask(node, scheduledNodes.size(), OptionalInt.empty());
+            remoteTask.ifPresent(task -> {
+                tasks.add(task);
+                scheduledNodes.add(node);
+            });
         }
 
         return tasks.build();

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -265,7 +265,7 @@ public class SqlQueryScheduler
             }
         });
         for (SqlStageExecution stage : stages.values()) {
-            stage.addFinalStatusListener(status -> queryStateMachine.updateQueryInfo(Optional.ofNullable(getStageInfo())));
+            stage.addFinalStageInfoListener(status -> queryStateMachine.updateQueryInfo(Optional.ofNullable(getStageInfo())));
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -60,6 +60,7 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 public class TestSqlStageExecution
@@ -115,7 +116,7 @@ public class TestSqlStageExecution
 
         // add listener that fetches stage info when the final status is available
         SettableFuture<StageInfo> finalStageInfo = SettableFuture.create();
-        stage.addFinalStatusListener(value -> finalStageInfo.set(stage.getStageInfo()));
+        stage.addFinalStageInfoListener(finalStageInfo::set);
 
         // in a background thread add a ton of tasks
         CountDownLatch latch = new CountDownLatch(1000);
@@ -150,7 +151,7 @@ public class TestSqlStageExecution
         StageInfo stageInfo = finalStageInfo.get(1, MINUTES);
         assertFalse(stageInfo.getTasks().isEmpty());
         assertTrue(stageInfo.isCompleteInfo());
-        assertTrue(stage.getStageInfo().isCompleteInfo());
+        assertSame(stage.getStageInfo(), stageInfo);
 
         // cancel the background thread adding tasks
         addTasksTask.cancel(true);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStageStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStageStateMachine.java
@@ -292,7 +292,7 @@ public class TestStageStateMachine
         assertEquals(stateMachine.getLocation(), LOCATION);
         assertSame(stateMachine.getSession(), TEST_SESSION);
 
-        StageInfo stageInfo = stateMachine.getStageInfo(ImmutableList::of, ImmutableList::of);
+        StageInfo stageInfo = stateMachine.getStageInfo(ImmutableList::of);
         assertEquals(stageInfo.getStageId(), STAGE_ID);
         assertEquals(stageInfo.getSelf(), LOCATION);
         assertEquals(stageInfo.getSubStages(), ImmutableList.of());

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStageStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStageStats.java
@@ -30,12 +30,10 @@ import static org.testng.Assert.assertEquals;
 
 public class TestStageStats
 {
-    public static final StageStats EXPECTED = new StageStats(
+    private static final StageStats EXPECTED = new StageStats(
             new DateTime(0),
 
             getTestDistribution(1),
-            getTestDistribution(2),
-            getTestDistribution(3),
 
             4,
             5,
@@ -92,13 +90,11 @@ public class TestStageStats
         assertExpectedStageStats(actual);
     }
 
-    public static void assertExpectedStageStats(StageStats actual)
+    private static void assertExpectedStageStats(StageStats actual)
     {
         assertEquals(actual.getSchedulingComplete().getMillis(), 0);
 
         assertEquals(actual.getGetSplitDistribution().getCount(), 1.0);
-        assertEquals(actual.getScheduleTaskDistribution().getCount(), 2.0);
-        assertEquals(actual.getAddSplitDistribution().getCount(), 3.0);
 
         assertEquals(actual.getTotalTasks(), 4);
         assertEquals(actual.getRunningTasks(), 5);

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.IntStream;
@@ -60,10 +61,10 @@ public class TestFixedCountScheduler
     public void testSingleNode()
     {
         FixedCountScheduler nodeScheduler = new FixedCountScheduler(
-                (node, partition, totalPartitions) -> taskFactory.createTableScanTask(
+                (node, partition, totalPartitions) -> Optional.of(taskFactory.createTableScanTask(
                         new TaskId("test", 1, 1),
                         node, ImmutableList.of(),
-                        new PartitionedSplitCountTracker(delta -> {})),
+                        new PartitionedSplitCountTracker(delta -> {}))),
                 generateRandomNodes(1));
 
         ScheduleResult result = nodeScheduler.schedule();
@@ -77,10 +78,10 @@ public class TestFixedCountScheduler
     public void testMultipleNodes()
     {
         FixedCountScheduler nodeScheduler = new FixedCountScheduler(
-                (node, partition, totalPartitions) -> taskFactory.createTableScanTask(
+                (node, partition, totalPartitions) -> Optional.of(taskFactory.createTableScanTask(
                         new TaskId("test", 1, 1),
                         node, ImmutableList.of(),
-                        new PartitionedSplitCountTracker(delta -> {})),
+                        new PartitionedSplitCountTracker(delta -> {}))),
                 generateRandomNodes(5));
 
         ScheduleResult result = nodeScheduler.schedule();


### PR DESCRIPTION
Two things that I think need to be fixed:

1) we should "capture" the final stage info once it is created, so it can not be changed.
2) we should not allow tasks to be added after the stage is in a done state.

I think the first one is pretty straight forward, but I think the second one should be fixed first since it would be strange to have tasks in a stage that are not in the stage info.  The second one is more tricky to fix, because we can't do the easy thing and simply throw an exception because a stage could finish early due to a limit.  Instead, we need to adapt the callers to expect an `Optional<RemoteTask>`.  I'm working on these now.

Fixes #12095