### PR TITLE
Support partial merge pushdown 

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -930,11 +930,13 @@ public class HiveClientConfig
         return this;
     }
 
+    @Deprecated
     public boolean isOptimizeMismatchedBucketCount()
     {
         return optimizeMismatchedBucketCount;
     }
 
+    @Deprecated
     @Config("hive.optimize-mismatched-bucket-count")
     public HiveClientConfig setOptimizeMismatchedBucketCount(boolean optimizeMismatchedBucketCount)
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1839,6 +1839,25 @@ public class HiveMetadata
                 maxCompatibleBucketCount));
     }
 
+    @Override
+    public boolean isRefinedPartitioningOver(ConnectorSession session, ConnectorPartitioningHandle left, ConnectorPartitioningHandle right)
+    {
+        HivePartitioningHandle leftHandle = (HivePartitioningHandle) left;
+        HivePartitioningHandle rightHandle = (HivePartitioningHandle) right;
+
+        if (!leftHandle.getHiveTypes().equals(rightHandle.getHiveTypes())) {
+            return false;
+        }
+
+        int leftBucketCount = leftHandle.getBucketCount();
+        int rightBucketCount = rightHandle.getBucketCount();
+        return leftBucketCount == rightBucketCount || // must be evenly divisible
+                (leftBucketCount % rightBucketCount == 0 &&
+                        // ratio must be power of two
+                        // TODO: this can be relaxed
+                        Integer.bitCount(leftBucketCount / rightBucketCount) == 1);
+    }
+
     private static OptionalInt min(OptionalInt left, OptionalInt right)
     {
         if (!left.isPresent()) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -541,6 +541,7 @@ public final class HiveSessionProperties
         return session.getProperty(COLLECT_COLUMN_STATISTICS_ON_WRITE, Boolean.class);
     }
 
+    @Deprecated
     public static boolean isOptimizedMismatchedBucketCount(ConnectorSession session)
     {
         return session.getProperty(OPTIMIZE_MISMATCHED_BUCKET_COUNT, Boolean.class);

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialMergePushdownStrategy;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -87,6 +88,7 @@ public final class SystemSessionProperties
     public static final String CONCURRENT_LIFESPANS_PER_NODE = "concurrent_lifespans_per_task";
     public static final String REORDER_JOINS = "reorder_joins";
     public static final String JOIN_REORDERING_STRATEGY = "join_reordering_strategy";
+    public static final String PARTIAL_MERGE_PUSHDOWN_STRATEGY = "partial_merge_pushdown_strategy";
     public static final String MAX_REORDERED_JOINS = "max_reordered_joins";
     public static final String INITIAL_SPLITS_PER_NODE = "initial_splits_per_node";
     public static final String SPLIT_CONCURRENCY_ADJUSTMENT_INTERVAL = "split_concurrency_adjustment_interval";
@@ -369,6 +371,18 @@ public final class SystemSessionProperties
                         false,
                         value -> JoinReorderingStrategy.valueOf(((String) value).toUpperCase()),
                         JoinReorderingStrategy::name),
+                new PropertyMetadata<>(
+                        PARTIAL_MERGE_PUSHDOWN_STRATEGY,
+                        format("Experimental: Partial merge pushdown strategy to use. Optionas are %s",
+                                Stream.of(PartialMergePushdownStrategy.values())
+                                        .map(PartialMergePushdownStrategy::name)
+                                        .collect(joining(","))),
+                        VARCHAR,
+                        PartialMergePushdownStrategy.class,
+                        featuresConfig.getPartialMergePushdownStrategy(),
+                        false,
+                        value -> PartialMergePushdownStrategy.valueOf(((String) value).toUpperCase()),
+                        PartialMergePushdownStrategy::name),
                 new PropertyMetadata<>(
                         MAX_REORDERED_JOINS,
                         "The maximum number of joins to reorder as one group in cost-based join reordering",
@@ -748,6 +762,11 @@ public final class SystemSessionProperties
             return ELIMINATE_CROSS_JOINS;
         }
         return session.getSystemProperty(JOIN_REORDERING_STRATEGY, JoinReorderingStrategy.class);
+    }
+
+    public static PartialMergePushdownStrategy getPartialMergePushdownStrategy(Session session)
+    {
+        return session.getSystemProperty(PARTIAL_MERGE_PUSHDOWN_STRATEGY, PartialMergePushdownStrategy.class);
     }
 
     public static int getMaxReorderedJoins(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -92,6 +92,7 @@ public interface Metadata
     /**
      * Return a partitioning handle which the connector can transparently convert both {@code left} and {@code right} into.
      */
+    @Deprecated
     Optional<PartitioningHandle> getCommonPartitioning(Session session, PartitioningHandle left, PartitioningHandle right);
 
     /**

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -18,6 +18,7 @@ import com.facebook.presto.connector.ConnectorId;
 import com.facebook.presto.spi.CatalogSchemaName;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
@@ -25,6 +26,7 @@ import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrestoPrincipal;
@@ -91,6 +93,18 @@ public interface Metadata
      * Return a partitioning handle which the connector can transparently convert both {@code left} and {@code right} into.
      */
     Optional<PartitioningHandle> getCommonPartitioning(Session session, PartitioningHandle left, PartitioningHandle right);
+
+    /**
+     * Return whether {@code left} is a refined partitioning over {@code right}.
+     * See
+     * {@link com.facebook.presto.spi.connector.ConnectorMetadata#isRefinedPartitioningOver(ConnectorSession, ConnectorPartitioningHandle, ConnectorPartitioningHandle)}
+     * for details about refined partitioning.
+     * <p>
+     * Refined-over relation is reflexive.
+     * <p>
+     * This SPI is unstable and subject to change in the future.
+     */
+    boolean isRefinedPartitioningOver(Session session, PartitioningHandle a, PartitioningHandle b);
 
     /**
      * Provides partitioning handle for exchange.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -437,6 +437,24 @@ public class MetadataManager
     }
 
     @Override
+    public boolean isRefinedPartitioningOver(Session session, PartitioningHandle left, PartitioningHandle right)
+    {
+        Optional<ConnectorId> leftConnectorId = left.getConnectorId();
+        Optional<ConnectorId> rightConnectorId = right.getConnectorId();
+        if (!leftConnectorId.isPresent() || !rightConnectorId.isPresent() || !leftConnectorId.equals(rightConnectorId)) {
+            return false;
+        }
+        if (!left.getTransactionHandle().equals(right.getTransactionHandle())) {
+            return false;
+        }
+        ConnectorId connectorId = leftConnectorId.get();
+        CatalogMetadata catalogMetadata = getCatalogMetadata(session, connectorId);
+        ConnectorMetadata metadata = catalogMetadata.getMetadataFor(connectorId);
+
+        return metadata.isRefinedPartitioningOver(session.toConnectorSession(connectorId), left.getConnectorHandle(), right.getConnectorHandle());
+    }
+
+    @Override
     public PartitioningHandle getPartitioningHandleForExchange(Session session, String catalogName, int partitionCount, List<Type> partitionTypes)
     {
         CatalogMetadata catalogMetadata = getOptionalCatalogMetadata(session, catalogName)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -72,6 +72,7 @@ public class FeaturesConfig
     private boolean spatialJoinsEnabled = true;
     private boolean fastInequalityJoins = true;
     private JoinReorderingStrategy joinReorderingStrategy = ELIMINATE_CROSS_JOINS;
+    private PartialMergePushdownStrategy partialMergePushdownStrategy = PartialMergePushdownStrategy.NONE;
     private int maxReorderedJoins = 9;
     private boolean redistributeWrites = true;
     private boolean scaleWriters;
@@ -151,6 +152,12 @@ public class FeaturesConfig
         {
             return this == BROADCAST || this == AUTOMATIC;
         }
+    }
+
+    public enum PartialMergePushdownStrategy
+    {
+        NONE,
+        PUSH_THROUGH_LOW_MEMORY_OPERATORS
     }
 
     public double getCpuCostWeight()
@@ -399,6 +406,18 @@ public class FeaturesConfig
     public FeaturesConfig setJoinReorderingStrategy(JoinReorderingStrategy joinReorderingStrategy)
     {
         this.joinReorderingStrategy = joinReorderingStrategy;
+        return this;
+    }
+
+    public PartialMergePushdownStrategy getPartialMergePushdownStrategy()
+    {
+        return partialMergePushdownStrategy;
+    }
+
+    @Config("experimental.optimizer.partial-merge-pushdown-strategy")
+    public FeaturesConfig setPartialMergePushdownStrategy(PartialMergePushdownStrategy partialMergePushdownStrategy)
+    {
+        this.partialMergePushdownStrategy = partialMergePushdownStrategy;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
@@ -123,6 +123,46 @@ public final class Partitioning
         return true;
     }
 
+    //  Refined-over relation is reflexive.
+    public boolean isRefinedPartitioningOver(
+            Partitioning right,
+            Metadata metadata,
+            Session session)
+    {
+        if (!handle.equals(right.handle) && !metadata.isRefinedPartitioningOver(session, handle, right.handle)) {
+            return false;
+        }
+
+        return arguments.equals(right.arguments);
+    }
+
+    //  Refined-over relation is reflexive.
+    public boolean isRefinedPartitioningOver(
+            Partitioning right,
+            Function<Symbol, Set<Symbol>> leftToRightMappings,
+            Function<Symbol, Optional<NullableValue>> leftConstantMapping,
+            Function<Symbol, Optional<NullableValue>> rightConstantMapping,
+            Metadata metadata,
+            Session session)
+    {
+        if (!metadata.isRefinedPartitioningOver(session, handle, right.handle)) {
+            return false;
+        }
+        if (arguments.size() != right.arguments.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < arguments.size(); i++) {
+            ArgumentBinding leftArgument = arguments.get(i);
+            ArgumentBinding rightArgument = right.arguments.get(i);
+
+            if (!isPartitionedWith(leftArgument, leftConstantMapping, rightArgument, rightConstantMapping, leftToRightMappings)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private static boolean isPartitionedWith(
             ArgumentBinding leftArgument,
             Function<Symbol, Optional<NullableValue>> leftConstantMapping,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
@@ -84,6 +84,7 @@ public final class Partitioning
                 .collect(toImmutableSet());
     }
 
+    @Deprecated
     public boolean isCompatibleWith(
             Partitioning right,
             Metadata metadata,
@@ -96,6 +97,7 @@ public final class Partitioning
         return arguments.equals(right.arguments);
     }
 
+    @Deprecated
     public boolean isCompatibleWith(
             Partitioning right,
             Function<Symbol, Set<Symbol>> leftToRightMappings,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -747,6 +747,10 @@ public class PlanFragmenter
                 return this;
             }
 
+            if (metadata.isRefinedPartitioningOver(session, distribution, currentPartitioning)) {
+                return this;
+            }
+
             throw new IllegalStateException(format(
                     "Cannot set distribution to %s. Already set to %s",
                     distribution,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
@@ -119,11 +119,13 @@ public class ActualProperties
         return global.isNodePartitionedOn(columns, constants.keySet(), nullsAndAnyReplicated);
     }
 
+    @Deprecated
     public boolean isCompatibleTablePartitioningWith(Partitioning partitioning, boolean nullsAndAnyReplicated, Metadata metadata, Session session)
     {
         return global.isCompatibleTablePartitioningWith(partitioning, nullsAndAnyReplicated, metadata, session);
     }
 
+    @Deprecated
     public boolean isCompatibleTablePartitioningWith(ActualProperties other, Function<Symbol, Set<Symbol>> symbolMappings, Metadata metadata, Session session)
     {
         return global.isCompatibleTablePartitioningWith(

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -139,6 +139,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public boolean isRefinedPartitioningOver(Session session, PartitioningHandle a, PartitioningHandle b)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public PartitioningHandle getPartitioningHandleForExchange(Session session, String catalogName, int partitionCount, List<Type> partitionTypes)
     {
         throw new UnsupportedOperationException();

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -29,6 +29,7 @@ import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionTy
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.PARTITIONED;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.NONE;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.PartialMergePushdownStrategy.PUSH_THROUGH_LOW_MEMORY_OPERATORS;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.SPILLER_SPILL_PATH;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.SPILL_ENABLED;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
@@ -60,6 +61,7 @@ public class TestFeaturesConfig
                 .setColocatedJoinsEnabled(false)
                 .setSpatialJoinsEnabled(true)
                 .setJoinReorderingStrategy(ELIMINATE_CROSS_JOINS)
+                .setPartialMergePushdownStrategy(FeaturesConfig.PartialMergePushdownStrategy.NONE)
                 .setMaxReorderedJoins(9)
                 .setRedistributeWrites(true)
                 .setScaleWriters(false)
@@ -142,6 +144,7 @@ public class TestFeaturesConfig
                 .put("colocated-joins-enabled", "true")
                 .put("spatial-joins-enabled", "false")
                 .put("optimizer.join-reordering-strategy", "NONE")
+                .put("experimental.optimizer.partial-merge-pushdown-strategy", PUSH_THROUGH_LOW_MEMORY_OPERATORS.name())
                 .put("optimizer.max-reordered-joins", "5")
                 .put("redistribute-writes", "false")
                 .put("scale-writers", "true")
@@ -202,6 +205,7 @@ public class TestFeaturesConfig
                 .setColocatedJoinsEnabled(true)
                 .setSpatialJoinsEnabled(false)
                 .setJoinReorderingStrategy(NONE)
+                .setPartialMergePushdownStrategy(PUSH_THROUGH_LOW_MEMORY_OPERATORS)
                 .setMaxReorderedJoins(5)
                 .setRedistributeWrites(false)
                 .setScaleWriters(true)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -125,6 +125,7 @@ public interface ConnectorMetadata
     /**
      * Return a partitioning handle which the connector can transparently convert both {@code left} and {@code right} into.
      */
+    @Deprecated
     default Optional<ConnectorPartitioningHandle> getCommonPartitioningHandle(ConnectorSession session, ConnectorPartitioningHandle left, ConnectorPartitioningHandle right)
     {
         if (left.equals(right)) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -134,6 +134,40 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Partitioning <code>a = {a_1, ... a_n}</code> is considered as a refined partitioning over
+     * partitioning <code>b = {b_1, ... b_m}</code> if:
+     * <ul>
+     * <li> n >= m </li>
+     * <li> For every partition <code>b_i</code> in partitioning <code>b</code>,
+     *      the rows it contains is the same as union of a set of partitions <code>a_{i_1}, a_{i_2}, ... a_{i_k}</code>
+     *      in partitioning <code>a</code>, i.e.
+     *      <p>
+     *          <code>b_i = a_{i_1} + a_{i_2} + ... + a_{i_k}</code>
+     * <li> Connector can transparently convert partitioning <code>a</code> to partitioning <code>b</code>
+     *      associated with the provided table layout handle.
+     * </ul>
+     *
+     * <p>
+     * For example, consider two partitioning over <code>order</code> table:
+     * <ul>
+     * <li> partitioning <code>a</code> has 256 partitions by <code>orderkey % 256</code>
+     * <li> partitioning <code>b</code> has 128 partitions by <code>orderkey % 128</code>
+     * </ul>
+     *
+     * <p>
+     * Partitioning <code>a</code> is a refined partitioning over <code>b</code> if Connector supports
+     * transparently convert <code>a</code> to <code>b</code>.
+     * <p>
+     * Refined-over relation is reflexive.
+     * <p>
+     * This SPI is unstable and subject to change in the future.
+     */
+    default boolean isRefinedPartitioningOver(ConnectorSession session, ConnectorPartitioningHandle left, ConnectorPartitioningHandle right)
+    {
+        return left.equals(right);
+    }
+
+    /**
      * Provides partitioning handle for exchange.
      */
     default ConnectorPartitioningHandle getPartitioningHandleForExchange(ConnectorSession session, int partitionCount, List<Type> partitionTypes)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -96,6 +96,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public boolean isRefinedPartitioningOver(ConnectorSession session, ConnectorPartitioningHandle left, ConnectorPartitioningHandle right)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.isRefinedPartitioningOver(session, left, right);
+        }
+    }
+
+    @Override
     public ConnectorPartitioningHandle getPartitioningHandleForExchange(ConnectorSession session, int partitionCount, List<Type> partitionTypes)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
## Introduction 

Grouped execution was introduced to Presto in https://github.com/prestodb/presto/pull/8951 to support huge join and aggregation raised in ETL pipelines. 

A large scale warehouse often optimize table layout by pre-bucketing tables on frequently-used join/aggregation keys to avoid the cost of data re-partitioning. However, tables often have different (yet compatible) number of buckets. 

For example, an extremely huge table A might have 8192 buckets, while another large table have 1024 buckets. A full repartitioning for queries like A JOIN B is undesired because:

- In-memory repartitioning loses the benefit of grouped execution and the query may exceeded maximum distributed memory allowed.
- Materialized exchange (https://github.com/prestodb/presto/issues/12387) will help run the query within memory limit, however it will be very inefficient in terms of CPU and IO. 

https://github.com/prestodb/presto/pull/11749 is the first work  try to optimize this problem, and lay some fundamental building blocks to this problem. However, in practice we found the following issue impedes it from a general useful solution: (e.g. we have to ask users to opt-in, instead of enable it by default). 

- It couples partitioning selection and partial merge pushdown. So it can change how partitioning is chosen and  cause query to fail. For example:

```
          AGGR
            |
          JOIN
         /     \
 TS(2048)    TS(1024)
```

`AddExchange` always prefer to use left side partitioning if exists. In this case, it will cause less number of lifespan for aggregation and increase the global memory usage. 



- The common partitioning selection logic is opaque to engine. Thus engine cannot reason about whether this partial merge pushdown is safe or not, for example:

```
          JOIN
         /     \
 TS(1024)    AGGR(2048)
                    \
                   TS(2048)
```

Push partial merge to the right TS can cause OOM. However, since engine doesn't know whether the common partitioning returned by Connector is a refinement or coarsening, it cannot reason which partitioning to use. 

## Partial Repartitioning  and Partial Merge

This PR explores an alternative attempt based on the supports built in https://github.com/prestodb/presto/pull/11749 . The idea is to efficiently support these partitioning adaptions, we need the two "partial repartitioning" and "partial merge"  exchange types introduced in SCOPE paper ([1]):  

<img width="952" alt="Screen Shot 2019-04-07 at 8 45 10 PM" src="https://user-images.githubusercontent.com/799346/55697471-68c0f580-5976-11e9-92a5-aba2510e2b29.png">

Consider the same example above `A (8192) JOIN B (1024)`.  Instead of do a full re-partitioning over A or B, we can do a "partial merge" over A into 1024 buckets (we can also do "partial re-partitioning" over B, but this is beyond the scope of this PR).   


## Implementation

We are going to discuss about implementation of Partial Repartitioning  and Partial Merge in the context of materialized exchange. In memory exchange would be more interesting to discuss. 

### Partial Repartitioning

Partial repartitioning implementations is more straightforward. Since it's always going to be like this in the materialized exchange context:

```
      TableWriter
            |
      Exchange (partial repartitinoing)
            |
      ...............
``` 

Instead of a remote exchange, the `ExchangeNode` can be simply expanded to a local exchange operator.  It can even be pushed into `TableWriter` if parallelism is not a concern.


### Partial Merge

Partial merge is more interesting since it can be handled in different ways.  For the convenience of discussion, we assuming we are trying to do partial merge from 4096 buckets to 1024 buckets. 


- Directly supporting it in Presto engine requires a bit more work, potential solutions:
    * We can use a local exchange operator to "merge" the data produced from different lifespans, but the engine needs to intelligently schedule lifespans to be coalesced in the same time and on the same nodes. 
    * We can allow partial writes to a bucket (e.g. doing a partial merge from 4096 buckets to 1024 buckets, one lifespan can finish but the target output bucket is only 25% finished)

```
      TableWriter
            |
      Exchange (partial merge)
            |
      ...............
``` 


- It can be fully eliminated by pushing down partial merge to the table scan. Note pushing through join/aggregation has the risk to increase memory usage.

- If it cannot be pushed down, another way would be doing "partial merge" in a lazy fashion. i.e. we still writes to 4096 buckets, but in the next table scan, it reads out as 1024 buckets. 







Note partial merge can be conveniently pushdown to Connector by asking an "alternative TableLayout". 

[1]: http://www.cs.columbia.edu/~jrzhou/pub/Scope-VLDBJ.pdf





## Misc

The idea here is if exchange materialization is considered as the primary way to support large queries; the problem is much simplified, since all partitioning will remain the same during query execution (same number of buckets as specified by `num_hash_partitions`). 

In this world, two major primitives (besides full repartitioning) are "partial merge" and "partial repartitioning" which used at beginning to adapt query specified partition count. And they can be modeled as "partial merge pushdown" and "partial repartitioning pushup".  

Compatible partitioning is supported as a by-product. 

## Open Questions

How do Hive/Spark handles "compatible buckets"? 

