### PR TITLE
Add analyze properties system table and documentation for ANALYZE statement

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -453,6 +453,27 @@ Column Type   Collectible Statistics
 Automatic column level statistics collection on write is controlled by
 the ``collect-column-statistics-on-write`` catalog session property.
 
+.. _hive_analyze:
+
+Collecting table and column statistics
+--------------------------------------
+
+The Hive connector supports collection of table and partition statistics
+via the :doc:`/sql/analyze` statement. When analyzing a partitioned table,
+the partitions to analyze can be specified via the optional ``partitions``
+property, which is an array containing the values of the partition keys
+in the order they are declared in the table schema::
+
+    ANALYZE hive.sales WITH (
+        partitions = ARRAY[
+            ARRAY['partition1_value1', 'partition1_value2'],
+            ARRAY['partition2_value1', 'partition2_value2']]);
+
+This query will collect statistics for 2 partitions with keys:
+
+* ``partition1_value1, partition1_value2``
+* ``partition2_value1, partition2_value2``
+
 Schema Evolution
 ----------------
 

--- a/presto-docs/src/main/sphinx/sql.rst
+++ b/presto-docs/src/main/sphinx/sql.rst
@@ -9,6 +9,7 @@ This chapter describes the SQL syntax used in Presto.
 
     sql/alter-schema
     sql/alter-table
+    sql/analyze
     sql/call
     sql/commit
     sql/create-role

--- a/presto-docs/src/main/sphinx/sql/analyze.rst
+++ b/presto-docs/src/main/sphinx/sql/analyze.rst
@@ -1,0 +1,41 @@
+=======
+ANALYZE
+=======
+
+Synopsis
+--------
+
+.. code-block:: none
+
+    ANALYZE table_name [ WITH ( property_name = expression [, ...] ) ]
+
+Description
+-----------
+
+Collects table and column statistics for a given table.
+
+The optional ``WITH`` clause can be used to provide
+connector-specific properties.
+
+Currently, this statement is only supported by the
+:ref:`Hive connector <hive_analyze>`.
+
+Examples
+--------
+
+Analyze table ``web`` to collect table and column statistics::
+
+    ANALYZE web;
+
+Analyze table ``stores`` in catalog ``hive`` and schema ``default``::
+
+    ANALYZE hive.default.stores;
+
+Analyze partitions ``'1992-01-01', '1992-01-02'`` from a Hive partitioned table ``sales``::
+
+    ANALYZE hive.default.sales WITH (partitions = ARRAY[ARRAY['1992-01-01'], ARRAY['1992-01-02']]);
+
+Analyze partitions with complex partition key (``state`` and ``city`` columns) from a Hive partitioned table ``customers``::
+
+    ANALYZE hive.default.customers WITH (partitions = ARRAY[ARRAY['CA', 'San Francisco'], ARRAY['NY', 'NY']]);
+

--- a/presto-docs/src/main/sphinx/sql/analyze.rst
+++ b/presto-docs/src/main/sphinx/sql/analyze.rst
@@ -15,7 +15,9 @@ Description
 Collects table and column statistics for a given table.
 
 The optional ``WITH`` clause can be used to provide
-connector-specific properties.
+connector-specific properties. To list all available properties, run the following query::
+
+    SELECT * FROM system.metadata.analyze_properties
 
 Currently, this statement is only supported by the
 :ref:`Hive connector <hive_analyze>`.

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -3084,6 +3084,13 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testAnalyzePropertiesSystemTable()
+    {
+        assertQuery("SELECT * FROM system.metadata.analyze_properties WHERE catalog_name = 'hive'",
+                "SELECT 'hive', 'partitions', '', 'array(array(varchar))', 'Partitions to be analyzed'");
+    }
+
+    @Test
     public void testAnalyzeEmptyTable()
     {
         String tableName = "test_analyze_empty_table";

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/AnalyzePropertiesSystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/AnalyzePropertiesSystemTable.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.system;
+
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.transaction.TransactionManager;
+
+import javax.inject.Inject;
+
+public class AnalyzePropertiesSystemTable
+        extends AbstractPropertiesSystemTable
+{
+    @Inject
+    public AnalyzePropertiesSystemTable(TransactionManager transactionManager, Metadata metadata)
+    {
+        super("analyze_properties", transactionManager, () -> metadata.getAnalyzePropertyManager().getAllProperties());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnectorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnectorModule.java
@@ -55,6 +55,7 @@ public class SystemConnectorModule
         globalTableBinder.addBinding().to(SchemaPropertiesSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(TablePropertiesSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(ColumnPropertiesSystemTable.class).in(Scopes.SINGLETON);
+        globalTableBinder.addBinding().to(AnalyzePropertiesSystemTable.class).in(Scopes.SINGLETON);
         globalTableBinder.addBinding().to(TransactionsSystemTable.class).in(Scopes.SINGLETON);
 
         globalTableBinder.addBinding().to(AttributeJdbcTable.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -20,6 +20,7 @@ import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.connector.ConnectorManager;
+import com.facebook.presto.connector.system.AnalyzePropertiesSystemTable;
 import com.facebook.presto.connector.system.CatalogSystemTable;
 import com.facebook.presto.connector.system.ColumnPropertiesSystemTable;
 import com.facebook.presto.connector.system.GlobalSystemConnector;
@@ -345,6 +346,7 @@ public class LocalQueryRunner
                 new SchemaPropertiesSystemTable(transactionManager, metadata),
                 new TablePropertiesSystemTable(transactionManager, metadata),
                 new ColumnPropertiesSystemTable(transactionManager, metadata),
+                new AnalyzePropertiesSystemTable(transactionManager, metadata),
                 new TransactionsSystemTable(typeRegistry, transactionManager)),
                 ImmutableSet.of());
 

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
@@ -35,6 +35,11 @@ system| information_schema| views| table_catalog| varchar| YES| null| null|
 system| information_schema| views| table_schema| varchar| YES| null| null|
 system| information_schema| views| table_name| varchar| YES| null| null|
 system| information_schema| views| view_definition| varchar| YES| null| null|
+system| metadata| analyze_properties| catalog_name| varchar| YES| null| null|
+system| metadata| analyze_properties| property_name| varchar| YES| null| null|
+system| metadata| analyze_properties| default_value| varchar| YES| null| null|
+system| metadata| analyze_properties| type| varchar| YES| null| null|
+system| metadata| analyze_properties| description| varchar| YES| null| null|
 system| metadata| catalogs| catalog_name| varchar| YES| null| null|
 system| metadata| catalogs| connector_id| varchar| YES| null| null|
 system| metadata| column_properties| catalog_name| varchar| YES| null| null|

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/showTablesSystemMetadata.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/showTablesSystemMetadata.result
@@ -1,5 +1,6 @@
 -- delimiter: |; ignoreOrder: true;
 catalogs|
+analyze_properties|
 schema_properties|
 table_properties|
 column_properties|

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchDistributedQueries.java
@@ -37,6 +37,12 @@ public class TestTpchDistributedQueries
     }
 
     @Test
+    public void testAnalyzePropertiesSystemTable()
+    {
+        assertQuery("SELECT COUNT(*) FROM system.metadata.analyze_properties WHERE catalog_name = 'tpch'", "SELECT 0");
+    }
+
+    @Test
     public void testAnalyze()
     {
         assertUpdate("ANALYZE orders", 15000);


### PR DESCRIPTION
The first commit adds a system table that lists all analyze properties supported in the cluster. The second commit adds documentation page for ANALYZE statement. 

#12400 