### PR TITLE
Disable bucket filter with compatible bucketing read

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -551,6 +551,15 @@ public class BackgroundHiveSplitLoader
 
             int tableBucketCount = bucketHandle.get().getTableBucketCount();
             int readBucketCount = bucketHandle.get().getReadBucketCount();
+
+            if (tableBucketCount != readBucketCount && bucketFilter.isPresent()) {
+                // TODO: support this once we fix the "$bucket" column for compatible bucketing read
+                throw new PrestoException(
+                        NOT_SUPPORTED,
+                        "Bucket filter (most likely using a filter on \"$bucket\") is not supported in this query. " +
+                                "Since the table has a different but compatible bucket number with another table in the query.");
+            }
+
             List<HiveColumnHandle> bucketColumns = bucketHandle.get().getColumns();
             IntPredicate predicate = bucketFilter
                     .<IntPredicate>map(filter -> filter.getBucketsToKeep()::contains)


### PR DESCRIPTION
Unnecessary remote exchange between compatible bucketing
in 57c70aee95fe6c00666f13ba5dc2f930fae87d84 (compatible bucketing
refers to when Hive tables have same bucketing key, and bucket numbers
are different but compatible).

To remove unnecessary remote exchange, the concept of `readBucketNumber`,
which might be different from `tableBucketNumber` was introduced. This
number indicates the logical bucket number from engine's perspective.

After the change `$bucket` column respects `readBucketNumber` instead of
`tableBucketNumber`, this can cause correctness issues,  as described in
https://github.com/prestodb/presto/issues/12329.

This commit disable bucket filter with compatible bucketing read to
avoid correctness problem. To fix the root cause, we should make `$bucket`
respect `tableBucketNumber`.



Short term fix to https://github.com/prestodb/presto/issues/12329