### PR TITLE
Fix memory leak when query fails with permission error

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -224,8 +224,14 @@ public class QueryStateMachine
                 ticker,
                 metadata,
                 warningCollector);
-        queryStateMachine.addStateChangeListener(newState -> QUERY_STATE_LOG.debug("Query %s is %s", queryStateMachine.getQueryId(), newState));
 
+        queryStateMachine.addStateChangeListener(newState -> {
+            QUERY_STATE_LOG.debug("Query %s is %s", queryStateMachine.getQueryId(), newState);
+            // mark finished or failed transaction as inactive
+            if (newState.isDone()) {
+                queryStateMachine.getSession().getTransactionId().ifPresent(transactionManager::trySetInactive);
+            }
+        });
         return queryStateMachine;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -204,7 +204,14 @@ public class SqlQueryExecution
                     Optional.of(queryExplainer),
                     preparedQuery.getParameters(),
                     warningCollector);
-            this.analysis = analyzer.analyze(preparedQuery.getStatement());
+
+            try {
+                this.analysis = analyzer.analyze(preparedQuery.getStatement());
+            }
+            catch (RuntimeException e) {
+                stateMachine.transitionToFailed(e);
+                throw e;
+            }
 
             stateMachine.setUpdateType(analysis.getUpdateType());
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -364,13 +364,6 @@ public class SqlQueryManager
                     preparedQuery,
                     selectionContext.getResourceGroupId(),
                     warningCollectorFactory.create());
-
-            // mark existing transaction as inactive
-            queryExecution.addStateChangeListener(newState -> {
-                if (newState.isDone()) {
-                    queryExecution.getSession().getTransactionId().ifPresent(transactionManager::trySetInactive);
-                }
-            });
         }
         catch (RuntimeException e) {
             // This is intentionally not a method, since after the state change listener is registered

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTransactionManagerIntegration.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTransactionManagerIntegration.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertTrue;
+
+public class TestTransactionManagerIntegration
+{
+    @Test
+    public void testTransactionMetadataCleanup()
+            throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder().build()) {
+            // test valid queries
+            queryRunner.execute("select count(*) from nation");
+            queryRunner.execute("select count(*) from lineitem");
+            assertTrue(queryRunner.getTransactionManager().getAllTransactionInfos().isEmpty());
+            // test invalid queries with different types of semantic error
+            assertThatThrownBy(() -> queryRunner.execute("SELECT non_existing_column FROM non_existing_table"))
+                    .isInstanceOf(RuntimeException.class);
+            assertThatThrownBy(() -> queryRunner.execute("select * from unnest('wrong_type')"))
+                    .isInstanceOf(RuntimeException.class);
+            assertThatThrownBy(() -> queryRunner.execute("select regionkey from nation group by regionkey having 'wrong_condition'"))
+                    .isInstanceOf(RuntimeException.class);
+            assertTrue(queryRunner.getTransactionManager().getAllTransactionInfos().isEmpty());
+            // test query that fails during plan
+            assertThatThrownBy(() -> queryRunner.execute("select 1/0"))
+                    .isInstanceOf(RuntimeException.class);
+            // test query that fails during execution
+            assertThatThrownBy(() -> queryRunner.execute("select regionkey / (regionkey - regionkey) from nation"))
+                    .isInstanceOf(RuntimeException.class);
+            assertTrue(queryRunner.getTransactionManager().getAllTransactionInfos().isEmpty());
+        }
+    }
+}


### PR DESCRIPTION
When permission error is thrown inside creation of QueryExecution object,
transaction metadata is not marked as inactive resulting in memory leak.

Existing handling of error via method TransactionMetadata::fail is not
working when transaction id is empty in session object.

A heapdump is taken to test that previously leaked objects become 
unreachable from GC roots after this fix.