### PR TITLE
Don't choose right inequality joins with CBO

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -77,13 +77,8 @@ public class DetermineJoinDistributionType
         return Result.ofPlanNode(getSyntacticOrderJoin(joinNode, context, joinDistributionType));
     }
 
-    public static boolean canReplicate(JoinNode joinNode, Context context)
+    public static boolean isBelowMaxBroadcastSize(JoinNode joinNode, Context context)
     {
-        JoinDistributionType joinDistributionType = getJoinDistributionType(context.getSession());
-        if (!joinDistributionType.canReplicate()) {
-            return false;
-        }
-
         Optional<DataSize> joinMaxBroadcastTableSize = getJoinMaxBroadcastTableSize(context.getSession());
         if (!joinMaxBroadcastTableSize.isPresent()) {
             return true;
@@ -113,7 +108,7 @@ public class DetermineJoinDistributionType
 
     private void addJoinsWithDifferentDistributions(JoinNode joinNode, List<PlanNodeWithCost> possibleJoinNodes, Context context)
     {
-        if (!mustPartition(joinNode) && canReplicate(joinNode, context)) {
+        if (!mustPartition(joinNode) && isBelowMaxBroadcastSize(joinNode, context)) {
             possibleJoinNodes.add(getJoinNodeWithCost(context, joinNode.withDistributionType(REPLICATED)));
         }
         // don't consider partitioned inequality joins because they execute on a single node.

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -116,7 +116,8 @@ public class DetermineJoinDistributionType
         if (!mustPartition(joinNode) && canReplicate(joinNode, context)) {
             possibleJoinNodes.add(getJoinNodeWithCost(context, joinNode.withDistributionType(REPLICATED)));
         }
-        if (!mustReplicate(joinNode, context)) {
+        // don't consider partitioned inequality joins because they execute on a single node.
+        if (!mustReplicate(joinNode, context) && !joinNode.getCriteria().isEmpty()) {
             possibleJoinNodes.add(getJoinNodeWithCost(context, joinNode.withDistributionType(PARTITIONED)));
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
@@ -63,7 +63,7 @@ import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStra
 import static com.facebook.presto.sql.planner.DeterminismEvaluator.isDeterministic;
 import static com.facebook.presto.sql.planner.EqualityInference.createEqualityInference;
 import static com.facebook.presto.sql.planner.EqualityInference.nonInferrableConjuncts;
-import static com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.canReplicate;
+import static com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType.isBelowMaxBroadcastSize;
 import static com.facebook.presto.sql.planner.iterative.rule.ReorderJoins.JoinEnumerationResult.INFINITE_COST_RESULT;
 import static com.facebook.presto.sql.planner.iterative.rule.ReorderJoins.JoinEnumerationResult.UNKNOWN_COST_RESULT;
 import static com.facebook.presto.sql.planner.iterative.rule.ReorderJoins.MultiJoinNode.toMultiJoinNode;
@@ -394,7 +394,7 @@ public class ReorderJoins
                 case AUTOMATIC:
                     ImmutableList.Builder<JoinEnumerationResult> result = ImmutableList.builder();
                     result.addAll(getPossibleJoinNodes(joinNode, PARTITIONED));
-                    if (canReplicate(joinNode, context)) {
+                    if (isBelowMaxBroadcastSize(joinNode, context)) {
                         result.addAll(getPossibleJoinNodes(joinNode, REPLICATED));
                     }
                     return result.build();


### PR DESCRIPTION
Even though sometimes right inequality joins will use fewer resources,
they execute on a single node so they can have very long wall times due
to a lack of parallelism for what is essentially a cross join.  Instead
only have cbo consider left outer joins, since the build side can be
replicated.  If the build table exceeds the max broadcast size, it will
fall back to using the syntactic join order.