### PR TITLE
Improve error messages in beta_cdf and inverse_beta_cdf math functions.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -638,8 +638,9 @@ public final class MathFunctions
             @SqlType(StandardTypes.DOUBLE) double b,
             @SqlType(StandardTypes.DOUBLE) double p)
     {
-        checkCondition(p >= 0 && p <= 1, INVALID_FUNCTION_ARGUMENT, "p must be 0 >= p >= 1");
-        checkCondition(a > 0 && b > 0, INVALID_FUNCTION_ARGUMENT, "a, b must be > 0");
+        checkCondition(p >= 0 && p <= 1, INVALID_FUNCTION_ARGUMENT, "p must be in the interval [0, 1]");
+        checkCondition(a > 0, INVALID_FUNCTION_ARGUMENT, "a must be > 0");
+        checkCondition(b > 0, INVALID_FUNCTION_ARGUMENT, "b must be > 0");
         BetaDistribution distribution = new BetaDistribution(null, a, b, BetaDistribution.DEFAULT_INVERSE_ABSOLUTE_ACCURACY);
         return distribution.inverseCumulativeProbability(p);
     }
@@ -652,8 +653,9 @@ public final class MathFunctions
             @SqlType(StandardTypes.DOUBLE) double b,
             @SqlType(StandardTypes.DOUBLE) double value)
     {
-        checkCondition(value >= 0 && value <= 1, INVALID_FUNCTION_ARGUMENT, "value must be 0 >= v >= 1");
-        checkCondition(a > 0 && b > 0, INVALID_FUNCTION_ARGUMENT, "a, b must be > 0");
+        checkCondition(value >= 0 && value <= 1, INVALID_FUNCTION_ARGUMENT, "value must be in the interval [0, 1]");
+        checkCondition(a > 0, INVALID_FUNCTION_ARGUMENT, "a must be > 0");
+        checkCondition(b > 0, INVALID_FUNCTION_ARGUMENT, "b must be > 0");
         BetaDistribution distribution = new BetaDistribution(null, a, b, BetaDistribution.DEFAULT_INVERSE_ABSOLUTE_ACCURACY);
         return distribution.cumulativeProbability(value);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1351,10 +1351,10 @@ public class TestMathFunctions
         assertFunction("inverse_beta_cdf(3, 3.6, 0.3)", DOUBLE, 0.3469675485440618);
         assertFunction("inverse_beta_cdf(3, 3.6, 0.95)", DOUBLE, 0.7600272463100223);
 
-        assertInvalidFunction("inverse_beta_cdf(0, 3, 0.5)", "a, b must be > 0");
-        assertInvalidFunction("inverse_beta_cdf(3, 0, 0.5)", "a, b must be > 0");
-        assertInvalidFunction("inverse_beta_cdf(3, 5, -0.1)", "p must be 0 >= p >= 1");
-        assertInvalidFunction("inverse_beta_cdf(3, 5, 1.1)", "p must be 0 >= p >= 1");
+        assertInvalidFunction("inverse_beta_cdf(0, 3, 0.5)", "a must be > 0");
+        assertInvalidFunction("inverse_beta_cdf(3, 0, 0.5)", "b must be > 0");
+        assertInvalidFunction("inverse_beta_cdf(3, 5, -0.1)", "p must be in the interval [0, 1]");
+        assertInvalidFunction("inverse_beta_cdf(3, 5, 1.1)", "p must be in the interval [0, 1]");
     }
 
     @Test
@@ -1366,10 +1366,10 @@ public class TestMathFunctions
         assertFunction("beta_cdf(3, 3.6, 0.3)", DOUBLE, 0.21764809997679938);
         assertFunction("beta_cdf(3, 3.6, 0.9)", DOUBLE, 0.9972502881611551);
 
-        assertInvalidFunction("beta_cdf(0, 3, 0.5)", "a, b must be > 0");
-        assertInvalidFunction("beta_cdf(3, 0, 0.5)", "a, b must be > 0");
-        assertInvalidFunction("beta_cdf(3, 5, -0.1)", "value must be 0 >= v >= 1");
-        assertInvalidFunction("beta_cdf(3, 5, 1.1)", "value must be 0 >= v >= 1");
+        assertInvalidFunction("beta_cdf(0, 3, 0.5)", "a must be > 0");
+        assertInvalidFunction("beta_cdf(3, 0, 0.5)", "b must be > 0");
+        assertInvalidFunction("beta_cdf(3, 5, -0.1)", "value must be in the interval [0, 1]");
+        assertInvalidFunction("beta_cdf(3, 5, 1.1)", "value must be in the interval [0, 1]");
     }
 
     @Test


### PR DESCRIPTION
This is follow-up to #11981 with improved error messages