### PR TITLE
Add counter for POST requests to statement resource

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -175,6 +175,7 @@ public class CoordinatorModule
         jsonCodecBinder(binder).bindJsonCodec(TaskInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(QueryResults.class);
         jaxrsBinder(binder).bind(StatementResource.class);
+        newExporter(binder).export(StatementResource.class).withGeneratedName();
         binder.bind(StatementHttpExecutionMBean.class).in(Scopes.SINGLETON);
         newExporter(binder).export(StatementHttpExecutionMBean.class).withGeneratedName();
 

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/StatementResource.java
@@ -28,8 +28,11 @@ import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.concurrent.BoundedExecutor;
+import io.airlift.stats.CounterStat;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
@@ -100,6 +103,8 @@ public class StatementResource
     private final ConcurrentMap<QueryId, Query> queries = new ConcurrentHashMap<>();
     private final ScheduledExecutorService queryPurger = newSingleThreadScheduledExecutor(threadsNamed("query-purger"));
 
+    private final CounterStat createQueryRequests = new CounterStat();
+
     @Inject
     public StatementResource(
             QueryManager queryManager,
@@ -133,6 +138,8 @@ public class StatementResource
             @Context HttpServletRequest servletRequest,
             @Context UriInfo uriInfo)
     {
+        createQueryRequests.update(1);
+
         if (isNullOrEmpty(statement)) {
             throw new WebApplicationException(Response
                     .status(Status.BAD_REQUEST)
@@ -271,5 +278,12 @@ public class StatementResource
         catch (UnsupportedEncodingException e) {
             throw new AssertionError(e);
         }
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getCreateQueryRequests()
+    {
+        return createQueryRequests;
     }
 }


### PR DESCRIPTION
Adding a new counter for tracking the number of times createQuery is invoked. We already have a counter - submittedQueries which is present in SqlQueryManagerStats - but the motivation here is to count the invocations at the very initial point to be able to count instances which don't end up reaching the SqlQueryManager callsite.