### PR TITLE
Minor method rename in GroupedExecutionTagger

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -613,22 +613,22 @@ public class PlanFragmenter
         @Override
         public GroupedExecutionProperties visitWindow(WindowNode node, Void context)
         {
-            return visitWindowFunctionNode(node);
+            return processWindowFunction(node);
         }
 
         @Override
         public GroupedExecutionProperties visitRowNumber(RowNumberNode node, Void context)
         {
-            return visitWindowFunctionNode(node);
+            return processWindowFunction(node);
         }
 
         @Override
         public GroupedExecutionProperties visitTopNRowNumber(TopNRowNumberNode node, Void context)
         {
-            return visitWindowFunctionNode(node);
+            return processWindowFunction(node);
         }
 
-        private GroupedExecutionProperties visitWindowFunctionNode(PlanNode node)
+        private GroupedExecutionProperties processWindowFunction(PlanNode node)
         {
             GroupedExecutionProperties properties = getOnlyElement(node.getSources()).accept(this, null);
             if (groupedExecutionForAggregation && properties.isCurrentNodeCapable()) {


### PR DESCRIPTION
Rename visitWindowFunctionNode to processWindowFunction to make it
clear it is not part of the visitor interface.

Extracted-From: https://github.com/prestosql/presto/commit/cd45f35ef429dbc8ee232b41047da7096656be7b

Original PR: https://github.com/prestodb/presto/pull/12234
