### PR TITLE
Fix check for oddness that won't work for negative numbers

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/FormatUtils.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/FormatUtils.java
@@ -176,7 +176,7 @@ public final class FormatUtils
         int range = width - markerWidth; // "lower" must fall within this range for the marker to fit within the bar
         int lower = tick % range;
 
-        if (((tick / range) % 2) == 1) { // are we going or coming back?
+        if (((tick / range) % 2) != 0) { // are we going or coming back?
             lower = range - lower;
         }
 


### PR DESCRIPTION
FindBugs-3.0.1 ([http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)) reported an IM_BAD_CHECK_FOR_ODD warning on master:
```
IM_BAD_CHECK_FOR_ODD: Check for oddness that won't work for negative numbers in com.facebook.presto.cli.FormatUtils.formatProgressBar(int, int) At FormatUtils.java:[line 179]
```
The description of this bug is as follows:
> IM: Check for oddness that won't work for negative numbers (IM_BAD_CHECK_FOR_ODD)
> The code uses `x % 2 == 1` to check to see if a value is odd, but this won't work for negative numbers (e.g., `(-5) % 2 == -1`). If this code is intending to check for oddness, consider using `x & 1 == 1`, or `x % 2 != 0`.
 [http://findbugs.sourceforge.net/bugDescriptions.html#IM_BAD_CHECK_FOR_ODD](http://findbugs.sourceforge.net/bugDescriptions.html#IM_BAD_CHECK_FOR_ODD)