### PR TITLE
Adapt Aria scan to schema evolution

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSource.java
@@ -149,8 +149,19 @@ public class OrcPageSource
                 Page page = recordReader.getNextPage();
                 if (page == null) {
                     close();
+                    return null;
                 }
-                return page;
+
+                Block[] blocks = new Block[page.getChannelCount()];
+                for (int fieldId = 0; fieldId < blocks.length; fieldId++) {
+                    if (constantBlocks[fieldId] != null) {
+                        blocks[fieldId] = constantBlocks[fieldId].getRegion(0, page.getPositionCount());
+                    }
+                    else {
+                        blocks[fieldId] = page.getBlock(fieldId);
+                    }
+                }
+                return new Page(page.getPositionCount(), blocks);
             }
             batchId++;
             int batchSize = recordReader.nextBatch();


### PR DESCRIPTION
Fix OrcPageSource to include all-nulls block if a column is not present in the
data file. This happens when a column is added after some data was already
inserted.

After this change TestHiveDistributedQueries.testAddColumn is passing.

Includes #12441