### PR TITLE
Add CURRENT_ROLE to the list of non reserved keywords

### DIFF
--- a/presto-docs/src/main/sphinx/language/reserved.rst
+++ b/presto-docs/src/main/sphinx/language/reserved.rst
@@ -22,7 +22,6 @@ Keyword                        SQL:2016      SQL-92
 ``CUBE``                       reserved
 ``CURRENT_DATE``               reserved      reserved
 ``CURRENT_PATH``               reserved
-``CURRENT_ROLE``               reserved      reserved
 ``CURRENT_TIME``               reserved      reserved
 ``CURRENT_TIMESTAMP``          reserved      reserved
 ``CURRENT_USER``               reserved

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -454,15 +454,15 @@ qualifiedName
     ;
 
 grantor
-    : principal             #specifiedPrincipal
-    | CURRENT_USER          #currentUserGrantor
+    : CURRENT_USER          #currentUserGrantor
     | CURRENT_ROLE          #currentRoleGrantor
+    | principal             #specifiedPrincipal
     ;
 
 principal
-    : identifier            #unspecifiedPrincipal
-    | USER identifier       #userPrincipal
+    : USER identifier       #userPrincipal
     | ROLE identifier       #rolePrincipal
+    | identifier            #unspecifiedPrincipal
     ;
 
 roles
@@ -487,7 +487,7 @@ nonReserved
     // IMPORTANT: this rule must only contain tokens. Nested rules are not supported. See SqlParser.exitNonReserved
     : ADD | ADMIN | ALL | ANALYZE | ANY | ARRAY | ASC | AT
     | BERNOULLI
-    | CALL | CASCADE | CATALOGS | COLUMN | COLUMNS | COMMENT | COMMIT | COMMITTED | CURRENT
+    | CALL | CASCADE | CATALOGS | COLUMN | COLUMNS | COMMENT | COMMIT | COMMITTED | CURRENT | CURRENT_ROLE
     | DATA | DATE | DAY | DESC | DISTRIBUTED
     | EXCLUDING | EXPLAIN
     | FILTER | FIRST | FOLLOWING | FORMAT | FUNCTIONS

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1854,12 +1854,19 @@ public class TestSqlParser
                                 new Identifier("SOME"),
                                 new Identifier("ANY")),
                         table(QualifiedName.of("t"))));
+        assertStatement("SELECT CURRENT_ROLE, t.current_role FROM t",
+                simpleQuery(
+                        selectList(
+                                new Identifier("CURRENT_ROLE"),
+                                new DereferenceExpression(new Identifier("t"), new Identifier("current_role"))),
+                        table(QualifiedName.of("t"))));
 
         assertExpression("stats", new Identifier("stats"));
         assertExpression("nfd", new Identifier("nfd"));
         assertExpression("nfc", new Identifier("nfc"));
         assertExpression("nfkd", new Identifier("nfkd"));
         assertExpression("nfkc", new Identifier("nfkc"));
+        assertExpression("current_role", new Identifier("current_role"));
     }
 
     @Test


### PR DESCRIPTION
The SQL standard allows queries like:

```
postgres=# SELECT CURRENT_ROLE;
 current_role
--------------
 postgres
(1 row)
```

That's why the `CURRENT_ROLE` is a reserved keyword in the SQL standard.

Currently Presto supports the `CURRENT_ROLE` keyword only in
`CREATE ROLE`, `GRANT` and `REVOKE` statements. So it is possible to
parse the `CURRENT_ROLE` token as a keyword in those statements, while
parsing the same token as an identifier in any other queries.

However this is only a temporary solution, as at some point the scope
of the `CURRENT_ROLE` might be extended to the SELECT queries as well.

