### PR TITLE
Don't push limit through full outer joins

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -121,6 +121,7 @@ public final class SystemSessionProperties
     public static final String MAX_DRIVERS_PER_TASK = "max_drivers_per_task";
     public static final String MAX_TASKS_PER_STAGE = "max_tasks_per_stage";
     public static final String DEFAULT_FILTER_FACTOR_ENABLED = "default_filter_factor_enabled";
+    public static final String PUSH_LIMIT_THROUGH_OUTER_JOIN = "push_limit_through_outer_join";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -575,6 +576,11 @@ public final class SystemSessionProperties
                         DEFAULT_FILTER_FACTOR_ENABLED,
                         "use a default filter factor for unknown filters in a filter node",
                         featuresConfig.isDefaultFilterFactorEnabled(),
+                        false),
+                booleanProperty(
+                        PUSH_LIMIT_THROUGH_OUTER_JOIN,
+                        "push limits to the outer side of an outer join",
+                        featuresConfig.isPushLimitThroughOuterJoin(),
                         false));
     }
 
@@ -976,5 +982,10 @@ public final class SystemSessionProperties
     public static boolean isDefaultFilterFactorEnabled(Session session)
     {
         return session.getSystemProperty(DEFAULT_FILTER_FACTOR_ENABLED, Boolean.class);
+    }
+
+    public static boolean isPushLimitThroughOuterJoin(Session session)
+    {
+        return session.getSystemProperty(PUSH_LIMIT_THROUGH_OUTER_JOIN, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -118,6 +118,7 @@ public class FeaturesConfig
     private boolean useMarkDistinct = true;
     private boolean preferPartialAggregation = true;
     private boolean optimizeTopNRowNumber = true;
+    private boolean pushLimitThroughOuterJoin = true;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
 
@@ -939,5 +940,17 @@ public class FeaturesConfig
     public boolean isJsonSerdeCodeGenerationEnabled()
     {
         return jsonSerdeCodeGenerationEnabled;
+    }
+
+    @Config("optimizer.push-limit-through-outer-join")
+    public FeaturesConfig setPushLimitThroughOuterJoin(boolean pushLimitThroughOuterJoin)
+    {
+        this.pushLimitThroughOuterJoin = pushLimitThroughOuterJoin;
+        return this;
+    }
+
+    public boolean isPushLimitThroughOuterJoin()
+    {
+        return pushLimitThroughOuterJoin;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -109,7 +109,8 @@ public class TestFeaturesConfig
                 .setDistributedSortEnabled(true)
                 .setMaxGroupingSets(2048)
                 .setLegacyUnnestArrayRows(false)
-                .setJsonSerdeCodeGenerationEnabled(false));
+                .setJsonSerdeCodeGenerationEnabled(false)
+                .setPushLimitThroughOuterJoin(true));
     }
 
     @Test
@@ -179,6 +180,7 @@ public class TestFeaturesConfig
                 .put("analyzer.max-grouping-sets", "2047")
                 .put("deprecated.legacy-unnest-array-rows", "true")
                 .put("experimental.json-serde-codegen-enabled", "true")
+                .put("optimizer.push-limit-through-outer-join", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -244,7 +246,8 @@ public class TestFeaturesConfig
                 .setMaxGroupingSets(2047)
                 .setLegacyUnnestArrayRows(true)
                 .setDefaultFilterFactorEnabled(true)
-                .setJsonSerdeCodeGenerationEnabled(true);
+                .setJsonSerdeCodeGenerationEnabled(true)
+                .setPushLimitThroughOuterJoin(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushLimitThroughOuterJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushLimitThroughOuterJoin.java
@@ -53,7 +53,7 @@ public class TestPushLimitThroughOuterJoin
     }
 
     @Test
-    public void testPushLimitThroughFullOuterJoin()
+    public void testDoesNotPushThroughFullOuterJoin()
     {
         tester().assertThat(new PushLimitThroughOuterJoin())
                 .on(p -> {
@@ -66,13 +66,7 @@ public class TestPushLimitThroughOuterJoin
                                     p.values(5, rightKey),
                                     new EquiJoinClause(leftKey, rightKey)));
                 })
-                .matches(
-                        limit(1,
-                                join(
-                                        FULL,
-                                        ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
-                                        limit(1, true, values("leftKey")),
-                                        limit(1, true, values("rightKey")))));
+                .doesNotFire();
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1064,6 +1064,34 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testLimitWithJoin()
+    {
+        MaterializedResult actual = computeActual("SELECT o1.orderkey, o2.orderkey FROM orders o1 JOIN orders o2 on o1.orderkey = o2.orderkey LIMIT 10");
+        MaterializedResult all = computeActual("SELECT o1.orderkey, o2.orderkey FROM orders o1 JOIN  orders o2 on o1.orderkey = o2.orderkey");
+
+        assertEquals(actual.getMaterializedRows().size(), 10);
+        assertContains(all, actual);
+
+        actual = computeActual("SELECT o1.orderkey, o2.orderkey FROM orders o1 LEFT OUTER JOIN orders o2 on o1.orderkey = o2.orderkey LIMIT 10");
+        all = computeActual("SELECT o1.orderkey, o2.orderkey FROM orders o1 LEFT OUTER JOIN orders o2 on o1.orderkey = o2.orderkey");
+
+        assertEquals(actual.getMaterializedRows().size(), 10);
+        assertContains(all, actual);
+
+        actual = computeActual("SELECT o1.orderkey, o2.orderkey FROM orders o1 RIGHT OUTER JOIN orders o2 on o1.orderkey = o2.orderkey LIMIT 10");
+        all = computeActual("SELECT o1.orderkey, o2.orderkey FROM orders o1 RIGHT OUTER JOIN orders o2 on o1.orderkey = o2.orderkey");
+
+        assertEquals(actual.getMaterializedRows().size(), 10);
+        assertContains(all, actual);
+
+        actual = computeActual("SELECT o1.orderkey, o2.orderkey FROM orders o1 FULL OUTER JOIN orders o2 on o1.orderkey = o2.orderkey LIMIT 10");
+        all = computeActual("SELECT o1.orderkey, o2.orderkey FROM orders o1 FULL OUTER JOIN orders o2 on o1.orderkey = o2.orderkey");
+
+        assertEquals(actual.getMaterializedRows().size(), 10);
+        assertContains(all, actual);
+    }
+
+    @Test
     public void testCountAll()
     {
         assertQuery("SELECT COUNT(*) FROM orders");


### PR DESCRIPTION
Fixes a wrong results issue with limits and full outer joins.
Because full outer joins return all rows from both tables, if you push
down a limit you can get incorrect nulls in your output.

Example:
```sql
SELECT * FROM
        (VALUES (1),(2),(3)
    ) AS a(id)
FULL OUTER JOIN (
        VALUES (2),(3), (1)
    ) AS b(id)
    ON a.id = b.id
LIMIT
    1;
```

This was already approved in #12639.  this pr is just to run tests on the release branch.