### PR TITLE
Fix DictionaryBlock#getSizeInBytes

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -195,19 +195,10 @@ public class DictionaryBlock
     }
 
     @Override
-
     public long getSizeInBytes()
     {
-        /* We return the size this takes passing through a partitioned output.*/
-
         if (sizeInBytes < 0) {
-            sizeInBytes = 0;
-            for (int i = 0; i < positionCount; i++) {
-                int position = getId(i);
-                if (!dictionary.isNull(position)) {
-                    sizeInBytes += dictionary.getRegionSizeInBytes(position, 1);
-                }
-            }
+            calculateCompactSize();
         }
         return sizeInBytes;
     }


### PR DESCRIPTION
Reverted Aria performance improvement in DictionaryBlock#getSizeInBytes to allow tests in presto-main to pass. This performance improvement will be re-introduced properly in #12399