### PR TITLE
Encode PlanFragmentId as string in JSON

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanFragmentId.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanFragmentId.java
@@ -18,28 +18,35 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import javax.annotation.concurrent.Immutable;
 
+import static java.util.Objects.requireNonNull;
+
 @Immutable
 public class PlanFragmentId
         implements Comparable<PlanFragmentId>
 {
     private final int id;
 
-    @JsonCreator
     public PlanFragmentId(int id)
     {
         this.id = id;
     }
 
-    @JsonValue
     public int getId()
     {
         return id;
     }
 
     @Override
+    @JsonValue
     public String toString()
     {
         return Integer.toString(id);
+    }
+
+    @JsonCreator
+    public static PlanFragmentId valueOf(String value)
+    {
+        return new PlanFragmentId(Integer.valueOf(requireNonNull(value, "value is null")));
     }
 
     @Override


### PR DESCRIPTION
The "Create stage id based on the plan fragment id" commit changed the
way the PlanFragmentId is encoded in JSON:

326f805

Before this patch the value had been encoded as a String, and after
this patch the PlanFragmentId started to be encoded as a number.

This breaks the "Live Plan" UI, as the "Live Plan" controller doesn't
match the remote source ids that are still encoded as strings
(see JsonRenderedNode):

https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/JsonRenderer.java#L53
https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/JsonRenderer.java#L64
https://github.com/prestodb/presto/blob/master/presto-main/src/main/resources/webapp/src/components/LivePlan.jsx#L238

An alternative solution is to encode JsonRenderedNode#remoteSources
as a number as well. However, since all other ids (PlanNodeId, StageId)
are encoded as a string, it seems to be more convenient to also have
the PlanFragmentId encoded as a string.