### PR TITLE
Propagate partition properties for full outer join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -396,7 +396,7 @@ public class LocalExecutionPlanner
                         if (argument.isConstant()) {
                             return -1;
                         }
-                        return outputLayout.indexOf(argument.getColumn());
+                        return outputLayout.indexOf(argument.getSymbol());
                     })
                     .collect(toImmutableList());
             partitionConstants = partitioningScheme.getPartitioning().getArguments().stream()
@@ -412,7 +412,7 @@ public class LocalExecutionPlanner
                         if (argument.isConstant()) {
                             return argument.getConstant().getType();
                         }
-                        return types.get(argument.getColumn());
+                        return types.get(argument.getSymbol());
                     })
                     .collect(toImmutableList());
         }
@@ -2441,7 +2441,7 @@ public class LocalExecutionPlanner
 
             List<Type> types = getSourceOperatorTypes(node, context.getTypes());
             List<Integer> channels = node.getPartitioningScheme().getPartitioning().getArguments().stream()
-                    .map(argument -> node.getOutputSymbols().indexOf(argument.getColumn()))
+                    .map(argument -> node.getOutputSymbols().indexOf(argument.getSymbol()))
                     .collect(toImmutableList());
             Optional<Integer> hashChannel = node.getPartitioningScheme().getHashColumn()
                     .map(symbol -> node.getOutputSymbols().indexOf(symbol));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
@@ -16,6 +16,8 @@ package com.facebook.presto.sql.planner;
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.predicate.NullableValue;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.SymbolReference;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -32,6 +34,7 @@ import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
@@ -51,7 +54,15 @@ public final class Partitioning
     public static Partitioning create(PartitioningHandle handle, List<Symbol> columns)
     {
         return new Partitioning(handle, columns.stream()
-                .map(ArgumentBinding::columnBinding)
+                .map(Symbol::toSymbolReference)
+                .map(ArgumentBinding::expressionBinding)
+                .collect(toImmutableList()));
+    }
+
+    public static Partitioning createWithExpressions(PartitioningHandle handle, List<Expression> expressions)
+    {
+        return new Partitioning(handle, expressions.stream()
+                .map(ArgumentBinding::expressionBinding)
                 .collect(toImmutableList()));
     }
 
@@ -160,13 +171,20 @@ public final class Partitioning
 
     public boolean isPartitionedOn(Collection<Symbol> columns, Set<Symbol> knownConstants)
     {
-        // partitioned on (k_1, k_2, ..., k_n) => partitioned on (k_1, k_2, ..., k_n, k_n+1, ...)
-        // can safely ignore all constant columns when comparing partition properties
-        return arguments.stream()
-                .filter(ArgumentBinding::isVariable)
-                .map(ArgumentBinding::getColumn)
-                .filter(symbol -> !knownConstants.contains(symbol))
-                .allMatch(columns::contains);
+        for (ArgumentBinding argument : arguments) {
+            // partitioned on (k_1, k_2, ..., k_n) => partitioned on (k_1, k_2, ..., k_n, k_n+1, ...)
+            // can safely ignore all constant columns when comparing partition properties
+            if (argument.isConstant()) {
+                continue;
+            }
+            if (!argument.isVariable()) {
+                return false;
+            }
+            if (!knownConstants.contains(argument.getColumn()) && !columns.contains(argument.getColumn())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public boolean isEffectivelySinglePartition(Set<Symbol> knownConstants)
@@ -194,11 +212,11 @@ public final class Partitioning
                 .collect(toImmutableList()));
     }
 
-    public Optional<Partitioning> translate(Function<Symbol, Optional<Symbol>> translator, Function<Symbol, Optional<NullableValue>> constants)
+    public Optional<Partitioning> translate(Translator translator)
     {
         ImmutableList.Builder<ArgumentBinding> newArguments = ImmutableList.builder();
         for (ArgumentBinding argument : arguments) {
-            Optional<ArgumentBinding> newArgument = argument.translate(translator, constants);
+            Optional<ArgumentBinding> newArgument = argument.translate(translator);
             if (!newArgument.isPresent()) {
                 return Optional.empty();
             }
@@ -243,24 +261,42 @@ public final class Partitioning
     }
 
     @Immutable
+    public static final class Translator
+    {
+        private final Function<Symbol, Optional<Symbol>> columnTranslator;
+        private final Function<Symbol, Optional<NullableValue>> constantTranslator;
+        private final Function<Expression, Optional<Symbol>> expressionTranslator;
+
+        public Translator(
+                Function<Symbol, Optional<Symbol>> columnTranslator,
+                Function<Symbol, Optional<NullableValue>> constantTranslator,
+                Function<Expression, Optional<Symbol>> expressionTranslator)
+        {
+            this.columnTranslator = requireNonNull(columnTranslator, "columnTranslator is null");
+            this.constantTranslator = requireNonNull(constantTranslator, "constantTranslator is null");
+            this.expressionTranslator = requireNonNull(expressionTranslator, "expressionTranslator is null");
+        }
+    }
+
+    @Immutable
     public static final class ArgumentBinding
     {
-        private final Symbol column;
+        private final Expression expression;
         private final NullableValue constant;
 
         @JsonCreator
         public ArgumentBinding(
-                @JsonProperty("column") Symbol column,
+                @JsonProperty("expression") Expression expression,
                 @JsonProperty("constant") NullableValue constant)
         {
-            this.column = column;
+            this.expression = expression;
             this.constant = constant;
-            checkArgument((column == null) != (constant == null), "Either column or constant must be set");
+            checkArgument((expression == null) != (constant == null), "Either expression or constant must be set");
         }
 
-        public static ArgumentBinding columnBinding(Symbol column)
+        public static ArgumentBinding expressionBinding(Expression expression)
         {
-            return new ArgumentBinding(requireNonNull(column, "column is null"), null);
+            return new ArgumentBinding(requireNonNull(expression, "expression is null"), null);
         }
 
         public static ArgumentBinding constantBinding(NullableValue constant)
@@ -275,13 +311,19 @@ public final class Partitioning
 
         public boolean isVariable()
         {
-            return column != null;
+            return expression instanceof SymbolReference;
+        }
+
+        public Symbol getColumn()
+        {
+            verify(expression instanceof SymbolReference, "Expect the expression to be a SymbolReference");
+            return Symbol.from(expression);
         }
 
         @JsonProperty
-        public Symbol getColumn()
+        public Expression getExpression()
         {
-            return column;
+            return expression;
         }
 
         @JsonProperty
@@ -295,25 +337,31 @@ public final class Partitioning
             if (isConstant()) {
                 return this;
             }
-            return columnBinding(translator.apply(column));
+            return expressionBinding(translator.apply(Symbol.from(expression)).toSymbolReference());
         }
 
-        public Optional<ArgumentBinding> translate(Function<Symbol, Optional<Symbol>> translator, Function<Symbol, Optional<NullableValue>> constants)
+        public Optional<ArgumentBinding> translate(Translator translator)
         {
             if (isConstant()) {
                 return Optional.of(this);
             }
 
-            Optional<ArgumentBinding> newColumn = translator.apply(column)
-                    .map(ArgumentBinding::columnBinding);
+            if (!isVariable()) {
+                return translator.expressionTranslator.apply(expression)
+                        .map(Symbol::toSymbolReference)
+                        .map(ArgumentBinding::expressionBinding);
+            }
+
+            Optional<ArgumentBinding> newColumn = translator.columnTranslator.apply(Symbol.from(expression))
+                    .map(Symbol::toSymbolReference)
+                    .map(ArgumentBinding::expressionBinding);
             if (newColumn.isPresent()) {
                 return newColumn;
             }
-
             // As a last resort, check for a constant mapping for the symbol
             // Note: this MUST be last because we want to favor the symbol representation
             // as it makes further optimizations possible.
-            return constants.apply(column)
+            return translator.constantTranslator.apply(Symbol.from(expression))
                     .map(ArgumentBinding::constantBinding);
         }
 
@@ -323,7 +371,8 @@ public final class Partitioning
             if (constant != null) {
                 return constant.toString();
             }
-            return "\"" + column + "\"";
+
+            return expression.toString();
         }
 
         @Override
@@ -336,14 +385,14 @@ public final class Partitioning
                 return false;
             }
             ArgumentBinding that = (ArgumentBinding) o;
-            return Objects.equals(column, that.column) &&
+            return Objects.equals(expression, that.expression) &&
                     Objects.equals(constant, that.constant);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(column, constant);
+            return Objects.hash(expression, constant);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -119,8 +119,8 @@ public class PushPartialAggregationThroughExchange
                     .getPartitioning()
                     .getArguments()
                     .stream()
-                    .filter(Partitioning.ArgumentBinding::isVariable)
-                    .map(Partitioning.ArgumentBinding::getColumn)
+                    .filter(Partitioning.ArgumentBinding::isSymbolReference)
+                    .map(Partitioning.ArgumentBinding::getSymbol)
                     .collect(Collectors.toList());
 
             if (!aggregationNode.getGroupingKeys().containsAll(partitioningColumns)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -490,10 +490,10 @@ public class HashGenerationOptimizer
             Optional<HashComputation> partitionSymbols = Optional.empty();
             PartitioningScheme partitioningScheme = node.getPartitioningScheme();
             if (partitioningScheme.getPartitioning().getHandle().equals(FIXED_HASH_DISTRIBUTION) &&
-                    partitioningScheme.getPartitioning().getArguments().stream().allMatch(ArgumentBinding::isVariable)) {
+                    partitioningScheme.getPartitioning().getArguments().stream().allMatch(ArgumentBinding::isSymbolReference)) {
                 // add precomputed hash for exchange
                 partitionSymbols = computeHash(partitioningScheme.getPartitioning().getArguments().stream()
-                        .map(ArgumentBinding::getColumn)
+                        .map(ArgumentBinding::getSymbol)
                         .collect(toImmutableList()));
                 preference = preference.withHashComputation(partitionSymbols);
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PreferredProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PreferredProperties.java
@@ -391,7 +391,7 @@ class PreferredProperties
                 return Optional.of(new PartitioningProperties(newPartitioningColumns, Optional.empty(), nullsAndAnyReplicated));
             }
 
-            Optional<Partitioning> newPartitioning = partitioning.get().translate(translator, symbol -> Optional.empty());
+            Optional<Partitioning> newPartitioning = partitioning.get().translate(new Partitioning.Translator(translator, symbol -> Optional.empty(), coalesceSymbols -> Optional.empty()));
             if (!newPartitioning.isPresent()) {
                 return Optional.empty();
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -31,6 +31,7 @@ import com.facebook.presto.sql.planner.DomainTranslator;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.NoOpSymbolResolver;
 import com.facebook.presto.sql.planner.OrderingScheme;
+import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.optimizations.ActualProperties.Global;
@@ -68,6 +69,7 @@ import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.UnnestNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.SymbolReference;
@@ -431,8 +433,22 @@ public class PropertyDerivations
                             .unordered(unordered)
                             .build();
                 case FULL:
-                    // We can't say anything about the partitioning scheme because any partition of
-                    // a hash-partitioned join can produce nulls in case of a lack of matches
+                    if (probeProperties.getNodePartitioning().isPresent()) {
+                        Partitioning nodePartitioning = probeProperties.getNodePartitioning().get();
+                        ImmutableList.Builder<Expression> coalesceExpressions = ImmutableList.builder();
+                        for (Symbol column : nodePartitioning.getColumns()) {
+                            for (JoinNode.EquiJoinClause equality : node.getCriteria()) {
+                                if (equality.getLeft().equals(column) || equality.getRight().equals(column)) {
+                                    coalesceExpressions.add(new CoalesceExpression(ImmutableList.of(equality.getLeft().toSymbolReference(), equality.getRight().toSymbolReference())));
+                                }
+                            }
+                        }
+
+                        return ActualProperties.builder()
+                                .global(partitionedOn(Partitioning.createWithExpressions(nodePartitioning.getHandle(), coalesceExpressions.build()), Optional.empty()))
+                                .unordered(unordered)
+                                .build();
+                    }
                     return ActualProperties.builder()
                             .global(probeProperties.isSingleNode() ? singleStreamPartition() : arbitraryPartition())
                             .unordered(unordered)
@@ -615,7 +631,7 @@ public class PropertyDerivations
 
             Map<Symbol, Symbol> identities = computeIdentityTranslations(node.getAssignments().getMap());
 
-            ActualProperties translatedProperties = properties.translate(column -> Optional.ofNullable(identities.get(column)));
+            ActualProperties translatedProperties = properties.translate(column -> Optional.ofNullable(identities.get(column)), expression -> rewriteExpression(node.getAssignments().getMap(), expression));
 
             // Extract additional constants
             Map<Symbol, NullableValue> constants = new HashMap<>();
@@ -831,6 +847,29 @@ public class PropertyDerivations
             }
         }
 
+        return Optional.empty();
+    }
+
+    private static Optional<Symbol> rewriteExpression(Map<Symbol, Expression> assignments, Expression expression)
+    {
+        checkArgument(expression instanceof CoalesceExpression, "The rewrite can only handle CoalesceExpression");
+        Set<Expression> expressionOperands = ImmutableSet.copyOf(((CoalesceExpression) expression).getOperands());
+        checkArgument(expressionOperands.stream().allMatch(SymbolReference.class::isInstance), "Expect operands of CoalesceExpression to be SymbolReference");
+        // We are using the property that the result of coalesce from full outer join keys would not be null despite of the order
+        // of the arguments. Thus we extract and compare the symbols of the CoalesceExpression as a set rather than compare the
+        // CoalesceExpression directly.
+        for (Map.Entry<Symbol, Expression> entry : assignments.entrySet()) {
+            if (entry.getValue() instanceof CoalesceExpression) {
+                Set<Expression> assignmentOperands = ImmutableSet.copyOf(((CoalesceExpression) entry.getValue()).getOperands());
+                if (!assignmentOperands.stream().allMatch(SymbolReference.class::isInstance)) {
+                    return Optional.empty();
+                }
+
+                if (assignmentOperands.equals(expressionOperands)) {
+                    return Optional.of(entry.getKey());
+                }
+            }
+        }
         return Optional.empty();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -314,7 +314,7 @@ public final class StreamPropertyDerivations
                     return new StreamProperties(
                             FIXED,
                             Optional.of(node.getPartitioningScheme().getPartitioning().getArguments().stream()
-                                    .map(ArgumentBinding::getColumn)
+                                    .map(ArgumentBinding::getSymbol)
                                     .collect(toImmutableList())), false);
                 case REPLICATE:
                     return new StreamProperties(MULTIPLE, Optional.empty(), false);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
@@ -95,7 +95,7 @@ public class ExchangeNode
             checkArgument(ImmutableSet.copyOf(sources.get(i).getOutputSymbols()).containsAll(inputs.get(i)), "Source does not supply all required input symbols");
         }
 
-        checkArgument(scope != LOCAL || partitioningScheme.getPartitioning().getArguments().stream().allMatch(ArgumentBinding::isVariable),
+        checkArgument(scope != LOCAL || partitioningScheme.getPartitioning().getArguments().stream().allMatch(ArgumentBinding::isSymbolReference),
                 "local exchanges do not support constant partition function arguments");
 
         checkArgument(scope != REMOTE || type == Type.REPARTITION || !partitioningScheme.isReplicateNullsAndAny(), "Only REPARTITION can replicate remotely");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -284,7 +284,7 @@ public class PlanPrinter
                         String printableValue = castToVarchar(constant.getType(), constant.getValue(), functionRegistry, session);
                         return constant.getType().getDisplayName() + "(" + printableValue + ")";
                     }
-                    return argument.getColumn().toString();
+                    return argument.getSymbol().toString();
                 })
                 .collect(toImmutableList());
         builder.append(indentString(1));

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -319,7 +319,8 @@ public final class GraphvizPrinter
         public Void visitExchange(ExchangeNode node, Void context)
         {
             List<ArgumentBinding> symbols = node.getOutputSymbols().stream()
-                    .map(ArgumentBinding::columnBinding)
+                    .map(Symbol::toSymbolReference)
+                    .map(ArgumentBinding::expressionBinding)
                     .collect(toImmutableList());
             if (node.getType() == REPARTITION) {
                 symbols = node.getPartitioningScheme().getPartitioning().getArguments();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestFullOuterJoinWithCoalesce.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestFullOuterJoinWithCoalesce.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.AggregationNode.Step.PARTIAL;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
+
+public class TestFullOuterJoinWithCoalesce
+        extends BasePlanTest
+{
+    @Test
+    public void testFullOuterJoinWithCoalesce()
+    {
+        assertDistributedPlan("SELECT coalesce(r.a, ts.a) " +
+                "FROM (" +
+                "   SELECT coalesce(t.a, s.a) AS a " +
+                "   FROM (VALUES (1), (2), (3)) t(a) " +
+                "   FULL OUTER JOIN (VALUES (1), (4)) s(a)" +
+                "   ON t.a = s.a) ts " +
+                "FULL OUTER JOIN (VALUES (2), (5)) r(a) " +
+                "ON ts.a = r.a",
+                anyTree(
+                        project(
+                                ImmutableMap.of("expr", expression("coalesce(r, ts)")),
+                                join(
+                                        FULL,
+                                        ImmutableList.of(equiJoinClause("ts", "r")),
+                                        project(
+                                                project(
+                                                        ImmutableMap.of("ts", expression("coalesce(t, s)")),
+                                                        join(
+                                                                FULL,
+                                                                ImmutableList.of(equiJoinClause("t", "s")),
+                                                                exchange(REMOTE, REPARTITION, anyTree(values(ImmutableList.of("t")))),
+                                                                exchange(LOCAL, GATHER, anyTree(values(ImmutableList.of("s"))))))),
+                                        exchange(LOCAL, GATHER, anyTree(values(ImmutableList.of("r"))))))));
+    }
+
+    @Test
+    public void testCoalesceWithManyArgumentsAndGroupBy()
+    {
+        assertDistributedPlan("SELECT coalesce(t.a, s.a, r.a) " +
+                        "FROM (VALUES (1), (2), (3)) t(a) " +
+                        "FULL OUTER JOIN (VALUES (1), (4)) s(a) " +
+                        "ON t.a = s.a " +
+                        "FULL OUTER JOIN (VALUES (2), (5)) r(a) " +
+                        "ON t.a = r.a " +
+                        "GROUP BY 1",
+                anyTree(exchange(
+                        REMOTE,
+                        REPARTITION,
+                        aggregation(
+                                ImmutableMap.of(),
+                                PARTIAL,
+                                project(
+                                        project(
+                                                ImmutableMap.of("expr", expression("coalesce(t, s, r)")),
+                                                join(
+                                                        FULL,
+                                                        ImmutableList.of(equiJoinClause("t", "r")),
+                                                        anyTree(
+                                                                join(
+                                                                        FULL,
+                                                                        ImmutableList.of(equiJoinClause("t", "s")),
+                                                                        exchange(REMOTE, REPARTITION, anyTree(values(ImmutableList.of("t")))),
+                                                                        exchange(LOCAL, GATHER, anyTree(values(ImmutableList.of("s")))))),
+                                                        exchange(LOCAL, GATHER, anyTree(values(ImmutableList.of("r")))))))))));
+    }
+
+    @Test
+    public void testCoalesceWithNonSymbolArguments()
+    {
+        assertDistributedPlan("SELECT coalesce(t.a, s.a + 1, r.a) " +
+                        "FROM (VALUES (1), (2), (3)) t(a) " +
+                        "FULL OUTER JOIN (VALUES (1), (4)) s(a) " +
+                        "ON t.a = s.a " +
+                        "FULL OUTER JOIN (VALUES (2), (5)) r(a) " +
+                        "ON t.a = r.a " +
+                        "GROUP BY 1",
+                anyTree(exchange(
+                        REMOTE,
+                        REPARTITION,
+                        aggregation(
+                                ImmutableMap.of(),
+                                PARTIAL,
+                                project(
+                                        project(
+                                                ImmutableMap.of("expr", expression("coalesce(t, s + 1, r)")),
+                                                join(
+                                                        FULL,
+                                                        ImmutableList.of(equiJoinClause("t", "r")),
+                                                        anyTree(
+                                                                join(
+                                                                        FULL,
+                                                                        ImmutableList.of(equiJoinClause("t", "s")),
+                                                                        exchange(REMOTE, REPARTITION, anyTree(values(ImmutableList.of("t")))),
+                                                                        exchange(LOCAL, GATHER, anyTree(values(ImmutableList.of("s")))))),
+                                                        exchange(LOCAL, GATHER, anyTree(values(ImmutableList.of("r")))))))))));
+    }
+}


### PR DESCRIPTION
For full outer join, if both sides of the equi-join contains all partitioning columns,
the output of the join would be partitioned on coalesce of these columns.

Fixed the issue with incorrectly optimize out remote exchange for aggregation. Added new test to verify aggregation is correct. Also changed existing test to be more robust.