### PR TITLE
Changes to IndexedPriorityQueue to be able to use elsewhere in the project

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/IndexedPriorityQueue.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/IndexedPriorityQueue.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.execution.resourceGroups;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -27,19 +28,31 @@ import static java.util.Objects.requireNonNull;
  * A priority queue with constant time contains(E) and log time remove(E)
  * Ties are broken by insertion order
  */
-final class IndexedPriorityQueue<E>
-        implements UpdateablePriorityQueue<E>
+public final class IndexedPriorityQueue<E>
+        implements UpdateablePriorityQueue<E>, Serializable
 {
+    private boolean highestPriorityfirst=true;
     private final Map<E, Entry<E>> index = new HashMap<>();
     private final Set<Entry<E>> queue = new TreeSet<>((entry1, entry2) -> {
         int priorityComparison = Long.compare(entry2.getPriority(), entry1.getPriority());
         if (priorityComparison != 0) {
-            return priorityComparison;
+            if(highestPriorityfirst)
+                return priorityComparison;
+            else
+                return -1*priorityComparison;
         }
         return Long.compare(entry1.getGeneration(), entry2.getGeneration());
     });
 
+
     private long generation;
+
+    public IndexedPriorityQueue(boolean highestPriorityfirst){
+            this.highestPriorityfirst = highestPriorityfirst;
+    }
+
+    public IndexedPriorityQueue(){
+    }
 
     @Override
     public boolean addOrUpdate(E element, long priority)

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/UpdateablePriorityQueue.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/UpdateablePriorityQueue.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.execution.resourceGroups;
 
-interface UpdateablePriorityQueue<E>
+public interface UpdateablePriorityQueue<E>
         extends Queue<E>, Iterable<E>
 {
     boolean addOrUpdate(E element, long priority);

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestUpdateablePriorityQueue.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestUpdateablePriorityQueue.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution.resourceGroups;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.Iterator;
 import java.util.List;
 
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
@@ -26,19 +27,25 @@ public class TestUpdateablePriorityQueue
     @Test
     public void testFifoQueue()
     {
-        assertEquals(populateAndExtract(new FifoQueue<>()), ImmutableList.of(1, 2, 3));
+        assertEquals(populateAndExtract(new FifoQueue<>()), ImmutableList.of(2, 3, 4, 5));
     }
 
     @Test
     public void testIndexedPriorityQueue()
     {
-        assertEquals(populateAndExtract(new IndexedPriorityQueue<>()), ImmutableList.of(3, 2, 1));
+        assertEquals(populateAndExtract(new IndexedPriorityQueue<>()), ImmutableList.of(2, 3, 5, 1));
+    }
+
+    @Test
+    public void testIndexedPriorityQueueReverse()
+    {
+        assertEquals(populateAndExtract(new IndexedPriorityQueue<>(false)), ImmutableList.of(5, 3, 2, 4));
     }
 
     @Test
     public void testStochasticPriorityQueue()
     {
-        assertTrue(populateAndExtract(new StochasticPriorityQueue<>()).size() == 3);
+        assertTrue(populateAndExtract(new StochasticPriorityQueue<>()).size() == 4);
     }
 
     private static List<Integer> populateAndExtract(UpdateablePriorityQueue<Integer> queue)
@@ -46,6 +53,16 @@ public class TestUpdateablePriorityQueue
         queue.addOrUpdate(1, 1);
         queue.addOrUpdate(2, 2);
         queue.addOrUpdate(3, 3);
+        queue.addOrUpdate(4, 7);
+        queue.addOrUpdate(2, 5);  //Update priority of existing entry
+        queue.addOrUpdate(5, 2);  //duplicate priority
+
+        queue.poll();
+        Iterator x = queue.iterator();
+        System.out.println(queue.getClass());
+        while (x.hasNext())
+            System.out.print(x.next() + " ");
+        System.out.println();
         return ImmutableList.copyOf(queue);
     }
 }


### PR DESCRIPTION
I am trying to implement a new approx agg function: https://github.com/prestodb/presto/issues/11807
which needs to use the IndexedPriorityQueue. Thus i made following changes to it.
1) Made the class serializable because the agg function needs the state to be serialized.
2) Had to make the class public
3) Added an option boolean highestPriorityFirst which can be set to false, to dequeue the low priority elements first.
4) Added a few more test cases to check for edge cases.

Please let me know where can i move the class to from resourceGroups as the recommendation is to not make the class public in the resourceGroups package. 
Please note i am not a java programmer so i may need a little more detailed instructions. I am more than happy to implement whatever is required to maintain the conventions of the code.
Thanks for your guidance in advance.