### PR TITLE
Mark split schedule done after lifespan finish execution

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -143,7 +143,7 @@ public class FixedSourcePartitionedScheduler
                     // Schedule the first few lifespans
                     lifespanScheduler.scheduleInitial(sourceScheduler);
                     // Schedule new lifespans for finished ones
-                    stage.addCompletedDriverGroupsChangedListener(lifespanScheduler::onLifespanFinished);
+                    stage.addCompletedDriverGroupsChangedListener(lifespanScheduler::onLifespanExecutionFinished);
                     groupedLifespanScheduler = Optional.of(lifespanScheduler);
                 }
             }
@@ -214,7 +214,7 @@ public class FixedSourcePartitionedScheduler
                 allBlocked = false;
             }
 
-            driverGroupsToStart = sourceScheduler.drainCompletedLifespans();
+            driverGroupsToStart = sourceScheduler.drainCompletelyScheduledLifespans();
 
             if (schedule.isFinished()) {
                 stage.schedulingComplete(sourceScheduler.getPlanNodeId());
@@ -297,7 +297,7 @@ public class FixedSourcePartitionedScheduler
     {
         private final SourceScheduler sourceScheduler;
         private boolean started;
-        private boolean completed;
+        private boolean scheduleCompleted;
         private final List<Lifespan> pendingCompleted;
 
         public AsGroupedSourceScheduler(SourceScheduler sourceScheduler)
@@ -343,15 +343,15 @@ public class FixedSourcePartitionedScheduler
         }
 
         @Override
-        public List<Lifespan> drainCompletedLifespans()
+        public List<Lifespan> drainCompletelyScheduledLifespans()
         {
-            if (!completed) {
-                List<Lifespan> lifespans = sourceScheduler.drainCompletedLifespans();
+            if (!scheduleCompleted) {
+                List<Lifespan> lifespans = sourceScheduler.drainCompletelyScheduledLifespans();
                 if (lifespans.isEmpty()) {
                     return ImmutableList.of();
                 }
                 checkState(ImmutableList.of(Lifespan.taskWide()).equals(lifespans));
-                completed = true;
+                scheduleCompleted = true;
             }
             List<Lifespan> result = ImmutableList.copyOf(pendingCompleted);
             pendingCompleted.clear();

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
@@ -79,7 +79,7 @@ public class SourcePartitionedScheduler
 
         /**
          * All splits have been provided to caller of this scheduler.
-         * Cleanup operations are done (e.g., drainCompletedLifespans has drained all driver groups).
+         * Cleanup operations are done (e.g., drainCompletelyScheduledLifespans has drained all driver groups).
          */
         FINISHED
     }
@@ -143,7 +143,7 @@ public class SourcePartitionedScheduler
             public ScheduleResult schedule()
             {
                 ScheduleResult scheduleResult = sourcePartitionedScheduler.schedule();
-                sourcePartitionedScheduler.drainCompletedLifespans();
+                sourcePartitionedScheduler.drainCompletelyScheduledLifespans();
                 return scheduleResult;
             }
 
@@ -162,7 +162,7 @@ public class SourcePartitionedScheduler
      * that is either ungrouped or grouped. However, the caller is responsible initializing
      * the driver groups in this scheduler accordingly.
      * <p>
-     * Besides, the caller is required to poll {@link #drainCompletedLifespans()}
+     * Besides, the caller is required to poll {@link #drainCompletelyScheduledLifespans()}
      * in addition to {@link #schedule()} on the returned object. Otherwise, lifecycle
      * transitioning of the object will not work properly.
      */
@@ -402,7 +402,7 @@ public class SourcePartitionedScheduler
     }
 
     @Override
-    public synchronized List<Lifespan> drainCompletedLifespans()
+    public synchronized List<Lifespan> drainCompletelyScheduledLifespans()
     {
         if (scheduleGroups.isEmpty()) {
             // Invoking splitSource.isFinished would fail if it was already closed, which is possible if scheduleGroups is empty.

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourceScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourceScheduler.java
@@ -32,5 +32,5 @@ public interface SourceScheduler
 
     void noMoreLifespans();
 
-    List<Lifespan> drainCompletedLifespans();
+    List<Lifespan> drainCompletelyScheduledLifespans();
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourceScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourceScheduler.java
@@ -30,7 +30,7 @@ public interface SourceScheduler
 
     void startLifespan(Lifespan lifespan, ConnectorPartitionHandle partitionHandle);
 
-    void noMoreLifespans();
-
     List<Lifespan> drainCompletelyScheduledLifespans();
+
+    void notifyAllLifespansFinishedExecution();
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/group/DynamicLifespanScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/group/DynamicLifespanScheduler.java
@@ -57,7 +57,7 @@ public class DynamicLifespanScheduler
     private SettableFuture<?> newDriverGroupReady = SettableFuture.create();
 
     @GuardedBy("this")
-    private final List<Lifespan> recentlyCompletedDriverGroups = new ArrayList<>();
+    private final List<Lifespan> recentlyCompletelyExecutedDriverGroups = new ArrayList<>();
 
     public DynamicLifespanScheduler(BucketNodeMap bucketNodeMap, List<Node> allNodes, List<ConnectorPartitionHandle> partitionHandles, OptionalInt concurrentLifespansPerTask)
     {
@@ -101,15 +101,15 @@ public class DynamicLifespanScheduler
     }
 
     @Override
-    public void onLifespanFinished(Iterable<Lifespan> newlyCompletedDriverGroups)
+    public void onLifespanExecutionFinished(Iterable<Lifespan> newlyCompletelyExecutedDriverGroups)
     {
         checkState(initialScheduled);
 
         SettableFuture<?> newDriverGroupReady;
         synchronized (this) {
-            for (Lifespan newlyCompletedDriverGroup : newlyCompletedDriverGroups) {
-                checkArgument(!newlyCompletedDriverGroup.isTaskWide());
-                recentlyCompletedDriverGroups.add(newlyCompletedDriverGroup);
+            for (Lifespan newlyCompletelyExecutedDriverGroup : newlyCompletelyExecutedDriverGroups) {
+                checkArgument(!newlyCompletelyExecutedDriverGroup.isTaskWide());
+                recentlyCompletelyExecutedDriverGroups.add(newlyCompletelyExecutedDriverGroup);
             }
             newDriverGroupReady = this.newDriverGroupReady;
         }
@@ -126,8 +126,8 @@ public class DynamicLifespanScheduler
 
         List<Lifespan> recentlyCompletedDriverGroups;
         synchronized (this) {
-            recentlyCompletedDriverGroups = ImmutableList.copyOf(this.recentlyCompletedDriverGroups);
-            this.recentlyCompletedDriverGroups.clear();
+            recentlyCompletedDriverGroups = ImmutableList.copyOf(this.recentlyCompletelyExecutedDriverGroups);
+            this.recentlyCompletelyExecutedDriverGroups.clear();
             newDriverGroupReady = SettableFuture.create();
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/group/FixedLifespanScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/group/FixedLifespanScheduler.java
@@ -56,7 +56,8 @@ public class FixedLifespanScheduler
     private SettableFuture<?> newDriverGroupReady = SettableFuture.create();
     @GuardedBy("this")
     private final List<Lifespan> recentlyCompletelyExecutedDriverGroups = new ArrayList<>();
-    private int totalDriverGroupsScheduled;
+    @GuardedBy("this")
+    private int totalLifespanExecutionFinished;
 
     public FixedLifespanScheduler(BucketNodeMap bucketNodeMap, List<ConnectorPartitionHandle> partitionHandles, OptionalInt concurrentLifespansPerTask)
     {
@@ -93,17 +94,11 @@ public class FixedLifespanScheduler
                 int driverGroupId = driverGroupsIterator.nextInt();
                 scheduler.startLifespan(Lifespan.driverGroup(driverGroupId), partitionHandles.get(driverGroupId));
 
-                totalDriverGroupsScheduled++;
                 driverGroupsScheduled++;
                 if (concurrentLifespansPerTask.isPresent() && driverGroupsScheduled == concurrentLifespansPerTask.getAsInt()) {
                     break;
                 }
             }
-        }
-
-        verify(totalDriverGroupsScheduled <= driverGroupToNodeMap.size());
-        if (totalDriverGroupsScheduled == driverGroupToNodeMap.size()) {
-            scheduler.noMoreLifespans();
         }
     }
 
@@ -116,10 +111,12 @@ public class FixedLifespanScheduler
             for (Lifespan newlyCompletelyExecutedDriverGroup : newlyCompletelyExecutedDriverGroups) {
                 checkArgument(!newlyCompletelyExecutedDriverGroup.isTaskWide());
                 recentlyCompletelyExecutedDriverGroups.add(newlyCompletelyExecutedDriverGroup);
+                totalLifespanExecutionFinished++;
             }
             newDriverGroupReady = this.newDriverGroupReady;
         }
         newDriverGroupReady.set(null);
+        verify(totalLifespanExecutionFinished <= partitionHandles.size());
     }
 
     public SettableFuture schedule(SourceScheduler scheduler)
@@ -143,14 +140,14 @@ public class FixedLifespanScheduler
             }
             int driverGroupId = driverGroupsIterator.nextInt();
             scheduler.startLifespan(Lifespan.driverGroup(driverGroupId), partitionHandles.get(driverGroupId));
-            totalDriverGroupsScheduled++;
-        }
-
-        verify(totalDriverGroupsScheduled <= driverGroupToNodeMap.size());
-        if (totalDriverGroupsScheduled == driverGroupToNodeMap.size()) {
-            scheduler.noMoreLifespans();
         }
 
         return newDriverGroupReady;
+    }
+
+    @Override
+    public synchronized boolean allLifespanExecutionFinished()
+    {
+        return totalLifespanExecutionFinished == partitionHandles.size();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/group/FixedLifespanScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/group/FixedLifespanScheduler.java
@@ -55,7 +55,7 @@ public class FixedLifespanScheduler
     private boolean initialScheduled;
     private SettableFuture<?> newDriverGroupReady = SettableFuture.create();
     @GuardedBy("this")
-    private final List<Lifespan> recentlyCompletedDriverGroups = new ArrayList<>();
+    private final List<Lifespan> recentlyCompletelyExecutedDriverGroups = new ArrayList<>();
     private int totalDriverGroupsScheduled;
 
     public FixedLifespanScheduler(BucketNodeMap bucketNodeMap, List<ConnectorPartitionHandle> partitionHandles, OptionalInt concurrentLifespansPerTask)
@@ -107,15 +107,15 @@ public class FixedLifespanScheduler
         }
     }
 
-    public void onLifespanFinished(Iterable<Lifespan> newlyCompletedDriverGroups)
+    public void onLifespanExecutionFinished(Iterable<Lifespan> newlyCompletelyExecutedDriverGroups)
     {
         checkState(initialScheduled);
 
         SettableFuture<?> newDriverGroupReady;
         synchronized (this) {
-            for (Lifespan newlyCompletedDriverGroup : newlyCompletedDriverGroups) {
-                checkArgument(!newlyCompletedDriverGroup.isTaskWide());
-                recentlyCompletedDriverGroups.add(newlyCompletedDriverGroup);
+            for (Lifespan newlyCompletelyExecutedDriverGroup : newlyCompletelyExecutedDriverGroups) {
+                checkArgument(!newlyCompletelyExecutedDriverGroup.isTaskWide());
+                recentlyCompletelyExecutedDriverGroups.add(newlyCompletelyExecutedDriverGroup);
             }
             newDriverGroupReady = this.newDriverGroupReady;
         }
@@ -131,8 +131,8 @@ public class FixedLifespanScheduler
 
         List<Lifespan> recentlyCompletedDriverGroups;
         synchronized (this) {
-            recentlyCompletedDriverGroups = ImmutableList.copyOf(this.recentlyCompletedDriverGroups);
-            this.recentlyCompletedDriverGroups.clear();
+            recentlyCompletedDriverGroups = ImmutableList.copyOf(this.recentlyCompletelyExecutedDriverGroups);
+            this.recentlyCompletelyExecutedDriverGroups.clear();
             newDriverGroupReady = SettableFuture.create();
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/group/LifespanScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/group/LifespanScheduler.java
@@ -31,4 +31,6 @@ public interface LifespanScheduler
     void onLifespanExecutionFinished(Iterable<Lifespan> newlyCompletelyExecutedDriverGroups);
 
     SettableFuture schedule(SourceScheduler scheduler);
+
+    boolean allLifespanExecutionFinished();
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/group/LifespanScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/group/LifespanScheduler.java
@@ -20,7 +20,7 @@ import com.google.common.util.concurrent.SettableFuture;
 public interface LifespanScheduler
 {
     // Thread Safety:
-    // * Invocation of onLifespanFinished can be parallel and in any thread.
+    // * Invocation of onLifespanExecutionFinished can be parallel and in any thread.
     //   There may be multiple invocations in flight at the same time,
     //   and may overlap with any other methods.
     // * Invocation of schedule happens sequentially in a single thread.
@@ -28,7 +28,7 @@ public interface LifespanScheduler
 
     void scheduleInitial(SourceScheduler scheduler);
 
-    void onLifespanFinished(Iterable<Lifespan> newlyCompletedDriverGroups);
+    void onLifespanExecutionFinished(Iterable<Lifespan> newlyCompletelyExecutedDriverGroups);
 
     SettableFuture schedule(SourceScheduler scheduler);
 }


### PR DESCRIPTION

With future partial recovery support to grouped execution, finishing
scheduling all known splits no longer means schedule finished, since a
lifespan might fail and the engine will rewind all pre-scheduled splits.

Thus, under the context of grouped execution, the schedule should be
considered as completed only after all lifespan finished execution.

Note this commit removed `noMoreLifespans` interface introduced in
4d56e365e4a726248179b89d3b631b3baf3fe7b2, since the new condition
"all lifespan finished execution" is stronger than
"all lifespan finished schedule".