### PR TITLE
Fix JVM crash in TestHiveDistributedQueries

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
@@ -25,9 +25,9 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.OrcInputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.ByteArrayUtils;
 import com.facebook.presto.spi.block.LongArrayBlock;
 import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.ByteArrays;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -261,7 +261,7 @@ public class DoubleStreamReader
                     }
                     double value;
                     if (available >= SIZE_OF_DOUBLE) {
-                        value = ByteArrayUtils.getDouble(inputBuffer, inputOffset);
+                        value = ByteArrays.getDouble(inputBuffer, inputOffset);
                         available -= SIZE_OF_DOUBLE;
                         inputOffset += SIZE_OF_DOUBLE;
                     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayUtils.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayUtils.java
@@ -13,20 +13,15 @@
  */
 package com.facebook.presto.spi.block;
 
-import java.lang.reflect.Field;
 import sun.misc.Unsafe;
 
+import java.lang.reflect.Field;
+
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
-import static sun.misc.Unsafe.ARRAY_BOOLEAN_INDEX_SCALE;
+import static java.lang.Math.min;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
-import static sun.misc.Unsafe.ARRAY_DOUBLE_INDEX_SCALE;
-import static sun.misc.Unsafe.ARRAY_FLOAT_INDEX_SCALE;
-import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
 import static sun.misc.Unsafe.ARRAY_LONG_BASE_OFFSET;
 import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
-import static sun.misc.Unsafe.ARRAY_SHORT_INDEX_SCALE;
-
-import static java.lang.Math.min;
 
 
 public class ByteArrayUtils
@@ -46,31 +41,6 @@ public class ByteArrayUtils
       throw new RuntimeException(e);
     }
   }
-
-    public static long getLong(byte[] array, int offset)
-    {
-        return unsafe.getLong(array, (long) (ARRAY_BYTE_BASE_OFFSET + offset));
-    }
-
-        public static double getDouble(byte[] array, int offset)
-    {
-        return unsafe.getDouble(array, (long) (ARRAY_BYTE_BASE_OFFSET + offset));
-    }
-
-        public static int getInt(byte[] array, int offset)
-    {
-        return unsafe.getInt(array, (long) (ARRAY_BYTE_BASE_OFFSET + offset));
-    }
-
-    public static float getFloat(byte[] array, int offset)
-    {
-        return unsafe.getFloat(array, (long) (ARRAY_BYTE_BASE_OFFSET + offset));
-    }
-
-    public static short getShort(byte[] array, int offset)
-    {
-        return unsafe.getShort(array, (long) (ARRAY_BYTE_BASE_OFFSET + offset));
-    }
 
     public static void gather( long[] source, int[] positions, int[] rowNumberMap, int sourceOffset, byte[] target, int targetOffset, int numWords)
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockEncoding.java
@@ -13,13 +13,13 @@
  */
 package com.facebook.presto.spi.block;
 
+import io.airlift.slice.ByteArrays;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
 import static com.facebook.presto.spi.block.EncoderUtil.decodeNullBits;
 import static com.facebook.presto.spi.block.EncoderUtil.encodeNullsAsBits;
-
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
@@ -103,7 +103,7 @@ public class LongArrayBlockEncoding
                         }
                         else {
                             if (toRead > 0) {
-                                values[position++] = ByteArrayUtils.getLong(buffer, offset + bytesRead);
+                                values[position++] = ByteArrays.getLong(buffer, offset + bytesRead);
                                 toRead--;
                                 bytesRead += SIZE_OF_LONG;
                             }


### PR DESCRIPTION
The following test was crashing JVM:

mvn test -pl presto-hive -Dtest=TestHiveDistributedQueries

```
J 23694 c1 com.facebook.presto.spi.block.ByteArrayUtils.getDouble([BI)D (14 bytes) @ 0x000000011366cb88 [0x000000011366cb40+0x0000000000000048]
j  com.facebook.presto.orc.reader.DoubleStreamReader.scan()V+347
j  com.facebook.presto.orc.ColumnGroupReader.advance()V+139
j  com.facebook.presto.orc.OrcRecordReader.getNextPage()Lcom/facebook/presto/spi/Page;+170
j  com.facebook.presto.hive.orc.OrcPageSource.getNextPage()Lcom/facebook/presto/spi/Page;+11
``` 

I believe this is because ByteArrayUtils doesn't perform a range check because reading from `Unsafe`. The fix is to use methods from ByteArrays instead.