### PR TITLE
Create stage id based on the plan fragment id

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -290,12 +290,12 @@ public class PlanFragmenter
 
         public SubPlan buildRootFragment(PlanNode root, FragmentProperties properties)
         {
-            return buildFragment(root, properties, new PlanFragmentId(String.valueOf(ROOT_FRAGMENT_ID)));
+            return buildFragment(root, properties, new PlanFragmentId(ROOT_FRAGMENT_ID));
         }
 
         private PlanFragmentId nextFragmentId()
         {
-            return new PlanFragmentId(String.valueOf(nextFragmentId++));
+            return new PlanFragmentId(nextFragmentId++);
         }
 
         private SubPlan buildFragment(PlanNode root, FragmentProperties properties, PlanFragmentId fragmentId)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanFragmentId.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanFragmentId.java
@@ -18,26 +18,28 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import javax.annotation.concurrent.Immutable;
 
-import static java.util.Objects.requireNonNull;
-
 @Immutable
 public class PlanFragmentId
         implements Comparable<PlanFragmentId>
 {
-    private final String id;
+    private final int id;
 
     @JsonCreator
-    public PlanFragmentId(String id)
+    public PlanFragmentId(int id)
     {
-        requireNonNull(id, "id is null");
         this.id = id;
     }
 
-    @Override
     @JsonValue
-    public String toString()
+    public int getId()
     {
         return id;
+    }
+
+    @Override
+    public String toString()
+    {
+        return Integer.toString(id);
     }
 
     @Override
@@ -52,27 +54,18 @@ public class PlanFragmentId
 
         PlanFragmentId that = (PlanFragmentId) o;
 
-        if (!id.equals(that.id)) {
-            return false;
-        }
-
-        return true;
+        return id == that.id;
     }
 
     @Override
     public int hashCode()
     {
-        return id.hashCode();
+        return Integer.hashCode(id);
     }
 
     @Override
     public int compareTo(PlanFragmentId o)
     {
-        try {
-            return Integer.compare(Integer.parseInt(id), Integer.parseInt(o.id));
-        }
-        catch (NumberFormatException e) {
-            return id.compareTo(o.id);
-        }
+        return Integer.compare(id, o.id);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -315,7 +315,7 @@ public class PlanPrinter
     {
         // TODO: This should move to something like GraphvizRenderer
         PlanFragment fragment = new PlanFragment(
-                new PlanFragmentId("graphviz_plan"),
+                new PlanFragmentId(0),
                 plan,
                 types.allTypes(),
                 SINGLE_DISTRIBUTION,

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -107,7 +107,7 @@ public class MockRemoteTaskFactory
         Symbol symbol = new Symbol("column");
         PlanNodeId sourceId = new PlanNodeId("sourceId");
         PlanFragment testFragment = new PlanFragment(
-                new PlanFragmentId("test"),
+                new PlanFragmentId(0),
                 new TableScanNode(
                         sourceId,
                         new TableHandle(new ConnectorId("test"), new TestingTableHandle()),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -90,7 +90,7 @@ public final class TaskTestUtils
     public static final Symbol SYMBOL = new Symbol("column");
 
     public static final PlanFragment PLAN_FRAGMENT = new PlanFragment(
-            new PlanFragmentId("fragment"),
+            new PlanFragmentId(0),
             new TableScanNode(
                     TABLE_SCAN_NODE_ID,
                     new TableHandle(CONNECTOR_ID, new TestingTableHandle()),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -161,7 +161,7 @@ public class TestSqlStageExecution
     {
         PlanNode planNode = new RemoteSourceNode(
                 new PlanNodeId("exchange"),
-                ImmutableList.of(new PlanFragmentId("source")),
+                ImmutableList.of(new PlanFragmentId(0)),
                 ImmutableList.of(new Symbol("column")),
                 Optional.empty(),
                 REPARTITION);
@@ -171,7 +171,7 @@ public class TestSqlStageExecution
             types.put(symbol, VARCHAR);
         }
         return new PlanFragment(
-                new PlanFragmentId("exchange_fragment_id"),
+                new PlanFragmentId(0),
                 planNode,
                 types.build(),
                 SOURCE_DISTRIBUTION,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStageStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStageStateMachine.java
@@ -324,7 +324,7 @@ public class TestStageStateMachine
         Symbol symbol = new Symbol("column");
         PlanNodeId valuesNodeId = new PlanNodeId("plan");
         PlanFragment planFragment = new PlanFragment(
-                new PlanFragmentId("plan"),
+                new PlanFragmentId(0),
                 new ValuesNode(valuesNodeId,
                         ImmutableList.of(symbol),
                         ImmutableList.of(ImmutableList.of(constant("foo", VARCHAR)))),

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPhasedExecutionSchedule.java
@@ -40,6 +40,7 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
@@ -55,6 +56,8 @@ import static org.testng.Assert.assertEquals;
 
 public class TestPhasedExecutionSchedule
 {
+    private static final AtomicInteger nextPlanFragmentId = new AtomicInteger();
+
     @Test
     public void testExchange()
     {
@@ -245,7 +248,7 @@ public class TestPhasedExecutionSchedule
             types.put(symbol, VARCHAR);
         }
         return new PlanFragment(
-                new PlanFragmentId(planNode.getId() + "_fragment_id"),
+                new PlanFragmentId(nextPlanFragmentId.incrementAndGet()),
                 planNode,
                 types.build(),
                 SOURCE_DISTRIBUTION,

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -460,9 +460,9 @@ public class TestSourcePartitionedScheduler
                 ImmutableList.of(symbol),
                 ImmutableMap.of(symbol, new TestingColumnHandle("column")));
 
-        RemoteSourceNode remote = new RemoteSourceNode(new PlanNodeId("remote_id"), new PlanFragmentId("plan_fragment_id"), ImmutableList.of(), Optional.empty(), GATHER);
+        RemoteSourceNode remote = new RemoteSourceNode(new PlanNodeId("remote_id"), new PlanFragmentId(0), ImmutableList.of(), Optional.empty(), GATHER);
         PlanFragment testFragment = new PlanFragment(
-                new PlanFragmentId("plan_id"),
+                new PlanFragmentId(0),
                 new JoinNode(new PlanNodeId("join_id"),
                         INNER,
                         tableScan,


### PR DESCRIPTION
Currently stage is always interpreted interchangeably with the plan
fragment id. However it was not explicitly assigned from the plan
fragment id. Changing the order of how PlanFragments are created,
or the orders of how the SqlStageExecution are created brakes this
implicit contract.