### PR TITLE
Remove useless output from EXPLAIN

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
@@ -100,7 +100,7 @@ public class TextRenderer
     {
         StringBuilder output = new StringBuilder();
         if (!node.getStats().isPresent() || !(plan.getTotalCpuTime().isPresent() && plan.getTotalScheduledTime().isPresent())) {
-            return "Cost: ?, Output: ? rows (?B)\n";
+            return "";
         }
 
         PlanNodeStats nodeStats = node.getStats().get();


### PR DESCRIPTION
Before the change, EXPLAIN would print "Cost: ?, Output: ? rows (?B)"
for every node. This information is available only in EXPLAIN ANALYZE.

Extracted-From: https://github.com/prestosql/presto/commit/ce9ecf97ed92c3c58494570bc2f17c512d2714a0

Original PR: https://github.com/prestosql/presto/pull/397