### PR TITLE
Fix flakiness of TestJdbcClient.testMetadata

### DIFF
--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcClient.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcClient.java
@@ -125,7 +125,7 @@ public class TestJdbcClient
     public void testCreateWithNullableColumns()
     {
         String tableName = randomUUID().toString().toUpperCase(ENGLISH);
-        SchemaTableName schemaTableName = new SchemaTableName("example", tableName);
+        SchemaTableName schemaTableName = new SchemaTableName("schema_for_create_table_tests", tableName);
         List<ColumnMetadata> expectedColumns = ImmutableList.of(
                 new ColumnMetadata("columnA", BigintType.BIGINT, null, null, false),
                 new ColumnMetadata("columnB", BigintType.BIGINT, true, null, null, false, emptyMap()),
@@ -153,7 +153,7 @@ public class TestJdbcClient
     public void testAlterColumns()
     {
         String tableName = randomUUID().toString().toUpperCase(ENGLISH);
-        SchemaTableName schemaTableName = new SchemaTableName("example", tableName);
+        SchemaTableName schemaTableName = new SchemaTableName("schema_for_create_table_tests", tableName);
         List<ColumnMetadata> expectedColumns = ImmutableList.of(
                 new ColumnMetadata("columnA", BigintType.BIGINT, null, null, false));
 

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
@@ -74,6 +74,7 @@ final class TestingDatabase
         connection.createStatement().execute("CREATE TABLE exa_ple.num_ers(te_t varchar primary key, \"VA%UE\" bigint)");
         connection.createStatement().execute("CREATE TABLE exa_ple.table_with_float_col(col1 bigint, col2 double, col3 float, col4 real)");
 
+        connection.createStatement().execute("CREATE SCHEMA schema_for_create_table_tests");
         connection.commit();
     }
 


### PR DESCRIPTION
We see that this test occasionally fails with the stack below. Some unit
tests in TestJdbcClient create tables in the `example` schema while the
failing test enumarates the tables in the same schema, and asserts on
the number of tables. Depending on how these runs are interleaved it's
possible to get more tables than expected.

This changes fixes that by making sure that tables are created in a
different schema.

```
java.lang.AssertionError: lists don't have the same size expected [3] but found [4]
	at org.testng.Assert.fail(Assert.java:94)
	at org.testng.Assert.failNotEquals(Assert.java:513)
	at org.testng.Assert.assertEqualsImpl(Assert.java:135)
	at org.testng.Assert.assertEquals(Assert.java:116)
	at org.testng.Assert.assertEquals(Assert.java:389)
	at org.testng.Assert.assertEquals(Assert.java:556)
	at org.testng.Assert.assertEquals(Assert.java:533)
	at com.facebook.presto.plugin.jdbc.TestJdbcClient.testMetadata(TestJdbcClient.java:79)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1177)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

Another way to solve this problem is to run the test as single threaded, but I didn't want to run these tests serially as our tests already run for a long time.