### PR TITLE
Aria scan fixes + optimize SliceDictionaryStreamReader

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestAriaHiveDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestAriaHiveDistributedQueries.java
@@ -233,6 +233,13 @@ public class TestAriaHiveDistributedQueries
                 "FROM lineitem\n" +
                 "WHERE\n" +
                 "    shipinstruct = 'TAKE BACK RETURN' AND shipmode = 'AIR'");
+
+        assertQuery(ariaSession(), "SELECT\n" +
+                "    linenumber,\n" +
+                "    orderkey\n" +
+                "FROM lineitem\n" +
+                "WHERE\n" +
+                "    shipinstruct = 'TAKE BACK RETURN' AND orderkey < 10");
     }
 
     // nulls1.sql

--- a/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
@@ -341,7 +341,7 @@ public class ScanFilterAndProjectOperator
 
         PageSourceOptions options = new PageSourceOptions(
                 channels,
-                projectionPushdownChannels == null ? channels : projectionInputChannels,
+                projectionPushdownChannels == null ? channels : projectionPushdownChannels,
                 reusePages,
                 filters,
                 ariaReorderFilters(operatorContext.getSession()),

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReader.java
@@ -441,12 +441,6 @@ public class OrcRecordReader
         return block;
     }
 
-    public StreamReader getStreamReader(int index)
-    {
-        checkArgument(index < streamReaders.length, "index does not exist");
-        return streamReaders[index];
-    }
-
     public Map<String, Slice> getUserMetadata()
     {
         return ImmutableMap.copyOf(Maps.transformValues(userMetadata, Slices::copyOf));
@@ -781,7 +775,6 @@ public class OrcRecordReader
     {
         reader.newBatch(numResults);
         numResults = 0;
-        nextRowGroup:
         for (; ; ) {
             if (currentRowGroup == -1 || qualifyingSet == null || (qualifyingSet.isEmpty() && !reader.hasUnfetchedRows())) {
                 if (currentPosition == totalRowCount) {
@@ -798,7 +791,7 @@ public class OrcRecordReader
                 qualifyingSet.setRange((int) currentGroupRowCount);
                 reader.setQualifyingSets(qualifyingSet, null);
                 if (reorderFilters && (currentRowGroup & 0x3) != 0 && currentRowGroup != 0) {
-                    // Reconsider filter order Every 4 row groups.
+                    // Reconsider filter order every 4 row groups.
                     reader.maybeReorderFilters();
                 }
             }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ColumnReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ColumnReader.java
@@ -42,6 +42,7 @@ abstract class ColumnReader
     Block block;
     int outputChannel = -1;
     Filter filter;
+    protected boolean deterministicFilter;
     int columnIndex;
     Type type;
     // First row number in row group that is not processed due to
@@ -114,6 +115,7 @@ abstract class ColumnReader
     public void setFilterAndChannel(Filter filter, int channel, int columnIndex, Type type)
     {
         this.filter = filter;
+        this.deterministicFilter = filter != null && filter.isDeterministic();
         outputChannel = channel;
         this.columnIndex = columnIndex;
         this.type = type;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectStreamReader.java
@@ -270,16 +270,21 @@ public class LongDirectStreamReader
         }
 
         @Override
-        public boolean consumeRepeated(int offsetIndex, long value, int count)
+        public int consumeRepeated(int offsetIndex, long value, int count)
         {
-            if (filter != null && !filter.testLong(value)) {
-                return false;
+            if (deterministicFilter && !filter.testLong(value)) {
+                return 0;
             }
 
+            int added = 0;
             for (int i = 0; i < count; i++) {
+                if (!deterministicFilter && filter != null && !filter.testLong(value)) {
+                    continue;
+                }
                 addResult(offsetIndex + i, value);
+                added++;
             }
-            return true;
+            return added;
         }
 
         private void addResult(int offsetIndex, long value)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectStreamReader.java
@@ -207,14 +207,15 @@ public class LongDirectStreamReader
         QualifyingSet input = hasNulls ? innerQualifyingSet : inputQualifyingSet;
         // Read dataStream if there are non-null values in the QualifyingSet.
         if (input.getPositionCount() > 0) {
-            resultsProcessor.reset();
             if (filter != null) {
                 int numInput = input.getPositionCount();
                 outputQualifyingSet.reset(numInput);
+                resultsProcessor.reset();
                 numInnerResults = dataStream.scan(input.getPositions(), 0, numInput, input.getEnd(), resultsProcessor);
                 outputQualifyingSet.setPositionCount(numInnerResults);
             }
             else {
+                resultsProcessor.reset();
                 numInnerResults = dataStream.scan(input.getPositions(), 0, input.getPositionCount(), input.getEnd(), resultsProcessor);
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryStreamReader.java
@@ -418,14 +418,15 @@ public class SliceDictionaryStreamReader
         }
 
         if (input.getPositionCount() > 0) {
-            resultsProcessor.reset();
             if (filter != null) {
                 int numInput = input.getPositionCount();
                 outputQualifyingSet.reset(numInput);
+                resultsProcessor.reset();
                 numInnerResults = dataStream.scan(input.getPositions(), 0, numInput, input.getEnd(), resultsProcessor);
                 outputQualifyingSet.setPositionCount(numInnerResults);
             }
             else {
+                resultsProcessor.reset();
                 numInnerResults = dataStream.scan(input.getPositions(), 0, input.getPositionCount(), input.getEnd(), resultsProcessor);
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStream.java
@@ -84,7 +84,7 @@ public interface LongInputStream
         boolean consume(int offsetIndex, long value)
                 throws IOException;
 
-        boolean consumeRepeated(int offsetIndex, long value, int count)
+        int consumeRepeated(int offsetIndex, long value, int count)
                 throws IOException;
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStreamV2.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStreamV2.java
@@ -413,9 +413,7 @@ public class LongInputStreamV2
             }
             int numInRle = numOffsetsWithin(length);
             if (numInRle > 0) {
-                if (resultsConsumer.consumeRepeated(offsetIdx, literal, numInRle)) {
-                    numResults += numInRle;
-                }
+                numResults += resultsConsumer.consumeRepeated(offsetIdx, literal, numInRle);
                 offsetIdx += numInRle;
                 currentRunOffset += length;
                 scanDone = true;


### PR DESCRIPTION
Fix queries with filters on multiple columns and output columns being a subset of input columns.

```
SELECT
   linenumber,
   orderkey
FROM lineitem
WHERE
   shipinstruct = 'TAKE BACK RETURN' AND orderkey < 10
```

TestAriaHiveDistributedQueries is passing.