### PR TITLE
Always escape row field names

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignature.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignature.java
@@ -84,7 +84,7 @@ public class ClientTypeSignature
                     Object value = literalArguments.get(i);
                     checkArgument(value instanceof String, "Expected literalArgument %d in %s to be a string", i, literalArguments);
                     convertedArguments.add(new ClientTypeSignatureParameter(TypeSignatureParameter.of(new NamedTypeSignature(
-                            Optional.of(new RowFieldName((String) value, false)),
+                            Optional.of(new RowFieldName((String) value)),
                             toTypeSignature(typeArguments.get(i))))));
                 }
             }

--- a/presto-client/src/test/java/com/facebook/presto/client/TestClientTypeSignature.java
+++ b/presto-client/src/test/java/com/facebook/presto/client/TestClientTypeSignature.java
@@ -53,8 +53,8 @@ public class TestClientTypeSignature
         assertJsonRoundTrip(new ClientTypeSignature(
                 "row",
                 ImmutableList.of(
-                        new ClientTypeSignatureParameter(TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("foo", false)), bigint))),
-                        new ClientTypeSignatureParameter(TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("bar", false)), bigint))))));
+                        new ClientTypeSignatureParameter(TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("foo")), bigint))),
+                        new ClientTypeSignatureParameter(TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("bar")), bigint))))));
     }
 
     @Test

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveType.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveType.java
@@ -240,7 +240,7 @@ public final class HiveType
                     // Users can't work around this by casting in their queries because Presto parser always lower case types.
                     // TODO: This is a hack. Presto engine should be able to handle identifiers in a case insensitive way where necessary.
                     String rowFieldName = structFieldNames.get(i).toLowerCase(Locale.US);
-                    typeSignatureBuilder.add(TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName(rowFieldName, false)), typeSignature)));
+                    typeSignatureBuilder.add(TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName(rowFieldName)), typeSignature)));
                 }
                 return new TypeSignature(StandardTypes.ROW, typeSignatureBuilder.build());
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -276,9 +276,9 @@ public abstract class AbstractTestHiveClient
     private static final Type ARRAY_TYPE = arrayType(createUnboundedVarcharType());
     private static final Type MAP_TYPE = mapType(createUnboundedVarcharType(), BIGINT);
     private static final Type ROW_TYPE = rowType(ImmutableList.of(
-            new NamedTypeSignature(Optional.of(new RowFieldName("f_string", false)), createUnboundedVarcharType().getTypeSignature()),
-            new NamedTypeSignature(Optional.of(new RowFieldName("f_bigint", false)), BIGINT.getTypeSignature()),
-            new NamedTypeSignature(Optional.of(new RowFieldName("f_boolean", false)), BOOLEAN.getTypeSignature())));
+            new NamedTypeSignature(Optional.of(new RowFieldName("f_string")), createUnboundedVarcharType().getTypeSignature()),
+            new NamedTypeSignature(Optional.of(new RowFieldName("f_bigint")), BIGINT.getTypeSignature()),
+            new NamedTypeSignature(Optional.of(new RowFieldName("f_boolean")), BOOLEAN.getTypeSignature())));
 
     private static final List<ColumnMetadata> CREATE_TABLE_COLUMNS = ImmutableList.<ColumnMetadata>builder()
             .add(new ColumnMetadata("id", BIGINT))
@@ -349,7 +349,7 @@ public abstract class AbstractTestHiveClient
     private static RowType toRowType(List<ColumnMetadata> columns)
     {
         return rowType(columns.stream()
-                .map(col -> new NamedTypeSignature(Optional.of(new RowFieldName(format("f_%s", col.getName()), false)), col.getType().getTypeSignature()))
+                .map(col -> new NamedTypeSignature(Optional.of(new RowFieldName(format("f_%s", col.getName()))), col.getType().getTypeSignature()))
                 .collect(toList()));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/type/TestJsonOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestJsonOperators.java
@@ -424,7 +424,7 @@ public class TestJsonOperators
         assertInvalidCastWithJsonParse(
                 "{\"a\" :1,  \"b\": {} }",
                 "ROW(a INTEGER, b ARRAY<INTEGER>)",
-                "Cannot cast to row(a integer,b array(integer)). Expected a json array, but got {\n{\"a\" :1,  \"b\": {} }");
+                "Cannot cast to row(\"a\" integer,\"b\" array(integer)). Expected a json array, but got {\n{\"a\" :1,  \"b\": {} }");
         assertInvalidCastWithJsonParse(
                 "[  1,  {}  ]",
                 "ROW(INTEGER, ARRAY<INTEGER>)",

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowOperators.java
@@ -377,8 +377,8 @@ public class TestRowOperators
                         null, asList(1L, 2L, 3L, null)));
 
         // invalid cast
-        assertInvalidCast("CAST(unchecked_to_json('{\"a\":1,\"b\":2,\"a\":3}') AS ROW(a BIGINT, b BIGINT))", "Cannot cast to row(a bigint,b bigint). Duplicate field: a\n{\"a\":1,\"b\":2,\"a\":3}");
-        assertInvalidCast("CAST(unchecked_to_json('[{\"a\":1,\"b\":2,\"a\":3}]') AS ARRAY<ROW(a BIGINT, b BIGINT)>)", "Cannot cast to array(row(a bigint,b bigint)). Duplicate field: a\n[{\"a\":1,\"b\":2,\"a\":3}]");
+        assertInvalidCast("CAST(unchecked_to_json('{\"a\":1,\"b\":2,\"a\":3}') AS ROW(a BIGINT, b BIGINT))", "Cannot cast to row(\"a\" bigint,\"b\" bigint). Duplicate field: a\n{\"a\":1,\"b\":2,\"a\":3}");
+        assertInvalidCast("CAST(unchecked_to_json('[{\"a\":1,\"b\":2,\"a\":3}]') AS ARRAY<ROW(a BIGINT, b BIGINT)>)", "Cannot cast to array(row(\"a\" bigint,\"b\" bigint)). Duplicate field: a\n[{\"a\":1,\"b\":2,\"a\":3}]");
     }
 
     @Test
@@ -499,14 +499,14 @@ public class TestRowOperators
         assertComparisonCombination("row(1, 2.0E0, TRUE, 'kittens', from_unixtime(1))", "row(1, 3.0E0, TRUE, 'kittens', from_unixtime(1))");
 
         assertInvalidFunction("cast(row(cast(cast ('' as varbinary) as hyperloglog)) as row(col0 hyperloglog)) = cast(row(cast(cast ('' as varbinary) as hyperloglog)) as row(col0 hyperloglog))",
-                SemanticErrorCode.TYPE_MISMATCH, "line 1:81: '=' cannot be applied to row(col0 HyperLogLog), row(col0 HyperLogLog)");
+                SemanticErrorCode.TYPE_MISMATCH, "line 1:81: '=' cannot be applied to row(\"col0\" HyperLogLog), row(\"col0\" HyperLogLog)");
         assertInvalidFunction("cast(row(cast(cast ('' as varbinary) as hyperloglog)) as row(col0 hyperloglog)) > cast(row(cast(cast ('' as varbinary) as hyperloglog)) as row(col0 hyperloglog))",
-                SemanticErrorCode.TYPE_MISMATCH, "line 1:81: '>' cannot be applied to row(col0 HyperLogLog), row(col0 HyperLogLog)");
+                SemanticErrorCode.TYPE_MISMATCH, "line 1:81: '>' cannot be applied to row(\"col0\" HyperLogLog), row(\"col0\" HyperLogLog)");
 
         assertInvalidFunction("cast(row(cast(cast ('' as varbinary) as qdigest(double))) as row(col0 qdigest(double))) = cast(row(cast(cast ('' as varbinary) as qdigest(double))) as row(col0 qdigest(double)))",
-                SemanticErrorCode.TYPE_MISMATCH, "line 1:89: '=' cannot be applied to row(col0 qdigest(double)), row(col0 qdigest(double))");
+                SemanticErrorCode.TYPE_MISMATCH, "line 1:89: '=' cannot be applied to row(\"col0\" qdigest(double)), row(\"col0\" qdigest(double))");
         assertInvalidFunction("cast(row(cast(cast ('' as varbinary) as qdigest(double))) as row(col0 qdigest(double))) > cast(row(cast(cast ('' as varbinary) as qdigest(double))) as row(col0 qdigest(double)))",
-                SemanticErrorCode.TYPE_MISMATCH, "line 1:89: '>' cannot be applied to row(col0 qdigest(double)), row(col0 qdigest(double))");
+                SemanticErrorCode.TYPE_MISMATCH, "line 1:89: '>' cannot be applied to row(\"col0\" qdigest(double)), row(\"col0\" qdigest(double))");
 
         assertFunction("row(TRUE, ARRAY [1], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0])) = row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0]))", BOOLEAN, false);
         assertFunction("row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0])) = row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0]))", BOOLEAN, true);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowParametricType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowParametricType.java
@@ -39,8 +39,8 @@ public class TestRowParametricType
         TypeManager typeManager = new TypeRegistry();
         TypeSignature typeSignature = new TypeSignature(
                 ROW,
-                TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("col1", false)), new TypeSignature(BIGINT))),
-                TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("col2", true)), new TypeSignature(DOUBLE))));
+                TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("col1")), new TypeSignature(BIGINT))),
+                TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("col2")), new TypeSignature(DOUBLE))));
         List<TypeParameter> parameters = typeSignature.getParameters().stream()
                 .map(parameter -> TypeParameter.of(parameter, typeManager))
                 .collect(Collectors.toList());

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -537,7 +537,7 @@ public class MongoSession
                 typeSignature = new TypeSignature(StandardTypes.ROW,
                         IntStream.range(0, subTypes.size())
                                 .mapToObj(idx -> TypeSignatureParameter.of(
-                                        new NamedTypeSignature(Optional.of(new RowFieldName(String.format("%s%d", implicitPrefix, idx + 1), false)), subTypes.get(idx).get())))
+                                        new NamedTypeSignature(Optional.of(new RowFieldName(String.format("%s%d", implicitPrefix, idx + 1))), subTypes.get(idx).get())))
                                 .collect(toList()));
             }
         }
@@ -550,7 +550,7 @@ public class MongoSession
                     return Optional.empty();
                 }
 
-                parameters.add(TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName(key, false)), fieldType.get())));
+                parameters.add(TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName(key)), fieldType.get())));
             }
             typeSignature = new TypeSignature(StandardTypes.ROW, parameters);
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1315,7 +1315,7 @@ public class OrcTester
         for (int i = 0; i < fieldTypes.length; i++) {
             String filedName = "field_" + i;
             Type fieldType = fieldTypes[i];
-            typeSignatureParameters.add(TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName(filedName, false)), fieldType.getTypeSignature())));
+            typeSignatureParameters.add(TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName(filedName)), fieldType.getTypeSignature())));
         }
         return TYPE_MANAGER.getParameterizedType(StandardTypes.ROW, typeSignatureParameters.build());
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestFlatMap.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestFlatMap.java
@@ -87,9 +87,9 @@ public class TestFlatMap
     private static final Type STRUCT_TYPE = TYPE_MANAGER.getParameterizedType(
             StandardTypes.ROW,
             ImmutableList.of(
-                    TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("value1", false)), IntegerType.INTEGER.getTypeSignature())),
-                    TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("value2", false)), IntegerType.INTEGER.getTypeSignature())),
-                    TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("value3", false)), IntegerType.INTEGER.getTypeSignature()))));
+                    TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("value1")), IntegerType.INTEGER.getTypeSignature())),
+                    TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("value2")), IntegerType.INTEGER.getTypeSignature())),
+                    TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName("value3")), IntegerType.INTEGER.getTypeSignature()))));
 
     @Test
     public void testByte()

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStructStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStructStreamReader.java
@@ -280,7 +280,7 @@ public class TestStructStreamReader
     {
         ImmutableList.Builder<TypeSignatureParameter> typeSignatureParameters = ImmutableList.builder();
         for (String fieldName : fieldNames) {
-            typeSignatureParameters.add(TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName(fieldName, false)), TEST_DATA_TYPE.getTypeSignature())));
+            typeSignatureParameters.add(TypeSignatureParameter.of(new NamedTypeSignature(Optional.of(new RowFieldName(fieldName)), TEST_DATA_TYPE.getTypeSignature())));
         }
         return TYPE_MANAGER.getParameterizedType(StandardTypes.ROW, typeSignatureParameters.build());
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -522,7 +522,7 @@ public class OrcStorageManager
                 ImmutableList.Builder<TypeSignatureParameter> fieldTypes = ImmutableList.builder();
                 for (int i = 0; i < type.getFieldCount(); i++) {
                     fieldTypes.add(TypeSignatureParameter.of(new NamedTypeSignature(
-                            Optional.of(new RowFieldName(fieldNames.get(i), false)),
+                            Optional.of(new RowFieldName(fieldNames.get(i))),
                             getType(types, type.getFieldTypeIndex(i)).getTypeSignature())));
                 }
                 return typeManager.getParameterizedType(StandardTypes.ROW, fieldTypes.build());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/RowFieldName.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/RowFieldName.java
@@ -23,27 +23,17 @@ import static java.util.Objects.requireNonNull;
 public class RowFieldName
 {
     private final String name;
-    private final boolean delimited;
 
     @JsonCreator
-    public RowFieldName(
-            @JsonProperty("name") String name,
-            @JsonProperty("delimited") boolean delimited)
+    public RowFieldName(@JsonProperty("name") String name)
     {
         this.name = requireNonNull(name, "name is null");
-        this.delimited = delimited;
     }
 
     @JsonProperty
     public String getName()
     {
         return name;
-    }
-
-    @JsonProperty
-    public boolean isDelimited()
-    {
-        return delimited;
     }
 
     @Override
@@ -58,22 +48,18 @@ public class RowFieldName
 
         RowFieldName other = (RowFieldName) o;
 
-        return Objects.equals(this.name, other.name) &&
-                Objects.equals(this.delimited, other.delimited);
+        return Objects.equals(this.name, other.name);
     }
 
     @Override
     public String toString()
     {
-        if (!isDelimited()) {
-            return name;
-        }
         return '"' + name.replace("\"", "\"\"") + '"';
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, delimited);
+        return Objects.hash(name);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
@@ -87,7 +87,7 @@ public class RowType
         }
 
         List<TypeSignatureParameter> parameters = fields.stream()
-                .map(field -> TypeSignatureParameter.of(new NamedTypeSignature(field.getName().map(name -> new RowFieldName(name, false)), field.getType().getTypeSignature())))
+                .map(field -> TypeSignatureParameter.of(new NamedTypeSignature(field.getName().map(name -> new RowFieldName(name)), field.getType().getTypeSignature())))
                 .collect(Collectors.toList());
 
         return new TypeSignature(ROW, parameters);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
@@ -253,7 +253,7 @@ public class TypeSignature
                         verify(tokenStart >= 0, "Expect tokenStart to be non-negative");
                         verify(delimitedColumnName != null, "Expect delimitedColumnName to be non-null");
                         fields.add(TypeSignatureParameter.of(new NamedTypeSignature(
-                                Optional.of(new RowFieldName(delimitedColumnName, true)),
+                                Optional.of(new RowFieldName(delimitedColumnName)),
                                 parseTypeSignature(signature.substring(tokenStart, i).trim(), literalParameters))));
                         delimitedColumnName = null;
                         tokenStart = -1;
@@ -263,7 +263,7 @@ public class TypeSignature
                         verify(tokenStart >= 0, "Expect tokenStart to be non-negative");
                         verify(delimitedColumnName != null, "Expect delimitedColumnName to be non-null");
                         fields.add(TypeSignatureParameter.of(new NamedTypeSignature(
-                                Optional.of(new RowFieldName(delimitedColumnName, true)),
+                                Optional.of(new RowFieldName(delimitedColumnName)),
                                 parseTypeSignature(signature.substring(tokenStart, i).trim(), literalParameters))));
                         delimitedColumnName = null;
                         tokenStart = -1;
@@ -297,7 +297,7 @@ public class TypeSignature
         String firstPart = typeOrNamedType.substring(0, split);
         if (IDENTIFIER_PATTERN.matcher(firstPart).matches()) {
             return TypeSignatureParameter.of(new NamedTypeSignature(
-                    Optional.of(new RowFieldName(firstPart, false)),
+                    Optional.of(new RowFieldName(firstPart)),
                     parseTypeSignature(typeOrNamedType.substring(split + 1).trim(), literalParameters)));
         }
 

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -50,32 +50,32 @@ public class TestTypeSignature
         // row signature with named fields
         assertRowSignature(
                 "row(a bigint,b varchar)",
-                rowSignature(namedParameter("a", false, signature("bigint")), namedParameter("b", false, varchar())));
+                rowSignature(namedParameter("a", signature("bigint")), namedParameter("b", varchar())));
         assertRowSignature(
                 "row(__a__ bigint,_b@_: _varchar)",
-                rowSignature(namedParameter("__a__", false, signature("bigint")), namedParameter("_b@_:", false, signature("_varchar"))));
+                rowSignature(namedParameter("__a__", signature("bigint")), namedParameter("_b@_:", signature("_varchar"))));
         assertRowSignature(
                 "row(a bigint,b array(bigint),c row(a bigint))",
                 rowSignature(
-                        namedParameter("a", false, signature("bigint")),
-                        namedParameter("b", false, array(signature("bigint"))),
-                        namedParameter("c", false, rowSignature(namedParameter("a", false, signature("bigint"))))));
+                        namedParameter("a", signature("bigint")),
+                        namedParameter("b", array(signature("bigint"))),
+                        namedParameter("c", rowSignature(namedParameter("a", signature("bigint"))))));
         assertRowSignature(
                 "row(a varchar(10),b row(a bigint))",
                 rowSignature(
-                        namedParameter("a", false, varchar(10)),
-                        namedParameter("b", false, rowSignature(namedParameter("a", false, signature("bigint"))))));
+                        namedParameter("a", varchar(10)),
+                        namedParameter("b", rowSignature(namedParameter("a", signature("bigint"))))));
         assertRowSignature(
                 "array(row(col0 bigint,col1 double))",
-                array(rowSignature(namedParameter("col0", false, signature("bigint")), namedParameter("col1", false, signature("double")))));
+                array(rowSignature(namedParameter("col0", signature("bigint")), namedParameter("col1", signature("double")))));
         assertRowSignature(
                 "row(col0 array(row(col0 bigint,col1 double)))",
-                rowSignature(namedParameter("col0", false, array(
-                        rowSignature(namedParameter("col0", false, signature("bigint")), namedParameter("col1", false, signature("double")))))));
+                rowSignature(namedParameter("col0", array(
+                        rowSignature(namedParameter("col0", signature("bigint")), namedParameter("col1", signature("double")))))));
         assertRowSignature(
                 "row(a decimal(p1,s1),b decimal(p2,s2))",
                 ImmutableSet.of("p1", "s1", "p2", "s2"),
-                rowSignature(namedParameter("a", false, decimal("p1", "s1")), namedParameter("b", false, decimal("p2", "s2"))));
+                rowSignature(namedParameter("a", decimal("p1", "s1")), namedParameter("b", decimal("p2", "s2"))));
 
         // row with mixed fields
         assertRowSignature(
@@ -86,40 +86,40 @@ public class TestTypeSignature
                 rowSignature(
                         unnamedParameter(signature("bigint")),
                         unnamedParameter(array(signature("bigint"))),
-                        unnamedParameter(rowSignature(namedParameter("a", false, signature("bigint"))))));
+                        unnamedParameter(rowSignature(namedParameter("a", signature("bigint"))))));
         assertRowSignature(
                 "row(varchar(10),b row(bigint))",
                 rowSignature(
                         unnamedParameter(varchar(10)),
-                        namedParameter("b", false, rowSignature(unnamedParameter(signature("bigint"))))));
+                        namedParameter("b", rowSignature(unnamedParameter(signature("bigint"))))));
         assertRowSignature(
                 "array(row(col0 bigint,double))",
-                array(rowSignature(namedParameter("col0", false, signature("bigint")), unnamedParameter(signature("double")))));
+                array(rowSignature(namedParameter("col0", signature("bigint")), unnamedParameter(signature("double")))));
         assertRowSignature(
                 "row(col0 array(row(bigint,double)))",
-                rowSignature(namedParameter("col0", false, array(
+                rowSignature(namedParameter("col0", array(
                         rowSignature(unnamedParameter(signature("bigint")), unnamedParameter(signature("double")))))));
         assertRowSignature(
                 "row(a decimal(p1,s1),decimal(p2,s2))",
                 ImmutableSet.of("p1", "s1", "p2", "s2"),
-                rowSignature(namedParameter("a", false, decimal("p1", "s1")), unnamedParameter(decimal("p2", "s2"))));
+                rowSignature(namedParameter("a", decimal("p1", "s1")), unnamedParameter(decimal("p2", "s2"))));
 
         // named fields of types with spaces
         assertRowSignature(
                 "row(time time with time zone)",
-                rowSignature(namedParameter("time", false, signature("time with time zone"))));
+                rowSignature(namedParameter("time", signature("time with time zone"))));
         assertRowSignature(
                 "row(time timestamp with time zone)",
-                rowSignature(namedParameter("time", false, signature("timestamp with time zone"))));
+                rowSignature(namedParameter("time", signature("timestamp with time zone"))));
         assertRowSignature(
                 "row(interval interval day to second)",
-                rowSignature(namedParameter("interval", false, signature("interval day to second"))));
+                rowSignature(namedParameter("interval", signature("interval day to second"))));
         assertRowSignature(
                 "row(interval interval year to month)",
-                rowSignature(namedParameter("interval", false, signature("interval year to month"))));
+                rowSignature(namedParameter("interval", signature("interval year to month"))));
         assertRowSignature(
                 "row(double double precision)",
-                rowSignature(namedParameter("double", false, signature("double precision"))));
+                rowSignature(namedParameter("double", signature("double precision"))));
 
         // unnamed fields of types with spaces
         assertRowSignature(
@@ -148,20 +148,19 @@ public class TestTypeSignature
         assertRowSignature(
                 "row(\"time with time zone\" time with time zone,\"double\" double)",
                 rowSignature(
-                        namedParameter("time with time zone", true, signature("time with time zone")),
-                        namedParameter("double", true, signature("double"))));
+                        namedParameter("time with time zone", signature("time with time zone")),
+                        namedParameter("double", signature("double"))));
 
         // allow spaces
-        assertSignature(
-                "row( time  time with time zone, array( interval day to seconds ) )",
-                "row",
-                ImmutableList.of("time time with time zone", "array(interval day to seconds)"),
-                "row(time time with time zone,array(interval day to seconds))");
+        assertRowSignature(
+                "row( time  time with time zone)",
+                rowSignature(
+                        namedParameter("time", signature("time with time zone"))));
 
         // preserve base name case
         assertRowSignature(
                 "RoW(a bigint,b varchar)",
-                rowSignature(namedParameter("a", false, signature("bigint")), namedParameter("b", false, varchar())));
+                rowSignature(namedParameter("a", signature("bigint")), namedParameter("b", varchar())));
 
         // field type canonicalization
         assertEquals(parseTypeSignature("row(col iNt)"), parseTypeSignature("row(col integer)"));
@@ -170,7 +169,7 @@ public class TestTypeSignature
         // signature with invalid type
         assertRowSignature(
                 "row(\"time\" with time zone)",
-                rowSignature(namedParameter("time", true, signature("with time zone"))));
+                rowSignature(namedParameter("time", signature("with time zone"))));
     }
 
     private TypeSignature varchar()
@@ -194,9 +193,9 @@ public class TestTypeSignature
         return new TypeSignature("row", transform(asList(columns), TypeSignatureParameter::of));
     }
 
-    private static NamedTypeSignature namedParameter(String name, boolean delimited, TypeSignature value)
+    private static NamedTypeSignature namedParameter(String name, TypeSignature value)
     {
-        return new NamedTypeSignature(Optional.of(new RowFieldName(name, delimited)), value);
+        return new NamedTypeSignature(Optional.of(new RowFieldName(name)), value);
     }
 
     private static NamedTypeSignature unnamedParameter(TypeSignature value)
@@ -296,7 +295,7 @@ public class TestTypeSignature
     {
         TypeSignature signature = parseTypeSignature(typeName, literalParameters);
         assertEquals(signature, expectedSignature);
-        assertEquals(signature.toString(), typeName);
+        assertEquals(parseTypeSignature(signature.toString(), literalParameters), expectedSignature);
     }
 
     private static void assertRowSignature(


### PR DESCRIPTION
When row type signature is fetched in a connector from the metadata, there's
no information regarding whether to escape or not the field name.

Fixes: https://github.com/prestodb/presto/issues/12262