### PR TITLE
Lazily build hashtable for map

### DIFF
--- a/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.array;
 
+import com.facebook.presto.spi.block.AbstractMapBlock;
 import com.facebook.presto.spi.block.Block;
 import io.airlift.slice.SizeOf;
 import io.airlift.slice.Slice;
@@ -89,6 +90,9 @@ public final class ReferenceCountMap
         }
         else if (key.getClass().isArray()) {
             extraIdentity = getLength(key);
+        }
+        else if (key instanceof AbstractMapBlock.HashTables) {
+            extraIdentity = (int) ((AbstractMapBlock.HashTables) key).getRetainedSizeInBytes();
         }
         else {
             throw new IllegalArgumentException(format("Unsupported type for %s", key));

--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.block;
 
 import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.spi.block.AbstractMapBlock.HashTables;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -70,6 +71,9 @@ public abstract class AbstractTestBlock
 
     protected <T> void assertBlock(Block block, Supplier<BlockBuilder> newBlockBuilder, T[] expectedValues)
     {
+        assertBlockSize(block);
+        assertRetainedSize(block);
+
         assertBlockPositions(block, newBlockBuilder, expectedValues);
         assertBlockPositions(copyBlockViaBlockSerde(block), newBlockBuilder, expectedValues);
         assertBlockPositions(copyBlockViaWritePositionTo(block, newBlockBuilder), newBlockBuilder, expectedValues);
@@ -153,6 +157,9 @@ public abstract class AbstractTestBlock
                 }
                 else if (type == DictionaryId.class) {
                     retainedSize += ClassLayout.parseClass(DictionaryId.class).instanceSize();
+                }
+                else if (type == HashTables.class) {
+                    retainedSize += ((HashTables) field.get(block)).getRetainedSizeInBytes();
                 }
                 else if (type == MethodHandle.class) {
                     // MethodHandles are only used in MapBlock/MapBlockBuilder,

--- a/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.ByteArrayBlock;
+import com.facebook.presto.spi.block.MapBlock;
 import com.facebook.presto.spi.block.MapBlockBuilder;
 import com.facebook.presto.spi.block.SingleMapBlock;
 import com.facebook.presto.spi.type.MapType;
@@ -27,6 +28,7 @@ import com.facebook.presto.type.TypeRegistry;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,6 +80,46 @@ public class TestMapBlock
 
         // underlying key/value block is not compact
         testIncompactBlock(mapType(TINYINT, TINYINT).createBlockFromKeyValue(Optional.of(mapIsNull), offsets, inCompactKeyBlock, inCompactValueBlock));
+    }
+
+    // TODO: remove this test when we have a more unified testWith() using assertBlock()
+    @Test
+    public void testLazyHashTableBuildOverBlockRegion()
+    {
+        Map<String, Long>[] values = createTestMap(9, 3, 4, 0, 8, 0, 6, 5);
+        Block block = createBlockWithValuesFromKeyValueBlock(values);
+        BlockBuilder blockBuilder = createBlockBuilderWithValues(values);
+
+        // Create a MapBlock that is a region of another MapBlock. It doesn't have hashtables built at the time of creation.
+        int offset = block.getPositionCount() / 2;
+        Block blockRegion = block.getRegion(offset, block.getPositionCount() - offset);
+
+        assertFalse(((MapBlock) blockRegion).isHashTablesPresent());
+        assertFalse(((MapBlock) block).isHashTablesPresent());
+
+        // Lazily build the hashtables for the block region and use them to do position/value check.
+        Map<String, Long>[] expectedValues = Arrays.copyOfRange(values, values.length / 2, values.length);
+        assertBlock(blockRegion, () -> blockBuilder.newBlockBuilderLike(null), expectedValues);
+
+        assertTrue(((MapBlock) blockRegion).isHashTablesPresent());
+        assertTrue(((MapBlock) block).isHashTablesPresent());
+
+        Map<String, Long>[] valuesWithNull = alternatingNullValues(values);
+        Block blockWithNull = createBlockWithValuesFromKeyValueBlock(valuesWithNull);
+
+        // Create a MapBlock that is a region of another MapBlock with null values. It doesn't have hashtables built at the time of creation.
+        offset = blockWithNull.getPositionCount() / 2;
+        Block blockRegionWithNull = blockWithNull.getRegion(offset, blockWithNull.getPositionCount() - offset);
+
+        assertFalse(((MapBlock) blockRegionWithNull).isHashTablesPresent());
+        assertFalse(((MapBlock) blockWithNull).isHashTablesPresent());
+
+        // Lazily build the hashtables for the block region and use them to do position/value check.
+        Map<String, Long>[] expectedValuesWithNull = Arrays.copyOfRange(valuesWithNull, valuesWithNull.length / 2, valuesWithNull.length);
+        assertBlock(blockRegionWithNull, () -> blockBuilder.newBlockBuilderLike(null), expectedValuesWithNull);
+
+        assertTrue(((MapBlock) blockRegionWithNull).isHashTablesPresent());
+        assertTrue(((MapBlock) blockWithNull).isHashTablesPresent());
     }
 
     private Map<String, Long>[] createTestMap(int... entryCounts)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
@@ -229,7 +229,7 @@ public class TestOrcFileRewriter
         File newFile = new File(temporary, randomUUID().toString());
         OrcFileInfo info = createFileRewriter(useOptimizedOrcWriter).rewrite(getColumnTypes(columnIds, columnTypes), file, newFile, rowsToDelete);
         assertEquals(info.getRowCount(), 2);
-        assertBetweenInclusive(info.getUncompressedSize(), 94L, 94L * 2);
+        assertBetweenInclusive(info.getUncompressedSize(), 94L, 118L * 2);
 
         try (OrcDataSource dataSource = fileOrcDataSource(newFile)) {
             OrcRecordReader reader = createReader(dataSource, columnIds, columnTypes);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
@@ -15,6 +15,7 @@
 package com.facebook.presto.spi.block;
 
 import com.facebook.presto.spi.type.Type;
+import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
@@ -28,6 +29,7 @@ import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.compactOffsets;
 import static com.facebook.presto.spi.block.MapBlock.createMapBlockInternal;
+import static io.airlift.slice.SizeOf.sizeOfIntArray;
 import static java.util.Objects.requireNonNull;
 
 public abstract class AbstractMapBlock
@@ -39,21 +41,23 @@ public abstract class AbstractMapBlock
     protected final Type keyType;
     protected final MethodHandle keyNativeHashCode;
     protected final MethodHandle keyBlockNativeEquals;
+    protected final MethodHandle keyBlockHashCode;
 
-    public AbstractMapBlock(Type keyType, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals)
+    public AbstractMapBlock(Type keyType, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals, MethodHandle keyBlockHashCode)
     {
         this.keyType = requireNonNull(keyType, "keyType is null");
         // keyNativeHashCode can only be null due to map block kill switch. deprecated.new-map-block
         this.keyNativeHashCode = keyNativeHashCode;
         // keyBlockNativeEquals can only be null due to map block kill switch. deprecated.new-map-block
         this.keyBlockNativeEquals = keyBlockNativeEquals;
+        this.keyBlockHashCode = requireNonNull(keyBlockHashCode, "keyBlockHashCode is null");
     }
 
     protected abstract Block getRawKeyBlock();
 
     protected abstract Block getRawValueBlock();
 
-    protected abstract int[] getHashTables();
+    protected abstract HashTables getHashTables();
 
     /**
      * offset is entry-based, not position-based. In other words,
@@ -69,6 +73,8 @@ public abstract class AbstractMapBlock
 
     @Nullable
     protected abstract boolean[] getMapIsNull();
+
+    protected abstract void ensureHashTableLoaded();
 
     int getOffset(int position)
     {
@@ -111,22 +117,37 @@ public abstract class AbstractMapBlock
             newPosition++;
         }
 
-        int[] hashTable = getHashTables();
-        int[] newHashTable = new int[newOffsets[newOffsets.length - 1] * HASH_MULTIPLIER];
-        int newHashIndex = 0;
-        for (int i = offset; i < offset + length; ++i) {
-            int position = positions[i];
-            int entriesStartOffset = getOffset(position);
-            int entriesEndOffset = getOffset(position + 1);
-            for (int hashIndex = entriesStartOffset * HASH_MULTIPLIER; hashIndex < entriesEndOffset * HASH_MULTIPLIER; hashIndex++) {
-                newHashTable[newHashIndex] = hashTable[hashIndex];
-                newHashIndex++;
+        int[] rawHashTables = getHashTables().get().orElse(null);
+        int[] newRawHashTables = null;
+        int newHashTableEntries = newOffsets[newOffsets.length - 1] * HASH_MULTIPLIER;
+        if (rawHashTables != null) {
+            newRawHashTables = new int[newHashTableEntries];
+            int newHashIndex = 0;
+            for (int i = offset; i < offset + length; ++i) {
+                int position = positions[i];
+                int entriesStartOffset = getOffset(position);
+                int entriesEndOffset = getOffset(position + 1);
+                for (int hashIndex = entriesStartOffset * HASH_MULTIPLIER; hashIndex < entriesEndOffset * HASH_MULTIPLIER; hashIndex++) {
+                    newRawHashTables[newHashIndex] = rawHashTables[hashIndex];
+                    newHashIndex++;
+                }
             }
         }
 
         Block newKeys = getRawKeyBlock().copyPositions(entriesPositions.elements(), 0, entriesPositions.size());
         Block newValues = getRawValueBlock().copyPositions(entriesPositions.elements(), 0, entriesPositions.size());
-        return createMapBlockInternal(0, length, Optional.of(newMapIsNull), newOffsets, newKeys, newValues, newHashTable, keyType, keyBlockNativeEquals, keyNativeHashCode);
+        return createMapBlockInternal(
+                0,
+                length,
+                Optional.of(newMapIsNull),
+                newOffsets,
+                newKeys,
+                newValues,
+                new HashTables(Optional.ofNullable(newRawHashTables), newHashTableEntries),
+                keyType,
+                keyBlockNativeEquals,
+                keyNativeHashCode,
+                keyBlockHashCode);
     }
 
     @Override
@@ -145,7 +166,8 @@ public abstract class AbstractMapBlock
                 getHashTables(),
                 keyType,
                 keyBlockNativeEquals,
-                keyNativeHashCode);
+                keyNativeHashCode,
+                keyBlockHashCode);
     }
 
     @Override
@@ -161,7 +183,8 @@ public abstract class AbstractMapBlock
         return getRawKeyBlock().getRegionSizeInBytes(entriesStart, entryCount) +
                 getRawValueBlock().getRegionSizeInBytes(entriesStart, entryCount) +
                 (Integer.BYTES + Byte.BYTES) * (long) length +
-                Integer.BYTES * HASH_MULTIPLIER * (long) entryCount;
+                Integer.BYTES * HASH_MULTIPLIER * (long) entryCount +
+                getHashTables().getInstanceSizeInBytes();
     }
 
     @Override
@@ -191,7 +214,8 @@ public abstract class AbstractMapBlock
         return getRawKeyBlock().getPositionsSizeInBytes(entryPositions) +
                 getRawValueBlock().getPositionsSizeInBytes(entryPositions) +
                 (Integer.BYTES + Byte.BYTES) * (long) usedPositionCount +
-                Integer.BYTES * HASH_MULTIPLIER * (long) usedEntryCount;
+                Integer.BYTES * HASH_MULTIPLIER * (long) usedEntryCount +
+                getHashTables().getInstanceSizeInBytes();
     }
     @Override
     public Block copyRegion(int position, int length)
@@ -207,9 +231,15 @@ public abstract class AbstractMapBlock
         int[] newOffsets = compactOffsets(getOffsets(), position + getOffsetBase(), length);
         boolean[] mapIsNull = getMapIsNull();
         boolean[] newMapIsNull = mapIsNull == null ? null : compactArray(mapIsNull, position + getOffsetBase(), length);
-        int[] newHashTable = compactArray(getHashTables(), startValueOffset * HASH_MULTIPLIER, (endValueOffset - startValueOffset) * HASH_MULTIPLIER);
 
-        if (newKeys == getRawKeyBlock() && newValues == getRawValueBlock() && newOffsets == getOffsets() && newMapIsNull == mapIsNull && newHashTable == getHashTables()) {
+        int[] rawHashTables = getHashTables().get().orElse(null);
+        int[] newRawHashTables = null;
+        int expectedNewHashTableEntries = (endValueOffset - startValueOffset) * HASH_MULTIPLIER;
+        if (rawHashTables != null) {
+            newRawHashTables = compactArray(rawHashTables, startValueOffset * HASH_MULTIPLIER, expectedNewHashTableEntries);
+        }
+
+        if (newKeys == getRawKeyBlock() && newValues == getRawValueBlock() && newOffsets == getOffsets() && newMapIsNull == mapIsNull && newRawHashTables == rawHashTables) {
             return this;
         }
         return createMapBlockInternal(
@@ -219,10 +249,11 @@ public abstract class AbstractMapBlock
                 newOffsets,
                 newKeys,
                 newValues,
-                newHashTable,
+                new HashTables(Optional.ofNullable(newRawHashTables), expectedNewHashTableEntries),
                 keyType,
                 keyBlockNativeEquals,
-                keyNativeHashCode);
+                keyNativeHashCode,
+                keyBlockHashCode);
     }
 
     @Override
@@ -238,12 +269,7 @@ public abstract class AbstractMapBlock
         return clazz.cast(new SingleMapBlock(
                 startEntryOffset * 2,
                 (endEntryOffset - startEntryOffset) * 2,
-                getRawKeyBlock(),
-                getRawValueBlock(),
-                getHashTables(),
-                keyType,
-                keyNativeHashCode,
-                keyBlockNativeEquals));
+                this));
     }
 
     @Override
@@ -263,7 +289,13 @@ public abstract class AbstractMapBlock
         int valueLength = endValueOffset - startValueOffset;
         Block newKeys = getRawKeyBlock().copyRegion(startValueOffset, valueLength);
         Block newValues = getRawValueBlock().copyRegion(startValueOffset, valueLength);
-        int[] newHashTable = Arrays.copyOfRange(getHashTables(), startValueOffset * HASH_MULTIPLIER, endValueOffset * HASH_MULTIPLIER);
+
+        int[] rawHashTables = getHashTables().get().orElse(null);
+        int[] newRawHashTables = null;
+        int expectedNewHashTableEntries = (endValueOffset - startValueOffset) * HASH_MULTIPLIER;
+        if (rawHashTables != null) {
+            newRawHashTables = Arrays.copyOfRange(rawHashTables, startValueOffset * HASH_MULTIPLIER, endValueOffset * HASH_MULTIPLIER);
+        }
 
         return createMapBlockInternal(
                 0,
@@ -272,10 +304,11 @@ public abstract class AbstractMapBlock
                 new int[] {0, valueLength},
                 newKeys,
                 newValues,
-                newHashTable,
+                new HashTables(Optional.ofNullable(newRawHashTables), expectedNewHashTableEntries),
                 keyType,
                 keyBlockNativeEquals,
-                keyNativeHashCode);
+                keyNativeHashCode,
+                keyBlockHashCode);
     }
 
     @Override
@@ -314,10 +347,63 @@ public abstract class AbstractMapBlock
         return mapIsNull != null && mapIsNull[position + getOffsetBase()];
     }
 
+    public boolean isHashTablesPresent()
+    {
+        return getHashTables().get().isPresent();
+    }
+
     private void checkReadablePosition(int position)
     {
         if (position < 0 || position >= getPositionCount()) {
             throw new IllegalArgumentException("position is not valid");
+        }
+    }
+
+    public static class HashTables
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(HashTables.class).instanceSize();
+
+        // Hash to location in map. Writes to the field by MapBlock is protected by "HashTables" monitor in MapBlock.
+        // MapBlockBuilder instances have their dedicated hashTables instances, so the write accesses to the hashTables
+        // fields do not need to be synchronized in that class.
+        @Nullable
+        private volatile int[] hashTables;
+
+        // The number of entries of hashTables array as if they are always built. It's used to calculate the retained size.
+        private int expectedEntryCount;
+
+        HashTables(Optional<int[]> hashTables, int expectedEntryCount)
+        {
+            if (hashTables.isPresent() && hashTables.get().length != expectedEntryCount) {
+                throw new IllegalArgumentException("hashTables size does not match expectedEntryCount");
+            }
+
+            this.hashTables = hashTables.orElse(null);
+            this.expectedEntryCount = expectedEntryCount;
+        }
+
+        Optional<int[]> get()
+        {
+            return Optional.ofNullable(hashTables);
+        }
+
+        void set(int[] hashTables)
+        {
+            requireNonNull(hashTables, "hashTables is null");
+            this.hashTables = hashTables;
+
+            // The passed in hashTables are always sized as if they are fully built.
+            this.expectedEntryCount = hashTables.length;
+        }
+
+        public long getInstanceSizeInBytes()
+        {
+            return INSTANCE_SIZE;
+        }
+
+        public long getRetainedSizeInBytes()
+        {
+            return INSTANCE_SIZE + sizeOfIntArray(expectedEntryCount);
         }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -39,7 +39,6 @@ public class MapBlockBuilder
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapBlockBuilder.class).instanceSize();
 
     private final MethodHandle keyBlockEquals;
-    private final MethodHandle keyBlockHashCode;
 
     @Nullable
     private final BlockBuilderStatus blockBuilderStatus;
@@ -49,7 +48,7 @@ public class MapBlockBuilder
     private boolean[] mapIsNull;
     private final BlockBuilder keyBlockBuilder;
     private final BlockBuilder valueBlockBuilder;
-    private int[] hashTables;
+    private HashTables hashTables;
 
     private boolean currentEntryOpened;
 
@@ -88,12 +87,11 @@ public class MapBlockBuilder
             BlockBuilder valueBlockBuilder,
             int[] offsets,
             boolean[] mapIsNull,
-            int[] hashTables)
+            int[] rawHashTables)
     {
-        super(keyType, keyNativeHashCode, keyBlockNativeEquals);
+        super(keyType, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode);
 
         this.keyBlockEquals = requireNonNull(keyBlockEquals, "keyBlockEquals is null");
-        this.keyBlockHashCode = requireNonNull(keyBlockHashCode, "keyBlockHashCode is null");
         this.blockBuilderStatus = blockBuilderStatus;
 
         this.positionCount = 0;
@@ -101,7 +99,7 @@ public class MapBlockBuilder
         this.mapIsNull = requireNonNull(mapIsNull, "mapIsNull is null");
         this.keyBlockBuilder = requireNonNull(keyBlockBuilder, "keyBlockBuilder is null");
         this.valueBlockBuilder = requireNonNull(valueBlockBuilder, "valueBlockBuilder is null");
-        this.hashTables = requireNonNull(hashTables, "hashTables is null");
+        this.hashTables = new HashTables(Optional.of(requireNonNull(rawHashTables, "hashTables is null")), rawHashTables.length);
     }
 
     @Override
@@ -117,7 +115,7 @@ public class MapBlockBuilder
     }
 
     @Override
-    protected int[] getHashTables()
+    protected HashTables getHashTables()
     {
         return hashTables;
     }
@@ -151,13 +149,19 @@ public class MapBlockBuilder
     {
         return keyBlockBuilder.getSizeInBytes() + valueBlockBuilder.getSizeInBytes() +
                 (Integer.BYTES + Byte.BYTES) * (long) positionCount +
-                Integer.BYTES * HASH_MULTIPLIER * (long) keyBlockBuilder.getPositionCount();
+                Integer.BYTES * HASH_MULTIPLIER * (long) keyBlockBuilder.getPositionCount() +
+                hashTables.getInstanceSizeInBytes();
     }
 
     @Override
     public long getRetainedSizeInBytes()
     {
-        long size = INSTANCE_SIZE + keyBlockBuilder.getRetainedSizeInBytes() + valueBlockBuilder.getRetainedSizeInBytes() + sizeOf(offsets) + sizeOf(mapIsNull) + sizeOf(hashTables);
+        long size = INSTANCE_SIZE
+                + keyBlockBuilder.getRetainedSizeInBytes()
+                + valueBlockBuilder.getRetainedSizeInBytes()
+                + sizeOf(offsets)
+                + sizeOf(mapIsNull)
+                + hashTables.getRetainedSizeInBytes();
         if (blockBuilderStatus != null) {
             size += BlockBuilderStatus.INSTANCE_SIZE;
         }
@@ -171,7 +175,7 @@ public class MapBlockBuilder
         consumer.accept(valueBlockBuilder, valueBlockBuilder.getRetainedSizeInBytes());
         consumer.accept(offsets, sizeOf(offsets));
         consumer.accept(mapIsNull, sizeOf(mapIsNull));
-        consumer.accept(hashTables, sizeOf(hashTables));
+        consumer.accept(hashTables, hashTables.getRetainedSizeInBytes());
         consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
@@ -199,7 +203,16 @@ public class MapBlockBuilder
         int previousAggregatedEntryCount = offsets[positionCount - 1];
         int aggregatedEntryCount = offsets[positionCount];
         int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
-        buildHashTable(keyBlockBuilder, previousAggregatedEntryCount, entryCount, keyBlockHashCode, hashTables, previousAggregatedEntryCount * HASH_MULTIPLIER, entryCount * HASH_MULTIPLIER);
+        Optional<int[]> rawHashTables = hashTables.get();
+        verify(rawHashTables.isPresent(), "rawHashTables is empty");
+        buildHashTable(
+                keyBlockBuilder,
+                previousAggregatedEntryCount,
+                entryCount,
+                keyBlockHashCode,
+                rawHashTables.get(),
+                previousAggregatedEntryCount * HASH_MULTIPLIER,
+                entryCount * HASH_MULTIPLIER);
         return this;
     }
 
@@ -224,19 +237,21 @@ public class MapBlockBuilder
         int previousAggregatedEntryCount = offsets[positionCount - 1];
         int aggregatedEntryCount = offsets[positionCount];
         int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
+        Optional<int[]> rawHashTables = hashTables.get();
+        verify(rawHashTables.isPresent(), "rawHashTables is empty");
         buildHashTableStrict(
                 keyBlockBuilder,
                 previousAggregatedEntryCount,
                 entryCount,
                 keyBlockEquals,
                 keyBlockHashCode,
-                hashTables,
+                rawHashTables.get(),
                 previousAggregatedEntryCount * HASH_MULTIPLIER,
                 entryCount * HASH_MULTIPLIER);
         return this;
     }
 
-    private BlockBuilder closeEntry(int[] providedHashTable, int providedHashTableOffset)
+    private BlockBuilder closeEntry(@Nullable int[] providedHashTable, int providedHashTableOffset)
     {
         if (!currentEntryOpened) {
             throw new IllegalStateException("Expected entry to be opened but was closed");
@@ -246,14 +261,31 @@ public class MapBlockBuilder
         currentEntryOpened = false;
 
         ensureHashTableSize();
+        int previousAggregatedEntryCount = offsets[positionCount - 1];
+        int aggregatedEntryCount = offsets[positionCount];
 
-        // Directly copy instead of building hashtable
-        int hashTableOffset = offsets[positionCount - 1] * HASH_MULTIPLIER;
-        int hashTableSize = (offsets[positionCount] - offsets[positionCount - 1]) * HASH_MULTIPLIER;
-        for (int i = 0; i < hashTableSize; i++) {
-            hashTables[hashTableOffset + i] = providedHashTable[providedHashTableOffset + i];
+        Optional<int[]> rawHashTables = hashTables.get();
+        verify(rawHashTables.isPresent(), "rawHashTables is empty");
+        if (providedHashTable != null) {
+            // Directly copy instead of building hashtable if providedHashTable is not null
+            int hashTableOffset = previousAggregatedEntryCount * HASH_MULTIPLIER;
+            int hashTableSize = (aggregatedEntryCount - previousAggregatedEntryCount) * HASH_MULTIPLIER;
+            for (int i = 0; i < hashTableSize; i++) {
+                rawHashTables.get()[hashTableOffset + i] = providedHashTable[providedHashTableOffset + i];
+            }
         }
-
+        else {
+            // Build hash table for this map entry.
+            int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
+            buildHashTable(
+                    keyBlockBuilder,
+                    previousAggregatedEntryCount,
+                    entryCount,
+                    keyBlockHashCode,
+                    rawHashTables.get(),
+                    previousAggregatedEntryCount * HASH_MULTIPLIER,
+                    entryCount * HASH_MULTIPLIER);
+        }
         return this;
     }
 
@@ -290,11 +322,13 @@ public class MapBlockBuilder
 
     private void ensureHashTableSize()
     {
-        if (hashTables.length < offsets[positionCount] * HASH_MULTIPLIER) {
+        Optional<int[]> rawHashTables = hashTables.get();
+        verify(rawHashTables.isPresent(), "rawHashTables is empty");
+        if (rawHashTables.get().length < offsets[positionCount] * HASH_MULTIPLIER) {
             int newSize = BlockUtil.calculateNewArraySize(offsets[positionCount] * HASH_MULTIPLIER);
-            int oldSize = hashTables.length;
-            hashTables = Arrays.copyOf(hashTables, newSize);
-            Arrays.fill(hashTables, oldSize, hashTables.length, -1);
+            int[] newRawHashTables = Arrays.copyOf(rawHashTables.get(), newSize);
+            Arrays.fill(newRawHashTables, rawHashTables.get().length, newSize, -1);
+            hashTables.set(newRawHashTables);
         }
     }
 
@@ -304,6 +338,10 @@ public class MapBlockBuilder
         if (currentEntryOpened) {
             throw new IllegalStateException("Current entry must be closed before the block can be built");
         }
+
+        Optional<int[]> rawHashTables = hashTables.get();
+        verify(rawHashTables.isPresent(), "rawHashTables is empty");
+        int hashTablesEntries = offsets[positionCount] * HASH_MULTIPLIER;
         return createMapBlockInternal(
                 0,
                 positionCount,
@@ -311,9 +349,11 @@ public class MapBlockBuilder
                 offsets,
                 keyBlockBuilder.build(),
                 valueBlockBuilder.build(),
-                Arrays.copyOf(hashTables, offsets[positionCount] * HASH_MULTIPLIER),
+                new HashTables(Optional.of(Arrays.copyOf(rawHashTables.get(), hashTablesEntries)), hashTablesEntries),
                 keyType,
-                keyBlockNativeEquals, keyNativeHashCode);
+                keyBlockNativeEquals,
+                keyNativeHashCode,
+                keyBlockHashCode);
     }
 
     @Override
@@ -388,7 +428,7 @@ public class MapBlockBuilder
             }
         }
 
-        closeEntry(mapBlock.getHashTables(), startValueOffset * HASH_MULTIPLIER);
+        closeEntry(mapBlock.getHashTables().get().orElse(null), startValueOffset * HASH_MULTIPLIER);
         return this;
     }
 
@@ -409,6 +449,9 @@ public class MapBlockBuilder
                 new boolean[newSize],
                 newNegativeOneFilledArray(newSize * HASH_MULTIPLIER));
     }
+
+    @Override
+    protected void ensureHashTableLoaded() {}
 
     private static int[] newNegativeOneFilledArray(int size)
     {
@@ -512,5 +555,12 @@ public class MapBlockBuilder
     static int computePosition(long hashcode, int hashTableSize)
     {
         return (int) ((Integer.toUnsignedLong(Long.hashCode(hashcode)) * hashTableSize) >> 32);
+    }
+
+    private static void verify(boolean assertion, String message)
+    {
+        if (!assertion) {
+            throw new AssertionError(message);
+        }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockEncoding.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.spi.block;
 
+import com.facebook.presto.spi.block.AbstractMapBlock.HashTables;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -54,7 +55,7 @@ public class MapBlockEncoding
 
         int offsetBase = mapBlock.getOffsetBase();
         int[] offsets = mapBlock.getOffsets();
-        int[] hashTable = mapBlock.getHashTables();
+        int[] hashTable = mapBlock.getHashTables().get().orElse(null);
 
         int entriesStartOffset = offsets[offsetBase];
         int entriesEndOffset = offsets[offsetBase + positionCount];
@@ -64,8 +65,15 @@ public class MapBlockEncoding
         blockEncodingSerde.writeBlock(sliceOutput, mapBlock.getRawKeyBlock().getRegion(entriesStartOffset, entriesEndOffset - entriesStartOffset));
         blockEncodingSerde.writeBlock(sliceOutput, mapBlock.getRawValueBlock().getRegion(entriesStartOffset, entriesEndOffset - entriesStartOffset));
 
-        sliceOutput.appendInt((entriesEndOffset - entriesStartOffset) * HASH_MULTIPLIER);
-        sliceOutput.writeBytes(wrappedIntArray(hashTable, entriesStartOffset * HASH_MULTIPLIER, (entriesEndOffset - entriesStartOffset) * HASH_MULTIPLIER));
+        if (hashTable != null) {
+            int hashTableLength = (entriesEndOffset - entriesStartOffset) * HASH_MULTIPLIER;
+            sliceOutput.appendInt(hashTableLength); // hashtable length
+            sliceOutput.writeBytes(wrappedIntArray(hashTable, entriesStartOffset * HASH_MULTIPLIER, hashTableLength));
+        }
+        else {
+            // if the hashTable is null, we write the length -1
+            sliceOutput.appendInt(-1);  // hashtable length
+        }
 
         sliceOutput.appendInt(positionCount);
         for (int position = 0; position < positionCount + 1; position++) {
@@ -82,18 +90,27 @@ public class MapBlockEncoding
         Block keyBlock = blockEncodingSerde.readBlock(sliceInput);
         Block valueBlock = blockEncodingSerde.readBlock(sliceInput);
 
-        int[] hashTable = new int[sliceInput.readInt()];
-        sliceInput.readBytes(wrappedIntArray(hashTable));
+        int hashTableLength = sliceInput.readInt();
+        int[] hashTable = null;
+        if (hashTableLength >= 0) {
+            hashTable = new int[hashTableLength];
+            sliceInput.readBytes(wrappedIntArray(hashTable));
+        }
 
-        if (keyBlock.getPositionCount() != valueBlock.getPositionCount() || keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
+        if (keyBlock.getPositionCount() != valueBlock.getPositionCount()) {
             throw new IllegalArgumentException(
-                    format("Deserialized MapBlock violates invariants: key %d, value %d, hash %d", keyBlock.getPositionCount(), valueBlock.getPositionCount(), hashTable.length));
+                    format("Deserialized MapBlock violates invariants: key %d, value %d", keyBlock.getPositionCount(), valueBlock.getPositionCount()));
+        }
+
+        if (hashTable != null && keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
+            throw new IllegalArgumentException(
+                    format("Deserialized MapBlock violates invariants: expected hashtable size %d, actual hashtable size %d", keyBlock.getPositionCount() * HASH_MULTIPLIER, hashTable.length));
         }
 
         int positionCount = sliceInput.readInt();
         int[] offsets = new int[positionCount + 1];
         sliceInput.readBytes(wrappedIntArray(offsets));
         Optional<boolean[]> mapIsNull = EncoderUtil.decodeNullBits(sliceInput, positionCount);
-        return MapType.createMapBlockInternal(typeManager, keyType, 0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, hashTable);
+        return MapType.createMapBlockInternal(typeManager, keyType, 0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, new HashTables(Optional.ofNullable(hashTable), hashTableLength));
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlock.java
@@ -19,14 +19,14 @@ import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
-import java.lang.invoke.MethodHandle;
+import javax.annotation.Nullable;
+
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.block.AbstractMapBlock.HASH_MULTIPLIER;
 import static com.facebook.presto.spi.block.MapBlockBuilder.computePosition;
-import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
 import static java.lang.String.format;
 
@@ -36,24 +36,14 @@ public class SingleMapBlock
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleMapBlock.class).instanceSize();
 
     private final int offset;
-    private final int positionCount;
-    private final Block keyBlock;
-    private final Block valueBlock;
-    private final int[] hashTable;
-    final Type keyType;
-    private final MethodHandle keyNativeHashCode;
-    private final MethodHandle keyBlockNativeEquals;
+    private final int positionCount;  // The number of keys in this single map * 2
+    private final AbstractMapBlock mapBlock;
 
-    SingleMapBlock(int offset, int positionCount, Block keyBlock, Block valueBlock, int[] hashTable, Type keyType, MethodHandle keyNativeHashCode, MethodHandle keyBlockNativeEquals)
+    SingleMapBlock(int offset, int positionCount, AbstractMapBlock mapBlock)
     {
         this.offset = offset;
         this.positionCount = positionCount;
-        this.keyBlock = keyBlock;
-        this.valueBlock = valueBlock;
-        this.hashTable = hashTable;
-        this.keyType = keyType;
-        this.keyNativeHashCode = keyNativeHashCode;
-        this.keyBlockNativeEquals = keyBlockNativeEquals;
+        this.mapBlock = mapBlock;
     }
 
     @Override
@@ -65,23 +55,26 @@ public class SingleMapBlock
     @Override
     public long getSizeInBytes()
     {
-        return keyBlock.getRegionSizeInBytes(offset / 2, positionCount / 2) +
-                valueBlock.getRegionSizeInBytes(offset / 2, positionCount / 2) +
+        return mapBlock.getRawKeyBlock().getRegionSizeInBytes(offset / 2, positionCount / 2) +
+                mapBlock.getRawValueBlock().getRegionSizeInBytes(offset / 2, positionCount / 2) +
                 sizeOfIntArray(positionCount / 2 * HASH_MULTIPLIER);
     }
 
     @Override
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE + keyBlock.getRetainedSizeInBytes() + valueBlock.getRetainedSizeInBytes() + sizeOf(hashTable);
+        return INSTANCE_SIZE +
+                mapBlock.getRawKeyBlock().getRetainedSizeInBytes() +
+                mapBlock.getRawValueBlock().getRetainedSizeInBytes() +
+                mapBlock.getHashTables().getRetainedSizeInBytes();
     }
 
     @Override
     public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
     {
-        consumer.accept(keyBlock, keyBlock.getRetainedSizeInBytes());
-        consumer.accept(valueBlock, valueBlock.getRetainedSizeInBytes());
-        consumer.accept(hashTable, sizeOf(hashTable));
+        consumer.accept(mapBlock.getRawKeyBlock(), mapBlock.getRawKeyBlock().getRetainedSizeInBytes());
+        consumer.accept(mapBlock.getRawValueBlock(), mapBlock.getRawValueBlock().getRetainedSizeInBytes());
+        consumer.accept(mapBlock.getHashTables(), mapBlock.getHashTables().getRetainedSizeInBytes());
         consumer.accept(this, (long) INSTANCE_SIZE);
     }
 
@@ -100,13 +93,13 @@ public class SingleMapBlock
     @Override
     Block getRawKeyBlock()
     {
-        return keyBlock;
+        return mapBlock.getRawKeyBlock();
     }
 
     @Override
     Block getRawValueBlock()
     {
-        return valueBlock;
+        return mapBlock.getRawValueBlock();
     }
 
     @Override
@@ -118,29 +111,30 @@ public class SingleMapBlock
     @Override
     public Block getLoadedBlock()
     {
-        if (keyBlock != keyBlock.getLoadedBlock()) {
+        if (mapBlock.getRawKeyBlock() != mapBlock.getRawKeyBlock().getLoadedBlock()) {
             // keyBlock has to be loaded since MapBlock constructs hash table eagerly.
             throw new IllegalStateException();
         }
 
-        Block loadedValueBlock = valueBlock.getLoadedBlock();
-        if (loadedValueBlock == valueBlock) {
+        Block loadedValueBlock = mapBlock.getRawValueBlock().getLoadedBlock();
+        if (loadedValueBlock == mapBlock.getRawValueBlock()) {
             return this;
         }
         return new SingleMapBlock(
                 offset,
                 positionCount,
-                keyBlock,
-                loadedValueBlock,
-                hashTable,
-                keyType,
-                keyNativeHashCode,
-                keyBlockNativeEquals);
+                mapBlock);
     }
 
+    @Nullable
     int[] getHashTable()
     {
-        return hashTable;
+        return mapBlock.getHashTables().get().orElse(null);
+    }
+
+    Type getKeyType()
+    {
+        return mapBlock.keyType;
     }
 
     /**
@@ -152,9 +146,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables().get().get();
+
         long hashCode;
         try {
-            hashCode = (long) keyNativeHashCode.invoke(nativeValue);
+            hashCode = (long) mapBlock.keyNativeHashCode.invoke(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -171,7 +168,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) keyBlockNativeEquals.invoke(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.keyBlockNativeEquals.invoke(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -196,9 +193,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables().get().get();
+
         long hashCode;
         try {
-            hashCode = (long) keyNativeHashCode.invokeExact(nativeValue);
+            hashCode = (long) mapBlock.keyNativeHashCode.invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -215,7 +215,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) keyBlockNativeEquals.invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -237,9 +237,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables().get().get();
+
         long hashCode;
         try {
-            hashCode = (long) keyNativeHashCode.invokeExact(nativeValue);
+            hashCode = (long) mapBlock.keyNativeHashCode.invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -256,7 +259,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) keyBlockNativeEquals.invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -278,9 +281,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables().get().get();
+
         long hashCode;
         try {
-            hashCode = (long) keyNativeHashCode.invokeExact(nativeValue);
+            hashCode = (long) mapBlock.keyNativeHashCode.invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -297,7 +303,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) keyBlockNativeEquals.invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -319,9 +325,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables().get().get();
+
         long hashCode;
         try {
-            hashCode = (long) keyNativeHashCode.invokeExact(nativeValue);
+            hashCode = (long) mapBlock.keyNativeHashCode.invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -338,7 +347,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) keyBlockNativeEquals.invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
@@ -360,9 +369,12 @@ public class SingleMapBlock
             return -1;
         }
 
+        mapBlock.ensureHashTableLoaded();
+        int[] hashTable = mapBlock.getHashTables().get().get();
+
         long hashCode;
         try {
-            hashCode = (long) keyNativeHashCode.invokeExact(nativeValue);
+            hashCode = (long) mapBlock.keyNativeHashCode.invokeExact(nativeValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
@@ -379,7 +391,7 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = (Boolean) keyBlockNativeEquals.invokeExact(keyBlock, offset / 2 + keyPosition, nativeValue);
+                match = (Boolean) mapBlock.keyBlockNativeEquals.invokeExact(mapBlock.getRawKeyBlock(), offset / 2 + keyPosition, nativeValue);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
@@ -14,6 +14,7 @@
 
 package com.facebook.presto.spi.block;
 
+import com.facebook.presto.spi.block.AbstractMapBlock.HashTables;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -22,6 +23,7 @@ import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
 import java.lang.invoke.MethodHandle;
+import java.util.Optional;
 
 import static com.facebook.presto.spi.block.AbstractMapBlock.HASH_MULTIPLIER;
 import static com.facebook.presto.spi.block.MethodHandleUtil.compose;
@@ -54,15 +56,23 @@ public class SingleMapBlockEncoding
     public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
     {
         SingleMapBlock singleMapBlock = (SingleMapBlock) block;
-        TypeSerde.writeType(sliceOutput, singleMapBlock.keyType);
+        TypeSerde.writeType(sliceOutput, singleMapBlock.getKeyType());
 
         int offset = singleMapBlock.getOffset();
         int positionCount = singleMapBlock.getPositionCount();
         blockEncodingSerde.writeBlock(sliceOutput, singleMapBlock.getRawKeyBlock().getRegion(offset / 2, positionCount / 2));
         blockEncodingSerde.writeBlock(sliceOutput, singleMapBlock.getRawValueBlock().getRegion(offset / 2, positionCount / 2));
         int[] hashTable = singleMapBlock.getHashTable();
-        sliceOutput.appendInt(positionCount / 2 * HASH_MULTIPLIER);
-        sliceOutput.writeBytes(wrappedIntArray(hashTable, offset / 2 * HASH_MULTIPLIER, positionCount / 2 * HASH_MULTIPLIER));
+
+        if (hashTable != null) {
+            int hashTableLength = positionCount / 2 * HASH_MULTIPLIER;
+            sliceOutput.appendInt(hashTableLength);  // hashtable length
+            sliceOutput.writeBytes(wrappedIntArray(hashTable, offset / 2 * HASH_MULTIPLIER, hashTableLength));
+        }
+        else {
+            // if the hashTable is null, we write the length -1
+            sliceOutput.appendInt(-1);
+        }
     }
 
     @Override
@@ -72,18 +82,41 @@ public class SingleMapBlockEncoding
         MethodHandle keyNativeEquals = typeManager.resolveOperator(OperatorType.EQUAL, asList(keyType, keyType));
         MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
         MethodHandle keyNativeHashCode = typeManager.resolveOperator(OperatorType.HASH_CODE, singletonList(keyType));
+        MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
 
         Block keyBlock = blockEncodingSerde.readBlock(sliceInput);
         Block valueBlock = blockEncodingSerde.readBlock(sliceInput);
 
-        int[] hashTable = new int[sliceInput.readInt()];
-        sliceInput.readBytes(wrappedIntArray(hashTable));
-
-        if (keyBlock.getPositionCount() != valueBlock.getPositionCount() || keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
-            throw new IllegalArgumentException(
-                    format("Deserialized SingleMapBlock violates invariants: key %d, value %d, hash %d", keyBlock.getPositionCount(), valueBlock.getPositionCount(), hashTable.length));
+        int hashTableLength = sliceInput.readInt();
+        int[] hashTable = null;
+        if (hashTableLength >= 0) {
+            hashTable = new int[hashTableLength];
+            sliceInput.readBytes(wrappedIntArray(hashTable));
         }
 
-        return new SingleMapBlock(0, keyBlock.getPositionCount() * 2, keyBlock, valueBlock, hashTable, keyType, keyNativeHashCode, keyBlockNativeEquals);
+        if (keyBlock.getPositionCount() != valueBlock.getPositionCount()) {
+            throw new IllegalArgumentException(
+                    format("Deserialized SingleMapBlock violates invariants: key %d, value %d", keyBlock.getPositionCount(), valueBlock.getPositionCount()));
+        }
+
+        if (hashTable != null && keyBlock.getPositionCount() * HASH_MULTIPLIER != hashTable.length) {
+            throw new IllegalArgumentException(
+                    format("Deserialized SingleMapBlock violates invariants: expected hashtable size %d, actual hashtable size %d", keyBlock.getPositionCount() * HASH_MULTIPLIER, hashTable.length));
+        }
+
+        MapBlock mapBlock = MapBlock.createMapBlockInternal(
+                0,
+                1,
+                Optional.empty(),
+                new int[] {0, keyBlock.getPositionCount()},
+                keyBlock,
+                valueBlock,
+                new HashTables(Optional.ofNullable(hashTable), hashTableLength),
+                keyType,
+                keyBlockNativeEquals,
+                keyNativeHashCode,
+                keyBlockHashCode);
+
+        return new SingleMapBlock(0, keyBlock.getPositionCount() * 2, mapBlock);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.type;
 
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.block.AbstractMapBlock.HashTables;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
@@ -278,11 +279,11 @@ public class MapType
             int[] offsets,
             Block keyBlock,
             Block valueBlock,
-            int[] hashTables)
+            HashTables hashTables)
     {
         // TypeManager caches types. Therefore, it is important that we go through it instead of coming up with the MethodHandles directly.
         // BIGINT is chosen arbitrarily here. Any type will do.
         MapType mapType = (MapType) typeManager.getType(new TypeSignature(StandardTypes.MAP, TypeSignatureParameter.of(keyType.getTypeSignature()), TypeSignatureParameter.of(BIGINT.getTypeSignature())));
-        return MapBlock.createMapBlockInternal(startOffset, positionCount, mapIsNull, offsets, keyBlock, valueBlock, hashTables, keyType, mapType.keyBlockNativeEquals, mapType.keyNativeHashCode);
+        return MapBlock.createMapBlockInternal(startOffset, positionCount, mapIsNull, offsets, keyBlock, valueBlock, hashTables, keyType, mapType.keyBlockNativeEquals, mapType.keyNativeHashCode, mapType.keyBlockHashCode);
     }
 }


### PR DESCRIPTION
This PR contains 
1) e9cecd5 The original lazily build hashtable(23de11f) that was merged in 0.214
2) 1ef0753 Fix lazy map hashtable regression

23de11f introduced a regression(Issue #12187) for the case where the 
MapBlock is created through AbstractMapBlock.getRegion(), in which the 
hashtables built on the MapBlock region was not updated in the original 
MapBlock, thus causing repeated hashtables build on the same base MapBlock. 

1ef0753 fixes the above issue. It encapsulates the int[] hashtables in 
AbstractMapBlock$HashTables object and make it a member of MapBlock/MapBlockBuilder, so that when the sliced MapBlock builds the hashtables, the base MapBlock would also gets
updated.

This PR is to review 1ef0753 mainly.