### PR TITLE
Enforce scan batch by exception on exceeding space budget

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/BatchTooLargeException.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/BatchTooLargeException.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+public class BatchTooLargeException
+        extends RuntimeException
+{
+    public BatchTooLargeException()
+    {
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/Filters.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/Filters.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.SubfieldPath;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static com.facebook.presto.spi.block.ByteArrayUtils.memcmp;
@@ -186,7 +187,7 @@ public class Filters
         private final long lower;
         private final long upper;
 
-        BigintRange(long lower, long upper, boolean nullAllowed)
+        public BigintRange(long lower, long upper, boolean nullAllowed)
         {
             super(nullAllowed);
             checkArgument(lower <= upper, "lower must be <= upper");
@@ -493,7 +494,7 @@ public class Filters
     public static class StructFilter
             extends Filter
     {
-        private final HashMap<SubfieldPath.PathElement, Filter> filters = new HashMap();
+        private final Map<SubfieldPath.PathElement, Filter> filters = new HashMap();
 
         StructFilter()
         {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
@@ -105,7 +105,7 @@ public class StripeReader
         this.writeValidation = requireNonNull(writeValidation, "writeValidation is null");
     }
 
-    public Stripe readStripe(StripeInformation stripe, AggregatedMemoryContext systemMemoryUsage)
+    public Stripe readStripe(StripeInformation stripe, AggregatedMemoryContext systemMemoryUsage, boolean alwaysUseCheckpoints)
             throws IOException
     {
         // read the stripe footer
@@ -139,7 +139,7 @@ public class StripeReader
 
         // handle stripes with more than one row group or a dictionary
         boolean invalidCheckPoint = false;
-        if ((stripe.getNumberOfRows() > rowsInRowGroup) || hasRowGroupDictionary) {
+        if ((stripe.getNumberOfRows() > rowsInRowGroup) || alwaysUseCheckpoints || hasRowGroupDictionary) {
             // determine ranges of the stripe to read
             Map<StreamId, DiskRange> diskRanges = getDiskRanges(stripeFooter.getStreams());
             diskRanges = Maps.filterKeys(diskRanges, Predicates.in(streams.keySet()));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanStreamReader.java
@@ -220,9 +220,6 @@ public class BooleanStreamReader
         int toSkip = 0;
         for (int i = 0; i < rowsInRange; i++) {
             if (i + posInRowGroup == nextActive) {
-                if (nextActive == truncationRow) {
-                    break;
-                }
                 if (presentStream != null && !present[i]) {
                     if (filter == null || filter.testNull()) {
                         if (filter != null) {
@@ -254,7 +251,7 @@ public class BooleanStreamReader
                 }
                 nextActive = inputPositions[activeIdx];
                 if (outputChannelSet && numResults > resultSizeBudget) {
-                    truncationRow = inputQualifyingSet.truncateAndReturnTruncationRow(activeIdx);
+                    throw batchTooLarge();
                 }
                 continue;
             }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteStreamReader.java
@@ -221,9 +221,6 @@ public class ByteStreamReader
         int toSkip = 0;
         for (int i = 0; i < rowsInRange; i++) {
             if (i + posInRowGroup == nextActive) {
-                if (nextActive == truncationRow) {
-                    break;
-                }
                 if (presentStream != null && !present[i]) {
                     if (filter == null || filter.testNull()) {
                         if (filter != null) {
@@ -255,7 +252,7 @@ public class ByteStreamReader
                 }
                 nextActive = inputPositions[activeIdx];
                 if (outputChannelSet && numResults > resultSizeBudget) {
-                    truncationRow = inputQualifyingSet.truncateAndReturnTruncationRow(activeIdx);
+                    throw batchTooLarge();
                 }
                 continue;
             }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DecimalStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DecimalStreamReader.java
@@ -294,9 +294,6 @@ public class DecimalStreamReader
         int toSkip = 0;
         for (int i = 0; i < rowsInRange; i++) {
             if (i + posInRowGroup == nextActive) {
-                if (nextActive == truncationRow) {
-                    break;
-                }
                 if (presentStream != null && !present[i]) {
                     if (filter == null || filter.testNull()) {
                         if (filter != null) {
@@ -351,7 +348,7 @@ public class DecimalStreamReader
                 }
                 nextActive = inputPositions[activeIdx];
                 if (outputChannelSet && numResults * numLongsPerValue > resultSizeBudget) {
-                    truncationRow = inputQualifyingSet.truncateAndReturnTruncationRow(activeIdx);
+                    throw batchTooLarge();
                 }
                 continue;
             }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleStreamReader.java
@@ -226,9 +226,6 @@ public class DoubleStreamReader
         int toSkip = 0;
         for (int i = 0; i < rowsInRange; i++) {
             if (i + posInRowGroup == nextActive) {
-                if (nextActive == truncationRow) {
-                    break;
-                }
                 if (presentStream != null && !present[i]) {
                     if (filter == null || filter.testNull()) {
                         if (filter != null) {
@@ -285,7 +282,7 @@ public class DoubleStreamReader
                 }
                 nextActive = inputPositions[activeIdx];
                 if (outputChannelSet && numResults * SIZE_OF_DOUBLE > resultSizeBudget) {
-                    truncationRow = inputQualifyingSet.truncateAndReturnTruncationRow(activeIdx);
+                    throw batchTooLarge();
                 }
                 continue;
             }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatStreamReader.java
@@ -222,9 +222,6 @@ public class FloatStreamReader
         int toSkip = 0;
         for (int i = 0; i < rowsInRange; i++) {
             if (i + posInRowGroup == nextActive) {
-                if (nextActive == truncationRow) {
-                    break;
-                }
                 if (presentStream != null && !present[i]) {
                     if (filter == null || filter.testNull()) {
                         if (filter != null) {
@@ -256,7 +253,7 @@ public class FloatStreamReader
                 }
                 nextActive = inputPositions[activeIdx];
                 if (outputChannelSet && numResults * SIZE_OF_INT > resultSizeBudget) {
-                    truncationRow = inputQualifyingSet.truncateAndReturnTruncationRow(activeIdx);
+                    throw batchTooLarge();
                 }
                 continue;
             }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongStreamReader.java
@@ -170,12 +170,6 @@ public class LongStreamReader
     }
 
     @Override
-    public int getTruncationRow()
-    {
-        return currentReader.getTruncationRow();
-    }
-
-    @Override
     public int getResultSizeInBytes()
     {
         if (currentReader == null) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/NullWrappingColumnReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/NullWrappingColumnReader.java
@@ -35,6 +35,7 @@ abstract class NullWrappingColumnReader
     protected int numNullsToAdd;
     // Number of elements retrieved from inner reader.
     protected int numInnerResults;
+    private int[] tempInt;
 
     protected NullWrappingColumnReader(OptionalInt fixedValueSize)
     {
@@ -66,10 +67,10 @@ abstract class NullWrappingColumnReader
         int numActive = inputQualifyingSet.getPositionCount();
 
         innerQualifyingSet.reset(numActive);
-        int prevRow = posInRowGroup;
+        int prevRow = 0;
         int prevInner = innerPosInRowGroup;
         numNullsToAdd = 0;
-        boolean keepNulls = filter == null || filter.testNull();
+        boolean keepNulls = filter == null || (deterministicFilter && filter.testNull());
         for (int activeIdx = 0; activeIdx < numActive; activeIdx++) {
             int row = inputRows[activeIdx] - posInRowGroup;
             if (!present[row]) {
@@ -88,7 +89,7 @@ abstract class NullWrappingColumnReader
         innerQualifyingSet.setEnd(skip + prevInner);
     }
 
-    private void addNullToKeep(int position, int inputIndex)
+    protected void addNullToKeep(int position, int inputIndex)
     {
         if (nullsToAdd == null) {
             nullsToAdd = new int[100];
@@ -219,19 +220,6 @@ abstract class NullWrappingColumnReader
                 }
             }
         }
-    }
-
-    // Sets the truncation position of the inner QualifyingSet according to that of the outer.
-    protected void setInnerTruncation()
-    {
-        int truncationPos = inputQualifyingSet.getTruncationPosition();
-        if (truncationPos == -1) {
-            innerQualifyingSet.clearTruncationPosition();
-            return;
-        }
-        int outerRow = inputQualifyingSet.getPositions()[truncationPos];
-        int numInner = countPresent(0, outerRow - posInRowGroup);
-        innerQualifyingSet.setTruncationRow(innerPosInRowGroup + numInner);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectStreamReader.java
@@ -353,9 +353,6 @@ public class SliceDirectStreamReader
         int toSkip = 0;
         for (int i = 0; i < rowsInRange; i++) {
             if (i + posInRowGroup == nextActive) {
-                if (truncationRow == nextActive) {
-                    break;
-                }
                 if (presentStream != null && !present[i]) {
                     if (filter == null || filter.testNull()) {
                         if (filter != null) {
@@ -415,7 +412,7 @@ public class SliceDirectStreamReader
                 }
                 nextActive = inputPositions[activeIdx];
                 if (bytesToGo <= 0) {
-                    truncationRow = input.truncateAndReturnTruncationRow(activeIdx);
+                    throw batchTooLarge();
                 }
                 continue;
             }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceStreamReader.java
@@ -179,12 +179,6 @@ public class SliceStreamReader
     }
 
     @Override
-    public int getTruncationRow()
-    {
-        return currentReader.getTruncationRow();
-    }
-
-    @Override
     public int getResultSizeInBytes()
     {
         if (currentReader == null) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StreamReader.java
@@ -106,8 +106,7 @@ public interface StreamReader
     }
 
     // Sets the number of additional result bytes a scan() is allowed
-    // to accumulate before truncating the result. A scan, even with
-    // truncation, will add at least one row.
+    // to accumulate.
     default void setResultSizeBudget(long bytes)
     {
         throw new UnsupportedOperationException();
@@ -126,15 +125,6 @@ public interface StreamReader
     default int getPosition()
     {
         throw new UnsupportedOperationException();
-    }
-
-    // Returns the row number of the first unprocessed input in the
-    // input QualifyingSet, -1 if the whole input QualifyingSet was
-    // processed by scan(). This is set when stopping due to reaching
-    // target datasize.
-    default int getTruncationRow()
-    {
-        return -1;
     }
 
     // Returns an approximation of the size of the Block to be returned from getBlock().

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructStreamReader.java
@@ -51,7 +51,6 @@ import java.util.Set;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.StreamReaders.createStreamReader;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
-import static com.facebook.presto.spi.block.RowBlock.createRowBlockInternal;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
@@ -79,8 +78,7 @@ public class StructStreamReader
     int fieldBlockSize;
     int[] fieldBlockOffset;
     int[] fieldSurviving;
-    // Copy of inputQualifyingSet. Needed when continuing after
-    // truncation since the original input may have been changed.
+    // Copy of inputQualifyingSet.
     QualifyingSet inputCopy;
     StreamReader[] streamReaders;
 
@@ -328,6 +326,11 @@ public class StructStreamReader
         if (!outputChannelSet) {
             // If the struct is not projected out, none of its members is either.
             Arrays.fill(fieldChannels, -1);
+            for (int i = 0; i < numFields; i++) {
+                if (filters.get(i) == null) {
+                    streamReaders[i] = null;
+                }
+            }
         }
         reader = new ColumnGroupReader(streamReaders,
                                        null,
@@ -347,14 +350,16 @@ public class StructStreamReader
         if (reader == null) {
             setupForScan();
         }
-        reader.setResultSizeBudget(bytes);
+        if (reader != null) {
+            reader.setResultSizeBudget(bytes);
+        }
     }
 
     @Override
     public void erase(int end)
     {
         // Without a reader there is nothing to erase, even if the struct is all nulls.
-        if (reader == null || !outputChannelSet) {
+        if (numValues == 0 || reader == null || !outputChannelSet) {
             return;
         }
         int fieldEnd;
@@ -394,6 +399,10 @@ public class StructStreamReader
     @Override
     public void compactValues(int[] surviving, int base, int numSurviving)
     {
+        if (fieldBlockOffset == null) {
+            // No values.
+            return;
+        }
         if (outputChannelSet) {
             check();
             if (fieldSurviving == null || fieldSurviving.length < numSurviving) {
@@ -452,64 +461,33 @@ public class StructStreamReader
         if (reader == null) {
             setupForScan();
         }
+
         if (!rowGroupOpen) {
             openRowGroup();
         }
-        callCount++;
-        if (stopCallCount != -1 && callCount >= stopCallCount) {
-            System.out.println("break");
-        }
-        check();
         beginScan(presentStream, null);
         int initialFieldResults = reader.getNumResults();
-        if (reader.hasUnfetchedRows()) {
-            // posInRowGroup is the first unprocessed enclosing level
-            // row, by definition part of the input qualifying set.
-            setInnerTruncation();
-            int originalTarget = innerQualifyingSet.getEnd();
-            reader.advance();
-            int newTruncation = reader.getTruncationRow();
-            if (newTruncation != -1) {
-                innerPosInRowGroup = newTruncation;
-                truncationRow = innerToOuterRow(newTruncation);
-                inputQualifyingSet.setTruncationRow(truncationRow);
-            }
-            else {
-                innerPosInRowGroup = originalTarget;
-            }
+        if (inputCopy == null) {
+            inputCopy = new QualifyingSet();
+        }
+        inputCopy.copyFrom(inputQualifyingSet);
+        makeInnerQualifyingSet();
+        if (hasNulls) {
+            innerQualifyingSet.setTranslateResultToParentRows(true);
+            innerQualifyingSet.setParent(inputQualifyingSet);
         }
         else {
-            if (inputCopy == null) {
-                inputCopy = new QualifyingSet();
+            // There are no nulls
+            if (innerQualifyingSet == null) {
+                innerQualifyingSet = new QualifyingSet();
             }
-            inputCopy.copyFrom(inputQualifyingSet);
-            makeInnerQualifyingSet();
-            if (hasNulls) {
-                innerQualifyingSet.setParent(inputQualifyingSet);
-                innerQualifyingSet.setTranslateResultToParentRows(true);
-            }
-            else {
-                // There are no nulls
-                if (innerQualifyingSet == null) {
-                    innerQualifyingSet = new QualifyingSet();
-                }
-                innerQualifyingSet.copyFrom(inputQualifyingSet);
-                innerQualifyingSet.setTranslateResultToParentRows(false);
-            }
-            reader.setQualifyingSets(innerQualifyingSet, outputQualifyingSet);
-            if (innerQualifyingSet.getPositionCount() > 0) {
-                reader.advance();
-                int truncated = reader.getTruncationRow();
-                if (truncated != -1) {
-                    innerPosInRowGroup = truncated;
-                    truncationRow = innerToOuterRow(truncated);
-                    inputQualifyingSet.setTruncationRow(truncationRow);
-                }
-                else {
-                    truncationRow = -1;
-                    innerPosInRowGroup = innerQualifyingSet.getEnd();
-                }
-            }
+            innerQualifyingSet.copyFrom(inputQualifyingSet);
+            innerQualifyingSet.setTranslateResultToParentRows(false);
+        }
+        reader.setQualifyingSets(innerQualifyingSet, outputQualifyingSet);
+        if (innerQualifyingSet.getPositionCount() > 0) {
+            reader.advance();
+            innerPosInRowGroup = innerQualifyingSet.getEnd();
         }
         ensureOutput(numInnerRows + numNullsToAdd);
         // The outputQualifyingSet is written by advance.
@@ -518,7 +496,7 @@ public class StructStreamReader
             addStructResult();
         }
         int lastFieldOffset = fieldBlockSize == 0 ? 0 : fieldBlockOffset[fieldBlockSize];
-        addNullsAfterScan(filter != null ? outputQualifyingSet : inputQualifyingSet, truncationRow != -1 ? truncationRow : inputQualifyingSet.getEnd());
+        addNullsAfterScan(filter != null ? outputQualifyingSet : inputQualifyingSet, inputQualifyingSet.getEnd());
         if (numResults > numInnerResults) {
             // Fill null positions in fieldBlockOffset  with the offset of the next non-null.
             fieldBlockOffset[numValues + numResults] = lastFieldOffset;
@@ -561,23 +539,6 @@ public class StructStreamReader
         fieldBlockOffset[position] = -1;
     }
 
-    // Returns the enclosing row number for a field column row number.
-    int innerToOuterRow(int inner)
-    {
-        if (!hasNulls) {
-            return inner;
-        }
-        int[] innerRows = innerQualifyingSet.getPositions();
-        int numRows = innerQualifyingSet.getPositionCount();
-        for (int i = 0; i < numRows; i++) {
-            if (inner == innerRows[i]) {
-                int[] innerToOuter = innerQualifyingSet.getInputNumbers();
-                return inputCopy.getPositions()[innerToOuter[i]];
-            }
-        }
-        throw new IllegalArgumentException("Can't translate from struct truncation row to enclosing truncation row");
-    }
-
     void ensureOutput(int numAdded)
     {
         int newSize = numValues + numAdded * 2;
@@ -615,7 +576,7 @@ public class StructStreamReader
         int[] offsets = mayReuse ? fieldBlockOffset : Arrays.copyOf(fieldBlockOffset, numFirstRows + 1);
         boolean[] nulls = valueIsNull == null ? null
             : mayReuse ? valueIsNull : Arrays.copyOf(valueIsNull, numFirstRows);
-        return createRowBlockInternal(0, numFirstRows, nulls, offsets, blocks);
+        return RowBlock.createRowBlockInternal(0, numFirstRows, nulls, offsets, blocks);
     }
 
     private Block[] fillUnreferencedWithNulls(Block[] blocks, int numRows)
@@ -651,7 +612,9 @@ public class StructStreamReader
         if (numValues > 0 && (fieldBlockOffset[numValues] != innerFirstRows || fieldBlockSize != numValues)) {
             throw new IllegalArgumentException("Last fieldBlockOffset inconsistent");
         }
-        reader.getBlocks(innerFirstRows, true, false);
+        if (reader != null) {
+            reader.getBlocks(innerFirstRows, true, false);
+        }
     }
 
     void setcc(int cc, int stop)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampStreamReader.java
@@ -283,9 +283,6 @@ public class TimestampStreamReader
         int toSkip = 0;
         for (int i = 0; i < rowsInRange; i++) {
             if (i + posInRowGroup == nextActive) {
-                if (nextActive == truncationRow) {
-                    break;
-                }
                 if (presentStream != null && !present[i]) {
                     if (filter == null || filter.testNull()) {
                         if (filter != null) {
@@ -318,7 +315,7 @@ public class TimestampStreamReader
                 }
                 nextActive = inputPositions[activeIdx];
                 if (outputChannelSet && numResults * SIZE_OF_LONG > resultSizeBudget) {
-                    truncationRow = inputQualifyingSet.truncateAndReturnTruncationRow(activeIdx);
+                    throw batchTooLarge();
                 }
                 continue;
             }


### PR DESCRIPTION
OrcRecordReader.getNextPage tracks the average bytes per rows of
initial qualifying set. The batch size is adapted to stay within
expected soft limits. If a hard limit is exceeded an exception is
thrown and the streams are reset to the beginning of the current row
group. This behavior only works when the streams are checkpointed,
hence ValueStreamSources are not used even if the stripe consisted of
a single row group.

This replaces the StreamReader result truncation mechanism.