### PR TITLE
Export JMX stats for more split schedule block reasons

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SplitSchedulerStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SplitSchedulerStats.java
@@ -30,6 +30,8 @@ public class SplitSchedulerStats
     private final TimeStat getSplitTime = new TimeStat(MILLISECONDS);
     private final CounterStat waitingForSource = new CounterStat();
     private final CounterStat splitQueuesFull = new CounterStat();
+    private final CounterStat mixedSplitQueuesFullAndWaitingForSource = new CounterStat();
+    private final CounterStat noActiveDriverGroup = new CounterStat();
     private final DistributionStat splitsPerIteration = new DistributionStat();
 
     @Managed
@@ -65,5 +67,19 @@ public class SplitSchedulerStats
     public CounterStat getSplitQueuesFull()
     {
         return splitQueuesFull;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getMixedSplitQueuesFullAndWaitingForSource()
+    {
+        return mixedSplitQueuesFullAndWaitingForSource;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getNoActiveDriverGroup()
+    {
+        return noActiveDriverGroup;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -575,7 +575,10 @@ public class SqlQueryScheduler
                                 schedulerStats.getSplitQueuesFull().update(1);
                                 break;
                             case MIXED_SPLIT_QUEUES_FULL_AND_WAITING_FOR_SOURCE:
+                                schedulerStats.getMixedSplitQueuesFullAndWaitingForSource().update(1);
+                                break;
                             case NO_ACTIVE_DRIVER_GROUP:
+                                schedulerStats.getNoActiveDriverGroup().update(1);
                                 break;
                             default:
                                 throw new UnsupportedOperationException("Unknown blocked reason: " + result.getBlockedReason().get());


### PR DESCRIPTION
Export stats for split schedule blocked on
MIXED_SPLIT_QUEUES_FULL_AND_WAITING_FOR_SOURCE or
NO_ACTIVE_DRIVER_GROUP.

This re-commits f30277d7267e9b24ee03389d98921da268563dcd (PR https://github.com/prestodb/presto/pull/12516), since it
get reverted in 3144d703b248ba06be19ad58919fc5c7b3f4a790 (PR https://github.com/prestodb/presto/pull/12527)  due to flaky
tests that block release.