### PR TITLE
Fix lazy map hashtable regression

### DIFF
--- a/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.array;
 
+import com.facebook.presto.spi.block.AbstractMapBlock;
 import com.facebook.presto.spi.block.Block;
 import io.airlift.slice.SizeOf;
 import io.airlift.slice.Slice;
@@ -89,6 +90,9 @@ public final class ReferenceCountMap
         }
         else if (key.getClass().isArray()) {
             extraIdentity = getLength(key);
+        }
+        else if (key instanceof AbstractMapBlock.HashTables) {
+            extraIdentity = (int) ((AbstractMapBlock.HashTables) key).getRetainedSizeInBytes();
         }
         else {
             throw new IllegalArgumentException(format("Unsupported type for %s", key));

--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.block;
 
 import com.facebook.presto.metadata.FunctionRegistry;
+import com.facebook.presto.spi.block.AbstractMapBlock.HashTables;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -153,6 +154,9 @@ public abstract class AbstractTestBlock
                 }
                 else if (type == DictionaryId.class) {
                     retainedSize += ClassLayout.parseClass(DictionaryId.class).instanceSize();
+                }
+                else if (type == HashTables.class) {
+                    retainedSize += ((HashTables) field.get(block)).getRetainedSizeInBytes();
                 }
                 else if (type == MethodHandle.class) {
                     // MethodHandles are only used in MapBlock/MapBlockBuilder,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -48,7 +48,7 @@ public class MapBlockBuilder
     private boolean[] mapIsNull;
     private final BlockBuilder keyBlockBuilder;
     private final BlockBuilder valueBlockBuilder;
-    private int[] hashTables;
+    private HashTables hashTables;
 
     private boolean currentEntryOpened;
 
@@ -87,7 +87,7 @@ public class MapBlockBuilder
             BlockBuilder valueBlockBuilder,
             int[] offsets,
             boolean[] mapIsNull,
-            int[] hashTables)
+            int[] rawHashTables)
     {
         super(keyType, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode);
 
@@ -99,7 +99,7 @@ public class MapBlockBuilder
         this.mapIsNull = requireNonNull(mapIsNull, "mapIsNull is null");
         this.keyBlockBuilder = requireNonNull(keyBlockBuilder, "keyBlockBuilder is null");
         this.valueBlockBuilder = requireNonNull(valueBlockBuilder, "valueBlockBuilder is null");
-        this.hashTables = requireNonNull(hashTables, "hashTables is null");
+        this.hashTables = new HashTables(requireNonNull(rawHashTables, "hashTables is null"));
     }
 
     @Override
@@ -115,7 +115,7 @@ public class MapBlockBuilder
     }
 
     @Override
-    protected int[] getHashTables()
+    protected HashTables getHashTables()
     {
         return hashTables;
     }
@@ -149,7 +149,8 @@ public class MapBlockBuilder
     {
         return keyBlockBuilder.getSizeInBytes() + valueBlockBuilder.getSizeInBytes() +
                 (Integer.BYTES + Byte.BYTES) * (long) positionCount +
-                Integer.BYTES * HASH_MULTIPLIER * (long) keyBlockBuilder.getPositionCount();
+                Integer.BYTES * HASH_MULTIPLIER * (long) keyBlockBuilder.getPositionCount() +
+                hashTables.getInstanceSizeInBytes();
     }
 
     @Override
@@ -160,7 +161,7 @@ public class MapBlockBuilder
                 + valueBlockBuilder.getRetainedSizeInBytes()
                 + sizeOf(offsets)
                 + sizeOf(mapIsNull)
-                + sizeOf(hashTables);
+                + hashTables.getRetainedSizeInBytes();
         if (blockBuilderStatus != null) {
             size += BlockBuilderStatus.INSTANCE_SIZE;
         }
@@ -174,7 +175,7 @@ public class MapBlockBuilder
         consumer.accept(valueBlockBuilder, valueBlockBuilder.getRetainedSizeInBytes());
         consumer.accept(offsets, sizeOf(offsets));
         consumer.accept(mapIsNull, sizeOf(mapIsNull));
-        consumer.accept(hashTables, sizeOf(hashTables));
+        consumer.accept(hashTables, hashTables.getRetainedSizeInBytes());
         consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
@@ -207,7 +208,7 @@ public class MapBlockBuilder
                 previousAggregatedEntryCount,
                 entryCount,
                 keyBlockHashCode,
-                hashTables,
+                hashTables.getRawHashTables(),
                 previousAggregatedEntryCount * HASH_MULTIPLIER,
                 entryCount * HASH_MULTIPLIER);
         return this;
@@ -240,7 +241,7 @@ public class MapBlockBuilder
                 entryCount,
                 keyBlockEquals,
                 keyBlockHashCode,
-                hashTables,
+                hashTables.getRawHashTables(),
                 previousAggregatedEntryCount * HASH_MULTIPLIER,
                 entryCount * HASH_MULTIPLIER);
         return this;
@@ -264,7 +265,7 @@ public class MapBlockBuilder
             int hashTableOffset = previousAggregatedEntryCount * HASH_MULTIPLIER;
             int hashTableSize = (aggregatedEntryCount - previousAggregatedEntryCount) * HASH_MULTIPLIER;
             for (int i = 0; i < hashTableSize; i++) {
-                hashTables[hashTableOffset + i] = providedHashTable[providedHashTableOffset + i];
+                hashTables.getRawHashTables()[hashTableOffset + i] = providedHashTable[providedHashTableOffset + i];
             }
         }
         else {
@@ -275,7 +276,7 @@ public class MapBlockBuilder
                     previousAggregatedEntryCount,
                     entryCount,
                     keyBlockHashCode,
-                    hashTables,
+                    hashTables.getRawHashTables(),
                     previousAggregatedEntryCount * HASH_MULTIPLIER,
                     entryCount * HASH_MULTIPLIER);
         }
@@ -315,11 +316,12 @@ public class MapBlockBuilder
 
     private void ensureHashTableSize()
     {
-        if (hashTables.length < offsets[positionCount] * HASH_MULTIPLIER) {
+        int[] rawHashTables = hashTables.getRawHashTables();
+        if (rawHashTables.length < offsets[positionCount] * HASH_MULTIPLIER) {
             int newSize = BlockUtil.calculateNewArraySize(offsets[positionCount] * HASH_MULTIPLIER);
-            int oldSize = hashTables.length;
-            hashTables = Arrays.copyOf(hashTables, newSize);
-            Arrays.fill(hashTables, oldSize, hashTables.length, -1);
+            int[] newRawHashTables = Arrays.copyOf(rawHashTables, newSize);
+            Arrays.fill(newRawHashTables, rawHashTables.length, newSize, -1);
+            hashTables.setRawHashTables(newRawHashTables);
         }
     }
 
@@ -329,6 +331,7 @@ public class MapBlockBuilder
         if (currentEntryOpened) {
             throw new IllegalStateException("Current entry must be closed before the block can be built");
         }
+
         return createMapBlockInternal(
                 0,
                 positionCount,
@@ -336,7 +339,7 @@ public class MapBlockBuilder
                 offsets,
                 keyBlockBuilder.build(),
                 valueBlockBuilder.build(),
-                Optional.of(Arrays.copyOf(hashTables, offsets[positionCount] * HASH_MULTIPLIER)),
+                new HashTables(Arrays.copyOf(hashTables.getRawHashTables(), offsets[positionCount] * HASH_MULTIPLIER)),
                 keyType,
                 keyBlockNativeEquals,
                 keyNativeHashCode,
@@ -415,7 +418,7 @@ public class MapBlockBuilder
             }
         }
 
-        closeEntry(mapBlock.getHashTables(), startValueOffset * HASH_MULTIPLIER);
+        closeEntry(mapBlock.getHashTables().getRawHashTables(), startValueOffset * HASH_MULTIPLIER);
         return this;
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.spi.block;
 
+import com.facebook.presto.spi.block.AbstractMapBlock.HashTables;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -54,7 +55,7 @@ public class MapBlockEncoding
 
         int offsetBase = mapBlock.getOffsetBase();
         int[] offsets = mapBlock.getOffsets();
-        int[] hashTable = mapBlock.getHashTables();
+        int[] hashTable = mapBlock.getHashTables().getRawHashTables();
 
         int entriesStartOffset = offsets[offsetBase];
         int entriesEndOffset = offsets[offsetBase + positionCount];
@@ -110,6 +111,6 @@ public class MapBlockEncoding
         int[] offsets = new int[positionCount + 1];
         sliceInput.readBytes(wrappedIntArray(offsets));
         Optional<boolean[]> mapIsNull = EncoderUtil.decodeNullBits(sliceInput, positionCount);
-        return MapType.createMapBlockInternal(typeManager, keyType, 0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, Optional.ofNullable(hashTable));
+        return MapType.createMapBlockInternal(typeManager, keyType, 0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, new HashTables(hashTable));
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
@@ -25,7 +25,6 @@ import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.block.AbstractMapBlock.HASH_MULTIPLIER;
 import static com.facebook.presto.spi.block.MapBlockBuilder.computePosition;
-import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
 import static java.lang.String.format;
 
@@ -62,7 +61,8 @@ public class SingleMapBlock
     @Override
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE + mapBlock.getRawKeyBlock().getRetainedSizeInBytes() + mapBlock.getRawValueBlock().getRetainedSizeInBytes() + sizeOf(mapBlock.getHashTables());
+        return INSTANCE_SIZE + mapBlock.getRawKeyBlock().getRetainedSizeInBytes() + mapBlock.getRawValueBlock().getRetainedSizeInBytes() +
+                mapBlock.getHashTables().getRetainedSizeInBytes();
     }
 
     @Override
@@ -70,7 +70,7 @@ public class SingleMapBlock
     {
         consumer.accept(mapBlock.getRawKeyBlock(), mapBlock.getRawKeyBlock().getRetainedSizeInBytes());
         consumer.accept(mapBlock.getRawValueBlock(), mapBlock.getRawValueBlock().getRetainedSizeInBytes());
-        consumer.accept(mapBlock.getHashTables(), sizeOf(mapBlock.getHashTables()));
+        consumer.accept(mapBlock.getHashTables(), mapBlock.getHashTables().getRetainedSizeInBytes());
         consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
@@ -124,7 +124,7 @@ public class SingleMapBlock
 
     int[] getHashTable()
     {
-        return mapBlock.getHashTables();
+        return mapBlock.getHashTables().getRawHashTables();
     }
 
     Type getKeyType()
@@ -142,7 +142,7 @@ public class SingleMapBlock
         }
 
         mapBlock.ensureHashTableLoaded();
-        int[] hashTable = mapBlock.getHashTables();
+        int[] hashTable = mapBlock.getHashTables().getRawHashTables();
 
         long hashCode;
         try {
@@ -189,7 +189,7 @@ public class SingleMapBlock
         }
 
         mapBlock.ensureHashTableLoaded();
-        int[] hashTable = mapBlock.getHashTables();
+        int[] hashTable = mapBlock.getHashTables().getRawHashTables();
 
         long hashCode;
         try {
@@ -233,7 +233,7 @@ public class SingleMapBlock
         }
 
         mapBlock.ensureHashTableLoaded();
-        int[] hashTable = mapBlock.getHashTables();
+        int[] hashTable = mapBlock.getHashTables().getRawHashTables();
 
         long hashCode;
         try {
@@ -277,7 +277,7 @@ public class SingleMapBlock
         }
 
         mapBlock.ensureHashTableLoaded();
-        int[] hashTable = mapBlock.getHashTables();
+        int[] hashTable = mapBlock.getHashTables().getRawHashTables();
 
         long hashCode;
         try {
@@ -321,7 +321,7 @@ public class SingleMapBlock
         }
 
         mapBlock.ensureHashTableLoaded();
-        int[] hashTable = mapBlock.getHashTables();
+        int[] hashTable = mapBlock.getHashTables().getRawHashTables();
 
         long hashCode;
         try {
@@ -365,7 +365,7 @@ public class SingleMapBlock
         }
 
         mapBlock.ensureHashTableLoaded();
-        int[] hashTable = mapBlock.getHashTables();
+        int[] hashTable = mapBlock.getHashTables().getRawHashTables();
 
         long hashCode;
         try {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.spi.block;
 
+import com.facebook.presto.spi.block.AbstractMapBlock.HashTables;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -110,7 +111,7 @@ public class SingleMapBlockEncoding
                 new int[] {0, keyBlock.getPositionCount()},
                 keyBlock,
                 valueBlock,
-                Optional.ofNullable(hashTable),
+                new HashTables(hashTable),
                 keyType,
                 keyBlockNativeEquals,
                 keyNativeHashCode,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.type;
 
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.AbstractMapBlock.HashTables;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -278,7 +279,7 @@ public class MapType
             int[] offsets,
             Block keyBlock,
             Block valueBlock,
-            Optional<int[]> hashTables)
+            HashTables hashTables)
     {
         // TypeManager caches types. Therefore, it is important that we go through it instead of coming up with the MethodHandles directly.
         // BIGINT is chosen arbitrarily here. Any type will do.


### PR DESCRIPTION
Resolves issue #12187

In 23de11f7d3 we lazily build the hashtables for map. It introduced a
regression for the case where the MapBlock is created through
AbstractMapBlock.getRegion(), in which the hashtables built on the
MapBlock region was not updated in the original MapBlock, thus causing
repeated hashtables build on the same base MapBlock. The change is to
encapsulate the int[] hashtables in AbstractMapBlock$HashTables object
and make it a member of MapBlock/MapBlockBuilder, so that when the
sliced MapBlock builds the hashtables, the base MapBlock would also gets
updated.

This PR was verified to fix the reported regression case on our verifier cluster. 
Query CPU cost before the Lazy Map change: 57 min
Query CPU cost with Lazy Map change without this fix: > 50 days
Query CPU cost with Lazy Map change with this fix: 37 min