### PR TITLE
Change error code for empty table name

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -838,6 +838,12 @@ class StatementAnalyzer
             }
 
             QualifiedObjectName name = createQualifiedObjectName(session, table, table.getName());
+            if (name.getObjectName().isEmpty()) {
+                throw new SemanticException(MISSING_TABLE, table, "Table name is empty");
+            }
+            if (name.getSchemaName().isEmpty()) {
+                throw new SemanticException(MISSING_SCHEMA, table, "Schema name is empty");
+            }
             analysis.addEmptyColumnReferencesForTable(accessControl, session.getIdentity(), name);
 
             Optional<ViewDefinition> optionalView = metadata.getView(session, name);

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -1499,6 +1499,18 @@ public class TestAnalyzer
         analyze("SELECT * FROM (VALUES array[2, 2]) a(x) FULL OUTER JOIN LATERAL(VALUES x) ON true");
     }
 
+    @Test
+    public void testEmptyTableName()
+    {
+        assertFails(MISSING_TABLE, "SELECT * FROM \"\"");
+    }
+
+    @Test
+    public void testEmptySchemaName()
+    {
+        assertFails(MISSING_SCHEMA, "SELECT * FROM \"\".foo");
+    }
+
     @BeforeClass
     public void setup()
     {


### PR DESCRIPTION
Changing the error code from GENERIC_INTERNAL to SYNTAX_ERROR
for queries where the table name is empty.