### PR TITLE
Fix exception created and dropped rather than thrown

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -207,7 +207,7 @@ public class SqlTaskManager
                 queryContexts.getUnchecked(assignment.getQueryId()).setMemoryPool(reservedPool);
             }
             else {
-                new IllegalArgumentException(format("Cannot move %s to %s as the target memory pool id is invalid", assignment.getQueryId(), assignment.getPoolId()));
+                throw new IllegalArgumentException(format("Cannot move %s to %s as the target memory pool id is invalid", assignment.getQueryId(), assignment.getPoolId()));
             }
         }
     }


### PR DESCRIPTION
FindBugs-3.0.1 ([http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)) reported an RV_EXCEPTION_NOT_THROWN warning on master:
```
RV_EXCEPTION_NOT_THROWN: new IllegalArgumentException(String) not thrown in com.facebook.presto.execution.SqlTaskManager.updateMemoryPoolAssignments(MemoryPoolAssignmentsRequest) At SqlTaskManager.java:[line 210]
```
The description of this bug is as follows:
> RV: Exception created and dropped rather than thrown (RV_EXCEPTION_NOT_THROWN)
> This code creates an exception (or error) object, but doesn't do anything with it. For example, something like
> ```
> if (x < 0)
>   new IllegalArgumentException("x must be nonnegative");
> ```
> It was probably the intent of the programmer to throw the created exception:
> ```
> if (x < 0)
>   throw new IllegalArgumentException("x must be nonnegative”);
> ```
 [http://findbugs.sourceforge.net/bugDescriptions.html#RV_EXCEPTION_NOT_THROWN](http://findbugs.sourceforge.net/bugDescriptions.html#RV_EXCEPTION_NOT_THROWN)