### PR TITLE
Add warnings field to coordinator v1/query endpoint

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -348,7 +348,8 @@ public class QueryStateMachine
                 queryStats,
                 errorCode == null ? null : errorCode.getType(),
                 errorCode,
-                queryType);
+                queryType,
+                warningCollector.getWarnings());
     }
 
     @VisibleForTesting

--- a/presto-main/src/main/java/com/facebook/presto/server/BasicQueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/BasicQueryInfo.java
@@ -18,6 +18,7 @@ import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.ErrorType;
+import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.resourceGroups.QueryType;
@@ -29,6 +30,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -53,6 +55,7 @@ public class BasicQueryInfo
     private final ErrorType errorType;
     private final ErrorCode errorCode;
     private final Optional<QueryType> queryType;
+    private final List<PrestoWarning> warnings;
 
     @JsonCreator
     public BasicQueryInfo(
@@ -67,7 +70,8 @@ public class BasicQueryInfo
             @JsonProperty("queryStats") BasicQueryStats queryStats,
             @JsonProperty("errorType") ErrorType errorType,
             @JsonProperty("errorCode") ErrorCode errorCode,
-            @JsonProperty("queryType") Optional<QueryType> queryType)
+            @JsonProperty("queryType") Optional<QueryType> queryType,
+            @JsonProperty("warnings") List<PrestoWarning> warnings)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.session = requireNonNull(session, "session is null");
@@ -81,6 +85,7 @@ public class BasicQueryInfo
         this.query = requireNonNull(query, "query is null");
         this.queryStats = requireNonNull(queryStats, "queryStats is null");
         this.queryType = requireNonNull(queryType, "queryType is null");
+        this.warnings = requireNonNull(warnings, "warnings is null");
     }
 
     public BasicQueryInfo(QueryInfo queryInfo)
@@ -96,7 +101,8 @@ public class BasicQueryInfo
                 new BasicQueryStats(queryInfo.getQueryStats()),
                 queryInfo.getErrorType(),
                 queryInfo.getErrorCode(),
-                queryInfo.getQueryType());
+                queryInfo.getQueryType(),
+                queryInfo.getWarnings());
     }
 
     @JsonProperty
@@ -171,6 +177,12 @@ public class BasicQueryInfo
     public Optional<QueryType> getQueryType()
     {
         return queryType;
+    }
+
+    @JsonProperty
+    public List<PrestoWarning> getWarnings()
+    {
+        return warnings;
     }
 
     @Override

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
@@ -100,6 +100,7 @@ public class TestClusterMemoryLeakDetector
                         OptionalDouble.of(20)),
                 null,
                 null,
-                Optional.empty());
+                Optional.empty(),
+                ImmutableList.of());
     }
 }


### PR DESCRIPTION
We want to add warnings field to the v1/query endpoint so that its easy to retrieve all the warnings for the queries running/finished on coordinator. It will also enable us to show the warnings on the main coordinator UI page and have a sort by warning or similar thing.