### PR TITLE
Add verify test to BenchmarkPartitionedOutputOperator

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -412,6 +412,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>-Xmx10G</argLine>
                     <!-- these tests take a very long time so only run them in the CI server -->
                     <excludes>
                         <exclude>**/TestLocalExecutionPlanner.java</exclude>

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
@@ -45,6 +45,7 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -212,12 +213,20 @@ public class BenchmarkPartitionedOutputOperator
         }
     }
 
+    @Test
+    public void verify()
+    {
+        BenchmarkData data = new BenchmarkData();
+        new BenchmarkPartitionedOutputOperator().addPage(data);
+    }
+
     public static void main(String[] args)
             throws RunnerException
     {
         // assure the benchmarks are valid before running
         BenchmarkData data = new BenchmarkData();
         new BenchmarkPartitionedOutputOperator().addPage(data);
+
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
                 .jvmArgs("-Xmx10g")


### PR DESCRIPTION
Such tests guard benchmark from being accidentally broken by code
changes.

For example, recently 8f59f2d3f6271472ab57ff7e1051f99f9b4a5f21 is
applied to fix the accidental break introduced by
849c165a27085982820643a38a03504ee50d7359.