### PR TITLE
Initial refactoring of pushdown subscripts rule

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
@@ -21,7 +21,7 @@ import com.facebook.presto.spi.type.TypeSignature;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -63,7 +63,7 @@ public class HiveColumnHandle
     private final ColumnType columnType;
     private final Optional<String> comment;
     private final SubfieldPath subfieldPath;
-    private final ArrayList<SubfieldPath> referencedSubfields;
+    private final List<SubfieldPath> referencedSubfields;
 
     @JsonCreator
     public HiveColumnHandle(
@@ -74,7 +74,7 @@ public class HiveColumnHandle
             @JsonProperty("columnType") ColumnType columnType,
             @JsonProperty("comment") Optional<String> comment,
             @JsonProperty("subfieldPath") SubfieldPath subfieldPath,
-            @JsonProperty("referencedSubfields") ArrayList<SubfieldPath> referencedSubfields)
+            @JsonProperty("referencedSubfields") List<SubfieldPath> referencedSubfields)
     {
         this.name = requireNonNull(name, "name is null");
         checkArgument(hiveColumnIndex >= 0 || columnType == PARTITION_KEY || columnType == SYNTHESIZED, "hiveColumnIndex is negative");
@@ -88,12 +88,12 @@ public class HiveColumnHandle
     }
 
     public HiveColumnHandle(
-                            String name,
-                            HiveType hiveType,
-                            TypeSignature typeSignature,
-                            int hiveColumnIndex,
-                            ColumnType columnType,
-                            Optional<String> comment)
+            String name,
+            HiveType hiveType,
+            TypeSignature typeSignature,
+            int hiveColumnIndex,
+            ColumnType columnType,
+            Optional<String> comment)
     {
         this(name, hiveType, typeSignature, hiveColumnIndex, columnType, comment, null, null);
     }
@@ -156,7 +156,7 @@ public class HiveColumnHandle
     }
 
     @JsonProperty
-    public ArrayList<SubfieldPath> getReferencedSubfields()
+    public List<SubfieldPath> getReferencedSubfields()
     {
         return referencedSubfields;
     }
@@ -233,19 +233,13 @@ public class HiveColumnHandle
     }
 
     @Override
-    public boolean supportsSubfieldPruning()
-    {
-        return true;
-    }
-
-    @Override
     public ColumnHandle createSubfieldColumnHandle(SubfieldPath path)
     {
         return new HiveColumnHandle(name, hiveType, typeName, hiveColumnIndex, columnType, comment, path, null);
     }
 
     @Override
-    public ColumnHandle createSubfieldPruningColumnHandle(ArrayList<SubfieldPath> referencedSubfields)
+    public ColumnHandle createSubfieldPruningColumnHandle(List<SubfieldPath> referencedSubfields)
     {
         return new HiveColumnHandle(name, hiveType, typeName, hiveColumnIndex, columnType, comment, null, referencedSubfields);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/DomainTranslator.java
@@ -18,6 +18,9 @@ import com.facebook.presto.execution.warnings.WarningCollector;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.OperatorNotFoundException;
 import com.facebook.presto.spi.SubfieldPath;
+import com.facebook.presto.spi.SubfieldPath.LongSubscript;
+import com.facebook.presto.spi.SubfieldPath.NestedField;
+import com.facebook.presto.spi.SubfieldPath.StringSubscript;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.predicate.DiscreteValues;
@@ -72,6 +75,8 @@ import static com.facebook.presto.sql.ExpressionUtils.and;
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.combineDisjunctsWithDefault;
 import static com.facebook.presto.sql.ExpressionUtils.or;
+import static com.facebook.presto.sql.planner.SubfieldUtils.deferenceOrSubscriptExpressionToPath;
+import static com.facebook.presto.sql.planner.SubfieldUtils.isDereferenceOrSubscriptExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.EQUAL;
@@ -113,30 +118,30 @@ public final class DomainTranslator
                 .collect(collectingAndThen(toImmutableList(), ExpressionUtils::combineConjuncts));
     }
 
-    private Expression toSymbolExpression(Symbol symbol)
+    private static Expression toSymbolExpression(Symbol symbol)
     {
         if (symbol instanceof SymbolWithSubfieldPath) {
-            SymbolWithSubfieldPath subfieldPath = (SymbolWithSubfieldPath) symbol;
-            SubfieldPath path = subfieldPath.getPath();
-            Expression base = new SymbolReference(path.getPath().get(0).getField());
+            SubfieldPath path = ((SymbolWithSubfieldPath) symbol).getSubfieldPath();
+            Expression base = new SymbolReference(symbol.getName());
             for (int i = 1; i < path.getPath().size(); i++) {
                 SubfieldPath.PathElement element = path.getPath().get(i);
-                String field = element.getField();
-                if (element.getIsSubscript()) {
-                    base = new SubscriptExpression(base, field != null ? new StringLiteral(field) : new LongLiteral(Long.valueOf(element.getSubscript()).toString()));
+                if (element instanceof NestedField) {
+                    base = new DereferenceExpression(base, new Identifier(((NestedField) element).getName()));
                 }
-                else if (field != null) {
-                    base = new DereferenceExpression(base, new Identifier(field));
+                else if (element instanceof LongSubscript) {
+                    base = new SubscriptExpression(base, new LongLiteral(String.valueOf(((LongSubscript) element).getIndex())));
+                }
+                else if (element instanceof StringSubscript) {
+                    base = new SubscriptExpression(base, new StringLiteral(((StringSubscript) element).getIndex()));
                 }
                 else {
-                    throw new IllegalArgumentException("Bad subfield path in DomainTranslator");
+                    throw new IllegalArgumentException("Unsupported path element: " + element.getClass().getSimpleName());
                 }
             }
             return base;
         }
-        else {
-            return symbol.toSymbolReference();
-        }
+
+        return symbol.toSymbolReference();
     }
 
     private Expression toPredicate(Domain domain, Expression reference)
@@ -436,6 +441,7 @@ public final class DomainTranslator
             if (!optionalNormalized.isPresent()) {
                 return super.visitComparisonExpression(node, complement);
             }
+
             NormalizedSimpleComparison normalized = optionalNormalized.get();
 
             Expression symbolExpression = normalized.getSymbolExpression();
@@ -445,7 +451,8 @@ public final class DomainTranslator
                 Type type = value.getType(); // common type for symbol and value
                 return createComparisonExtractionResult(normalized.getComparisonOperator(), symbol, type, value.getValue(), complement);
             }
-            else if (symbolExpression instanceof Cast) {
+
+            if (symbolExpression instanceof Cast) {
                 Cast castExpression = (Cast) symbolExpression;
                 if (!isImplicitCoercion(castExpression)) {
                     //
@@ -481,21 +488,23 @@ public final class DomainTranslator
 
                 return super.visitComparisonExpression(node, complement);
             }
-            else if (includeSubfields && SubfieldUtils.isSubfieldPath(symbolExpression)) {
-                SubfieldPath path = SubfieldUtils.subfieldToSubfieldPath(symbolExpression);
+
+            if (includeSubfields && isDereferenceOrSubscriptExpression(symbolExpression)) {
+                SubfieldPath path = deferenceOrSubscriptExpressionToPath(symbolExpression);
                 if (path == null) {
                     return super.visitComparisonExpression(node, complement);
                 }
-                else {
-                    Symbol symbol = new SymbolWithSubfieldPath(path);
-                    NullableValue value = normalized.getValue();
-                    Type type = value.getType(); // common type for symbol and value
-                    return createComparisonExtractionResult(normalized.getComparisonOperator(), symbol, type, value.getValue(), complement);
-                }
+
+                NullableValue value = normalized.getValue();
+                return createComparisonExtractionResult(
+                        normalized.getComparisonOperator(),
+                        new SymbolWithSubfieldPath(path),
+                        value.getType(),
+                        value.getValue(),
+                        complement);
             }
-            else {
-                return super.visitComparisonExpression(node, complement);
-            }
+
+            return super.visitComparisonExpression(node, complement);
         }
 
         /**

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -114,6 +114,7 @@ import com.facebook.presto.sql.planner.optimizations.OptimizeMixedDistinctAggreg
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.optimizations.PredicatePushDown;
 import com.facebook.presto.sql.planner.optimizations.PruneUnreferencedOutputs;
+import com.facebook.presto.sql.planner.optimizations.PushdownSubscripts;
 import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinInDelete;
 import com.facebook.presto.sql.planner.optimizations.SetFlatteningOptimizer;
 import com.facebook.presto.sql.planner.optimizations.StatsRecordingPlanOptimizer;
@@ -470,6 +471,7 @@ public class PlanOptimizers
         builder.add(inlineProjections);
         builder.add(new UnaliasSymbolReferences()); // Run unalias after merging projections to simplify projections more efficiently
         builder.add(new PruneUnreferencedOutputs());
+        builder.add(new PushdownSubscripts());
 
         builder.add(new IterativeOptimizer(
                 ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolWithSubfieldPath.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolWithSubfieldPath.java
@@ -17,6 +17,8 @@ import com.facebook.presto.spi.SubfieldPath;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -38,7 +40,7 @@ public class SymbolWithSubfieldPath
     }
 
     @JsonProperty("path")
-    public SubfieldPath getPath()
+    public SubfieldPath getSubfieldPath()
     {
         return path;
     }
@@ -64,13 +66,14 @@ public class SymbolWithSubfieldPath
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+
         SymbolWithSubfieldPath other = (SymbolWithSubfieldPath) o;
-        return path.equals(other.getPath());
+        return Objects.equals(path, other.path);
     }
 
     @Override
     public int hashCode()
     {
-        return path.hashCode();
+        return Objects.hash(path);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
@@ -360,14 +360,11 @@ public class PickTableLayout
     private static ColumnHandle toColumnHandle(Map<Symbol, ColumnHandle> assignments, Symbol symbol)
     {
         if (symbol instanceof SymbolWithSubfieldPath) {
-            SymbolWithSubfieldPath subfieldSymbol = (SymbolWithSubfieldPath) symbol;
-            SubfieldPath path = subfieldSymbol.getPath();
-            ColumnHandle topColumn = assignments.get(new Symbol(path.getPath().get(0).getField()));
-            return topColumn.createSubfieldColumnHandle(path);
+            SubfieldPath path = ((SymbolWithSubfieldPath) symbol).getSubfieldPath();
+            return assignments.get(path.getColumnName()).createSubfieldColumnHandle(path);
         }
-        else {
-            return assignments.get(symbol);
-        }
+
+        return assignments.get(symbol);
     }
 
     private static Symbol fromColumnHandle(Map<ColumnHandle, Symbol> assignments, ColumnHandle columnHandle)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -14,15 +14,10 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.execution.warnings.WarningCollector;
-import com.facebook.presto.spi.AriaFlags;
 import com.facebook.presto.spi.ColumnHandle;
-import com.facebook.presto.spi.SubfieldPath;
-import com.facebook.presto.spi.SubfieldPath.PathElement;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
-import com.facebook.presto.sql.planner.SubfieldUtils;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.SymbolsExtractor;
@@ -68,8 +63,6 @@ import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
-import com.facebook.presto.sql.tree.Node;
-import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -79,7 +72,6 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -119,27 +111,13 @@ public class PruneUnreferencedOutputs
         requireNonNull(types, "types is null");
         requireNonNull(symbolAllocator, "symbolAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
-        boolean pruneSubfields = (SystemSessionProperties.ariaFlags(session) & AriaFlags.pruneSubfields) != 0;
 
-        return SimplePlanRewriter.rewriteWith(new Rewriter(pruneSubfields), plan, ImmutableSet.of());
+        return SimplePlanRewriter.rewriteWith(new Rewriter(), plan, ImmutableSet.of());
     }
 
     private static class Rewriter
             extends SimplePlanRewriter<Set<Symbol>>
     {
-        private boolean pruneSubfields;
-        private HashSet<Symbol> fullColumnUses;
-        private HashSet<SubfieldPath> subfieldPaths;
-
-        public Rewriter(boolean pruneSubfields)
-        {
-            this.pruneSubfields = pruneSubfields;
-            if (pruneSubfields) {
-                fullColumnUses = new HashSet();
-                subfieldPaths = new HashSet();
-            }
-        }
-
         @Override
         public PlanNode visitExplainAnalyze(ExplainAnalyzeNode node, RewriteContext<Set<Symbol>> context)
         {
@@ -204,7 +182,6 @@ public class PruneUnreferencedOutputs
         {
             Set<Symbol> expectedFilterInputs = new HashSet<>();
             if (node.getFilter().isPresent()) {
-                collectSubfieldPaths(node.getFilter().get());
                 expectedFilterInputs = ImmutableSet.<Symbol>builder()
                         .addAll(SymbolsExtractor.extractUnique(node.getFilter().get()))
                         .addAll(context.get())
@@ -226,6 +203,7 @@ public class PruneUnreferencedOutputs
             }
             rightInputsBuilder.addAll(expectedFilterInputs);
             Set<Symbol> rightInputs = rightInputsBuilder.build();
+
             PlanNode left = context.rewrite(node.getLeft(), leftInputs);
             PlanNode right = context.rewrite(node.getRight(), rightInputs);
 
@@ -361,10 +339,6 @@ public class PruneUnreferencedOutputs
 
                 if (context.get().contains(symbol)) {
                     Aggregation aggregation = entry.getValue();
-                    collectSubfieldPaths(aggregation.getCall());
-                    if (pruneSubfields && aggregation.getMask().isPresent()) {
-                        fullColumnUses.add(aggregation.getMask().get());
-                    }
                     expectedInputs.addAll(SymbolsExtractor.extractUnique(aggregation.getCall()));
                     aggregation.getMask().ifPresent(expectedInputs::add);
                     aggregations.put(symbol, aggregation);
@@ -448,7 +422,6 @@ public class PruneUnreferencedOutputs
             Map<Symbol, ColumnHandle> newAssignments = newOutputs.stream()
                     .collect(Collectors.toMap(Function.identity(), node.getAssignments()::get));
 
-            newAssignments = annotateColumnsWithSubfields(newAssignments);
             return new TableScanNode(
                     node.getId(),
                     node.getTable(),
@@ -462,7 +435,6 @@ public class PruneUnreferencedOutputs
         @Override
         public PlanNode visitFilter(FilterNode node, RewriteContext<Set<Symbol>> context)
         {
-            collectSubfieldPaths(node.getPredicate());
             Set<Symbol> expectedInputs = ImmutableSet.<Symbol>builder()
                     .addAll(SymbolsExtractor.extractUnique(node.getPredicate()))
                     .addAll(context.get())
@@ -536,7 +508,6 @@ public class PruneUnreferencedOutputs
                 ordinalitySymbol = Optional.empty();
             }
             Map<Symbol, List<Symbol>> unnestSymbols = node.getUnnestSymbols();
-            processUnnestPaths(unnestSymbols);
             ImmutableSet.Builder<Symbol> expectedInputs = ImmutableSet.<Symbol>builder()
                     .addAll(replicateSymbols)
                     .addAll(unnestSymbols.keySet());
@@ -558,7 +529,6 @@ public class PruneUnreferencedOutputs
                 }
             });
 
-            processProjectionPaths(node.getAssignments());
             PlanNode source = context.rewrite(node.getSource(), expectedInputs.build());
 
             return new ProjectNode(node.getId(), source, builder.build());
@@ -568,9 +538,6 @@ public class PruneUnreferencedOutputs
         public PlanNode visitOutput(OutputNode node, RewriteContext<Set<Symbol>> context)
         {
             Set<Symbol> expectedInputs = ImmutableSet.copyOf(node.getOutputSymbols());
-            if (pruneSubfields) {
-                fullColumnUses.addAll(node.getOutputSymbols());
-            }
             PlanNode source = context.rewrite(node.getSource(), expectedInputs);
             return new OutputNode(node.getId(), source, node.getColumnNames(), node.getOutputSymbols());
         }
@@ -872,165 +839,6 @@ public class PruneUnreferencedOutputs
             }
 
             return new LateralJoinNode(node.getId(), input, subquery, newCorrelation, node.getType(), node.getOriginSubquery());
-        }
-
-        private Map<Symbol, ColumnHandle> annotateColumnsWithSubfields(Map<Symbol, ColumnHandle> assignments)
-        {
-            if (!pruneSubfields || subfieldPaths.size() == 0) {
-                return assignments;
-            }
-            Map<Symbol, ColumnHandle> newAssignments = new HashMap();
-            for (Map.Entry<Symbol, ColumnHandle> entry : assignments.entrySet()) {
-                if (fullColumnUses.contains(entry.getKey())) {
-                    newAssignments.put(entry.getKey(), entry.getValue());
-                    continue;
-                }
-                ArrayList<SubfieldPath> subfields = new ArrayList();
-                for (SubfieldPath path : subfieldPaths) {
-                    if (path.getPath().get(0).getField().equals(entry.getKey().getName())) {
-                        subfields.add(path);
-                    }
-                }
-                if (subfields.isEmpty()) {
-                    newAssignments.put(entry.getKey(), entry.getValue());
-                    continue;
-                }
-                // Compute the leaf subfields. If we have a.b.c and
-                // a.b then a.b is the result. If a path is a prefix
-                // of another path, then the longer is discarded.
-                ArrayList<SubfieldPath> leafPaths = new ArrayList();
-                for (SubfieldPath path : subfields) {
-                    boolean hasPrefix = false;
-                    for (SubfieldPath otherPath : subfields) {
-                        if (isPrefix(otherPath, path)) {
-                            hasPrefix = true;
-                            break;
-                        }
-                    }
-                    if (!hasPrefix) {
-                        leafPaths.add(path);
-                    }
-                    newAssignments.put(entry.getKey(), entry.getValue().createSubfieldPruningColumnHandle(leafPaths));
-                }
-            }
-            return newAssignments;
-        }
-
-        private static boolean isPrefix(SubfieldPath shorter, SubfieldPath longer)
-        {
-            ArrayList<SubfieldPath.PathElement> shorterPath = shorter.getPath();
-            ArrayList<SubfieldPath.PathElement> longerPath = longer.getPath();
-            if (shorterPath.size() >= longerPath.size()) {
-                return false;
-            }
-            for (int i = 0; i < shorterPath.size(); i++) {
-                if (!shorterPath.get(i).equals(longerPath.get(i))) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        private void processProjectionPaths(Assignments assignments)
-        {
-            if (!pruneSubfields) {
-                return;
-            }
-            HashSet<SubfieldPath> newPaths = new HashSet();
-            for (Map.Entry<Symbol, Expression> entry : assignments.getMap().entrySet()) {
-                Symbol key = entry.getKey();
-                Expression value = entry.getValue();
-                if (value instanceof SymbolReference) {
-                    SymbolReference valueRef = (SymbolReference) value;
-                    if (fullColumnUses.contains(key)) {
-                        fullColumnUses.add(new Symbol(valueRef.getName()));
-                    }
-                    for (SubfieldPath path : subfieldPaths) {
-                        if (path.getPath().get(0).equals(key.getName())) {
-                            ArrayList<SubfieldPath.PathElement> newSteps = new ArrayList(path.getPath());
-                            newSteps.set(0, new SubfieldPath.PathElement(valueRef.getName(), 0));
-                            newPaths.add(new SubfieldPath(newSteps));
-                        }
-                    }
-                }
-                else if (SubfieldUtils.isSubfieldPath(value)) {
-                    Node base = SubfieldUtils.getSubfieldBase(value);
-                    if (base instanceof SymbolReference) {
-                        if (fullColumnUses.contains(key)) {
-                            subfieldPaths.add(SubfieldUtils.subfieldToSubfieldPath(value));
-                        }
-                        for (SubfieldPath path : subfieldPaths) {
-                            if (path.getPath().get(0).getField().equals(key.getName())) {
-                                SubfieldPath basePath = SubfieldUtils.subfieldToSubfieldPath(value);
-                                ArrayList<SubfieldPath.PathElement> elements = basePath.getPath();
-                                for (int i = 1; i < path.getPath().size(); i++) {
-                                    elements.add(path.getPath().get(i));
-                                }
-                                newPaths.add(basePath);
-                            }
-                        }
-                    }
-                }
-            }
-            for (SubfieldPath newPath : newPaths) {
-                subfieldPaths.add(newPath);
-            }
-        }
-
-        private void processUnnestPaths(Map<Symbol, List<Symbol>> unnestSymbols)
-        {
-            // If a result is referenced or is a start of a path, add
-            // the unnest source + any subscript as the head of the
-            // path.
-            if (!pruneSubfields) {
-                return;
-            }
-            ArrayList<SubfieldPath> newPaths = new ArrayList();
-            for (Map.Entry<Symbol, List<Symbol>> entry : unnestSymbols.entrySet()) {
-                String source = entry.getKey().getName();
-                for (Symbol member : entry.getValue()) {
-                    if (fullColumnUses.contains(member)) {
-                        SubfieldPath newPath = new SubfieldPath(new ArrayList<PathElement>(Arrays.asList(new PathElement(source, 0, false), new PathElement(null, PathElement.allSubscripts, true), new PathElement(member.getName(), 0, false))));
-                        newPaths.add(newPath);
-                    }
-                    else {
-                        for (SubfieldPath path : subfieldPaths) {
-                            if (member.getName().equals(path.getPath().get(0).getField())) {
-                                ArrayList<PathElement> newSteps = new ArrayList(Arrays.asList(new PathElement(source, 0, false), new PathElement(null, PathElement.allSubscripts, true), new PathElement(member.getName(), 0, false)));
-                                for (int i = 1; i < path.getPath().size(); i++) {
-                                    newSteps.add(path.getPath().get(i));
-                                }
-                                subfieldPaths.add(new SubfieldPath(newSteps));
-                            }
-                        }
-                    }
-                }
-            }
-            for (SubfieldPath newPath : newPaths) {
-                subfieldPaths.add(newPath);
-            }
-        }
-
-        private void collectSubfieldPaths(Node expression)
-        {
-            if (!pruneSubfields) {
-                return;
-            }
-            if (expression instanceof SymbolReference) {
-                SymbolReference ref = (SymbolReference) expression;
-                Symbol symbol = new Symbol(ref.getName());
-                fullColumnUses.add(symbol);
-            }
-            if (SubfieldUtils.isSubfieldPath(expression)) {
-                SubfieldPath path = SubfieldUtils.subfieldToSubfieldPath(expression);
-                if (path != null) {
-                    subfieldPaths.add(path);
-                    return;
-                }
-            }
-            for (Node child : expression.getChildren()) {
-                collectSubfieldPaths(child);
-            }
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubscripts.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubscripts.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.execution.warnings.WarningCollector;
+import com.facebook.presto.spi.AriaFlags;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.SubfieldPath;
+import com.facebook.presto.spi.SubfieldPath.NestedField;
+import com.facebook.presto.spi.SubfieldPath.PathElement;
+import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.SubfieldUtils;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.Assignments;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.facebook.presto.sql.planner.plan.UnnestNode;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.spi.SubfieldPath.allSubscripts;
+import static com.facebook.presto.sql.planner.SubfieldUtils.deferenceOrSubscriptExpressionToPath;
+import static com.facebook.presto.sql.planner.SubfieldUtils.isDereferenceOrSubscriptExpression;
+import static java.util.Objects.requireNonNull;
+
+public class PushdownSubscripts
+        implements PlanOptimizer
+{
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        requireNonNull(plan, "plan is null");
+        requireNonNull(session, "session is null");
+        requireNonNull(types, "types is null");
+        requireNonNull(symbolAllocator, "symbolAllocator is null");
+        requireNonNull(idAllocator, "idAllocator is null");
+
+        if ((SystemSessionProperties.ariaFlags(session) & AriaFlags.pruneSubfields) == 0) {
+            return plan;
+        }
+
+        return SimplePlanRewriter.rewriteWith(new Rewriter(), plan, null);
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Void>
+    {
+        // TODO Move these into context
+        private Set<Symbol> fullColumnUses = new HashSet<>();
+        private Set<SubfieldPath> subfieldPaths = new HashSet<>();
+
+        @Override
+        public PlanNode visitJoin(JoinNode node, RewriteContext<Void> context)
+        {
+            if (node.getFilter().isPresent()) {
+                collectSubfieldPaths(node.getFilter().get());
+            }
+
+            PlanNode left = context.rewrite(node.getLeft(), context.get());
+            PlanNode right = context.rewrite(node.getRight(), context.get());
+            return node.replaceChildren(ImmutableList.of(left, right));
+        }
+
+        @Override
+        public PlanNode visitAggregation(AggregationNode node, RewriteContext<Void> context)
+        {
+            for (AggregationNode.Aggregation aggregation : node.getAggregations().values()) {
+                collectSubfieldPaths(aggregation.getCall());
+                if (aggregation.getMask().isPresent()) {
+                    fullColumnUses.add(aggregation.getMask().get());
+                }
+            }
+
+            PlanNode source = context.rewrite(node.getSource(), context.get());
+
+            return node.replaceChildren(ImmutableList.of(source));
+        }
+
+        @Override
+        public PlanNode visitTableScan(TableScanNode node, RewriteContext<Void> context)
+        {
+            return new TableScanNode(
+                    node.getId(),
+                    node.getTable(),
+                    node.getOutputSymbols(),
+                    annotateColumnsWithSubfields(node.getAssignments()),
+                    node.getLayout(),
+                    node.getCurrentConstraint(),
+                    node.getEnforcedConstraint());
+        }
+
+        @Override
+        public PlanNode visitFilter(FilterNode node, RewriteContext<Void> context)
+        {
+            collectSubfieldPaths(node.getPredicate());
+
+            PlanNode source = context.rewrite(node.getSource(), context.get());
+            return node.replaceChildren(ImmutableList.of(source));
+        }
+
+        @Override
+        public PlanNode visitUnnest(UnnestNode node, RewriteContext<Void> context)
+        {
+            processUnnestPaths(node.getUnnestSymbols());
+
+            PlanNode source = context.rewrite(node.getSource(), context.get());
+            return node.replaceChildren(ImmutableList.of(source));
+        }
+
+        @Override
+        public PlanNode visitProject(ProjectNode node, RewriteContext<Void> context)
+        {
+            processProjectionPaths(node.getAssignments());
+
+            PlanNode source = context.rewrite(node.getSource(), context.get());
+            return node.replaceChildren(ImmutableList.of(source));
+        }
+
+        @Override
+        public PlanNode visitOutput(OutputNode node, RewriteContext<Void> context)
+        {
+            fullColumnUses.addAll(node.getOutputSymbols());
+
+            PlanNode source = context.rewrite(node.getSource(), context.get());
+            return node.replaceChildren(ImmutableList.of(source));
+        }
+
+        private Map<Symbol, ColumnHandle> annotateColumnsWithSubfields(Map<Symbol, ColumnHandle> assignments)
+        {
+            if (subfieldPaths.isEmpty()) {
+                return assignments;
+            }
+
+            Map<Symbol, ColumnHandle> newAssignments = new HashMap<>();
+            for (Map.Entry<Symbol, ColumnHandle> entry : assignments.entrySet()) {
+                if (fullColumnUses.contains(entry.getKey())) {
+                    newAssignments.put(entry.getKey(), entry.getValue());
+                    continue;
+                }
+
+                List<SubfieldPath> subfields = new ArrayList();
+                for (SubfieldPath path : subfieldPaths) {
+                    if (path.getColumnName().equals(entry.getKey().getName())) {
+                        subfields.add(path);
+                    }
+                }
+                if (subfields.isEmpty()) {
+                    newAssignments.put(entry.getKey(), entry.getValue());
+                    continue;
+                }
+                // Compute the leaf subfields. If we have a.b.c and
+                // a.b then a.b is the result. If a path is a prefix
+                // of another path, then the longer is discarded.
+                List<SubfieldPath> leafPaths = new ArrayList();
+                for (SubfieldPath path : subfields) {
+                    if (!prefixExists(path, subfields)) {
+                        leafPaths.add(path);
+                    }
+                    newAssignments.put(entry.getKey(), entry.getValue().createSubfieldPruningColumnHandle(leafPaths));
+                }
+            }
+            return ImmutableMap.copyOf(newAssignments);
+        }
+
+        private static boolean prefixExists(SubfieldPath subfieldPath, Collection<SubfieldPath> subfieldPaths)
+        {
+            return subfieldPaths.stream()
+                    .filter(path -> path.isPrefix(subfieldPath))
+                    .findAny()
+                    .isPresent();
+        }
+
+        private void processProjectionPaths(Assignments assignments)
+        {
+            Set<SubfieldPath> newPaths = new HashSet();
+            for (Map.Entry<Symbol, Expression> entry : assignments.getMap().entrySet()) {
+                Symbol key = entry.getKey();
+                Expression value = entry.getValue();
+                if (value instanceof SymbolReference) {
+                    SymbolReference valueRef = (SymbolReference) value;
+                    if (fullColumnUses.contains(key)) {
+                        fullColumnUses.add(new Symbol(valueRef.getName()));
+                    }
+                    for (SubfieldPath path : subfieldPaths) {
+                        if (key.getName().equals(path.getColumnName())) {
+                            newPaths.add(new SubfieldPath(ImmutableList.<PathElement>builder()
+                                    .add(new NestedField(valueRef.getName()))
+                                    .addAll(path.getPath().subList(1, path.getPath().size()))
+                                    .build()));
+                        }
+                    }
+                }
+                else if (isDereferenceOrSubscriptExpression(value)) {
+                    Expression base = SubfieldUtils.getDerefenceOrSubscriptBase(value);
+                    if (base instanceof SymbolReference) {
+                        if (fullColumnUses.contains(key)) {
+                            subfieldPaths.add(deferenceOrSubscriptExpressionToPath(value));
+                        }
+                        for (SubfieldPath path : subfieldPaths) {
+                            if (key.getName().equals(path.getColumnName())) {
+                                newPaths.add(new SubfieldPath(ImmutableList.<PathElement>builder()
+                                        .addAll(deferenceOrSubscriptExpressionToPath(value).getPath())
+                                        .addAll(path.getPath())
+                                        .build()));
+                            }
+                        }
+                    }
+                }
+            }
+            subfieldPaths.addAll(newPaths);
+        }
+
+        private void processUnnestPaths(Map<Symbol, List<Symbol>> unnestSymbols)
+        {
+            // If a result is referenced or is a start of a path, add
+            // the unnest source + any subscript as the head of the
+            // path.
+            List<SubfieldPath> newPaths = new ArrayList();
+            for (Map.Entry<Symbol, List<Symbol>> entry : unnestSymbols.entrySet()) {
+                String source = entry.getKey().getName();
+                for (Symbol member : entry.getValue()) {
+                    if (fullColumnUses.contains(member)) {
+                        newPaths.add(new SubfieldPath(ImmutableList.of(
+                                new NestedField(source),
+                                allSubscripts(),
+                                new NestedField(member.getName()))));
+                    }
+                    else {
+                        for (SubfieldPath path : subfieldPaths) {
+                            if (member.getName().equals(path.getColumnName())) {
+                                subfieldPaths.add(new SubfieldPath(ImmutableList.<PathElement>builder()
+                                        .add(new NestedField(source))
+                                        .add(allSubscripts())
+                                        .add(new NestedField(member.getName()))
+                                        .addAll(path.getPath())
+                                        .build()));
+                            }
+                        }
+                    }
+                }
+            }
+            for (SubfieldPath newPath : newPaths) {
+                subfieldPaths.add(newPath);
+            }
+        }
+
+        private void collectSubfieldPaths(Node expression)
+        {
+            if (expression instanceof SymbolReference) {
+                fullColumnUses.add(new Symbol(((SymbolReference) expression).getName()));
+            }
+            if (isDereferenceOrSubscriptExpression(expression)) {
+                SubfieldPath path = deferenceOrSubscriptExpressionToPath(expression);
+                if (path != null) {
+                    subfieldPaths.add(path);
+                    return;
+                }
+            }
+            for (Node child : expression.getChildren()) {
+                collectSubfieldPaths(child);
+            }
+        }
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListStreamReader.java
@@ -22,10 +22,13 @@ import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.SubfieldPath;
+import com.facebook.presto.spi.SubfieldPath.LongSubscript;
 import com.facebook.presto.spi.SubfieldPath.PathElement;
 import com.facebook.presto.spi.block.ArrayBlock;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Closer;
 import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
@@ -34,9 +37,6 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,7 +44,9 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.StreamReaders.createStreamReader;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.facebook.presto.spi.SubfieldPath.allSubscripts;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -73,7 +75,7 @@ public class ListStreamReader
     // The set of subscripts for which data needs to be
     // returned. Other positions can be initialized to null. If this
     // is null, values for all subscripts must be returned.
-    long[] subscripts;
+    private int[] subscripts;
 
     public ListStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone, AggregatedMemoryContext systemMemoryContext)
     {
@@ -84,20 +86,18 @@ public class ListStreamReader
     @Override
     public void setReferencedSubfields(List<SubfieldPath> subfields, int depth)
     {
-        HashSet<Long> referencedSubscripts = new HashSet();
+        ImmutableSet.Builder<Integer> referencedSubscripts = ImmutableSet.builder();
+        ImmutableList.Builder<SubfieldPath> pathsForElement = ImmutableList.builder();
         boolean mayPruneElement = true;
-        ArrayList<SubfieldPath> pathsForElement = new ArrayList();
         for (SubfieldPath subfield : subfields) {
             List<PathElement> pathElements = subfield.getPath();
             PathElement subscript = pathElements.get(depth + 1);
-            if (!subscript.getIsSubscript()) {
-                throw new IllegalArgumentException("List reader needs a PathElement with a subscript");
-            }
-            if (subscript.getSubscript() == PathElement.allSubscripts) {
+            checkArgument(subscript instanceof LongSubscript, "List reader needs a PathElement with a subscript");
+            if (subscript == allSubscripts()) {
                 referencedSubscripts = null;
             }
             else {
-                referencedSubscripts.add(subscript.getSubscript());
+                referencedSubscripts.add(toIntExact(((LongSubscript) subscript).getIndex()));
             }
             if (pathElements.size() > depth + 1) {
                 pathsForElement.add(subfield);
@@ -107,12 +107,12 @@ public class ListStreamReader
             }
         }
         if (mayPruneElement) {
-            elementStreamReader.setReferencedSubfields(pathsForElement, depth + 1);
+            elementStreamReader.setReferencedSubfields(pathsForElement.build(), depth + 1);
         }
-        if (referencedSubscripts != null) {
-            subscripts = referencedSubscripts.stream().mapToLong(Long::longValue).toArray();
-            Arrays.sort(subscripts);
-        }
+        subscripts = referencedSubscripts.build().stream()
+                .sorted()
+                .mapToInt(Integer::intValue)
+                .toArray();
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ColumnHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ColumnHandle.java
@@ -13,15 +13,10 @@
  */
 package com.facebook.presto.spi;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public interface ColumnHandle
 {
-    default boolean supportsSubfieldPruning()
-    {
-        return false;
-    }
-
     default boolean supportsSubfieldTupleDomain()
     {
         return false;
@@ -37,7 +32,7 @@ public interface ColumnHandle
 
     /* Returns an equivalent ColumnHandle where the connector is free
      * to leave out any subfields not in the 'paths'. Such a ColumnHandle may occur in the list of projected columns for a PageSource.  */
-    default ColumnHandle createSubfieldPruningColumnHandle(ArrayList<SubfieldPath> referencedSubfields)
+    default ColumnHandle createSubfieldPruningColumnHandle(List<SubfieldPath> referencedSubfields)
     {
         return this;
     }
@@ -47,7 +42,7 @@ public interface ColumnHandle
         return null;
     }
 
-    default ArrayList<SubfieldPath> getReferencedSubfields()
+    default List<SubfieldPath> getReferencedSubfields()
     {
         return null;
     }


### PR DESCRIPTION
- Extracted pushdown subscripts logic into its own rule, PushDownSubscripts,
from PruneUnreferencedOutputs.
- Replaced Subfield.PathElement with a hierarchy of classes: empty base class
PathElement + NestedField, IntegerSubscript, StringSubscript sub-classes.
NestedField represents subfield of a struct: c.a, IntegerSubscript - element
of an array or map with integer keys: c[2], StringSubscript - element of a
map with varchar keys c["a"].

Supersedes #12515.