### PR TITLE
Make each fragment contain at most 1 TableWriterNode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubPlan.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubPlan.java
@@ -13,10 +13,15 @@
  */
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
+import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
+import com.facebook.presto.sql.planner.plan.TableWriterNode;
+import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multiset;
+import com.google.common.graph.Traverser;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -25,6 +30,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableMultiset.toImmutableMultiset;
+import static com.google.common.collect.Streams.stream;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -85,6 +91,17 @@ public class SubPlan
                 .collect(toImmutableMultiset());
 
         checkState(childrenIds.containsAll(remoteSourceIds), "child fragments must include all remote source fragments (%s vs %s)", remoteSourceIds, childrenIds);
+        long tableWriteCount = stream(Traverser.forTree(PlanNode::getSources).depthFirstPreOrder(fragment.getRoot()))
+                .filter(TableWriterNode.class::isInstance)
+                .count();
+        checkState(tableWriteCount <= 1, "Fragment cannot contain more than one TableWriterNode");
+        if (tableWriteCount == 1) {
+            if (!(fragment.getRoot() instanceof OutputNode || fragment.getRoot() instanceof TableWriterNode)) {
+                // Root can be OutputNode when forceSingleNode is enabled.
+                // In that case the whole plan has single fragment.
+                throw new VerifyException("For a fragment contains TableWriteNode, the root has to be either OutputNode or TableWriterNode");
+            }
+        }
 
         for (SubPlan child : children) {
             child.sanityCheck();


### PR DESCRIPTION
To support grouped execution failure recovery, lifespans might be
re-executed and thus write the same data multiple times. Coordinator
will guaranteed only one execution's output get committed.

This guarantee is easy to satisfy if each stage have at most one
TableWriter, as coordinator can simply choose one execution per each
(stage, lifespan) pair. Multiple TableWriter operators in one stage
complicates the design of failure recovery without other benefits.
