### PR TITLE
Fix sporadic test failures in presto-hive modules

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -2343,12 +2343,12 @@ public class TestHiveIntegrationSmokeTest
     {
         try {
             assertUpdate(
-                    "CREATE TABLE test_mismatch_bucketing8\n" +
+                    "CREATE TABLE test_mismatch_bucketing_with_predicate_8\n" +
                             "WITH (bucket_count = 8, bucketed_by = ARRAY['key8']) AS\n" +
                             "SELECT custkey key8, comment value8 FROM orders",
                     15000);
             assertUpdate(
-                    "CREATE TABLE test_mismatch_bucketing32\n" +
+                    "CREATE TABLE test_mismatch_bucketing_with_predicate_32\n" +
                             "WITH (bucket_count = 32, bucketed_by = ARRAY['key32']) AS\n" +
                             "SELECT custkey key32, comment value32 FROM orders",
                     15000);
@@ -2365,18 +2365,18 @@ public class TestHiveIntegrationSmokeTest
             @Language("SQL") String query = "SELECT count(*) AS count\n" +
                     "FROM (\n" +
                     "  SELECT key32\n" +
-                    "  FROM test_mismatch_bucketing32\n" +
+                    "  FROM test_mismatch_bucketing_with_predicate_32\n" +
                     "  WHERE \"$bucket\" between 16 AND 31\n" +
                     ") a\n" +
-                    "JOIN test_mismatch_bucketing8 b\n" +
+                    "JOIN test_mismatch_bucketing_with_predicate_8 b\n" +
                     "ON a.key32 = b.key8";
 
             assertQuery(withMismatchOptimization, query, "SELECT 130361");
             assertQuery(withoutMismatchOptimization, query, "SELECT 130361");
         }
         finally {
-            assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing8");
-            assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing32");
+            assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing_with_predicate_8");
+            assertUpdate("DROP TABLE IF EXISTS test_mismatch_bucketing_with_predicate_32");
         }
     }
 


### PR DESCRIPTION
Tests from TestHiveIntegrationSmokeTest are run simultaneously in
multiple threads. Thus the table names used in tests must be unique.