### PR TITLE
Make Arrayblock, MapBlock, RowBlock support mayHaveNull

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractArrayBlock.java
@@ -201,6 +201,12 @@ public abstract class AbstractArrayBlock
     }
 
     @Override
+    public boolean mayHaveNull()
+    {
+        return getValueIsNull() != null;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractMapBlock.java
@@ -301,6 +301,12 @@ public abstract class AbstractMapBlock
     }
 
     @Override
+    public boolean mayHaveNull()
+    {
+        return getMapIsNull() != null;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
@@ -210,6 +210,12 @@ public abstract class AbstractRowBlock
     }
 
     @Override
+    public boolean mayHaveNull()
+    {
+        return getRowIsNull() != null;
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(position);


### PR DESCRIPTION
Currently the serialization/deserialization code always encode
/ decode every null values in Arrayblock, MapBlock, RowBlock, 
even when there're no null vectors in these blocks. This can be
seen in  encodeNullsAsBits() and decodeNullBits() in EncoderUtil
class. This is because these blocks don't support the Block.mayHaveNull()
function and the default implementation always return true. By 
making these blocks support the Block.mayHaveNull() check,
the code would follow the early return route in encodeNullsAsBits() 
and decodeNullBits() and do not encode the null value for every position.