### PR TITLE
Add ST_Length(SphericalGeography)

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -316,6 +316,11 @@ Accessors
     Returns the length of a linestring or multi-linestring using Euclidean measurement on a
     two dimensional plane (based on spatial ref) in projected units.
 
+.. function:: ST_Length(SphericalGeography) -> double
+
+    Returns the length of a linestring or multi-linestring on a spherical model of the Earth.
+    This is equivalent to the sum of great-circle distances between adjacent points on the linestring.
+
 .. function:: ST_PointN(LineString, index) -> Point
 
     Returns the vertex of a linestring at a given index (indices start at 1).

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
@@ -203,4 +203,52 @@ public class TestSphericalGeoFunctions
     {
         assertFunction(format("ABS(ROUND((ST_Area(to_spherical_geography(ST_GeometryFromText('%s'))) / %f - 1 ) * %d, 0))", wkt, expectedArea, 10000), DOUBLE, 0.0);
     }
+
+    @Test
+    public void testLength()
+    {
+        // Empty linestring returns null
+        assertLength("LINESTRING EMPTY", null);
+
+        // Linestring with one point has length 0
+        assertLength("LINESTRING (0 0)", 0.0);
+
+        // Linestring with only one distinct point has length 0
+        assertLength("LINESTRING (0 0, 0 0, 0 0)", 0.0);
+
+        double length = 4350866.6362;
+
+        // ST_Length is equivalent to sums of ST_DISTANCE between points in the LineString
+        assertLength("LINESTRING (-71.05 42.36, -87.62 41.87, -122.41 37.77)", length);
+
+        // Linestring has same length as its reverse
+        assertLength("LINESTRING (-122.41 37.77, -87.62 41.87, -71.05 42.36)", length);
+
+        // Path north pole -> south pole -> north pole should be roughly the circumference of the Earth
+        assertLength("LINESTRING (0.0 90.0, 0.0 -90.0, 0.0 90.0)", 4.003e7);
+
+        // Empty multi-linestring returns null
+        assertLength("MULTILINESTRING (EMPTY)", null);
+
+        // Multi-linestring with one path is equivalent to a single linestring
+        assertLength("MULTILINESTRING ((-71.05 42.36, -87.62 41.87, -122.41 37.77))", length);
+
+        // Multi-linestring with two disjoint paths has length equal to sum of lengths of lines
+        assertLength("MULTILINESTRING ((-71.05 42.36, -87.62 41.87, -122.41 37.77), (-73.05 42.36, -89.62 41.87, -124.41 37.77))", 2 * length);
+
+        // Multi-linestring with adjacent paths is equivalent to a single linestring
+        assertLength("MULTILINESTRING ((-71.05 42.36, -87.62 41.87), (-87.62 41.87, -122.41 37.77))", length);
+    }
+
+    private void assertLength(String lineString, Double expectedLength)
+    {
+        String function = format("ST_Length(to_spherical_geography(ST_GeometryFromText('%s')))", lineString);
+
+        if (expectedLength == null || expectedLength == 0.0) {
+            assertFunction(function, DOUBLE, expectedLength);
+        }
+        else {
+            assertFunction(format("ROUND(ABS((%s / %f) - 1.0) / %f, 0)", function, expectedLength, 1e-4), DOUBLE, 0.0);
+        }
+    }
 }


### PR DESCRIPTION
Adds `ST_Length(SphericalGeography)` which computes the length of a `LINESTRING` on the surface of a spherical model of Earth's surface, i.e. the sum of great-circle distances between adjacent points along the linestring. 