### PR TITLE
Fix memory accounting for geometry aggregations

### DIFF
--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/ConvexHullAggregation.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/ConvexHullAggregation.java
@@ -53,10 +53,11 @@ public class ConvexHullAggregation
     {
         OGCGeometry geometry = GeometrySerde.deserialize(input);
         if (state.getGeometry() == null) {
-            state.setGeometry(geometry.convexHull());
+            state.setGeometry(geometry.convexHull(), 0);
         }
         else if (!geometry.isEmpty()) {
-            state.setGeometry(state.getGeometry().union(geometry).convexHull());
+            long previousMemorySize = state.getGeometry().estimateMemorySize();
+            state.setGeometry(state.getGeometry().union(geometry).convexHull(), previousMemorySize);
         }
     }
 
@@ -65,10 +66,11 @@ public class ConvexHullAggregation
             @AggregationState GeometryState otherState)
     {
         if (state.getGeometry() == null) {
-            state.setGeometry(otherState.getGeometry());
+            state.setGeometry(otherState.getGeometry(), 0);
         }
         else if (otherState.getGeometry() != null && !otherState.getGeometry().isEmpty()) {
-            state.setGeometry(state.getGeometry().union(otherState.getGeometry()).convexHull());
+            long previousMemorySize = state.getGeometry().estimateMemorySize();
+            state.setGeometry(state.getGeometry().union(otherState.getGeometry()).convexHull(), previousMemorySize);
         }
     }
 

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryState.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryState.java
@@ -23,5 +23,5 @@ public interface GeometryState
 {
     OGCGeometry getGeometry();
 
-    void setGeometry(OGCGeometry geometry);
+    void setGeometry(OGCGeometry geometry, long previousMemorySize);
 }

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryStateSerializer.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryStateSerializer.java
@@ -44,6 +44,7 @@ public class GeometryStateSerializer
     @Override
     public void deserialize(Block block, int index, GeometryState state)
     {
-        state.setGeometry(GeometrySerde.deserialize(GEOMETRY.getSlice(block, index)));
+        long previousMemorySize = state.getGeometry() != null ? state.getGeometry().estimateMemorySize() : 0;
+        state.setGeometry(GeometrySerde.deserialize(GEOMETRY.getSlice(block, index)), previousMemorySize);
     }
 }

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryUnionAgg.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/aggregation/GeometryUnionAgg.java
@@ -43,10 +43,11 @@ public class GeometryUnionAgg
     {
         OGCGeometry geometry = GeometrySerde.deserialize(input);
         if (state.getGeometry() == null) {
-            state.setGeometry(geometry);
+            state.setGeometry(geometry, 0);
         }
         else if (!geometry.isEmpty()) {
-            state.setGeometry(state.getGeometry().union(geometry));
+            long previousMemorySize = state.getGeometry().estimateMemorySize();
+            state.setGeometry(state.getGeometry().union(geometry), previousMemorySize);
         }
     }
 
@@ -54,10 +55,11 @@ public class GeometryUnionAgg
     public static void combine(@AggregationState GeometryState state, @AggregationState GeometryState otherState)
     {
         if (state.getGeometry() == null) {
-            state.setGeometry(otherState.getGeometry());
+            state.setGeometry(otherState.getGeometry(), 0);
         }
         else if (otherState.getGeometry() != null && !otherState.getGeometry().isEmpty()) {
-            state.setGeometry(state.getGeometry().union(otherState.getGeometry()));
+            long previousMemorySize = state.getGeometry().estimateMemorySize();
+            state.setGeometry(state.getGeometry().union(otherState.getGeometry()), previousMemorySize);
         }
     }
 

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/TestGeometryStateSerializer.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/TestGeometryStateSerializer.java
@@ -35,7 +35,7 @@ public class TestGeometryStateSerializer
         AccumulatorStateSerializer<GeometryState> serializer = StateCompiler.generateStateSerializer(GeometryState.class);
         GeometryState state = factory.createSingleState();
 
-        state.setGeometry(OGCGeometry.fromText("POINT (1 2)"));
+        state.setGeometry(OGCGeometry.fromText("POINT (1 2)"), 0);
 
         BlockBuilder builder = GeometryType.GEOMETRY.createBlockBuilder(null, 1);
         serializer.serialize(state, builder);
@@ -43,7 +43,8 @@ public class TestGeometryStateSerializer
 
         assertEquals(GeometryType.GEOMETRY.getObjectValue(null, block, 0), "POINT (1 2)");
 
-        state.setGeometry(null);
+        long previousMemorySize = state.getGeometry().estimateMemorySize();
+        state.setGeometry(null, previousMemorySize);
         serializer.deserialize(block, 0, state);
 
         assertEquals(state.getGeometry().asText(), "POINT (1 2)");
@@ -58,10 +59,10 @@ public class TestGeometryStateSerializer
 
         // Add state to group 1
         state.setGroupId(1);
-        state.setGeometry(OGCGeometry.fromText("POINT (1 2)"));
+        state.setGeometry(OGCGeometry.fromText("POINT (1 2)"), 0);
         // Add another state to group 2, to show that this doesn't affect the group under test (group 1)
         state.setGroupId(2);
-        state.setGeometry(OGCGeometry.fromText("POINT (2 3)"));
+        state.setGeometry(OGCGeometry.fromText("POINT (2 3)"), 0);
         // Return to group 1
         state.setGroupId(1);
 
@@ -71,7 +72,8 @@ public class TestGeometryStateSerializer
 
         assertEquals(GeometryType.GEOMETRY.getObjectValue(null, block, 0), "POINT (1 2)");
 
-        state.setGeometry(null);
+        long previousMemorySize = state.getGeometry().estimateMemorySize();
+        state.setGeometry(null, previousMemorySize);
         serializer.deserialize(block, 0, state);
 
         // Assert the state of group 1


### PR DESCRIPTION
OGCGeometry objects are stateful and may change in memory size due
simply to being queried.  This means memory usage must be updated before
any OGCGeometry operation is performed and then after.

Fixes #12356

cc: @mbasmanova 