### PR TITLE
Fix schedule deadlock in presence of grouped execution and broadcast join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -106,14 +106,16 @@ public class FixedSourcePartitionedScheduler
         Optional<LifespanScheduler> groupedLifespanScheduler = Optional.empty();
         for (PlanNodeId planNodeId : schedulingOrder) {
             SplitSource splitSource = splitSources.get(planNodeId);
+            boolean groupedExecutionForScanNode = stageExecutionStrategy.isGroupedExecution(planNodeId);
             SourceScheduler sourceScheduler = newSourcePartitionedSchedulerAsSourceScheduler(
                     stage,
                     planNodeId,
                     splitSource,
                     splitPlacementPolicy,
-                    Math.max(splitBatchSize / concurrentLifespans, 1));
+                    Math.max(splitBatchSize / concurrentLifespans, 1),
+                    groupedExecutionForScanNode);
 
-            if (stageExecutionStrategy.isAnyScanGroupedExecution() && !stageExecutionStrategy.isGroupedExecution(planNodeId)) {
+            if (stageExecutionStrategy.isAnyScanGroupedExecution() && !groupedExecutionForScanNode) {
                 sourceScheduler = new AsGroupedSourceScheduler(sourceScheduler);
             }
             sourceSchedulers.add(sourceScheduler);

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
@@ -258,6 +258,7 @@ public class SourcePartitionedScheduler
             Multimap<Node, Split> splitAssignment = ImmutableMultimap.of();
             if (!pendingSplits.isEmpty()) {
                 if (!scheduleGroup.placementFuture.isDone()) {
+                    anyBlockedOnPlacements = true;
                     continue;
                 }
 


### PR DESCRIPTION

Previously, all tasks are proactively created when schedule
is blocked on SPLIT_QUEUES_FULL to prevent potential deadlock in the
presence of broadcast join.

Such deadlock usually happens with blockedReason SPLIT_QUEUES_FULL.
However, it could also happen with blockedReason NO_ACTIVE_DRIVER_GROUP,
when the probe side of broadcast join enables grouped execution,
and partitions on the probe side table are small.
So lifespan can finish split schedule without blocked by
SPLIT_QUEUES_FULL.

This is a regression introduced by 55c10010bbe97ac5de8febf59c7ef58aa4d33f95. 
Prior to this commit, all tasks are created unconditionally. 