### PR TITLE
Use non-Aria scan if no columns need to be read

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
@@ -335,9 +335,13 @@ public class ScanFilterAndProjectOperator
             populateChannels(channels, filters[i].getInputChannels());
         }
 
+        if (channels.length == 0) {
+            return;
+        }
+
         PageSourceOptions options = new PageSourceOptions(
                 channels,
-                projectionPushdownChannels,
+                projectionPushdownChannels == null ? channels : projectionInputChannels,
                 reusePages,
                 filters,
                 ariaReorderFilters(operatorContext.getSession()),

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageSourceOptions;
+import com.facebook.presto.spi.PageSourceOptions.FilterFunction;
 import com.facebook.presto.spi.UpdatablePageSource;
 import com.facebook.presto.split.EmptySplit;
 import com.facebook.presto.split.EmptySplitPageSource;
@@ -279,7 +280,7 @@ public class TableScanOperator
                 channels,
                 channels,
                 reusePages,
-                null,
+                new FilterFunction[0],
                 false,
                 512 * 1024,
                 ariaFlags(operatorContext.getSession()));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/ColumnGroupReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ColumnGroupReader.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 public class ColumnGroupReader
 {
@@ -80,10 +81,7 @@ public class ColumnGroupReader
         this.reuseBlocks = reuseBlocks;
         this.reorderFilters = reorderFilters;
         this.ariaFlags = ariaFlags;
-        if (outputChannels == null) {
-            outputChannels = internalChannels;
-        }
-        this.outputChannels = outputChannels;
+        this.outputChannels = requireNonNull(outputChannels, "outputChannels is null");
         channelToStreamReader = new HashMap();
         for (int i = 0; i < channelColumns.length; i++) {
             int columnIndex = channelColumns[i];
@@ -102,7 +100,7 @@ public class ColumnGroupReader
             streamReader.setFilterAndChannel(filter, internalChannel, columnIndex, types.get(i));
             channelToStreamReader.put(internalChannel, streamReader);
         }
-        this.filterFunctions = filterFunctions != null ? filterFunctions : new FilterFunction[0];
+        this.filterFunctions = requireNonNull(filterFunctions, "filterFunctions is null");
         for (int i = 0; i < outputChannels.length; i++) {
             maxOutputChannel = Math.max(maxOutputChannel, outputChannels[i]);
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/PageSourceOptions.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/PageSourceOptions.java
@@ -15,6 +15,8 @@ package com.facebook.presto.spi;
 
 import java.util.Arrays;
 
+import static java.util.Objects.requireNonNull;
+
 public class PageSourceOptions
 {
     private final boolean reusePages;
@@ -187,10 +189,14 @@ public class PageSourceOptions
                              int targetBytes,
                              int ariaFlags)
     {
+        requireNonNull(internalChannels, "internalChannels is null");
+        if (internalChannels.length == 0) {
+            throw new IllegalArgumentException("internalChannels must not be empty");
+        };
         this.internalChannels = internalChannels;
-        this.outputChannels = outputChannels;
+        this.outputChannels = requireNonNull(outputChannels, "outputChannels is null");
         this.reusePages = reusePages;
-        this.filterFunctions = filterFunctions;
+        this.filterFunctions = requireNonNull(filterFunctions, "filterFunctions is null");
         this.reorderFilters = reorderFilters;
         this.targetBytes = targetBytes;
         this.ariaFlags = ariaFlags;


### PR DESCRIPTION
Fix `SELECT count(null) FROM orders` query from `AbstractTestQueries#testCountAll` by using non-Aria scan path when no columns need to be read. Added input validation to `PageSourceOptions`'s constructor.

Ran `mvn test -pl presto-hive -Dtest=TestHiveDistributedQueries`:

Tests run: 600, Failures: 89, Errors: 0, Skipped: 0, Time elapsed: 206.375 s