### PR TITLE
Update geospatial docs

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -2,14 +2,16 @@
 Geospatial Functions
 ====================
 
-Presto Geospatial functions that begin with the ``ST_`` prefix support the SQL/MM specification
-and are compliant with the Open Geospatial Consortium’s (OGC) OpenGIS Specifications.
-As such, many Presto Geospatial functions require, or more accurately, assume that
-geometries that are operated on are both simple and valid. For example, it does not
-make sense to calculate the area of a polygon that has a hole defined outside of the
-polygon, or to construct a polygon from a non-simple boundary line.
+Presto Geospatial functions that begin with the ``ST_`` prefix support the
+SQL/MM specification and are compliant with the Open Geospatial Consortium’s
+(OGC) OpenGIS Specifications.  As such, many Presto Geospatial functions
+require, or more accurately, assume that geometries that are operated on are
+both simple and valid. For example, it does not make sense to calculate the
+area of a polygon that has a hole defined outside of the polygon, or to
+construct a polygon from a non-simple boundary line.
 
-Presto Geospatial functions support the Well-Known Text (WKT) and Well-Known Binary (WKB) form of spatial objects:
+Presto Geospatial functions support the Well-Known Text (WKT) and Well-Known
+Binary (WKB) form of spatial objects:
 
 * ``POINT (0 0)``
 * ``LINESTRING (0 0, 1 1, 1 2)``
@@ -19,24 +21,38 @@ Presto Geospatial functions support the Well-Known Text (WKT) and Well-Known Bin
 * ``MULTIPOLYGON (((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1)), ((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)))``
 * ``GEOMETRYCOLLECTION (POINT(2 3), LINESTRING (2 3, 3 4))``
 
-Use ST_GeometryFromText and ST_GeomFromBinary functions to create geometry objects from WKT or WKB.
+Use ST_GeometryFromText and ST_GeomFromBinary functions to create geometry
+objects from WKT or WKB.
 
-The SphericalGeography type provides native support for spatial features represented on "geographic" coordinates (sometimes called "geodetic" coordinates,
-or "lat/lon", or "lon/lat"). Geographic coordinates are spherical coordinates expressed in angular units (degrees).
+The SphericalGeography type provides native support for spatial features
+represented on "geographic" coordinates (sometimes called "geodetic"
+coordinates, or "lat/lon", or "lon/lat"). Geographic coordinates are spherical
+coordinates expressed in angular units (degrees).
 
-The basis for the Geometry type is a plane. The shortest path between two points on the plane is a straight line. That means calculations on geometries (areas, distances, lengths,
-intersections, etc) can be calculated using cartesian mathematics and straight line vectors.
+The basis for the Geometry type is a plane. The shortest path between two
+points on the plane is a straight line. That means calculations on geometries
+(areas, distances, lengths, intersections, etc) can be calculated using
+cartesian mathematics and straight line vectors.
 
-The basis for the SphericalGeography type is a sphere. The shortest path between two points on the sphere is a great circle arc. That means that calculations on geographies
-(areas, distances, lengths, intersections, etc) must be calculated on the sphere, using more complicated mathematics. More accurate measurements that take the actual spheroidal
-shape of the world into account are not supported.
+The basis for the SphericalGeography type is a sphere. The shortest path
+between two points on the sphere is a great circle arc. That means that
+calculations on geographies (areas, distances, lengths, intersections, etc)
+must be calculated on the sphere, using more complicated mathematics. More
+accurate measurements that take the actual spheroidal shape of the world into
+account are not supported.
 
-Values returned by the measurement functions ST_Distance and ST_Length are in the unit of meters; values returned by ST_Area are in square meters.
+Values returned by the measurement functions ST_Distance and ST_Length are in
+the unit of meters; values returned by ST_Area are in square meters.
 
-Use ``to_spherical_geography()`` function to convert a geometry object to geography object.
+Use ``to_spherical_geography()`` function to convert a geometry object to
+geography object.
 
-For example, ``ST_Distance(ST_Point(-71.0882, 42.3607), ST_Point(-74.1197, 40.6976))`` returns 3.4577 in the unit of the passed-in values on the euclidean plane, while
-``ST_Distance(to_spherical_geography(ST_Point(-71.0882, 42.3607)), to_spherical_geography(ST_Point(-74.1197, 40.6976)))`` returns 312822.179 in meters.
+For example,
+``ST_Distance(ST_Point(-71.0882, 42.3607), ST_Point(-74.1197, 40.6976))``
+returns 3.4577 in the unit of the passed-in values on the euclidean plane,
+while
+``ST_Distance(to_spherical_geography(ST_Point(-71.0882, 42.3607)), to_spherical_geography(ST_Point(-74.1197, 40.6976)))``
+returns 312822.179 in meters.
 
 
 Constructors
@@ -49,8 +65,9 @@ Constructors
 .. function:: ST_AsText(Geometry) -> varchar
 
     Returns the WKT representation of the geometry. For empty geometries,
-    ``ST_AsText(ST_LineFromText('LINESTRING EMPTY'))`` will produce ``'MULTILINESTRING EMPTY'``
-    and ``ST_AsText(ST_Polygon('POLYGON EMPTY'))`` will produce ``'MULTIPOLYGON EMPTY'``.
+    ``ST_AsText(ST_LineFromText('LINESTRING EMPTY'))`` will produce
+    ``'MULTILINESTRING EMPTY'`` and ``ST_AsText(ST_Polygon('POLYGON EMPTY'))``
+    will produce ``'MULTIPOLYGON EMPTY'``.
 
 .. function:: ST_GeometryFromText(varchar) -> Geometry
 
@@ -66,17 +83,19 @@ Constructors
 
 .. function:: ST_LineString(array(Point)) -> LineString
 
-    Returns a LineString formed from an array of points. If there are fewer than
-    two non-empty points in the input array, an empty LineString will be returned.
-    Throws an exception if any element in the array is `null` or empty or same as the previous one.
-    The returned geometry may not be simple, e.g. may self-intersect or may contain
-    duplicate vertexes depending on the input.
+    Returns a LineString formed from an array of points. If there are fewer
+    than two non-empty points in the input array, an empty LineString will be
+    returned.  Throws an exception if any element in the array is `null` or
+    empty or same as the previous one.  The returned geometry may not be
+    simple, e.g. may self-intersect or may contain duplicate vertexes depending
+    on the input.
 
 .. function:: ST_MultiPoint(array(Point)) -> MultiPoint
 
-    Returns a MultiPoint geometry object formed from the specified points. Return `null` if input array is empty.
-    Throws an exception if any element in the array is `null` or empty.
-    The returned geometry may not be simple and may contain duplicate points if input array has duplicates.
+    Returns a MultiPoint geometry object formed from the specified points.
+    Return `null` if input array is empty.  Throws an exception if any element
+    in the array is `null` or empty.  The returned geometry may not be simple
+    and may contain duplicate points if input array has duplicates.
 
 .. function:: ST_Point(double, double) -> Point
 
@@ -88,10 +107,14 @@ Constructors
 
 .. function:: to_spherical_geography(Geometry) -> SphericalGeography
 
-    Converts a Geometry object to a SphericalGeography object on the sphere of the Earth's radius. This function is only applicable to ``POINT``,
-    ``MULTIPOINT``, ``LINESTRING``, ``MULTILINESTRING``, ``POLYGON``, ``MULTIPOLYGON`` geometries defined in 2D space, or ``GEOMETRYCOLLECTION``
-    of such geometries. For each point of the input geometry, it verifies that point.x is within [-180.0, 180.0] and point.y is within [-90.0, 90.0],
-    and uses them as (longitude, latitude) degrees to construct the shape of the SphericalGeography result.
+    Converts a Geometry object to a SphericalGeography object on the sphere of
+    the Earth's radius. This function is only applicable to ``POINT``,
+    ``MULTIPOINT``, ``LINESTRING``, ``MULTILINESTRING``, ``POLYGON``,
+    ``MULTIPOLYGON`` geometries defined in 2D space, or ``GEOMETRYCOLLECTION``
+    of such geometries. For each point of the input geometry, it verifies that
+    point.x is within [-180.0, 180.0] and point.y is within [-90.0, 90.0], and
+    uses them as (longitude, latitude) degrees to construct the shape of the
+    SphericalGeography result.
 
 .. function:: to_geometry(SphericalGeography) -> Geometry
 
@@ -102,18 +125,19 @@ Relationship Tests
 
 .. function:: ST_Contains(Geometry, Geometry) -> boolean
 
-    Returns ``true`` if and only if no points of the second geometry lie in the exterior
-    of the first geometry, and at least one point of the interior of the first geometry
-    lies in the interior of the second geometry.
+    Returns ``true`` if and only if no points of the second geometry lie in the
+    exterior of the first geometry, and at least one point of the interior of
+    the first geometry lies in the interior of the second geometry.
 
 .. function:: ST_Crosses(Geometry, Geometry) -> boolean
 
-    Returns ``true`` if the supplied geometries have some, but not all, interior points in common.
+    Returns ``true`` if the supplied geometries have some, but not all,
+    interior points in common.
 
 .. function:: ST_Disjoint(Geometry, Geometry) -> boolean
 
-    Returns ``true`` if the give geometries do not *spatially intersect* --
-    if they do not share any space together.
+    Returns ``true`` if the give geometries do not *spatially intersect* -- if
+    they do not share any space together.
 
 .. function:: ST_Equals(Geometry, Geometry) -> boolean
 
@@ -121,13 +145,14 @@ Relationship Tests
 
 .. function:: ST_Intersects(Geometry, Geometry) -> boolean
 
-    Returns ``true`` if the given geometries spatially intersect in two dimensions
-    (share any portion of space) and ``false`` if they do not (they are disjoint).
+    Returns ``true`` if the given geometries spatially intersect in two
+    dimensions (share any portion of space) and ``false`` if they do not (they
+    are disjoint).
 
 .. function:: ST_Overlaps(Geometry, Geometry) -> boolean
 
-    Returns ``true`` if the given geometries share space, are of the same dimension,
-    but are not completely contained by each other.
+    Returns ``true`` if the given geometries share space, are of the same
+    dimension, but are not completely contained by each other.
 
 .. function:: ST_Relate(Geometry, Geometry) -> boolean
 
@@ -147,9 +172,11 @@ Operations
 
 .. function:: geometry_union(array(Geometry)) -> Geometry
 
-    Returns a geometry that represents the point set union of the input geometries. Performance
-    of this function, in conjunction with :func:`array_agg` to first aggregate the input geometries,
-    may be better than :func:`geometry_union_agg`, at the expense of higher memory utilization.
+    Returns a geometry that represents the point set union of the input
+    geometries. Performance of this function, in conjunction with
+    :func:`array_agg` to first aggregate the input geometries, may be better
+    than :func:`geometry_union_agg`, at the expense of higher memory
+    utilization.
 
 .. function:: ST_Boundary(Geometry) -> Geometry
 
@@ -157,12 +184,13 @@ Operations
 
 .. function:: ST_Buffer(Geometry, distance) -> Geometry
 
-    Returns the geometry that represents all points whose distance from the specified geometry
-    is less than or equal to the specified distance.
+    Returns the geometry that represents all points whose distance from the
+    specified geometry is less than or equal to the specified distance.
 
 .. function:: ST_Difference(Geometry, Geometry) -> Geometry
 
-    Returns the geometry value that represents the point set difference of the given geometries.
+    Returns the geometry value that represents the point set difference of the
+    given geometries.
 
 .. function:: ST_Envelope(Geometry) -> Geometry
 
@@ -170,8 +198,9 @@ Operations
 
 .. function:: ST_EnvelopeAsPts(Geometry) -> array(Geometry)
 
-    Returns an array of two points: the lower left and upper right corners of the bounding
-    rectangular polygon of a geometry. Returns null if input geometry is empty.
+    Returns an array of two points: the lower left and upper right corners of
+    the bounding rectangular polygon of a geometry. Returns null if input
+    geometry is empty.
 
 .. function:: ST_ExteriorRing(Geometry) -> Geometry
 
@@ -179,15 +208,18 @@ Operations
 
 .. function:: ST_Intersection(Geometry, Geometry) -> Geometry
 
-    Returns the geometry value that represents the point set intersection of two geometries.
+    Returns the geometry value that represents the point set intersection of
+    two geometries.
 
 .. function:: ST_SymDifference(Geometry, Geometry) -> Geometry
 
-    Returns the geometry value that represents the point set symmetric difference of two geometries.
+    Returns the geometry value that represents the point set symmetric
+    difference of two geometries.
 
 .. function:: ST_Union(Geometry, Geometry) -> Geometry
 
-    Returns a geometry that represents the point set union of the input geometries.
+    Returns a geometry that represents the point set union of the input
+    geometries.
 
     See also:  :func:`geometry_union`, :func:`geometry_union_agg`
 

--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -87,7 +87,7 @@ Constructors
 
     Returns a LineString formed from an array of points. If there are fewer
     than two non-empty points in the input array, an empty LineString will be
-    returned.  Throws an exception if any element in the array is `null` or
+    returned.  Throws an exception if any element in the array is ``null`` or
     empty or same as the previous one.  The returned geometry may not be
     simple, e.g. may self-intersect or may contain duplicate vertexes depending
     on the input.
@@ -95,8 +95,8 @@ Constructors
 .. function:: ST_MultiPoint(array(Point)) -> MultiPoint
 
     Returns a MultiPoint geometry object formed from the specified points.
-    Return `null` if input array is empty.  Throws an exception if any element
-    in the array is `null` or empty.  The returned geometry may not be simple
+    Return ``null`` if input array is empty.  Throws an exception if any element
+    in the array is ``null`` or empty.  The returned geometry may not be simple
     and may contain duplicate points if input array has duplicates.
 
 .. function:: ST_Point(x, y) -> Point
@@ -201,7 +201,7 @@ Operations
 .. function:: ST_EnvelopeAsPts(Geometry) -> array(Geometry)
 
     Returns an array of two points: the lower left and upper right corners of
-    the bounding rectangular polygon of a geometry. Returns null if input
+    the bounding rectangular polygon of a geometry. Returns ``null`` if input
     geometry is empty.
 
 .. function:: ST_ExteriorRing(Geometry) -> Geometry
@@ -365,7 +365,7 @@ Accessors
 .. function:: ST_InteriorRings(Geometry) -> Geometry
 
    Returns an array of all interior rings found in the input geometry, or an empty
-   array if the polygon has no interior rings. Returns null if the input geometry
+   array if the polygon has no interior rings. Returns ``null`` if the input geometry
    is empty. Throws an error if the input geometry is not a polygon.
 
 .. function:: ST_NumGeometries(Geometry) -> bigint
@@ -379,7 +379,7 @@ Accessors
 .. function:: ST_Geometries(Geometry) -> Geometry
 
    Returns an array of geometries in the specified collection. Returns a one-element array
-   if the input geometry is not a multi-geometry. Returns null if input geometry is empty.
+   if the input geometry is not a multi-geometry. Returns ``null`` if input geometry is empty.
 
 .. function:: ST_NumPoints(Geometry) -> bigint
 

--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -22,7 +22,9 @@ Binary (WKB) form of spatial objects:
 * ``GEOMETRYCOLLECTION (POINT(2 3), LINESTRING (2 3, 3 4))``
 
 Use ST_GeometryFromText and ST_GeomFromBinary functions to create geometry
-objects from WKT or WKB.
+objects from WKT or WKB.  In WKT/WKB, the coordinate order is ``(x, y)``.
+For spherical/geospatial uses, this implies ``(longitude, latitude)`` instead
+of ``(latitude, longitude)``.
 
 The SphericalGeography type provides native support for spatial features
 represented on "geographic" coordinates (sometimes called "geodetic"
@@ -97,7 +99,7 @@ Constructors
     in the array is `null` or empty.  The returned geometry may not be simple
     and may contain duplicate points if input array has duplicates.
 
-.. function:: ST_Point(double, double) -> Point
+.. function:: ST_Point(x, y) -> Point
 
     Returns a geometry type point object with the given coordinate values.
 
@@ -398,7 +400,7 @@ Accessors
 .. function:: geometry_invalid_reason(Geometry) -> varchar
 
     Returns the reason for why the input geometry is not valid.
-    Returns null if the input is valid.
+    Returns ``null`` if the input is valid.
 
 .. function:: great_circle_distance(latitude1, longitude1, latitude2, longitude2) -> double
 
@@ -418,7 +420,8 @@ Bing Tiles
 ----------
 
 These functions convert between geometries and
-`Bing tiles <https://msdn.microsoft.com/en-us/library/bb259689.aspx>`_.
+`Bing tiles <https://msdn.microsoft.com/en-us/library/bb259689.aspx>`_.  For
+Bing tiles, ``x`` and ``y`` refer to ``tile_x`` and ``tile_y``.
 
 .. function:: bing_tile(x, y, zoom_level) -> BingTile
 


### PR DESCRIPTION
ST_Point signature is `double, double`, which is not clear whether that
should be `latitude, longitude` or `longitude, latitude`.  This message
clarifies that.

cc @mbasmanova 