### PR TITLE
Add support for smile encoding

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -242,6 +242,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-smile</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>

--- a/presto-main/src/main/java/com/facebook/presto/server/smile/ForSmile.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/smile/ForSmile.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER})
+@BindingAnnotation
+public @interface ForSmile
+{
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/smile/FullSmileResponseHandler.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/smile/FullSmileResponseHandler.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.net.MediaType;
+import io.airlift.http.client.HeaderName;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.Response;
+import io.airlift.http.client.ResponseHandler;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.io.ByteStreams.toByteArray;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static io.airlift.http.client.ResponseHandlerUtils.propagate;
+import static java.util.Objects.requireNonNull;
+
+public class FullSmileResponseHandler<T>
+        implements ResponseHandler<FullSmileResponseHandler.SmileResponse<T>, RuntimeException>
+{
+    private static final MediaType MEDIA_TYPE_SMILE = MediaType.create("application", "x-jackson-smile");
+
+    public static <T> FullSmileResponseHandler<T> createFullSmileResponseHandler(SmileCodec<T> smileCodec)
+    {
+        return new FullSmileResponseHandler<>(smileCodec);
+    }
+
+    private final SmileCodec<T> smileCodec;
+
+    private FullSmileResponseHandler(SmileCodec<T> smileCodec)
+    {
+        this.smileCodec = smileCodec;
+    }
+
+    @Override
+    public SmileResponse<T> handleException(Request request, Exception exception)
+    {
+        throw propagate(request, exception);
+    }
+
+    @Override
+    public SmileResponse<T> handle(Request request, Response response)
+    {
+        byte[] bytes = readResponseBytes(response);
+        String contentType = response.getHeader(CONTENT_TYPE);
+        if ((contentType == null) || !MediaType.parse(contentType).is(MEDIA_TYPE_SMILE)) {
+            return new SmileResponse<>(response.getStatusCode(), response.getStatusMessage(), response.getHeaders(), bytes);
+        }
+        return new SmileResponse<>(response.getStatusCode(), response.getStatusMessage(), response.getHeaders(), smileCodec, bytes);
+    }
+
+    private static byte[] readResponseBytes(Response response)
+    {
+        try {
+            return toByteArray(response.getInputStream());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Error reading response from server", e);
+        }
+    }
+
+    public static class SmileResponse<T>
+    {
+        private final int statusCode;
+        private final String statusMessage;
+        private final ListMultimap<HeaderName, String> headers;
+        private final boolean hasValue;
+        private final byte[] smileBytes;
+        private final byte[] responseBytes;
+        private final T value;
+        private final IllegalArgumentException exception;
+
+        public SmileResponse(int statusCode, String statusMessage, ListMultimap<HeaderName, String> headers, byte[] responseBytes)
+        {
+            this.statusCode = statusCode;
+            this.statusMessage = statusMessage;
+            this.headers = ImmutableListMultimap.copyOf(headers);
+
+            this.hasValue = false;
+            this.smileBytes = null;
+            this.responseBytes = requireNonNull(responseBytes, "responseBytes is null");
+            this.value = null;
+            this.exception = null;
+        }
+
+        @SuppressWarnings("ThrowableInstanceNeverThrown")
+        public SmileResponse(int statusCode, String statusMessage, ListMultimap<HeaderName, String> headers, SmileCodec<T> smileCodec, byte[] smileBytes)
+        {
+            this.statusCode = statusCode;
+            this.statusMessage = statusMessage;
+            this.headers = ImmutableListMultimap.copyOf(headers);
+
+            this.smileBytes = requireNonNull(smileBytes, "smileBytes is null");
+            this.responseBytes = smileBytes;
+
+            T value = null;
+            IllegalArgumentException exception = null;
+            try {
+                value = smileCodec.fromSmile(smileBytes);
+            }
+            catch (IllegalArgumentException e) {
+                exception = new IllegalArgumentException("Unable to create " + smileCodec.getType() + " from SMILE response", e);
+            }
+
+            this.hasValue = (exception == null);
+            this.value = value;
+            this.exception = exception;
+        }
+
+        public int getStatusCode()
+        {
+            return statusCode;
+        }
+
+        public String getStatusMessage()
+        {
+            return statusMessage;
+        }
+
+        public String getHeader(String name)
+        {
+            List<String> values = getHeaders().get(HeaderName.of(name));
+            if (values.isEmpty()) {
+                return null;
+            }
+            return values.get(0);
+        }
+
+        public List<String> getHeaders(String name)
+        {
+            return headers.get(HeaderName.of(name));
+        }
+
+        public ListMultimap<HeaderName, String> getHeaders()
+        {
+            return headers;
+        }
+
+        public boolean hasValue()
+        {
+            return hasValue;
+        }
+
+        public T getValue()
+        {
+            if (!hasValue) {
+                throw new IllegalStateException("Response does not contain a SMILE value", exception);
+            }
+            return value;
+        }
+
+        public byte[] getSmileBytes()
+        {
+            return (smileBytes == null) ? null : smileBytes.clone();
+        }
+
+        public int getResponseSize()
+        {
+            return responseBytes.length;
+        }
+
+        public byte[] getResponseBytes()
+        {
+            return responseBytes.clone();
+        }
+
+        public IllegalArgumentException getException()
+        {
+            return exception;
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("statusCode", statusCode)
+                    .add("statusMessage", statusMessage)
+                    .add("headers", headers)
+                    .add("hasValue", hasValue)
+                    .add("value", value)
+                    .toString();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/smile/SmileBodyGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/smile/SmileBodyGenerator.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.google.common.annotations.Beta;
+import io.airlift.http.client.StaticBodyGenerator;
+
+@Beta
+public class SmileBodyGenerator<T>
+        extends StaticBodyGenerator
+{
+    public static <T> SmileBodyGenerator<T> smileBodyGenerator(SmileCodec<T> smileCodec, T instance)
+    {
+        return new SmileBodyGenerator<>(smileCodec, instance);
+    }
+
+    private SmileBodyGenerator(SmileCodec<T> smileCodec, T instance)
+    {
+        super(smileCodec.toBytes(instance));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/smile/SmileCodec.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/smile/SmileCodec.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.Beta;
+import com.google.common.base.Suppliers;
+import com.google.common.reflect.TypeParameter;
+import com.google.common.reflect.TypeToken;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+@Beta
+public class SmileCodec<T>
+{
+    private static final Supplier<ObjectMapper> OBJECT_MAPPER_SUPPLIER =
+            Suppliers.memoize(() -> new SmileObjectMapperProvider().get());
+
+    public static <T> SmileCodec<T> smileCodec(Class<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        return new SmileCodec<>(OBJECT_MAPPER_SUPPLIER.get(), type);
+    }
+
+    public static <T> SmileCodec<T> smileCodec(TypeToken<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        return new SmileCodec<>(OBJECT_MAPPER_SUPPLIER.get(), type.getType());
+    }
+
+    public static <T> SmileCodec<List<T>> listSmileCodec(Class<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        Type listType = new TypeToken<List<T>>() {}
+                .where(new TypeParameter<T>() {}, type)
+                .getType();
+
+        return new SmileCodec<>(OBJECT_MAPPER_SUPPLIER.get(), listType);
+    }
+
+    public static <T> SmileCodec<List<T>> listSmileCodec(SmileCodec<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        Type listType = new TypeToken<List<T>>() {}
+                .where(new TypeParameter<T>() {}, type.getTypeToken())
+                .getType();
+
+        return new SmileCodec<>(OBJECT_MAPPER_SUPPLIER.get(), listType);
+    }
+
+    public static <K, V> SmileCodec<Map<K, V>> mapSmileCodec(Class<K> keyType, Class<V> valueType)
+    {
+        requireNonNull(keyType, "keyType is null");
+        requireNonNull(valueType, "valueType is null");
+
+        Type mapType = new TypeToken<Map<K, V>>() {}
+                .where(new TypeParameter<K>() {}, keyType)
+                .where(new TypeParameter<V>() {}, valueType)
+                .getType();
+
+        return new SmileCodec<>(OBJECT_MAPPER_SUPPLIER.get(), mapType);
+    }
+
+    public static <K, V> SmileCodec<Map<K, V>> mapSmileCodec(Class<K> keyType, SmileCodec<V> valueType)
+    {
+        requireNonNull(keyType, "keyType is null");
+        requireNonNull(valueType, "valueType is null");
+
+        Type mapType = new TypeToken<Map<K, V>>() {}
+                .where(new TypeParameter<K>() {}, keyType)
+                .where(new TypeParameter<V>() {}, valueType.getTypeToken())
+                .getType();
+
+        return new SmileCodec<>(OBJECT_MAPPER_SUPPLIER.get(), mapType);
+    }
+
+    private final ObjectMapper mapper;
+    private final Type type;
+    private final JavaType javaType;
+
+    SmileCodec(ObjectMapper mapper, Type type)
+    {
+        this.mapper = mapper;
+        this.type = type;
+        this.javaType = mapper.getTypeFactory().constructType(type);
+    }
+
+    /**
+     * Gets the type this codec supports.
+     */
+    public Type getType()
+    {
+        return type;
+    }
+
+    /**
+     * Converts the specified smile bytes (UTF-8) into an instance of type T.
+     *
+     * @param bytes the bytes (UTF-8) to parse
+     * @return parsed response; never null
+     * @throws IllegalArgumentException if the bytes bytes can not be converted to the type T
+     */
+    public T fromSmile(byte[] bytes)
+            throws IllegalArgumentException
+    {
+        try {
+            return mapper.readValue(bytes, javaType);
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException(format("Invalid SMILE bytes for %s", javaType), e);
+        }
+    }
+
+    /**
+     * Converts the specified instance to smile encoded bytes.
+     *
+     * @param instance the instance to convert to smile encoded bytes
+     * @return smile encoded bytes (UTF-8)
+     * @throws IllegalArgumentException if the specified instance can not be converted to smile
+     */
+    public byte[] toBytes(T instance)
+            throws IllegalArgumentException
+    {
+        try {
+            return mapper.writeValueAsBytes(instance);
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException(format("%s could not be converted to SMILE", instance.getClass().getName()), e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    TypeToken<T> getTypeToken()
+    {
+        return (TypeToken<T>) TypeToken.of(type);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/smile/SmileCodecBinder.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/smile/SmileCodecBinder.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import com.google.inject.internal.MoreTypes.ParameterizedTypeImpl;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+@Beta
+public class SmileCodecBinder
+{
+    private final Binder binder;
+
+    public static SmileCodecBinder smileCodecBinder(Binder binder)
+    {
+        return new SmileCodecBinder(binder);
+    }
+
+    private SmileCodecBinder(Binder binder)
+    {
+        this.binder = requireNonNull(binder, "binder is null").skipSources(getClass());
+    }
+
+    public void bindSmileCodec(Class<?> type)
+    {
+        requireNonNull(type, "type is null");
+
+        binder.bind(getSmileCodecKey(type)).toProvider(new SmileCodecProvider(type)).in(Scopes.SINGLETON);
+    }
+
+    public void bindSmileCodec(TypeLiteral<?> type)
+    {
+        requireNonNull(type, "type is null");
+
+        binder.bind(getSmileCodecKey(type.getType())).toProvider(new SmileCodecProvider(type.getType())).in(Scopes.SINGLETON);
+    }
+
+    public void bindListSmileCodec(Class<?> type)
+    {
+        requireNonNull(type, "type is null");
+
+        ParameterizedTypeImpl listType = new ParameterizedTypeImpl(null, List.class, type);
+        binder.bind(getSmileCodecKey(listType)).toProvider(new SmileCodecProvider(listType)).in(Scopes.SINGLETON);
+    }
+
+    public void bindListSmileCodec(SmileCodec<?> type)
+    {
+        requireNonNull(type, "type is null");
+
+        ParameterizedTypeImpl listType = new ParameterizedTypeImpl(null, List.class, type.getType());
+        binder.bind(getSmileCodecKey(listType)).toProvider(new SmileCodecProvider(listType)).in(Scopes.SINGLETON);
+    }
+
+    public void bindMapSmileCodec(Class<?> keyType, Class<?> valueType)
+    {
+        requireNonNull(keyType, "keyType is null");
+        requireNonNull(valueType, "valueType is null");
+
+        ParameterizedTypeImpl mapType = new ParameterizedTypeImpl(null, Map.class, keyType, valueType);
+        binder.bind(getSmileCodecKey(mapType)).toProvider(new SmileCodecProvider(mapType)).in(Scopes.SINGLETON);
+    }
+
+    public void bindMapSmileCodec(Class<?> keyType, SmileCodec<?> valueType)
+    {
+        requireNonNull(keyType, "keyType is null");
+        requireNonNull(valueType, "valueType is null");
+
+        ParameterizedTypeImpl mapType = new ParameterizedTypeImpl(null, Map.class, keyType, valueType.getType());
+        binder.bind(getSmileCodecKey(mapType)).toProvider(new SmileCodecProvider(mapType)).in(Scopes.SINGLETON);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Key<SmileCodec<?>> getSmileCodecKey(Type type)
+    {
+        return (Key<SmileCodec<?>>) Key.get(new ParameterizedTypeImpl(null, SmileCodec.class, type));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/smile/SmileCodecFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/smile/SmileCodecFactory.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.Beta;
+import com.google.common.reflect.TypeParameter;
+import com.google.common.reflect.TypeToken;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+@Beta
+public class SmileCodecFactory
+{
+    private final Provider<ObjectMapper> objectMapperProvider;
+
+    public SmileCodecFactory()
+    {
+        this(new SmileObjectMapperProvider());
+    }
+
+    @Inject
+    public SmileCodecFactory(@ForSmile Provider<ObjectMapper> smileObjectMapperProvider)
+    {
+        this.objectMapperProvider = requireNonNull(smileObjectMapperProvider, "smileObjectMapperProvider is null");
+    }
+
+    public <T> SmileCodec<T> smileCodec(Class<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        return new SmileCodec<>(createObjectMapper(), type);
+    }
+
+    public <T> SmileCodec<T> smileCodec(Type type)
+    {
+        requireNonNull(type, "type is null");
+
+        return new SmileCodec<>(createObjectMapper(), type);
+    }
+
+    public <T> SmileCodec<T> smileCodec(TypeToken<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        return new SmileCodec<>(createObjectMapper(), type.getType());
+    }
+
+    public <T> SmileCodec<List<T>> listSmileCodec(Class<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        Type listType = new TypeToken<List<T>>() {}
+                .where(new TypeParameter<T>() {}, type)
+                .getType();
+
+        return new SmileCodec<>(createObjectMapper(), listType);
+    }
+
+    public <T> SmileCodec<List<T>> listSmileCodec(SmileCodec<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        Type listType = new TypeToken<List<T>>() {}
+                .where(new TypeParameter<T>() {}, type.getTypeToken())
+                .getType();
+
+        return new SmileCodec<>(createObjectMapper(), listType);
+    }
+
+    public <K, V> SmileCodec<Map<K, V>> mapSmileCodec(Class<K> keyType, Class<V> valueType)
+    {
+        requireNonNull(keyType, "keyType is null");
+        requireNonNull(valueType, "valueType is null");
+
+        Type mapType = new TypeToken<Map<K, V>>() {}
+                .where(new TypeParameter<K>() {}, keyType)
+                .where(new TypeParameter<V>() {}, valueType)
+                .getType();
+
+        return new SmileCodec<>(createObjectMapper(), mapType);
+    }
+
+    public <K, V> SmileCodec<Map<K, V>> mapSmileCodec(Class<K> keyType, SmileCodec<V> valueType)
+    {
+        requireNonNull(keyType, "keyType is null");
+        requireNonNull(valueType, "valueType is null");
+
+        Type mapType = new TypeToken<Map<K, V>>() {}
+                .where(new TypeParameter<K>() {}, keyType)
+                .where(new TypeParameter<V>() {}, valueType.getTypeToken())
+                .getType();
+
+        return new SmileCodec<>(createObjectMapper(), mapType);
+    }
+
+    private ObjectMapper createObjectMapper()
+    {
+        return objectMapperProvider.get();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/smile/SmileCodecProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/smile/SmileCodecProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.reflect.Type;
+
+import static java.util.Objects.requireNonNull;
+
+class SmileCodecProvider
+        implements Provider<SmileCodec<?>>
+{
+    private final Type type;
+    private SmileCodecFactory smileCodecFactory;
+
+    public SmileCodecProvider(Type type)
+    {
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @Inject
+    public void setSmileCodecFactory(SmileCodecFactory smileCodecFactory)
+    {
+        this.smileCodecFactory = smileCodecFactory;
+    }
+
+    @Override
+    public SmileCodec<?> get()
+    {
+        return smileCodecFactory.smileCodec(type);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SmileCodecProvider that = (SmileCodecProvider) o;
+
+        if (!type.equals(that.type)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return type.hashCode();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/smile/SmileModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/smile/SmileModule.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.Beta;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+@Beta
+public class SmileModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.disableCircularProxies();
+        binder.bind(ObjectMapper.class).annotatedWith(ForSmile.class).toProvider(SmileObjectMapperProvider.class);
+        binder.bind(SmileCodecFactory.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/smile/SmileObjectMapperProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/smile/SmileObjectMapperProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import com.google.inject.Inject;
+import io.airlift.json.ObjectMapperProvider;
+
+public class SmileObjectMapperProvider
+        extends ObjectMapperProvider
+{
+    @Inject
+    public SmileObjectMapperProvider()
+    {
+        super(new SmileFactory());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/smile/ImmutablePerson.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/smile/ImmutablePerson.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonCodec;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * This class is copied from airlift as is. Once smile support is released in airlift
+ * smile support in Presto should be entirely removed.
+ */
+public class ImmutablePerson
+{
+    private final String name;
+    private final boolean rocks;
+    private final String notWritable = null;
+
+    public static void validatePersonJsonCodec(JsonCodec<ImmutablePerson> jsonCodec)
+    {
+        ImmutablePerson expected = new ImmutablePerson("dain", true);
+
+        String json = jsonCodec.toJson(expected);
+        assertEquals(jsonCodec.fromJson(json), expected);
+
+        byte[] bytes = jsonCodec.toJsonBytes(expected);
+        assertEquals(jsonCodec.fromJson(bytes), expected);
+    }
+
+    public static void validatePersonListJsonCodec(JsonCodec<List<ImmutablePerson>> jsonCodec)
+    {
+        ImmutableList<ImmutablePerson> expected = ImmutableList.of(
+                new ImmutablePerson("dain", true),
+                new ImmutablePerson("martin", true),
+                new ImmutablePerson("mark", true));
+
+        String json = jsonCodec.toJson(expected);
+        assertEquals(jsonCodec.fromJson(json), expected);
+
+        byte[] bytes = jsonCodec.toJsonBytes(expected);
+        assertEquals(jsonCodec.fromJson(bytes), expected);
+    }
+
+    public static void validatePersonMapJsonCodec(JsonCodec<Map<String, ImmutablePerson>> jsonCodec)
+    {
+        ImmutableMap<String, ImmutablePerson> expected = ImmutableMap.<String, ImmutablePerson>builder()
+                .put("dain", new ImmutablePerson("dain", true))
+                .put("martin", new ImmutablePerson("martin", true))
+                .put("mark", new ImmutablePerson("mark", true))
+                .build();
+
+        String json = jsonCodec.toJson(expected);
+        assertEquals(jsonCodec.fromJson(json), expected);
+
+        byte[] bytes = jsonCodec.toJsonBytes(expected);
+        assertEquals(jsonCodec.fromJson(bytes), expected);
+    }
+
+    @JsonCreator
+    public ImmutablePerson(
+            @JsonProperty("name") String name,
+            @JsonProperty("rocks") boolean rocks)
+    {
+        this.name = name;
+        this.rocks = rocks;
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public boolean isRocks()
+    {
+        return rocks;
+    }
+
+    @JsonProperty
+    public String getNotWritable()
+    {
+        return notWritable;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        ImmutablePerson o = (ImmutablePerson) obj;
+        return Objects.equals(this.name, o.name) &&
+                Objects.equals(this.rocks, o.rocks) &&
+                Objects.equals(this.notWritable, o.notWritable);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, rocks, notWritable);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .add("rocks", rocks)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/smile/Person.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/smile/Person.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonCodec;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * This class is copied from airlift as is. Once smile support is released in airlift
+ * smile support in Presto should be entirely removed.
+ */
+public class Person
+{
+    private String name;
+    private boolean rocks;
+    private Optional<String> lastName;
+
+    public static void validatePersonJsonCodec(JsonCodec<Person> jsonCodec)
+    {
+        // create object with null lastName
+        Person expected = new Person().setName("dain").setRocks(true);
+
+        String json = jsonCodec.toJson(expected);
+        assertFalse(json.contains("lastName"));
+        assertEquals(jsonCodec.fromJson(json), expected);
+
+        byte[] bytes = jsonCodec.toJsonBytes(expected);
+        assertEquals(jsonCodec.fromJson(bytes), expected);
+
+        // create object with missing lastName
+        expected.setLastName(Optional.empty());
+
+        json = jsonCodec.toJson(expected);
+        assertFalse(json.contains("lastName"));
+        assertEquals(jsonCodec.fromJson(json), expected);
+
+        bytes = jsonCodec.toJsonBytes(expected);
+        assertEquals(jsonCodec.fromJson(bytes), expected);
+
+        // create object with present lastName
+        expected.setLastName(Optional.of("Awesome"));
+
+        json = jsonCodec.toJson(expected);
+        assertTrue(json.contains("lastName"));
+        assertEquals(jsonCodec.fromJson(json), expected);
+
+        bytes = jsonCodec.toJsonBytes(expected);
+        assertEquals(jsonCodec.fromJson(bytes), expected);
+    }
+
+    public static void validatePersonListJsonCodec(JsonCodec<List<Person>> jsonCodec)
+    {
+        ImmutableList<Person> expected = ImmutableList.of(
+                new Person().setName("dain").setRocks(true),
+                new Person().setName("martin").setRocks(true),
+                new Person().setName("mark").setRocks(true));
+
+        String json = jsonCodec.toJson(expected);
+        assertEquals(jsonCodec.fromJson(json), expected);
+
+        byte[] bytes = jsonCodec.toJsonBytes(expected);
+        assertEquals(jsonCodec.fromJson(bytes), expected);
+    }
+
+    public static void validatePersonMapJsonCodec(JsonCodec<Map<String, Person>> jsonCodec)
+    {
+        ImmutableMap<String, Person> expected = ImmutableMap.<String, Person>builder()
+                .put("dain", new Person().setName("dain").setRocks(true))
+                .put("martin", new Person().setName("martin").setRocks(true))
+                .put("mark", new Person().setName("mark").setRocks(true))
+                .build();
+
+        String json = jsonCodec.toJson(expected);
+        assertEquals(jsonCodec.fromJson(json), expected);
+
+        byte[] bytes = jsonCodec.toJsonBytes(expected);
+        assertEquals(jsonCodec.fromJson(bytes), expected);
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public Person setName(String name)
+    {
+        this.name = name;
+        return this;
+    }
+
+    @JsonProperty
+    public boolean isRocks()
+    {
+        return rocks;
+    }
+
+    @JsonProperty
+    public Person setRocks(boolean rocks)
+    {
+        this.rocks = rocks;
+        return this;
+    }
+
+    @JsonProperty
+    public Optional<String> getLastName()
+    {
+        return lastName;
+    }
+
+    @JsonProperty
+    public void setLastName(Optional<String> lastName)
+    {
+        this.lastName = lastName;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        Person o = (Person) obj;
+        return Objects.equals(this.name, o.name) &&
+                Objects.equals(this.rocks, o.rocks);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, rocks);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .add("rocks", rocks)
+                .add("lastName", lastName)
+                .toString();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/smile/TestFullSmileResponseHandler.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/smile/TestFullSmileResponseHandler.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.facebook.presto.server.smile.FullSmileResponseHandler.SmileResponse;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.net.MediaType;
+import io.airlift.http.client.HttpStatus;
+import io.airlift.http.client.Response;
+import io.airlift.http.client.testing.TestingResponse;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.server.smile.FullSmileResponseHandler.createFullSmileResponseHandler;
+import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
+import static io.airlift.http.client.HttpStatus.INTERNAL_SERVER_ERROR;
+import static io.airlift.http.client.HttpStatus.OK;
+import static io.airlift.http.client.testing.TestingResponse.contentType;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestFullSmileResponseHandler
+{
+    private static final MediaType MEDIA_TYPE_SMILE = MediaType.create("application", "x-jackson-smile");
+
+    private final SmileCodecFactory codecFactory = new SmileCodecFactory();
+    private final SmileCodec<User> codec = codecFactory.smileCodec(User.class);
+    private final FullSmileResponseHandler<User> handler = createFullSmileResponseHandler(codec);
+
+    @Test
+    public void testValidSmile()
+    {
+        User user = new User("Joe", 25);
+        byte[] smileBytes = codec.toBytes(user);
+        SmileResponse<User> response = handler.handle(null, mockResponse(OK, MEDIA_TYPE_SMILE, smileBytes));
+
+        assertTrue(response.hasValue());
+        assertEquals(response.getSmileBytes(), smileBytes);
+        assertEquals(response.getValue().getName(), user.getName());
+        assertEquals(response.getValue().getAge(), user.getAge());
+
+        assertNotSame(response.getSmileBytes(), response.getSmileBytes());
+        assertNotSame(response.getResponseBytes(), response.getResponseBytes());
+
+        assertEquals(response.getResponseBytes(), response.getSmileBytes());
+    }
+
+    @Test
+    public void testInvalidSmile()
+    {
+        byte[] invalidSmileBytes = "test".getBytes(UTF_8);
+        SmileResponse<User> response = handler.handle(null, mockResponse(OK, MEDIA_TYPE_SMILE, invalidSmileBytes));
+
+        assertFalse(response.hasValue());
+        assertEquals(response.getException().getMessage(), format("Unable to create %s from SMILE response", User.class));
+        assertTrue(response.getException().getCause() instanceof IllegalArgumentException);
+        assertEquals(response.getException().getCause().getMessage(), "Invalid SMILE bytes for [simple type, class com.facebook.presto.server.smile.TestFullSmileResponseHandler$User]");
+
+        assertEquals(response.getSmileBytes(), invalidSmileBytes);
+        assertEquals(response.getResponseBytes(), response.getSmileBytes());
+    }
+
+    @Test
+    public void testInvalidSmileGetValue()
+    {
+        byte[] invalidSmileBytes = "test".getBytes(UTF_8);
+        SmileResponse<User> response = handler.handle(null, mockResponse(OK, MEDIA_TYPE_SMILE, invalidSmileBytes));
+
+        try {
+            response.getValue();
+            fail("expected exception");
+        }
+        catch (IllegalStateException e) {
+            assertEquals(e.getMessage(), "Response does not contain a SMILE value");
+            assertEquals(e.getCause(), response.getException());
+
+            assertEquals(response.getSmileBytes(), invalidSmileBytes);
+            assertEquals(response.getResponseBytes(), response.getSmileBytes());
+        }
+    }
+
+    @Test
+    public void testNonSmileResponse()
+    {
+        SmileResponse<User> response = handler.handle(null, TestingResponse.mockResponse(OK, PLAIN_TEXT_UTF_8, "hello"));
+
+        assertFalse(response.hasValue());
+        assertNull(response.getException());
+        assertNull(response.getSmileBytes());
+        assertEquals(response.getResponseBytes(), "hello".getBytes(UTF_8));
+    }
+
+    @Test
+    public void testMissingContentType()
+    {
+        SmileResponse<User> response = handler.handle(null,
+                new TestingResponse(OK, ImmutableListMultimap.of(), "hello".getBytes(UTF_8)));
+
+        assertFalse(response.hasValue());
+        assertNull(response.getException());
+        assertNull(response.getSmileBytes());
+        assertEquals(response.getResponseBytes(), "hello".getBytes(UTF_8));
+        assertTrue(response.getHeaders().isEmpty());
+    }
+
+    @Test
+    public void testSmileErrorResponse()
+    {
+        User user = new User("Joe", 25);
+        byte[] smileBytes = codec.toBytes(user);
+        SmileResponse<User> response = handler.handle(null, mockResponse(INTERNAL_SERVER_ERROR, MEDIA_TYPE_SMILE, smileBytes));
+
+        assertTrue(response.hasValue());
+        assertEquals(response.getStatusCode(), INTERNAL_SERVER_ERROR.code());
+        assertEquals(response.getResponseBytes(), response.getSmileBytes());
+    }
+
+    public static class User
+    {
+        private final String name;
+        private final int age;
+
+        @JsonCreator
+        public User(@JsonProperty("name") String name, @JsonProperty("age") int age)
+        {
+            this.name = name;
+            this.age = age;
+        }
+
+        @JsonProperty
+        public String getName()
+        {
+            return name;
+        }
+
+        @JsonProperty
+        public int getAge()
+        {
+            return age;
+        }
+    }
+
+    private static Response mockResponse(HttpStatus status, MediaType type, byte[] content)
+    {
+        return new TestingResponse(status, contentType(type), content);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/smile/TestSmileCodecBinder.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/smile/TestSmileCodecBinder.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+import static com.facebook.presto.server.smile.SmileCodecBinder.smileCodecBinder;
+import static org.testng.Assert.assertNotNull;
+
+public class TestSmileCodecBinder
+{
+    @Test
+    public void ignoresRepeatedBinding()
+    {
+        Injector injector = Guice.createInjector((Module) binder -> {
+            smileCodecBinder(binder).bindSmileCodec(Integer.class);
+            smileCodecBinder(binder).bindSmileCodec(Integer.class);
+            binder.bind(ObjectMapper.class).annotatedWith(ForSmile.class).toProvider(SmileObjectMapperProvider.class);
+            binder.bind(Dummy.class).in(Scopes.SINGLETON);
+        });
+
+        assertNotNull(injector.getInstance(Dummy.class).getCodec());
+    }
+
+    private static class Dummy
+    {
+        private final SmileCodec<Integer> codec;
+
+        @Inject
+        public Dummy(SmileCodec<Integer> codec)
+        {
+            this.codec = codec;
+        }
+
+        public SmileCodec<Integer> getCodec()
+        {
+            return codec;
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/smile/TestSmileCodecFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/smile/TestSmileCodecFactory.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestSmileCodecFactory
+{
+    private final SmileCodecFactory codecFactory = new SmileCodecFactory();
+
+    @Test
+    public void testSmileCodec()
+    {
+        SmileCodec<Person> smileCodec = codecFactory.smileCodec(Person.class);
+        Person expected = new Person().setName("person-1").setRocks(true);
+        byte[] smile = smileCodec.toBytes(expected);
+        assertEquals(smileCodec.fromSmile(smile), expected);
+    }
+
+    @Test
+    public void testListSmileCodec()
+    {
+        SmileCodec<List<Person>> smileCodec = codecFactory.listSmileCodec(Person.class);
+        this.validatePersonListSmileCodec(smileCodec);
+    }
+
+    @Test
+    public void testTypeTokenList()
+    {
+        SmileCodec<List<Person>> smileCodec = codecFactory.smileCodec(new TypeToken<List<Person>>() {});
+        this.validatePersonListSmileCodec(smileCodec);
+    }
+
+    @Test
+    public void testListNullValues()
+    {
+        SmileCodec<List<String>> smileCodec = codecFactory.listSmileCodec(String.class);
+
+        List<String> list = new ArrayList<>();
+        list.add(null);
+        list.add("abc");
+
+        assertEquals(smileCodec.fromSmile(smileCodec.toBytes(list)), list);
+    }
+
+    @Test
+    public void testMapSmileCodec()
+    {
+        SmileCodec<Map<String, Person>> smileCodec = codecFactory.mapSmileCodec(String.class, Person.class);
+        validatePersonMapSmileCodec(smileCodec);
+    }
+
+    @Test
+    public void testMapSmileCodecFromSmileCodec()
+    {
+        SmileCodec<Map<String, Person>> smileCodec = codecFactory.mapSmileCodec(String.class, codecFactory.smileCodec(Person.class));
+        validatePersonMapSmileCodec(smileCodec);
+    }
+
+    @Test
+    public void testTypeLiteralMap()
+    {
+        SmileCodec<Map<String, Person>> smileCodec = codecFactory.smileCodec(new TypeToken<Map<String, Person>>() {});
+        validatePersonMapSmileCodec(smileCodec);
+    }
+
+    @Test
+    public void testMapNullValues()
+    {
+        SmileCodec<Map<String, String>> smileCodec = codecFactory.mapSmileCodec(String.class, String.class);
+
+        Map<String, String> map = new HashMap<>();
+        map.put("x", null);
+        map.put("y", "abc");
+
+        assertEquals(smileCodec.fromSmile(smileCodec.toBytes(map)), map);
+    }
+
+    @Test
+    public void testImmutableSmileCodec()
+    {
+        SmileCodec<ImmutablePerson> smileCodec = codecFactory.smileCodec(ImmutablePerson.class);
+        ImmutablePerson expected = new ImmutablePerson("person-1", true);
+        assertEquals(smileCodec.fromSmile(smileCodec.toBytes(expected)), expected);
+    }
+
+    @Test
+    public void testImmutableListSmileCodec()
+    {
+        SmileCodec<List<ImmutablePerson>> smileCodec = codecFactory.listSmileCodec(ImmutablePerson.class);
+        validateImmutablePersonListSmileCodec(smileCodec);
+    }
+
+    @Test
+    public void testImmutableListSmileCodecFromSmileCodec()
+    {
+        SmileCodec<List<ImmutablePerson>> smileCodec = codecFactory.listSmileCodec(codecFactory.smileCodec(ImmutablePerson.class));
+        validateImmutablePersonListSmileCodec(smileCodec);
+    }
+
+    @Test
+    public void testImmutableTypeTokenList()
+    {
+        SmileCodec<List<ImmutablePerson>> smileCodec = codecFactory.smileCodec(new TypeToken<List<ImmutablePerson>>() {});
+        validateImmutablePersonListSmileCodec(smileCodec);
+    }
+
+    @Test
+    public void testImmutableMapSmileCodec()
+    {
+        SmileCodec<Map<String, ImmutablePerson>> smileCodec = codecFactory.mapSmileCodec(String.class, ImmutablePerson.class);
+        validateImmutablePersonMapSmileCodec(smileCodec);
+    }
+
+    @Test
+    public void testImmutableMapSmileCodecFromSmileCodec()
+    {
+        SmileCodec<Map<String, ImmutablePerson>> smileCodec = codecFactory.mapSmileCodec(String.class, codecFactory.smileCodec(ImmutablePerson.class));
+        validateImmutablePersonMapSmileCodec(smileCodec);
+    }
+
+    @Test
+    public void testImmutableTypeTokenMap()
+    {
+        SmileCodec<Map<String, ImmutablePerson>> smileCodec = codecFactory.smileCodec(new TypeToken<Map<String, ImmutablePerson>>() {});
+        validateImmutablePersonMapSmileCodec(smileCodec);
+    }
+
+    private void validatePersonListSmileCodec(SmileCodec<List<Person>> smileCodec)
+    {
+        List<Person> expected = ImmutableList.of(
+                new Person().setName("person-1").setRocks(true),
+                new Person().setName("person-2").setRocks(true),
+                new Person().setName("person-3").setRocks(true));
+
+        byte[] smileBytes = smileCodec.toBytes(expected);
+        List<Person> actual = smileCodec.fromSmile(smileBytes);
+        assertEquals(actual, expected);
+    }
+
+    private void validatePersonMapSmileCodec(SmileCodec<Map<String, Person>> smileCodec)
+    {
+        Map<String, Person> expected = ImmutableMap.<String, Person>builder()
+                .put("person-1", new Person().setName("person-1").setRocks(true))
+                .put("person-2", new Person().setName("person-2").setRocks(true))
+                .put("person-3", new Person().setName("person-3").setRocks(true))
+                .build();
+
+        byte[] smileBytes = smileCodec.toBytes(expected);
+        Map<String, Person> actual = smileCodec.fromSmile(smileBytes);
+        assertEquals(actual, expected);
+    }
+
+    private void validateImmutablePersonMapSmileCodec(SmileCodec<Map<String, ImmutablePerson>> smileCodec)
+    {
+        Map<String, ImmutablePerson> expected = ImmutableMap.<String, ImmutablePerson>builder()
+                .put("person-1", new ImmutablePerson("person-1", true))
+                .put("person-2", new ImmutablePerson("person-2", true))
+                .put("person-3", new ImmutablePerson("person-3", true))
+                .build();
+
+        byte[] smileBytes = smileCodec.toBytes(expected);
+        Map<String, ImmutablePerson> actual = smileCodec.fromSmile(smileBytes);
+        assertEquals(actual, expected);
+    }
+
+    private void validateImmutablePersonListSmileCodec(SmileCodec<List<ImmutablePerson>> smileCodec)
+    {
+        List<ImmutablePerson> expected = ImmutableList.of(
+                new ImmutablePerson("person-1", true),
+                new ImmutablePerson("person-2", true),
+                new ImmutablePerson("person-3", true));
+
+        byte[] smileBytes = smileCodec.toBytes(expected);
+        List<ImmutablePerson> actual = smileCodec.fromSmile(smileBytes);
+        assertEquals(actual, expected);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/smile/TestSmileSupport.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/smile/TestSmileSupport.java
@@ -1,0 +1,462 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.smile;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.json.JsonBinder.jsonBinder;
+import static java.util.Objects.requireNonNull;
+import static org.joda.time.DateTimeZone.UTC;
+import static org.testng.Assert.assertEquals;
+
+public class TestSmileSupport
+{
+    private static final Car CAR = new Car()
+            .setMake("BMW")
+            .setModel("M3")
+            .setYear(2011)
+            .setPurchased(new DateTime().withZone(UTC))
+            .setNotes("sweet!")
+            .setNameList(superDuper("d*a*i*n"));
+
+    private ObjectMapper objectMapper;
+
+    @BeforeClass
+    public void setUp()
+    {
+        Injector injector = Guice.createInjector(new SmileModule(),
+                binder -> {
+                    jsonBinder(binder).addSerializerBinding(SuperDuperNameList.class).toInstance(ToStringSerializer.instance);
+                    jsonBinder(binder).addDeserializerBinding(SuperDuperNameList.class).to(SuperDuperNameListDeserializer.class);
+                });
+        objectMapper = injector.getInstance(Key.get(ObjectMapper.class, ForSmile.class));
+    }
+
+    @Test
+    public void testSmileCodecFactoryBinding()
+    {
+        Injector injector = Guice.createInjector(new SmileModule());
+        SmileCodecFactory codecFactory = injector.getInstance(SmileCodecFactory.class);
+        SmileCodec<Person> personJsonCodec = codecFactory.smileCodec(Person.class);
+        Person person = new Person();
+        person.setName("name");
+        person.setLastName(Optional.of("lastname"));
+        Person actual = personJsonCodec.fromSmile(personJsonCodec.toBytes(person));
+        assertEquals(actual, person);
+    }
+
+    @Test
+    public void testObjectMapper()
+            throws IOException
+    {
+        byte[] bytes = objectMapper.writeValueAsBytes(CAR);
+        Car car = objectMapper.readValue(bytes, CAR.getClass());
+        assertEquals(car, CAR);
+    }
+
+    @Test
+    public void testFieldDetection()
+            throws Exception
+    {
+        Map<String, Object> actual = createCarMap();
+
+        // notes is not annotated so should not be included
+        // color is null so should not be included
+        assertEquals(actual.keySet(), ImmutableSet.of("make", "model", "year", "purchased", "nameList"));
+    }
+
+    @Test
+    public void testDateTimeRendered()
+            throws Exception
+    {
+        Map<String, Object> actual = createCarMap();
+
+        assertEquals(actual.get("purchased"), ISODateTimeFormat.dateTime().print(CAR.getPurchased()));
+    }
+
+    @Test
+    public void testGuavaRoundTrip()
+            throws Exception
+    {
+        List<Integer> list = ImmutableList.of(3, 5, 8);
+
+        byte[] json = objectMapper.writeValueAsBytes(list);
+        List<Integer> actual = objectMapper.readValue(json, new TypeReference<ImmutableList<Integer>>() {});
+
+        assertEquals(actual, list);
+    }
+
+    @Test
+    public void testIgnoreUnknownFields()
+            throws Exception
+    {
+        Map<String, Object> data = new HashMap<>(createCarMap());
+
+        // add an unknown field
+        data.put("unknown", "bogus");
+
+        // Jackson should deserialize the object correctly with the extra unknown data
+        assertEquals(objectMapper.readValue(objectMapper.writeValueAsBytes(data), Car.class), CAR);
+    }
+
+    @Test
+    public void testPropertyNamesFromParameterNames()
+            throws Exception
+    {
+        NoJsonPropertiesInJsonCreator value = new NoJsonPropertiesInJsonCreator("first value", "second value");
+        NoJsonPropertiesInJsonCreator mapped = objectMapper.readValue(objectMapper.writeValueAsBytes(value), NoJsonPropertiesInJsonCreator.class);
+        assertEquals(mapped.getFirst(), "first value");
+        assertEquals(mapped.getSecond(), "second value");
+    }
+
+    @Test
+    public void testJsonValueAndStaticFactoryMethod()
+            throws Exception
+    {
+        JsonValueAndStaticFactoryMethod value = JsonValueAndStaticFactoryMethod.valueOf("some value");
+        JsonValueAndStaticFactoryMethod mapped = objectMapper.readValue(objectMapper.writeValueAsBytes(value), JsonValueAndStaticFactoryMethod.class);
+        assertEquals(mapped.getValue(), "some value");
+    }
+
+    private Map<String, Object> createCarMap()
+            throws IOException
+    {
+        return objectMapper.readValue(objectMapper.writeValueAsBytes(CAR), new TypeReference<Object>() {});
+    }
+
+    /**
+     * Classes below are copied from airlift as is. Once smile support is released in airlift
+     * smile support in Presto should be entirely removed.
+     */
+    public static class Car
+    {
+        // These fields are public to make sure that Jackson is ignoring them
+        public String make;
+        public String model;
+        public int year;
+        public DateTime purchased;
+
+        // property that will be null to verify that null fields are not rendered
+        public String color;
+
+        // non-json property to verify that auto-detection is disabled
+        public String notes;
+
+        // property that requires special serializer and deserializer
+        public SuperDuperNameList nameList;
+
+        @JsonProperty
+        public String getMake()
+        {
+            return make;
+        }
+
+        @JsonProperty
+        public Car setMake(String make)
+        {
+            this.make = make;
+            return this;
+        }
+
+        @JsonProperty
+        public String getModel()
+        {
+            return model;
+        }
+
+        @JsonProperty
+        public Car setModel(String model)
+        {
+            this.model = model;
+            return this;
+        }
+
+        @JsonProperty
+        public int getYear()
+        {
+            return year;
+        }
+
+        @JsonProperty
+        public Car setYear(int year)
+        {
+            this.year = year;
+            return this;
+        }
+
+        @JsonProperty
+        public DateTime getPurchased()
+        {
+            return purchased;
+        }
+
+        @JsonProperty
+        public Car setPurchased(DateTime purchased)
+        {
+            this.purchased = purchased;
+            return this;
+        }
+
+        @JsonProperty
+        public String getColor()
+        {
+            return color;
+        }
+
+        @JsonProperty
+        public Car setColor(String color)
+        {
+            this.color = color;
+            return this;
+        }
+
+        @JsonProperty
+        public SuperDuperNameList getNameList()
+        {
+            return nameList;
+        }
+
+        @JsonProperty
+        public Car setNameList(SuperDuperNameList nameList)
+        {
+            this.nameList = nameList;
+            return this;
+        }
+
+        // this field should not be written
+
+        public String getNotes()
+        {
+            return notes;
+        }
+
+        public Car setNotes(String notes)
+        {
+            this.notes = notes;
+            return this;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Car)) {
+                return false;
+            }
+
+            Car car = (Car) o;
+
+            if (year != car.year) {
+                return false;
+            }
+            if (color != null ? !color.equals(car.color) : car.color != null) {
+                return false;
+            }
+            if (make != null ? !make.equals(car.make) : car.make != null) {
+                return false;
+            }
+            if (model != null ? !model.equals(car.model) : car.model != null) {
+                return false;
+            }
+            if (nameList != null ? !nameList.equals(car.nameList) : car.nameList != null) {
+                return false;
+            }
+            if (purchased != null ? !purchased.equals(car.purchased) : car.purchased != null) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = make != null ? make.hashCode() : 0;
+            result = 31 * result + (model != null ? model.hashCode() : 0);
+            result = 31 * result + year;
+            result = 31 * result + (purchased != null ? purchased.hashCode() : 0);
+            result = 31 * result + (color != null ? color.hashCode() : 0);
+            result = 31 * result + (nameList != null ? nameList.hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("make", make)
+                    .add("model", model)
+                    .add("year", year)
+                    .add("purchased", purchased)
+                    .add("color", color)
+                    .add("notes", notes)
+                    .add("nameList", nameList)
+                    .toString();
+        }
+    }
+
+    public static class NoJsonPropertiesInJsonCreator
+    {
+        private final String first;
+        private final String second;
+
+        @JsonCreator
+        public NoJsonPropertiesInJsonCreator(/* no @JsonProperty here*/ String first, String second)
+        {
+            this.first = first;
+            this.second = second;
+        }
+
+        @JsonProperty
+        public String getFirst()
+        {
+            return first;
+        }
+
+        @JsonProperty
+        public String getSecond()
+        {
+            return second;
+        }
+    }
+
+    public static class JsonValueAndStaticFactoryMethod
+    {
+        private final String value;
+
+        @JsonCreator
+        public static JsonValueAndStaticFactoryMethod valueOf(String value)
+        {
+            return new JsonValueAndStaticFactoryMethod(value);
+        }
+
+        private JsonValueAndStaticFactoryMethod(String value)
+        {
+            this.value = requireNonNull(value, "value is null");
+        }
+
+        @JsonValue
+        public String getValue()
+        {
+            return value;
+        }
+    }
+
+    public static class SuperDuperNameList
+    {
+        private List<String> name;
+
+        private SuperDuperNameList(String superDuperNameList)
+        {
+            this(superDuperNameList, null);
+        }
+
+        private SuperDuperNameList(String superDuperNameList, Object stopJacksonFromUsingStringConstructor)
+        {
+            this.name = ImmutableList.copyOf(Splitter.on('*').split(superDuperNameList));
+        }
+
+        public List<String> getName()
+        {
+            return name;
+        }
+
+        @Override
+        public String toString()
+        {
+            return Joiner.on("*").join(name);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof SuperDuperNameList)) {
+                return false;
+            }
+
+            SuperDuperNameList that = (SuperDuperNameList) o;
+
+            if (!name.equals(that.name)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return name.hashCode();
+        }
+    }
+
+    public static final class SuperDuperNameListDeserializer
+            extends StdScalarDeserializer<SuperDuperNameList>
+    {
+        public SuperDuperNameListDeserializer()
+        {
+            super(SuperDuperNameList.class);
+        }
+
+        @Override
+        public SuperDuperNameList deserialize(JsonParser jp, DeserializationContext context)
+                throws IOException
+        {
+            JsonToken token = jp.getCurrentToken();
+            if (token == JsonToken.VALUE_STRING) {
+                return new SuperDuperNameList(jp.getText(), null);
+            }
+            context.handleUnexpectedToken(handledType(), jp);
+            throw JsonMappingException.from(jp, null);
+        }
+    }
+
+    public static SuperDuperNameList superDuper(String superDuperNameList)
+    {
+        return new SuperDuperNameList(superDuperNameList, null);
+    }
+}


### PR DESCRIPTION
This change adds support for smile encoding to Presto.  When the
corresponding PR in Airlift is merged (https://github.com/airlift/airlift/pull/706)
Airlift should be used and these changes should be removed.