### PR TITLE
Upgrading to parquet 0.10.1 and handling TIMESTAMP type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.logback.version>1.2.3</dep.logback.version>
+        <dep.parquet.version>1.10.0</dep.parquet.version>
 
         <!--
           America/Bahia_Banderas has:

--- a/presto-geospatial-toolkit/pom.xml
+++ b/presto-geospatial-toolkit/pom.xml
@@ -75,4 +75,19 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredResourcePatterns>
+                        <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
+                        <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                    </ignoredResourcePatterns>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-geospatial/pom.xml
+++ b/presto-geospatial/pom.xml
@@ -167,4 +167,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredResourcePatterns>
+                        <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
+                        <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                    </ignoredResourcePatterns>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -116,6 +116,16 @@
                             </excludes>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.basepom.maven</groupId>
+                        <artifactId>duplicate-finder-maven-plugin</artifactId>
+                        <configuration>
+                            <ignoredResourcePatterns>
+                                <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
+                                <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                            </ignoredResourcePatterns>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -130,6 +140,16 @@
                             <includes>
                                 <include>**/TestHiveClient.java</include>
                             </includes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.basepom.maven</groupId>
+                        <artifactId>duplicate-finder-maven-plugin</artifactId>
+                        <configuration>
+                            <ignoredResourcePatterns>
+                                <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
+                                <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                            </ignoredResourcePatterns>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -147,6 +167,16 @@
                                 <include>**/TestHiveFileSystemS3.java</include>
                                 <include>**/TestHiveFileSystemS3SelectPushdown.java</include>
                             </includes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.basepom.maven</groupId>
+                        <artifactId>duplicate-finder-maven-plugin</artifactId>
+                        <configuration>
+                            <ignoredResourcePatterns>
+                                <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
+                                <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                            </ignoredResourcePatterns>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -348,6 +348,16 @@
                             </excludes>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.basepom.maven</groupId>
+                        <artifactId>duplicate-finder-maven-plugin</artifactId>
+                        <configuration>
+                            <ignoredResourcePatterns>
+                                <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
+                                <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                            </ignoredResourcePatterns>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -362,6 +372,16 @@
                             <includes>
                                 <include>**/TestHiveClientGlueMetastore.java</include>
                             </includes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.basepom.maven</groupId>
+                        <artifactId>duplicate-finder-maven-plugin</artifactId>
+                        <configuration>
+                            <ignoredResourcePatterns>
+                                <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
+                                <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                            </ignoredResourcePatterns>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -38,6 +38,34 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-column</artifactId>
+            <version>${dep.parquet.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop</artifactId>
+            <version>${dep.parquet.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.xerial.snappy</groupId>
+                    <artifactId>snappy-java</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-memory-context</artifactId>
         </dependency>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -28,8 +28,8 @@ import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableList;
-import parquet.io.MessageColumnIO;
-import parquet.schema.MessageType;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.schema.MessageType;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -45,7 +45,7 @@ import static com.facebook.presto.parquet.ParquetTypeUtils.getFieldIndex;
 import static com.facebook.presto.parquet.ParquetTypeUtils.lookupColumnByName;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
-import static parquet.io.ColumnIOConverter.constructField;
+import static org.apache.parquet.io.ColumnIOConverter.constructField;
 
 public class ParquetPageSource
         implements ConnectorPageSource

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -37,13 +37,13 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.schema.MessageType;
 import org.joda.time.DateTimeZone;
-import parquet.column.ColumnDescriptor;
-import parquet.hadoop.metadata.BlockMetaData;
-import parquet.hadoop.metadata.FileMetaData;
-import parquet.hadoop.metadata.ParquetMetadata;
-import parquet.io.MessageColumnIO;
-import parquet.schema.MessageType;
 
 import javax.inject.Inject;
 
@@ -158,7 +158,7 @@ public class ParquetPageSourceFactory
             MessageType fileSchema = fileMetaData.getSchema();
             dataSource = buildHdfsParquetDataSource(inputStream, path, fileSize, stats);
 
-            List<parquet.schema.Type> fields = columns.stream()
+            List<org.apache.parquet.schema.Type> fields = columns.stream()
                     .filter(column -> column.getColumnType() == REGULAR)
                     .map(column -> getParquetType(column, fileSchema, useParquetColumnNames))
                     .filter(Objects::nonNull)
@@ -249,7 +249,7 @@ public class ParquetPageSourceFactory
         return TupleDomain.withColumnDomains(predicate.build());
     }
 
-    public static parquet.schema.Type getParquetType(HiveColumnHandle column, MessageType messageType, boolean useParquetColumnNames)
+    public static org.apache.parquet.schema.Type getParquetType(HiveColumnHandle column, MessageType messageType, boolean useParquetColumnNames)
     {
         if (useParquetColumnNames) {
             return getParquetTypeByName(column.getName(), messageType);

--- a/presto-hive/src/main/java/org/apache/parquet/io/ColumnIOConverter.java
+++ b/presto-hive/src/main/java/org/apache/parquet/io/ColumnIOConverter.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parquet.io;
+package org.apache.parquet.io;
 
 import com.facebook.presto.parquet.Field;
 import com.facebook.presto.parquet.GroupField;
@@ -33,10 +33,10 @@ import static com.facebook.presto.parquet.ParquetTypeUtils.lookupColumnByName;
 import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
 import static com.facebook.presto.spi.type.StandardTypes.MAP;
 import static com.facebook.presto.spi.type.StandardTypes.ROW;
-import static parquet.schema.Type.Repetition.OPTIONAL;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 
 /**
- * Placed in parquet.io package to have access to ColumnIO getRepetitionLevel() and getDefinitionLevel() methods.
+ * Placed in org.apache.parquet.io package to have access to ColumnIO getRepetitionLevel() and getDefinitionLevel() methods.
  */
 public class ColumnIOConverter
 {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/predicate/TestParquetPredicateUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/predicate/TestParquetPredicateUtils.java
@@ -26,12 +26,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
 import org.testng.annotations.Test;
-import parquet.column.ColumnDescriptor;
-import parquet.column.Encoding;
-import parquet.schema.GroupType;
-import parquet.schema.MessageType;
-import parquet.schema.PrimitiveType;
 
 import java.util.List;
 import java.util.Map;
@@ -48,18 +48,18 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.google.common.collect.Sets.union;
+import static org.apache.parquet.column.Encoding.BIT_PACKED;
+import static org.apache.parquet.column.Encoding.PLAIN;
+import static org.apache.parquet.column.Encoding.PLAIN_DICTIONARY;
+import static org.apache.parquet.column.Encoding.RLE;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
+import static org.apache.parquet.schema.Type.Repetition.REPEATED;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-import static parquet.column.Encoding.BIT_PACKED;
-import static parquet.column.Encoding.PLAIN;
-import static parquet.column.Encoding.PLAIN_DICTIONARY;
-import static parquet.column.Encoding.RLE;
-import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
-import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
-import static parquet.schema.Type.Repetition.OPTIONAL;
-import static parquet.schema.Type.Repetition.REPEATED;
-import static parquet.schema.Type.Repetition.REQUIRED;
 
 public class TestParquetPredicateUtils
 {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriteSupport.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/write/TestDataWritableWriteSupport.java
@@ -14,13 +14,14 @@
 package com.facebook.presto.hive.parquet.write;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport;
 import org.apache.hadoop.hive.serde2.io.ParquetHiveRecord;
 import parquet.hadoop.api.WriteSupport;
 import parquet.io.api.RecordConsumer;
 import parquet.schema.MessageType;
 
 import java.util.HashMap;
+
+import static parquet.schema.MessageTypeParser.parseMessageType;
 
 /**
  * This class is copied from org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport
@@ -41,7 +42,7 @@ class TestDataWritableWriteSupport
     @Override
     public WriteContext init(final Configuration configuration)
     {
-        schema = DataWritableWriteSupport.getSchema(configuration);
+        schema = parseMessageType(configuration.get("parquet.hive.schema"));
         return new WriteContext(schema, new HashMap<>());
     }
 

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -174,6 +174,17 @@
             </plugin>
 
             <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredResourcePatterns>
+                        <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
+                        <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                    </ignoredResourcePatterns>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>

--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -53,6 +53,70 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-column</artifactId>
+            <version>${dep.parquet.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-common</artifactId>
+            <version>${dep.parquet.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop</artifactId>
+            <version>${dep.parquet.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.xerial.snappy</groupId>
+                    <artifactId>snappy-java</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-encoding</artifactId>
+            <version>${dep.parquet.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-format</artifactId>
+            <version>2.6.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.xerial.snappy</groupId>
+                    <artifactId>snappy-java</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>io.airlift</groupId>

--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -222,6 +222,16 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredResourcePatterns>
+                        <ignoredResourcePattern>parquet.thrift</ignoredResourcePattern>
+                        <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                    </ignoredResourcePatterns>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/DataPageV1.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/DataPageV1.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.parquet;
 
 import io.airlift.slice.Slice;
-import parquet.column.statistics.Statistics;
+import org.apache.parquet.column.statistics.Statistics;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/DataPageV2.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/DataPageV2.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.parquet;
 
 import io.airlift.slice.Slice;
-import parquet.column.statistics.Statistics;
+import org.apache.parquet.column.statistics.Statistics;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetCompressionUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetCompressionUtils.java
@@ -18,7 +18,7 @@ import io.airlift.compress.lzo.LzoDecompressor;
 import io.airlift.compress.snappy.SnappyDecompressor;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
-import parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetEncoding.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetEncoding.java
@@ -20,32 +20,32 @@ import com.facebook.presto.parquet.dictionary.DoubleDictionary;
 import com.facebook.presto.parquet.dictionary.FloatDictionary;
 import com.facebook.presto.parquet.dictionary.IntegerDictionary;
 import com.facebook.presto.parquet.dictionary.LongDictionary;
-import parquet.bytes.BytesUtils;
-import parquet.column.ColumnDescriptor;
-import parquet.column.values.ValuesReader;
-import parquet.column.values.bitpacking.ByteBitPackingValuesReader;
-import parquet.column.values.boundedint.ZeroIntegerValuesReader;
-import parquet.column.values.delta.DeltaBinaryPackingValuesReader;
-import parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesReader;
-import parquet.column.values.deltastrings.DeltaByteArrayReader;
-import parquet.column.values.plain.BinaryPlainValuesReader;
-import parquet.column.values.plain.BooleanPlainValuesReader;
-import parquet.column.values.plain.FixedLenByteArrayPlainValuesReader;
-import parquet.column.values.plain.PlainValuesReader.DoublePlainValuesReader;
-import parquet.column.values.plain.PlainValuesReader.FloatPlainValuesReader;
-import parquet.column.values.plain.PlainValuesReader.IntegerPlainValuesReader;
-import parquet.column.values.plain.PlainValuesReader.LongPlainValuesReader;
-import parquet.column.values.rle.RunLengthBitPackingHybridValuesReader;
-import parquet.io.ParquetDecodingException;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.bitpacking.ByteBitPackingValuesReader;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesReader;
+import org.apache.parquet.column.values.deltastrings.DeltaByteArrayReader;
+import org.apache.parquet.column.values.plain.BinaryPlainValuesReader;
+import org.apache.parquet.column.values.plain.BooleanPlainValuesReader;
+import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesReader;
+import org.apache.parquet.column.values.plain.PlainValuesReader.DoublePlainValuesReader;
+import org.apache.parquet.column.values.plain.PlainValuesReader.FloatPlainValuesReader;
+import org.apache.parquet.column.values.plain.PlainValuesReader.IntegerPlainValuesReader;
+import org.apache.parquet.column.values.plain.PlainValuesReader.LongPlainValuesReader;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesReader;
+import org.apache.parquet.column.values.rle.ZeroIntegerValuesReader;
+import org.apache.parquet.io.ParquetDecodingException;
 
 import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static parquet.column.values.bitpacking.Packer.BIG_ENDIAN;
-import static parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
-import static parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
-import static parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
-import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.column.values.bitpacking.Packer.BIG_ENDIAN;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 
 public enum ParquetEncoding
 {
@@ -145,7 +145,7 @@ public enum ParquetEncoding
         @Override
         public ValuesReader getValuesReader(ColumnDescriptor descriptor, ValuesType valuesType)
         {
-            checkArgument(descriptor.getType() == INT32, "Encoding DELTA_BINARY_PACKED is only supported for type INT32");
+            checkArgument(descriptor.getPrimitiveType().getPrimitiveTypeName() == INT32, "Encoding DELTA_BINARY_PACKED is only supported for type INT32");
             return new DeltaBinaryPackingValuesReader();
         }
     },
@@ -154,7 +154,7 @@ public enum ParquetEncoding
         @Override
         public ValuesReader getValuesReader(ColumnDescriptor descriptor, ValuesType valuesType)
         {
-            checkArgument(descriptor.getType() == BINARY, "Encoding DELTA_LENGTH_BYTE_ARRAY is only supported for type BINARY");
+            checkArgument(descriptor.getPrimitiveType().getPrimitiveTypeName() == BINARY, "Encoding DELTA_LENGTH_BYTE_ARRAY is only supported for type BINARY");
             return new DeltaLengthByteArrayValuesReader();
         }
     },
@@ -164,7 +164,7 @@ public enum ParquetEncoding
         public ValuesReader getValuesReader(ColumnDescriptor descriptor, ValuesType valuesType)
         {
             checkArgument(
-                    descriptor.getType() == BINARY || descriptor.getType() == FIXED_LEN_BYTE_ARRAY,
+                    descriptor.getPrimitiveType().getPrimitiveTypeName() == BINARY || descriptor.getPrimitiveType().getPrimitiveTypeName() == FIXED_LEN_BYTE_ARRAY,
                     "Encoding DELTA_BYTE_ARRAY is only supported for type BINARY and FIXED_LEN_BYTE_ARRAY");
             return new DeltaByteArrayReader();
         }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTimestampUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTimestampUtils.java
@@ -16,7 +16,7 @@ package com.facebook.presto.parquet;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
-import parquet.io.api.Binary;
+import org.apache.parquet.io.api.Binary;
 
 import java.util.concurrent.TimeUnit;
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
@@ -25,18 +25,18 @@ import com.facebook.presto.spi.type.RealType;
 import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
-import parquet.column.ColumnDescriptor;
-import parquet.column.Encoding;
-import parquet.io.ColumnIO;
-import parquet.io.ColumnIOFactory;
-import parquet.io.GroupColumnIO;
-import parquet.io.InvalidRecordException;
-import parquet.io.MessageColumnIO;
-import parquet.io.ParquetDecodingException;
-import parquet.io.PrimitiveColumnIO;
-import parquet.schema.DecimalMetadata;
-import parquet.schema.MessageType;
-import parquet.schema.OriginalType;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.io.ColumnIO;
+import org.apache.parquet.io.ColumnIOFactory;
+import org.apache.parquet.io.GroupColumnIO;
+import org.apache.parquet.io.InvalidRecordException;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.io.PrimitiveColumnIO;
+import org.apache.parquet.schema.DecimalMetadata;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -48,8 +48,8 @@ import java.util.Optional;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.google.common.base.Preconditions.checkArgument;
-import static parquet.schema.OriginalType.DECIMAL;
-import static parquet.schema.Type.Repetition.REPEATED;
+import static org.apache.parquet.schema.OriginalType.DECIMAL;
+import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 
 public final class ParquetTypeUtils
 {
@@ -161,7 +161,7 @@ public final class ParquetTypeUtils
 
     public static Type getPrestoType(TupleDomain<ColumnDescriptor> effectivePredicate, RichColumnDescriptor descriptor)
     {
-        switch (descriptor.getType()) {
+        switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
             case BOOLEAN:
                 return BooleanType.BOOLEAN;
             case BINARY:
@@ -205,7 +205,7 @@ public final class ParquetTypeUtils
             return fileSchema.getFieldIndex(name.toLowerCase(Locale.ENGLISH));
         }
         catch (InvalidRecordException e) {
-            for (parquet.schema.Type type : fileSchema.getFields()) {
+            for (org.apache.parquet.schema.Type type : fileSchema.getFields()) {
                 if (type.getName().equalsIgnoreCase(name)) {
                     return fileSchema.getFieldIndex(type.getName());
                 }
@@ -238,14 +238,14 @@ public final class ParquetTypeUtils
         }
     }
 
-    public static parquet.schema.Type getParquetTypeByName(String columnName, MessageType messageType)
+    public static org.apache.parquet.schema.Type getParquetTypeByName(String columnName, MessageType messageType)
     {
         if (messageType.containsField(columnName)) {
             return messageType.getType(columnName);
         }
         // parquet is case-sensitive, but hive is not. all hive columns get converted to lowercase
         // check for direct match above but if no match found, try case-insensitive match
-        for (parquet.schema.Type type : messageType.getFields()) {
+        for (org.apache.parquet.schema.Type type : messageType.getFields()) {
             if (type.getName().equalsIgnoreCase(columnName)) {
                 return type;
             }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/RichColumnDescriptor.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/RichColumnDescriptor.java
@@ -13,10 +13,10 @@
  */
 package com.facebook.presto.parquet;
 
-import parquet.column.ColumnDescriptor;
-import parquet.schema.PrimitiveType;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.PrimitiveType;
 
-import static parquet.schema.Type.Repetition.OPTIONAL;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 
 // extension of parquet's ColumnDescriptor. Exposes full Primitive type information
 public class RichColumnDescriptor

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/BinaryDictionary.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/BinaryDictionary.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.parquet.dictionary;
 
 import com.facebook.presto.parquet.DictionaryPage;
-import parquet.io.api.Binary;
+import org.apache.parquet.io.api.Binary;
 
 import java.io.IOException;
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/Dictionary.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/Dictionary.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.parquet.dictionary;
 
 import com.facebook.presto.parquet.ParquetEncoding;
-import parquet.io.api.Binary;
+import org.apache.parquet.io.api.Binary;
 
 import static com.google.common.base.Preconditions.checkArgument;
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/DictionaryReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/DictionaryReader.java
@@ -13,16 +13,15 @@
  */
 package com.facebook.presto.parquet.dictionary;
 
-import parquet.bytes.BytesUtils;
-import parquet.column.values.ValuesReader;
-import parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
-import parquet.io.ParquetDecodingException;
-import parquet.io.api.Binary;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
+import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.io.api.Binary;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndianOnOneByte;
 
 public class DictionaryReader
         extends ValuesReader
@@ -36,13 +35,11 @@ public class DictionaryReader
     }
 
     @Override
-    public void initFromPage(int valueCount, byte[] page, int offset)
+    public void initFromPage(int valueCount, ByteBufferInputStream inputStream)
             throws IOException
     {
-        checkArgument(page.length > offset, "Attempt to read offset not in the  page");
-        ByteArrayInputStream in = new ByteArrayInputStream(page, offset, page.length - offset);
-        int bitWidth = BytesUtils.readIntLittleEndianOnOneByte(in);
-        decoder = new RunLengthBitPackingHybridDecoder(bitWidth, in);
+        int bitWidth = readIntLittleEndianOnOneByte(inputStream);
+        decoder = new RunLengthBitPackingHybridDecoder(bitWidth, inputStream);
     }
 
     @Override

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/DoubleDictionary.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/DoubleDictionary.java
@@ -14,9 +14,12 @@
 package com.facebook.presto.parquet.dictionary;
 
 import com.facebook.presto.parquet.DictionaryPage;
-import parquet.column.values.plain.PlainValuesReader.DoublePlainValuesReader;
+import com.google.common.collect.ImmutableList;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.plain.PlainValuesReader.DoublePlainValuesReader;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -31,7 +34,9 @@ public class DoubleDictionary
         super(dictionaryPage.getEncoding());
         content = new double[dictionaryPage.getDictionarySize()];
         DoublePlainValuesReader doubleReader = new DoublePlainValuesReader();
-        doubleReader.initFromPage(dictionaryPage.getDictionarySize(), dictionaryPage.getSlice().getBytes(), 0);
+        ByteBuffer byteBuffer = ByteBuffer.wrap(dictionaryPage.getSlice().getBytes());
+        ByteBufferInputStream inputStream = ByteBufferInputStream.wrap(ImmutableList.of(byteBuffer));
+        doubleReader.initFromPage(dictionaryPage.getDictionarySize(), inputStream);
         for (int i = 0; i < content.length; i++) {
             content[i] = doubleReader.readDouble();
         }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/FloatDictionary.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/FloatDictionary.java
@@ -14,9 +14,12 @@
 package com.facebook.presto.parquet.dictionary;
 
 import com.facebook.presto.parquet.DictionaryPage;
-import parquet.column.values.plain.PlainValuesReader.FloatPlainValuesReader;
+import com.google.common.collect.ImmutableList;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.plain.PlainValuesReader.FloatPlainValuesReader;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -31,7 +34,9 @@ public class FloatDictionary
         super(dictionaryPage.getEncoding());
         content = new float[dictionaryPage.getDictionarySize()];
         FloatPlainValuesReader floatReader = new FloatPlainValuesReader();
-        floatReader.initFromPage(dictionaryPage.getDictionarySize(), dictionaryPage.getSlice().getBytes(), 0);
+        ByteBuffer byteBuffer = ByteBuffer.wrap(dictionaryPage.getSlice().getBytes());
+        ByteBufferInputStream inputStream = ByteBufferInputStream.wrap(ImmutableList.of(byteBuffer));
+        floatReader.initFromPage(dictionaryPage.getDictionarySize(), inputStream);
         for (int i = 0; i < content.length; i++) {
             content[i] = floatReader.readFloat();
         }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/IntegerDictionary.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/IntegerDictionary.java
@@ -14,9 +14,12 @@
 package com.facebook.presto.parquet.dictionary;
 
 import com.facebook.presto.parquet.DictionaryPage;
-import parquet.column.values.plain.PlainValuesReader.IntegerPlainValuesReader;
+import com.google.common.collect.ImmutableList;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.plain.PlainValuesReader.IntegerPlainValuesReader;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -31,7 +34,9 @@ public class IntegerDictionary
         super(dictionaryPage.getEncoding());
         content = new int[dictionaryPage.getDictionarySize()];
         IntegerPlainValuesReader intReader = new IntegerPlainValuesReader();
-        intReader.initFromPage(dictionaryPage.getDictionarySize(), dictionaryPage.getSlice().getBytes(), 0);
+        ByteBuffer byteBuffer = ByteBuffer.wrap(dictionaryPage.getSlice().getBytes());
+        ByteBufferInputStream inputStream = ByteBufferInputStream.wrap(ImmutableList.of(byteBuffer));
+        intReader.initFromPage(dictionaryPage.getDictionarySize(), inputStream);
         for (int i = 0; i < content.length; i++) {
             content[i] = intReader.readInteger();
         }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/LongDictionary.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/LongDictionary.java
@@ -14,9 +14,12 @@
 package com.facebook.presto.parquet.dictionary;
 
 import com.facebook.presto.parquet.DictionaryPage;
-import parquet.column.values.plain.PlainValuesReader.LongPlainValuesReader;
+import com.google.common.collect.ImmutableList;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.plain.PlainValuesReader.LongPlainValuesReader;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -31,7 +34,9 @@ public class LongDictionary
         super(dictionaryPage.getEncoding());
         content = new long[dictionaryPage.getDictionarySize()];
         LongPlainValuesReader longReader = new LongPlainValuesReader();
-        longReader.initFromPage(dictionaryPage.getDictionarySize(), dictionaryPage.getSlice().getBytes(), 0);
+        ByteBuffer byteBuffer = ByteBuffer.wrap(dictionaryPage.getSlice().getBytes());
+        ByteBufferInputStream inputStream = ByteBufferInputStream.wrap(ImmutableList.of(byteBuffer));
+        longReader.initFromPage(dictionaryPage.getDictionarySize(), inputStream);
         for (int i = 0; i < content.length; i++) {
             content[i] = longReader.readLong();
         }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/DictionaryDescriptor.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/DictionaryDescriptor.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.parquet.predicate;
 
 import com.facebook.presto.parquet.DictionaryPage;
-import parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.ColumnDescriptor;
 
 import java.util.Optional;
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/Predicate.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/Predicate.java
@@ -15,8 +15,8 @@ package com.facebook.presto.parquet.predicate;
 
 import com.facebook.presto.parquet.ParquetCorruptionException;
 import com.facebook.presto.parquet.ParquetDataSourceId;
-import parquet.column.ColumnDescriptor;
-import parquet.column.statistics.Statistics;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.statistics.Statistics;
 
 import java.util.Map;
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/PredicateUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/PredicateUtils.java
@@ -26,17 +26,17 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.airlift.slice.Slice;
-import parquet.column.ColumnDescriptor;
-import parquet.column.Encoding;
-import parquet.column.statistics.Statistics;
-import parquet.format.DictionaryPageHeader;
-import parquet.format.PageHeader;
-import parquet.format.PageType;
-import parquet.format.Util;
-import parquet.hadoop.metadata.BlockMetaData;
-import parquet.hadoop.metadata.ColumnChunkMetaData;
-import parquet.hadoop.metadata.CompressionCodecName;
-import parquet.schema.MessageType;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.format.DictionaryPageHeader;
+import org.apache.parquet.format.PageHeader;
+import org.apache.parquet.format.PageType;
+import org.apache.parquet.format.Util;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.MessageType;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -54,9 +54,9 @@ import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.Math.toIntExact;
-import static parquet.column.Encoding.BIT_PACKED;
-import static parquet.column.Encoding.PLAIN_DICTIONARY;
-import static parquet.column.Encoding.RLE;
+import static org.apache.parquet.column.Encoding.BIT_PACKED;
+import static org.apache.parquet.column.Encoding.PLAIN_DICTIONARY;
+import static org.apache.parquet.column.Encoding.RLE;
 
 public final class PredicateUtils
 {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
@@ -28,15 +28,15 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import parquet.column.ColumnDescriptor;
-import parquet.column.statistics.BinaryStatistics;
-import parquet.column.statistics.BooleanStatistics;
-import parquet.column.statistics.DoubleStatistics;
-import parquet.column.statistics.FloatStatistics;
-import parquet.column.statistics.IntStatistics;
-import parquet.column.statistics.LongStatistics;
-import parquet.column.statistics.Statistics;
-import parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.statistics.BinaryStatistics;
+import org.apache.parquet.column.statistics.BooleanStatistics;
+import org.apache.parquet.column.statistics.DoubleStatistics;
+import org.apache.parquet.column.statistics.FloatStatistics;
+import org.apache.parquet.column.statistics.IntStatistics;
+import org.apache.parquet.column.statistics.LongStatistics;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -196,8 +196,8 @@ public class TupleDomainParquetPredicate
         }
         else if (isVarcharType(type) && statistics instanceof BinaryStatistics) {
             BinaryStatistics binaryStatistics = (BinaryStatistics) statistics;
-            Slice minSlice = Slices.wrappedBuffer(binaryStatistics.getMin().getBytes());
-            Slice maxSlice = Slices.wrappedBuffer(binaryStatistics.getMax().getBytes());
+            Slice minSlice = Slices.wrappedBuffer(binaryStatistics.genericGetMin().getBytes());
+            Slice maxSlice = Slices.wrappedBuffer(binaryStatistics.genericGetMax().getBytes());
             if (minSlice.compareTo(maxSlice) > 0) {
                 failWithCorruptionException(failOnCorruptedParquetStatistics, column, id, binaryStatistics);
                 return Domain.create(ValueSet.all(type), hasNullValue);

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/BinaryColumnReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/BinaryColumnReader.java
@@ -17,7 +17,7 @@ import com.facebook.presto.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
-import parquet.io.api.Binary;
+import org.apache.parquet.io.api.Binary;
 
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.Chars.truncateToLengthAndTrimSpaces;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ColumnChunkDescriptor.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ColumnChunkDescriptor.java
@@ -13,8 +13,8 @@
  */
 package com.facebook.presto.parquet.reader;
 
-import parquet.column.ColumnDescriptor;
-import parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 
 public class ColumnChunkDescriptor
 {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/LevelRLEReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/LevelRLEReader.java
@@ -13,8 +13,8 @@
  */
 package com.facebook.presto.parquet.reader;
 
-import parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
-import parquet.io.ParquetDecodingException;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
+import org.apache.parquet.io.ParquetDecodingException;
 
 import java.io.IOException;
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/LevelValuesReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/LevelValuesReader.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.parquet.reader;
 
-import parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.ValuesReader;
 
 public class LevelValuesReader
         implements LevelReader

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/LongDecimalColumnReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/LongDecimalColumnReader.java
@@ -17,7 +17,7 @@ import com.facebook.presto.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.Type;
-import parquet.io.api.Binary;
+import org.apache.parquet.io.api.Binary;
 
 import java.math.BigInteger;
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/MetadataReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/MetadataReader.java
@@ -16,26 +16,28 @@ package com.facebook.presto.parquet.reader;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import parquet.format.ColumnChunk;
-import parquet.format.ColumnMetaData;
-import parquet.format.ConvertedType;
-import parquet.format.Encoding;
-import parquet.format.FileMetaData;
-import parquet.format.KeyValue;
-import parquet.format.RowGroup;
-import parquet.format.SchemaElement;
-import parquet.format.Statistics;
-import parquet.format.Type;
-import parquet.hadoop.metadata.BlockMetaData;
-import parquet.hadoop.metadata.ColumnChunkMetaData;
-import parquet.hadoop.metadata.ColumnPath;
-import parquet.hadoop.metadata.CompressionCodecName;
-import parquet.hadoop.metadata.ParquetMetadata;
-import parquet.schema.MessageType;
-import parquet.schema.OriginalType;
-import parquet.schema.PrimitiveType.PrimitiveTypeName;
-import parquet.schema.Type.Repetition;
-import parquet.schema.Types;
+import org.apache.parquet.format.ColumnChunk;
+import org.apache.parquet.format.ColumnMetaData;
+import org.apache.parquet.format.ConvertedType;
+import org.apache.parquet.format.Encoding;
+import org.apache.parquet.format.FileMetaData;
+import org.apache.parquet.format.KeyValue;
+import org.apache.parquet.format.RowGroup;
+import org.apache.parquet.format.SchemaElement;
+import org.apache.parquet.format.Statistics;
+import org.apache.parquet.format.Type;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Type.Repetition;
+import org.apache.parquet.schema.Types;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -53,7 +55,7 @@ import java.util.Set;
 
 import static com.facebook.presto.parquet.ParquetValidationUtils.validateParquet;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static parquet.format.Util.readFileMetaData;
+import static org.apache.parquet.format.Util.readFileMetaData;
 
 public final class MetadataReader
 {
@@ -106,6 +108,7 @@ public final class MetadataReader
         MessageType messageType = readParquetSchema(schema);
         List<BlockMetaData> blocks = new ArrayList<>();
         List<RowGroup> rowGroups = fileMetaData.getRow_groups();
+        ParquetMetadataConverter metadataConverter = new ParquetMetadataConverter();
         if (rowGroups != null) {
             for (RowGroup rowGroup : rowGroups) {
                 BlockMetaData blockMetaData = new BlockMetaData();
@@ -124,11 +127,14 @@ public final class MetadataReader
                             .map(value -> value.toLowerCase(Locale.ENGLISH))
                             .toArray(String[]::new);
                     ColumnPath columnPath = ColumnPath.get(path);
-                    PrimitiveTypeName primitiveTypeName = messageType.getType(columnPath.toArray()).asPrimitiveType().getPrimitiveTypeName();
+                    PrimitiveType primitiveType = messageType.getType(columnPath.toArray()).asPrimitiveType();
+                    PrimitiveTypeName primitiveTypeName = primitiveType.getPrimitiveTypeName();
+
                     ColumnChunkMetaData column = ColumnChunkMetaData.get(
                             columnPath,
-                            primitiveTypeName,
+                            primitiveType,
                             CompressionCodecName.fromParquet(metaData.codec),
+                            metadataConverter.convertEncodingStats(metaData.encoding_stats),
                             readEncodings(metaData.encodings),
                             readStats(metaData.statistics, primitiveTypeName),
                             metaData.data_page_offset,
@@ -150,7 +156,7 @@ public final class MetadataReader
                 keyValueMetaData.put(keyValue.key, keyValue.value);
             }
         }
-        return new ParquetMetadata(new parquet.hadoop.metadata.FileMetaData(messageType, keyValueMetaData, fileMetaData.getCreated_by()), blocks);
+        return new ParquetMetadata(new org.apache.parquet.hadoop.metadata.FileMetaData(messageType, keyValueMetaData, fileMetaData.getCreated_by()), blocks);
     }
 
     private static MessageType readParquetSchema(List<SchemaElement> schema)
@@ -195,9 +201,9 @@ public final class MetadataReader
         }
     }
 
-    public static parquet.column.statistics.Statistics<?> readStats(Statistics statistics, PrimitiveTypeName type)
+    public static org.apache.parquet.column.statistics.Statistics<?> readStats(Statistics statistics, PrimitiveTypeName type)
     {
-        parquet.column.statistics.Statistics<?> stats = parquet.column.statistics.Statistics.getStatsBasedOnType(type);
+        org.apache.parquet.column.statistics.Statistics<?> stats = org.apache.parquet.column.statistics.Statistics.getStatsBasedOnType(type);
         if (statistics != null) {
             if (statistics.isSetMax() && statistics.isSetMin()) {
                 stats.setMinMaxFromBytes(statistics.min.array(), statistics.max.array());
@@ -207,11 +213,11 @@ public final class MetadataReader
         return stats;
     }
 
-    private static Set<parquet.column.Encoding> readEncodings(List<Encoding> encodings)
+    private static Set<org.apache.parquet.column.Encoding> readEncodings(List<Encoding> encodings)
     {
-        Set<parquet.column.Encoding> columnEncodings = new HashSet<>();
+        Set<org.apache.parquet.column.Encoding> columnEncodings = new HashSet<>();
         for (Encoding encoding : encodings) {
-            columnEncodings.add(parquet.column.Encoding.valueOf(encoding.name()));
+            columnEncodings.add(org.apache.parquet.column.Encoding.valueOf(encoding.name()));
         }
         return Collections.unmodifiableSet(columnEncodings);
     }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/PageReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/PageReader.java
@@ -17,7 +17,7 @@ import com.facebook.presto.parquet.DataPage;
 import com.facebook.presto.parquet.DataPageV1;
 import com.facebook.presto.parquet.DataPageV2;
 import com.facebook.presto.parquet.DictionaryPage;
-import parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 import java.io.IOException;
 import java.util.LinkedList;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetColumnChunk.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetColumnChunk.java
@@ -19,12 +19,12 @@ import com.facebook.presto.parquet.DataPageV2;
 import com.facebook.presto.parquet.DictionaryPage;
 import com.facebook.presto.parquet.ParquetCorruptionException;
 import io.airlift.slice.Slice;
-import parquet.column.Encoding;
-import parquet.format.DataPageHeader;
-import parquet.format.DataPageHeaderV2;
-import parquet.format.DictionaryPageHeader;
-import parquet.format.PageHeader;
-import parquet.format.Util;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.format.DataPageHeader;
+import org.apache.parquet.format.DataPageHeaderV2;
+import org.apache.parquet.format.DictionaryPageHeader;
+import org.apache.parquet.format.PageHeader;
+import org.apache.parquet.format.Util;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetReader.java
@@ -32,12 +32,12 @@ import it.unimi.dsi.fastutil.booleans.BooleanArrayList;
 import it.unimi.dsi.fastutil.booleans.BooleanList;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
-import parquet.column.ColumnDescriptor;
-import parquet.hadoop.metadata.BlockMetaData;
-import parquet.hadoop.metadata.ColumnChunkMetaData;
-import parquet.hadoop.metadata.ColumnPath;
-import parquet.io.MessageColumnIO;
-import parquet.io.PrimitiveColumnIO;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.io.PrimitiveColumnIO;
 
 import java.io.Closeable;
 import java.io.IOException;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/PrimitiveColumnReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/PrimitiveColumnReader.java
@@ -26,17 +26,20 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
-import parquet.bytes.BytesUtils;
-import parquet.column.ColumnDescriptor;
-import parquet.column.values.ValuesReader;
-import parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
-import parquet.io.ParquetDecodingException;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
+import org.apache.parquet.io.ParquetDecodingException;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -266,17 +269,21 @@ public abstract class PrimitiveColumnReader
 
     private ValuesReader readPageV1(DataPageV1 page)
     {
-        ValuesReader rlReader = page.getRepetitionLevelEncoding().getValuesReader(columnDescriptor, REPETITION_LEVEL);
-        ValuesReader dlReader = page.getDefinitionLevelEncoding().getValuesReader(columnDescriptor, DEFINITION_LEVEL);
-        repetitionReader = new LevelValuesReader(rlReader);
-        definitionReader = new LevelValuesReader(dlReader);
+        ValuesReader repetitionLevelReader = page.getRepetitionLevelEncoding().getValuesReader(columnDescriptor, REPETITION_LEVEL);
+        ValuesReader definitionLevelReader = page.getDefinitionLevelEncoding().getValuesReader(columnDescriptor, DEFINITION_LEVEL);
+        repetitionReader = new LevelValuesReader(repetitionLevelReader);
+        definitionReader = new LevelValuesReader(definitionLevelReader);
         try {
             byte[] bytes = page.getSlice().getBytes();
-            rlReader.initFromPage(page.getValueCount(), bytes, 0);
-            int offset = rlReader.getNextOffset();
-            dlReader.initFromPage(page.getValueCount(), bytes, offset);
-            offset = dlReader.getNextOffset();
-            return initDataReader(page.getValueEncoding(), bytes, offset, page.getValueCount());
+            ByteBufferInputStream bufferInputStream = ByteBufferInputStream.wrap(ImmutableList.of(ByteBuffer.wrap(bytes)));
+            repetitionLevelReader.initFromPage(page.getValueCount(), bufferInputStream);
+            int offset = bytes.length - bufferInputStream.available();
+            ByteBuffer definitionLevelByteBuffer = ByteBuffer.wrap(bytes, offset, bytes.length - offset);
+            ByteBufferInputStream definitionLevelInputStream = ByteBufferInputStream.wrap(ImmutableList.of(definitionLevelByteBuffer));
+            definitionLevelReader.initFromPage(page.getValueCount(), definitionLevelInputStream);
+            offset = bytes.length - definitionLevelInputStream.available();
+            ByteBuffer byteBuffer = ByteBuffer.wrap(bytes, offset, bytes.length - offset);
+            return initDataReader(page.getValueEncoding(), ByteBufferInputStream.wrap(ImmutableList.of(byteBuffer)), page.getValueCount());
         }
         catch (IOException e) {
             throw new ParquetDecodingException("Error reading parquet page " + page + " in column " + columnDescriptor, e);
@@ -287,7 +294,8 @@ public abstract class PrimitiveColumnReader
     {
         repetitionReader = buildLevelRLEReader(columnDescriptor.getMaxRepetitionLevel(), page.getRepetitionLevels());
         definitionReader = buildLevelRLEReader(columnDescriptor.getMaxDefinitionLevel(), page.getDefinitionLevels());
-        return initDataReader(page.getDataEncoding(), page.getSlice().getBytes(), 0, page.getValueCount());
+        ByteBuffer byteBuffer = ByteBuffer.wrap(page.getSlice().getBytes());
+        return initDataReader(page.getDataEncoding(), ByteBufferInputStream.wrap(ImmutableList.of(byteBuffer)), page.getValueCount());
     }
 
     private LevelReader buildLevelRLEReader(int maxLevel, Slice slice)
@@ -295,10 +303,11 @@ public abstract class PrimitiveColumnReader
         if (maxLevel == 0) {
             return new LevelNullReader();
         }
+
         return new LevelRLEReader(new RunLengthBitPackingHybridDecoder(BytesUtils.getWidthFromMaxInt(maxLevel), new ByteArrayInputStream(slice.getBytes())));
     }
 
-    private ValuesReader initDataReader(ParquetEncoding dataEncoding, byte[] bytes, int offset, int valueCount)
+    private ValuesReader initDataReader(ParquetEncoding dataEncoding, ByteBufferInputStream inputStream, int valueCount)
     {
         ValuesReader valuesReader;
         if (dataEncoding.usesDictionary()) {
@@ -312,7 +321,7 @@ public abstract class PrimitiveColumnReader
         }
 
         try {
-            valuesReader.initFromPage(valueCount, bytes, offset);
+            valuesReader.initFromPage(valueCount, inputStream);
             return valuesReader;
         }
         catch (IOException e) {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ShortDecimalColumnReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ShortDecimalColumnReader.java
@@ -18,8 +18,8 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 
 import static com.facebook.presto.parquet.ParquetTypeUtils.getShortDecimalValue;
-import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
-import static parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 
 public class ShortDecimalColumnReader
         extends PrimitiveColumnReader
@@ -35,10 +35,10 @@ public class ShortDecimalColumnReader
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
             long decimalValue;
             // When decimals are encoded with primitive types Parquet stores unscaled values
-            if (columnDescriptor.getType().equals(INT32)) {
+            if (columnDescriptor.getPrimitiveType().getPrimitiveTypeName().equals(INT32)) {
                 decimalValue = valuesReader.readInteger();
             }
-            else if (columnDescriptor.getType().equals(INT64)) {
+            else if (columnDescriptor.getPrimitiveType().getPrimitiveTypeName().equals(INT64)) {
                 decimalValue = valuesReader.readLong();
             }
             else {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/TimestampColumnReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/TimestampColumnReader.java
@@ -16,7 +16,7 @@ package com.facebook.presto.parquet.reader;
 import com.facebook.presto.parquet.RichColumnDescriptor;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import parquet.io.api.Binary;
+import org.apache.parquet.io.api.Binary;
 
 import static com.facebook.presto.parquet.ParquetTimestampUtils.getTimestampMillis;
 

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/TestParquetTimestampUtils.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/TestParquetTimestampUtils.java
@@ -14,14 +14,17 @@
 package com.facebook.presto.parquet;
 
 import com.facebook.presto.spi.PrestoException;
-import org.apache.hadoop.hive.ql.io.parquet.timestamp.NanoTimeUtils;
+import org.apache.hadoop.hive.ql.io.parquet.timestamp.NanoTime;
+import org.apache.parquet.io.api.Binary;
 import org.testng.annotations.Test;
-import parquet.io.api.Binary;
 
+import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 
 import static com.facebook.presto.parquet.ParquetTimestampUtils.getTimestampMillis;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static org.apache.hadoop.hive.ql.io.parquet.timestamp.NanoTimeUtils.getNanoTime;
+import static org.apache.parquet.io.api.Binary.fromConstantByteBuffer;
 import static org.testng.Assert.assertEquals;
 
 public class TestParquetTimestampUtils
@@ -50,8 +53,9 @@ public class TestParquetTimestampUtils
     private static void assertTimestampCorrect(String timestampString)
     {
         Timestamp timestamp = Timestamp.valueOf(timestampString);
-        Binary timestampBytes = NanoTimeUtils.getNanoTime(timestamp, false).toBinary();
-        long decodedTimestampMillis = getTimestampMillis(timestampBytes);
+        NanoTime nanoTime = getNanoTime(timestamp, false);
+        ByteBuffer buffer = ByteBuffer.wrap(nanoTime.toBinary().getBytes());
+        long decodedTimestampMillis = getTimestampMillis(fromConstantByteBuffer(buffer));
         assertEquals(decodedTimestampMillis, timestamp.getTime());
     }
 }

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/TestParquetTypeUtils.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/TestParquetTypeUtils.java
@@ -14,17 +14,17 @@
 package com.facebook.presto.parquet;
 
 import com.facebook.presto.spi.predicate.TupleDomain;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.testng.annotations.Test;
-import parquet.column.ColumnDescriptor;
-import parquet.schema.OriginalType;
-import parquet.schema.PrimitiveType;
-import parquet.schema.PrimitiveType.PrimitiveTypeName;
 
 import static com.facebook.presto.parquet.ParquetTypeUtils.getPrestoType;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.testng.Assert.assertEquals;
-import static parquet.schema.Type.Repetition.OPTIONAL;
 
 public class TestParquetTypeUtils
 {


### PR DESCRIPTION
This patch upgrades parquet to version 0.10.1. The test cases still write using the old version of parquet which is still pulled in through ```presto-hive-apache``` dependency. The old version of parquet lived in `parquet` namespace and the new version is in `org.apache.parquet` namespace so they both can coexist without any conflicts. I have left the unit tests so they are still writing using the old version and reading using the new version to show the backward compatibility. We can add more tests that writes using new version and reads using the new version if everyone agrees with the version upgrade. 

The ```duplicate-finder-plugin``` snippets can be avoided if we remove the ```parquet.thrift``` and ```about.html``` resources from ```presto-hive-apache```.