### PR TITLE
Fix int value cast to float and then passed to Math.round

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/BackupStats.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/BackupStats.java
@@ -39,7 +39,7 @@ public class BackupStats
     public void addCopyShardDataRate(DataSize size, Duration duration)
     {
         DataSize rate = dataRate(size, duration).convertToMostSuccinctDataSize();
-        copyToBackupBytesPerSecond.add(Math.round(rate.toBytes()));
+        copyToBackupBytesPerSecond.add(rate.toBytes());
         copyToBackupShardSizeBytes.add(size.toBytes());
         copyToBackupTimeInMilliSeconds.add(duration.toMillis());
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardRecoveryStats.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardRecoveryStats.java
@@ -65,7 +65,7 @@ public class ShardRecoveryStats
 
     public void addShardRecoveryDataRate(DataSize rate, DataSize size, Duration duration)
     {
-        shardRecoveryBytesPerSecond.add(Math.round(rate.toBytes()));
+        shardRecoveryBytesPerSecond.add(rate.toBytes());
         shardRecoveryShardSizeBytes.add(size.toBytes());
         shardRecoveryTimeInMilliSeconds.add(duration.toMillis());
     }


### PR DESCRIPTION
FindBugs-3.0.1 ([http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)) reported two ICAST_INT_CAST_TO_FLOAT_PASSED_TO_ROUND warnings on master:
```
ICAST_INT_CAST_TO_FLOAT_PASSED_TO_ROUND: int value cast to float and then passed to Math.round in com.facebook.presto.raptor.storage.BackupStats.addCopyShardDataRate(DataSize, Duration) At BackupStats.java:[line 42]
ICAST_INT_CAST_TO_FLOAT_PASSED_TO_ROUND: int value cast to float and then passed to Math.round in com.facebook.presto.raptor.storage.ShardRecoveryStats.addShardRecoveryDataRate(DataSize, DataSize, Duration) At ShardRecoveryStats.java:[line 68]
```
The description of this bug is as follows:
> ICAST: int value cast to float and then passed to Math.round (ICAST_INT_CAST_TO_FLOAT_PASSED_TO_ROUND)
> This code converts an int value to a float precision floating point number and then passing the result to the Math.round() function, which returns the int/long closest to the argument. This operation should always be a no-op, since the converting an integer to a float should give a number with no fractional part. It is likely that the operation that generated the value to be passed to Math.round was intended to be performed using floating point arithmetic.
[http://findbugs.sourceforge.net/bugDescriptions.html#ICAST_INT_CAST_TO_FLOAT_PASSED_TO_ROUND](http://findbugs.sourceforge.net/bugDescriptions.html#ICAST_INT_CAST_TO_FLOAT_PASSED_TO_ROUND)