### PR TITLE
Fix Aria scan for partitioned tables

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -113,7 +113,7 @@ public final class SystemSessionProperties
     public static final String LEGACY_UNNEST = "legacy_unnest";
     public static final String STATISTICS_CPU_TIMER_ENABLED = "statistics_cpu_timer_enabled";
     public static final String ENABLE_STATS_CALCULATOR = "enable_stats_calculator";
-    public static final String ARIA = "aria";
+    public static final String ARIA_SCAN = "aria_scan";
     public static final String ARIA_REUSE_PAGES = "aria_reuse_pages";
     public static final String ARIA_REORDER = "aria_reorder";
     public static final String ARIA_FLAGS = "aria_flags";
@@ -529,7 +529,7 @@ public final class SystemSessionProperties
                         "Experimental: Enable statistics calculator",
                         featuresConfig.isEnableStatsCalculator(),
                         false),
-                booleanProperty(ARIA,
+                booleanProperty(ARIA_SCAN,
                                 "Enable Aria Presto! scan operator",
                                 true,
                                 false),
@@ -936,9 +936,9 @@ public final class SystemSessionProperties
         return session.getSystemProperty(ENABLE_STATS_CALCULATOR, Boolean.class);
     }
 
-    public static boolean enableAria(Session session)
+    public static boolean isAriaScanEnabled(Session session)
     {
-        return session.getSystemProperty(ARIA, Boolean.class);
+        return session.getSystemProperty(ARIA_SCAN, Boolean.class);
     }
 
     public static boolean enableAriaReusePages(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
@@ -309,7 +309,7 @@ public class ScanFilterAndProjectOperator
 
     private void setupAria()
     {
-        boolean enableAria = SystemSessionProperties.enableAria(operatorContext.getSession());
+        boolean enableAria = SystemSessionProperties.isAriaScanEnabled(operatorContext.getSession());
         if (enableAria) {
             int[] projectionPushdownChannels = pageProcessor.getIdentityInputToOutputChannel();
             boolean projectionPushedDown = projectionPushdownChannels != null;

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator;
 
-import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ColumnHandle;
@@ -37,6 +36,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+import static com.facebook.presto.SystemSessionProperties.ariaFlags;
+import static com.facebook.presto.SystemSessionProperties.isAriaScanEnabled;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static java.util.Objects.requireNonNull;
@@ -265,22 +266,24 @@ public class TableScanOperator
 
     private void setupAria()
     {
-        boolean enableAria = SystemSessionProperties.isAriaScanEnabled(operatorContext.getSession());
-        if (enableAria && !columns.isEmpty()) {
-            int[] channels = new int[columns.size()];
-            for (int i = 0; i < channels.length; i++) {
-                channels[i] = i;
-            }
-            int ariaFlags = SystemSessionProperties.ariaFlags(operatorContext.getSession());
-            PageSourceOptions options = new PageSourceOptions(channels,
-                                                              channels,
-                                                              reusePages,
-                                                              null,
-                                                              false,
-                                                              512 * 1024,
-                                                              ariaFlags);
-            source.pushdownFilterAndProjection(options);
+        if (!isAriaScanEnabled(operatorContext.getSession()) || columns.isEmpty()) {
+            return;
         }
+
+        int[] channels = new int[columns.size()];
+        for (int i = 0; i < channels.length; i++) {
+            channels[i] = i;
+        }
+
+        PageSourceOptions options = new PageSourceOptions(
+                channels,
+                channels,
+                reusePages,
+                null,
+                false,
+                512 * 1024,
+                ariaFlags(operatorContext.getSession()));
+        source.pushdownFilterAndProjection(options);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -265,7 +265,7 @@ public class TableScanOperator
 
     private void setupAria()
     {
-        boolean enableAria = SystemSessionProperties.enableAria(operatorContext.getSession());
+        boolean enableAria = SystemSessionProperties.isAriaScanEnabled(operatorContext.getSession());
         if (enableAria && !columns.isEmpty()) {
             int[] channels = new int[columns.size()];
             for (int i = 0; i < channels.length; i++) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
@@ -55,7 +55,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.SystemSessionProperties.enableAria;
+import static com.facebook.presto.SystemSessionProperties.isAriaScanEnabled;
 import static com.facebook.presto.SystemSessionProperties.isNewOptimizerEnabled;
 import static com.facebook.presto.matching.Capture.newCapture;
 import static com.facebook.presto.metadata.TableLayoutResult.computeEnforced;
@@ -258,7 +258,7 @@ public class PickTableLayout
         // don't include non-deterministic predicates
         Expression deterministicPredicate = filterDeterministicConjuncts(predicate);
         boolean supportsSubfieldTupleDomain = false;
-        if (enableAria(session)) {
+        if (isAriaScanEnabled(session)) {
             // Subfield TupleDomain extraction is only on for Aria
             // because even if the Aria path were not run, this
             // extraction would alter predicate order and the non-Aria

--- a/presto-orc/src/main/java/com/facebook/presto/orc/ColumnGroupReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ColumnGroupReader.java
@@ -368,7 +368,9 @@ public class ColumnGroupReader
                 continue;
             }
             StreamReader reader = channelToStreamReader.get(channel);
-            blocks[channel] = reader.getBlock(numFirstRows, false);
+            if (reader != null) {
+                blocks[channel] = reader.getBlock(numFirstRows, false);
+            }
             return blocks;
         }
         return blocks;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReader.java
@@ -759,7 +759,7 @@ public class OrcRecordReader
             return false;
         }
         int[] internalChannels = options.getInternalChannels();
-        int[] targetChannels = options.getOutputChannels();
+        int[] outputChannels = options.getOutputChannels();
         reuseBlocks = options.getReusePages();
         reorderFilters = options.getReorderFilters();
         reader = new ColumnGroupReader(streamReaders,
@@ -767,7 +767,7 @@ public class OrcRecordReader
                                        channelColumns,
                                        types,
                                        internalChannels,
-                                       targetChannels,
+                                       outputChannels,
                                        filters,
                                        options.getFilterFunctions(),
                                        reuseBlocks,
@@ -813,7 +813,7 @@ public class OrcRecordReader
         }
     }
 
-    Page resultPage()
+    private Page resultPage()
     {
         if (numResults == 0) {
             return null;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ColumnReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ColumnReader.java
@@ -102,6 +102,7 @@ abstract class ColumnReader
     {
         return outputChannel;
     }
+
     @Override
     public Filter getFilter()
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/PageSourceOptions.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/PageSourceOptions.java
@@ -231,4 +231,4 @@ public class PageSourceOptions
     {
         return ariaFlags;
     }
-    }
+}


### PR DESCRIPTION
When reading from partitioned tables, `outputChannels` may include partition key columns, but there are no `StreamReader`s for these columns in the `ColumnGroupReader`. This causes NPE in `ColumnGroupReader.getBlocks()`. This PR fixes the NPE and allows 
 `TestOrcPageSourceMemoryTracking#testScanFilterAndProjectOperator` to pass.

`TestOrcPageSourceMemoryTracking#testTableScanOperator` is still failing, but with a different error:

```
java.lang.AssertionError: expected:<362883> to be between <460000> and <469999> inclusive

	at io.airlift.testing.Assertions.fail(Assertions.java:323)
	at io.airlift.testing.Assertions.assertBetweenInclusive(Assertions.java:252)
	at io.airlift.testing.Assertions.assertBetweenInclusive(Assertions.java:230)
	at com.facebook.presto.hive.TestOrcPageSourceMemoryTracking.testTableScanOperator(TestOrcPageSourceMemoryTracking.java:344)
```

CC: @oerling @nezihyigitbasi @elonazoulay @yingsu00 @tdcmeehan 