### PR TITLE
Change like_pattern to be a hidden function

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/LikeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LikeFunctions.java
@@ -94,7 +94,7 @@ public final class LikeFunctions
         return likePattern(pattern.toStringUtf8(), '0', false);
     }
 
-    @ScalarFunction
+    @ScalarFunction(hidden = true)
     @LiteralParameters({"x", "y"})
     @SqlType(LikePatternType.NAME)
     public static Regex likePattern(@SqlType("varchar(x)") Slice pattern, @SqlType("varchar(y)") Slice escape)


### PR DESCRIPTION
like_pattern should be a hidden function. Currently this function is visible, and calling it would result in an error:
```
presto:abc> select like_pattern('%abc', '-');
Query 20190323_010558_14283_hu9zg failed: object.getClass (class io.airlift.joni.Regex) and type.getJavaType (class io.airlift.slice.Slice) do not agree
```