### PR TITLE
Fix missing child node for ProjectNode in PlanPrinter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -727,7 +727,13 @@ public class PlanPrinter
                     .map(PlanNode::getId)
                     .collect(toList());
 
-            NodeRepresentation nodeOutput = addNode(node, operatorName, format(formatString, arguments.toArray(new Object[0])), allNodes, ImmutableList.of(), ImmutableList.of());
+            NodeRepresentation nodeOutput = addNode(
+                    node,
+                    operatorName,
+                    format(formatString, arguments.toArray(new Object[0])),
+                    allNodes,
+                    ImmutableList.of(sourceNode),
+                    ImmutableList.of());
 
             if (projectNode.isPresent()) {
                 printAssignments(nodeOutput, projectNode.get().getAssignments());


### PR DESCRIPTION
Previous code will ignore any child node of the ProjectNode while printing text query plan in EXPLAIN.