### PR TITLE
Fix joni regex not matching some word boundaries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -603,7 +603,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>joni</artifactId>
-                <version>2.1.5.2</version>
+                <version>2.1.5.3</version>
             </dependency>
 
             <dependency>

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestRegexpFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestRegexpFunctions.java
@@ -90,6 +90,7 @@ public class TestRegexpFunctions
         assertFunction("REGEXP_LIKE('Hello', '^[a-z]+$')", BOOLEAN, false);
         assertFunction("REGEXP_LIKE('Hello', '^(?i)[a-z]+$')", BOOLEAN, true);
         assertFunction("REGEXP_LIKE('Hello', '^[a-zA-Z]+$')", BOOLEAN, true);
+        assertFunction("REGEXP_LIKE('Hello', 'Hello\\b')", BOOLEAN, true);
     }
 
     @Test


### PR DESCRIPTION
Update Joni library to 2.1.5.3 to fix a regression where regular
expressions with word boundaries were not matching boundaries at the end
of the line.

```
Example:

Without this fix:
presto> select regexp_like('test', 'test\b');
 _col0
-------
 false
(1 row)

With this fix:
presto> select regexp_like('test', 'test\b');
 _col0
-------
 true
(1 row)
```

Fixes #12581 