### PR TITLE
Auto-resolve EXCEEDED_TIME_LIMIT regardless of CPU time increase

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededTimeLimitFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededTimeLimitFailureResolver.java
@@ -33,8 +33,7 @@ public class ExceededTimeLimitFailureResolver
     @Override
     public Optional<String> resolveTestQueryFailure(ErrorCodeSupplier errorCode, QueryStats controlQueryStats, QueryStats testQueryStats)
     {
-        if (errorCode == EXCEEDED_TIME_LIMIT &&
-                controlQueryStats.getCpuTimeMillis() > testQueryStats.getCpuTimeMillis()) {
+        if (errorCode == EXCEEDED_TIME_LIMIT) {
             return Optional.of("Auto Resolved: Test cluster has less computing resource");
         }
         return Optional.empty();

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestExceededTimeLimitFailureResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestExceededTimeLimitFailureResolver.java
@@ -22,7 +22,6 @@ import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_TIME_LIMIT;
 import static com.facebook.presto.verifier.framework.QueryOrigin.TargetCluster.TEST;
 import static com.facebook.presto.verifier.framework.QueryOrigin.forMain;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 
 public class TestExceededTimeLimitFailureResolver
         extends AbstractTestPrestoQueryFailureResolver
@@ -30,20 +29,6 @@ public class TestExceededTimeLimitFailureResolver
     public TestExceededTimeLimitFailureResolver()
     {
         super(new ExceededTimeLimitFailureResolver());
-    }
-
-    @Test
-    public void testHigherCpuTime()
-    {
-        assertFalse(getFailureResolver().resolve(
-                CONTROL_QUERY_STATS,
-                QueryException.forPresto(
-                        new RuntimeException(),
-                        Optional.of(EXCEEDED_TIME_LIMIT),
-                        false,
-                        Optional.of(createQueryStats(CONTROL_CPU_TIME_MILLIS * 2, CONTROL_PEAK_MEMORY_BYTES)),
-                        forMain(TEST)))
-                .isPresent());
     }
 
     @Test


### PR DESCRIPTION
Until we're able to identify the cause of huge CPU time difference between control and test queries and to reduce it, we should allow the verifier to automatically resolve those failures to minimize noise.