### PR TITLE
Use Builder to construct ParsingOptions in Verifier

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryRewriter.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.verifier.framework;
 
-import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
@@ -40,12 +39,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
 import static com.facebook.presto.sql.tree.LikeClause.PropertiesOption.INCLUDING;
 import static com.facebook.presto.verifier.framework.QueryOrigin.QueryGroup.CONTROL;
 import static com.facebook.presto.verifier.framework.QueryOrigin.QueryGroup.TEST;
 import static com.facebook.presto.verifier.framework.QueryOrigin.QueryStage.DESCRIBE;
 import static com.facebook.presto.verifier.framework.QueryType.Category.DATA_PRODUCING;
+import static com.facebook.presto.verifier.framework.VerifierUtil.PARSING_OPTIONS;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -69,7 +68,7 @@ public class QueryRewriter
 
     public QueryBundle rewriteQuery(@Language("SQL") String query, QueryGroup group, QueryConfiguration controlConfiguration, VerificationContext context)
     {
-        Statement statement = sqlParser.createStatement(query, new ParsingOptions(AS_DOUBLE));
+        Statement statement = sqlParser.createStatement(query, PARSING_OPTIONS);
         if (QueryType.of(statement).getCategory() != DATA_PRODUCING) {
             return new QueryBundle(Optional.empty(), ImmutableList.of(), statement, ImmutableList.of());
         }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.verifier.framework;
 
-import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.resolver.FailureResolver;
@@ -22,7 +21,7 @@ import javax.inject.Inject;
 
 import java.util.List;
 
-import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
+import static com.facebook.presto.verifier.framework.VerifierUtil.PARSING_OPTIONS;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -54,7 +53,7 @@ public class VerificationFactory
 
     public Verification get(SourceQuery sourceQuery)
     {
-        QueryType queryType = QueryType.of(sqlParser.createStatement(sourceQuery.getControlQuery(), new ParsingOptions(AS_DOUBLE)));
+        QueryType queryType = QueryType.of(sqlParser.createStatement(sourceQuery.getControlQuery(), PARSING_OPTIONS));
         switch (queryType.getCategory()) {
             case DATA_PRODUCING:
                 return new DataVerification(prestoAction, sourceQuery, queryRewriter, failureResolvers, config, checksumValidator);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationManager.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationManager.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.verifier.framework;
 
 import com.facebook.presto.sql.parser.ParsingException;
-import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.verifier.event.VerifierQueryEvent;
 import com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus;
@@ -40,13 +39,13 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
 
-import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
 import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.FAILED;
 import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.FAILED_RESOLVED;
 import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.SKIPPED;
 import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.SUCCEEDED;
 import static com.facebook.presto.verifier.framework.JdbcDriverUtil.initializeDrivers;
 import static com.facebook.presto.verifier.framework.QueryType.Category.DATA_PRODUCING;
+import static com.facebook.presto.verifier.framework.VerifierUtil.PARSING_OPTIONS;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;
@@ -202,8 +201,8 @@ public class VerificationManager
         ImmutableList.Builder<SourceQuery> selected = ImmutableList.builder();
         for (SourceQuery sourceQuery : sourceQueries) {
             try {
-                QueryType controlQueryType = QueryType.of(sqlParser.createStatement(sourceQuery.getControlQuery(), new ParsingOptions(AS_DOUBLE)));
-                QueryType testQueryType = QueryType.of(sqlParser.createStatement(sourceQuery.getTestQuery(), new ParsingOptions(AS_DOUBLE)));
+                QueryType controlQueryType = QueryType.of(sqlParser.createStatement(sourceQuery.getControlQuery(), PARSING_OPTIONS));
+                QueryType testQueryType = QueryType.of(sqlParser.createStatement(sourceQuery.getTestQuery(), PARSING_OPTIONS));
                 if (controlQueryType == testQueryType && controlQueryType.getCategory() == DATA_PRODUCING) {
                     selected.add(sourceQuery);
                 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierUtil.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierUtil.java
@@ -13,13 +13,18 @@
  */
 package com.facebook.presto.verifier.framework;
 
+import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.tree.Identifier;
+
+import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
 
 public class VerifierUtil
 {
     private VerifierUtil()
     {
     }
+
+    public static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build();
 
     public static Identifier delimitedIdentifier(String name)
     {

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
@@ -18,7 +18,6 @@ import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.SqlVarbinary;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
-import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.tree.QualifiedName;
@@ -43,10 +42,10 @@ import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.SqlFormatter.formatSql;
 import static com.facebook.presto.sql.parser.IdentifierSymbol.AT_SIGN;
 import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
-import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
 import static com.facebook.presto.verifier.framework.Column.Category.FLOATING_POINT;
 import static com.facebook.presto.verifier.framework.Column.Category.ORDERABLE_ARRAY;
 import static com.facebook.presto.verifier.framework.Column.Category.SIMPLE;
+import static com.facebook.presto.verifier.framework.VerifierUtil.PARSING_OPTIONS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -117,7 +116,7 @@ public class TestChecksumValidator
                         ", \"checksum\"(\"map_array\") \"map_array_checksum\"\n" +
                         "FROM\n" +
                         "  test:di",
-                new ParsingOptions(AS_DOUBLE));
+                PARSING_OPTIONS);
         assertEquals(checksumQuery, expectedChecksumQuery, "Actual: " + formatSql(checksumQuery, Optional.empty()));
     }
 

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryRewriter.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryRewriter.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.verifier.framework;
 
-import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.tree.Statement;
@@ -33,11 +32,11 @@ import java.util.Optional;
 
 import static com.facebook.presto.sql.parser.IdentifierSymbol.AT_SIGN;
 import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
-import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
 import static com.facebook.presto.verifier.VerifierTestUtil.CATALOG;
 import static com.facebook.presto.verifier.VerifierTestUtil.SCHEMA;
 import static com.facebook.presto.verifier.VerifierTestUtil.setupPresto;
 import static com.facebook.presto.verifier.framework.QueryOrigin.QueryGroup.CONTROL;
+import static com.facebook.presto.verifier.framework.VerifierUtil.PARSING_OPTIONS;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
@@ -183,7 +182,7 @@ public class TestQueryRewriter
     {
         return templates.stream()
                 .map(template -> format(template, tableName))
-                .map(query -> sqlParser.createStatement(query, new ParsingOptions(AS_DOUBLE)))
+                .map(query -> sqlParser.createStatement(query, PARSING_OPTIONS))
                 .collect(toImmutableList());
     }
 


### PR DESCRIPTION
The one-argument constructor has been depreacted.