### PR TITLE
Fix bug in COALESCE + FULL OUTER JOIN optimization

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
@@ -87,6 +87,11 @@ public final class Partitioning
         return arguments;
     }
 
+    public boolean isOnlyPartitionedOnColumns()
+    {
+        return arguments.stream().allMatch(ArgumentBinding::isSymbolReference);
+    }
+
     public Set<Symbol> getColumns()
     {
         return arguments.stream()


### PR DESCRIPTION
Previously we didn't check that all partition arguments are used in join,
as a result, we'd wrongly optimize a FULL OUTER JOIN node that has input partitioned on (a, b)
but only joined on (a) as partitioned on COALESCE(a), which is not true (missing a local exchange).