### PR TITLE
View columns should be able to be referenced with the schema name prefixed

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Field.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Field.java
@@ -17,6 +17,7 @@ import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.tree.QualifiedName;
 
+import java.util.List;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -122,7 +123,25 @@ public class Field
 
     public boolean matchesPrefix(Optional<QualifiedName> prefix)
     {
-        return !prefix.isPresent() || relationAlias.isPresent() && relationAlias.get().hasSuffix(prefix.get());
+        if (!prefix.isPresent() || relationAlias.isPresent() && relationAlias.get().hasSuffix(prefix.get())) {
+            return true;
+        }
+
+        if (!originTable.isPresent()) {
+            return false;
+        }
+
+        QualifiedObjectName origin = originTable.get();
+        List<String> prefixes = prefix.get().getParts();
+
+        if (prefixes.size() == 3 && (!origin.getCatalogName().equalsIgnoreCase(prefixes.get(0)) || !origin.getSchemaName().equalsIgnoreCase(prefixes.get(1)))) {
+            return false;
+        }
+        else if (prefixes.size() == 2 && !origin.getSchemaName().equalsIgnoreCase(prefixes.get(0))) {
+            return false;
+        }
+
+        return origin.getObjectName().equalsIgnoreCase(prefixes.get(prefixes.size() - 1));
     }
 
     /*

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -1179,6 +1179,12 @@ public class TestAnalyzer
     {
         // it should be possible to qualify the column reference with the view name
         analyze("SELECT v1.a FROM v1");
+
+        // it should be possible to qualify the column reference with the schema/view name
+        analyze("SELECT s1.v1.a FROM s1.v1");
+
+        // it should be possible to qualify the column reference with the catalog/schema/view name
+        analyze("SELECT tpch.s1.v1.a FROM tpch.s1.v1");
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/prestodb/presto/issues/9173

The base of the code fix is from the above mentioned issue. We were having the same problem, so I thought I'd start the work with the code given in the issue.

Currently, Metabase(a popular dashboard/visualization tool) references its columns with all parts(schema, table/view name, column name) and it breaks only on Presto views.

Considering the fact that a simple query that works with a table doesn't work with a view, I think it should be addressed!