### PR TITLE
[POC] Benchmarking Aria OrcInputStream

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStream.java
@@ -28,6 +28,12 @@ public interface LongInputStream
     long next()
             throws IOException;
 
+    default long nextLong()
+            throws IOException
+    {
+        return next();
+    }
+
     default void nextIntVector(int items, int[] vector, int offset)
             throws IOException
     {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStreamV1.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStreamV1.java
@@ -34,6 +34,10 @@ public class LongInputStreamV1
     private boolean repeat;
     private long lastReadInputCheckpoint;
 
+    private int[] positions;
+    private int offset;
+    private int count;
+
     public LongInputStreamV1(OrcInputStream input, boolean signed)
     {
         this.input = input;
@@ -74,6 +78,23 @@ public class LongInputStreamV1
                 literals[i] = LongDecode.readVInt(signed, input);
             }
         }
+    }
+
+    public void setPositions(int[] positions)
+    {
+        this.positions = positions;
+    }
+
+    public long nextLong()
+            throws IOException
+    {
+        long value;
+        do {
+            value = next();
+        }
+        while (count++ < positions[offset]);
+        offset++;
+        return value;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/aria/AriaLongInputStreamV1.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/aria/AriaLongInputStreamV1.java
@@ -1,0 +1,450 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream.aria;
+
+import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
+import com.facebook.presto.orc.checkpoint.LongStreamV1Checkpoint;
+import com.facebook.presto.orc.stream.LongDecode;
+import com.facebook.presto.orc.stream.LongInputStream;
+import io.airlift.slice.ByteArrays;
+
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+
+public class AriaLongInputStreamV1
+        implements LongInputStream
+{
+    private static final int MIN_REPEAT_SIZE = 3;
+    private static final int MAX_LITERAL_SIZE = 128;
+    private static final long VARINT_MASK = 0x8080_8080_8080_8080L;
+    private static final int VARINT_MASK32 = 0x8080_8080;
+
+    private final AriaOrcInputStream input;
+    private final boolean signed;
+    private final long[] literals = new long[MAX_LITERAL_SIZE];
+    private int numLiterals;
+    private int delta;
+    private int used;
+    private boolean repeat;
+    private long lastReadInputCheckpoint;
+
+    private Positions positions;
+    private final Range range = new Range();
+
+    private byte[] buffer;
+    private int bufferPosition;
+    private int bufferLength;
+
+    public AriaLongInputStreamV1(AriaOrcInputStream input, boolean signed)
+    {
+        this.input = input;
+        this.signed = signed;
+        lastReadInputCheckpoint = input.getCheckpoint();
+    }
+
+    private void readValuesAria()
+            throws IOException
+    {
+        readHeader();
+        while (!range.contains(positions.get())) {
+            if (!repeat) {
+                refreshBuffer();
+                skipVarintsFully(numLiterals);
+            }
+            readHeader();
+        }
+        if (!repeat) {
+            refreshBuffer();
+            int skipCount = positions.get() - range.getBegin();
+            while (range.contains(positions.get())) {
+                refreshBuffer();
+                skipVarintsFully(skipCount);
+                do {
+                    literals[used++] = LongDecode.readVInt(signed, input);
+                    positions.advance();
+                }
+                while (!positions.isEmpty() && positions.isConsecutive() && range.contains(positions.get()));
+
+                if (positions.isEmpty()) {
+                    break;
+                }
+                skipCount = positions.getSkipCount();
+            }
+            refreshBuffer();
+            skipVarintsFully(range.getEnd() - positions.get() + skipCount);
+            numLiterals = used;
+            used = 0;
+        }
+    }
+
+    private void readHeader()
+            throws IOException
+    {
+        lastReadInputCheckpoint = input.getCheckpoint();
+
+        int control = input.read();
+        if (control == -1) {
+            throw new OrcCorruptionException(input.getOrcDataSourceId(), "Read past end of RLE integer");
+        }
+        if (control < 0x80) {
+            numLiterals = control + MIN_REPEAT_SIZE;
+            repeat = true;
+            delta = input.read();
+            if (delta == -1) {
+                throw new OrcCorruptionException(input.getOrcDataSourceId(), "End of stream in RLE Integer");
+            }
+
+            // convert from 0 to 255 to -128 to 127 by converting to a signed byte
+            // noinspection SillyAssignment
+            delta = (byte) delta;
+            literals[0] = LongDecode.readVInt(signed, input);
+        }
+        else {
+            numLiterals = 0x100 - control;
+            repeat = false;
+        }
+        used = 0;
+        range.setNextRange(numLiterals);
+    }
+
+    /**
+     * Force input to advance if buffer is used up.
+     * Adjust this.bufferPosition to account for the extra read.
+     */
+    private void advanceAndRefreshBuffer()
+            throws IOException
+    {
+        input.advance();
+        refreshBuffer();
+    }
+
+    /**
+     * Fetch the underlying buffer from the AriaOrcInputStream
+     *
+     * NOTE: if the input stream is advanced with input.read()
+     * the buffer, bufferPosition or bufferLength may be modified
+     */
+    private void refreshBuffer()
+    {
+        buffer = input.getBufferNotSafe();
+        bufferPosition = input.getBufferPositionNotSafe();
+        bufferLength = bufferPosition + input.available();
+    }
+
+    /**
+     * Syncs input position with this.bufferPosition
+     */
+    private void syncToInput()
+            throws IOException
+    {
+        input.skip(Math.max(0, input.available() - bufferLength + bufferPosition));
+    }
+
+    private void skipVarintsFully(int items)
+            throws IOException
+    {
+        for (int skipCount = items; skipCount > 0; ) {
+            skipCount -= skipVarints(skipCount);
+            if (skipCount > 0 && input.available() == 0) {
+                advanceAndRefreshBuffer();
+            }
+        }
+    }
+
+    /**
+     * Skips varints in the current buffer
+     * @param items number of items to skip
+     * @return number varints skipped
+     */
+    private int skipVarints(int items)
+            throws IOException
+    {
+        int remaining = Math.min(numLiterals - used, items);
+        checkState(remaining >= 0, "remaining < 0");
+        if (remaining == 0) {
+            return items - remaining;
+        }
+
+        if (bufferPosition + SIZE_OF_LONG <= bufferLength) {
+            remaining = skipVarint8(remaining);
+        }
+        else if (bufferPosition + SIZE_OF_INT <= bufferLength) {
+            remaining = skipVarint4(remaining);
+        }
+        else {
+            remaining = skipVarint1(remaining);
+        }
+        syncToInput();
+        return items - remaining;
+    }
+
+    /**
+     * Skip varints 1 byte at a time
+     * @param remaining remaining varints to skip
+     * @return varints still remaining, i.e. if buffer is exhausted
+     */
+    private int skipVarint1(int remaining)
+    {
+        while (remaining > 0 && bufferPosition < bufferLength) {
+            if ((buffer[bufferPosition++] & 0x80) == 0) {
+                remaining--;
+            }
+        }
+        return remaining;
+    }
+
+    /**
+     * Skip varints 4 bytes at a time
+     * @param remaining remaining varints to skip
+     * @return varints still remaining, i.e. if buffer is exhausted
+     */
+    private int skipVarint4(int remaining)
+    {
+        int value = ByteArrays.getInt(buffer, bufferPosition);
+        int mask = (value & VARINT_MASK32) ^ VARINT_MASK32;
+        remaining -= Integer.bitCount(mask);
+        bufferPosition += SIZE_OF_INT;
+        if (remaining < 0) {
+            for (; remaining < 0; remaining++) {
+                mask ^= Integer.highestOneBit(mask);
+            }
+            bufferPosition -= Long.numberOfLeadingZeros(mask) >> 3;
+        }
+        else if (remaining == 0) {
+            bufferPosition -= Long.numberOfLeadingZeros(mask) >> 3;
+        }
+        else {
+            remaining = skipVarint1(remaining);
+        }
+        return remaining;
+    }
+
+    /**
+     * Skip varints 8 bytes at a time
+     * @param remaining remaining varints to skip
+     * @return varints still remaining, i.e. if buffer is exhausted
+     */
+    private int skipVarint8(int remaining)
+    {
+        long mask = 0;
+        while (remaining > 0 && bufferPosition + SIZE_OF_LONG <= bufferLength) {
+            long value = ByteArrays.getLong(buffer, bufferPosition);
+            mask = (value & VARINT_MASK) ^ VARINT_MASK;
+            remaining -= Long.bitCount(mask);
+            bufferPosition += SIZE_OF_LONG;
+        }
+        if (remaining < 0) {
+            for (; remaining < 0; remaining++) {
+                mask ^= Long.highestOneBit(mask);
+            }
+            bufferPosition -= Long.numberOfLeadingZeros(mask) >> 3;
+        }
+        else if (remaining == 0) {
+            bufferPosition -= Long.numberOfLeadingZeros(mask) >> 3;
+        }
+        else {
+            remaining = skipVarint1(remaining);
+        }
+        return remaining;
+    }
+
+    public long nextLong()
+            throws IOException
+    {
+        long result;
+        if (repeat && !range.contains(positions.get()) || (!repeat && used == numLiterals)) {
+            readValuesAria();
+        }
+        if (repeat) {
+            result = literals[0] + (range.getRelativePosition(positions.get())) * delta;
+            positions.advance();
+        }
+        else {
+            result = literals[used++];
+        }
+        return result;
+    }
+
+    // This comes from the Apache Hive ORC code
+    private void readValues()
+            throws IOException
+    {
+        lastReadInputCheckpoint = input.getCheckpoint();
+
+        int control = input.read();
+        if (control == -1) {
+            throw new OrcCorruptionException(input.getOrcDataSourceId(), "Read past end of RLE integer");
+        }
+
+        if (control < 0x80) {
+            numLiterals = control + MIN_REPEAT_SIZE;
+            used = 0;
+            repeat = true;
+            delta = input.read();
+            if (delta == -1) {
+                throw new OrcCorruptionException(input.getOrcDataSourceId(), "End of stream in RLE Integer");
+            }
+
+            // convert from 0 to 255 to -128 to 127 by converting to a signed byte
+            // noinspection SillyAssignment
+            delta = (byte) delta;
+            literals[0] = LongDecode.readVInt(signed, input);
+        }
+        else {
+            numLiterals = 0x100 - control;
+            used = 0;
+            repeat = false;
+            for (int i = 0; i < numLiterals; ++i) {
+                literals[i] = LongDecode.readVInt(signed, input);
+            }
+        }
+    }
+
+    @Override
+    // This comes from the Apache Hive ORC code
+    public long next()
+            throws IOException
+    {
+        long result;
+        if (used == numLiterals) {
+            readValues();
+        }
+        if (repeat) {
+            result = literals[0] + (used++) * delta;
+        }
+        else {
+            result = literals[used++];
+        }
+        return result;
+    }
+
+    @Override
+    public Class<? extends LongStreamV1Checkpoint> getCheckpointType()
+    {
+        return LongStreamV1Checkpoint.class;
+    }
+
+    @Override
+    public void seekToCheckpoint(LongStreamCheckpoint checkpoint)
+            throws IOException
+    {
+        LongStreamV1Checkpoint v1Checkpoint = (LongStreamV1Checkpoint) checkpoint;
+
+        // if the checkpoint is within the current buffer, just adjust the pointer
+        if (lastReadInputCheckpoint == v1Checkpoint.getInputStreamCheckpoint() && v1Checkpoint.getOffset() <= numLiterals) {
+            used = v1Checkpoint.getOffset();
+        }
+        else {
+            // otherwise, discard the buffer and start over
+            input.seekToCheckpoint(v1Checkpoint.getInputStreamCheckpoint());
+            numLiterals = 0;
+            used = 0;
+            skip(v1Checkpoint.getOffset());
+        }
+    }
+
+    @Override
+    public void skip(long items)
+            throws IOException
+    {
+        while (items > 0) {
+            if (used == numLiterals) {
+                readValues();
+            }
+            long consume = Math.min(items, numLiterals - used);
+            used += consume;
+            items -= consume;
+        }
+    }
+
+    public void setPositions(int[] positions)
+    {
+        checkState(this.positions == null, "positions is already set");
+        this.positions = new Positions(positions);
+    }
+
+    private static class Positions
+    {
+        private int[] positions;
+        private int offset;
+
+        public Positions(int[] positions)
+        {
+            this.positions = positions;
+        }
+
+        public int get()
+        {
+            return positions[offset];
+        }
+
+        public void advance()
+        {
+            offset++;
+        }
+
+        public boolean isConsecutive()
+        {
+            return offset > 0 && positions[offset] - positions[offset - 1] == 1;
+        }
+
+        public boolean isEmpty()
+        {
+            return offset >= positions.length;
+        }
+
+        public int getSkipCount()
+        {
+            return positions[offset] - positions[offset - 1] - 1;
+        }
+    }
+
+    private static class Range
+    {
+        // Begin offset in current buffer
+        private int begin;
+        // End offset exclusive
+        private int end;
+
+        public void setNextRange(int end)
+        {
+            this.begin = this.end;
+            this.end += end;
+        }
+
+        public boolean contains(int offset)
+        {
+            return offset < end;
+        }
+
+        public int getRelativePosition(int offset)
+        {
+            return offset - begin;
+        }
+
+        public int getBegin()
+        {
+            return begin;
+        }
+
+        public int getEnd()
+        {
+            return end;
+        }
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/aria/AriaOrcInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/aria/AriaOrcInputStream.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream.aria;
+
+import com.facebook.presto.memory.context.AggregatedMemoryContext;
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.OrcDataSourceId;
+import com.facebook.presto.orc.OrcDecompressor;
+import io.airlift.slice.FixedLengthSliceInput;
+import io.airlift.slice.Slice;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.facebook.presto.orc.checkpoint.InputStreamCheckpoint.createInputStreamCheckpoint;
+import static com.facebook.presto.orc.checkpoint.InputStreamCheckpoint.decodeCompressedBlockOffset;
+import static com.facebook.presto.orc.checkpoint.InputStreamCheckpoint.decodeDecompressedOffset;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+
+public final class AriaOrcInputStream
+        extends InputStream
+{
+    private final OrcDataSourceId orcDataSourceId;
+    private final FixedLengthSliceInput compressedSliceInput;
+    private final Optional<OrcDecompressor> decompressor;
+
+    private int currentCompressedBlockOffset;
+
+    private byte[] buffer;
+    private int bufferLength;
+    private int bufferPosition;
+    private final LocalMemoryContext bufferMemoryUsage;
+
+    public AriaOrcInputStream(
+            OrcDataSourceId orcDataSourceId,
+            FixedLengthSliceInput sliceInput,
+            Optional<OrcDecompressor> decompressor,
+            AggregatedMemoryContext systemMemoryContext,
+            long sliceInputRetainedSizeInBytes)
+    {
+        this.orcDataSourceId = requireNonNull(orcDataSourceId, "orcDataSource is null");
+
+        requireNonNull(sliceInput, "sliceInput is null");
+
+        this.decompressor = requireNonNull(decompressor, "decompressor is null");
+
+        // memory reserved in the systemMemoryContext is never release and instead it is
+        // expected that the context itself will be destroyed at the end of the read
+        requireNonNull(systemMemoryContext, "systemMemoryContext is null");
+        this.bufferMemoryUsage = systemMemoryContext.newLocalMemoryContext(AriaOrcInputStream.class.getSimpleName());
+        checkArgument(sliceInputRetainedSizeInBytes >= 0, "sliceInputRetainedSizeInBytes is negative");
+        systemMemoryContext.newLocalMemoryContext(AriaOrcInputStream.class.getSimpleName()).setBytes(sliceInputRetainedSizeInBytes);
+
+        if (!decompressor.isPresent()) {
+            this.compressedSliceInput = EMPTY_SLICE.getInput();
+            this.buffer = new byte[toIntExact(sliceInput.remaining())];
+            this.bufferLength = buffer.length;
+            long position = sliceInput.position();
+            sliceInput.readFully(buffer, toIntExact(sliceInput.position()), toIntExact(sliceInput.remaining()));
+            sliceInput.setPosition(position);
+        }
+        else {
+            this.compressedSliceInput = sliceInput;
+            this.buffer = new byte[0];
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        // close is never called, so do not add code here
+    }
+
+    @Override
+    public int available()
+    {
+        if (buffer == null) {
+            return 0;
+        }
+        return bufferLength - bufferPosition;
+    }
+
+    @Override
+    public boolean markSupported()
+    {
+        return false;
+    }
+
+    @Override
+    public int read()
+            throws IOException
+    {
+        if (buffer == null) {
+            return -1;
+        }
+        if (available() > 0) {
+            return 0xff & buffer[bufferPosition++];
+        }
+
+        advance();
+        return read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int length)
+            throws IOException
+    {
+        if (buffer == null) {
+            return -1;
+        }
+
+        if (available() == 0) {
+            advance();
+            if (buffer == null) {
+                return -1;
+            }
+        }
+        length = Math.min(length, available());
+        System.arraycopy(buffer, bufferPosition, b, off, length);
+        bufferPosition += length;
+        return length;
+    }
+
+    public void skipFully(long length)
+            throws IOException
+    {
+        while (length > 0) {
+            long result = skip(length);
+            if (result < 0) {
+                throw new OrcCorruptionException(orcDataSourceId, "Unexpected end of stream");
+            }
+            length -= result;
+        }
+    }
+
+    public void readFully(byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        while (offset < length) {
+            int result = read(buffer, offset, length - offset);
+            if (result < 0) {
+                throw new OrcCorruptionException(orcDataSourceId, "Unexpected end of stream");
+            }
+            offset += result;
+        }
+    }
+
+    public OrcDataSourceId getOrcDataSourceId()
+    {
+        return orcDataSourceId;
+    }
+
+    public long getCheckpoint()
+    {
+        // if the decompressed buffer is empty, return a checkpoint starting at the next block
+        if (buffer == null || (bufferPosition == 0 && available() == 0)) {
+            return createInputStreamCheckpoint(toIntExact(compressedSliceInput.position()), 0);
+        }
+        // otherwise return a checkpoint at the last compressed block read and the current position in the buffer
+        return createInputStreamCheckpoint(currentCompressedBlockOffset, bufferPosition);
+    }
+
+    public boolean seekToCheckpoint(long checkpoint)
+            throws IOException
+    {
+        int compressedBlockOffset = decodeCompressedBlockOffset(checkpoint);
+        int decompressedOffset = decodeDecompressedOffset(checkpoint);
+        boolean discardedBuffer;
+        if (compressedBlockOffset != currentCompressedBlockOffset) {
+            if (!decompressor.isPresent()) {
+                throw new OrcCorruptionException(orcDataSourceId, "Reset stream has a compressed block offset but stream is not compressed");
+            }
+            compressedSliceInput.setPosition(compressedBlockOffset);
+            buffer = new byte[0];
+            bufferLength = 0;
+            bufferPosition = 0;
+            discardedBuffer = true;
+        }
+        else {
+            discardedBuffer = false;
+        }
+
+        if (decompressedOffset != bufferPosition) {
+            bufferPosition = 0;
+            if (available() < decompressedOffset) {
+                decompressedOffset -= available();
+                advance();
+            }
+            bufferPosition = decompressedOffset;
+        }
+        return discardedBuffer;
+    }
+
+    @Override
+    public long skip(long n)
+            throws IOException
+    {
+        if (buffer == null || n <= 0) {
+            return -1;
+        }
+
+        long result = Math.min(available(), n);
+        bufferPosition += toIntExact(result);
+        if (result != 0) {
+            return result;
+        }
+        if (read() == -1) {
+            return 0;
+        }
+        result = Math.min(available(), n - 1);
+        bufferPosition += toIntExact(result);
+        return 1 + result;
+    }
+
+    // NOT SAFE: buffer position is not advanced.
+    // Callers must track bytes read and call skip() to keep in sync with read()
+    public byte[] getBufferNotSafe()
+    {
+        return buffer;
+    }
+
+    // NOT SAFE: care must be taken to ensure the bufferPosition refers this buffer
+    // Callers must track bytes read and call skip() to keep in sync with read()
+    public int getBufferPositionNotSafe()
+    {
+        return bufferPosition;
+    }
+
+    // This comes from the Apache Hive ORC code
+    public void advance()
+            throws IOException
+    {
+        if (compressedSliceInput == null || compressedSliceInput.remaining() == 0) {
+            buffer = null;
+            bufferPosition = 0;
+            bufferLength = 0;
+            return;
+        }
+
+        // 3 byte header
+        // NOTE: this must match BLOCK_HEADER_SIZE
+        currentCompressedBlockOffset = toIntExact(compressedSliceInput.position());
+        int b0 = compressedSliceInput.readUnsignedByte();
+        int b1 = compressedSliceInput.readUnsignedByte();
+        int b2 = compressedSliceInput.readUnsignedByte();
+
+        boolean isUncompressed = (b0 & 0x01) == 1;
+        int chunkLength = (b2 << 15) | (b1 << 7) | (b0 >>> 1);
+        if (chunkLength < 0 || chunkLength > compressedSliceInput.remaining()) {
+            throw new OrcCorruptionException(orcDataSourceId, "The chunkLength (%s) must not be negative or greater than remaining size (%s)", chunkLength, compressedSliceInput.remaining());
+        }
+
+        Slice chunk = compressedSliceInput.readSlice(chunkLength);
+
+        if (isUncompressed) {
+            buffer = (byte[]) chunk.getBase();
+            bufferLength = buffer.length;
+            bufferPosition = 0;
+        }
+        else {
+            OrcDecompressor.OutputBuffer output = new OrcDecompressor.OutputBuffer()
+            {
+                @Override
+                public byte[] initialize(int size)
+                {
+                    if (buffer == null || size > buffer.length) {
+                        buffer = new byte[size];
+                        bufferMemoryUsage.setBytes(buffer.length);
+                        bufferPosition = 0;
+                        bufferLength = 0;
+                    }
+                    return buffer;
+                }
+
+                @Override
+                public byte[] grow(int size)
+                {
+                    if (size > buffer.length) {
+                        buffer = Arrays.copyOfRange(buffer, 0, size);
+                        bufferMemoryUsage.setBytes(buffer.length);
+                    }
+                    return buffer;
+                }
+            };
+
+            bufferLength = decompressor.get().decompress((byte[]) chunk.getBase(), (int) (chunk.getAddress() - ARRAY_BYTE_BASE_OFFSET), chunk.length(), output);
+            bufferPosition = 0;
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("source", orcDataSourceId)
+                .add("compressedOffset", compressedSliceInput.position())
+                .add("uncompressedOffset", buffer == null ? null : bufferPosition)
+                .add("decompressor", decompressor.map(Object::toString).orElse("none"))
+                .toString();
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/BenchmarkAriatest.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/BenchmarkAriatest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import io.airlift.slice.ByteArrays;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.DTraceAsmProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static org.testng.Assert.assertEquals;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkAriatest
+{
+    private static final long VARINT_MASK = 0x8080_8080_8080_8080L;
+    private static final byte[] DATA = getData();
+
+    @Benchmark
+    @OperationsPerInvocation(10)
+    public Object benchmarkBitCount(BenchmarkData data)
+    {
+        return data.bitCounter.countBits(data.data);
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"false", "true"})
+        boolean useUnsafe;
+
+        byte[] data;
+        BitCounter bitCounter;
+
+        @Setup
+        public void setup()
+        {
+            this.data = DATA;
+            if (useUnsafe) {
+                bitCounter = new UnsafeBitCounter();
+            }
+            else {
+                bitCounter = new SafeBitCounter();
+            }
+        }
+    }
+
+    public static class UnsafeBitCounter
+            implements BitCounter
+    {
+        public int countBits(byte[] array)
+        {
+            int count = 0;
+            int position = 0;
+            while (position + SIZE_OF_LONG <= array.length) {
+                long value = ByteArrays.getLong(array, position);
+                count += Long.bitCount((value & VARINT_MASK) ^ VARINT_MASK);
+                position += SIZE_OF_LONG;
+            }
+            while (position < array.length) {
+                if ((array[position++] & 0x80) == 0) {
+                    count++;
+                }
+            }
+            return count;
+        }
+    }
+
+    public static class SafeBitCounter
+            implements BitCounter
+    {
+        public int countBits(byte[] array)
+        {
+            int count = 0;
+            int position = 0;
+            while (position < array.length) {
+                if ((array[position++] & 0x80) == 0) {
+                    count++;
+                }
+            }
+            return count;
+        }
+    }
+
+    interface BitCounter
+    {
+        int countBits(byte[] data);
+    }
+    private static byte[] getData()
+    {
+        int count = 1_000_000;
+        Random random = new Random(22);
+        byte[] data = new byte[count];
+        random.nextBytes(data);
+        return data;
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkAriatest.BenchmarkData();
+        data.setup();
+        data.useUnsafe = true;
+        Integer countUnsafe = (Integer) new BenchmarkAriatest().benchmarkBitCount(data);
+        data = new BenchmarkAriatest.BenchmarkData();
+        data.setup();
+        data.useUnsafe = false;
+        Integer countSafe = (Integer) new BenchmarkAriatest().benchmarkBitCount(data);
+        assertEquals(countSafe, countUnsafe);
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkAriatest.class.getSimpleName() + ".*")
+                .jvmArgs("-Xmx5g")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/BenchmarkDecodeVarint.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/BenchmarkDecodeVarint.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import io.airlift.slice.ByteArrays;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkDecodeVarint
+{
+    private static final long VARINT_MASK = 0x8080_8080_8080_8080L;
+    private static final byte[] ENCODED_DATA;
+    private static final long[] DATA;
+    private static final int LENGTH;
+    private static final int COUNT = 1_000_000;
+
+    static {
+        DATA = getData();
+        ENCODED_DATA = new byte[DATA.length * 10];
+        LENGTH = getEncoded(DATA, ENCODED_DATA);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(10)
+    public Object benchmarkDecodeVarints(BenchmarkData data)
+    {
+        return data.varintDecoder.decodeVarint(data.destination, data.data, LENGTH);
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"false", "true"})
+        boolean useUnsafe;
+
+        byte[] data;
+        VarintDecoder varintDecoder;
+        long[] destination;
+        @Setup
+        public void setup()
+        {
+            this.data = ENCODED_DATA;
+            this.destination = new long[COUNT];
+            if (useUnsafe) {
+                varintDecoder = new UnsafeVarintDecoder();
+            }
+            else {
+                varintDecoder = new SafeVarintDecoder();
+            }
+        }
+    }
+
+    public static class UnsafeVarintDecoder
+            implements VarintDecoder
+    {
+        public long decodeVarint(long[] destination, byte[] array, int arrayLength)
+        {
+            int position = 0;
+            int offset = 0;
+            long result = 0;
+            while (offset + SIZE_OF_LONG + 2 < arrayLength) {
+                long value = ByteArrays.getLong(array, offset);
+                offset += SIZE_OF_LONG;
+                long mask = (value & VARINT_MASK) ^ VARINT_MASK;
+                if (mask == 0) {
+                    result = decode1(value, 8);
+                    result |= (long) (array[offset] & 0x7f) << 56;
+                    if ((array[offset++] & 0x80) != 0) {
+                        if ((array[offset] & 0x80) != 0) {
+                            throw new IllegalStateException("invalid format");
+                        }
+                        result |= (long) array[offset++] << 63;
+                    }
+                }
+                else {
+                    int count = (Long.numberOfTrailingZeros(mask) + 1) >>> 3;
+                    result = decode1(value, count);
+                }
+                destination[position++] = result;
+            }
+            result = 0;
+            for (int shift = 0; offset < arrayLength; offset++) {
+                result |= (long) (array[offset] & 0x7f) << shift;
+                if ((array[offset] & 0x80) == 0) {
+                    destination[position++] = result;
+                    result = 0;
+                    shift = 0;
+                }
+                else {
+                    shift += 7;
+                }
+            }
+            return position;
+        }
+
+        private long decode1(long value, int count)
+        {
+            switch (count) {
+                case 1:
+                   return (value & 0x7f);
+                case 2:
+                    return (value & 0x7f) |
+                            ((value & 0x7f00L) >> 1);
+                case 3:
+                    return (value & 0x7f) |
+                            ((value & 0x7f00L) >> 1) |
+                            ((value & 0x7f_0000L) >> 2);
+                case 4:
+                    return (value & 0x7f) |
+                            ((value & 0x7f00L) >> 1) |
+                            ((value & 0x7f_0000L) >> 2) |
+                            ((value & 0x7f00_0000L) >> 3);
+                case 5:
+                    return (value & 0x7f) |
+                            ((value & 0x7f00L) >> 1) |
+                            ((value & 0x7f_0000L) >> 2) |
+                            ((value & 0x7f00_0000L) >> 3) |
+                            ((value & 0x7f_0000_0000L) >> 4);
+                case 6:
+                    return (value & 0x7f) |
+                            ((value & 0x7f00L) >> 1) |
+                            ((value & 0x7f_0000L) >> 2) |
+                            ((value & 0x7f00_0000L) >> 3) |
+                            ((value & 0x7f_0000_0000L) >> 4)|
+                            ((value & 0x7f00_0000_0000L) >> 5);
+                case 7:
+                    return (value & 0x7f) |
+                            ((value & 0x7f00L) >> 1) |
+                            ((value & 0x7f_0000L) >> 2) |
+                            ((value & 0x7f00_0000L) >> 3) |
+                            ((value & 0x7f_0000_0000L) >> 4) |
+                            ((value & 0x7f00_0000_0000L) >> 5) |
+                            ((value & 0x7f_0000_0000_0000L) >> 6);
+                case 8:
+                    return (value & 0x7f) |
+                            ((value & 0x7f00L) >> 1) |
+                            ((value & 0x7f_0000L) >> 2) |
+                            ((value & 0x7f00_0000L) >> 3) |
+                            ((value & 0x7f_0000_0000L) >> 4) |
+                            ((value & 0x7f00_0000_0000L) >> 5) |
+                            ((value & 0x7f_0000_0000_0000L) >> 6) |
+                            ((value & 0x7f00_0000_0000_0000L) >> 7);
+                default:
+                    throw new IllegalStateException();
+            }
+        }
+    }
+
+    public static class SafeVarintDecoder
+            implements VarintDecoder
+    {
+        public long decodeVarint(long[] destination, byte[] array, int arrayLength)
+        {
+            int position = 0;
+            int offset = 0;
+            long result = 0;
+            for (int shift = 0; offset < arrayLength; offset++) {
+                result |= (long) (array[offset] & 0x7f) << shift;
+                if ((array[offset] & 0x80) == 0) {
+                    destination[position++] = result;
+                    result = 0;
+                    shift = 0;
+                }
+                else {
+                    shift += 7;
+                }
+            }
+            return position;
+        }
+    }
+
+    interface VarintDecoder
+    {
+        long decodeVarint(long[] destination, byte[] data, int dataLength);
+    }
+
+    private static int getEncoded(long[] data, byte[] destination)
+    {
+        Random random = new Random(22);
+        int offset = 0;
+        for (int i = 0; i < COUNT; i++) {
+            offset += encode(data[i], destination, offset);
+        }
+        return offset;
+    }
+
+    private static long[] getData()
+    {
+        int count = COUNT;
+        Random random = new Random(22);
+        long[] data = new long[count];
+        for (int i = 0, offset = 0; i < count; i++) {
+            data[i] = random.nextLong();
+        }
+        return data;
+    }
+    private static int encode(long value, byte[] destination, int offset)
+    {
+        int start = offset;
+        while (offset < destination.length) {
+            // if there are less than 7 bits left, we are done
+            if ((value & ~0b111_1111) == 0) {
+                destination[offset++] = (byte) value;
+                return offset - start;
+            }
+            else {
+                destination[offset++] = (byte) (0x80 | (value & 0x7f));
+                value >>>= 7;
+            }
+        }
+        // if buffer was not long enough make sure last value is a varint
+        if (offset == destination.length) {
+            destination[destination.length - 1] &= 0x7f;
+        }
+        return offset - start;
+    }
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkDecodeVarint.BenchmarkData();
+        data.setup();
+        data.useUnsafe = true;
+        long countUnsafe = (long) new BenchmarkDecodeVarint().benchmarkDecodeVarints(data);
+        assertTrue(Arrays.equals(data.destination, DATA));
+        data = new BenchmarkDecodeVarint.BenchmarkData();
+        data.setup();
+        data.useUnsafe = false;
+        long countSafe = (long) new BenchmarkDecodeVarint().benchmarkDecodeVarints(data);
+        assertTrue(Arrays.equals(data.destination, DATA));
+        assertEquals(countSafe, countUnsafe);
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkDecodeVarint.class.getSimpleName() + ".*")
+                .jvmArgs("-Xmx5g")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/BenchmarkLongStreamV1.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/BenchmarkLongStreamV1.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.OrcDecompressor;
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.Stream;
+import com.facebook.presto.orc.stream.aria.AriaLongInputStreamV1;
+import com.facebook.presto.orc.stream.aria.AriaOrcInputStream;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
+import static com.facebook.presto.orc.stream.AbstractTestValueStream.COMPRESSION_BLOCK_SIZE;
+import static com.facebook.presto.orc.stream.AbstractTestValueStream.ORC_DATA_SOURCE_ID;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.stream.Collectors.toList;
+import static org.testng.Assert.assertEquals;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkLongStreamV1
+{
+    private static final List<List<Long>> GROUPS = getData();
+
+    @Benchmark
+    @OperationsPerInvocation(2)
+    public Object benchmarkDecoding(BenchmarkData data)
+            throws IOException
+    {
+        long actualValue = 0L;
+        for (int i = 0; i < data.positions.length; i++) {
+            actualValue = data.input.nextLong();
+            long expectedValue = data.data.get(data.positions[i]);
+            assertEquals(actualValue, expectedValue, "index=" + i + " position=" + data.positions[i]);
+        }
+        return actualValue;
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"false", "true"})
+        boolean useLegacy;
+
+        //@Param({"NONE", "SNAPPY", "ZSTD", "ZLIB", "LZ4"})
+        @Param("SNAPPY")
+        String kind = "NONE";
+
+        @Param({"ALL", "ODD", "SECOND_HALF", "RANDOM_QUARTER"})
+        String positionsType = "ODD";
+
+        int[] positions;
+        LongInputStream input;
+        List<Long> data;
+
+        @Setup(Level.Invocation)
+        public void setup()
+                throws IOException
+        {
+            data = GROUPS.stream()
+                .flatMap(Collection::stream)
+                .collect(toImmutableList());
+            CompressionKind compressionKind = CompressionKind.valueOf(kind);
+            Slice slice = getSlice(GROUPS, compressionKind);
+            this.positions = getPositions(data, PositionsType.valueOf(positionsType));
+            if (useLegacy) {
+                input = createValueStream(slice, compressionKind, positions);
+            }
+            else {
+                input = createAriaValueStream(slice, compressionKind, positions);
+            }
+        }
+    }
+
+    private static LongInputStreamV1 createValueStream(Slice slice, CompressionKind compressionKind, int[] positions)
+            throws OrcCorruptionException
+    {
+        Optional<OrcDecompressor> orcDecompressor = createOrcDecompressor(ORC_DATA_SOURCE_ID, compressionKind, COMPRESSION_BLOCK_SIZE);
+        OrcInputStream input = new OrcInputStream(ORC_DATA_SOURCE_ID, slice.getInput(), orcDecompressor, newSimpleAggregatedMemoryContext(), slice.getRetainedSize());
+        LongInputStreamV1 stream = new LongInputStreamV1(input, true);
+        stream.setPositions(positions);
+        return stream;
+    }
+
+    private static AriaLongInputStreamV1 createAriaValueStream(Slice slice, CompressionKind compressionKind, int[] positions)
+            throws OrcCorruptionException
+    {
+        Optional<OrcDecompressor> orcDecompressor = createOrcDecompressor(ORC_DATA_SOURCE_ID, compressionKind, COMPRESSION_BLOCK_SIZE);
+        AriaOrcInputStream input = new AriaOrcInputStream(ORC_DATA_SOURCE_ID, slice.getInput(), orcDecompressor, newSimpleAggregatedMemoryContext(), slice.getRetainedSize());
+        AriaLongInputStreamV1 stream = new AriaLongInputStreamV1(input, true);
+        stream.setPositions(positions);
+        return stream;
+    }
+
+    private static Slice getSlice(List<List<Long>> groups, CompressionKind kind)
+    {
+        LongOutputStreamV1 outputStream = new LongOutputStreamV1(kind, COMPRESSION_BLOCK_SIZE, true, DATA);
+        outputStream.reset();
+        for (List<Long> group : groups) {
+            outputStream.recordCheckpoint();
+            group.forEach(outputStream::writeLong);
+        }
+        outputStream.close();
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
+        StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(1);
+        streamDataOutput.writeData(sliceOutput);
+        Stream stream = streamDataOutput.getStream();
+        assertEquals(stream.getStreamKind(), DATA);
+        assertEquals(stream.getColumn(), 1);
+        assertEquals(stream.getLength(), sliceOutput.size());
+        return sliceOutput.slice();
+    }
+
+    private static List<List<Long>> getData()
+    {
+        List<List<Long>> groups = new ArrayList<>();
+        List<Long> group;
+
+        group = new ArrayList<>();
+        Random random = new Random(22);
+        for (int i = 0; i < 70000; i++) {
+            group.add(-1000L + random.nextInt(17));
+        }
+        groups.add(group);
+
+        group = new ArrayList<>();
+        for (int i = 0; i < 10000; i++) {
+            group.add((long) (i));
+        }
+        groups.add(group);
+
+        group = new ArrayList<>();
+        for (int i = 0; i < 10000; i++) {
+            group.add((long) (10_000 + (i * 17)));
+        }
+        groups.add(group);
+
+        group = new ArrayList<>();
+        for (int i = 0; i < 10000; i++) {
+            group.add((long) (10_000 - (i * 17)));
+        }
+        groups.add(group);
+        return groups;
+    }
+
+    private static int[] getPositions(List<Long> data, PositionsType positionsType)
+    {
+        int size = data.size();
+        int[] positions;
+        switch (positionsType) {
+            case ALL:
+                positions = IntStream.range(0, size).toArray();
+                break;
+            case ODD:
+                int oddCount = (size & 1) == 1 ? (size - 1) >> 1 : size >> 1;
+                positions = new int[oddCount];
+                for (int i = 0; i < oddCount; i++) {
+                    positions[i] = 2 * i + 1;
+                }
+                break;
+            case SECOND_HALF:
+                int mid = size >> 1;
+                positions = new int[size - mid];
+                for (int i = mid; i < size; i++) {
+                    positions[i - mid] = i;
+                }
+                break;
+            case RANDOM_QUARTER:
+                List<Integer> all = IntStream.range(0, size).boxed().collect(toList());
+                Collections.shuffle(all);
+                int quarterSize = all.size() >> 2;
+                positions = new int[quarterSize];
+                for (int i = 0; i < quarterSize; i++) {
+                    positions[i] = all.get(i);
+                }
+                Arrays.sort(positions);
+                break;
+            default:
+                throw new IllegalStateException("Invalid PositionsType");
+        }
+        return positions;
+    }
+
+    private enum PositionsType
+    {
+        ALL,
+        ODD,
+        SECOND_HALF,
+        RANDOM_QUARTER
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkLongStreamV1().benchmarkDecoding(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkLongStreamV1.class.getSimpleName() + ".*")
+                .jvmArgs("-Xmx5g")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/BenchmarkSliceTest.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/BenchmarkSliceTest.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import io.airlift.slice.BasicSliceInput;
+import io.airlift.slice.ByteArrays;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static org.testng.Assert.assertEquals;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkSliceTest
+{
+    private static final long VARINT_MASK = 0x8080_8080_8080_8080L;
+    private static final byte[] DATA = getData();
+
+    @Benchmark
+    @OperationsPerInvocation(10)
+    public Object benchmarkBitCount(BenchmarkData data)
+    {
+        return data.bitCounter.countBits();
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"false", "true"})
+        boolean useUnsafe;
+
+        BitCounter bitCounter;
+
+        @Setup(Level.Invocation)
+        public void setup()
+        {
+            if (useUnsafe) {
+                bitCounter = new UnsafeBitCounter();
+            }
+            else {
+                bitCounter = new SliceArrayBitCounter();
+            }
+            bitCounter.setData(DATA);
+        }
+    }
+
+    public static class UnsafeBitCounter
+            implements BitCounter
+    {
+        byte[] array;
+        public int countBits()
+        {
+            int count = 0;
+            int position = 0;
+            while (position + SIZE_OF_LONG <= array.length) {
+                long value = ByteArrays.getLong(array, position);
+                count += Long.bitCount((value & VARINT_MASK) ^ VARINT_MASK);
+                position += SIZE_OF_LONG;
+            }
+            while (position < array.length) {
+                if ((array[position++] & 0x80) == 0) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        public void setData(byte[] array) {
+            this.array = array;
+        }
+    }
+
+    public static class SliceArrayBitCounter
+            implements BitCounter
+    {
+        BasicSliceInput input;
+        byte[] buffer;
+
+        public int countBits()
+        {
+            int count = 0;
+            input.readFully(buffer);
+            input.setPosition(0);
+            int position = 0;
+            while (position + SIZE_OF_LONG <= buffer.length) {
+                long value = ByteArrays.getLong(buffer, position);
+                count += Long.bitCount((value & VARINT_MASK) ^ VARINT_MASK);
+                position += SIZE_OF_LONG;
+            }
+            while (position < buffer.length) {
+                if ((buffer[position++] & 0x80) == 0) {
+                    count++;
+                }
+            }
+            return count;
+        }
+        public void setData(byte[] array) {
+            Slice slice = Slices.wrappedBuffer(array);
+            input = slice.getInput();
+            buffer = new byte[array.length];
+        }
+
+    }
+    public static class SliceBitCounter
+            implements BitCounter
+    {
+        BasicSliceInput input;
+        public int countBits()
+        {
+            int count = 0;
+            while (input.position() + SIZE_OF_LONG <= input.length()) {
+                long value = input.readLong();
+                count += Long.bitCount((value & VARINT_MASK) ^ VARINT_MASK);
+            }
+            while (input.available() > 0) {
+                if ((input.readByte() & 0x80) == 0) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        public void setData(byte[] array) {
+            Slice slice = Slices.wrappedBuffer(array);
+            input = slice.getInput();
+        }
+    }
+
+    public static class SafeBitCounter
+            implements BitCounter
+    {
+        byte[] array;
+        public int countBits()
+        {
+            int count = 0;
+            int position = 0;
+            while (position < array.length) {
+                if ((array[position++] & 0x80) == 0) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        public void setData(byte[] array) {
+            this.array = array;
+        }
+    }
+
+    interface BitCounter
+    {
+        int countBits();
+        void setData(byte[] array);
+    }
+    private static byte[] getData()
+    {
+        int count = 1_000_000;
+        Random random = new Random(22);
+        byte[] data = new byte[count];
+        random.nextBytes(data);
+        return data;
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkSliceTest.BenchmarkData();
+        data.setup();
+        data.useUnsafe = true;
+        Integer countUnsafe = (Integer) new BenchmarkSliceTest().benchmarkBitCount(data);
+        data = new BenchmarkSliceTest.BenchmarkData();
+        data.setup();
+        data.useUnsafe = false;
+        Integer countSafe = (Integer) new BenchmarkSliceTest().benchmarkBitCount(data);
+        assertEquals(countSafe, countUnsafe);
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkSliceTest.class.getSimpleName() + ".*")
+                .jvmArgs("-Xmx5g")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestAriaLongStreamV1.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestAriaLongStreamV1.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.OrcDecompressor;
+import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.Stream;
+import com.facebook.presto.orc.stream.aria.AriaLongInputStreamV1;
+import com.facebook.presto.orc.stream.aria.AriaOrcInputStream;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
+import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.testng.Assert.assertEquals;
+
+public class TestAriaLongStreamV1
+        extends AbstractTestValueStream<Long, LongStreamCheckpoint, LongOutputStreamV1, AriaLongInputStreamV1>
+{
+    @Test
+    public void testWithPositions()
+            throws IOException
+    {
+        List<List<Long>> data = getData();
+        List<Long> flattened = data.stream()
+                .flatMap(Collection::stream)
+                .collect(toImmutableList());
+        int[] positions = IntStream.range(flattened.size() / 11, flattened.size()).toArray();
+        for (CompressionKind kind : CompressionKind.values()) {
+            testWriteValueWithPositions(getData(), kind, positions);
+        }
+    }
+
+    public void testWriteValueWithPositions(List<List<Long>> groups, CompressionKind compressionKind, int[] positions)
+            throws IOException
+    {
+        LongOutputStreamV1 outputStream = createValueOutputStream(groups, compressionKind);
+        List<LongStreamCheckpoint> checkpoints = outputStream.getCheckpoints();
+        assertEquals(checkpoints.size(), groups.size());
+        Slice slice = createSlice(outputStream, 33);
+        AriaLongInputStreamV1 valueStream = createValueStream(slice, compressionKind);
+        valueStream.setPositions(positions);
+        List<Long> flattened = groups.stream()
+                .flatMap(Collection::stream)
+                .collect(toImmutableList());
+        for (int position : positions) {
+            long expectedValue = flattened.get(position);
+            long actualValue = valueStream.nextLong();
+            assertEquals(actualValue, expectedValue, "index=" + position);
+        }
+    }
+    @Test
+    public void test()
+            throws IOException
+    {
+        List<List<Long>> groups = new ArrayList<>();
+        List<Long> group;
+
+        group = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            group.add((long) (i));
+        }
+        groups.add(group);
+
+        group = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            group.add((long) (10_000 + (i * 17)));
+        }
+        groups.add(group);
+
+        group = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            group.add((long) (10_000 - (i * 17)));
+        }
+        groups.add(group);
+
+        group = new ArrayList<>();
+        Random random = new Random(22);
+        for (int i = 0; i < 1000; i++) {
+            group.add(-1000L + random.nextInt(17));
+        }
+        groups.add(group);
+
+        testWriteValue(groups);
+    }
+
+    private LongOutputStreamV1 createValueOutputStream(List<List<Long>> groups, CompressionKind compressionKind)
+    {
+        LongOutputStreamV1 outputStream = new LongOutputStreamV1(compressionKind, COMPRESSION_BLOCK_SIZE, true, DATA);
+        outputStream.reset();
+        for (List<Long> group : groups) {
+            outputStream.recordCheckpoint();
+            group.forEach(outputStream::writeLong);
+        }
+        outputStream.close();
+        return outputStream;
+    }
+
+    private Slice createSlice(LongOutputStreamV1 outputStream, int column)
+    {
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
+        StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(column);
+        streamDataOutput.writeData(sliceOutput);
+        Stream stream = streamDataOutput.getStream();
+        assertEquals(stream.getStreamKind(), Stream.StreamKind.DATA);
+        assertEquals(stream.getColumn(), column);
+        assertEquals(stream.getLength(), sliceOutput.size());
+        return sliceOutput.slice();
+    }
+
+    private AriaLongInputStreamV1 createValueStream(Slice slice, CompressionKind compressionKind)
+            throws OrcCorruptionException
+    {
+        Optional<OrcDecompressor> orcDecompressor = createOrcDecompressor(ORC_DATA_SOURCE_ID, compressionKind, COMPRESSION_BLOCK_SIZE);
+        AriaOrcInputStream input = new AriaOrcInputStream(ORC_DATA_SOURCE_ID, slice.getInput(), orcDecompressor, newSimpleAggregatedMemoryContext(), slice.getRetainedSize());
+        return new AriaLongInputStreamV1(input, true);
+    }
+
+    private List<List<Long>> getData()
+    {
+        List<List<Long>> groups = new ArrayList<>();
+        List<Long> group;
+
+        group = new ArrayList<>();
+        Random random = new Random(22);
+        for (int i = 0; i < 470000; i++) {
+            group.add(-1000L + random.nextInt(17));
+        }
+        groups.add(group);
+
+        group = new ArrayList<>();
+        for (int i = 0; i < 10000; i++) {
+            group.add((long) (i));
+        }
+        groups.add(group);
+
+        group = new ArrayList<>();
+        for (int i = 0; i < 10000; i++) {
+            group.add((long) (10_000 + (i * 17)));
+        }
+        groups.add(group);
+
+        group = new ArrayList<>();
+        for (int i = 0; i < 10000; i++) {
+            group.add((long) (10_000 - (i * 17)));
+        }
+        groups.add(group);
+        return groups;
+    }
+
+    @Override
+    protected LongOutputStreamV1 createValueOutputStream()
+    {
+        return new LongOutputStreamV1(SNAPPY, COMPRESSION_BLOCK_SIZE, true, DATA);
+    }
+
+    @Override
+    protected void writeValue(LongOutputStreamV1 outputStream, Long value)
+    {
+        outputStream.writeLong(value);
+    }
+
+    @Override
+    protected AriaLongInputStreamV1 createValueStream(Slice slice)
+            throws OrcCorruptionException
+    {
+        Optional<OrcDecompressor> orcDecompressor = createOrcDecompressor(ORC_DATA_SOURCE_ID, SNAPPY, COMPRESSION_BLOCK_SIZE);
+        AriaOrcInputStream input = new AriaOrcInputStream(ORC_DATA_SOURCE_ID, slice.getInput(), orcDecompressor, newSimpleAggregatedMemoryContext(), slice.getRetainedSize());
+        return new AriaLongInputStreamV1(input, true);
+    }
+
+    @Override
+    protected Long readValue(AriaLongInputStreamV1 valueStream)
+            throws IOException
+    {
+        return valueStream.next();
+    }
+}


### PR DESCRIPTION
This is the code that I will be integrating into the LongInputStream.scan 

Here is the benchmark:
useLegacy - when false it will use the aria orc input stream
ALL - all positions
ODD - odd positions (skip every other position)
SECOND_HALF - skip the first half of the positions
RANDOM_QUARTER - randomly select one quarter of the positions

```
Benchmark                                (kind)  (positionsType)  (useLegacy)  Mode  Cnt        Score        Error  Units
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY              ALL        false  avgt   20  2832764.895 ± 712283.606  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY              ALL         true  avgt   20  2863730.214 ±  48448.861  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY              ODD        false  avgt   20  1782792.212 ±  57939.622  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY              ODD         true  avgt   20  1936096.294 ±  26035.053  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY      SECOND_HALF        false  avgt   20  1411742.888 ±  54394.088  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY      SECOND_HALF         true  avgt   20  1624873.619 ±  31678.500  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY   RANDOM_QUARTER        false  avgt   20  1253702.675 ± 255791.670  ns/op
BenchmarkLongStreamV1.benchmarkDecoding  SNAPPY   RANDOM_QUARTER         true  avgt   20  1639870.272 ± 375710.338  ns/op
```