### PR TITLE
Fix BenchmarkPartitionedOutputOperator

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
@@ -124,6 +124,7 @@ public class BenchmarkPartitionedOutputOperator
             PartitionedOutputBuffer buffer = createPartitionedBuffer(
                     buffers.withNoMoreBufferIds(),
                     new DataSize(Long.MAX_VALUE, BYTE)); // don't let output buffer block
+            buffer.registerLifespanCompletionCallback(ignore -> {});
             PartitionedOutputFactory operatorFactory = new PartitionedOutputFactory(
                     partitionFunction,
                     ImmutableList.of(0),


### PR DESCRIPTION
Before this commit there was this error running this benchmark:
Exception in thread "main" java.lang.IllegalStateException:
lifespanCompletionCallback must be set before enqueueing data