### PR TITLE
Revert "Fix Hive table read within transaction"

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1116,13 +1116,7 @@ public class HiveMetadata
             tableStatistics = new PartitionStatistics(createEmptyStatistics(), ImmutableMap.of());
         }
 
-        metastore.createTable(
-                session,
-                table,
-                principalPrivileges,
-                table.getPartitionColumns().isEmpty() ? Optional.of(writeInfo.getWritePath()) : Optional.empty(),
-                false,
-                tableStatistics);
+        metastore.createTable(session, table, principalPrivileges, Optional.of(writeInfo.getWritePath()), false, tableStatistics);
 
         if (!handle.getPartitionedBy().isEmpty()) {
             if (isRespectTableFormat(session)) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -3145,13 +3145,12 @@ public abstract class AbstractTestHiveClient
                 assertEquals(otherTableStatistics.getRowCount().getAsLong(), CREATE_TABLE_DATA.getRowCount() * 3L);
             }
 
-            // verify we did not modify the table target directory
-            HdfsContext context = new HdfsContext(session, tableName.getSchemaName(), tableName.getTableName());
-            Path targetPathRoot = getTargetPathRoot(insertTableHandle);
-            assertEquals(listAllDataFiles(context, targetPathRoot), existingFiles);
+            // verify we did not modify the table directory
+            assertEquals(listAllDataFiles(transaction, tableName.getSchemaName(), tableName.getTableName()), existingFiles);
 
             // verify all temp files start with the unique prefix
             stagingPathRoot = getStagingPathRoot(insertTableHandle);
+            HdfsContext context = new HdfsContext(session, tableName.getSchemaName(), tableName.getTableName());
             Set<String> tempFiles = listAllDataFiles(context, stagingPathRoot);
             assertTrue(!tempFiles.isEmpty());
             for (String filePath : tempFiles) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -2181,35 +2181,6 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
-    public void testCreateUnpartitionedTableAndQuery()
-    {
-        Session session = getSession();
-
-        List<MaterializedRow> expected = MaterializedResult.resultBuilder(session, BIGINT, BIGINT)
-                .row(101L, 1L)
-                .row(201L, 2L)
-                .row(202L, 2L)
-                .row(301L, 3L)
-                .row(302L, 3L)
-                .build()
-                .getMaterializedRows();
-
-        transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
-                .execute(session, transactionSession -> {
-                    assertUpdate(
-                            transactionSession,
-                            "CREATE TABLE tmp_create_query AS " +
-                                    "SELECT * from (VALUES (CAST (101 AS BIGINT), CAST (1 AS BIGINT)), (201, 2), (202, 2), (301, 3), (302, 3)) t(a, z)",
-                            5);
-                    MaterializedResult actualFromCurrentTransaction = computeActual(transactionSession, "SELECT * FROM tmp_create_query");
-                    assertEqualsIgnoreOrder(actualFromCurrentTransaction, expected);
-                });
-
-        MaterializedResult actualAfterTransaction = computeActual(session, "SELECT * FROM tmp_create_query");
-        assertEqualsIgnoreOrder(actualAfterTransaction, expected);
-    }
-
-    @Test
     public void testAddColumn()
     {
         assertUpdate("CREATE TABLE test_add_column (a bigint COMMENT 'test comment AAA')");


### PR DESCRIPTION
This reverts the following commits:
 * a452ccf59bdc09750abd63bf285c1b2e9347a578
 * 4666559c319d6b1118568b03083d9e12479018d4
 * 90f8e3acfb6591afcef6718c65ce6b350defa012

In order to fix reading new created Hive unpartitioned table within
transaction, 90f8e3acfb6591afcef6718c65ce6b350defa012 fix the
currentLocation contract in TableAndMore. However, it turns out
there are places implicitly rely on currentLocation is always provided
(e.g. CREATE TABLE AS SELECT partitioned table, with WriteMode is
DIRECT_TO_TARGET_NEW_DIRECTORY)