### PR TITLE
Aria orc input stream

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStreamV1.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStreamV1.java
@@ -16,14 +16,26 @@ package com.facebook.presto.orc.stream;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.LongStreamV1Checkpoint;
+import com.facebook.presto.orc.stream.aria.BufferConsumer;
+import io.airlift.slice.ByteArrays;
 
 import java.io.IOException;
+
+import static com.facebook.presto.orc.stream.LongDecode.zigzagDecode;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 
 public class LongInputStreamV1
         implements LongInputStream
 {
     private static final int MIN_REPEAT_SIZE = 3;
     private static final int MAX_LITERAL_SIZE = 128;
+    private static final long VARINT_MASK = 0x8080_8080_8080_8080L;
+    private static final int VARINT_MASK32 = 0x8080_8080;
+    private static final int BYTES_IN_LONG = SIZE_OF_LONG / SIZE_OF_BYTE;
+    private static final int BYTES_IN_INT = SIZE_OF_INT / SIZE_OF_BYTE;
 
     private final OrcInputStream input;
     private final boolean signed;
@@ -33,6 +45,7 @@ public class LongInputStreamV1
     private int used;
     private boolean repeat;
     private long lastReadInputCheckpoint;
+    private PositionsFilter positionsFilter;
 
     public LongInputStreamV1(OrcInputStream input, boolean signed)
     {
@@ -130,6 +143,202 @@ public class LongInputStreamV1
             long consume = Math.min(items, numLiterals - used);
             used += consume;
             items -= consume;
+        }
+    }
+
+    public void setPositionsFilter(int[] positions, boolean useLegacy)
+    {
+        if (useLegacy) {
+            positionsFilter = new LegacyPositionsFilter(positions);
+        }
+        else {
+            positionsFilter = new SkippingPositionsFilter(positions);
+        }
+    }
+
+    public long nextLong()
+            throws IOException
+    {
+        return positionsFilter.nextLong();
+    }
+
+    interface PositionsFilter
+    {
+        long nextLong()
+                throws IOException;
+    }
+
+    private class LegacyPositionsFilter
+            implements PositionsFilter
+    {
+        private int[] positions;
+        private int offset;
+        private int currentPosition;
+
+        public LegacyPositionsFilter(int[] positions)
+        {
+            this.positions = positions;
+        }
+        public long nextLong()
+                throws IOException
+        {
+            while (currentPosition < positions[offset]) {
+                next();
+                currentPosition++;
+            }
+            long result = next();
+            offset++;
+            currentPosition++;
+            return result;
+        }
+    }
+
+    private class SkippingPositionsFilter
+            implements PositionsFilter
+    {
+        private int[] positions;
+        private int offset;
+
+        private int currentStartPosition;
+        private int currentEndPosition;
+        private LongBufferConsumer longBufferConsumer = new LongBufferConsumer();
+        private int currentLiteralsToProcess;
+
+        public SkippingPositionsFilter(int[] positions)
+        {
+            this.positions = positions;
+        }
+
+        public long nextLong()
+                throws IOException
+        {
+            while (positions[offset] >= currentEndPosition) {
+                if (!repeat) {
+                    longBufferConsumer.skip(currentLiteralsToProcess);
+                }
+
+                used = 0;
+                int control = longBufferConsumer.read();
+                if (control == -1) {
+                    throw new OrcCorruptionException(input.getOrcDataSourceId(), "Read past end of RLE integer");
+                }
+                currentStartPosition = currentEndPosition;
+                if (control < 0x80) {
+                    numLiterals = control + MIN_REPEAT_SIZE;
+                    repeat = true;
+                    delta = longBufferConsumer.read();
+                    if (delta == -1) {
+                        throw new OrcCorruptionException(input.getOrcDataSourceId(), "Read past end of RLE integer");
+                    }
+                    delta = (byte) delta;
+                    literals[0] = longBufferConsumer.decodeVint();
+                }
+                else {
+                    numLiterals = 0x100 - control;
+                    repeat = false;
+                    delta = 0;
+                    currentLiteralsToProcess = numLiterals;
+                }
+                currentEndPosition += numLiterals;
+            }
+            long result;
+            if (repeat) {
+                used = positions[offset] - currentStartPosition;
+                result = literals[0] + used * delta;
+            }
+            else {
+                int processed = numLiterals - currentLiteralsToProcess;
+                int skipCount = positions[offset] - currentStartPosition - processed;
+                longBufferConsumer.skip(skipCount);
+                result = longBufferConsumer.decodeVint();
+                currentLiteralsToProcess -= skipCount + 1;
+            }
+            offset++;
+            return result;
+        }
+    }
+    private class LongBufferConsumer
+            extends BufferConsumer
+    {
+        @Override
+        public void skip(int items)
+                throws IOException
+        {
+            if (items == 0) {
+                return;
+            }
+            checkState(items > 0, "items to skip < 0");
+
+            int count = 0;
+            long value = 0;
+            while (items > 0 && remaining() >= SIZE_OF_LONG) {
+                value = ByteArrays.getLong(buffer, position);
+                count = BYTES_IN_LONG - Long.bitCount(value & VARINT_MASK);
+                items -= count;
+                position += SIZE_OF_LONG;
+            }
+            if (items == 0) {
+                long inverted = (value & VARINT_MASK) ^ VARINT_MASK;
+                position -= Long.numberOfLeadingZeros(inverted) >>> 3;
+                return;
+            }
+            if (items < 0) {
+                items += count;
+                position -= SIZE_OF_LONG;
+            }
+
+            if (items > 0 && remaining() >= SIZE_OF_INT) {
+                value = ByteArrays.getInt(buffer, position);
+                count = BYTES_IN_INT - Integer.bitCount((int) value & VARINT_MASK32);
+                items -= count;
+                position += SIZE_OF_INT;
+            }
+            if (items == 0) {
+                int inverted = ((int) value & VARINT_MASK32) ^ VARINT_MASK32;
+                position -= Long.numberOfLeadingZeros(inverted) >>> 3;
+                return;
+            }
+            if (items < 0) {
+                items += count;
+                position -= SIZE_OF_INT;
+            }
+
+            while (items > 0 && remaining() > 0) {
+                if ((0x80 & this.read()) == 0) {
+                    items--;
+                }
+            }
+            if (items > 0) {
+                throw new OrcCorruptionException(input.getOrcDataSourceId(), "EOF while reading unsigned vint");
+            }
+        }
+
+        public long decodeVint()
+                throws IOException
+        {
+            long result = 0;
+            long offset = 0;
+            long b;
+            do {
+                b = read();
+                if (b == -1) {
+                    throw new OrcCorruptionException(input.getOrcDataSourceId(), "EOF while reading unsigned vint");
+                }
+                result |= (b & 0b0111_1111) << offset;
+                offset += 7;
+            }
+            while ((b & 0b1000_0000) != 0);
+            if (signed) {
+                return zigzagDecode(result);
+            }
+            else {
+                return result;
+            }
+        }
+        protected void refresh()
+                throws IOException
+        {
+            input.readBuffer(this);
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/aria/BufferConsumer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/aria/BufferConsumer.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream.aria;
+
+import java.io.IOException;
+
+public abstract class BufferConsumer
+{
+    protected byte[] buffer;
+    protected int length;
+    protected int position;
+
+    public void setBuffer(byte[] buffer, int length)
+    {
+        this.buffer = buffer;
+        this.length = length;
+        this.position = 0;
+    }
+
+    public abstract void skip(int items)
+            throws IOException;
+
+    protected abstract void refresh()
+            throws IOException;
+
+    public int length()
+    {
+        return length;
+    }
+
+    public int remaining()
+            throws IOException
+    {
+        if (length - position == 0) {
+            refresh();
+        }
+        return length - position;
+    }
+
+    public int read()
+            throws IOException
+    {
+        if (remaining() == 0) {
+            return -1;
+        }
+        return 0xff & buffer[position++];
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/BenchmarkLongStreamV1.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/BenchmarkLongStreamV1.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import com.facebook.presto.orc.OrcDecompressor;
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.Stream;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
+import static com.facebook.presto.orc.stream.AbstractTestValueStream.COMPRESSION_BLOCK_SIZE;
+import static com.facebook.presto.orc.stream.AbstractTestValueStream.ORC_DATA_SOURCE_ID;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.stream.Collectors.toList;
+import static org.testng.Assert.assertEquals;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkLongStreamV1
+{
+    private static final List<List<Long>> GROUPS = getData();
+
+    @Benchmark
+    @OperationsPerInvocation(2)
+    public Object benchmarkDecoding(BenchmarkData data)
+            throws IOException
+    {
+        long actualValue = 0L;
+        //data.input = getInputStream(data.slice, CompressionKind.valueOf(data.kind));
+        //data.input.setPositionsFilter(data.positions, data.useLegacy);
+        for (int i = 0; i < data.positions.length; i++) {
+            actualValue = data.input.nextLong();
+            /*
+            try {
+                long expectedValue = data.data.get(data.positions[i]);
+                actualValue = data.input.nextLong();
+                assertEquals(actualValue, expectedValue, "index=" + data.positions[i]);
+            }
+            catch (IOException t) {
+                for (int j = Math.max(0, i - 10); j <= i; j++) {
+                    System.err.println("POSITION " + j + ", " + data.positions[j]);
+                }
+                throw t;
+            }
+            */
+        }
+        return actualValue;
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"false", "true"})
+        boolean useLegacy;
+
+        @Param({"NONE", "SNAPPY", "ZSTD", "ZLIB", "LZ4"})
+        String kind = "NONE";
+
+        @Param({"ALL", "ODD", "SECOND_HALF", "RANDOM_QUARTER"})
+        String positionsType = "RANDOM_QUARTER";
+
+        LongInputStreamV1 input;
+
+        int[] positions;
+        Slice slice;
+
+        List<Long> data;
+
+        @Setup(Level.Invocation)
+        public void setup()
+                throws IOException
+        {
+            this.data = GROUPS.stream()
+                    .flatMap(Collection::stream)
+                    .collect(toImmutableList());
+
+            CompressionKind compressionKind = CompressionKind.valueOf(kind);
+            this.slice = getInput(GROUPS, compressionKind);
+            this.positions = getPositions(data, PositionsType.valueOf(positionsType));
+            input = getInputStream(slice, compressionKind);
+            input.setPositionsFilter(positions, useLegacy);
+        }
+    }
+
+    public static Slice getInput(List<List<Long>> groups, CompressionKind kind)
+    {
+        LongOutputStreamV1 outputStream = new LongOutputStreamV1(kind, COMPRESSION_BLOCK_SIZE, true, DATA);
+        outputStream.reset();
+        for (List<Long> group : groups) {
+            outputStream.recordCheckpoint();
+            group.forEach(outputStream::writeLong);
+        }
+        outputStream.close();
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
+        StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(1);
+        streamDataOutput.writeData(sliceOutput);
+        Stream stream = streamDataOutput.getStream();
+        assertEquals(stream.getStreamKind(), DATA);
+        assertEquals(stream.getColumn(), 1);
+        assertEquals(stream.getLength(), sliceOutput.size());
+        return sliceOutput.slice();
+    }
+
+    public static LongInputStreamV1 getInputStream(Slice slice, CompressionKind kind)
+            throws IOException
+    {
+        Optional<OrcDecompressor> orcDecompressor = createOrcDecompressor(ORC_DATA_SOURCE_ID, kind, COMPRESSION_BLOCK_SIZE);
+        OrcInputStream input = new OrcInputStream(ORC_DATA_SOURCE_ID, slice.getInput(), orcDecompressor, newSimpleAggregatedMemoryContext(), slice.getRetainedSize());
+        return new LongInputStreamV1(input, true);
+    }
+
+    public static List<List<Long>> getData()
+    {
+        List<List<Long>> groups = new ArrayList<>();
+        List<Long> group;
+        for (int j = 0; j < 3; j++) {
+            group = new ArrayList<>();
+            for (int i = 0; i < 1000; i++) {
+                group.add((long) (i));
+            }
+            groups.add(group);
+
+            group = new ArrayList<>();
+            for (int i = 0; i < 1000; i++) {
+                group.add((long) (10_000 + (i * 17)));
+            }
+            groups.add(group);
+
+            group = new ArrayList<>();
+            for (int i = 0; i < 1000; i++) {
+                group.add((long) (10_000 - (i * 17)));
+            }
+            groups.add(group);
+
+            group = new ArrayList<>();
+            Random random = new Random(22);
+            for (int i = 0; i < 1000; i++) {
+                group.add(-1000L + random.nextInt(17));
+            }
+            groups.add(group);
+        }
+        return groups;
+    }
+
+    public static int[] getPositions(List<Long> data, PositionsType positionsType)
+    {
+        int size = data.size();
+        int[] positions;
+        switch (positionsType) {
+            case ALL:
+                positions = IntStream.range(0, size).toArray();
+                break;
+            case ODD:
+                int oddCount = (size & 1) == 1 ? (size - 1) >> 1 : size >> 1;
+                positions = new int[oddCount];
+                for (int i = 0; i < oddCount; i++) {
+                    positions[i] = 2 * i + 1;
+                }
+                break;
+            case SECOND_HALF:
+                int mid = size >> 1;
+                positions = new int[size - mid];
+                for (int i = mid; i < size; i++) {
+                    positions[i - mid] = i;
+                }
+                break;
+            case RANDOM_QUARTER:
+                List<Integer> all = IntStream.range(0, size).boxed().collect(toList());
+                Collections.shuffle(all);
+                int quarterSize = all.size() >> 2;
+                positions = new int[quarterSize];
+                for (int i = 0; i < quarterSize; i++) {
+                    positions[i] = all.get(i);
+                }
+                Arrays.sort(positions);
+                break;
+            default:
+                throw new IllegalStateException("Invalid PositionsType");
+        }
+        return positions;
+    }
+    public enum PositionsType
+    {
+        ALL,
+        ODD,
+        SECOND_HALF,
+        RANDOM_QUARTER
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkLongStreamV1().benchmarkDecoding(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkLongStreamV1.class.getSimpleName() + ".*")
+                .jvmArgs("-Xmx5g")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamV1Aria.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamV1Aria.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import com.facebook.presto.orc.OrcDecompressor;
+import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.Stream;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
+import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
+import static com.facebook.presto.orc.stream.AbstractTestValueStream.ORC_DATA_SOURCE_ID;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.testng.Assert.assertEquals;
+
+public class TestLongStreamV1Aria
+{
+    private static final int COMPRESSION_BLOCK_SIZE = 256 * 1024;
+
+    @Test
+    public void testLiterals()
+            throws IOException
+    {
+        int[] positions = IntStream.range(210, 20011).toArray();
+        testWriteValueWithPositions(getData2(), SNAPPY, positions);
+    }
+
+    public void testWriteValueWithPositions(List<List<Long>> groups, CompressionKind kind, int[] positions)
+            throws IOException
+    {
+        LongOutputStreamV1 outputStream = createOutputStream(groups, kind);
+
+        Slice slice = getSlice(outputStream, 33);
+        List<LongStreamCheckpoint> checkpoints = outputStream.getCheckpoints();
+
+        assertEquals(checkpoints.size(), groups.size());
+
+        LongInputStream valueStream = getInputStream(slice, kind);
+        ((LongInputStreamV1) valueStream).setPositionsFilter(positions, false);
+        List<Long> flattened = groups.stream()
+                .flatMap(Collection::stream)
+                .collect(toImmutableList());
+        for (int position : positions) {
+            long expectedValue = flattened.get(position);
+            long actualValue = ((LongInputStreamV1) valueStream).nextLong();
+            assertEquals(actualValue, expectedValue, "index=" + position);
+        }
+    }
+
+    public void testWriteValue(List<List<Long>> groups, CompressionKind kind)
+            throws IOException
+    {
+        LongOutputStreamV1 outputStream = createOutputStream(groups, kind);
+
+        Slice slice = getSlice(outputStream, 33);
+        List<LongStreamCheckpoint> checkpoints = outputStream.getCheckpoints();
+
+        assertEquals(checkpoints.size(), groups.size());
+
+        LongInputStream valueStream = getInputStream(slice, kind);
+
+        for (List<Long> group : groups) {
+            int index = 0;
+            for (Long expectedValue : group) {
+                index++;
+                Long actualValue = valueStream.next();
+                if (!actualValue.equals(expectedValue)) {
+                    assertEquals(actualValue, expectedValue, "index=" + index);
+                }
+            }
+        }
+        for (int groupIndex = groups.size() - 1; groupIndex >= 0; groupIndex--) {
+            valueStream.seekToCheckpoint(checkpoints.get(groupIndex));
+            for (Long expectedValue : groups.get(groupIndex)) {
+                Long actualValue = valueStream.next();
+                if (!actualValue.equals(expectedValue)) {
+                    assertEquals(actualValue, expectedValue);
+                }
+            }
+        }
+    }
+
+    public LongInputStreamV1 getInputStream(Slice slice, CompressionKind kind)
+            throws IOException
+    {
+        Optional<OrcDecompressor> orcDecompressor = createOrcDecompressor(ORC_DATA_SOURCE_ID, kind, COMPRESSION_BLOCK_SIZE);
+        OrcInputStream input = new OrcInputStream(ORC_DATA_SOURCE_ID, slice.getInput(), orcDecompressor, newSimpleAggregatedMemoryContext(), slice.getRetainedSize());
+        return new LongInputStreamV1(input, true);
+    }
+
+    public Slice getSlice(LongOutputStreamV1 outputStream, int column)
+    {
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
+        StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(column);
+        streamDataOutput.writeData(sliceOutput);
+        Stream stream = streamDataOutput.getStream();
+        assertEquals(stream.getStreamKind(), Stream.StreamKind.DATA);
+        assertEquals(stream.getColumn(), column);
+        assertEquals(stream.getLength(), sliceOutput.size());
+        return sliceOutput.slice();
+    }
+
+    public LongOutputStreamV1 createOutputStream(List<List<Long>> groups, CompressionKind kind)
+    {
+        LongOutputStreamV1 outputStream = new LongOutputStreamV1(kind, COMPRESSION_BLOCK_SIZE, true, DATA);
+        outputStream.reset();
+        for (List<Long> group : groups) {
+            outputStream.recordCheckpoint();
+            group.forEach(outputStream::writeLong);
+        }
+        outputStream.close();
+        return outputStream;
+    }
+
+    public List<List<Long>> getRun()
+    {
+        List<List<Long>> groups = new ArrayList<>();
+        List<Long> group;
+
+        group = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            group.add(Long.MIN_VALUE);
+        }
+        groups.add(group);
+        return groups;
+    }
+
+    public List<List<Long>> getLiterals()
+    {
+        List<List<Long>> groups = new ArrayList<>();
+        List<Long> group;
+        group = new ArrayList<>();
+        Random random = new Random();
+        for (int i = 0; i < 1000; i++) {
+            group.add(-1000L + random.nextInt(17));
+        }
+        groups.add(group);
+        return groups;
+    }
+
+    public List<List<Long>> getData()
+    {
+        List<List<Long>> groups = new ArrayList<>();
+        List<Long> group;
+
+        group = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            group.add((long) (i));
+        }
+        groups.add(group);
+
+        group = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            group.add((long) (10_000 + (i * 17)));
+        }
+        groups.add(group);
+
+        group = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            group.add((long) (10_000 - (i * 17)));
+        }
+        groups.add(group);
+
+        group = new ArrayList<>();
+        Random random = new Random(22);
+        for (int i = 0; i < 1000; i++) {
+            group.add(-1000L + random.nextInt(17));
+        }
+        groups.add(group);
+        return groups;
+    }
+
+    public static List<List<Long>> getData2()
+    {
+        List<List<Long>> groups = new ArrayList<>();
+        List<Long> group;
+        for (int j = 0; j < 4; j++) {
+            group = new ArrayList<>();
+            for (int i = 0; i < 10000; i++) {
+                group.add((long) (i));
+            }
+            groups.add(group);
+
+            group = new ArrayList<>();
+            for (int i = 0; i < 5000; i++) {
+                group.add((long) (10_000 + (i * 17)));
+            }
+            groups.add(group);
+
+            group = new ArrayList<>();
+            for (int i = 0; i < 5000; i++) {
+                group.add((long) (10_000 - (i * 17)));
+            }
+            groups.add(group);
+
+            group = new ArrayList<>();
+            Random random = new Random(22);
+            for (int i = 0; i < 30000; i++) {
+                group.add(-1000L + random.nextInt(17));
+            }
+            groups.add(group);
+        }
+        return groups;
+    }
+}


### PR DESCRIPTION
Preliminary benchmark to test the hypothesis that directly accessing the underlying byte[] buffer in OrcInputStream can speed up decoding varints:

Legend:
kind:
CompressionKind in orc: NONE, SNAPPY, ZLIB, LZ4, ZSTD

positionsType:
ALL: all positions in the generated data
ODD: odd positions in the generated data
SECOND_HALF: the second half of positions (i.e. 3,4,5 for 0,1,2,3,4,5)
RANDOM_QUARTER: one quarter of the positions are randomly selected (i.e. 5, 7 for 0,1,2,3,4,5,6,7)

useLegacy:
true: use the original api to decode all varints
false: use the underlying byte[] to decode varints
```
Benchmark                                (kind)  (positionsType)  (useLegacy)  Mode  Cnt      Score      Error  Units
BenchmarkLongStreamV1.benchmarkDecoding    NONE              ALL        false  avgt   20  45080.417 ± 1375.709  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    NONE              ALL         true  avgt   20  38865.211 ± 1150.178  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    NONE              ODD        false  avgt   20  31190.495 ±  506.008  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    NONE              ODD         true  avgt   20  42197.612 ±  664.235  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    NONE      SECOND_HALF        false  avgt   20  26741.290 ± 1424.076  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    NONE      SECOND_HALF         true  avgt   20  45175.933 ± 1564.881  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    NONE   RANDOM_QUARTER        false  avgt   20  24132.613 ± 1580.426  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    NONE   RANDOM_QUARTER         true  avgt   20  64106.730 ± 8208.055  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY              ALL        false  avgt   20  49234.447 ± 1461.745  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY              ALL         true  avgt   20  45448.406 ± 3704.516  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY              ODD        false  avgt   20  34305.697 ± 1039.228  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY              ODD         true  avgt   20  41636.785 ± 2150.768  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY      SECOND_HALF        false  avgt   20  29100.552 ±  840.056  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY      SECOND_HALF         true  avgt   20  49366.219 ±  684.970  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY   RANDOM_QUARTER        false  avgt   20  27046.045 ± 1753.520  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY   RANDOM_QUARTER         true  avgt   20  64718.664 ± 1268.438  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZSTD              ALL        false  avgt   20  54727.205 ± 3781.865  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZSTD              ALL         true  avgt   20  50054.131 ± 4087.994  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZSTD              ODD        false  avgt   20  39482.508 ±  831.207  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZSTD              ODD         true  avgt   20  46988.306 ± 1848.540  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZSTD      SECOND_HALF        false  avgt   20  34400.093 ± 1165.061  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZSTD      SECOND_HALF         true  avgt   20  56019.832 ± 1225.329  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZSTD   RANDOM_QUARTER        false  avgt   20  33280.886 ± 1012.340  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZSTD   RANDOM_QUARTER         true  avgt   20  72025.874 ± 3885.905  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZLIB              ALL        false  avgt   20  58024.044 ± 4275.707  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZLIB              ALL         true  avgt   20  52234.260 ± 1665.090  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZLIB              ODD        false  avgt   20  42934.222 ± 2802.383  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZLIB              ODD         true  avgt   20  50042.328 ± 2000.023  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZLIB      SECOND_HALF        false  avgt   20  37886.548 ± 2411.626  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZLIB      SECOND_HALF         true  avgt   20  58136.255 ± 1937.070  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZLIB   RANDOM_QUARTER        false  avgt   20  35589.022 ± 1192.427  ns/op
BenchmarkLongStreamV1.benchmarkDecoding    ZLIB   RANDOM_QUARTER         true  avgt   20  74613.471 ± 1732.159  ns/op
BenchmarkLongStreamV1.benchmarkDecoding     LZ4              ALL        false  avgt   20  53920.146 ± 1379.967  ns/op
BenchmarkLongStreamV1.benchmarkDecoding     LZ4              ALL         true  avgt   20  51285.604 ± 5631.195  ns/op
BenchmarkLongStreamV1.benchmarkDecoding     LZ4              ODD        false  avgt   20  41544.817 ± 2962.042  ns/op
BenchmarkLongStreamV1.benchmarkDecoding     LZ4              ODD         true  avgt   20  46796.653 ± 1128.737  ns/op
BenchmarkLongStreamV1.benchmarkDecoding     LZ4      SECOND_HALF        false  avgt   20  35283.128 ± 1461.526  ns/op
BenchmarkLongStreamV1.benchmarkDecoding     LZ4      SECOND_HALF         true  avgt   20  55832.532 ± 1867.267  ns/op
BenchmarkLongStreamV1.benchmarkDecoding     LZ4   RANDOM_QUARTER        false  avgt   20  31793.921 ±  691.252  ns/op
BenchmarkLongStreamV1.benchmarkDecoding     LZ4   RANDOM_QUARTER         true  avgt   20  71105.540 ± 1758.922  ns/op
```