### PR TITLE
 Allow materializing partitioning inferred by join

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithExchangeMaterialization.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithExchangeMaterialization.java
@@ -189,6 +189,99 @@ public class TestHiveDistributedQueriesWithExchangeMaterialization
     }
 
     @Test
+    public void testExchangeMaterializationWithConstantFolding()
+    {
+        try {
+            assertUpdate(
+                    // bucket count has to be different from materialized bucket number
+                    "CREATE TABLE test_constant_folding_lineitem_bucketed\n" +
+                            "WITH (bucket_count = 17, bucketed_by = ARRAY['partkey_mod_9', 'partkey', 'suppkey', 'suppkey_varchar']) AS\n" +
+                            "SELECT partkey % 9 partkey_mod_9, partkey, suppkey, CAST(suppkey AS VARCHAR) suppkey_varchar, comment FROM lineitem",
+                    "SELECT count(*) from lineitem");
+            assertUpdate(
+                    "CREATE TABLE test_constant_folding_partsupp_unbucketed AS\n" +
+                            "SELECT partkey % 9 partkey_mod_9, partkey, suppkey, CAST(suppkey AS VARCHAR) suppkey_varchar, comment FROM partsupp",
+                    "SELECT count(*) from partsupp");
+
+            // one constant, third position (suppkey BIGINT)
+            assertQuery(
+                    getSession(),
+                    "SELECT lineitem.partkey, lineitem.suppkey, lineitem.comment lineitem_comment, partsupp.comment partsupp_comment\n" +
+                            "FROM test_constant_folding_lineitem_bucketed lineitem JOIN test_constant_folding_partsupp_unbucketed partsupp\n" +
+                            "ON\n" +
+                            "  lineitem.partkey = partsupp.partkey AND\n" +
+                            "  lineitem.partkey_mod_9 = partsupp.partkey_mod_9 AND\n" +
+                            "  lineitem.suppkey = partsupp.suppkey AND\n" +
+                            "  lineitem.suppkey_varchar = partsupp.suppkey_varchar\n" +
+                            "WHERE lineitem.suppkey = 42",
+                    "SELECT lineitem.partkey, lineitem.suppkey, lineitem.comment lineitem_comment, partsupp.comment partsupp_comment\n" +
+                            "FROM lineitem JOIN partsupp\n" +
+                            "ON lineitem.partkey = partsupp.partkey AND\n" +
+                            "lineitem.suppkey = partsupp.suppkey\n" +
+                            "WHERE lineitem.suppkey = 42",
+                    assertRemoteMaterializedExchangesCount(1));
+
+            // one constant, fourth position (suppkey_varchar VARCHAR)
+            assertQuery(
+                    getSession(),
+                    "SELECT lineitem.partkey, lineitem.suppkey, lineitem.comment lineitem_comment, partsupp.comment partsupp_comment\n" +
+                            "FROM test_constant_folding_lineitem_bucketed lineitem JOIN test_constant_folding_partsupp_unbucketed partsupp\n" +
+                            "ON\n" +
+                            "  lineitem.partkey = partsupp.partkey AND\n" +
+                            "  lineitem.partkey_mod_9 = partsupp.partkey_mod_9 AND\n" +
+                            "  lineitem.suppkey = partsupp.suppkey AND\n" +
+                            "  lineitem.suppkey_varchar = partsupp.suppkey_varchar\n" +
+                            "WHERE lineitem.suppkey_varchar = '42'",
+                    "SELECT lineitem.partkey, lineitem.suppkey, lineitem.comment lineitem_comment, partsupp.comment partsupp_comment\n" +
+                            "FROM lineitem JOIN partsupp\n" +
+                            "ON lineitem.partkey = partsupp.partkey AND\n" +
+                            "lineitem.suppkey = partsupp.suppkey\n" +
+                            "WHERE lineitem.suppkey = 42",
+                    assertRemoteMaterializedExchangesCount(1));
+
+            // two constants, first and third position (partkey_mod_9 BIGINT, suppkey BIGINT)
+            assertQuery(
+                    getSession(),
+                    "SELECT lineitem.partkey, lineitem.suppkey, lineitem.comment lineitem_comment, partsupp.comment partsupp_comment\n" +
+                    "FROM test_constant_folding_lineitem_bucketed lineitem JOIN test_constant_folding_partsupp_unbucketed partsupp\n" +
+                    "ON\n" +
+                    "  lineitem.partkey = partsupp.partkey AND\n" +
+                    "  lineitem.partkey_mod_9 = partsupp.partkey_mod_9 AND\n" +
+                    "  lineitem.suppkey = partsupp.suppkey AND\n" +
+                    "  lineitem.suppkey_varchar = partsupp.suppkey_varchar\n" +
+                    "WHERE lineitem.partkey_mod_9 = 7 AND lineitem.suppkey = 42",
+                    "SELECT lineitem.partkey, lineitem.suppkey, lineitem.comment lineitem_comment, partsupp.comment partsupp_comment\n" +
+                            "FROM lineitem JOIN partsupp\n" +
+                            "ON lineitem.partkey = partsupp.partkey AND\n" +
+                            "lineitem.suppkey = partsupp.suppkey\n" +
+                            "WHERE lineitem.partkey % 9 = 7 AND lineitem.suppkey = 42",
+                    assertRemoteMaterializedExchangesCount(1));
+
+            // two constants, first and forth position (partkey_mod_9 BIGINT, suppkey_varchar VARCHAR)
+            assertQuery(
+                    getSession(),
+                    "SELECT lineitem.partkey, lineitem.suppkey, lineitem.comment lineitem_comment, partsupp.comment partsupp_comment\n" +
+                    "FROM test_constant_folding_lineitem_bucketed lineitem JOIN test_constant_folding_partsupp_unbucketed partsupp\n" +
+                    "ON\n" +
+                    "  lineitem.partkey = partsupp.partkey AND\n" +
+                    "  lineitem.partkey_mod_9 = partsupp.partkey_mod_9 AND\n" +
+                    "  lineitem.suppkey = partsupp.suppkey AND\n" +
+                    "  lineitem.suppkey_varchar = partsupp.suppkey_varchar\n" +
+                    "WHERE lineitem.partkey_mod_9 = 7 AND lineitem.suppkey_varchar = '42'",
+                    "SELECT lineitem.partkey, lineitem.suppkey, lineitem.comment lineitem_comment, partsupp.comment partsupp_comment\n" +
+                            "FROM lineitem JOIN partsupp\n" +
+                            "ON lineitem.partkey = partsupp.partkey AND\n" +
+                            "lineitem.suppkey = partsupp.suppkey\n" +
+                            "WHERE lineitem.partkey % 9 = 7 AND lineitem.suppkey = 42",
+                    assertRemoteMaterializedExchangesCount(1));
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS test_constant_folding_lineitem_bucketed");
+            assertUpdate("DROP TABLE IF EXISTS test_constant_folding_partsupp_unbucketed");
+        }
+    }
+
+    @Test
     public void testExplainOfCreateTableAs()
     {
         String query = "CREATE TABLE copy_orders AS SELECT * FROM orders";

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -717,9 +717,12 @@ public class AddExchanges
                 Partitioning rightPartitioning = left.getProperties().translate(createTranslator(leftToRight)).getNodePartitioning().get();
                 right = node.getRight().accept(this, PreferredProperties.partitioned(rightPartitioning));
                 if (!right.getProperties().isCompatibleTablePartitioningWith(left.getProperties(), rightToLeft::get, metadata, session)) {
-                    // TODO: support materialization when one of the tables is pre-bucketed
                     right = withDerivedProperties(
-                            partitionedExchange(idAllocator.getNextId(), REMOTE_STREAMING, right.getNode(), new PartitioningScheme(rightPartitioning, right.getNode().getOutputSymbols())),
+                            partitionedExchange(
+                                    idAllocator.getNextId(),
+                                    selectExchangeScopeForPartitionedRemoteExchange(right.getNode()),
+                                    right.getNode(),
+                                    new PartitioningScheme(rightPartitioning, right.getNode().getOutputSymbols())),
                             right.getProperties());
                 }
             }
@@ -728,9 +731,12 @@ public class AddExchanges
 
                 if (right.getProperties().isNodePartitionedOn(rightSymbols) && !right.getProperties().isSingleNode()) {
                     Partitioning leftPartitioning = right.getProperties().translate(createTranslator(rightToLeft)).getNodePartitioning().get();
-                    // TODO: support materialization when one of the tables is pre-bucketed
                     left = withDerivedProperties(
-                            partitionedExchange(idAllocator.getNextId(), REMOTE_STREAMING, left.getNode(), new PartitioningScheme(leftPartitioning, left.getNode().getOutputSymbols())),
+                            partitionedExchange(
+                                    idAllocator.getNextId(),
+                                    selectExchangeScopeForPartitionedRemoteExchange(left.getNode()),
+                                    left.getNode(),
+                                    new PartitioningScheme(leftPartitioning, left.getNode().getOutputSymbols())),
                             left.getProperties());
                 }
                 else {
@@ -758,9 +764,11 @@ public class AddExchanges
             // if colocated joins are disabled, force redistribute when using a custom partitioning
             if (!isColocatedJoinEnabled(session) && hasMultipleTableScans(left.getNode(), right.getNode())) {
                 Partitioning rightPartitioning = left.getProperties().translate(createTranslator(leftToRight)).getNodePartitioning().get();
-                // TODO: support materialization when one of the tables is pre-bucketed
                 right = withDerivedProperties(
-                        partitionedExchange(idAllocator.getNextId(), REMOTE_STREAMING, right.getNode(), new PartitioningScheme(rightPartitioning, right.getNode().getOutputSymbols())),
+                        partitionedExchange(
+                                idAllocator.getNextId(),
+                                selectExchangeScopeForPartitionedRemoteExchange(right.getNode()), right.getNode(),
+                                new PartitioningScheme(rightPartitioning, right.getNode().getOutputSymbols())),
                         right.getProperties());
             }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -81,6 +81,7 @@ import static io.airlift.tpch.TpchTable.LINE_ITEM;
 import static io.airlift.tpch.TpchTable.NATION;
 import static io.airlift.tpch.TpchTable.ORDERS;
 import static io.airlift.tpch.TpchTable.PART;
+import static io.airlift.tpch.TpchTable.PART_SUPPLIER;
 import static io.airlift.tpch.TpchTable.REGION;
 import static java.lang.String.format;
 import static java.util.Collections.nCopies;
@@ -129,6 +130,16 @@ public class H2QueryRunner
                 "  PRIMARY KEY (orderkey, linenumber)" +
                 ")");
         insertRows(tpchMetadata, LINE_ITEM);
+
+        handle.execute(" CREATE TABLE partsupp (\n" +
+                "  partkey BIGINT NOT NULL,\n" +
+                "  suppkey BIGINT NOT NULL,\n" +
+                "  availqty INTEGER NOT NULL,\n" +
+                "  supplycost DOUBLE NOT NULL,\n" +
+                "  comment VARCHAR(199) NOT NULL,\n" +
+                "  PRIMARY KEY(partkey, suppkey)" +
+                ")");
+        insertRows(tpchMetadata, PART_SUPPLIER);
 
         handle.execute("CREATE TABLE nation (\n" +
                 "  nationkey BIGINT PRIMARY KEY,\n" +


### PR DESCRIPTION
A loose ends from https://github.com/prestodb/presto/pull/12568, the first commit are squashed from https://github.com/prestodb/presto/pull/12604. Thus it's part of #12387 :) 