### PR TITLE
Make Geometry values comparable

### DIFF
--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoPlugin.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoPlugin.java
@@ -41,6 +41,7 @@ public class GeoPlugin
     public Set<Class<?>> getFunctions()
     {
         return ImmutableSet.<Class<?>>builder()
+                .add(GeometryOperators.class)
                 .add(GeoFunctions.class)
                 .add(BingTileOperators.class)
                 .add(BingTileFunctions.class)

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeometryOperators.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeometryOperators.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial;
+
+import com.facebook.presto.spi.function.IsNull;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
+
+import static com.facebook.presto.geospatial.serde.GeometrySerde.deserialize;
+import static com.facebook.presto.plugin.geospatial.GeometryType.GEOMETRY_TYPE_NAME;
+import static com.facebook.presto.spi.function.OperatorType.EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.HASH_CODE;
+import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+
+public final class GeometryOperators
+{
+    private GeometryOperators() {}
+
+    @ScalarOperator(EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean equal(@SqlType(GEOMETRY_TYPE_NAME) Slice left, @SqlType(GEOMETRY_TYPE_NAME) Slice right)
+    {
+        return deserialize(left).Equals(deserialize(right));
+    }
+
+    @ScalarOperator(NOT_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean notEqual(@SqlType(GEOMETRY_TYPE_NAME) Slice left, @SqlType(GEOMETRY_TYPE_NAME) Slice right)
+    {
+        return !equal(left, right);
+    }
+
+    @ScalarOperator(IS_DISTINCT_FROM)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean isDistinctFrom(
+            @SqlType(GEOMETRY_TYPE_NAME) Slice left,
+            @IsNull boolean leftNull,
+            @SqlType(GEOMETRY_TYPE_NAME) Slice right,
+            @IsNull boolean rightNull)
+    {
+        if (leftNull != rightNull) {
+            return true;
+        }
+        if (leftNull) {
+            return false;
+        }
+        return notEqual(left, right);
+    }
+
+    @ScalarOperator(HASH_CODE)
+    @SqlType(StandardTypes.BIGINT)
+    public static long hashCode(@SqlType(GEOMETRY_TYPE_NAME) Slice slice)
+    {
+        return XxHash64.hash(deserialize(slice).hashCode());
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/AbstractTestSpatialQueries.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/AbstractTestSpatialQueries.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.hive.HdfsConfiguration;
+import com.facebook.presto.hive.HdfsConfigurationUpdater;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveHdfsConfiguration;
+import com.facebook.presto.hive.HivePlugin;
+import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
+import com.facebook.presto.hive.metastore.Database;
+import com.facebook.presto.hive.metastore.PrincipalType;
+import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+
+import java.io.File;
+import java.util.Optional;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public abstract class AbstractTestSpatialQueries
+        extends AbstractTestQueryFramework
+{
+    protected AbstractTestSpatialQueries()
+    {
+        super(() -> createQueryRunner());
+    }
+
+    private static DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setSource(TestSpatialJoins.class.getSimpleName())
+                .setCatalog("hive")
+                .setSchema("default")
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                .setNodeCount(4)
+                .build();
+        queryRunner.installPlugin(new GeoPlugin());
+
+        File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toFile();
+
+        HiveClientConfig hiveClientConfig = new HiveClientConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationUpdater(hiveClientConfig));
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveClientConfig, new NoHdfsAuthentication());
+
+        FileHiveMetastore metastore = new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
+        metastore.createDatabase(Database.builder()
+                .setDatabaseName("default")
+                .setOwnerName("public")
+                .setOwnerType(PrincipalType.ROLE)
+                .build());
+        queryRunner.installPlugin(new HivePlugin("hive", Optional.of(metastore)));
+
+        queryRunner.createCatalog("hive", "hive");
+        return queryRunner;
+    }
+}

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialQueries.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialQueries.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.geospatial;
+
+import org.testng.annotations.Test;
+
+public class TestSpatialQueries
+        extends AbstractTestSpatialQueries
+{
+    @Test
+    public void testUnionAll()
+    {
+        assertQuery("SELECT ST_AsText(point) FROM (" +
+                "SELECT * FROM (VALUES (ST_Point(1, 2)), (ST_Point(3, 4))) as t(point) " +
+                "   UNION ALL " +
+                "SELECT * FROM (VALUES (ST_Point(3, 4)), (ST_Point(5, 6))) as t(point) " +
+                ")",
+                "SELECT * FROM (VALUES ('POINT (1 2)'), ('POINT (3 4)'), ('POINT (3 4)'), ('POINT (5 6)'))");
+    }
+
+    @Test
+    public void testUnion()
+    {
+        assertQuery("SELECT ST_AsText(point) FROM (" +
+                        "SELECT * FROM (VALUES (ST_Point(1, 2)), (ST_Point(3, 4))) as t(point) " +
+                        "   UNION " +
+                        "SELECT * FROM (VALUES (ST_Point(3, 4)), (ST_Point(5, 6))) as t(point) " +
+                        ")",
+                "SELECT * FROM (VALUES ('POINT (1 2)'), ('POINT (3 4)'), ('POINT (5 6)'))");
+    }
+
+    @Test
+    public void testAggregation()
+    {
+        assertQuery("SELECT ST_AsText(point), COUNT(*) " +
+                "FROM (VALUES (ST_Point(1, 2)), (ST_Point(3, 4)), (ST_Point(3, 4)), (ST_Point(5, 6))) as t(point) " +
+                "GROUP BY 1",
+                "SELECT * FROM (VALUES ('POINT (1 2)', 1), ('POINT (3 4)', 2), ('POINT (5 6)', 1))");
+    }
+}


### PR DESCRIPTION
Fixes #12340 and allows to apply UNION ALL to datasets with Geometry columns. Also, allows GROUP BY for Geometry columns.