### PR TITLE
Replace FileStream with Files.newStream

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
@@ -75,13 +75,13 @@ import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
@@ -1021,7 +1021,7 @@ public class PrestoS3FileSystem
                 PrestoS3AclType aclType)
                 throws IOException
         {
-            super(new BufferedOutputStream(new FileOutputStream(requireNonNull(tempFile, "tempFile is null"))));
+            super(new BufferedOutputStream(Files.newOutputStream(requireNonNull(tempFile, "tempFile is null").toPath())));
 
             transferManager = TransferManagerBuilder.standard()
                     .withS3Client(requireNonNull(s3, "s3 is null"))

--- a/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileRecordCursor.java
+++ b/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileRecordCursor.java
@@ -29,12 +29,12 @@ import io.airlift.slice.Slices;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.RandomAccessFile;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -293,8 +293,7 @@ public class LocalFileRecordCursor
                 return null;
             }
             File file = files.next();
-            FileInputStream fileInputStream = new FileInputStream(file);
-
+            InputStream fileInputStream = Files.newInputStream(file.toPath());
             InputStream in = isGZipped(file) ? new GZIPInputStream(fileInputStream) : fileInputStream;
             return new BufferedReader(new InputStreamReader(in));
         }

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginDiscovery.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginDiscovery.java
@@ -20,13 +20,12 @@ import org.objectweb.asm.ClassReader;
 import org.sonatype.aether.artifact.Artifact;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -76,7 +75,7 @@ final class PluginDiscovery
     {
         Path path = root.toPath().resolve(SERVICES_FILE);
         createDirectories(path.getParent());
-        try (Writer out = new OutputStreamWriter(new FileOutputStream(path.toFile()), UTF_8)) {
+        try (Writer out = Files.newBufferedWriter(path, UTF_8)) {
             for (String plugin : plugins) {
                 out.write(plugin + "\n");
             }

--- a/presto-main/src/main/java/com/facebook/presto/util/PropertiesUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/PropertiesUtil.java
@@ -14,9 +14,9 @@
 package com.facebook.presto.util;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Properties;
 
@@ -30,7 +30,7 @@ public final class PropertiesUtil
             throws IOException
     {
         Properties properties = new Properties();
-        try (InputStream in = new FileInputStream(file)) {
+        try (InputStream in = Files.newInputStream(file.toPath())) {
             properties.load(in);
         }
         return fromProperties(properties);


### PR DESCRIPTION
Use Files.new{Input,Output}Stream instead of File{Input,Output}Stream where possible. FileStream classes use a finalizer to ensure the backing descriptor is closed which can lead to longer GC pause cycles when the streams are closed correctly. See [HDFS-8562](https://issues.apache.org/jira/browse/HDFS-8562) or [JENKINS-42934](https://issues.jenkins-ci.org/browse/JENKINS-42934) for instances of other projects making this change.

This is no longer an issue as of JDK 12, which [removes the finalizer](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8213888). The usages changed in this PR can operate on any {Input,Output}Stream implementation and therefore straightforward to replace.

