### PR TITLE
Emit checksum query ID in the Verifier output event

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/event/QueryInfo.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/event/QueryInfo.java
@@ -31,6 +31,7 @@ public class QueryInfo
     private final String schema;
     private final String originalQuery;
     private final String queryId;
+    private final String checksumQueryId;
     private final String query;
     private final List<String> setupQueries;
     private final List<String> teardownQueries;
@@ -44,6 +45,7 @@ public class QueryInfo
             String schema,
             String originalQuery,
             Optional<String> queryId,
+            Optional<String> checksumQueryId,
             Optional<String> query,
             Optional<List<String>> setupQueries,
             Optional<List<String>> teardownQueries,
@@ -56,6 +58,7 @@ public class QueryInfo
         this.schema = requireNonNull(schema, "schema is null");
         this.originalQuery = requireNonNull(originalQuery, "originalQuery is null");
         this.queryId = queryId.orElse(null);
+        this.checksumQueryId = checksumQueryId.orElse(null);
         this.query = query.orElse(null);
         this.setupQueries = setupQueries.orElse(null);
         this.teardownQueries = teardownQueries.orElse(null);
@@ -87,6 +90,12 @@ public class QueryInfo
     public String getQueryId()
     {
         return queryId;
+    }
+
+    @EventField
+    public String getChecksumQueryId()
+    {
+        return checksumQueryId;
     }
 
     @EventField

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/event/QueryInfo.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/event/QueryInfo.java
@@ -66,12 +66,6 @@ public class QueryInfo
     }
 
     @EventField
-    public String getQueryId()
-    {
-        return queryId;
-    }
-
-    @EventField
     public String getCatalog()
     {
         return catalog;
@@ -87,6 +81,12 @@ public class QueryInfo
     public String getOriginalQuery()
     {
         return originalQuery;
+    }
+
+    @EventField
+    public String getQueryId()
+    {
+        return queryId;
     }
 
     @EventField

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
@@ -21,8 +21,8 @@ import com.facebook.presto.verifier.event.FailureInfo;
 import com.facebook.presto.verifier.event.QueryInfo;
 import com.facebook.presto.verifier.event.VerifierQueryEvent;
 import com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus;
+import com.facebook.presto.verifier.framework.MatchResult.MatchType;
 import com.facebook.presto.verifier.framework.QueryOrigin.QueryGroup;
-import com.facebook.presto.verifier.framework.VerificationResult.MatchType;
 import com.facebook.presto.verifier.resolver.FailureResolver;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
@@ -84,7 +84,7 @@ public abstract class AbstractVerification
         this.runTearDownOnResultMismatch = config.isRunTearDownOnResultMismatch();
     }
 
-    protected abstract VerificationResult verify(QueryBundle control, QueryBundle test);
+    protected abstract MatchResult verify(QueryBundle control, QueryBundle test);
 
     protected abstract Optional<Boolean> isDeterministic(QueryBundle control, ChecksumResult firstChecksum);
 
@@ -105,7 +105,7 @@ public abstract class AbstractVerification
         boolean resultMismatched = false;
         QueryBundle control = null;
         QueryBundle test = null;
-        VerificationResult verificationResult = null;
+        MatchResult verificationResult = null;
         Optional<Boolean> deterministic = Optional.empty();
 
         try {
@@ -199,7 +199,7 @@ public abstract class AbstractVerification
             Optional<QueryStats> controlStats,
             Optional<QueryStats> testStats,
             Optional<QueryException> queryException,
-            Optional<VerificationResult> verificationResult,
+            Optional<MatchResult> verificationResult,
             Optional<Boolean> deterministic)
     {
         boolean succeeded = verificationResult.isPresent() && verificationResult.get().isMatched();
@@ -244,7 +244,7 @@ public abstract class AbstractVerification
         Optional<String> errorCode = Optional.empty();
         if (!succeeded) {
             errorCode = Optional.ofNullable(queryException.map(QueryException::getErrorCode).orElse(
-                    verificationResult.map(VerificationResult::getMatchType).map(MatchType::name).orElse(null)));
+                    verificationResult.map(MatchResult::getMatchType).map(MatchType::name).orElse(null)));
         }
 
         return new VerifierQueryEvent(
@@ -257,14 +257,14 @@ public abstract class AbstractVerification
                 buildQueryInfo(
                         sourceQuery.getControlConfiguration(),
                         sourceQuery.getControlQuery(),
-                        verificationResult.flatMap(VerificationResult::getControlChecksumQuery),
+                        verificationResult.flatMap(MatchResult::getControlChecksumQuery),
                         control,
                         controlStats,
                         verificationContext.getAllFailures(CONTROL)),
                 buildQueryInfo(
                         sourceQuery.getTestConfiguration(),
                         sourceQuery.getTestQuery(),
-                        verificationResult.flatMap(VerificationResult::getTestChecksumQuery),
+                        verificationResult.flatMap(MatchResult::getTestChecksumQuery),
                         test,
                         testStats,
                         verificationContext.getAllFailures(TEST)),

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
@@ -257,6 +257,7 @@ public abstract class AbstractVerification
                 buildQueryInfo(
                         sourceQuery.getControlConfiguration(),
                         sourceQuery.getControlQuery(),
+                        verificationResult.map(VerificationResult::getControlChecksumQueryId),
                         verificationResult.map(VerificationResult::getControlChecksumQuery),
                         control,
                         controlStats,
@@ -264,6 +265,7 @@ public abstract class AbstractVerification
                 buildQueryInfo(
                         sourceQuery.getTestConfiguration(),
                         sourceQuery.getTestQuery(),
+                        verificationResult.map(VerificationResult::getTestChecksumQueryId),
                         verificationResult.map(VerificationResult::getTestChecksumQuery),
                         test,
                         testStats,
@@ -286,6 +288,7 @@ public abstract class AbstractVerification
     private static QueryInfo buildQueryInfo(
             QueryConfiguration configuration,
             String originalQuery,
+            Optional<String> checksumQueryId,
             Optional<String> checksumQuery,
             Optional<QueryBundle> queryBundle,
             Optional<QueryStats> queryStats,
@@ -296,6 +299,7 @@ public abstract class AbstractVerification
                 configuration.getSchema(),
                 originalQuery,
                 queryStats.map(QueryStats::getQueryId),
+                checksumQueryId,
                 queryBundle.map(QueryBundle::getQuery).map(AbstractVerification::formatSql),
                 queryBundle.map(QueryBundle::getSetupQueries).map(AbstractVerification::formatSqls),
                 queryBundle.map(QueryBundle::getTeardownQueries).map(AbstractVerification::formatSqls),

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/MatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/MatchResult.java
@@ -40,8 +40,6 @@ public class MatchResult
     }
 
     private final MatchType matchType;
-    private final Optional<String> controlChecksumQuery;
-    private final Optional<String> testChecksumQuery;
     private final Optional<ChecksumResult> controlChecksum;
     private final OptionalLong controlRowCount;
     private final OptionalLong testRowCount;
@@ -49,16 +47,12 @@ public class MatchResult
 
     public MatchResult(
             MatchType matchType,
-            Optional<String> controlChecksumQuery,
-            Optional<String> testChecksumQuery,
             Optional<ChecksumResult> controlChecksum,
             OptionalLong controlRowCount,
             OptionalLong testRowCount,
             Map<Column, ColumnMatchResult> mismatchedColumns)
     {
         this.matchType = requireNonNull(matchType, "type is null");
-        this.controlChecksumQuery = requireNonNull(controlChecksumQuery, "controlChecksumQuery is null");
-        this.testChecksumQuery = requireNonNull(testChecksumQuery, "testChecksumQuery is null");
         this.controlChecksum = requireNonNull(controlChecksum, "controlChecksum is null");
         this.controlRowCount = requireNonNull(controlRowCount, "controlRowCount is null");
         this.testRowCount = requireNonNull(testRowCount, "testRowCount is null");
@@ -73,16 +67,6 @@ public class MatchResult
     public MatchType getMatchType()
     {
         return matchType;
-    }
-
-    public Optional<String> getControlChecksumQuery()
-    {
-        return controlChecksumQuery;
-    }
-
-    public Optional<String> getTestChecksumQuery()
-    {
-        return testChecksumQuery;
     }
 
     public ChecksumResult getControlChecksum()

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/MatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/MatchResult.java
@@ -21,15 +21,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-import static com.facebook.presto.verifier.framework.VerificationResult.MatchType.COLUMN_MISMATCH;
-import static com.facebook.presto.verifier.framework.VerificationResult.MatchType.MATCH;
-import static com.facebook.presto.verifier.framework.VerificationResult.MatchType.ROW_COUNT_MISMATCH;
-import static com.facebook.presto.verifier.framework.VerificationResult.MatchType.SCHEMA_MISMATCH;
+import static com.facebook.presto.verifier.framework.MatchResult.MatchType.COLUMN_MISMATCH;
+import static com.facebook.presto.verifier.framework.MatchResult.MatchType.MATCH;
+import static com.facebook.presto.verifier.framework.MatchResult.MatchType.ROW_COUNT_MISMATCH;
+import static com.facebook.presto.verifier.framework.MatchResult.MatchType.SCHEMA_MISMATCH;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-public class VerificationResult
+public class MatchResult
 {
     public enum MatchType
     {
@@ -47,7 +47,7 @@ public class VerificationResult
     private final OptionalLong testRowCount;
     private final Map<Column, ColumnMatchResult> mismatchedColumns;
 
-    public VerificationResult(
+    public MatchResult(
             MatchType matchType,
             Optional<String> controlChecksumQuery,
             Optional<String> testChecksumQuery,

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationResult.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import static java.util.Objects.requireNonNull;
+
+public class VerificationResult
+{
+    private final String controlChecksumQuery;
+    private final String testChecksumQuery;
+    private final MatchResult matchResult;
+
+    public VerificationResult(
+            String controlChecksumQuery,
+            String testChecksumQuery,
+            MatchResult matchResult)
+    {
+        this.controlChecksumQuery = requireNonNull(controlChecksumQuery, "controlChecksumQuery is null");
+        this.testChecksumQuery = requireNonNull(testChecksumQuery, "testChecksumQuery is null");
+        this.matchResult = requireNonNull(matchResult, "matchResult is null");
+    }
+
+    public String getControlChecksumQuery()
+    {
+        return controlChecksumQuery;
+    }
+
+    public String getTestChecksumQuery()
+    {
+        return testChecksumQuery;
+    }
+
+    public MatchResult getMatchResult()
+    {
+        return matchResult;
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationResult.java
@@ -17,23 +17,39 @@ import static java.util.Objects.requireNonNull;
 
 public class VerificationResult
 {
+    private final String controlChecksumQueryId;
+    private final String testChecksumQueryId;
     private final String controlChecksumQuery;
     private final String testChecksumQuery;
     private final MatchResult matchResult;
 
     public VerificationResult(
+            String controlChecksumQueryId,
+            String testChecksumQueryId,
             String controlChecksumQuery,
             String testChecksumQuery,
             MatchResult matchResult)
     {
+        this.controlChecksumQueryId = requireNonNull(controlChecksumQueryId, "controlChecksumQueryId is null");
+        this.testChecksumQueryId = requireNonNull(testChecksumQueryId, "testChecksumQueryId is null");
         this.controlChecksumQuery = requireNonNull(controlChecksumQuery, "controlChecksumQuery is null");
         this.testChecksumQuery = requireNonNull(testChecksumQuery, "testChecksumQuery is null");
         this.matchResult = requireNonNull(matchResult, "matchResult is null");
     }
 
+    public String getControlChecksumQueryId()
+    {
+        return controlChecksumQueryId;
+    }
+
     public String getControlChecksumQuery()
     {
         return controlChecksumQuery;
+    }
+
+    public String getTestChecksumQueryId()
+    {
+        return testChecksumQueryId;
     }
 
     public String getTestChecksumQuery()


### PR DESCRIPTION
During the process of debugging row count mismatch, we found it useful to have the verifier log checksum query id.