### PR TITLE
Allow extract fixed domain from RowExpression

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
@@ -15,7 +15,18 @@ package com.facebook.presto.cost;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.warnings.WarningCollector;
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.metadata.FunctionMetadata;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.ExpressionAnalyzer;
 import com.facebook.presto.sql.analyzer.Scope;
@@ -23,8 +34,10 @@ import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.LiteralInterpreter;
 import com.facebook.presto.sql.planner.NoOpSymbolResolver;
+import com.facebook.presto.sql.planner.RowExpressionInterpreter;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.relational.StandardFunctionResolution;
 import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.BetweenPredicate;
 import com.facebook.presto.sql.tree.BooleanLiteral;
@@ -45,6 +58,7 @@ import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nullable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -55,11 +69,19 @@ import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.addStatsAndSumD
 import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.capStats;
 import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.subtractSubsetStats;
 import static com.facebook.presto.cost.StatsUtil.toStatsRepresentation;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.sql.ExpressionUtils.and;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.and;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.EQUAL;
+import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.GREATER_THAN;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.IS_DISTINCT_FROM;
+import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.LESS_THAN;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.NOT_EQUAL;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Double.NaN;
@@ -78,6 +100,7 @@ public class FilterStatsCalculator
     private final ScalarStatsCalculator scalarStatsCalculator;
     private final StatsNormalizer normalizer;
     private final LiteralEncoder literalEncoder;
+    private final StandardFunctionResolution functionResolution;
 
     public FilterStatsCalculator(Metadata metadata, ScalarStatsCalculator scalarStatsCalculator, StatsNormalizer normalizer)
     {
@@ -85,8 +108,10 @@ public class FilterStatsCalculator
         this.scalarStatsCalculator = requireNonNull(scalarStatsCalculator, "scalarStatsCalculator is null");
         this.normalizer = requireNonNull(normalizer, "normalizer is null");
         this.literalEncoder = new LiteralEncoder(metadata.getBlockEncodingSerde());
+        this.functionResolution = new StandardFunctionResolution(metadata.getFunctionManager());
     }
 
+    @Deprecated
     public PlanNodeStatsEstimate filterStats(
             PlanNodeStatsEstimate statsEstimate,
             Expression predicate,
@@ -96,6 +121,17 @@ public class FilterStatsCalculator
         Expression simplifiedExpression = simplifyExpression(session, predicate, types);
         return new FilterExpressionStatsCalculatingVisitor(statsEstimate, session, types)
                 .process(simplifiedExpression);
+    }
+
+    // TODO: remove types once we have type info in PlanNodeStatsEstimate
+    public PlanNodeStatsEstimate filterStats(
+            PlanNodeStatsEstimate statsEstimate,
+            RowExpression predicate,
+            Session session,
+            TypeProvider types)
+    {
+        RowExpression simplifiedExpression = simplifyExpression(session, predicate);
+        return new FilterRowExpressionStatsCalculatingVisitor(statsEstimate, session, metadata.getFunctionManager(), types).process(simplifiedExpression);
     }
 
     private Expression simplifyExpression(Session session, Expression predicate, TypeProvider types)
@@ -111,6 +147,18 @@ public class FilterStatsCalculator
             value = false;
         }
         return literalEncoder.toExpression(value, BOOLEAN);
+    }
+
+    private RowExpression simplifyExpression(Session session, RowExpression predicate)
+    {
+        RowExpressionInterpreter interpreter = new RowExpressionInterpreter(predicate, metadata, session, true);
+        Object value = interpreter.optimize();
+
+        if (value == null) {
+            // Expression evaluates to SQL null, which in Filter is equivalent to false. This assumes the expression is a top-level expression (eg. not in NOT).
+            value = false;
+        }
+        return LiteralEncoder.toRowExpression(value, BOOLEAN);
     }
 
     private Map<NodeRef<Expression>, Type> getExpressionTypes(Session session, Expression expression, TypeProvider types)
@@ -421,6 +469,363 @@ public class FilterStatsCalculator
         {
             Object literalValue = LiteralInterpreter.evaluate(metadata, session.toConnectorSession(), literal);
             return toStatsRepresentation(metadata, session, type, literalValue);
+        }
+    }
+
+    private class FilterRowExpressionStatsCalculatingVisitor
+            implements RowExpressionVisitor<PlanNodeStatsEstimate, Void>
+    {
+        private final PlanNodeStatsEstimate input;
+        private final Session session;
+        private final FunctionManager functionManager;
+        private final TypeProvider types;
+
+        FilterRowExpressionStatsCalculatingVisitor(PlanNodeStatsEstimate input, Session session, FunctionManager functionManager, TypeProvider types)
+        {
+            this.input = requireNonNull(input, "input is null");
+            this.session = requireNonNull(session, "session is null");
+            this.functionManager = requireNonNull(functionManager, "functionManager is null");
+            this.types = requireNonNull(types, "types is null");
+        }
+
+        @Override
+        public PlanNodeStatsEstimate visitSpecialForm(SpecialFormExpression node, Void context)
+        {
+            switch (node.getForm()) {
+                case AND: {
+                    return estimateLogicalAnd(node.getArguments().get(0), node.getArguments().get(1));
+                }
+                case OR: {
+                    return estimateLogicalOr(node.getArguments().get(0), node.getArguments().get(1));
+                }
+                case IN: {
+                    return estimateIn(node.getArguments().get(0), node.getArguments().subList(1, node.getArguments().size()));
+                }
+                case IS_NULL: {
+                    return estimateIsNull(node.getArguments().get(0));
+                }
+                default:
+                    return PlanNodeStatsEstimate.unknown();
+            }
+        }
+
+        @Override
+        public PlanNodeStatsEstimate visitConstant(ConstantExpression node, Void context)
+        {
+            if (node.getType().equals(BOOLEAN)) {
+                if ((boolean) node.getValue()) {
+                    return input;
+                }
+                PlanNodeStatsEstimate.Builder result = PlanNodeStatsEstimate.builder();
+                result.setOutputRowCount(0.0);
+                input.getSymbolsWithKnownStatistics().forEach(symbol -> result.addSymbolStatistics(symbol, SymbolStatsEstimate.zero()));
+                return result.build();
+            }
+            return PlanNodeStatsEstimate.unknown();
+        }
+
+        @Override
+        public PlanNodeStatsEstimate visitLambda(LambdaDefinitionExpression node, Void context)
+        {
+            return PlanNodeStatsEstimate.unknown();
+        }
+
+        @Override
+        public PlanNodeStatsEstimate visitVariableReference(VariableReferenceExpression node, Void context)
+        {
+            return PlanNodeStatsEstimate.unknown();
+        }
+
+        @Override
+        public PlanNodeStatsEstimate visitCall(CallExpression node, Void context)
+        {
+            // comparison case
+            FunctionMetadata functionMetadata = metadata.getFunctionManager().getFunctionMetadata(node.getFunctionHandle());
+            if (functionMetadata.getOperatorType().map(OperatorType::isComparisonOperator).orElse(false)) {
+                OperatorType operatorType = functionMetadata.getOperatorType().get();
+                RowExpression left = node.getArguments().get(0);
+                RowExpression right = node.getArguments().get(1);
+
+                checkArgument(!(left instanceof ConstantExpression && right instanceof ConstantExpression), "Literal-to-literal not supported here, should be eliminated earlier");
+
+                if (!(left instanceof VariableReferenceExpression) && right instanceof VariableReferenceExpression) {
+                    // normalize so that symbol is on the left
+                    return process(call(metadata.getFunctionManager().resolveOperator(flip(operatorType), fromTypes(right.getType(), left.getType())), BOOLEAN, right, left));
+                }
+
+                if (left instanceof ConstantExpression) {
+                    // normalize so that literal is on the right
+                    return process(call(metadata.getFunctionManager().resolveOperator(flip(operatorType), fromTypes(right.getType(), left.getType())), BOOLEAN, right, left));
+                }
+
+                if (left instanceof VariableReferenceExpression && left.equals(right)) {
+                    return process(not(isNull(left)));
+                }
+
+                SymbolStatsEstimate leftStats = getRowExpressionStats(left);
+                Optional<Symbol> leftSymbol = left instanceof VariableReferenceExpression ? Optional.of(new Symbol(((VariableReferenceExpression) left).getName())) : Optional.empty();
+                if (right instanceof ConstantExpression) {
+                    OptionalDouble literal = toStatsRepresentation(metadata, session, right.getType(), ((ConstantExpression) right).getValue());
+                    return estimateExpressionToLiteralComparison(input, leftStats, leftSymbol, literal, getComparisonOperator(operatorType));
+                }
+
+                SymbolStatsEstimate rightStats = getRowExpressionStats(right);
+                if (rightStats.isSingleValue()) {
+                    OptionalDouble value = isNaN(rightStats.getLowValue()) ? OptionalDouble.empty() : OptionalDouble.of(rightStats.getLowValue());
+                    return estimateExpressionToLiteralComparison(input, leftStats, leftSymbol, value, getComparisonOperator(operatorType));
+                }
+
+                Optional<Symbol> rightSymbol = right instanceof VariableReferenceExpression ? Optional.of(new Symbol(((VariableReferenceExpression) right).getName())) : Optional.empty();
+                return estimateExpressionToExpressionComparison(input, leftStats, leftSymbol, rightStats, rightSymbol, getComparisonOperator(operatorType));
+            }
+
+            // NOT case
+            if (node.getFunctionHandle().equals(functionResolution.notFunction())) {
+                RowExpression arguemnt = node.getArguments().get(0);
+                if (arguemnt instanceof SpecialFormExpression && ((SpecialFormExpression) arguemnt).getForm().equals(IS_NULL)) {
+                    // IS NOT NULL case
+                    RowExpression innerArugment = ((SpecialFormExpression) arguemnt).getArguments().get(0);
+                    if (innerArugment instanceof VariableReferenceExpression) {
+                        Symbol symbol = new Symbol(((VariableReferenceExpression) innerArugment).getName());
+                        SymbolStatsEstimate symbolStats = input.getSymbolStatistics(symbol);
+                        PlanNodeStatsEstimate.Builder result = PlanNodeStatsEstimate.buildFrom(input);
+                        result.setOutputRowCount(input.getOutputRowCount() * (1 - symbolStats.getNullsFraction()));
+                        result.addSymbolStatistics(symbol, symbolStats.mapNullsFraction(x -> 0.0));
+                        return result.build();
+                    }
+                    return PlanNodeStatsEstimate.unknown();
+                }
+                return subtractSubsetStats(input, process(arguemnt));
+            }
+
+            // BETWEEN case
+            if (functionResolution.isBetweenFunction(node.getFunctionHandle())) {
+                RowExpression value = node.getArguments().get(0);
+                RowExpression min = node.getArguments().get(1);
+                RowExpression max = node.getArguments().get(2);
+                if (!(value instanceof VariableReferenceExpression)) {
+                    return PlanNodeStatsEstimate.unknown();
+                }
+                if (!getRowExpressionStats(min).isSingleValue()) {
+                    return PlanNodeStatsEstimate.unknown();
+                }
+                if (!getRowExpressionStats(max).isSingleValue()) {
+                    return PlanNodeStatsEstimate.unknown();
+                }
+
+                SymbolStatsEstimate valueStats = input.getSymbolStatistics(new Symbol(((VariableReferenceExpression) value).getName()));
+                RowExpression lowerBound = call(
+                        metadata.getFunctionManager().resolveOperator(OperatorType.GREATER_THAN_OR_EQUAL, fromTypes(value.getType(), min.getType())),
+                        BOOLEAN,
+                        value,
+                        min);
+                RowExpression upperBound = call(
+                        metadata.getFunctionManager().resolveOperator(OperatorType.LESS_THAN_OR_EQUAL, fromTypes(value.getType(), max.getType())),
+                        BOOLEAN,
+                        value,
+                        max);
+
+                RowExpression transformed;
+                if (isInfinite(valueStats.getLowValue())) {
+                    // We want to do heuristic cut (infinite range to finite range) ASAP and then do filtering on finite range.
+                    // We rely on 'and()' being processed left to right
+                    transformed = and(lowerBound, upperBound);
+                }
+                else {
+                    transformed = and(upperBound, lowerBound);
+                }
+                return process(transformed);
+            }
+
+            return PlanNodeStatsEstimate.unknown();
+        }
+
+        @Override
+        public PlanNodeStatsEstimate visitInputReference(InputReferenceExpression node, Void context)
+        {
+            throw new UnsupportedOperationException("plan node stats estimation should not reach channel mapping");
+        }
+
+        private FilterRowExpressionStatsCalculatingVisitor newEstimate(PlanNodeStatsEstimate input)
+        {
+            return new FilterRowExpressionStatsCalculatingVisitor(input, session, functionManager, types);
+        }
+
+        private PlanNodeStatsEstimate process(RowExpression rowExpression)
+        {
+            return normalizer.normalize(rowExpression.accept(this, null), types);
+        }
+
+        private PlanNodeStatsEstimate estimateLogicalAnd(RowExpression left, RowExpression right)
+        {
+            // first try to estimate in the fair way
+            PlanNodeStatsEstimate leftEstimate = process(left);
+            if (!leftEstimate.isOutputRowCountUnknown()) {
+                PlanNodeStatsEstimate logicalAndEstimate = newEstimate(leftEstimate).process(right);
+                if (!logicalAndEstimate.isOutputRowCountUnknown()) {
+                    return logicalAndEstimate;
+                }
+            }
+
+            // If some of the filters cannot be estimated, take the smallest estimate.
+            // Apply 0.9 filter factor as "unknown filter" factor.
+            PlanNodeStatsEstimate rightEstimate = process(right);
+            PlanNodeStatsEstimate smallestKnownEstimate;
+            if (leftEstimate.isOutputRowCountUnknown()) {
+                smallestKnownEstimate = rightEstimate;
+            }
+            else if (rightEstimate.isOutputRowCountUnknown()) {
+                smallestKnownEstimate = leftEstimate;
+            }
+            else {
+                smallestKnownEstimate = leftEstimate.getOutputRowCount() <= rightEstimate.getOutputRowCount() ? leftEstimate : rightEstimate;
+            }
+            if (smallestKnownEstimate.isOutputRowCountUnknown()) {
+                return PlanNodeStatsEstimate.unknown();
+            }
+            return smallestKnownEstimate.mapOutputRowCount(rowCount -> rowCount * UNKNOWN_FILTER_COEFFICIENT);
+        }
+
+        private PlanNodeStatsEstimate estimateLogicalOr(RowExpression left, RowExpression right)
+        {
+            PlanNodeStatsEstimate leftEstimate = process(left);
+            if (leftEstimate.isOutputRowCountUnknown()) {
+                return PlanNodeStatsEstimate.unknown();
+            }
+
+            PlanNodeStatsEstimate rightEstimate = process(right);
+            if (rightEstimate.isOutputRowCountUnknown()) {
+                return PlanNodeStatsEstimate.unknown();
+            }
+
+            PlanNodeStatsEstimate andEstimate = newEstimate(leftEstimate).process(right);
+            if (andEstimate.isOutputRowCountUnknown()) {
+                return PlanNodeStatsEstimate.unknown();
+            }
+
+            return capStats(
+                    subtractSubsetStats(
+                            addStatsAndSumDistinctValues(leftEstimate, rightEstimate),
+                            andEstimate),
+                    input);
+        }
+
+        private PlanNodeStatsEstimate estimateIn(RowExpression value, List<RowExpression> candidates)
+        {
+            ImmutableList<PlanNodeStatsEstimate> equalityEstimates = candidates.stream()
+                    .map(inValue -> process(call(metadata.getFunctionManager().resolveOperator(OperatorType.EQUAL, fromTypes(value.getType(), inValue.getType())), BOOLEAN, value, inValue)))
+                    .collect(toImmutableList());
+
+            if (equalityEstimates.stream().anyMatch(PlanNodeStatsEstimate::isOutputRowCountUnknown)) {
+                return PlanNodeStatsEstimate.unknown();
+            }
+
+            PlanNodeStatsEstimate inEstimate = equalityEstimates.stream()
+                    .reduce(PlanNodeStatsEstimateMath::addStatsAndSumDistinctValues)
+                    .orElse(PlanNodeStatsEstimate.unknown());
+
+            if (inEstimate.isOutputRowCountUnknown()) {
+                return PlanNodeStatsEstimate.unknown();
+            }
+
+            SymbolStatsEstimate valueStats = getRowExpressionStats(value);
+            if (valueStats.isUnknown()) {
+                return PlanNodeStatsEstimate.unknown();
+            }
+
+            double notNullValuesBeforeIn = input.getOutputRowCount() * (1 - valueStats.getNullsFraction());
+
+            PlanNodeStatsEstimate.Builder result = PlanNodeStatsEstimate.buildFrom(input);
+            result.setOutputRowCount(min(inEstimate.getOutputRowCount(), notNullValuesBeforeIn));
+
+            if (value instanceof VariableReferenceExpression) {
+                Symbol valueSymbol = new Symbol(((VariableReferenceExpression) value).getName());
+                SymbolStatsEstimate newSymbolStats = inEstimate.getSymbolStatistics(valueSymbol)
+                        .mapDistinctValuesCount(newDistinctValuesCount -> min(newDistinctValuesCount, valueStats.getDistinctValuesCount()));
+                result.addSymbolStatistics(valueSymbol, newSymbolStats);
+            }
+            return result.build();
+        }
+
+        private PlanNodeStatsEstimate estimateIsNull(RowExpression expression)
+        {
+            if (expression instanceof VariableReferenceExpression) {
+                Symbol symbol = new Symbol(((VariableReferenceExpression) expression).getName());
+                SymbolStatsEstimate symbolStats = input.getSymbolStatistics(symbol);
+                PlanNodeStatsEstimate.Builder result = PlanNodeStatsEstimate.buildFrom(input);
+                result.setOutputRowCount(input.getOutputRowCount() * symbolStats.getNullsFraction());
+                result.addSymbolStatistics(symbol, SymbolStatsEstimate.builder()
+                        .setNullsFraction(1.0)
+                        .setLowValue(NaN)
+                        .setHighValue(NaN)
+                        .setDistinctValuesCount(0.0)
+                        .build());
+                return result.build();
+            }
+            return PlanNodeStatsEstimate.unknown();
+        }
+
+        private RowExpression isNull(RowExpression expression)
+        {
+            return new SpecialFormExpression(IS_NULL, BOOLEAN, expression);
+        }
+
+        private RowExpression not(RowExpression expression)
+        {
+            return call(functionResolution.notFunction(), expression.getType(), expression);
+        }
+
+        private ComparisonExpression.Operator getComparisonOperator(OperatorType operator)
+        {
+            switch (operator) {
+                case EQUAL:
+                    return EQUAL;
+                case NOT_EQUAL:
+                    return NOT_EQUAL;
+                case LESS_THAN:
+                    return LESS_THAN;
+                case LESS_THAN_OR_EQUAL:
+                    return LESS_THAN_OR_EQUAL;
+                case GREATER_THAN:
+                    return GREATER_THAN;
+                case GREATER_THAN_OR_EQUAL:
+                    return GREATER_THAN_OR_EQUAL;
+                case IS_DISTINCT_FROM:
+                    return IS_DISTINCT_FROM;
+                default:
+                    throw new IllegalStateException("Unsupported comparison operator type: " + operator);
+            }
+        }
+
+        private OperatorType flip(OperatorType operatorType)
+        {
+            switch (operatorType) {
+                case EQUAL:
+                    return OperatorType.EQUAL;
+                case NOT_EQUAL:
+                    return OperatorType.NOT_EQUAL;
+                case LESS_THAN:
+                    return OperatorType.GREATER_THAN;
+                case LESS_THAN_OR_EQUAL:
+                    return OperatorType.GREATER_THAN_OR_EQUAL;
+                case GREATER_THAN:
+                    return OperatorType.LESS_THAN;
+                case GREATER_THAN_OR_EQUAL:
+                    return OperatorType.LESS_THAN_OR_EQUAL;
+                case IS_DISTINCT_FROM:
+                    return OperatorType.IS_DISTINCT_FROM;
+                default:
+                    throw new IllegalArgumentException("Unsupported comparison: " + operatorType);
+            }
+        }
+
+        private SymbolStatsEstimate getRowExpressionStats(RowExpression expression)
+        {
+            if (expression instanceof VariableReferenceExpression) {
+                Symbol symbol = new Symbol(((VariableReferenceExpression) expression).getName());
+                return requireNonNull(input.getSymbolStatistics(symbol), () -> format("No statistics for symbol %s", symbol));
+            }
+            return scalarStatsCalculator.calculate(expression, input, session);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsRule.java
@@ -24,6 +24,8 @@ import java.util.Optional;
 import static com.facebook.presto.SystemSessionProperties.isDefaultFilterFactorEnabled;
 import static com.facebook.presto.cost.FilterStatsCalculator.UNKNOWN_FILTER_COEFFICIENT;
 import static com.facebook.presto.sql.planner.plan.Patterns.filter;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.isExpression;
 
 public class FilterStatsRule
         extends SimpleStatsRule<FilterNode>
@@ -48,7 +50,13 @@ public class FilterStatsRule
     public Optional<PlanNodeStatsEstimate> doCalculate(FilterNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
     {
         PlanNodeStatsEstimate sourceStats = statsProvider.getStats(node.getSource());
-        PlanNodeStatsEstimate estimate = filterStatsCalculator.filterStats(sourceStats, node.getPredicate(), session, types);
+        PlanNodeStatsEstimate estimate;
+        if (isExpression(node.getPredicate())) {
+            estimate = filterStatsCalculator.filterStats(sourceStats, castToExpression(node.getPredicate()), session, types);
+        }
+        else {
+            estimate = filterStatsCalculator.filterStats(sourceStats, node.getPredicate(), session, types);
+        }
         if (isDefaultFilterFactorEnabled(session) && estimate.isOutputRowCountUnknown()) {
             estimate = sourceStats.mapOutputRowCount(sourceRowCount -> sourceStats.getOutputRowCount() * UNKNOWN_FILTER_COEFFICIENT);
         }

--- a/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
@@ -15,17 +15,27 @@ package com.facebook.presto.cost;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.warnings.WarningCollector;
+import com.facebook.presto.metadata.FunctionMetadata;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.spi.type.DecimalType;
-import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.sql.analyzer.ExpressionAnalyzer;
 import com.facebook.presto.sql.analyzer.Scope;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.NoOpSymbolResolver;
+import com.facebook.presto.sql.planner.RowExpressionInterpreter;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.relational.StandardFunctionResolution;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.ArithmeticUnaryExpression;
 import com.facebook.presto.sql.tree.AstVisitor;
@@ -38,6 +48,7 @@ import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.type.TypeUtils;
 import com.google.common.collect.ImmutableList;
 
 import javax.inject.Inject;
@@ -46,9 +57,13 @@ import java.util.Map;
 import java.util.OptionalDouble;
 
 import static com.facebook.presto.cost.StatsUtil.toStatsRepresentation;
+import static com.facebook.presto.spi.function.OperatorType.DIVIDE;
+import static com.facebook.presto.spi.function.OperatorType.MODULUS;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
 import static com.facebook.presto.sql.planner.LiteralInterpreter.evaluate;
 import static com.facebook.presto.util.MoreMath.max;
 import static com.facebook.presto.util.MoreMath.min;
+import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Double.NaN;
 import static java.lang.Double.isFinite;
 import static java.lang.Double.isNaN;
@@ -66,19 +81,249 @@ public class ScalarStatsCalculator
         this.metadata = requireNonNull(metadata, "metadata can not be null");
     }
 
+    @Deprecated
     public SymbolStatsEstimate calculate(Expression scalarExpression, PlanNodeStatsEstimate inputStatistics, Session session, TypeProvider types)
     {
-        return new Visitor(inputStatistics, session, types).process(scalarExpression);
+        return new ExpressionStatsVisitor(inputStatistics, session, types).process(scalarExpression);
     }
 
-    private class Visitor
+    public SymbolStatsEstimate calculate(RowExpression scalarExpression, PlanNodeStatsEstimate inputStatistics, Session session)
+    {
+        return scalarExpression.accept(new RowExpressionStatsVisitor(inputStatistics, session), null);
+    }
+
+    private class RowExpressionStatsVisitor
+            implements RowExpressionVisitor<SymbolStatsEstimate, Void>
+    {
+        private final PlanNodeStatsEstimate input;
+        private final Session session;
+        private final StandardFunctionResolution resolution = new StandardFunctionResolution(metadata.getFunctionManager());
+
+        public RowExpressionStatsVisitor(PlanNodeStatsEstimate input, Session session)
+        {
+            this.input = requireNonNull(input, "input is null");
+            this.session = requireNonNull(session, "session is null");
+        }
+
+        @Override
+        public SymbolStatsEstimate visitCall(CallExpression call, Void context)
+        {
+            if (resolution.isCastFunction(call.getFunctionHandle())) {
+                return visitCast(call, context);
+            }
+
+            if (resolution.isNegateFunction(call.getFunctionHandle())) {
+                return visitArithmeticUnary(call, context);
+            }
+
+            FunctionMetadata functionMetadata = metadata.getFunctionManager().getFunctionMetadata(call.getFunctionHandle());
+            if (functionMetadata.getOperatorType().map(OperatorType::isArithmeticOperator).orElse(false)) {
+                return visitArithmeticBinary(call, context);
+            }
+
+            Object value = new RowExpressionInterpreter(call, metadata, session, true).optimize();
+
+            if (value == null) {
+                return nullStatsEstimate();
+            }
+
+            if (value instanceof RowExpression) {
+                // value is not a constant
+                return SymbolStatsEstimate.unknown();
+            }
+
+            // value is a constant
+            return SymbolStatsEstimate.builder()
+                    .setNullsFraction(0)
+                    .setDistinctValuesCount(1)
+                    .build();
+        }
+
+        @Override
+        public SymbolStatsEstimate visitInputReference(InputReferenceExpression reference, Void context)
+        {
+            throw new UnsupportedOperationException("symbol stats estimation should not reach channel mapping");
+        }
+
+        @Override
+        public SymbolStatsEstimate visitConstant(ConstantExpression literal, Void context)
+        {
+            if (literal.getValue() == null) {
+                return nullStatsEstimate();
+            }
+
+            OptionalDouble doubleValue = toStatsRepresentation(metadata, session, literal.getType(), literal.getValue());
+            SymbolStatsEstimate.Builder estimate = SymbolStatsEstimate.builder()
+                    .setNullsFraction(0)
+                    .setDistinctValuesCount(1);
+
+            if (doubleValue.isPresent()) {
+                estimate.setLowValue(doubleValue.getAsDouble());
+                estimate.setHighValue(doubleValue.getAsDouble());
+            }
+            return estimate.build();
+        }
+
+        @Override
+        public SymbolStatsEstimate visitLambda(LambdaDefinitionExpression lambda, Void context)
+        {
+            return SymbolStatsEstimate.unknown();
+        }
+
+        @Override
+        public SymbolStatsEstimate visitVariableReference(VariableReferenceExpression reference, Void context)
+        {
+            return input.getSymbolStatistics(new Symbol(reference.getName()));
+        }
+
+        @Override
+        public SymbolStatsEstimate visitSpecialForm(SpecialFormExpression specialForm, Void context)
+        {
+            if (specialForm.getForm().equals(COALESCE)) {
+                SymbolStatsEstimate result = null;
+                for (RowExpression operand : specialForm.getArguments()) {
+                    SymbolStatsEstimate operandEstimates = operand.accept(this, context);
+                    if (result != null) {
+                        result = estimateCoalesce(input, result, operandEstimates);
+                    }
+                    else {
+                        result = operandEstimates;
+                    }
+                }
+                return requireNonNull(result, "result is null");
+            }
+            return SymbolStatsEstimate.unknown();
+        }
+
+        private SymbolStatsEstimate visitCast(CallExpression call, Void context)
+        {
+            requireNonNull(call, "call is null");
+            SymbolStatsEstimate sourceStats = call.getArguments().get(0).accept(this, context);
+
+            // todo - make this general postprocessing rule.
+            double distinctValuesCount = sourceStats.getDistinctValuesCount();
+            double lowValue = sourceStats.getLowValue();
+            double highValue = sourceStats.getHighValue();
+
+            if (TypeUtils.isIntegralType(call.getType().getTypeSignature(), metadata.getTypeManager())) {
+                // todo handle low/high value changes if range gets narrower due to cast (e.g. BIGINT -> SMALLINT)
+                if (isFinite(lowValue)) {
+                    lowValue = Math.round(lowValue);
+                }
+                if (isFinite(highValue)) {
+                    highValue = Math.round(highValue);
+                }
+                if (isFinite(lowValue) && isFinite(highValue)) {
+                    double integersInRange = highValue - lowValue + 1;
+                    if (!isNaN(distinctValuesCount) && distinctValuesCount > integersInRange) {
+                        distinctValuesCount = integersInRange;
+                    }
+                }
+            }
+
+            return SymbolStatsEstimate.builder()
+                    .setNullsFraction(sourceStats.getNullsFraction())
+                    .setLowValue(lowValue)
+                    .setHighValue(highValue)
+                    .setDistinctValuesCount(distinctValuesCount)
+                    .build();
+        }
+
+        private SymbolStatsEstimate visitArithmeticUnary(CallExpression call, Void context)
+        {
+            requireNonNull(call, "call is null");
+            SymbolStatsEstimate stats = call.getArguments().get(0).accept(this, context);
+            if (resolution.isNegateFunction(call.getFunctionHandle())) {
+                return SymbolStatsEstimate.buildFrom(stats)
+                        .setLowValue(-stats.getHighValue())
+                        .setHighValue(-stats.getLowValue())
+                        .build();
+            }
+            throw new IllegalStateException("Unexpected sign: " + call.getFunctionHandle().getSignature());
+        }
+
+        private SymbolStatsEstimate visitArithmeticBinary(CallExpression call, Void context)
+        {
+            requireNonNull(call, "call is null");
+            SymbolStatsEstimate left = call.getArguments().get(0).accept(this, context);
+            SymbolStatsEstimate right = call.getArguments().get(1).accept(this, context);
+
+            SymbolStatsEstimate.Builder result = SymbolStatsEstimate.builder()
+                    .setAverageRowSize(Math.max(left.getAverageRowSize(), right.getAverageRowSize()))
+                    .setNullsFraction(left.getNullsFraction() + right.getNullsFraction() - left.getNullsFraction() * right.getNullsFraction())
+                    .setDistinctValuesCount(min(left.getDistinctValuesCount() * right.getDistinctValuesCount(), input.getOutputRowCount()));
+
+            FunctionMetadata functionMetadata = metadata.getFunctionManager().getFunctionMetadata(call.getFunctionHandle());
+            checkState(functionMetadata.getOperatorType().isPresent());
+            OperatorType operatorType = functionMetadata.getOperatorType().get();
+            double leftLow = left.getLowValue();
+            double leftHigh = left.getHighValue();
+            double rightLow = right.getLowValue();
+            double rightHigh = right.getHighValue();
+            if (isNaN(leftLow) || isNaN(leftHigh) || isNaN(rightLow) || isNaN(rightHigh)) {
+                result.setLowValue(NaN).setHighValue(NaN);
+            }
+            else if (operatorType.equals(DIVIDE) && rightLow < 0 && rightHigh > 0) {
+                result.setLowValue(Double.NEGATIVE_INFINITY)
+                        .setHighValue(Double.POSITIVE_INFINITY);
+            }
+            else if (operatorType.equals(MODULUS)) {
+                double maxDivisor = max(abs(rightLow), abs(rightHigh));
+                if (leftHigh <= 0) {
+                    result.setLowValue(max(-maxDivisor, leftLow))
+                            .setHighValue(0);
+                }
+                else if (leftLow >= 0) {
+                    result.setLowValue(0)
+                            .setHighValue(min(maxDivisor, leftHigh));
+                }
+                else {
+                    result.setLowValue(max(-maxDivisor, leftLow))
+                            .setHighValue(min(maxDivisor, leftHigh));
+                }
+            }
+            else {
+                double v1 = operate(operatorType, leftLow, rightLow);
+                double v2 = operate(operatorType, leftLow, rightHigh);
+                double v3 = operate(operatorType, leftHigh, rightLow);
+                double v4 = operate(operatorType, leftHigh, rightHigh);
+                double lowValue = min(v1, v2, v3, v4);
+                double highValue = max(v1, v2, v3, v4);
+
+                result.setLowValue(lowValue)
+                        .setHighValue(highValue);
+            }
+
+            return result.build();
+        }
+
+        private double operate(OperatorType operator, double left, double right)
+        {
+            switch (operator) {
+                case ADD:
+                    return left + right;
+                case SUBTRACT:
+                    return left - right;
+                case MULTIPLY:
+                    return left * right;
+                case DIVIDE:
+                    return left / right;
+                case MODULUS:
+                    return left % right;
+                default:
+                    throw new IllegalStateException("Unsupported ArithmeticBinaryExpression.Operator: " + operator);
+            }
+        }
+    }
+
+    private class ExpressionStatsVisitor
             extends AstVisitor<SymbolStatsEstimate, Void>
     {
         private final PlanNodeStatsEstimate input;
         private final Session session;
         private final TypeProvider types;
 
-        Visitor(PlanNodeStatsEstimate input, Session session, TypeProvider types)
+        ExpressionStatsVisitor(PlanNodeStatsEstimate input, Session session, TypeProvider types)
         {
             this.input = input;
             this.session = session;
@@ -169,7 +414,7 @@ public class ScalarStatsCalculator
             double lowValue = sourceStats.getLowValue();
             double highValue = sourceStats.getHighValue();
 
-            if (isIntegralType(targetType)) {
+            if (TypeUtils.isIntegralType(targetType, metadata.getTypeManager())) {
                 // todo handle low/high value changes if range gets narrower due to cast (e.g. BIGINT -> SMALLINT)
                 if (isFinite(lowValue)) {
                     lowValue = Math.round(lowValue);
@@ -191,22 +436,6 @@ public class ScalarStatsCalculator
                     .setHighValue(highValue)
                     .setDistinctValuesCount(distinctValuesCount)
                     .build();
-        }
-
-        private boolean isIntegralType(TypeSignature targetType)
-        {
-            switch (targetType.getBase()) {
-                case StandardTypes.BIGINT:
-                case StandardTypes.INTEGER:
-                case StandardTypes.SMALLINT:
-                case StandardTypes.TINYINT:
-                    return true;
-                case StandardTypes.DECIMAL:
-                    DecimalType decimalType = (DecimalType) metadata.getType(targetType);
-                    return decimalType.getScale() == 0;
-                default:
-                    return false;
-            }
         }
 
         @Override
@@ -306,7 +535,7 @@ public class ScalarStatsCalculator
             for (Expression operand : node.getOperands()) {
                 SymbolStatsEstimate operandEstimates = process(operand);
                 if (result != null) {
-                    result = estimateCoalesce(result, operandEstimates);
+                    result = estimateCoalesce(input, result, operandEstimates);
                 }
                 else {
                     result = operandEstimates;
@@ -314,27 +543,27 @@ public class ScalarStatsCalculator
             }
             return requireNonNull(result, "result is null");
         }
+    }
 
-        private SymbolStatsEstimate estimateCoalesce(SymbolStatsEstimate left, SymbolStatsEstimate right)
-        {
-            // Question to reviewer: do you have a method to check if fraction is empty or saturated?
-            if (left.getNullsFraction() == 0) {
-                return left;
-            }
-            else if (left.getNullsFraction() == 1.0) {
-                return right;
-            }
-            else {
-                return SymbolStatsEstimate.builder()
-                        .setLowValue(min(left.getLowValue(), right.getLowValue()))
-                        .setHighValue(max(left.getHighValue(), right.getHighValue()))
-                        .setDistinctValuesCount(left.getDistinctValuesCount() +
-                                min(right.getDistinctValuesCount(), input.getOutputRowCount() * left.getNullsFraction()))
-                        .setNullsFraction(left.getNullsFraction() * right.getNullsFraction())
-                        // TODO check if dataSize estimation method is correct
-                        .setAverageRowSize(max(left.getAverageRowSize(), right.getAverageRowSize()))
-                        .build();
-            }
+    private static SymbolStatsEstimate estimateCoalesce(PlanNodeStatsEstimate input, SymbolStatsEstimate left, SymbolStatsEstimate right)
+    {
+        // Question to reviewer: do you have a method to check if fraction is empty or saturated?
+        if (left.getNullsFraction() == 0) {
+            return left;
+        }
+        else if (left.getNullsFraction() == 1.0) {
+            return right;
+        }
+        else {
+            return SymbolStatsEstimate.builder()
+                    .setLowValue(min(left.getLowValue(), right.getLowValue()))
+                    .setHighValue(max(left.getHighValue(), right.getHighValue()))
+                    .setDistinctValuesCount(left.getDistinctValuesCount() +
+                            min(right.getDistinctValuesCount(), input.getOutputRowCount() * left.getNullsFraction()))
+                    .setNullsFraction(left.getNullsFraction() * right.getNullsFraction())
+                    // TODO check if dataSize estimation method is correct
+                    .setAverageRowSize(max(left.getAverageRowSize(), right.getAverageRowSize()))
+                    .build();
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/cost/SimpleFilterProjectSemiJoinStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/SimpleFilterProjectSemiJoinStatsRule.java
@@ -15,6 +15,10 @@ package com.facebook.presto.cost;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.iterative.Lookup;
@@ -22,6 +26,8 @@ import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.facebook.presto.sql.relational.LogicalRowExpressions;
+import com.facebook.presto.sql.relational.StandardFunctionResolution;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.SymbolReference;
@@ -36,7 +42,11 @@ import static com.facebook.presto.cost.SemiJoinStatsCalculator.computeSemiJoin;
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
 import static com.facebook.presto.sql.planner.plan.Patterns.filter;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.isExpression;
 import static com.facebook.presto.sql.relational.ProjectNodeUtils.isIdentity;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
@@ -50,11 +60,16 @@ public class SimpleFilterProjectSemiJoinStatsRule
     private static final Pattern<FilterNode> PATTERN = filter();
 
     private final FilterStatsCalculator filterStatsCalculator;
+    private final LogicalRowExpressions logicalRowExpressions;
+    private final StandardFunctionResolution functionResolution;
 
-    public SimpleFilterProjectSemiJoinStatsRule(StatsNormalizer normalizer, FilterStatsCalculator filterStatsCalculator)
+    public SimpleFilterProjectSemiJoinStatsRule(StatsNormalizer normalizer, FilterStatsCalculator filterStatsCalculator, FunctionManager functionManager)
     {
         super(normalizer);
         this.filterStatsCalculator = requireNonNull(filterStatsCalculator, "filterStatsCalculator can not be null");
+        requireNonNull(functionManager, "functionManager can not be null");
+        this.logicalRowExpressions = new LogicalRowExpressions(functionManager);
+        this.functionResolution = new StandardFunctionResolution(functionManager);
     }
 
     @Override
@@ -96,7 +111,14 @@ public class SimpleFilterProjectSemiJoinStatsRule
         Symbol filteringSourceJoinSymbol = semiJoinNode.getFilteringSourceJoinSymbol();
         Symbol sourceJoinSymbol = semiJoinNode.getSourceJoinSymbol();
 
-        Optional<SemiJoinOutputFilter> semiJoinOutputFilter = extractSemiJoinOutputFilter(filterNode.getPredicate(), semiJoinNode.getSemiJoinOutput());
+        Optional<SemiJoinOutputFilter> semiJoinOutputFilter;
+        Symbol semiJoinOutput = semiJoinNode.getSemiJoinOutput();
+        if (isExpression(filterNode.getPredicate())) {
+            semiJoinOutputFilter = extractSemiJoinOutputFilter(castToExpression(filterNode.getPredicate()), semiJoinOutput);
+        }
+        else {
+            semiJoinOutputFilter = extractSemiJoinOutputFilter(filterNode.getPredicate(), new VariableReferenceExpression(semiJoinOutput.getName(), types.get(semiJoinOutput)));
+        }
 
         if (!semiJoinOutputFilter.isPresent()) {
             return Optional.empty();
@@ -115,14 +137,21 @@ public class SimpleFilterProjectSemiJoinStatsRule
         }
 
         // apply remaining predicate
-        PlanNodeStatsEstimate filteredStats = filterStatsCalculator.filterStats(semiJoinStats, semiJoinOutputFilter.get().getRemainingPredicate(), session, types);
+        PlanNodeStatsEstimate filteredStats;
+        if (isExpression(filterNode.getPredicate())) {
+            filteredStats = filterStatsCalculator.filterStats(semiJoinStats, castToExpression(semiJoinOutputFilter.get().getRemainingPredicate()), session, types);
+        }
+        else {
+            filteredStats = filterStatsCalculator.filterStats(semiJoinStats, semiJoinOutputFilter.get().getRemainingPredicate(), session, types);
+        }
+
         if (filteredStats.isOutputRowCountUnknown()) {
             return Optional.of(semiJoinStats.mapOutputRowCount(rowCount -> rowCount * UNKNOWN_FILTER_COEFFICIENT));
         }
         return Optional.of(filteredStats);
     }
 
-    private static Optional<SemiJoinOutputFilter> extractSemiJoinOutputFilter(Expression predicate, Symbol semiJoinOutput)
+    private Optional<SemiJoinOutputFilter> extractSemiJoinOutputFilter(Expression predicate, Symbol semiJoinOutput)
     {
         List<Expression> conjuncts = extractConjuncts(predicate);
         List<Expression> semiJoinOutputReferences = conjuncts.stream()
@@ -138,7 +167,32 @@ public class SimpleFilterProjectSemiJoinStatsRule
                 .filter(conjunct -> conjunct != semiJoinOutputReference)
                 .collect(toImmutableList()));
         boolean negated = semiJoinOutputReference instanceof NotExpression;
+        return Optional.of(new SemiJoinOutputFilter(negated, castToRowExpression(remainingPredicate)));
+    }
+
+    private Optional<SemiJoinOutputFilter> extractSemiJoinOutputFilter(RowExpression predicate, RowExpression input)
+    {
+        checkState(!isExpression(predicate));
+        List<RowExpression> conjuncts = LogicalRowExpressions.extractConjuncts(predicate);
+        List<RowExpression> semiJoinOutputReferences = conjuncts.stream()
+                .filter(conjunct -> isSemiJoinOutputReference(conjunct, input))
+                .collect(toImmutableList());
+
+        if (semiJoinOutputReferences.size() != 1) {
+            return Optional.empty();
+        }
+
+        RowExpression semiJoinOutputReference = Iterables.getOnlyElement(semiJoinOutputReferences);
+        RowExpression remainingPredicate = logicalRowExpressions.combineConjuncts(conjuncts.stream()
+                .filter(conjunct -> conjunct != semiJoinOutputReference)
+                .collect(toImmutableList()));
+        boolean negated = isNotFunction(semiJoinOutputReference);
         return Optional.of(new SemiJoinOutputFilter(negated, remainingPredicate));
+    }
+
+    private boolean isSemiJoinOutputReference(RowExpression conjunct, RowExpression input)
+    {
+        return conjunct.equals(input) || (isNotFunction(conjunct) && ((CallExpression) conjunct).getArguments().get(0).equals(input));
     }
 
     private static boolean isSemiJoinOutputReference(Expression conjunct, Symbol semiJoinOutput)
@@ -148,12 +202,17 @@ public class SimpleFilterProjectSemiJoinStatsRule
                 (conjunct instanceof NotExpression && ((NotExpression) conjunct).getValue().equals(semiJoinOuputSymbolReference));
     }
 
+    private boolean isNotFunction(RowExpression expression)
+    {
+        return expression instanceof CallExpression && functionResolution.isNotFunction(((CallExpression) expression).getFunctionHandle());
+    }
+
     private static class SemiJoinOutputFilter
     {
         private final boolean negated;
-        private final Expression remainingPredicate;
+        private final RowExpression remainingPredicate;
 
-        public SemiJoinOutputFilter(boolean negated, Expression remainingPredicate)
+        public SemiJoinOutputFilter(boolean negated, RowExpression remainingPredicate)
         {
             this.negated = negated;
             this.remainingPredicate = requireNonNull(remainingPredicate, "remainingPredicate can not be null");
@@ -164,7 +223,7 @@ public class SimpleFilterProjectSemiJoinStatsRule
             return negated;
         }
 
-        public Expression getRemainingPredicate()
+        public RowExpression getRemainingPredicate()
         {
             return remainingPredicate;
         }

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
@@ -40,7 +40,7 @@ public class StatsCalculatorModule
         ImmutableList.Builder<ComposableStatsCalculator.Rule<?>> rules = ImmutableList.builder();
         rules.add(new OutputStatsRule());
         rules.add(new TableScanStatsRule(metadata, normalizer));
-        rules.add(new SimpleFilterProjectSemiJoinStatsRule(normalizer, filterStatsCalculator)); // this must be before FilterStatsRule
+        rules.add(new SimpleFilterProjectSemiJoinStatsRule(normalizer, filterStatsCalculator, metadata.getFunctionManager())); // this must be before FilterStatsRule
         rules.add(new FilterStatsRule(normalizer, filterStatsCalculator));
         rules.add(new ValuesStatsRule(metadata));
         rules.add(new LimitStatsRule(normalizer));

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionMetadata.java
@@ -14,10 +14,12 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.spi.function.FunctionKind;
+import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -27,15 +29,24 @@ public class FunctionMetadata
     private final List<TypeSignature> argumentTypes;
     private final TypeSignature returnType;
     private final FunctionKind functionKind;
+    private final Optional<OperatorType> operatorType;
     private final boolean deterministic;
     private final boolean calledOnNullInput;
 
-    public FunctionMetadata(String name, List<TypeSignature> argumentTypes, TypeSignature returnType, FunctionKind functionKind, boolean deterministic, boolean calledOnNullInput)
+    public FunctionMetadata(
+            String name,
+            List<TypeSignature> argumentTypes,
+            TypeSignature returnType,
+            FunctionKind functionKind,
+            Optional<OperatorType> operatorType,
+            boolean deterministic,
+            boolean calledOnNullInput)
     {
         this.name = requireNonNull(name, "name is null");
         this.argumentTypes = ImmutableList.copyOf(requireNonNull(argumentTypes, "argumentTypes is null"));
         this.returnType = requireNonNull(returnType, "returnType is null");
         this.functionKind = requireNonNull(functionKind, "functionKind is null");
+        this.operatorType = requireNonNull(operatorType, "operatorType is null");
         this.deterministic = deterministic;
         this.calledOnNullInput = calledOnNullInput;
     }
@@ -58,6 +69,11 @@ public class FunctionMetadata
     public TypeSignature getReturnType()
     {
         return returnType;
+    }
+
+    public Optional<OperatorType> getOperatorType()
+    {
+        return operatorType;
     }
 
     public boolean isDeterministic()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -44,6 +44,8 @@ import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.planner.planPrinter.IOPlanPrinter.textIOPlan;
+import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.graphvizDistributedPlan;
+import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.graphvizLogicalPlan;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -142,10 +144,10 @@ public class QueryExplainer
         switch (planType) {
             case LOGICAL:
                 Plan plan = getLogicalPlan(session, statement, parameters, warningCollector);
-                return PlanPrinter.graphvizLogicalPlan(plan.getRoot(), plan.getTypes());
+                return graphvizLogicalPlan(plan.getRoot(), plan.getTypes(), session);
             case DISTRIBUTED:
                 SubPlan subPlan = getDistributedPlan(session, statement, parameters, warningCollector);
-                return PlanPrinter.graphvizDistributedPlan(subPlan);
+                return graphvizDistributedPlan(subPlan, session);
         }
         throw new IllegalArgumentException("Unhandled plan type: " + planType);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -54,6 +54,7 @@ import static com.facebook.presto.sql.ExpressionUtils.expressionOrNullSymbols;
 import static com.facebook.presto.sql.ExpressionUtils.extractConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.filterDeterministicConjuncts;
 import static com.facebook.presto.sql.planner.EqualityInference.createEqualityInference;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.google.common.base.Predicates.in;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -128,7 +129,7 @@ public class EffectivePredicateExtractor
         {
             Expression underlyingPredicate = node.getSource().accept(this, context);
 
-            Expression predicate = node.getPredicate();
+            Expression predicate = castToExpression(node.getPredicate());
 
             // Remove non-deterministic conjuncts
             predicate = filterDeterministicConjuncts(predicate);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -78,9 +78,9 @@ public class EffectivePredicateExtractor
                 return new ComparisonExpression(ComparisonExpression.Operator.EQUAL, reference, expression);
             };
 
-    private final DomainTranslator domainTranslator;
+    private final ExpressionDomainTranslator domainTranslator;
 
-    public EffectivePredicateExtractor(DomainTranslator domainTranslator)
+    public EffectivePredicateExtractor(ExpressionDomainTranslator domainTranslator)
     {
         this.domainTranslator = requireNonNull(domainTranslator, "domainTranslator is null");
     }
@@ -93,9 +93,9 @@ public class EffectivePredicateExtractor
     private static class Visitor
             extends PlanVisitor<Expression, Void>
     {
-        private final DomainTranslator domainTranslator;
+        private final ExpressionDomainTranslator domainTranslator;
 
-        public Visitor(DomainTranslator domainTranslator)
+        public Visitor(ExpressionDomainTranslator domainTranslator)
         {
             this.domainTranslator = requireNonNull(domainTranslator, "domainTranslator is null");
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionDomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionDomainTranslator.java
@@ -85,11 +85,12 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
 
-public final class DomainTranslator
+@Deprecated
+public final class ExpressionDomainTranslator
 {
     private final LiteralEncoder literalEncoder;
 
-    public DomainTranslator(LiteralEncoder literalEncoder)
+    public ExpressionDomainTranslator(LiteralEncoder literalEncoder)
     {
         this.literalEncoder = requireNonNull(literalEncoder, "literalEncoder is null");
     }
@@ -608,24 +609,20 @@ public final class DomainTranslator
                     if (coercedValueIsGreaterThanOriginal) {
                         return new ComparisonExpression(GREATER_THAN_OR_EQUAL, symbolExpression, coercedLiteral);
                     }
-                    else if (coercedValueIsEqualToOriginal) {
+                    if (coercedValueIsEqualToOriginal) {
                         return new ComparisonExpression(comparisonOperator, symbolExpression, coercedLiteral);
                     }
-                    else if (coercedValueIsLessThanOriginal) {
-                        return new ComparisonExpression(GREATER_THAN, symbolExpression, coercedLiteral);
-                    }
+                    return new ComparisonExpression(GREATER_THAN, symbolExpression, coercedLiteral);
                 }
                 case LESS_THAN_OR_EQUAL:
                 case LESS_THAN: {
                     if (coercedValueIsLessThanOriginal) {
                         return new ComparisonExpression(LESS_THAN_OR_EQUAL, symbolExpression, coercedLiteral);
                     }
-                    else if (coercedValueIsEqualToOriginal) {
+                    if (coercedValueIsEqualToOriginal) {
                         return new ComparisonExpression(comparisonOperator, symbolExpression, coercedLiteral);
                     }
-                    else if (coercedValueIsGreaterThanOriginal) {
-                        return new ComparisonExpression(LESS_THAN, symbolExpression, coercedLiteral);
-                    }
+                    return new ComparisonExpression(LESS_THAN, symbolExpression, coercedLiteral);
                 }
                 case EQUAL: {
                     if (coercedValueIsEqualToOriginal) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
@@ -99,7 +99,7 @@ public class ExpressionExtractor
         @Override
         public Void visitFilter(FilterNode node, ImmutableList.Builder<RowExpression> context)
         {
-            context.add(castToRowExpression(node.getPredicate()));
+            context.add(node.getPredicate());
             return super.visitFilter(node, context);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -83,6 +83,7 @@ import static com.facebook.presto.sql.planner.optimizations.WindowNodeUtil.toBou
 import static com.facebook.presto.sql.planner.optimizations.WindowNodeUtil.toWindowType;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.groupingSets;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.singleGroupingSet;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -319,7 +320,7 @@ class QueryPlanner
         subPlan = subqueryPlanner.handleSubqueries(subPlan, rewrittenBeforeSubqueries, node);
         Expression rewrittenAfterSubqueries = subPlan.rewrite(predicate);
 
-        return subPlan.withNewRoot(new FilterNode(idAllocator.getNextId(), subPlan.getRoot(), rewrittenAfterSubqueries));
+        return subPlan.withNewRoot(new FilterNode(idAllocator.getNextId(), subPlan.getRoot(), castToRowExpression(rewrittenAfterSubqueries)));
     }
 
     private PlanBuilder project(PlanBuilder subPlan, Iterable<Expression> expressions, RelationPlan parentRelationPlan)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -385,7 +385,7 @@ class RelationPlanner
             Expression postInnerJoinCriteria;
             if (!postInnerJoinConditions.isEmpty()) {
                 postInnerJoinCriteria = ExpressionUtils.and(postInnerJoinConditions);
-                root = new FilterNode(idAllocator.getNextId(), root, postInnerJoinCriteria);
+                root = new FilterNode(idAllocator.getNextId(), root, castToRowExpression(postInnerJoinCriteria));
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -148,10 +148,19 @@ public class RowExpressionInterpreter
         return expression.accept(visitor, null);
     }
 
+    public Object optimize()
+    {
+        checkState(optimize, "optimize() not allowed for interpreter");
+        return expression.accept(visitor, null);
+    }
+
+    /**
+     * For test only; convenient to replace symbol with constants. Production code should not replace any symbols; use the interface above
+     */
     @VisibleForTesting
     public Object optimize(SymbolResolver inputs)
     {
-        checkState(optimize, "evaluate(SymbolResolver) not allowed for interpreter");
+        checkState(optimize, "optimize(SymbolResolver) not allowed for interpreter");
         return expression.accept(visitor, inputs);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -584,7 +584,7 @@ class SubqueryPlanner
         public PlanNode visitFilter(FilterNode node, RewriteContext<Void> context)
         {
             FilterNode rewrittenNode = (FilterNode) context.defaultRewrite(node);
-            return new FilterNode(idAllocator.getNextId(), rewrittenNode.getSource(), replaceExpression(rewrittenNode.getPredicate(), mapping));
+            return new FilterNode(idAllocator.getNextId(), rewrittenNode.getSource(), castToRowExpression(replaceExpression(castToExpression(rewrittenNode.getPredicate()), mapping)));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -27,6 +27,7 @@ import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.facebook.presto.sql.relational.OriginalExpressionUtils;
 import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.DefaultExpressionTraversalVisitor;
 import com.facebook.presto.sql.tree.DereferenceExpression;
@@ -504,6 +505,8 @@ class SubqueryPlanner
         // when reference expression is not rewritten that means it cannot be satisfied within given PlaNode
         // see that TranslationMap only resolves (local) fields in current scope
         return ExpressionExtractor.extractExpressions(planNode).stream()
+                .filter(OriginalExpressionUtils::isExpression)
+                .map(OriginalExpressionUtils::castToExpression)
                 .flatMap(expression -> extractColumnReferences(expression, analysis.getColumnReferences()).stream())
                 .collect(toImmutableSet());
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateCrossJoins.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStra
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
 import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictOutputs;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -195,7 +196,7 @@ public class EliminateCrossJoins
             result = new FilterNode(
                     idAllocator.getNextId(),
                     result,
-                    filter);
+                    castToRowExpression(filter));
         }
 
         if (graph.getAssignments().isPresent()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
@@ -195,7 +195,13 @@ public class ExpressionRewriteRuleSet
         @Override
         public Result apply(FilterNode filterNode, Captures captures, Context context)
         {
-            Expression rewritten = rewriter.rewrite(filterNode.getPredicate(), context);
+            RowExpression rewritten;
+            if (isExpression(filterNode.getPredicate())) {
+                rewritten = castToRowExpression(rewriter.rewrite(castToExpression(filterNode.getPredicate()), context));
+            }
+            else {
+                rewritten = filterNode.getPredicate();
+            }
             if (filterNode.getPredicate().equals(rewritten)) {
                 return Result.empty();
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExtractSpatialJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExtractSpatialJoins.java
@@ -51,6 +51,7 @@ import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.plan.ProjectNode;
 import com.facebook.presto.sql.planner.plan.SpatialJoinNode;
 import com.facebook.presto.sql.planner.plan.UnnestNode;
+import com.facebook.presto.sql.relational.OriginalExpressionUtils;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
@@ -214,7 +215,7 @@ public class ExtractSpatialJoins
         public Result apply(FilterNode node, Captures captures, Context context)
         {
             JoinNode joinNode = captures.get(JOIN);
-            Expression filter = node.getPredicate();
+            Expression filter = OriginalExpressionUtils.castToExpression(node.getPredicate());
             List<FunctionCall> spatialFunctions = extractSupportedSpatialFunctions(filter);
             for (FunctionCall spatialFunction : spatialFunctions) {
                 Result result = tryCreateSpatialJoin(context, joinNode, filter, node.getId(), node.getOutputSymbols(), spatialFunction, Optional.empty(), metadata, splitManager, pageSourceManager, sqlParser);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementBernoulliSampleAsFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementBernoulliSampleAsFilter.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import static com.facebook.presto.sql.planner.plan.Patterns.Sample.sampleType;
 import static com.facebook.presto.sql.planner.plan.Patterns.sample;
 import static com.facebook.presto.sql.planner.plan.SampleNode.Type.BERNOULLI;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 
 /**
  * Transforms:
@@ -58,9 +59,9 @@ public class ImplementBernoulliSampleAsFilter
         return Result.ofPlanNode(new FilterNode(
                 sample.getId(),
                 sample.getSource(),
-                new ComparisonExpression(
+                castToRowExpression(new ComparisonExpression(
                         ComparisonExpression.Operator.LESS_THAN,
                         new FunctionCall(QualifiedName.of("rand"), ImmutableList.of()),
-                        new DoubleLiteral(Double.toString(sample.getSampleRatio())))));
+                        new DoubleLiteral(Double.toString(sample.getSampleRatio()))))));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementFilteredAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ImplementFilteredAggregations.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.sql.ExpressionUtils.combineDisjunctsWithDefault;
 import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.google.common.base.Verify.verify;
 
@@ -128,7 +129,7 @@ public class ImplementFilteredAggregations
                                         context.getIdAllocator().getNextId(),
                                         aggregation.getSource(),
                                         newAssignments.build()),
-                                predicate),
+                                castToRowExpression(predicate)),
                         aggregations.build(),
                         aggregation.getGroupingSets(),
                         ImmutableList.of(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeFilters.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MergeFilters.java
@@ -23,6 +23,8 @@ import static com.facebook.presto.matching.Capture.newCapture;
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.planner.plan.Patterns.filter;
 import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 
 public class MergeFilters
         implements Rule<FilterNode>
@@ -47,6 +49,6 @@ public class MergeFilters
                 new FilterNode(
                         parent.getId(),
                         child.getSource(),
-                        combineConjuncts(child.getPredicate(), parent.getPredicate())));
+                        castToRowExpression(combineConjuncts(castToExpression(child.getPredicate()), castToExpression(parent.getPredicate())))));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
@@ -64,6 +64,8 @@ import static com.facebook.presto.sql.planner.iterative.rule.PreconditionRules.c
 import static com.facebook.presto.sql.planner.plan.Patterns.filter;
 import static com.facebook.presto.sql.planner.plan.Patterns.source;
 import static com.facebook.presto.sql.planner.plan.Patterns.tableScan;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -144,7 +146,7 @@ public class PickTableLayout
         {
             TableScanNode tableScan = captures.get(TABLE_SCAN);
 
-            PlanNode rewritten = planTableScan(tableScan, filterNode.getPredicate(), context.getSession(), context.getSymbolAllocator().getTypes(), context.getIdAllocator(), metadata, parser, domainTranslator);
+            PlanNode rewritten = planTableScan(tableScan, castToExpression(filterNode.getPredicate()), context.getSession(), context.getSymbolAllocator().getTypes(), context.getIdAllocator(), metadata, parser, domainTranslator);
 
             if (arePlansSame(filterNode, tableScan, rewritten)) {
                 return Result.empty();
@@ -336,7 +338,7 @@ public class PickTableLayout
                             decomposedPredicate.getRemainingExpression());
 
                     if (!TRUE_LITERAL.equals(resultingPredicate)) {
-                        return new FilterNode(idAllocator.getNextId(), tableScan, resultingPredicate);
+                        return new FilterNode(idAllocator.getNextId(), tableScan, castToRowExpression(resultingPredicate));
                     }
 
                     return tableScan;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
@@ -27,7 +27,7 @@ import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.DomainTranslator;
+import com.facebook.presto.sql.planner.ExpressionDomainTranslator;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.LookupSymbolResolver;
@@ -81,13 +81,13 @@ public class PickTableLayout
 {
     private final Metadata metadata;
     private final SqlParser parser;
-    private final DomainTranslator domainTranslator;
+    private final ExpressionDomainTranslator domainTranslator;
 
     public PickTableLayout(Metadata metadata, SqlParser parser)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.parser = requireNonNull(parser, "parser is null");
-        this.domainTranslator = new DomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde()));
+        this.domainTranslator = new ExpressionDomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde()));
     }
 
     public Set<Rule<?>> rules()
@@ -113,9 +113,9 @@ public class PickTableLayout
     {
         private final Metadata metadata;
         private final SqlParser parser;
-        private final DomainTranslator domainTranslator;
+        private final ExpressionDomainTranslator domainTranslator;
 
-        private PickTableLayoutForPredicate(Metadata metadata, SqlParser parser, DomainTranslator domainTranslator)
+        private PickTableLayoutForPredicate(Metadata metadata, SqlParser parser, ExpressionDomainTranslator domainTranslator)
         {
             this.metadata = requireNonNull(metadata, "metadata is null");
             this.parser = requireNonNull(parser, "parser is null");
@@ -184,9 +184,9 @@ public class PickTableLayout
     {
         private final Metadata metadata;
         private final SqlParser parser;
-        private final DomainTranslator domainTranslator;
+        private final ExpressionDomainTranslator domainTranslator;
 
-        private PickTableLayoutWithoutPredicate(Metadata metadata, SqlParser parser, DomainTranslator domainTranslator)
+        private PickTableLayoutWithoutPredicate(Metadata metadata, SqlParser parser, ExpressionDomainTranslator domainTranslator)
         {
             this.metadata = requireNonNull(metadata, "metadata is null");
             this.parser = requireNonNull(parser, "parser is null");
@@ -226,7 +226,7 @@ public class PickTableLayout
             PlanNodeIdAllocator idAllocator,
             Metadata metadata,
             SqlParser parser,
-            DomainTranslator domainTranslator)
+            ExpressionDomainTranslator domainTranslator)
     {
         return listTableLayouts(
                 node,
@@ -250,12 +250,12 @@ public class PickTableLayout
             PlanNodeIdAllocator idAllocator,
             Metadata metadata,
             SqlParser parser,
-            DomainTranslator domainTranslator)
+            ExpressionDomainTranslator domainTranslator)
     {
         // don't include non-deterministic predicates
         Expression deterministicPredicate = filterDeterministicConjuncts(predicate);
 
-        DomainTranslator.ExtractionResult decomposedPredicate = DomainTranslator.fromPredicate(
+        ExpressionDomainTranslator.ExtractionResult decomposedPredicate = ExpressionDomainTranslator.fromPredicate(
                 metadata,
                 session,
                 deterministicPredicate,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneFilterColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneFilterColumns.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictChildOutputs;
 import static com.facebook.presto.sql.planner.plan.Patterns.filter;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 public class PruneFilterColumns
@@ -40,7 +41,7 @@ public class PruneFilterColumns
     {
         Set<Symbol> prunedFilterInputs = Streams.concat(
                 referencedOutputs.stream(),
-                SymbolsExtractor.extractUnique(filterNode.getPredicate()).stream())
+                SymbolsExtractor.extractUnique(castToExpression(filterNode.getPredicate())).stream())
                 .collect(toImmutableSet());
 
         return restrictChildOutputs(idAllocator, filterNode, prunedFilterInputs);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveTrivialFilters.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveTrivialFilters.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.ImmutableList;
 
 import static com.facebook.presto.sql.planner.plan.Patterns.filter;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 
@@ -39,7 +40,7 @@ public class RemoveTrivialFilters
     @Override
     public Result apply(FilterNode filterNode, Captures captures, Context context)
     {
-        Expression predicate = filterNode.getPredicate();
+        Expression predicate = castToExpression(filterNode.getPredicate());
 
         if (predicate.equals(TRUE_LITERAL)) {
             return Result.ofPlanNode(filterNode.getSource());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
@@ -72,6 +72,7 @@ import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PAR
 import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.EQUAL;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -338,7 +339,7 @@ public class ReorderJoins
                         .forEach(predicates::add);
                 Expression filter = combineConjuncts(predicates.build());
                 if (!TRUE_LITERAL.equals(filter)) {
-                    planNode = new FilterNode(idAllocator.getNextId(), planNode, filter);
+                    planNode = new FilterNode(idAllocator.getNextId(), planNode, castToRowExpression(filter));
                 }
                 return createJoinEnumerationResult(planNode);
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
@@ -65,6 +65,7 @@ import static com.facebook.presto.sql.ExpressionUtils.or;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.singleGroupingSet;
 import static com.facebook.presto.sql.planner.plan.Patterns.Apply.correlation;
 import static com.facebook.presto.sql.planner.plan.Patterns.applyNode;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Objects.requireNonNull;
 
@@ -350,7 +351,7 @@ public class TransformCorrelatedInPredicateToJoin
                             ImmutableList.<Expression>builder()
                                     .addAll(decorrelated.getCorrelatedPredicates())
                                     // No need to retain uncorrelated conditions, predicate push down will push them back
-                                    .add(node.getPredicate())
+                                    .add(castToExpression(node.getPredicate()))
                                     .build(),
                             decorrelated.getDecorrelatedNode()));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
@@ -45,6 +45,7 @@ import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.sea
 import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isAtMostScalar;
 import static com.facebook.presto.sql.planner.plan.Patterns.LateralJoin.correlation;
 import static com.facebook.presto.sql.planner.plan.Patterns.lateralJoin;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 
 /**
@@ -138,7 +139,7 @@ public class TransformCorrelatedScalarSubquery
         FilterNode filterNode = new FilterNode(
                 context.getIdAllocator().getNextId(),
                 markDistinctNode,
-                new SimpleCaseExpression(
+                castToRowExpression(new SimpleCaseExpression(
                         isDistinct.toSymbolReference(),
                         ImmutableList.of(
                                 new WhenClause(TRUE_LITERAL, TRUE_LITERAL)),
@@ -148,7 +149,7 @@ public class TransformCorrelatedScalarSubquery
                                         ImmutableList.of(
                                                 new LongLiteral(Integer.toString(SUBQUERY_MULTIPLE_ROWS.toErrorCode().getCode())),
                                                 new StringLiteral("Scalar sub-query has returned multiple rows"))),
-                                BOOLEAN))));
+                                BOOLEAN)))));
 
         return Result.ofPlanNode(new ProjectNode(
                 context.getIdAllocator().getNextId(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -23,7 +23,7 @@ import com.facebook.presto.spi.LocalProperty;
 import com.facebook.presto.spi.SortingProperty;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.DomainTranslator;
+import com.facebook.presto.sql.planner.ExpressionDomainTranslator;
 import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningHandle;
@@ -135,12 +135,12 @@ public class AddExchanges
 {
     private final SqlParser parser;
     private final Metadata metadata;
-    private final DomainTranslator domainTranslator;
+    private final ExpressionDomainTranslator domainTranslator;
 
     public AddExchanges(Metadata metadata, SqlParser parser)
     {
         this.metadata = metadata;
-        this.domainTranslator = new DomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde()));
+        this.domainTranslator = new ExpressionDomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde()));
         this.parser = parser;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -121,6 +121,7 @@ import static com.facebook.presto.sql.planner.plan.ExchangeNode.mergingExchange;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.partitionedExchange;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.replicatedExchange;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.roundRobinExchange;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -523,7 +524,7 @@ public class AddExchanges
         public PlanWithProperties visitFilter(FilterNode node, PreferredProperties preferredProperties)
         {
             if (node.getSource() instanceof TableScanNode) {
-                return planTableScan((TableScanNode) node.getSource(), node.getPredicate(), preferredProperties);
+                return planTableScan((TableScanNode) node.getSource(), castToExpression(node.getPredicate()), preferredProperties);
             }
 
             return rebaseAndDeriveProperties(node, planChild(node, preferredProperties));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
@@ -15,70 +15,35 @@ package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.warnings.WarningCollector;
-import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.spi.function.FunctionHandle;
-import com.facebook.presto.spi.relation.CallExpression;
-import com.facebook.presto.spi.relation.ConstantExpression;
-import com.facebook.presto.spi.relation.InputReferenceExpression;
-import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
 import com.facebook.presto.spi.relation.RowExpression;
-import com.facebook.presto.spi.relation.RowExpressionVisitor;
-import com.facebook.presto.spi.relation.SpecialFormExpression;
-import com.facebook.presto.spi.relation.SpecialFormExpression.Form;
-import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.NodeRef;
-import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Ordering;
-import io.airlift.slice.Slice;
 
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
-import static com.facebook.presto.metadata.OperatorSignatureUtils.mangleOperatorName;
-import static com.facebook.presto.spi.function.OperatorType.EQUAL;
-import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
-import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
-import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
-import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
-import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
-import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
-import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
-import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
-import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
-import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.relational.SqlToRowExpressionTranslator.translate;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.lang.Integer.min;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
 public class ExpressionEquivalence
 {
-    private static final Ordering<RowExpression> ROW_EXPRESSION_ORDERING = Ordering.from(new RowExpressionComparator());
     private final Metadata metadata;
     private final SqlParser sqlParser;
-    private final CanonicalizationVisitor canonicalizationVisitor;
+    private final RowExpressionCanonicalizer rowExpressionCanonicalizer;
 
     public ExpressionEquivalence(Metadata metadata, SqlParser sqlParser)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
-        this.canonicalizationVisitor = new CanonicalizationVisitor(metadata.getFunctionManager());
+        this.rowExpressionCanonicalizer = new RowExpressionCanonicalizer(metadata.getFunctionManager());
     }
 
     public boolean areExpressionsEquivalent(Session session, Expression leftExpression, Expression rightExpression, TypeProvider types)
@@ -92,8 +57,8 @@ public class ExpressionEquivalence
         RowExpression leftRowExpression = toRowExpression(session, leftExpression, symbolInput, types);
         RowExpression rightRowExpression = toRowExpression(session, rightExpression, symbolInput, types);
 
-        RowExpression canonicalizedLeft = leftRowExpression.accept(canonicalizationVisitor, null);
-        RowExpression canonicalizedRight = rightRowExpression.accept(canonicalizationVisitor, null);
+        RowExpression canonicalizedLeft = rowExpressionCanonicalizer.canonicalize(leftRowExpression);
+        RowExpression canonicalizedRight = rowExpressionCanonicalizer.canonicalize(rightRowExpression);
 
         return canonicalizedLeft.equals(canonicalizedRight);
     }
@@ -114,266 +79,5 @@ public class ExpressionEquivalence
 
         // convert to row expression
         return translate(expression, expressionTypes, symbolInput, metadata.getFunctionManager(), metadata.getTypeManager(), session, false);
-    }
-
-    private static class CanonicalizationVisitor
-            implements RowExpressionVisitor<RowExpression, Void>
-    {
-        private final FunctionManager functionManager;
-
-        public CanonicalizationVisitor(FunctionManager functionManager)
-        {
-            this.functionManager = requireNonNull(functionManager, "functionManager is null");
-        }
-
-        @Override
-        public RowExpression visitCall(CallExpression call, Void context)
-        {
-            call = new CallExpression(
-                    call.getDisplayName(),
-                    call.getFunctionHandle(),
-                    call.getType(),
-                    call.getArguments().stream()
-                            .map(expression -> expression.accept(this, context))
-                            .collect(toImmutableList()));
-
-            String callName = functionManager.getFunctionMetadata(call.getFunctionHandle()).getName();
-
-            if (callName.equals(mangleOperatorName(EQUAL)) || callName.equals(mangleOperatorName(NOT_EQUAL)) || callName.equals(mangleOperatorName(IS_DISTINCT_FROM))) {
-                // sort arguments
-                return new CallExpression(
-                        call.getDisplayName(),
-                        call.getFunctionHandle(),
-                        call.getType(),
-                        ROW_EXPRESSION_ORDERING.sortedCopy(call.getArguments()));
-            }
-
-            if (callName.equals(mangleOperatorName(GREATER_THAN)) || callName.equals(mangleOperatorName(GREATER_THAN_OR_EQUAL))) {
-                // convert greater than to less than
-
-                FunctionHandle functionHandle = functionManager.resolveOperator(
-                        callName.equals(mangleOperatorName(GREATER_THAN)) ? LESS_THAN : LESS_THAN_OR_EQUAL,
-                        swapPair(fromTypes(call.getArguments().stream().map(RowExpression::getType).collect(toImmutableList()))));
-                return new CallExpression(
-                        call.getDisplayName(),
-                        functionHandle,
-                        call.getType(),
-                        swapPair(call.getArguments()));
-            }
-
-            return call;
-        }
-
-        public static List<RowExpression> flattenNestedSpecialForms(SpecialFormExpression specialForm)
-        {
-            Form form = specialForm.getForm();
-            ImmutableList.Builder<RowExpression> newArguments = ImmutableList.builder();
-            for (RowExpression argument : specialForm.getArguments()) {
-                if (argument instanceof SpecialFormExpression && form.equals(((SpecialFormExpression) argument).getForm())) {
-                    // same special form type, so flatten the args
-                    newArguments.addAll(flattenNestedSpecialForms((SpecialFormExpression) argument));
-                }
-                else {
-                    newArguments.add(argument);
-                }
-            }
-            return newArguments.build();
-        }
-
-        @Override
-        public RowExpression visitConstant(ConstantExpression constant, Void context)
-        {
-            return constant;
-        }
-
-        @Override
-        public RowExpression visitInputReference(InputReferenceExpression node, Void context)
-        {
-            return node;
-        }
-
-        @Override
-        public RowExpression visitLambda(LambdaDefinitionExpression lambda, Void context)
-        {
-            return new LambdaDefinitionExpression(lambda.getArgumentTypes(), lambda.getArguments(), lambda.getBody().accept(this, context));
-        }
-
-        @Override
-        public RowExpression visitVariableReference(VariableReferenceExpression reference, Void context)
-        {
-            return reference;
-        }
-
-        @Override
-        public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Void context)
-        {
-            specialForm = new SpecialFormExpression(
-                    specialForm.getForm(),
-                    specialForm.getType(),
-                    specialForm.getArguments().stream()
-                            .map(expression -> expression.accept(this, context))
-                            .collect(toImmutableList()));
-
-            if (specialForm.getForm() == AND || specialForm.getForm() == OR) {
-                // if we have nested calls (of the same type) flatten them
-                List<RowExpression> flattenedArguments = flattenNestedSpecialForms(specialForm);
-
-                // only consider distinct arguments
-                Set<RowExpression> distinctArguments = ImmutableSet.copyOf(flattenedArguments);
-                if (distinctArguments.size() == 1) {
-                    return Iterables.getOnlyElement(distinctArguments);
-                }
-
-                // canonicalize the argument order (i.e., sort them)
-                List<RowExpression> sortedArguments = ROW_EXPRESSION_ORDERING.sortedCopy(distinctArguments);
-
-                return new SpecialFormExpression(specialForm.getForm(), BOOLEAN, sortedArguments);
-            }
-
-            return specialForm;
-        }
-    }
-
-    private static class RowExpressionComparator
-            implements Comparator<RowExpression>
-    {
-        private final Comparator<Object> classComparator = Ordering.arbitrary();
-        private final ListComparator<RowExpression> argumentComparator = new ListComparator<>(this);
-
-        @Override
-        public int compare(RowExpression left, RowExpression right)
-        {
-            int result = classComparator.compare(left.getClass(), right.getClass());
-            if (result != 0) {
-                return result;
-            }
-
-            if (left instanceof CallExpression) {
-                CallExpression leftCall = (CallExpression) left;
-                CallExpression rightCall = (CallExpression) right;
-                return ComparisonChain.start()
-                        .compare(leftCall.getFunctionHandle().toString(), rightCall.getFunctionHandle().toString())
-                        .compare(leftCall.getArguments(), rightCall.getArguments(), argumentComparator)
-                        .result();
-            }
-
-            if (left instanceof ConstantExpression) {
-                ConstantExpression leftConstant = (ConstantExpression) left;
-                ConstantExpression rightConstant = (ConstantExpression) right;
-
-                result = leftConstant.getType().getTypeSignature().toString().compareTo(right.getType().getTypeSignature().toString());
-                if (result != 0) {
-                    return result;
-                }
-
-                Object leftValue = leftConstant.getValue();
-                Object rightValue = rightConstant.getValue();
-
-                if (leftValue == null) {
-                    if (rightValue == null) {
-                        return 0;
-                    }
-                    else {
-                        return -1;
-                    }
-                }
-                else if (rightValue == null) {
-                    return 1;
-                }
-
-                Class<?> javaType = leftConstant.getType().getJavaType();
-                if (javaType == boolean.class) {
-                    return ((Boolean) leftValue).compareTo((Boolean) rightValue);
-                }
-                if (javaType == byte.class || javaType == short.class || javaType == int.class || javaType == long.class) {
-                    return Long.compare(((Number) leftValue).longValue(), ((Number) rightValue).longValue());
-                }
-                if (javaType == float.class || javaType == double.class) {
-                    return Double.compare(((Number) leftValue).doubleValue(), ((Number) rightValue).doubleValue());
-                }
-                if (javaType == Slice.class) {
-                    return ((Slice) leftValue).compareTo((Slice) rightValue);
-                }
-
-                // value is some random type (say regex), so we just randomly choose a greater value
-                // todo: support all known type
-                return -1;
-            }
-
-            if (left instanceof InputReferenceExpression) {
-                return Integer.compare(((InputReferenceExpression) left).getField(), ((InputReferenceExpression) right).getField());
-            }
-
-            if (left instanceof LambdaDefinitionExpression) {
-                LambdaDefinitionExpression leftLambda = (LambdaDefinitionExpression) left;
-                LambdaDefinitionExpression rightLambda = (LambdaDefinitionExpression) right;
-
-                return ComparisonChain.start()
-                        .compare(
-                                leftLambda.getArgumentTypes(),
-                                rightLambda.getArgumentTypes(),
-                                new ListComparator<>(Comparator.comparing(Object::toString)))
-                        .compare(
-                                leftLambda.getArguments(),
-                                rightLambda.getArguments(),
-                                new ListComparator<>(Comparator.<String>naturalOrder()))
-                        .compare(leftLambda.getBody(), rightLambda.getBody(), this)
-                        .result();
-            }
-
-            if (left instanceof VariableReferenceExpression) {
-                VariableReferenceExpression leftVariableReference = (VariableReferenceExpression) left;
-                VariableReferenceExpression rightVariableReference = (VariableReferenceExpression) right;
-
-                return ComparisonChain.start()
-                        .compare(leftVariableReference.getName(), rightVariableReference.getName())
-                        .compare(leftVariableReference.getType(), rightVariableReference.getType(), Comparator.comparing(Object::toString))
-                        .result();
-            }
-
-            if (left instanceof SpecialFormExpression) {
-                SpecialFormExpression leftSpecialForm = (SpecialFormExpression) left;
-                SpecialFormExpression rightSpecialForm = (SpecialFormExpression) right;
-
-                return ComparisonChain.start()
-                        .compare(leftSpecialForm.getForm(), rightSpecialForm.getForm())
-                        .compare(leftSpecialForm.getType(), rightSpecialForm.getType(), Comparator.comparing(Object::toString))
-                        .compare(leftSpecialForm.getArguments(), rightSpecialForm.getArguments(), argumentComparator)
-                        .result();
-            }
-
-            throw new IllegalArgumentException("Unsupported RowExpression type " + left.getClass().getSimpleName());
-        }
-    }
-
-    private static class ListComparator<T>
-            implements Comparator<List<T>>
-    {
-        private final Comparator<T> elementComparator;
-
-        public ListComparator(Comparator<T> elementComparator)
-        {
-            this.elementComparator = requireNonNull(elementComparator, "elementComparator is null");
-        }
-
-        @Override
-        public int compare(List<T> left, List<T> right)
-        {
-            int compareLength = min(left.size(), right.size());
-            for (int i = 0; i < compareLength; i++) {
-                int result = elementComparator.compare(left.get(i), right.get(i));
-                if (result != 0) {
-                    return result;
-                }
-            }
-            return Integer.compare(left.size(), right.size());
-        }
-    }
-
-    private static <T> List<T> swapPair(List<T> pair)
-    {
-        requireNonNull(pair, "pair is null");
-        checkArgument(pair.size() == 2, "Expected pair to have two elements");
-        return ImmutableList.of(pair.get(1), pair.get(0));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
@@ -55,6 +55,7 @@ import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.singleGroupingSet;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.EQUAL;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL;
@@ -267,7 +268,7 @@ public class ImplementIntersectAndExceptAsUnion
             ImmutableList<Expression> predicates = aggregation.getAggregations().keySet().stream()
                     .map(column -> new ComparisonExpression(GREATER_THAN_OR_EQUAL, column.toSymbolReference(), new GenericLiteral("BIGINT", "1")))
                     .collect(toImmutableList());
-            return new FilterNode(idAllocator.getNextId(), aggregation, ExpressionUtils.and(predicates));
+            return new FilterNode(idAllocator.getNextId(), aggregation, castToRowExpression(ExpressionUtils.and(predicates)));
         }
 
         private FilterNode addFilterForExcept(AggregationNode aggregation, Symbol firstSource, List<Symbol> remainingSources)
@@ -278,7 +279,7 @@ public class ImplementIntersectAndExceptAsUnion
                 predicatesBuilder.add(new ComparisonExpression(EQUAL, symbol.toSymbolReference(), new GenericLiteral("BIGINT", "0")));
             }
 
-            return new FilterNode(idAllocator.getNextId(), aggregation, ExpressionUtils.and(predicatesBuilder.build()));
+            return new FilterNode(idAllocator.getNextId(), aggregation, castToRowExpression(ExpressionUtils.and(predicatesBuilder.build())));
         }
 
         private ProjectNode project(PlanNode node, List<Symbol> columns)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -19,7 +19,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.ResolvedIndex;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
-import com.facebook.presto.sql.planner.DomainTranslator;
+import com.facebook.presto.sql.planner.ExpressionDomainTranslator;
 import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
@@ -226,13 +226,13 @@ public class IndexJoinOptimizer
         private final SymbolAllocator symbolAllocator;
         private final PlanNodeIdAllocator idAllocator;
         private final Metadata metadata;
-        private final DomainTranslator domainTranslator;
+        private final ExpressionDomainTranslator domainTranslator;
         private final Session session;
 
         private IndexSourceRewriter(SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, Metadata metadata, Session session)
         {
             this.metadata = requireNonNull(metadata, "metadata is null");
-            this.domainTranslator = new DomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde()));
+            this.domainTranslator = new ExpressionDomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde()));
             this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.session = requireNonNull(session, "session is null");
@@ -270,7 +270,7 @@ public class IndexJoinOptimizer
 
         private PlanNode planTableScan(TableScanNode node, Expression predicate, Context context)
         {
-            DomainTranslator.ExtractionResult decomposedPredicate = DomainTranslator.fromPredicate(
+            ExpressionDomainTranslator.ExtractionResult decomposedPredicate = ExpressionDomainTranslator.fromPredicate(
                     metadata,
                     session,
                     predicate,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -19,9 +19,9 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.DeterminismEvaluator;
-import com.facebook.presto.sql.planner.DomainTranslator;
 import com.facebook.presto.sql.planner.EffectivePredicateExtractor;
 import com.facebook.presto.sql.planner.EqualityInference;
+import com.facebook.presto.sql.planner.ExpressionDomainTranslator;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.NoOpSymbolResolver;
@@ -108,7 +108,7 @@ public class PredicatePushDown
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.literalEncoder = new LiteralEncoder(metadata.getBlockEncodingSerde());
-        this.effectivePredicateExtractor = new EffectivePredicateExtractor(new DomainTranslator(literalEncoder));
+        this.effectivePredicateExtractor = new EffectivePredicateExtractor(new ExpressionDomainTranslator(literalEncoder));
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -27,7 +27,7 @@ import com.facebook.presto.spi.SortingProperty;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.DomainTranslator;
+import com.facebook.presto.sql.planner.ExpressionDomainTranslator;
 import com.facebook.presto.sql.planner.ExpressionInterpreter;
 import com.facebook.presto.sql.planner.NoOpSymbolResolver;
 import com.facebook.presto.sql.planner.OrderingScheme;
@@ -591,7 +591,7 @@ public class PropertyDerivations
         {
             ActualProperties properties = Iterables.getOnlyElement(inputProperties);
 
-            DomainTranslator.ExtractionResult decomposedPredicate = DomainTranslator.fromPredicate(
+            ExpressionDomainTranslator.ExtractionResult decomposedPredicate = ExpressionDomainTranslator.fromPredicate(
                     metadata,
                     session,
                     node.getPredicate(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -600,7 +600,8 @@ public class PropertyDerivations
                 tupleDomain = ExpressionDomainTranslator.fromPredicate(metadata, session, castToExpression(node.getPredicate()), types).getTupleDomain();
             }
             else {
-                tupleDomain = RowExpressionDomainTranslator.fromPredicate(metadata, session, node.getPredicate())
+                // we will deprecate PropertyDerivation later.
+                tupleDomain = new RowExpressionDomainTranslator(metadata.getFunctionManager()).fromPredicate(metadata, session, node.getPredicate())
                         .getTupleDomain()
                         .transform(column -> new Symbol(column.getName()));
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -84,6 +84,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isScalar;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.concat;
@@ -437,7 +438,7 @@ public class PruneUnreferencedOutputs
         public PlanNode visitFilter(FilterNode node, RewriteContext<Set<Symbol>> context)
         {
             Set<Symbol> expectedInputs = ImmutableSet.<Symbol>builder()
-                    .addAll(SymbolsExtractor.extractUnique(node.getPredicate()))
+                    .addAll(SymbolsExtractor.extractUnique(castToExpression(node.getPredicate())))
                     .addAll(context.get())
                     .build();
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RowExpressionCanonicalizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RowExpressionCanonicalizer.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.relational.StandardFunctionResolution;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Ordering;
+import io.airlift.slice.Slice;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.metadata.OperatorSignatureUtils.mangleOperatorName;
+import static com.facebook.presto.spi.function.OperatorType.EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.Integer.min;
+import static java.util.Objects.requireNonNull;
+
+public class RowExpressionCanonicalizer
+{
+    private static final Ordering<RowExpression> ROW_EXPRESSION_ORDERING = Ordering.from(new RowExpressionComparator());
+    private final CanonicalizationVisitor canonicalizationVisitor;
+
+    public RowExpressionCanonicalizer(FunctionManager functionManager)
+    {
+        this.canonicalizationVisitor = new CanonicalizationVisitor(requireNonNull(functionManager, "funcionManager is null"));
+    }
+
+    public RowExpression canonicalize(RowExpression input)
+    {
+        return input.accept(canonicalizationVisitor, null);
+    }
+
+    private static class CanonicalizationVisitor
+            implements RowExpressionVisitor<RowExpression, Void>
+    {
+        private final FunctionManager functionManager;
+
+        public CanonicalizationVisitor(FunctionManager functionManager)
+        {
+            this.functionManager = requireNonNull(functionManager, "functionManager is null");
+        }
+
+        @Override
+        public RowExpression visitCall(CallExpression call, Void context)
+        {
+            call = new CallExpression(
+                    call.getDisplayName(),
+                    call.getFunctionHandle(),
+                    call.getType(),
+                    call.getArguments().stream()
+                            .map(expression -> expression.accept(this, context))
+                            .collect(toImmutableList()));
+
+            String callName = call.getFunctionHandle().getSignature().getName();
+
+            if (callName.equals(mangleOperatorName(EQUAL)) || callName.equals(mangleOperatorName(NOT_EQUAL)) || callName.equals(mangleOperatorName(IS_DISTINCT_FROM))) {
+                // sort arguments
+                return new CallExpression(
+                        call.getDisplayName(),
+                        call.getFunctionHandle(),
+                        call.getType(),
+                        ROW_EXPRESSION_ORDERING.sortedCopy(call.getArguments()));
+            }
+
+            if (callName.equals(mangleOperatorName(GREATER_THAN)) || callName.equals(mangleOperatorName(GREATER_THAN_OR_EQUAL))) {
+                // convert greater than to less than
+
+                FunctionHandle functionHandle = functionManager.resolveOperator(
+                        callName.equals(mangleOperatorName(GREATER_THAN)) ? LESS_THAN : LESS_THAN_OR_EQUAL,
+                        swapPair(fromTypes(call.getArguments().stream().map(RowExpression::getType).collect(toImmutableList()))));
+                return new CallExpression(
+                        call.getDisplayName(),
+                        functionHandle,
+                        call.getType(),
+                        swapPair(call.getArguments()));
+            }
+
+            return call;
+        }
+
+        public static List<RowExpression> flattenNestedSpecialForms(SpecialFormExpression specialForm)
+        {
+            SpecialFormExpression.Form form = specialForm.getForm();
+            ImmutableList.Builder<RowExpression> newArguments = ImmutableList.builder();
+            for (RowExpression argument : specialForm.getArguments()) {
+                if (argument instanceof SpecialFormExpression && form.equals(((SpecialFormExpression) argument).getForm())) {
+                    // same special form type, so flatten the args
+                    newArguments.addAll(flattenNestedSpecialForms((SpecialFormExpression) argument));
+                }
+                else {
+                    newArguments.add(argument);
+                }
+            }
+            return newArguments.build();
+        }
+
+        @Override
+        public RowExpression visitConstant(ConstantExpression constant, Void context)
+        {
+            return constant;
+        }
+
+        @Override
+        public RowExpression visitInputReference(InputReferenceExpression node, Void context)
+        {
+            return node;
+        }
+
+        @Override
+        public RowExpression visitLambda(LambdaDefinitionExpression lambda, Void context)
+        {
+            return new LambdaDefinitionExpression(lambda.getArgumentTypes(), lambda.getArguments(), lambda.getBody().accept(this, context));
+        }
+
+        @Override
+        public RowExpression visitVariableReference(VariableReferenceExpression reference, Void context)
+        {
+            return reference;
+        }
+
+        @Override
+        public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Void context)
+        {
+            specialForm = new SpecialFormExpression(
+                    specialForm.getForm(),
+                    specialForm.getType(),
+                    specialForm.getArguments().stream()
+                            .map(expression -> expression.accept(this, context))
+                            .collect(toImmutableList()));
+
+            if (specialForm.getForm() == AND || specialForm.getForm() == OR) {
+                // if we have nested calls (of the same type) flatten them
+                List<RowExpression> flattenedArguments = flattenNestedSpecialForms(specialForm);
+
+                // only consider distinct arguments
+                Set<RowExpression> distinctArguments = ImmutableSet.copyOf(flattenedArguments);
+                if (distinctArguments.size() == 1) {
+                    return Iterables.getOnlyElement(distinctArguments);
+                }
+
+                // canonicalize the argument order (i.e., sort them)
+                List<RowExpression> sortedArguments = ROW_EXPRESSION_ORDERING.sortedCopy(distinctArguments);
+
+                return new SpecialFormExpression(specialForm.getForm(), BOOLEAN, sortedArguments);
+            }
+            if (specialForm.getForm() == IN && specialForm.getArguments().size() == 2) {
+                // if single value, convert to equal
+                RowExpression left = specialForm.getArguments().get(0);
+                RowExpression right = specialForm.getArguments().get(1);
+                return new CallExpression(
+                        EQUAL.name(),
+                        new StandardFunctionResolution(functionManager).comparisonFunction(ComparisonExpression.Operator.EQUAL, left.getType(), right.getType()),
+                        BOOLEAN,
+                        specialForm.getArguments()).accept(this, context);
+            }
+
+            return specialForm;
+        }
+    }
+
+    private static class RowExpressionComparator
+            implements Comparator<RowExpression>
+    {
+        private final Comparator<Object> classComparator = Ordering.arbitrary();
+        private final ListComparator<RowExpression> argumentComparator = new ListComparator<>(this);
+
+        @Override
+        public int compare(RowExpression left, RowExpression right)
+        {
+            int result = classComparator.compare(left.getClass(), right.getClass());
+            if (result != 0) {
+                return result;
+            }
+
+            if (left instanceof CallExpression) {
+                CallExpression leftCall = (CallExpression) left;
+                CallExpression rightCall = (CallExpression) right;
+                return ComparisonChain.start()
+                        .compare(leftCall.getFunctionHandle().toString(), rightCall.getFunctionHandle().toString())
+                        .compare(leftCall.getArguments(), rightCall.getArguments(), argumentComparator)
+                        .result();
+            }
+
+            if (left instanceof ConstantExpression) {
+                ConstantExpression leftConstant = (ConstantExpression) left;
+                ConstantExpression rightConstant = (ConstantExpression) right;
+
+                result = leftConstant.getType().getTypeSignature().toString().compareTo(right.getType().getTypeSignature().toString());
+                if (result != 0) {
+                    return result;
+                }
+
+                Object leftValue = leftConstant.getValue();
+                Object rightValue = rightConstant.getValue();
+
+                if (leftValue == null) {
+                    if (rightValue == null) {
+                        return 0;
+                    }
+                    else {
+                        return -1;
+                    }
+                }
+                else if (rightValue == null) {
+                    return 1;
+                }
+
+                Class<?> javaType = leftConstant.getType().getJavaType();
+                if (javaType == boolean.class) {
+                    return ((Boolean) leftValue).compareTo((Boolean) rightValue);
+                }
+                if (javaType == byte.class || javaType == short.class || javaType == int.class || javaType == long.class) {
+                    return Long.compare(((Number) leftValue).longValue(), ((Number) rightValue).longValue());
+                }
+                if (javaType == float.class || javaType == double.class) {
+                    return Double.compare(((Number) leftValue).doubleValue(), ((Number) rightValue).doubleValue());
+                }
+                if (javaType == Slice.class) {
+                    return ((Slice) leftValue).compareTo((Slice) rightValue);
+                }
+
+                // value is some random type (say regex), so we just randomly choose a greater value
+                // todo: support all known type
+                return -1;
+            }
+
+            if (left instanceof InputReferenceExpression) {
+                return Integer.compare(((InputReferenceExpression) left).getField(), ((InputReferenceExpression) right).getField());
+            }
+
+            if (left instanceof LambdaDefinitionExpression) {
+                LambdaDefinitionExpression leftLambda = (LambdaDefinitionExpression) left;
+                LambdaDefinitionExpression rightLambda = (LambdaDefinitionExpression) right;
+
+                return ComparisonChain.start()
+                        .compare(
+                                leftLambda.getArgumentTypes(),
+                                rightLambda.getArgumentTypes(),
+                                new ListComparator<>(Comparator.comparing(Object::toString)))
+                        .compare(
+                                leftLambda.getArguments(),
+                                rightLambda.getArguments(),
+                                new ListComparator<>(Comparator.<String>naturalOrder()))
+                        .compare(leftLambda.getBody(), rightLambda.getBody(), this)
+                        .result();
+            }
+
+            if (left instanceof VariableReferenceExpression) {
+                VariableReferenceExpression leftVariableReference = (VariableReferenceExpression) left;
+                VariableReferenceExpression rightVariableReference = (VariableReferenceExpression) right;
+
+                return ComparisonChain.start()
+                        .compare(leftVariableReference.getName(), rightVariableReference.getName())
+                        .compare(leftVariableReference.getType(), rightVariableReference.getType(), Comparator.comparing(Object::toString))
+                        .result();
+            }
+
+            if (left instanceof SpecialFormExpression) {
+                SpecialFormExpression leftSpecialForm = (SpecialFormExpression) left;
+                SpecialFormExpression rightSpecialForm = (SpecialFormExpression) right;
+
+                return ComparisonChain.start()
+                        .compare(leftSpecialForm.getForm(), rightSpecialForm.getForm())
+                        .compare(leftSpecialForm.getType(), rightSpecialForm.getType(), Comparator.comparing(Object::toString))
+                        .compare(leftSpecialForm.getArguments(), rightSpecialForm.getArguments(), argumentComparator)
+                        .result();
+            }
+
+            throw new IllegalArgumentException("Unsupported RowExpression type " + left.getClass().getSimpleName());
+        }
+    }
+
+    private static class ListComparator<T>
+            implements Comparator<List<T>>
+    {
+        private final Comparator<T> elementComparator;
+
+        public ListComparator(Comparator<T> elementComparator)
+        {
+            this.elementComparator = requireNonNull(elementComparator, "elementComparator is null");
+        }
+
+        @Override
+        public int compare(List<T> left, List<T> right)
+        {
+            int compareLength = min(left.size(), right.size());
+            for (int i = 0; i < compareLength; i++) {
+                int result = elementComparator.compare(left.get(i), right.get(i));
+                if (result != 0) {
+                    return result;
+                }
+            }
+            return Integer.compare(left.size(), right.size());
+        }
+    }
+
+    private static <T> List<T> swapPair(List<T> pair)
+    {
+        requireNonNull(pair, "pair is null");
+        checkArgument(pair.size() == 2, "Expected pair to have two elements");
+        return ImmutableList.of(pair.get(1), pair.get(0));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RowExpressionCanonicalizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RowExpressionCanonicalizer.java
@@ -200,7 +200,9 @@ public class RowExpressionCanonicalizer
     private static class RowExpressionComparator
             implements Comparator<RowExpression>
     {
-        private final Comparator<Object> classComparator = Ordering.arbitrary();
+        private final Comparator<Object> classComparator = Ordering.explicit(
+                ImmutableList.of(InputReferenceExpression.class, VariableReferenceExpression.class, ConstantExpression.class,
+                        SpecialFormExpression.class, CallExpression.class, LambdaDefinitionExpression.class));
         private final ListComparator<RowExpression> argumentComparator = new ListComparator<>(this);
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RowExpressionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/RowExpressionUtils.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+public class RowExpressionUtils
+{
+    private RowExpressionUtils()
+    {
+    }
+
+    public static RowExpression inlineExpressions(RowExpression rowExpression, Map<RowExpression, RowExpression> assignments)
+    {
+        return rowExpression.accept(new InlineVisitor(), assignments).orElse(rowExpression);
+    }
+
+    private static class InlineVisitor
+            implements RowExpressionVisitor<Optional<RowExpression>, Map<RowExpression, RowExpression>>
+    {
+        @Override
+        public Optional<RowExpression> visitCall(CallExpression call, Map<RowExpression, RowExpression> context)
+        {
+            if (context.containsKey(call)) {
+                return Optional.of(context.get(call));
+            }
+            List<RowExpression> rewritten = returnChanged(call.getArguments(), argument -> argument.accept(this, context));
+            if (rewritten.size() == call.getArguments().size()) {
+                return Optional.of(new CallExpression(call.getDisplayName(), call.getFunctionHandle(), call.getType(), rewritten));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<RowExpression> visitInputReference(InputReferenceExpression reference, Map<RowExpression, RowExpression> context)
+        {
+            if (context.containsKey(reference)) {
+                return Optional.of(context.get(reference));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<RowExpression> visitConstant(ConstantExpression literal, Map<RowExpression, RowExpression> context)
+        {
+            if (context.containsKey(literal)) {
+                return Optional.of(context.get(literal));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<RowExpression> visitLambda(LambdaDefinitionExpression lambda, Map<RowExpression, RowExpression> context)
+        {
+            if (context.containsKey(lambda)) {
+                return Optional.of(context.get(lambda));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<RowExpression> visitVariableReference(VariableReferenceExpression reference, Map<RowExpression, RowExpression> context)
+        {
+            if (context.containsKey(reference)) {
+                return Optional.of(context.get(reference));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<RowExpression> visitSpecialForm(SpecialFormExpression specialForm, Map<RowExpression, RowExpression> context)
+        {
+            if (context.containsKey(specialForm)) {
+                return Optional.of(context.get(specialForm));
+            }
+            List<RowExpression> rewritten = returnChanged(specialForm.getArguments(), argument -> argument.accept(this, context));
+            if (rewritten.size() == specialForm.getArguments().size()) {
+                return Optional.of(new SpecialFormExpression(specialForm.getForm(), specialForm.getType(), rewritten));
+            }
+            return Optional.empty();
+        }
+
+        private static <T> List<T> returnChanged(List<T> input, Function<T, Optional<T>> transformer)
+        {
+            Iterator<T> iterator = input.iterator();
+            ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(input.size());
+            boolean changed = false;
+            while (iterator.hasNext()) {
+                T item = iterator.next();
+                Optional<T> result = transformer.apply(item);
+                builder.add(result.orElse(item));
+                if (result.isPresent()) {
+                    changed = true;
+                }
+            }
+            if (changed) {
+                return builder.build();
+            }
+            return ImmutableList.of();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -413,7 +413,7 @@ public class UnaliasSymbolReferences
         {
             PlanNode source = context.rewrite(node.getSource());
 
-            return new FilterNode(node.getId(), source, canonicalize(node.getPredicate()));
+            return new FilterNode(node.getId(), source, castToRowExpression(canonicalize(castToExpression(node.getPredicate()))));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/WindowFilterPushDown.java
@@ -25,7 +25,7 @@ import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.predicate.ValueSet;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.sql.ExpressionUtils;
-import com.facebook.presto.sql.planner.DomainTranslator;
+import com.facebook.presto.sql.planner.ExpressionDomainTranslator;
 import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.PlanNodeIdAllocator;
 import com.facebook.presto.sql.planner.Symbol;
@@ -51,8 +51,8 @@ import static com.facebook.presto.spi.function.FunctionKind.WINDOW;
 import static com.facebook.presto.spi.predicate.Marker.Bound.BELOW;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
-import static com.facebook.presto.sql.planner.DomainTranslator.ExtractionResult;
-import static com.facebook.presto.sql.planner.DomainTranslator.fromPredicate;
+import static com.facebook.presto.sql.planner.ExpressionDomainTranslator.ExtractionResult;
+import static com.facebook.presto.sql.planner.ExpressionDomainTranslator.fromPredicate;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -67,12 +67,12 @@ public class WindowFilterPushDown
     private static final Signature ROW_NUMBER_SIGNATURE = new Signature("row_number", WINDOW, parseTypeSignature(StandardTypes.BIGINT), ImmutableList.of());
 
     private final Metadata metadata;
-    private final DomainTranslator domainTranslator;
+    private final ExpressionDomainTranslator domainTranslator;
 
     public WindowFilterPushDown(Metadata metadata)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
-        this.domainTranslator = new DomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde()));
+        this.domainTranslator = new ExpressionDomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde()));
     }
 
     @Override
@@ -92,11 +92,11 @@ public class WindowFilterPushDown
     {
         private final PlanNodeIdAllocator idAllocator;
         private final Metadata metadata;
-        private final DomainTranslator domainTranslator;
+        private final ExpressionDomainTranslator domainTranslator;
         private final Session session;
         private final TypeProvider types;
 
-        private Rewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, DomainTranslator domainTranslator, Session session, TypeProvider types)
+        private Rewriter(PlanNodeIdAllocator idAllocator, Metadata metadata, ExpressionDomainTranslator domainTranslator, Session session, TypeProvider types)
         {
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.metadata = requireNonNull(metadata, "metadata is null");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/joins/JoinGraph.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/joins/JoinGraph.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
 import static com.facebook.presto.sql.relational.ProjectNodeUtils.isIdentity;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -253,7 +254,7 @@ public class JoinGraph
         public JoinGraph visitFilter(FilterNode node, Context context)
         {
             JoinGraph graph = node.getSource().accept(this, context);
-            return graph.withFilter(node.getPredicate());
+            return graph.withFilter(castToExpression(node.getPredicate()));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/FilterNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/FilterNode.java
@@ -13,8 +13,8 @@
  */
 package com.facebook.presto.sql.planner.plan;
 
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.sql.planner.Symbol;
-import com.facebook.presto.sql.tree.Expression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -29,12 +29,12 @@ public class FilterNode
         extends PlanNode
 {
     private final PlanNode source;
-    private final Expression predicate;
+    private final RowExpression predicate;
 
     @JsonCreator
     public FilterNode(@JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
-            @JsonProperty("predicate") Expression predicate)
+            @JsonProperty("predicate") RowExpression predicate)
     {
         super(id);
 
@@ -43,7 +43,7 @@ public class FilterNode
     }
 
     @JsonProperty("predicate")
-    public Expression getPredicate()
+    public RowExpression getPredicate()
     {
         return predicate;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -311,7 +311,7 @@ public class PlanPrinter
         return builder.toString();
     }
 
-    public static String graphvizLogicalPlan(PlanNode plan, TypeProvider types)
+    public static String graphvizLogicalPlan(PlanNode plan, TypeProvider types, Session session)
     {
         // TODO: This should move to something like GraphvizRenderer
         PlanFragment fragment = new PlanFragment(
@@ -324,12 +324,12 @@ public class PlanPrinter
                 StageExecutionDescriptor.ungroupedExecution(),
                 StatsAndCosts.empty(),
                 Optional.empty());
-        return GraphvizPrinter.printLogical(ImmutableList.of(fragment));
+        return GraphvizPrinter.printLogical(ImmutableList.of(fragment), session);
     }
 
-    public static String graphvizDistributedPlan(SubPlan plan)
+    public static String graphvizDistributedPlan(SubPlan plan, Session session)
     {
-        return GraphvizPrinter.printDistributed(plan);
+        return GraphvizPrinter.printDistributed(plan, session);
     }
 
     private class Visitor
@@ -708,7 +708,7 @@ public class PlanPrinter
             if (filterNode.isPresent()) {
                 operatorName += "Filter";
                 formatString += "filterPredicate = %s, ";
-                arguments.add(filterNode.get().getPredicate());
+                arguments.add(formatter.formatRowExpression(filterNode.get().getPredicate()));
             }
 
             if (formatString.length() > 1) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoIdentifierLeftChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoIdentifierLeftChecker.java
@@ -21,9 +21,12 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.ExpressionExtractor;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.relational.OriginalExpressionUtils;
 import com.facebook.presto.sql.tree.Identifier;
 
 import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public final class NoIdentifierLeftChecker
         implements PlanSanityChecker.Checker
@@ -31,7 +34,13 @@ public final class NoIdentifierLeftChecker
     @Override
     public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
     {
-        List<Identifier> identifiers = ExpressionTreeUtils.extractExpressions(ExpressionExtractor.extractExpressions(plan), Identifier.class);
+        List<Identifier> identifiers = ExpressionTreeUtils.extractExpressions(
+                ExpressionExtractor.extractExpressions(plan)
+                        .stream()
+                        .filter(OriginalExpressionUtils::isExpression)
+                        .map(OriginalExpressionUtils::castToExpression)
+                        .collect(toImmutableList()),
+                Identifier.class);
         if (!identifiers.isEmpty()) {
             throw new IllegalStateException("Unexpected identifier in logical plan: " + identifiers.get(0));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -74,6 +74,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.sql.planner.optimizations.IndexJoinOptimizer.IndexKeyTracer;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.isExpression;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -228,7 +230,13 @@ public final class ValidateDependenciesChecker
             Set<Symbol> inputs = createInputs(source, boundSymbols);
             checkDependencies(inputs, node.getOutputSymbols(), "Invalid node. Output symbols (%s) not in source plan output (%s)", node.getOutputSymbols(), node.getSource().getOutputSymbols());
 
-            Set<Symbol> dependencies = SymbolsExtractor.extractUnique(node.getPredicate());
+            Set<Symbol> dependencies;
+            if (isExpression(node.getPredicate())) {
+                dependencies = SymbolsExtractor.extractUnique(castToExpression(node.getPredicate()));
+            }
+            else {
+                dependencies = SymbolsExtractor.extractUnique(node.getPredicate());
+            }
             checkDependencies(inputs, dependencies, "Invalid node. Predicate dependencies (%s) not in source plan output (%s)", dependencies, node.getSource().getOutputSymbols());
 
             return null;

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/DefaultRowExpressionTraversalVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/DefaultRowExpressionTraversalVisitor.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+
+/**
+ * The default visitor serves as a template for "consumer-like" tree traversal.
+ * {@param context} is the consumer to apply customized actions on the visiting RowExpression.
+ */
+public class DefaultRowExpressionTraversalVisitor<C>
+        implements RowExpressionVisitor<Void, C>
+{
+    @Override
+    public Void visitInputReference(InputReferenceExpression input, C context)
+    {
+        return null;
+    }
+
+    @Override
+    public Void visitCall(CallExpression call, C context)
+    {
+        call.getArguments().forEach(argument -> argument.accept(this, context));
+        return null;
+    }
+
+    @Override
+    public Void visitConstant(ConstantExpression literal, C context)
+    {
+        return null;
+    }
+
+    @Override
+    public Void visitLambda(LambdaDefinitionExpression lambda, C context)
+    {
+        return null;
+    }
+
+    @Override
+    public Void visitVariableReference(VariableReferenceExpression reference, C context)
+    {
+        return null;
+    }
+
+    @Override
+    public Void visitSpecialForm(SpecialFormExpression specialForm, C context)
+    {
+        specialForm.getArguments().forEach(argument -> argument.accept(this, context));
+        return null;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/DomainExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/DomainExtractor.java
@@ -1,0 +1,936 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.OperatorNotFoundException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.predicate.DiscreteValues;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.Marker;
+import com.facebook.presto.spi.predicate.Range;
+import com.facebook.presto.spi.predicate.Ranges;
+import com.facebook.presto.spi.predicate.SortedRangeSet;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.predicate.Utils;
+import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.InterpretedFunctionInvoker;
+import com.facebook.presto.sql.planner.RowExpressionInterpreter;
+import com.facebook.presto.sql.planner.optimizations.RowExpressionCanonicalizer;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.PeekingIterator;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.metadata.CastType.CAST;
+import static com.facebook.presto.metadata.CastType.SATURATED_FLOOR_CAST;
+import static com.facebook.presto.spi.function.OperatorType.BETWEEN;
+import static com.facebook.presto.spi.function.OperatorType.EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.predicate.TupleDomain.columnWiseUnion;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.LiteralEncoder.toRowExpression;
+import static com.facebook.presto.sql.relational.DomainExtractor.ExtractionResult.resultOf;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.FALSE;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.and;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.or;
+import static com.facebook.presto.sql.relational.StandardFunctionResolution.getComparisonOperator;
+import static com.facebook.presto.sql.relational.StandardFunctionResolution.isComparisonFunction;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.Iterators.peekingIterator;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.partitioningBy;
+import static java.util.stream.Collectors.toList;
+
+public class DomainExtractor
+{
+    private final FunctionManager functionManager;
+    private final LogicalRowExpressions logicalRowExpressions;
+    private final StandardFunctionResolution functionResolution;
+
+    public DomainExtractor(FunctionManager functionManager)
+    {
+        this.functionManager = requireNonNull(functionManager, "functionManager is null");
+        this.logicalRowExpressions = new LogicalRowExpressions(functionManager);
+        this.functionResolution = new StandardFunctionResolution(functionManager);
+    }
+
+    public RowExpression toPredicate(TupleDomain<? extends RowExpression> tupleDomain)
+    {
+        if (tupleDomain.isNone()) {
+            return FALSE;
+        }
+
+        Map<? extends RowExpression, Domain> domains = tupleDomain.getDomains().get();
+        return domains.entrySet().stream()
+                .map(entry -> toPredicate(entry.getValue(), entry.getKey()))
+                .collect(collectingAndThen(toImmutableList(), logicalRowExpressions::combineConjuncts));
+    }
+
+    private RowExpression toPredicate(Domain domain, RowExpression reference)
+    {
+        if (domain.getValues().isNone()) {
+            return domain.isNullAllowed() ? isNull(reference) : FALSE;
+        }
+
+        if (domain.getValues().isAll()) {
+            return domain.isNullAllowed() ? TRUE : not(functionResolution, isNull(reference));
+        }
+
+        List<RowExpression> disjuncts = new ArrayList<>();
+
+        disjuncts.addAll(domain.getValues().getValuesProcessor().transform(
+                ranges -> extractDisjuncts(domain.getType(), ranges, reference),
+                discreteValues -> extractDisjuncts(domain.getType(), discreteValues, reference),
+                allOrNone -> {
+                    throw new IllegalStateException("Case should not be reachable");
+                }));
+
+        // Add nullability disjuncts
+        if (domain.isNullAllowed()) {
+            disjuncts.add(isNull(reference));
+        }
+
+        return logicalRowExpressions.combineDisjunctsWithDefault(disjuncts, TRUE);
+    }
+
+    private RowExpression processRange(Type type, Range range, RowExpression reference)
+    {
+        if (range.isAll()) {
+            return TRUE;
+        }
+
+        if (isBetween(range)) {
+            // specialize the range with BETWEEN expression if possible b/c it is currently more efficient
+            return call(
+                    functionManager.resolveOperator(BETWEEN, fromTypes(reference.getType(), type, type)),
+                    BOOLEAN,
+                    reference,
+                    toRowExpression(range.getLow().getValue(), type),
+                    toRowExpression(range.getHigh().getValue(), type));
+        }
+
+        List<RowExpression> rangeConjuncts = new ArrayList<>();
+        if (!range.getLow().isLowerUnbounded()) {
+            switch (range.getLow().getBound()) {
+                case ABOVE:
+                    rangeConjuncts.add(greaterThan(reference, toRowExpression(range.getLow().getValue(), type)));
+                    break;
+                case EXACTLY:
+                    rangeConjuncts.add(greaterThanOrEqual(reference, toRowExpression(range.getLow().getValue(), type)));
+                    break;
+                case BELOW:
+                    throw new IllegalStateException("Low Marker should never use BELOW bound: " + range);
+                default:
+                    throw new AssertionError("Unhandled bound: " + range.getLow().getBound());
+            }
+        }
+        if (!range.getHigh().isUpperUnbounded()) {
+            switch (range.getHigh().getBound()) {
+                case ABOVE:
+                    throw new IllegalStateException("High Marker should never use ABOVE bound: " + range);
+                case EXACTLY:
+                    rangeConjuncts.add(lessThanOrEqual(reference, toRowExpression(range.getHigh().getValue(), type)));
+                    break;
+                case BELOW:
+                    rangeConjuncts.add(lessThan(reference, toRowExpression(range.getHigh().getValue(), type)));
+                    break;
+                default:
+                    throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
+            }
+        }
+        // If rangeConjuncts is null, then the range was ALL, which should already have been checked for
+        checkState(!rangeConjuncts.isEmpty());
+        return logicalRowExpressions.combineConjuncts(rangeConjuncts);
+    }
+
+    private RowExpression combineRangeWithExcludedPoints(Type type, RowExpression reference, Range range, List<RowExpression> excludedPoints)
+    {
+        if (excludedPoints.isEmpty()) {
+            return processRange(type, range, reference);
+        }
+
+        RowExpression excludedPointsExpression = not(functionResolution, in(reference, excludedPoints));
+        if (excludedPoints.size() == 1) {
+            excludedPointsExpression = notEqual(reference, getOnlyElement(excludedPoints));
+        }
+
+        return logicalRowExpressions.combineConjuncts(processRange(type, range, reference), excludedPointsExpression);
+    }
+
+    private List<RowExpression> extractDisjuncts(Type type, Ranges ranges, RowExpression reference)
+    {
+        List<RowExpression> disjuncts = new ArrayList<>();
+        List<RowExpression> singleValues = new ArrayList<>();
+        List<Range> orderedRanges = ranges.getOrderedRanges();
+
+        SortedRangeSet sortedRangeSet = SortedRangeSet.copyOf(type, orderedRanges);
+        SortedRangeSet complement = sortedRangeSet.complement();
+
+        List<Range> singleValueExclusionsList = complement.getOrderedRanges().stream().filter(Range::isSingleValue).collect(toList());
+        List<Range> originalUnionSingleValues = SortedRangeSet.copyOf(type, singleValueExclusionsList).union(sortedRangeSet).getOrderedRanges();
+        PeekingIterator<Range> singleValueExclusions = peekingIterator(singleValueExclusionsList.iterator());
+
+        for (Range range : originalUnionSingleValues) {
+            if (range.isSingleValue()) {
+                singleValues.add(toRowExpression(range.getSingleValue(), type));
+                continue;
+            }
+
+            // attempt to optimize ranges that can be coalesced as long as single value points are excluded
+            List<RowExpression> singleValuesInRange = new ArrayList<>();
+            while (singleValueExclusions.hasNext() && range.contains(singleValueExclusions.peek())) {
+                singleValuesInRange.add(toRowExpression(singleValueExclusions.next().getSingleValue(), type));
+            }
+
+            if (!singleValuesInRange.isEmpty()) {
+                disjuncts.add(combineRangeWithExcludedPoints(type, reference, range, singleValuesInRange));
+                continue;
+            }
+
+            disjuncts.add(processRange(type, range, reference));
+        }
+
+        // Add back all of the possible single values either as an equality or an IN predicate
+        if (singleValues.size() == 1) {
+            disjuncts.add(equal(reference, getOnlyElement(singleValues)));
+        }
+        else if (singleValues.size() > 1) {
+            disjuncts.add(in(reference, singleValues));
+        }
+        return disjuncts;
+    }
+
+    private List<RowExpression> extractDisjuncts(Type type, DiscreteValues discreteValues, RowExpression reference)
+    {
+        List<RowExpression> values = discreteValues.getValues().stream()
+                .map(object -> toRowExpression(object, type))
+                .collect(toList());
+
+        // If values is empty, then the equatableValues was either ALL or NONE, both of which should already have been checked for
+        checkState(!values.isEmpty());
+
+        RowExpression predicate;
+        if (values.size() == 1) {
+            predicate = equal(reference, getOnlyElement(values));
+        }
+        else {
+            predicate = in(reference, values);
+        }
+
+        if (!discreteValues.isWhiteList()) {
+            predicate = not(functionResolution, predicate);
+        }
+        return ImmutableList.of(predicate);
+    }
+
+    private static boolean isBetween(Range range)
+    {
+        return !range.getLow().isLowerUnbounded() && range.getLow().getBound() == Marker.Bound.EXACTLY
+                && !range.getHigh().isUpperUnbounded() && range.getHigh().getBound() == Marker.Bound.EXACTLY;
+    }
+
+    /**
+     * Convert an Expression predicate into an ExtractionResult consisting of:
+     * 1) A successfully extracted TupleDomain
+     * 2) An Expression fragment which represents the part of the original Expression that will need to be re-evaluated
+     * after filtering with the TupleDomain.
+     */
+    public static ExtractionResult fromPredicate(Metadata metadata, Session session, RowExpression predicate)
+    {
+        return predicate.accept(new Visitor(metadata, session), false);
+    }
+
+    private static class Visitor
+            implements RowExpressionVisitor<ExtractionResult, Boolean>
+    {
+        private final InterpretedFunctionInvoker functionInvoker;
+        private final Metadata metadata;
+        private final Session session;
+        private final FunctionManager functionManager;
+        private final LogicalRowExpressions logicalRowExpressions;
+        private final DeterminismEvaluator determinismEvaluator;
+        private final StandardFunctionResolution resolution;
+        private final RowExpressionCanonicalizer canonicalizer;
+
+        private Visitor(Metadata metadata, Session session)
+        {
+            this.functionInvoker = new InterpretedFunctionInvoker(metadata.getFunctionManager());
+            this.metadata = metadata;
+            this.session = session;
+            this.functionManager = metadata.getFunctionManager();
+            this.logicalRowExpressions = new LogicalRowExpressions(functionManager);
+            this.determinismEvaluator = new DeterminismEvaluator(functionManager);
+            this.resolution = new StandardFunctionResolution(functionManager);
+            this.canonicalizer = new RowExpressionCanonicalizer(functionManager);
+        }
+
+        @Override
+        public ExtractionResult visitSpecialForm(SpecialFormExpression node, Boolean complement)
+        {
+            switch (node.getForm()) {
+                case AND:
+                case OR: {
+                    return visitBinaryLogic(node, complement);
+                }
+                case IN: {
+                    RowExpression target = node.getArguments().get(0);
+                    // optimize nodes first and split into constant list and those cannot be optimized into constant
+                    Map<Boolean, List<RowExpression>> values = node.getArguments().subList(1, node.getArguments().size())
+                            .stream()
+                            .map(this::optimize)
+                            .collect(partitioningBy(value -> value instanceof ConstantExpression && value.getType() == target.getType()));
+
+                    // only contains constant
+                    if (values.containsKey(true) && !values.isEmpty() && (!values.containsKey(false) || values.get(false).isEmpty())) {
+                        // has to handle complement specifically here since complement of in should still not be null aware
+                        List<Object> notNullValues = values.get(true)
+                                .stream()
+                                .map(value -> ((ConstantExpression) value).getValue())
+                                .filter(object -> object != null)
+                                .collect(toImmutableList());
+                        boolean allowsNull = notNullValues.size() != values.get(true).size();
+                        ValueSet valueSet = ValueSet.copyOf(target.getType(), notNullValues);
+                        if (complement) {
+                            valueSet = valueSet.complement();
+                        }
+
+                        return resultOf(target, Domain.create(valueSet, allowsNull));
+                    }
+
+                    ImmutableList.Builder<RowExpression> disjuncts = ImmutableList.builder();
+                    int numDisjuncts = 0;
+                    if (values.containsKey(true)) {
+                        numDisjuncts++;
+                        disjuncts.add(in(target, values.get(true)));
+                    }
+                    if (values.containsKey(false)) {
+                        for (RowExpression expression : values.get(false)) {
+                            numDisjuncts++;
+                            disjuncts.add(call(functionManager.resolveOperator(EQUAL, fromTypes(target.getType(), expression.getType())), BOOLEAN, target, expression));
+                        }
+                    }
+                    checkArgument(numDisjuncts > 0, "Cannot have empty in list");
+                    ExtractionResult extractionResult = or(disjuncts.build()).accept(this, complement);
+
+                    // preserve original IN predicate as remaining predicate
+                    if (extractionResult.getTupleDomain().isAll()) {
+                        RowExpression originalPredicate = node;
+                        if (complement) {
+                            originalPredicate = not(resolution, originalPredicate);
+                        }
+                        return resultOf(originalPredicate);
+                    }
+                    return extractionResult;
+                }
+                case IS_NULL: {
+                    RowExpression target = node.getArguments().get(0);
+                    Domain domain = complementIfNecessary(Domain.onlyNull(target.getType()), complement);
+                    return resultOf(optimize(target), domain);
+                }
+                default:
+                    return resultOf(complementIfNecessary(node, complement));
+            }
+        }
+
+        @Override
+        public ExtractionResult visitConstant(ConstantExpression node, Boolean complement)
+        {
+            if (node.getValue() == null) {
+                return new ExtractionResult(TupleDomain.none(), TRUE);
+            }
+            if (node.getType() == BOOLEAN) {
+                boolean value = complement != (boolean) node.getValue();
+                return new ExtractionResult(value ? TupleDomain.all() : TupleDomain.none(), TRUE);
+            }
+            throw new IllegalStateException("Can not extract predicate from constant type: " + node.getType());
+        }
+
+        @Override
+        public ExtractionResult visitLambda(LambdaDefinitionExpression node, Boolean complement)
+        {
+            return resultOf(complementIfNecessary(node, complement));
+        }
+
+        @Override
+        public ExtractionResult visitVariableReference(VariableReferenceExpression node, Boolean complement)
+        {
+            return resultOf(complementIfNecessary(node, complement));
+        }
+
+        @Override
+        public ExtractionResult visitCall(CallExpression node, Boolean complement)
+        {
+            if (node.getFunctionHandle().equals(resolution.notFunction())) {
+                return node.getArguments().get(0).accept(this, !complement);
+            }
+
+            if (resolution.isBetweenFunction(node.getFunctionHandle())) {
+                // Re-write as two comparison expressions
+                return and(
+                        binaryOperator(GREATER_THAN_OR_EQUAL, node.getArguments().get(0), node.getArguments().get(1)),
+                        binaryOperator(LESS_THAN_OR_EQUAL, node.getArguments().get(0), node.getArguments().get(2))).accept(this, complement);
+            }
+
+            if (isComparisonFunction(node.getFunctionHandle())) {
+                Optional<NormalizedSimpleComparison> optionalNormalized = toNormalizedSimpleComparison(getComparisonOperator(node), node.getArguments().get(0), node.getArguments().get(1));
+                if (!optionalNormalized.isPresent()) {
+                    return resultOf(complementIfNecessary(node, complement));
+                }
+                NormalizedSimpleComparison normalized = optionalNormalized.get();
+
+                RowExpression expression = normalized.getExpression();
+                if (expression instanceof CallExpression && resolution.isCastFunction(((CallExpression) expression).getFunctionHandle())) {
+                    CallExpression castExpression = (CallExpression) expression;
+                    if (!isImplicitCoercion(castExpression)) {
+                        //
+                        // we cannot use non-coercion cast to literal_type on symbol side to build tuple domain
+                        //
+                        // example which illustrates the problem:
+                        //
+                        // let t be of timestamp type:
+                        //
+                        // and expression be:
+                        // cast(t as date) == date_literal
+                        //
+                        // after dropping cast we end up with:
+                        //
+                        // t == date_literal
+                        //
+                        // if we build tuple domain based coercion of date_literal to timestamp type we would
+                        // end up with tuple domain with just one time point (cast(date_literal as timestamp).
+                        // While we need range which maps to single date pointed by date_literal.
+                        //
+                        return resultOf(complementIfNecessary(node, complement));
+                    }
+
+                    CallExpression cast = (CallExpression) expression;
+                    Type sourceType = cast.getArguments().get(0).getType();
+
+                    // we use saturated floor cast value -> castSourceType to rewrite original expression to new one with one cast peeled off the symbol side
+                    Optional<RowExpression> coercedExpression = coerceComparisonWithRounding(
+                            sourceType, cast.getArguments().get(0), normalized.getValue(), normalized.getComparisonOperator());
+
+                    if (coercedExpression.isPresent()) {
+                        return coercedExpression.get().accept(this, complement);
+                    }
+                    return resultOf(complementIfNecessary(node, complement));
+                }
+                else {
+                    ConstantExpression value = normalized.getValue();
+                    Type type = value.getType(); // common type for symbol and value
+                    return createComparisonExtractionResult(normalized.getComparisonOperator(), expression, type, value.getValue(), complement);
+                }
+            }
+
+            return resultOf(complementIfNecessary(node, complement));
+        }
+
+        @Override
+        public ExtractionResult visitInputReference(InputReferenceExpression node, Boolean complement)
+        {
+            return resultOf(complementIfNecessary(node, complement));
+        }
+
+        private Optional<RowExpression> coerceComparisonWithRounding(
+                Type expressionType,
+                RowExpression compareTarget,
+                ConstantExpression constant,
+                OperatorType comparisonOperator)
+        {
+            requireNonNull(constant, "nullableValue is null");
+            if (constant.getValue() == null) {
+                return Optional.empty();
+            }
+            Type valueType = constant.getType();
+            Object value = constant.getValue();
+            return floorValue(valueType, expressionType, value)
+                    .map((floorValue) -> rewriteComparisonExpression(expressionType, compareTarget, valueType, value, floorValue, comparisonOperator));
+        }
+
+        private RowExpression rewriteComparisonExpression(
+                Type expressionType,
+                RowExpression compareTarget,
+                Type valueType,
+                Object originalValue,
+                Object coercedValue,
+                OperatorType comparisonOperator)
+        {
+            int originalComparedToCoerced = compareOriginalValueToCoerced(valueType, originalValue, expressionType, coercedValue);
+            boolean coercedValueIsEqualToOriginal = originalComparedToCoerced == 0;
+            boolean coercedValueIsLessThanOriginal = originalComparedToCoerced > 0;
+            boolean coercedValueIsGreaterThanOriginal = originalComparedToCoerced < 0;
+            RowExpression coercedLiteral = toRowExpression(coercedValue, expressionType);
+
+            switch (comparisonOperator) {
+                case GREATER_THAN_OR_EQUAL:
+                case GREATER_THAN: {
+                    if (coercedValueIsGreaterThanOriginal) {
+                        return binaryOperator(GREATER_THAN_OR_EQUAL, compareTarget, coercedLiteral);
+                    }
+                    if (coercedValueIsEqualToOriginal) {
+                        return binaryOperator(comparisonOperator, compareTarget, coercedLiteral);
+                    }
+                    return binaryOperator(GREATER_THAN, compareTarget, coercedLiteral);
+                }
+                case LESS_THAN_OR_EQUAL:
+                case LESS_THAN: {
+                    if (coercedValueIsLessThanOriginal) {
+                        return binaryOperator(LESS_THAN_OR_EQUAL, compareTarget, coercedLiteral);
+                    }
+                    if (coercedValueIsEqualToOriginal) {
+                        return binaryOperator(comparisonOperator, compareTarget, coercedLiteral);
+                    }
+                    return binaryOperator(LESS_THAN, compareTarget, coercedLiteral);
+                }
+                case EQUAL: {
+                    if (coercedValueIsEqualToOriginal) {
+                        return binaryOperator(EQUAL, compareTarget, coercedLiteral);
+                    }
+                    // Return something that is false for all non-null values
+                    return and(binaryOperator(EQUAL, compareTarget, coercedLiteral),
+                            binaryOperator(NOT_EQUAL, compareTarget, coercedLiteral));
+                }
+                case NOT_EQUAL: {
+                    if (coercedValueIsEqualToOriginal) {
+                        return binaryOperator(comparisonOperator, compareTarget, coercedLiteral);
+                    }
+                    // Return something that is true for all non-null values
+                    return or(binaryOperator(EQUAL, compareTarget, coercedLiteral),
+                            binaryOperator(NOT_EQUAL, compareTarget, coercedLiteral));
+                }
+                case IS_DISTINCT_FROM: {
+                    if (coercedValueIsEqualToOriginal) {
+                        return binaryOperator(comparisonOperator, compareTarget, coercedLiteral);
+                    }
+                    return TRUE;
+                }
+            }
+
+            throw new IllegalArgumentException("Unhandled operator: " + comparisonOperator);
+        }
+
+        private RowExpression binaryOperator(OperatorType operatorType, RowExpression left, RowExpression right)
+        {
+            return call(
+                    metadata.getFunctionManager().resolveOperator(operatorType, fromTypes(left.getType(), right.getType())),
+                    BOOLEAN,
+                    left,
+                    right);
+        }
+
+        private Optional<Object> floorValue(Type fromType, Type toType, Object value)
+        {
+            return getSaturatedFloorCastOperator(fromType, toType)
+                    .map((operator) -> functionInvoker.invoke(operator, session.toConnectorSession(), value));
+        }
+
+        private Optional<FunctionHandle> getSaturatedFloorCastOperator(Type fromType, Type toType)
+        {
+            try {
+                return Optional.of(metadata.getFunctionManager().lookupCast(SATURATED_FLOOR_CAST, fromType.getTypeSignature(), toType.getTypeSignature()));
+            }
+            catch (OperatorNotFoundException e) {
+                return Optional.empty();
+            }
+        }
+
+        private int compareOriginalValueToCoerced(Type originalValueType, Object originalValue, Type coercedValueType, Object coercedValue)
+        {
+            FunctionHandle castToOriginalTypeOperator = metadata.getFunctionManager().lookupCast(CAST, coercedValueType.getTypeSignature(), originalValueType.getTypeSignature());
+            Object coercedValueInOriginalType = functionInvoker.invoke(castToOriginalTypeOperator, session.toConnectorSession(), coercedValue);
+            Block originalValueBlock = Utils.nativeValueToBlock(originalValueType, originalValue);
+            Block coercedValueBlock = Utils.nativeValueToBlock(originalValueType, coercedValueInOriginalType);
+            return originalValueType.compareTo(originalValueBlock, 0, coercedValueBlock, 0);
+        }
+
+        private boolean isImplicitCoercion(CallExpression cast)
+        {
+            Type sourceType = cast.getArguments().get(0).getType();
+            Type targetType = cast.getType();
+            return metadata.getTypeManager().canCoerce(sourceType, targetType);
+        }
+
+        private static Domain extractOrderableDomain(OperatorType comparisonOperator, Type type, Object value, boolean complement)
+        {
+            checkArgument(value != null);
+            switch (comparisonOperator) {
+                case EQUAL:
+                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.equal(type, value)), complement), false);
+                case GREATER_THAN:
+                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.greaterThan(type, value)), complement), false);
+                case GREATER_THAN_OR_EQUAL:
+                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.greaterThanOrEqual(type, value)), complement), false);
+                case LESS_THAN:
+                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.lessThan(type, value)), complement), false);
+                case LESS_THAN_OR_EQUAL:
+                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.lessThanOrEqual(type, value)), complement), false);
+                case NOT_EQUAL:
+                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.lessThan(type, value), Range.greaterThan(type, value)), complement), false);
+                case IS_DISTINCT_FROM:
+                    // Need to potential complement the whole domain for IS_DISTINCT_FROM since it is null-aware
+                    return complementIfNecessary(Domain.create(ValueSet.ofRanges(Range.lessThan(type, value), Range.greaterThan(type, value)), true), complement);
+                default:
+                    throw new AssertionError("Unhandled operator: " + comparisonOperator);
+            }
+        }
+
+        private static Domain extractEquatableDomain(OperatorType comparisonOperator, Type type, Object value, boolean complement)
+        {
+            checkArgument(value != null);
+            switch (comparisonOperator) {
+                case EQUAL:
+                    return Domain.create(complementIfNecessary(ValueSet.of(type, value), complement), false);
+                case NOT_EQUAL:
+                    return Domain.create(complementIfNecessary(ValueSet.of(type, value).complement(), complement), false);
+                case IS_DISTINCT_FROM:
+                    // Need to potential complement the whole domain for IS_DISTINCT_FROM since it is null-aware
+                    return complementIfNecessary(Domain.create(ValueSet.of(type, value).complement(), true), complement);
+                default:
+                    throw new AssertionError("Unhandled operator: " + comparisonOperator);
+            }
+        }
+
+        private RowExpression optimize(RowExpression input)
+        {
+            if (input instanceof ConstantExpression || input instanceof VariableReferenceExpression || input instanceof InputReferenceExpression) {
+                return input;
+            }
+            Object result = new RowExpressionInterpreter(input, metadata, session, true).optimize();
+            if (result instanceof RowExpression) {
+                return canonicalizer.canonicalize((RowExpression) result);
+            }
+            return toRowExpression(result, input.getType());
+        }
+
+        /**
+         * Extract a normalized simple comparison between a QualifiedNameReference and a native value if possible.
+         */
+        private Optional<NormalizedSimpleComparison> toNormalizedSimpleComparison(OperatorType operatorType, RowExpression leftExpression, RowExpression rightExpression)
+        {
+            RowExpression left = optimize(leftExpression);
+            RowExpression right = optimize(rightExpression);
+
+            if (right instanceof ConstantExpression) {
+                return Optional.of(new NormalizedSimpleComparison(left, operatorType, (ConstantExpression) right));
+            }
+            else if (left instanceof ConstantExpression) {
+                return Optional.of(new NormalizedSimpleComparison(right, flip(operatorType), (ConstantExpression) left));
+            }
+
+            // we expect one side to be row expression and other to be value.
+            return Optional.empty();
+        }
+
+        private static ExtractionResult createComparisonExtractionResult(OperatorType comparisonOperator, RowExpression column, Type type, @Nullable Object value, boolean complement)
+        {
+            if (value == null) {
+                switch (comparisonOperator) {
+                    case EQUAL:
+                    case GREATER_THAN:
+                    case GREATER_THAN_OR_EQUAL:
+                    case LESS_THAN:
+                    case LESS_THAN_OR_EQUAL:
+                    case NOT_EQUAL:
+                        return new ExtractionResult(TupleDomain.none(), TRUE);
+
+                    case IS_DISTINCT_FROM:
+                        Domain domain = complementIfNecessary(Domain.notNull(type), complement);
+                        return resultOf(column, domain);
+
+                    default:
+                        throw new AssertionError("Unhandled operator: " + comparisonOperator);
+                }
+            }
+
+            Domain domain;
+            if (type.isOrderable()) {
+                domain = extractOrderableDomain(comparisonOperator, type, value, complement);
+            }
+            else if (type.isComparable()) {
+                domain = extractEquatableDomain(comparisonOperator, type, value, complement);
+            }
+            else {
+                throw new AssertionError("Type cannot be used in a comparison expression (should have been caught in analysis): " + type);
+            }
+
+            return resultOf(column, domain);
+        }
+
+        private static OperatorType flip(OperatorType operatorType)
+        {
+            switch (operatorType) {
+                case EQUAL:
+                    return EQUAL;
+                case NOT_EQUAL:
+                    return NOT_EQUAL;
+                case LESS_THAN:
+                    return GREATER_THAN;
+                case LESS_THAN_OR_EQUAL:
+                    return GREATER_THAN_OR_EQUAL;
+                case GREATER_THAN:
+                    return LESS_THAN;
+                case GREATER_THAN_OR_EQUAL:
+                    return LESS_THAN_OR_EQUAL;
+                case IS_DISTINCT_FROM:
+                    return IS_DISTINCT_FROM;
+                default:
+                    throw new IllegalArgumentException("Unsupported comparison: " + operatorType);
+            }
+        }
+
+        private static ValueSet complementIfNecessary(ValueSet valueSet, boolean complement)
+        {
+            return complement ? valueSet.complement() : valueSet;
+        }
+
+        private static Domain complementIfNecessary(Domain domain, boolean complement)
+        {
+            return complement ? domain.complement() : domain;
+        }
+
+        private RowExpression complementIfNecessary(RowExpression expression, boolean complement)
+        {
+            return complement ? not(resolution, expression) : expression;
+        }
+
+        private ExtractionResult visitBinaryLogic(SpecialFormExpression node, Boolean complement)
+        {
+            ExtractionResult leftResult = node.getArguments().get(0).accept(this, complement);
+            ExtractionResult rightResult = node.getArguments().get(1).accept(this, complement);
+
+            TupleDomain<RowExpression> leftTupleDomain = leftResult.getTupleDomain();
+            TupleDomain<RowExpression> rightTupleDomain = rightResult.getTupleDomain();
+
+            SpecialFormExpression.Form operator = node.getForm();
+            if (complement) {
+                if (operator == AND) {
+                    operator = OR;
+                }
+                else if (operator == OR) {
+                    operator = AND;
+                }
+                else {
+                    throw new IllegalStateException("Can not extract predicate from special form: " + node.getForm());
+                }
+            }
+
+            switch (operator) {
+                case AND: {
+                    return new ExtractionResult(
+                            leftTupleDomain.intersect(rightTupleDomain),
+                            logicalRowExpressions.combineConjuncts(leftResult.getRemainingExpression(), rightResult.getRemainingExpression()));
+                }
+                case OR: {
+                    TupleDomain<RowExpression> columnUnionedTupleDomain = columnWiseUnion(leftTupleDomain, rightTupleDomain);
+
+                    // In most rest cases, the columnUnionedTupleDomain is only a superset of the actual strict union
+                    // and so we can return the current node as the remainingExpression so that all bounds will be double checked again at execution time.
+                    RowExpression remainingExpression = complementIfNecessary(node, complement);
+
+                    // However, there are a few cases where the column-wise union is actually equivalent to the strict union, so we if can detect
+                    // some of these cases, we won't have to double check the bounds unnecessarily at execution time.
+
+                    // We can only make inferences if the remaining expressions on both side are equal and deterministic
+                    if (leftResult.getRemainingExpression().equals(rightResult.getRemainingExpression()) &&
+                            determinismEvaluator.isDeterministic(leftResult.getRemainingExpression())) {
+                        // The column-wise union is equivalent to the strict union if
+                        // 1) If both TupleDomains consist of the same exact single column (e.g. left TupleDomain => (a > 0), right TupleDomain => (a < 10))
+                        // 2) If one TupleDomain is a superset of the other (e.g. left TupleDomain => (a > 0, b > 0 && b < 10), right TupleDomain => (a > 5, b = 5))
+                        boolean matchingSingleSymbolDomains = !leftTupleDomain.isNone()
+                                && !rightTupleDomain.isNone()
+                                && leftTupleDomain.getDomains().get().size() == 1
+                                && rightTupleDomain.getDomains().get().size() == 1
+                                && leftTupleDomain.getDomains().get().keySet().equals(rightTupleDomain.getDomains().get().keySet());
+                        boolean oneSideIsSuperSet = leftTupleDomain.contains(rightTupleDomain) || rightTupleDomain.contains(leftTupleDomain);
+
+                        if (matchingSingleSymbolDomains || oneSideIsSuperSet) {
+                            remainingExpression = leftResult.getRemainingExpression();
+                        }
+                    }
+
+                    return new ExtractionResult(columnUnionedTupleDomain, remainingExpression);
+                }
+                default:
+                    throw new IllegalStateException("Can not extract predicate from special form: " + node.getForm());
+            }
+        }
+    }
+
+    private static List<RowExpression> extractColumns(TupleDomain<RowExpression> tupleDomain)
+    {
+        return tupleDomain.getColumnDomains().orElse(ImmutableList.of())
+                .stream()
+                .map(TupleDomain.ColumnDomain::getColumn)
+                .collect(toImmutableList());
+    }
+
+    private static RowExpression isNull(RowExpression expression)
+    {
+        return new SpecialFormExpression(IS_NULL, BOOLEAN, expression);
+    }
+
+    private static RowExpression not(StandardFunctionResolution resolution, RowExpression expression)
+    {
+        return call(resolution.notFunction(), expression.getType(), expression);
+    }
+
+    private static RowExpression in(RowExpression value, List<RowExpression> inList)
+    {
+        return new SpecialFormExpression(IN, BOOLEAN, ImmutableList.<RowExpression>builder().add(value).addAll(inList).build());
+    }
+
+    private RowExpression binaryOperator(OperatorType operatorType, RowExpression left, RowExpression right)
+    {
+        return call(functionManager.resolveOperator(operatorType, fromTypes(left.getType(), right.getType())), BOOLEAN, left, right);
+    }
+
+    private RowExpression greaterThan(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.GREATER_THAN, left, right);
+    }
+
+    private RowExpression lessThan(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.LESS_THAN, left, right);
+    }
+
+    private RowExpression greaterThanOrEqual(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(GREATER_THAN_OR_EQUAL, left, right);
+    }
+
+    private RowExpression lessThanOrEqual(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(LESS_THAN_OR_EQUAL, left, right);
+    }
+
+    private RowExpression equal(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(EQUAL, left, right);
+    }
+
+    private RowExpression notEqual(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(NOT_EQUAL, left, right);
+    }
+
+    private static class NormalizedSimpleComparison
+    {
+        private final RowExpression expression;
+        private final OperatorType comparisonOperator;
+        private final ConstantExpression value;
+
+        public NormalizedSimpleComparison(RowExpression expression, OperatorType comparisonOperator, ConstantExpression value)
+        {
+            this.expression = requireNonNull(expression, "expression is null");
+            this.comparisonOperator = requireNonNull(comparisonOperator, "comparisonOperator is null");
+            this.value = requireNonNull(value, "value is null");
+        }
+
+        public RowExpression getExpression()
+        {
+            return expression;
+        }
+
+        public OperatorType getComparisonOperator()
+        {
+            return comparisonOperator;
+        }
+
+        public ConstantExpression getValue()
+        {
+            return value;
+        }
+    }
+
+    public static class ExtractionResult
+    {
+        private final TupleDomain<RowExpression> extracted;
+        private final RowExpression rest;
+
+        public static ExtractionResult resultOf(RowExpression... results)
+        {
+            RowExpression rest = TRUE;
+            if (results.length == 1) {
+                rest = results[0];
+            }
+            else if (results.length > 1) {
+                rest = new SpecialFormExpression(AND, BOOLEAN, results);
+            }
+            return new ExtractionResult(TupleDomain.all(), rest);
+        }
+
+        public static ExtractionResult resultOf(TupleDomain<RowExpression> tupleDomain)
+        {
+            return new ExtractionResult(tupleDomain, TRUE);
+        }
+
+        public static ExtractionResult resultOf(RowExpression key, Domain domain)
+        {
+            return new ExtractionResult(TupleDomain.withColumnDomains(ImmutableMap.of(key, domain)), TRUE);
+        }
+
+        public ExtractionResult(TupleDomain<RowExpression> tupleDomain, RowExpression rest)
+        {
+            this.extracted = requireNonNull(tupleDomain, "remainingExpression is null");
+            this.rest = rest;
+        }
+
+        public TupleDomain<RowExpression> getTupleDomain()
+        {
+            return extracted;
+        }
+
+        public RowExpression getRemainingExpression()
+        {
+            return rest;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/Expressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/Expressions.java
@@ -55,6 +55,11 @@ public final class Expressions
         return new CallExpression(displayName, functionHandle, returnType, arguments);
     }
 
+    public static VariableReferenceExpression variable(String name, Type type)
+    {
+        return new VariableReferenceExpression(name, type);
+    }
+
     public static InputReferenceExpression field(int field, Type type)
     {
         return new InputReferenceExpression(field, type);

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/InterpretedPredicateOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/InterpretedPredicateOptimizer.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.OperatorNotFoundException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.predicate.Utils;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.InterpretedFunctionInvoker;
+import com.facebook.presto.sql.planner.RowExpressionInterpreter;
+import com.facebook.presto.sql.planner.optimizations.RowExpressionCanonicalizer;
+
+import java.util.Optional;
+
+import static com.facebook.presto.metadata.CastType.CAST;
+import static com.facebook.presto.metadata.CastType.SATURATED_FLOOR_CAST;
+import static com.facebook.presto.spi.function.OperatorType.EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.LiteralEncoder.toRowExpression;
+import static com.facebook.presto.sql.relational.DomainExtractor.PredicateOptimizer;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.and;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.or;
+import static java.util.Objects.requireNonNull;
+
+public class InterpretedPredicateOptimizer
+        implements PredicateOptimizer
+{
+    private final Metadata metadata;
+    private final Session session;
+    private final FunctionManager functionManager;
+    private final InterpretedFunctionInvoker functionInvoker;
+    private final RowExpressionCanonicalizer canonicalizer;
+
+    public InterpretedPredicateOptimizer(Metadata metadata, Session session)
+    {
+        this.metadata = metadata;
+        this.session = session;
+        this.functionManager = metadata.getFunctionManager();
+        this.functionInvoker = new InterpretedFunctionInvoker(functionManager);
+        this.canonicalizer = new RowExpressionCanonicalizer(functionManager);
+    }
+
+    @Override
+    public RowExpression optimize(RowExpression input)
+    {
+        if (input instanceof ConstantExpression || input instanceof VariableReferenceExpression || input instanceof InputReferenceExpression) {
+            return input;
+        }
+        Object result = new RowExpressionInterpreter(input, metadata, session, true).optimize();
+        if (result instanceof RowExpression) {
+            return canonicalizer.canonicalize((RowExpression) result);
+        }
+        return toRowExpression(result, input.getType());
+    }
+
+    @Override
+    public Optional<RowExpression> coerceComparisonWithRounding(
+            Type expressionType,
+            RowExpression compareTarget,
+            ConstantExpression constant,
+            OperatorType comparisonOperator)
+    {
+        requireNonNull(constant, "nullableValue is null");
+        if (constant.getValue() == null) {
+            return Optional.empty();
+        }
+        Type valueType = constant.getType();
+        Object value = constant.getValue();
+        return floorValue(valueType, expressionType, value)
+                .map((floorValue) -> rewriteComparisonExpression(expressionType, compareTarget, valueType, value, floorValue, comparisonOperator));
+    }
+
+    private RowExpression rewriteComparisonExpression(
+            Type expressionType,
+            RowExpression compareTarget,
+            Type valueType,
+            Object originalValue,
+            Object coercedValue,
+            OperatorType comparisonOperator)
+    {
+        int originalComparedToCoerced = compareOriginalValueToCoerced(valueType, originalValue, expressionType, coercedValue);
+        boolean coercedValueIsEqualToOriginal = originalComparedToCoerced == 0;
+        boolean coercedValueIsLessThanOriginal = originalComparedToCoerced > 0;
+        boolean coercedValueIsGreaterThanOriginal = originalComparedToCoerced < 0;
+        RowExpression coercedLiteral = toRowExpression(coercedValue, expressionType);
+
+        switch (comparisonOperator) {
+            case GREATER_THAN_OR_EQUAL:
+            case GREATER_THAN: {
+                if (coercedValueIsGreaterThanOriginal) {
+                    return binaryOperator(GREATER_THAN_OR_EQUAL, compareTarget, coercedLiteral);
+                }
+                if (coercedValueIsEqualToOriginal) {
+                    return binaryOperator(comparisonOperator, compareTarget, coercedLiteral);
+                }
+                return binaryOperator(GREATER_THAN, compareTarget, coercedLiteral);
+            }
+            case LESS_THAN_OR_EQUAL:
+            case LESS_THAN: {
+                if (coercedValueIsLessThanOriginal) {
+                    return binaryOperator(LESS_THAN_OR_EQUAL, compareTarget, coercedLiteral);
+                }
+                if (coercedValueIsEqualToOriginal) {
+                    return binaryOperator(comparisonOperator, compareTarget, coercedLiteral);
+                }
+                return binaryOperator(LESS_THAN, compareTarget, coercedLiteral);
+            }
+            case EQUAL: {
+                if (coercedValueIsEqualToOriginal) {
+                    return binaryOperator(EQUAL, compareTarget, coercedLiteral);
+                }
+                // Return something that is false for all non-null values
+                return and(binaryOperator(EQUAL, compareTarget, coercedLiteral),
+                        binaryOperator(NOT_EQUAL, compareTarget, coercedLiteral));
+            }
+            case NOT_EQUAL: {
+                if (coercedValueIsEqualToOriginal) {
+                    return binaryOperator(comparisonOperator, compareTarget, coercedLiteral);
+                }
+                // Return something that is true for all non-null values
+                return or(binaryOperator(EQUAL, compareTarget, coercedLiteral),
+                        binaryOperator(NOT_EQUAL, compareTarget, coercedLiteral));
+            }
+            case IS_DISTINCT_FROM: {
+                if (coercedValueIsEqualToOriginal) {
+                    return binaryOperator(comparisonOperator, compareTarget, coercedLiteral);
+                }
+                return TRUE;
+            }
+        }
+
+        throw new IllegalArgumentException("Unhandled operator: " + comparisonOperator);
+    }
+
+    private RowExpression binaryOperator(OperatorType operatorType, RowExpression left, RowExpression right)
+    {
+        return call(
+                operatorType.name(),
+                metadata.getFunctionManager().resolveOperator(operatorType, fromTypes(left.getType(), right.getType())),
+                BOOLEAN,
+                left,
+                right);
+    }
+
+    private int compareOriginalValueToCoerced(Type originalValueType, Object originalValue, Type coercedValueType, Object coercedValue)
+    {
+        FunctionHandle castToOriginalTypeOperator = functionManager.lookupCast(CAST, coercedValueType.getTypeSignature(), originalValueType.getTypeSignature());
+        Object coercedValueInOriginalType = functionInvoker.invoke(castToOriginalTypeOperator, session.toConnectorSession(), coercedValue);
+        Block originalValueBlock = Utils.nativeValueToBlock(originalValueType, originalValue);
+        Block coercedValueBlock = Utils.nativeValueToBlock(originalValueType, coercedValueInOriginalType);
+        return originalValueType.compareTo(originalValueBlock, 0, coercedValueBlock, 0);
+    }
+
+    private Optional<Object> floorValue(Type fromType, Type toType, Object value)
+    {
+        return getSaturatedFloorCastOperator(fromType, toType)
+                .map((operator) -> functionInvoker.invoke(operator, session.toConnectorSession(), value));
+    }
+
+    private Optional<FunctionHandle> getSaturatedFloorCastOperator(Type fromType, Type toType)
+    {
+        try {
+            return Optional.of(functionManager.lookupCast(SATURATED_FLOOR_CAST, fromType.getTypeSignature(), toType.getTypeSignature()));
+        }
+        catch (OperatorNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/LogicalRowExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/LogicalRowExpressions.java
@@ -33,7 +33,6 @@ import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.google.common.base.Predicates.not;
-import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -75,11 +74,9 @@ public final class LogicalRowExpressions
     {
         if (expression instanceof SpecialFormExpression && ((SpecialFormExpression) expression).getForm() == form) {
             SpecialFormExpression specialFormExpression = (SpecialFormExpression) expression;
-            verify(specialFormExpression.getArguments().size() == 2, "logical binary expression requires exactly 2 operands");
-            return ImmutableList.<RowExpression>builder()
-                    .addAll(extractPredicates(form, specialFormExpression.getArguments().get(0)))
-                    .addAll(extractPredicates(form, specialFormExpression.getArguments().get(1)))
-                    .build();
+            return specialFormExpression.getArguments().stream()
+                    .flatMap(argument -> extractPredicates(form, argument).stream())
+                    .collect(toImmutableList());
         }
 
         return ImmutableList.of(expression);

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionDomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionDomainTranslator.java
@@ -1,0 +1,905 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.metadata.FunctionMetadata;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.OperatorNotFoundException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.predicate.DiscreteValues;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.Marker;
+import com.facebook.presto.spi.predicate.NullableValue;
+import com.facebook.presto.spi.predicate.Range;
+import com.facebook.presto.spi.predicate.Ranges;
+import com.facebook.presto.spi.predicate.SortedRangeSet;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.predicate.Utils;
+import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression.Form;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.InterpretedFunctionInvoker;
+import com.facebook.presto.sql.planner.RowExpressionInterpreter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.PeekingIterator;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.metadata.CastType.CAST;
+import static com.facebook.presto.metadata.CastType.SATURATED_FLOOR_CAST;
+import static com.facebook.presto.spi.function.OperatorType.BETWEEN;
+import static com.facebook.presto.spi.function.OperatorType.EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.LiteralEncoder.toRowExpression;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.FALSE;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.and;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.or;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.Iterators.peekingIterator;
+import static java.util.Comparator.comparing;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+
+public final class RowExpressionDomainTranslator
+{
+    private final FunctionManager functionManager;
+    private final LogicalRowExpressions logicalRowExpressions;
+    private final StandardFunctionResolution functionResolution;
+
+    public RowExpressionDomainTranslator(FunctionManager functionManager)
+    {
+        this.functionManager = requireNonNull(functionManager, "functionManager is null");
+        this.logicalRowExpressions = new LogicalRowExpressions(functionManager);
+        this.functionResolution = new StandardFunctionResolution(functionManager);
+    }
+
+    public RowExpression toPredicate(TupleDomain<VariableReferenceExpression> tupleDomain)
+    {
+        if (tupleDomain.isNone()) {
+            return FALSE;
+        }
+
+        Map<VariableReferenceExpression, Domain> domains = tupleDomain.getDomains().get();
+        return domains.entrySet().stream()
+                .sorted(comparing(entry -> entry.getKey().getName()))
+                .map(entry -> toPredicate(entry.getValue(), entry.getKey()))
+                .collect(collectingAndThen(toImmutableList(), logicalRowExpressions::combineConjuncts));
+    }
+
+    private RowExpression toPredicate(Domain domain, VariableReferenceExpression reference)
+    {
+        if (domain.getValues().isNone()) {
+            return domain.isNullAllowed() ? isNull(reference) : FALSE;
+        }
+
+        if (domain.getValues().isAll()) {
+            return domain.isNullAllowed() ? TRUE : not(functionResolution, isNull(reference));
+        }
+
+        List<RowExpression> disjuncts = new ArrayList<>();
+
+        disjuncts.addAll(domain.getValues().getValuesProcessor().transform(
+                ranges -> extractDisjuncts(domain.getType(), ranges, reference),
+                discreteValues -> extractDisjuncts(domain.getType(), discreteValues, reference),
+                allOrNone -> {
+                    throw new IllegalStateException("Case should not be reachable");
+                }));
+
+        // Add nullability disjuncts
+        if (domain.isNullAllowed()) {
+            disjuncts.add(isNull(reference));
+        }
+
+        return logicalRowExpressions.combineDisjunctsWithDefault(disjuncts, TRUE);
+    }
+
+    private RowExpression processRange(Type type, Range range, VariableReferenceExpression reference)
+    {
+        if (range.isAll()) {
+            return TRUE;
+        }
+
+        if (isBetween(range)) {
+            // specialize the range with BETWEEN expression if possible b/c it is currently more efficient
+            return call(
+                    BETWEEN.name(),
+                    functionManager.resolveOperator(BETWEEN, fromTypes(reference.getType(), type, type)),
+                    BOOLEAN,
+                    reference,
+                    toRowExpression(range.getLow().getValue(), type),
+                    toRowExpression(range.getHigh().getValue(), type));
+        }
+
+        List<RowExpression> rangeConjuncts = new ArrayList<>();
+        if (!range.getLow().isLowerUnbounded()) {
+            switch (range.getLow().getBound()) {
+                case ABOVE:
+                    rangeConjuncts.add(greaterThan(reference, toRowExpression(range.getLow().getValue(), type)));
+                    break;
+                case EXACTLY:
+                    rangeConjuncts.add(greaterThanOrEqual(reference, toRowExpression(range.getLow().getValue(), type)));
+                    break;
+                case BELOW:
+                    throw new IllegalStateException("Low Marker should never use BELOW bound: " + range);
+                default:
+                    throw new AssertionError("Unhandled bound: " + range.getLow().getBound());
+            }
+        }
+        if (!range.getHigh().isUpperUnbounded()) {
+            switch (range.getHigh().getBound()) {
+                case ABOVE:
+                    throw new IllegalStateException("High Marker should never use ABOVE bound: " + range);
+                case EXACTLY:
+                    rangeConjuncts.add(lessThanOrEqual(reference, toRowExpression(range.getHigh().getValue(), type)));
+                    break;
+                case BELOW:
+                    rangeConjuncts.add(lessThan(reference, toRowExpression(range.getHigh().getValue(), type)));
+                    break;
+                default:
+                    throw new AssertionError("Unhandled bound: " + range.getHigh().getBound());
+            }
+        }
+        // If rangeConjuncts is null, then the range was ALL, which should already have been checked for
+        checkState(!rangeConjuncts.isEmpty());
+        return logicalRowExpressions.combineConjuncts(rangeConjuncts);
+    }
+
+    private RowExpression combineRangeWithExcludedPoints(Type type, VariableReferenceExpression reference, Range range, List<RowExpression> excludedPoints)
+    {
+        if (excludedPoints.isEmpty()) {
+            return processRange(type, range, reference);
+        }
+
+        RowExpression excludedPointsExpression = not(functionResolution, in(reference, excludedPoints));
+        if (excludedPoints.size() == 1) {
+            excludedPointsExpression = notEqual(reference, getOnlyElement(excludedPoints));
+        }
+
+        return logicalRowExpressions.combineConjuncts(processRange(type, range, reference), excludedPointsExpression);
+    }
+
+    private List<RowExpression> extractDisjuncts(Type type, Ranges ranges, VariableReferenceExpression reference)
+    {
+        List<RowExpression> disjuncts = new ArrayList<>();
+        List<RowExpression> singleValues = new ArrayList<>();
+        List<Range> orderedRanges = ranges.getOrderedRanges();
+
+        SortedRangeSet sortedRangeSet = SortedRangeSet.copyOf(type, orderedRanges);
+        SortedRangeSet complement = sortedRangeSet.complement();
+
+        List<Range> singleValueExclusionsList = complement.getOrderedRanges().stream().filter(Range::isSingleValue).collect(toList());
+        List<Range> originalUnionSingleValues = SortedRangeSet.copyOf(type, singleValueExclusionsList).union(sortedRangeSet).getOrderedRanges();
+        PeekingIterator<Range> singleValueExclusions = peekingIterator(singleValueExclusionsList.iterator());
+
+        for (Range range : originalUnionSingleValues) {
+            if (range.isSingleValue()) {
+                singleValues.add(toRowExpression(range.getSingleValue(), type));
+                continue;
+            }
+
+            // attempt to optimize ranges that can be coalesced as long as single value points are excluded
+            List<RowExpression> singleValuesInRange = new ArrayList<>();
+            while (singleValueExclusions.hasNext() && range.contains(singleValueExclusions.peek())) {
+                singleValuesInRange.add(toRowExpression(singleValueExclusions.next().getSingleValue(), type));
+            }
+
+            if (!singleValuesInRange.isEmpty()) {
+                disjuncts.add(combineRangeWithExcludedPoints(type, reference, range, singleValuesInRange));
+                continue;
+            }
+
+            disjuncts.add(processRange(type, range, reference));
+        }
+
+        // Add back all of the possible single values either as an equality or an IN predicate
+        if (singleValues.size() == 1) {
+            disjuncts.add(equal(reference, getOnlyElement(singleValues)));
+        }
+        else if (singleValues.size() > 1) {
+            disjuncts.add(in(reference, singleValues));
+        }
+        return disjuncts;
+    }
+
+    private List<RowExpression> extractDisjuncts(Type type, DiscreteValues discreteValues, VariableReferenceExpression reference)
+    {
+        List<RowExpression> values = discreteValues.getValues().stream()
+                .map(object -> toRowExpression(object, type))
+                .collect(toList());
+
+        // If values is empty, then the equatableValues was either ALL or NONE, both of which should already have been checked for
+        checkState(!values.isEmpty());
+
+        RowExpression predicate;
+        if (values.size() == 1) {
+            predicate = equal(reference, getOnlyElement(values));
+        }
+        else {
+            predicate = in(reference, values);
+        }
+
+        if (!discreteValues.isWhiteList()) {
+            predicate = not(functionResolution, predicate);
+        }
+        return ImmutableList.of(predicate);
+    }
+
+    private static boolean isBetween(Range range)
+    {
+        return !range.getLow().isLowerUnbounded() && range.getLow().getBound() == Marker.Bound.EXACTLY
+                && !range.getHigh().isUpperUnbounded() && range.getHigh().getBound() == Marker.Bound.EXACTLY;
+    }
+
+    /**
+     * Convert an Expression predicate into an ExtractionResult consisting of:
+     * 1) A successfully extracted TupleDomain
+     * 2) An Expression fragment which represents the part of the original Expression that will need to be re-evaluated
+     * after filtering with the TupleDomain.
+     */
+    public static ExtractionResult fromPredicate(Metadata metadata, Session session, RowExpression predicate)
+    {
+        return predicate.accept(new Visitor(metadata, session), false);
+    }
+
+    private static class Visitor
+            implements RowExpressionVisitor<ExtractionResult, Boolean>
+    {
+        private final InterpretedFunctionInvoker functionInvoker;
+        private final Metadata metadata;
+        private final Session session;
+        private final FunctionManager functionManager;
+        private final LogicalRowExpressions logicalRowExpressions;
+        private final DeterminismEvaluator determinismEvaluator;
+        private final StandardFunctionResolution resolution;
+
+        private Visitor(Metadata metadata, Session session)
+        {
+            this.functionInvoker = new InterpretedFunctionInvoker(metadata.getFunctionManager());
+            this.metadata = metadata;
+            this.session = session;
+            this.functionManager = metadata.getFunctionManager();
+            this.logicalRowExpressions = new LogicalRowExpressions(functionManager);
+            this.determinismEvaluator = new DeterminismEvaluator(functionManager);
+            this.resolution = new StandardFunctionResolution(functionManager);
+        }
+
+        @Override
+        public ExtractionResult visitSpecialForm(SpecialFormExpression node, Boolean complement)
+        {
+            switch (node.getForm()) {
+                case AND:
+                case OR: {
+                    return visitBinaryLogic(node, complement);
+                }
+                case IN: {
+                    RowExpression target = node.getArguments().get(0);
+                    List<RowExpression> values = node.getArguments().subList(1, node.getArguments().size());
+                    checkState(!values.isEmpty(), "values should never be empty");
+
+                    ImmutableList.Builder<RowExpression> disjuncts = ImmutableList.builder();
+                    for (RowExpression expression : values) {
+                        disjuncts.add(call(EQUAL.name(), functionManager.resolveOperator(EQUAL, fromTypes(target.getType(), expression.getType())), BOOLEAN, target, expression));
+                    }
+                    ExtractionResult extractionResult = or(disjuncts.build()).accept(this, complement);
+
+                    // preserve original IN predicate as remaining predicate
+                    if (extractionResult.tupleDomain.isAll()) {
+                        RowExpression originalPredicate = node;
+                        if (complement) {
+                            originalPredicate = not(resolution, originalPredicate);
+                        }
+                        return new ExtractionResult(extractionResult.tupleDomain, originalPredicate);
+                    }
+                    return extractionResult;
+                }
+                case IS_NULL: {
+                    RowExpression value = node.getArguments().get(0);
+                    if (!(value instanceof VariableReferenceExpression)) {
+                        return visitRowExpression(node, complement);
+                    }
+
+                    Domain domain = complementIfNecessary(Domain.onlyNull(value.getType()), complement);
+                    return new ExtractionResult(TupleDomain.withColumnDomains(ImmutableMap.of((VariableReferenceExpression) value, domain)), TRUE);
+                }
+                default:
+                    return visitRowExpression(node, complement);
+            }
+        }
+
+        @Override
+        public ExtractionResult visitConstant(ConstantExpression node, Boolean complement)
+        {
+            if (node.getValue() == null) {
+                return new ExtractionResult(TupleDomain.none(), TRUE);
+            }
+            if (node.getType() == BOOLEAN) {
+                boolean value = complement != (boolean) node.getValue();
+                return new ExtractionResult(value ? TupleDomain.all() : TupleDomain.none(), TRUE);
+            }
+            throw new IllegalStateException("Can not extract predicate from constant type: " + node.getType());
+        }
+
+        @Override
+        public ExtractionResult visitLambda(LambdaDefinitionExpression node, Boolean complement)
+        {
+            return visitRowExpression(node, complement);
+        }
+
+        @Override
+        public ExtractionResult visitVariableReference(VariableReferenceExpression node, Boolean complement)
+        {
+            return visitRowExpression(node, complement);
+        }
+
+        @Override
+        public ExtractionResult visitCall(CallExpression node, Boolean complement)
+        {
+            if (node.getFunctionHandle().equals(resolution.notFunction())) {
+                return node.getArguments().get(0).accept(this, !complement);
+            }
+
+            if (resolution.isBetweenFunction(node.getFunctionHandle())) {
+                // Re-write as two comparison expressions
+                return and(
+                        binaryOperator(GREATER_THAN_OR_EQUAL, node.getArguments().get(0), node.getArguments().get(1)),
+                        binaryOperator(LESS_THAN_OR_EQUAL, node.getArguments().get(0), node.getArguments().get(2))).accept(this, complement);
+            }
+
+            FunctionMetadata functionMetadata = metadata.getFunctionManager().getFunctionMetadata(node.getFunctionHandle());
+            if (functionMetadata.getOperatorType().map(OperatorType::isComparisonOperator).orElse(false)) {
+                Optional<NormalizedSimpleComparison> optionalNormalized = toNormalizedSimpleComparison(functionMetadata.getOperatorType().get(), node.getArguments().get(0), node.getArguments().get(1));
+                if (!optionalNormalized.isPresent()) {
+                    return visitRowExpression(node, complement);
+                }
+                NormalizedSimpleComparison normalized = optionalNormalized.get();
+
+                RowExpression expression = normalized.getExpression();
+                if (expression instanceof VariableReferenceExpression) {
+                    NullableValue value = normalized.getValue();
+                    Type type = value.getType(); // common type for symbol and value
+                    return createComparisonExtractionResult(normalized.getComparisonOperator(), (VariableReferenceExpression) expression, type, value.getValue(), complement);
+                }
+                else if (expression instanceof CallExpression && resolution.isCastFunction(((CallExpression) expression).getFunctionHandle())) {
+                    CallExpression castExpression = (CallExpression) expression;
+                    if (!isImplicitCoercion(castExpression)) {
+                        //
+                        // we cannot use non-coercion cast to literal_type on symbol side to build tuple domain
+                        //
+                        // example which illustrates the problem:
+                        //
+                        // let t be of timestamp type:
+                        //
+                        // and expression be:
+                        // cast(t as date) == date_literal
+                        //
+                        // after dropping cast we end up with:
+                        //
+                        // t == date_literal
+                        //
+                        // if we build tuple domain based coercion of date_literal to timestamp type we would
+                        // end up with tuple domain with just one time point (cast(date_literal as timestamp).
+                        // While we need range which maps to single date pointed by date_literal.
+                        //
+                        return visitRowExpression(node, complement);
+                    }
+
+                    CallExpression cast = (CallExpression) expression;
+                    Type sourceType = cast.getArguments().get(0).getType();
+
+                    // we use saturated floor cast value -> castSourceType to rewrite original expression to new one with one cast peeled off the symbol side
+                    Optional<RowExpression> coercedExpression = coerceComparisonWithRounding(
+                            sourceType, cast.getArguments().get(0), normalized.getValue(), normalized.getComparisonOperator());
+
+                    if (coercedExpression.isPresent()) {
+                        return coercedExpression.get().accept(this, complement);
+                    }
+
+                    return visitRowExpression(node, complement);
+                }
+                else {
+                    return visitRowExpression(node, complement);
+                }
+            }
+
+            return visitRowExpression(node, complement);
+        }
+
+        @Override
+        public ExtractionResult visitInputReference(InputReferenceExpression node, Boolean complement)
+        {
+            return visitRowExpression(node, complement);
+        }
+
+        private Optional<RowExpression> coerceComparisonWithRounding(
+                Type expressionType,
+                RowExpression expression,
+                NullableValue nullableValue,
+                OperatorType comparisonOperator)
+        {
+            requireNonNull(nullableValue, "nullableValue is null");
+            if (nullableValue.isNull()) {
+                return Optional.empty();
+            }
+            Type valueType = nullableValue.getType();
+            Object value = nullableValue.getValue();
+            return floorValue(valueType, expressionType, value)
+                    .map((floorValue) -> rewriteComparisonExpression(expressionType, expression, valueType, value, floorValue, comparisonOperator));
+        }
+
+        private RowExpression rewriteComparisonExpression(
+                Type expressionType,
+                RowExpression expression,
+                Type valueType,
+                Object originalValue,
+                Object coercedValue,
+                OperatorType comparisonOperator)
+        {
+            int originalComparedToCoerced = compareOriginalValueToCoerced(valueType, originalValue, expressionType, coercedValue);
+            boolean coercedValueIsEqualToOriginal = originalComparedToCoerced == 0;
+            boolean coercedValueIsLessThanOriginal = originalComparedToCoerced > 0;
+            boolean coercedValueIsGreaterThanOriginal = originalComparedToCoerced < 0;
+            RowExpression coercedLiteral = toRowExpression(coercedValue, expressionType);
+
+            switch (comparisonOperator) {
+                case GREATER_THAN_OR_EQUAL:
+                case GREATER_THAN: {
+                    if (coercedValueIsGreaterThanOriginal) {
+                        return binaryOperator(GREATER_THAN_OR_EQUAL, expression, coercedLiteral);
+                    }
+                    if (coercedValueIsEqualToOriginal) {
+                        return binaryOperator(comparisonOperator, expression, coercedLiteral);
+                    }
+                    return binaryOperator(GREATER_THAN, expression, coercedLiteral);
+                }
+                case LESS_THAN_OR_EQUAL:
+                case LESS_THAN: {
+                    if (coercedValueIsLessThanOriginal) {
+                        return binaryOperator(LESS_THAN_OR_EQUAL, expression, coercedLiteral);
+                    }
+                    if (coercedValueIsEqualToOriginal) {
+                        return binaryOperator(comparisonOperator, expression, coercedLiteral);
+                    }
+                    return binaryOperator(LESS_THAN, expression, coercedLiteral);
+                }
+                case EQUAL: {
+                    if (coercedValueIsEqualToOriginal) {
+                        return binaryOperator(EQUAL, expression, coercedLiteral);
+                    }
+                    // Return something that is false for all non-null values
+                    return and(binaryOperator(EQUAL, expression, coercedLiteral),
+                            binaryOperator(NOT_EQUAL, expression, coercedLiteral));
+                }
+                case NOT_EQUAL: {
+                    if (coercedValueIsEqualToOriginal) {
+                        return binaryOperator(comparisonOperator, expression, coercedLiteral);
+                    }
+                    // Return something that is true for all non-null values
+                    return or(binaryOperator(EQUAL, expression, coercedLiteral),
+                            binaryOperator(NOT_EQUAL, expression, coercedLiteral));
+                }
+                case IS_DISTINCT_FROM: {
+                    if (coercedValueIsEqualToOriginal) {
+                        return binaryOperator(comparisonOperator, expression, coercedLiteral);
+                    }
+                    return TRUE;
+                }
+            }
+
+            throw new IllegalArgumentException("Unhandled operator: " + comparisonOperator);
+        }
+
+        private RowExpression binaryOperator(OperatorType operatorType, RowExpression left, RowExpression right)
+        {
+            return call(
+                    operatorType.name(),
+                    metadata.getFunctionManager().resolveOperator(operatorType, fromTypes(left.getType(), right.getType())),
+                    BOOLEAN,
+                    left,
+                    right);
+        }
+
+        private Optional<Object> floorValue(Type fromType, Type toType, Object value)
+        {
+            return getSaturatedFloorCastOperator(fromType, toType)
+                    .map((operator) -> functionInvoker.invoke(operator, session.toConnectorSession(), value));
+        }
+
+        private Optional<FunctionHandle> getSaturatedFloorCastOperator(Type fromType, Type toType)
+        {
+            try {
+                return Optional.of(metadata.getFunctionManager().lookupCast(SATURATED_FLOOR_CAST, fromType.getTypeSignature(), toType.getTypeSignature()));
+            }
+            catch (OperatorNotFoundException e) {
+                return Optional.empty();
+            }
+        }
+
+        private int compareOriginalValueToCoerced(Type originalValueType, Object originalValue, Type coercedValueType, Object coercedValue)
+        {
+            FunctionHandle castToOriginalTypeOperator = metadata.getFunctionManager().lookupCast(CAST, coercedValueType.getTypeSignature(), originalValueType.getTypeSignature());
+            Object coercedValueInOriginalType = functionInvoker.invoke(castToOriginalTypeOperator, session.toConnectorSession(), coercedValue);
+            Block originalValueBlock = Utils.nativeValueToBlock(originalValueType, originalValue);
+            Block coercedValueBlock = Utils.nativeValueToBlock(originalValueType, coercedValueInOriginalType);
+            return originalValueType.compareTo(originalValueBlock, 0, coercedValueBlock, 0);
+        }
+
+        private boolean isImplicitCoercion(CallExpression cast)
+        {
+            Type sourceType = cast.getArguments().get(0).getType();
+            Type targetType = cast.getType();
+            return metadata.getTypeManager().canCoerce(sourceType, targetType);
+        }
+
+        private static Domain extractOrderableDomain(OperatorType comparisonOperator, Type type, Object value, boolean complement)
+        {
+            checkArgument(value != null);
+            switch (comparisonOperator) {
+                case EQUAL:
+                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.equal(type, value)), complement), false);
+                case GREATER_THAN:
+                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.greaterThan(type, value)), complement), false);
+                case GREATER_THAN_OR_EQUAL:
+                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.greaterThanOrEqual(type, value)), complement), false);
+                case LESS_THAN:
+                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.lessThan(type, value)), complement), false);
+                case LESS_THAN_OR_EQUAL:
+                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.lessThanOrEqual(type, value)), complement), false);
+                case NOT_EQUAL:
+                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.lessThan(type, value), Range.greaterThan(type, value)), complement), false);
+                case IS_DISTINCT_FROM:
+                    // Need to potential complement the whole domain for IS_DISTINCT_FROM since it is null-aware
+                    return complementIfNecessary(Domain.create(ValueSet.ofRanges(Range.lessThan(type, value), Range.greaterThan(type, value)), true), complement);
+                default:
+                    throw new AssertionError("Unhandled operator: " + comparisonOperator);
+            }
+        }
+
+        private static Domain extractEquatableDomain(OperatorType comparisonOperator, Type type, Object value, boolean complement)
+        {
+            checkArgument(value != null);
+            switch (comparisonOperator) {
+                case EQUAL:
+                    return Domain.create(complementIfNecessary(ValueSet.of(type, value), complement), false);
+                case NOT_EQUAL:
+                    return Domain.create(complementIfNecessary(ValueSet.of(type, value).complement(), complement), false);
+                case IS_DISTINCT_FROM:
+                    // Need to potential complement the whole domain for IS_DISTINCT_FROM since it is null-aware
+                    return complementIfNecessary(Domain.create(ValueSet.of(type, value).complement(), true), complement);
+                default:
+                    throw new AssertionError("Unhandled operator: " + comparisonOperator);
+            }
+        }
+
+        /**
+         * Extract a normalized simple comparison between a QualifiedNameReference and a native value if possible.
+         */
+        private Optional<NormalizedSimpleComparison> toNormalizedSimpleComparison(OperatorType operatorType, RowExpression leftExpression, RowExpression rightExpression)
+        {
+            Object left;
+            Object right;
+            if (leftExpression instanceof VariableReferenceExpression) {
+                left = leftExpression;
+            }
+            else {
+                left = new RowExpressionInterpreter(leftExpression, metadata, session, true).optimize();
+            }
+            if (rightExpression instanceof VariableReferenceExpression) {
+                right = rightExpression;
+            }
+            else {
+                right = new RowExpressionInterpreter(rightExpression, metadata, session, true).optimize();
+            }
+
+            if (left instanceof RowExpression == right instanceof RowExpression) {
+                // we expect one side to be row expression and other to be value.
+                return Optional.empty();
+            }
+
+            RowExpression expression;
+            OperatorType comparisonOperator;
+            NullableValue value;
+
+            if (left instanceof RowExpression) {
+                expression = leftExpression;
+                comparisonOperator = operatorType;
+                value = new NullableValue(rightExpression.getType(), right);
+            }
+            else {
+                expression = rightExpression;
+                comparisonOperator = flip(operatorType);
+                value = new NullableValue(leftExpression.getType(), left);
+            }
+
+            return Optional.of(new NormalizedSimpleComparison(expression, comparisonOperator, value));
+        }
+
+        private static ExtractionResult createComparisonExtractionResult(OperatorType comparisonOperator, VariableReferenceExpression column, Type type, @Nullable Object value, boolean complement)
+        {
+            if (value == null) {
+                switch (comparisonOperator) {
+                    case EQUAL:
+                    case GREATER_THAN:
+                    case GREATER_THAN_OR_EQUAL:
+                    case LESS_THAN:
+                    case LESS_THAN_OR_EQUAL:
+                    case NOT_EQUAL:
+                        return new ExtractionResult(TupleDomain.none(), TRUE);
+
+                    case IS_DISTINCT_FROM:
+                        Domain domain = complementIfNecessary(Domain.notNull(type), complement);
+                        return new ExtractionResult(
+                                TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)),
+                                TRUE);
+
+                    default:
+                        throw new AssertionError("Unhandled operator: " + comparisonOperator);
+                }
+            }
+
+            Domain domain;
+            if (type.isOrderable()) {
+                domain = extractOrderableDomain(comparisonOperator, type, value, complement);
+            }
+            else if (type.isComparable()) {
+                domain = extractEquatableDomain(comparisonOperator, type, value, complement);
+            }
+            else {
+                throw new AssertionError("Type cannot be used in a comparison expression (should have been caught in analysis): " + type);
+            }
+
+            return new ExtractionResult(TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)), TRUE);
+        }
+
+        private static OperatorType flip(OperatorType operatorType)
+        {
+            switch (operatorType) {
+                case EQUAL:
+                    return EQUAL;
+                case NOT_EQUAL:
+                    return NOT_EQUAL;
+                case LESS_THAN:
+                    return GREATER_THAN;
+                case LESS_THAN_OR_EQUAL:
+                    return GREATER_THAN_OR_EQUAL;
+                case GREATER_THAN:
+                    return LESS_THAN;
+                case GREATER_THAN_OR_EQUAL:
+                    return LESS_THAN_OR_EQUAL;
+                case IS_DISTINCT_FROM:
+                    return IS_DISTINCT_FROM;
+                default:
+                    throw new IllegalArgumentException("Unsupported comparison: " + operatorType);
+            }
+        }
+
+        private static ValueSet complementIfNecessary(ValueSet valueSet, boolean complement)
+        {
+            return complement ? valueSet.complement() : valueSet;
+        }
+
+        private static Domain complementIfNecessary(Domain domain, boolean complement)
+        {
+            return complement ? domain.complement() : domain;
+        }
+
+        private RowExpression complementIfNecessary(RowExpression expression, boolean complement)
+        {
+            return complement ? not(resolution, expression) : expression;
+        }
+
+        private ExtractionResult visitRowExpression(RowExpression node, Boolean complement)
+        {
+            // If we don't know how to process this node, the default response is to say that the TupleDomain is "all"
+            return new ExtractionResult(TupleDomain.all(), complementIfNecessary(node, complement));
+        }
+
+        private ExtractionResult visitBinaryLogic(SpecialFormExpression node, Boolean complement)
+        {
+            ExtractionResult leftResult = node.getArguments().get(0).accept(this, complement);
+            ExtractionResult rightResult = node.getArguments().get(1).accept(this, complement);
+
+            TupleDomain<VariableReferenceExpression> leftTupleDomain = leftResult.getTupleDomain();
+            TupleDomain<VariableReferenceExpression> rightTupleDomain = rightResult.getTupleDomain();
+
+            Form operator = node.getForm();
+            if (complement) {
+                if (operator == AND) {
+                    operator = OR;
+                }
+                else if (operator == OR) {
+                    operator = AND;
+                }
+                else {
+                    throw new IllegalStateException("Can not extract predicate from special form: " + node.getForm());
+                }
+            }
+
+            switch (operator) {
+                case AND: {
+                    return new ExtractionResult(
+                            leftTupleDomain.intersect(rightTupleDomain),
+                            logicalRowExpressions.combineConjuncts(leftResult.getRemainingExpression(), rightResult.getRemainingExpression()));
+                }
+                case OR: {
+                    TupleDomain<VariableReferenceExpression> columnUnionedTupleDomain = TupleDomain.columnWiseUnion(leftTupleDomain, rightTupleDomain);
+
+                    // In most cases, the columnUnionedTupleDomain is only a superset of the actual strict union
+                    // and so we can return the current node as the remainingExpression so that all bounds will be double checked again at execution time.
+                    RowExpression remainingExpression = complementIfNecessary(node, complement);
+
+                    // However, there are a few cases where the column-wise union is actually equivalent to the strict union, so we if can detect
+                    // some of these cases, we won't have to double check the bounds unnecessarily at execution time.
+
+                    // We can only make inferences if the remaining expressions on both side are equal and deterministic
+                    if (leftResult.getRemainingExpression().equals(rightResult.getRemainingExpression()) &&
+                            determinismEvaluator.isDeterministic(leftResult.getRemainingExpression())) {
+                        // The column-wise union is equivalent to the strict union if
+                        // 1) If both TupleDomains consist of the same exact single column (e.g. left TupleDomain => (a > 0), right TupleDomain => (a < 10))
+                        // 2) If one TupleDomain is a superset of the other (e.g. left TupleDomain => (a > 0, b > 0 && b < 10), right TupleDomain => (a > 5, b = 5))
+                        boolean matchingSingleSymbolDomains = !leftTupleDomain.isNone()
+                                && !rightTupleDomain.isNone()
+                                && leftTupleDomain.getDomains().get().size() == 1
+                                && rightTupleDomain.getDomains().get().size() == 1
+                                && leftTupleDomain.getDomains().get().keySet().equals(rightTupleDomain.getDomains().get().keySet());
+                        boolean oneSideIsSuperSet = leftTupleDomain.contains(rightTupleDomain) || rightTupleDomain.contains(leftTupleDomain);
+
+                        if (matchingSingleSymbolDomains || oneSideIsSuperSet) {
+                            remainingExpression = leftResult.getRemainingExpression();
+                        }
+                    }
+
+                    return new ExtractionResult(columnUnionedTupleDomain, remainingExpression);
+                }
+                default:
+                    throw new IllegalStateException("Can not extract predicate from special form: " + node.getForm());
+            }
+        }
+    }
+
+    private static RowExpression isNull(RowExpression expression)
+    {
+        return new SpecialFormExpression(IS_NULL, BOOLEAN, expression);
+    }
+
+    private static RowExpression not(StandardFunctionResolution resolution, RowExpression expression)
+    {
+        return call("not", resolution.notFunction(), expression.getType(), expression);
+    }
+
+    private RowExpression in(RowExpression value, List<RowExpression> inList)
+    {
+        return new SpecialFormExpression(IN, BOOLEAN, ImmutableList.<RowExpression>builder().add(value).addAll(inList).build());
+    }
+
+    private RowExpression binaryOperator(OperatorType operatorType, RowExpression left, RowExpression right)
+    {
+        return call(operatorType.name(), functionManager.resolveOperator(operatorType, fromTypes(left.getType(), right.getType())), BOOLEAN, left, right);
+    }
+
+    private RowExpression greaterThan(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.GREATER_THAN, left, right);
+    }
+
+    private RowExpression lessThan(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.LESS_THAN, left, right);
+    }
+
+    private RowExpression greaterThanOrEqual(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(GREATER_THAN_OR_EQUAL, left, right);
+    }
+
+    private RowExpression lessThanOrEqual(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(LESS_THAN_OR_EQUAL, left, right);
+    }
+
+    private RowExpression equal(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(EQUAL, left, right);
+    }
+
+    private RowExpression notEqual(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(NOT_EQUAL, left, right);
+    }
+
+    private static class NormalizedSimpleComparison
+    {
+        private final RowExpression expression;
+        private final OperatorType comparisonOperator;
+        private final NullableValue value;
+
+        public NormalizedSimpleComparison(RowExpression expression, OperatorType comparisonOperator, NullableValue value)
+        {
+            this.expression = requireNonNull(expression, "expression is null");
+            this.comparisonOperator = requireNonNull(comparisonOperator, "comparisonOperator is null");
+            this.value = requireNonNull(value, "value is null");
+        }
+
+        public RowExpression getExpression()
+        {
+            return expression;
+        }
+
+        public OperatorType getComparisonOperator()
+        {
+            return comparisonOperator;
+        }
+
+        public NullableValue getValue()
+        {
+            return value;
+        }
+    }
+
+    public static class ExtractionResult
+    {
+        private final TupleDomain<VariableReferenceExpression> tupleDomain;
+        private final RowExpression remainingExpression;
+
+        public ExtractionResult(TupleDomain<VariableReferenceExpression> tupleDomain, RowExpression remainingExpression)
+        {
+            this.tupleDomain = requireNonNull(tupleDomain, "tupleDomain is null");
+            this.remainingExpression = requireNonNull(remainingExpression, "remainingExpression is null");
+        }
+
+        public TupleDomain<VariableReferenceExpression> getTupleDomain()
+        {
+            return tupleDomain;
+        }
+
+        public RowExpression getRemainingExpression()
+        {
+            return remainingExpression;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionDomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionDomainTranslator.java
@@ -15,39 +15,23 @@ package com.facebook.presto.sql.relational;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.FunctionManager;
-import com.facebook.presto.metadata.FunctionMetadata;
 import com.facebook.presto.metadata.Metadata;
-import com.facebook.presto.metadata.OperatorNotFoundException;
-import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.predicate.DiscreteValues;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.Marker;
-import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.Range;
 import com.facebook.presto.spi.predicate.Ranges;
 import com.facebook.presto.spi.predicate.SortedRangeSet;
 import com.facebook.presto.spi.predicate.TupleDomain;
-import com.facebook.presto.spi.predicate.Utils;
-import com.facebook.presto.spi.predicate.ValueSet;
-import com.facebook.presto.spi.relation.CallExpression;
-import com.facebook.presto.spi.relation.ConstantExpression;
-import com.facebook.presto.spi.relation.InputReferenceExpression;
-import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.predicate.TupleDomain.ColumnDomain;
 import com.facebook.presto.spi.relation.RowExpression;
-import com.facebook.presto.spi.relation.RowExpressionVisitor;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
-import com.facebook.presto.spi.relation.SpecialFormExpression.Form;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.sql.InterpretedFunctionInvoker;
-import com.facebook.presto.sql.planner.RowExpressionInterpreter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.PeekingIterator;
-
-import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -55,20 +39,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.facebook.presto.metadata.CastType.CAST;
-import static com.facebook.presto.metadata.CastType.SATURATED_FLOOR_CAST;
 import static com.facebook.presto.spi.function.OperatorType.BETWEEN;
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
-import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
 import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
-import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
-import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
-import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
-import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.planner.LiteralEncoder.toRowExpression;
@@ -76,11 +53,8 @@ import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.LogicalRowExpressions.FALSE;
 import static com.facebook.presto.sql.relational.LogicalRowExpressions.TRUE;
 import static com.facebook.presto.sql.relational.LogicalRowExpressions.and;
-import static com.facebook.presto.sql.relational.LogicalRowExpressions.or;
-import static com.facebook.presto.sql.relational.StandardFunctionResolution.getComparisonOperator;
-import static com.facebook.presto.sql.relational.StandardFunctionResolution.isComparisonFunction;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.builder;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Iterators.peekingIterator;
@@ -285,523 +259,10 @@ public final class RowExpressionDomainTranslator
      * 2) An Expression fragment which represents the part of the original Expression that will need to be re-evaluated
      * after filtering with the TupleDomain.
      */
-    public static ExtractionResult fromPredicate(Metadata metadata, Session session, RowExpression predicate)
+    public ExtractionResult fromPredicate(Metadata metadata, Session session, RowExpression predicate)
     {
-        return predicate.accept(new Visitor(metadata, session), false);
-    }
-
-    private static class Visitor
-            implements RowExpressionVisitor<ExtractionResult, Boolean>
-    {
-        private final InterpretedFunctionInvoker functionInvoker;
-        private final Metadata metadata;
-        private final Session session;
-        private final FunctionManager functionManager;
-        private final LogicalRowExpressions logicalRowExpressions;
-        private final DeterminismEvaluator determinismEvaluator;
-        private final StandardFunctionResolution resolution;
-
-        private Visitor(Metadata metadata, Session session)
-        {
-            this.functionInvoker = new InterpretedFunctionInvoker(metadata.getFunctionManager());
-            this.metadata = metadata;
-            this.session = session;
-            this.functionManager = metadata.getFunctionManager();
-            this.logicalRowExpressions = new LogicalRowExpressions(functionManager);
-            this.determinismEvaluator = new DeterminismEvaluator(functionManager);
-            this.resolution = new StandardFunctionResolution(functionManager);
-        }
-
-        @Override
-        public ExtractionResult visitSpecialForm(SpecialFormExpression node, Boolean complement)
-        {
-            switch (node.getForm()) {
-                case AND:
-                case OR: {
-                    return visitBinaryLogic(node, complement);
-                }
-                case IN: {
-                    RowExpression target = node.getArguments().get(0);
-                    List<RowExpression> values = node.getArguments().subList(1, node.getArguments().size());
-                    checkState(!values.isEmpty(), "values should never be empty");
-
-                    ImmutableList.Builder<RowExpression> disjuncts = ImmutableList.builder();
-                    for (RowExpression expression : values) {
-                        disjuncts.add(call(EQUAL.name(), functionManager.resolveOperator(EQUAL, fromTypes(target.getType(), expression.getType())), BOOLEAN, target, expression));
-                    }
-                    ExtractionResult extractionResult = or(disjuncts.build()).accept(this, complement);
-
-                    // preserve original IN predicate as remaining predicate
-                    if (extractionResult.tupleDomain.isAll()) {
-                        RowExpression originalPredicate = node;
-                        if (complement) {
-                            originalPredicate = not(resolution, originalPredicate);
-                        }
-                        return new ExtractionResult(extractionResult.tupleDomain, originalPredicate);
-                    }
-                    return extractionResult;
-                }
-                case IS_NULL: {
-                    RowExpression value = node.getArguments().get(0);
-                    if (!(value instanceof VariableReferenceExpression)) {
-                        return visitRowExpression(node, complement);
-                    }
-
-                    Domain domain = complementIfNecessary(Domain.onlyNull(value.getType()), complement);
-                    return new ExtractionResult(TupleDomain.withColumnDomains(ImmutableMap.of((VariableReferenceExpression) value, domain)), TRUE);
-                }
-                default:
-                    return visitRowExpression(node, complement);
-            }
-        }
-
-        @Override
-        public ExtractionResult visitConstant(ConstantExpression node, Boolean complement)
-        {
-            if (node.getValue() == null) {
-                return new ExtractionResult(TupleDomain.none(), TRUE);
-            }
-            if (node.getType() == BOOLEAN) {
-                boolean value = complement != (boolean) node.getValue();
-                return new ExtractionResult(value ? TupleDomain.all() : TupleDomain.none(), TRUE);
-            }
-            throw new IllegalStateException("Can not extract predicate from constant type: " + node.getType());
-        }
-
-        @Override
-        public ExtractionResult visitLambda(LambdaDefinitionExpression node, Boolean complement)
-        {
-            return visitRowExpression(node, complement);
-        }
-
-        @Override
-        public ExtractionResult visitVariableReference(VariableReferenceExpression node, Boolean complement)
-        {
-            return visitRowExpression(node, complement);
-        }
-
-        @Override
-        public ExtractionResult visitCall(CallExpression node, Boolean complement)
-        {
-            if (node.getFunctionHandle().equals(resolution.notFunction())) {
-                return node.getArguments().get(0).accept(this, !complement);
-            }
-
-            if (resolution.isBetweenFunction(node.getFunctionHandle())) {
-                // Re-write as two comparison expressions
-                return and(
-                        binaryOperator(GREATER_THAN_OR_EQUAL, node.getArguments().get(0), node.getArguments().get(1)),
-                        binaryOperator(LESS_THAN_OR_EQUAL, node.getArguments().get(0), node.getArguments().get(2))).accept(this, complement);
-            }
-
-            if (isComparisonFunction(node.getFunctionHandle())) {
-                Optional<NormalizedSimpleComparison> optionalNormalized = toNormalizedSimpleComparison(getComparisonOperator(node), node.getArguments().get(0), node.getArguments().get(1));
-                if (!optionalNormalized.isPresent()) {
-                    return visitRowExpression(node, complement);
-                }
-                NormalizedSimpleComparison normalized = optionalNormalized.get();
-
-                RowExpression expression = normalized.getExpression();
-                if (expression instanceof VariableReferenceExpression) {
-                    NullableValue value = normalized.getValue();
-                    Type type = value.getType(); // common type for symbol and value
-                    return createComparisonExtractionResult(normalized.getComparisonOperator(), (VariableReferenceExpression) expression, type, value.getValue(), complement);
-                }
-                else if (expression instanceof CallExpression && resolution.isCastFunction(((CallExpression) expression).getFunctionHandle())) {
-                    CallExpression castExpression = (CallExpression) expression;
-                    if (!isImplicitCoercion(castExpression)) {
-                        //
-                        // we cannot use non-coercion cast to literal_type on symbol side to build tuple domain
-                        //
-                        // example which illustrates the problem:
-                        //
-                        // let t be of timestamp type:
-                        //
-                        // and expression be:
-                        // cast(t as date) == date_literal
-                        //
-                        // after dropping cast we end up with:
-                        //
-                        // t == date_literal
-                        //
-                        // if we build tuple domain based coercion of date_literal to timestamp type we would
-                        // end up with tuple domain with just one time point (cast(date_literal as timestamp).
-                        // While we need range which maps to single date pointed by date_literal.
-                        //
-                        return visitRowExpression(node, complement);
-                    }
-
-                    CallExpression cast = (CallExpression) expression;
-                    Type sourceType = cast.getArguments().get(0).getType();
-
-                    // we use saturated floor cast value -> castSourceType to rewrite original expression to new one with one cast peeled off the symbol side
-                    Optional<RowExpression> coercedExpression = coerceComparisonWithRounding(
-                            sourceType, cast.getArguments().get(0), normalized.getValue(), normalized.getComparisonOperator());
-
-                    if (coercedExpression.isPresent()) {
-                        return coercedExpression.get().accept(this, complement);
-                    }
-
-                    return visitRowExpression(node, complement);
-                }
-                else {
-                    return visitRowExpression(node, complement);
-                }
-            }
-
-            return visitRowExpression(node, complement);
-        }
-
-        @Override
-        public ExtractionResult visitInputReference(InputReferenceExpression node, Boolean complement)
-        {
-            return visitRowExpression(node, complement);
-        }
-
-        private Optional<RowExpression> coerceComparisonWithRounding(
-                Type expressionType,
-                RowExpression expression,
-                NullableValue nullableValue,
-                OperatorType comparisonOperator)
-        {
-            requireNonNull(nullableValue, "nullableValue is null");
-            if (nullableValue.isNull()) {
-                return Optional.empty();
-            }
-            Type valueType = nullableValue.getType();
-            Object value = nullableValue.getValue();
-            return floorValue(valueType, expressionType, value)
-                    .map((floorValue) -> rewriteComparisonExpression(expressionType, expression, valueType, value, floorValue, comparisonOperator));
-        }
-
-        private RowExpression rewriteComparisonExpression(
-                Type expressionType,
-                RowExpression expression,
-                Type valueType,
-                Object originalValue,
-                Object coercedValue,
-                OperatorType comparisonOperator)
-        {
-            int originalComparedToCoerced = compareOriginalValueToCoerced(valueType, originalValue, expressionType, coercedValue);
-            boolean coercedValueIsEqualToOriginal = originalComparedToCoerced == 0;
-            boolean coercedValueIsLessThanOriginal = originalComparedToCoerced > 0;
-            boolean coercedValueIsGreaterThanOriginal = originalComparedToCoerced < 0;
-            RowExpression coercedLiteral = toRowExpression(coercedValue, expressionType);
-
-            switch (comparisonOperator) {
-                case GREATER_THAN_OR_EQUAL:
-                case GREATER_THAN: {
-                    if (coercedValueIsGreaterThanOriginal) {
-                        return binaryOperator(GREATER_THAN_OR_EQUAL, expression, coercedLiteral);
-                    }
-                    if (coercedValueIsEqualToOriginal) {
-                        return binaryOperator(comparisonOperator, expression, coercedLiteral);
-                    }
-                    return binaryOperator(GREATER_THAN, expression, coercedLiteral);
-                }
-                case LESS_THAN_OR_EQUAL:
-                case LESS_THAN: {
-                    if (coercedValueIsLessThanOriginal) {
-                        return binaryOperator(LESS_THAN_OR_EQUAL, expression, coercedLiteral);
-                    }
-                    if (coercedValueIsEqualToOriginal) {
-                        return binaryOperator(comparisonOperator, expression, coercedLiteral);
-                    }
-                    return binaryOperator(LESS_THAN, expression, coercedLiteral);
-                }
-                case EQUAL: {
-                    if (coercedValueIsEqualToOriginal) {
-                        return binaryOperator(EQUAL, expression, coercedLiteral);
-                    }
-                    // Return something that is false for all non-null values
-                    return and(binaryOperator(EQUAL, expression, coercedLiteral),
-                            binaryOperator(NOT_EQUAL, expression, coercedLiteral));
-                }
-                case NOT_EQUAL: {
-                    if (coercedValueIsEqualToOriginal) {
-                        return binaryOperator(comparisonOperator, expression, coercedLiteral);
-                    }
-                    // Return something that is true for all non-null values
-                    return or(binaryOperator(EQUAL, expression, coercedLiteral),
-                            binaryOperator(NOT_EQUAL, expression, coercedLiteral));
-                }
-                case IS_DISTINCT_FROM: {
-                    if (coercedValueIsEqualToOriginal) {
-                        return binaryOperator(comparisonOperator, expression, coercedLiteral);
-                    }
-                    return TRUE;
-                }
-            }
-
-            throw new IllegalArgumentException("Unhandled operator: " + comparisonOperator);
-        }
-
-        private RowExpression binaryOperator(OperatorType operatorType, RowExpression left, RowExpression right)
-        {
-            return call(
-                    operatorType.name(),
-                    metadata.getFunctionManager().resolveOperator(operatorType, fromTypes(left.getType(), right.getType())),
-                    BOOLEAN,
-                    left,
-                    right);
-        }
-
-        private Optional<Object> floorValue(Type fromType, Type toType, Object value)
-        {
-            return getSaturatedFloorCastOperator(fromType, toType)
-                    .map((operator) -> functionInvoker.invoke(operator, session.toConnectorSession(), value));
-        }
-
-        private Optional<FunctionHandle> getSaturatedFloorCastOperator(Type fromType, Type toType)
-        {
-            try {
-                return Optional.of(metadata.getFunctionManager().lookupCast(SATURATED_FLOOR_CAST, fromType.getTypeSignature(), toType.getTypeSignature()));
-            }
-            catch (OperatorNotFoundException e) {
-                return Optional.empty();
-            }
-        }
-
-        private int compareOriginalValueToCoerced(Type originalValueType, Object originalValue, Type coercedValueType, Object coercedValue)
-        {
-            FunctionHandle castToOriginalTypeOperator = metadata.getFunctionManager().lookupCast(CAST, coercedValueType.getTypeSignature(), originalValueType.getTypeSignature());
-            Object coercedValueInOriginalType = functionInvoker.invoke(castToOriginalTypeOperator, session.toConnectorSession(), coercedValue);
-            Block originalValueBlock = Utils.nativeValueToBlock(originalValueType, originalValue);
-            Block coercedValueBlock = Utils.nativeValueToBlock(originalValueType, coercedValueInOriginalType);
-            return originalValueType.compareTo(originalValueBlock, 0, coercedValueBlock, 0);
-        }
-
-        private boolean isImplicitCoercion(CallExpression cast)
-        {
-            Type sourceType = cast.getArguments().get(0).getType();
-            Type targetType = cast.getType();
-            return metadata.getTypeManager().canCoerce(sourceType, targetType);
-        }
-
-        private static Domain extractOrderableDomain(OperatorType comparisonOperator, Type type, Object value, boolean complement)
-        {
-            checkArgument(value != null);
-            switch (comparisonOperator) {
-                case EQUAL:
-                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.equal(type, value)), complement), false);
-                case GREATER_THAN:
-                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.greaterThan(type, value)), complement), false);
-                case GREATER_THAN_OR_EQUAL:
-                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.greaterThanOrEqual(type, value)), complement), false);
-                case LESS_THAN:
-                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.lessThan(type, value)), complement), false);
-                case LESS_THAN_OR_EQUAL:
-                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.lessThanOrEqual(type, value)), complement), false);
-                case NOT_EQUAL:
-                    return Domain.create(complementIfNecessary(ValueSet.ofRanges(Range.lessThan(type, value), Range.greaterThan(type, value)), complement), false);
-                case IS_DISTINCT_FROM:
-                    // Need to potential complement the whole domain for IS_DISTINCT_FROM since it is null-aware
-                    return complementIfNecessary(Domain.create(ValueSet.ofRanges(Range.lessThan(type, value), Range.greaterThan(type, value)), true), complement);
-                default:
-                    throw new AssertionError("Unhandled operator: " + comparisonOperator);
-            }
-        }
-
-        private static Domain extractEquatableDomain(OperatorType comparisonOperator, Type type, Object value, boolean complement)
-        {
-            checkArgument(value != null);
-            switch (comparisonOperator) {
-                case EQUAL:
-                    return Domain.create(complementIfNecessary(ValueSet.of(type, value), complement), false);
-                case NOT_EQUAL:
-                    return Domain.create(complementIfNecessary(ValueSet.of(type, value).complement(), complement), false);
-                case IS_DISTINCT_FROM:
-                    // Need to potential complement the whole domain for IS_DISTINCT_FROM since it is null-aware
-                    return complementIfNecessary(Domain.create(ValueSet.of(type, value).complement(), true), complement);
-                default:
-                    throw new AssertionError("Unhandled operator: " + comparisonOperator);
-            }
-        }
-
-        /**
-         * Extract a normalized simple comparison between a QualifiedNameReference and a native value if possible.
-         */
-        private Optional<NormalizedSimpleComparison> toNormalizedSimpleComparison(OperatorType operatorType, RowExpression leftExpression, RowExpression rightExpression)
-        {
-            Object left;
-            Object right;
-            if (leftExpression instanceof VariableReferenceExpression) {
-                left = leftExpression;
-            }
-            else {
-                left = new RowExpressionInterpreter(leftExpression, metadata, session, true).optimize();
-            }
-            if (rightExpression instanceof VariableReferenceExpression) {
-                right = rightExpression;
-            }
-            else {
-                right = new RowExpressionInterpreter(rightExpression, metadata, session, true).optimize();
-            }
-
-            if (left instanceof RowExpression == right instanceof RowExpression) {
-                // we expect one side to be row expression and other to be value.
-                return Optional.empty();
-            }
-
-            RowExpression expression;
-            OperatorType comparisonOperator;
-            NullableValue value;
-
-            if (left instanceof RowExpression) {
-                expression = leftExpression;
-                comparisonOperator = operatorType;
-                value = new NullableValue(rightExpression.getType(), right);
-            }
-            else {
-                expression = rightExpression;
-                comparisonOperator = flip(operatorType);
-                value = new NullableValue(leftExpression.getType(), left);
-            }
-
-            return Optional.of(new NormalizedSimpleComparison(expression, comparisonOperator, value));
-        }
-
-        private static ExtractionResult createComparisonExtractionResult(OperatorType comparisonOperator, VariableReferenceExpression column, Type type, @Nullable Object value, boolean complement)
-        {
-            if (value == null) {
-                switch (comparisonOperator) {
-                    case EQUAL:
-                    case GREATER_THAN:
-                    case GREATER_THAN_OR_EQUAL:
-                    case LESS_THAN:
-                    case LESS_THAN_OR_EQUAL:
-                    case NOT_EQUAL:
-                        return new ExtractionResult(TupleDomain.none(), TRUE);
-
-                    case IS_DISTINCT_FROM:
-                        Domain domain = complementIfNecessary(Domain.notNull(type), complement);
-                        return new ExtractionResult(
-                                TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)),
-                                TRUE);
-
-                    default:
-                        throw new AssertionError("Unhandled operator: " + comparisonOperator);
-                }
-            }
-
-            Domain domain;
-            if (type.isOrderable()) {
-                domain = extractOrderableDomain(comparisonOperator, type, value, complement);
-            }
-            else if (type.isComparable()) {
-                domain = extractEquatableDomain(comparisonOperator, type, value, complement);
-            }
-            else {
-                throw new AssertionError("Type cannot be used in a comparison expression (should have been caught in analysis): " + type);
-            }
-
-            return new ExtractionResult(TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)), TRUE);
-        }
-
-        private static OperatorType flip(OperatorType operatorType)
-        {
-            switch (operatorType) {
-                case EQUAL:
-                    return EQUAL;
-                case NOT_EQUAL:
-                    return NOT_EQUAL;
-                case LESS_THAN:
-                    return GREATER_THAN;
-                case LESS_THAN_OR_EQUAL:
-                    return GREATER_THAN_OR_EQUAL;
-                case GREATER_THAN:
-                    return LESS_THAN;
-                case GREATER_THAN_OR_EQUAL:
-                    return LESS_THAN_OR_EQUAL;
-                case IS_DISTINCT_FROM:
-                    return IS_DISTINCT_FROM;
-                default:
-                    throw new IllegalArgumentException("Unsupported comparison: " + operatorType);
-            }
-        }
-
-        private static ValueSet complementIfNecessary(ValueSet valueSet, boolean complement)
-        {
-            return complement ? valueSet.complement() : valueSet;
-        }
-
-        private static Domain complementIfNecessary(Domain domain, boolean complement)
-        {
-            return complement ? domain.complement() : domain;
-        }
-
-        private RowExpression complementIfNecessary(RowExpression expression, boolean complement)
-        {
-            return complement ? not(resolution, expression) : expression;
-        }
-
-        private ExtractionResult visitRowExpression(RowExpression node, Boolean complement)
-        {
-            // If we don't know how to process this node, the default response is to say that the TupleDomain is "all"
-            return new ExtractionResult(TupleDomain.all(), complementIfNecessary(node, complement));
-        }
-
-        private ExtractionResult visitBinaryLogic(SpecialFormExpression node, Boolean complement)
-        {
-            ExtractionResult leftResult = node.getArguments().get(0).accept(this, complement);
-            ExtractionResult rightResult = node.getArguments().get(1).accept(this, complement);
-
-            TupleDomain<VariableReferenceExpression> leftTupleDomain = leftResult.getTupleDomain();
-            TupleDomain<VariableReferenceExpression> rightTupleDomain = rightResult.getTupleDomain();
-
-            Form operator = node.getForm();
-            if (complement) {
-                if (operator == AND) {
-                    operator = OR;
-                }
-                else if (operator == OR) {
-                    operator = AND;
-                }
-                else {
-                    throw new IllegalStateException("Can not extract predicate from special form: " + node.getForm());
-                }
-            }
-
-            switch (operator) {
-                case AND: {
-                    return new ExtractionResult(
-                            leftTupleDomain.intersect(rightTupleDomain),
-                            logicalRowExpressions.combineConjuncts(leftResult.getRemainingExpression(), rightResult.getRemainingExpression()));
-                }
-                case OR: {
-                    TupleDomain<VariableReferenceExpression> columnUnionedTupleDomain = TupleDomain.columnWiseUnion(leftTupleDomain, rightTupleDomain);
-
-                    // In most cases, the columnUnionedTupleDomain is only a superset of the actual strict union
-                    // and so we can return the current node as the remainingExpression so that all bounds will be double checked again at execution time.
-                    RowExpression remainingExpression = complementIfNecessary(node, complement);
-
-                    // However, there are a few cases where the column-wise union is actually equivalent to the strict union, so we if can detect
-                    // some of these cases, we won't have to double check the bounds unnecessarily at execution time.
-
-                    // We can only make inferences if the remaining expressions on both side are equal and deterministic
-                    if (leftResult.getRemainingExpression().equals(rightResult.getRemainingExpression()) &&
-                            determinismEvaluator.isDeterministic(leftResult.getRemainingExpression())) {
-                        // The column-wise union is equivalent to the strict union if
-                        // 1) If both TupleDomains consist of the same exact single column (e.g. left TupleDomain => (a > 0), right TupleDomain => (a < 10))
-                        // 2) If one TupleDomain is a superset of the other (e.g. left TupleDomain => (a > 0, b > 0 && b < 10), right TupleDomain => (a > 5, b = 5))
-                        boolean matchingSingleSymbolDomains = !leftTupleDomain.isNone()
-                                && !rightTupleDomain.isNone()
-                                && leftTupleDomain.getDomains().get().size() == 1
-                                && rightTupleDomain.getDomains().get().size() == 1
-                                && leftTupleDomain.getDomains().get().keySet().equals(rightTupleDomain.getDomains().get().keySet());
-                        boolean oneSideIsSuperSet = leftTupleDomain.contains(rightTupleDomain) || rightTupleDomain.contains(leftTupleDomain);
-
-                        if (matchingSingleSymbolDomains || oneSideIsSuperSet) {
-                            remainingExpression = leftResult.getRemainingExpression();
-                        }
-                    }
-
-                    return new ExtractionResult(columnUnionedTupleDomain, remainingExpression);
-                }
-                default:
-                    throw new IllegalStateException("Can not extract predicate from special form: " + node.getForm());
-            }
-        }
+        return fromDomainExtraction(new DomainExtractor(metadata.getFunctionManager(), metadata.getTypeManager(), new InterpretedPredicateOptimizer(metadata, session))
+                .extract(predicate));
     }
 
     private static RowExpression isNull(RowExpression expression)
@@ -854,33 +315,26 @@ public final class RowExpressionDomainTranslator
         return binaryOperator(NOT_EQUAL, left, right);
     }
 
-    private static class NormalizedSimpleComparison
+    public ExtractionResult fromDomainExtraction(DomainExtractor.ExtractionResult result)
     {
-        private final RowExpression expression;
-        private final OperatorType comparisonOperator;
-        private final NullableValue value;
-
-        public NormalizedSimpleComparison(RowExpression expression, OperatorType comparisonOperator, NullableValue value)
-        {
-            this.expression = requireNonNull(expression, "expression is null");
-            this.comparisonOperator = requireNonNull(comparisonOperator, "comparisonOperator is null");
-            this.value = requireNonNull(value, "value is null");
+        Optional<List<ColumnDomain<RowExpression>>> domains = result.getTupleDomain().getColumnDomains();
+        if (domains.isPresent()) {
+            ImmutableMap.Builder<VariableReferenceExpression, Domain> variableDomains = ImmutableMap.builder();
+            ImmutableList.Builder<RowExpression> unResolvable = builder();
+            if (result.getRemainingExpression() != TRUE) {
+                unResolvable.add(result.getRemainingExpression());
+            }
+            for (ColumnDomain<RowExpression> domain : domains.get()) {
+                if (domain.getColumn() instanceof VariableReferenceExpression) {
+                    variableDomains.put((VariableReferenceExpression) domain.getColumn(), domain.getDomain());
+                }
+                else if (!domain.getDomain().isAll()) {
+                    unResolvable.add(toPredicate(domain.getDomain(), domain.getColumn()));
+                }
+            }
+            return new ExtractionResult(TupleDomain.withColumnDomains(variableDomains.build()), and(unResolvable.build()));
         }
-
-        public RowExpression getExpression()
-        {
-            return expression;
-        }
-
-        public OperatorType getComparisonOperator()
-        {
-            return comparisonOperator;
-        }
-
-        public NullableValue getValue()
-        {
-            return value;
-        }
+        return new ExtractionResult(TupleDomain.none(), result.getRemainingExpression());
     }
 
     public static class ExtractionResult
@@ -888,7 +342,7 @@ public final class RowExpressionDomainTranslator
         private final TupleDomain<VariableReferenceExpression> tupleDomain;
         private final RowExpression remainingExpression;
 
-        public ExtractionResult(TupleDomain<VariableReferenceExpression> tupleDomain, RowExpression remainingExpression)
+        private ExtractionResult(TupleDomain<VariableReferenceExpression> tupleDomain, RowExpression remainingExpression)
         {
             this.tupleDomain = requireNonNull(tupleDomain, "tupleDomain is null");
             this.remainingExpression = requireNonNull(remainingExpression, "remainingExpression is null");

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionUtils.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+public class RowExpressionUtils
+{
+    private RowExpressionUtils()
+    {
+    }
+
+    public static RowExpression inlineExpressions(RowExpression rowExpression, Map<RowExpression, RowExpression> assignments)
+    {
+        return rowExpression.accept(new InlineVisitor(), assignments).orElse(rowExpression);
+    }
+
+    private static class InlineVisitor
+            implements RowExpressionVisitor<Optional<RowExpression>, Map<RowExpression, RowExpression>>
+    {
+        @Override
+        public Optional<RowExpression> visitCall(CallExpression call, Map<RowExpression, RowExpression> context)
+        {
+            if (context.containsKey(call)) {
+                return Optional.of(context.get(call));
+            }
+            List<RowExpression> rewritten = returnChanged(call.getArguments(), argument -> argument.accept(this, context));
+            if (rewritten.size() == call.getArguments().size()) {
+                return Optional.of(new CallExpression(call.getDisplayName(), call.getFunctionHandle(), call.getType(), rewritten));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<RowExpression> visitInputReference(InputReferenceExpression reference, Map<RowExpression, RowExpression> context)
+        {
+            if (context.containsKey(reference)) {
+                return Optional.of(context.get(reference));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<RowExpression> visitConstant(ConstantExpression literal, Map<RowExpression, RowExpression> context)
+        {
+            if (context.containsKey(literal)) {
+                return Optional.of(context.get(literal));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<RowExpression> visitLambda(LambdaDefinitionExpression lambda, Map<RowExpression, RowExpression> context)
+        {
+            if (context.containsKey(lambda)) {
+                return Optional.of(context.get(lambda));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<RowExpression> visitVariableReference(VariableReferenceExpression reference, Map<RowExpression, RowExpression> context)
+        {
+            if (context.containsKey(reference)) {
+                return Optional.of(context.get(reference));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<RowExpression> visitSpecialForm(SpecialFormExpression specialForm, Map<RowExpression, RowExpression> context)
+        {
+            if (context.containsKey(specialForm)) {
+                return Optional.of(context.get(specialForm));
+            }
+            List<RowExpression> rewritten = returnChanged(specialForm.getArguments(), argument -> argument.accept(this, context));
+            if (rewritten.size() == specialForm.getArguments().size()) {
+                return Optional.of(new SpecialFormExpression(specialForm.getForm(), specialForm.getType(), rewritten));
+            }
+            return Optional.empty();
+        }
+
+        private static <T> List<T> returnChanged(List<T> input, Function<T, Optional<T>> transformer)
+        {
+            Iterator<T> iterator = input.iterator();
+            ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(input.size());
+            boolean changed = false;
+            while (iterator.hasNext()) {
+                T item = iterator.next();
+                Optional<T> result = transformer.apply(item);
+                builder.add(result.orElse(item));
+                if (result.isPresent()) {
+                    changed = true;
+                }
+            }
+            if (changed) {
+                return builder.build();
+            }
+            return ImmutableList.of();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/StandardFunctionResolution.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/StandardFunctionResolution.java
@@ -86,6 +86,11 @@ public final class StandardFunctionResolution
         return functionManager.getFunctionMetadata(functionHandle).getName().equals(mangleOperatorName(OperatorType.CAST.name()));
     }
 
+    public boolean isBetweenFunction(FunctionHandle functionHandle)
+    {
+        return functionHandle.getSignature().getName().equals(mangleOperatorName(OperatorType.BETWEEN.name()));
+    }
+
     public FunctionHandle arithmeticFunction(ArithmeticBinaryExpression.Operator operator, Type leftType, Type rightType)
     {
         OperatorType operatorType;

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/StandardFunctionResolution.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/StandardFunctionResolution.java
@@ -35,6 +35,7 @@ import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.MODULUS;
 import static com.facebook.presto.spi.function.OperatorType.MULTIPLY;
+import static com.facebook.presto.spi.function.OperatorType.NEGATION;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.SUBTRACT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -108,6 +109,11 @@ public final class StandardFunctionResolution
                 throw new IllegalStateException("Unknown arithmetic operator: " + operator);
         }
         return functionManager.resolveOperator(operatorType, fromTypes(leftType, rightType));
+    }
+
+    public boolean isNegateFunction(FunctionHandle functionHandle)
+    {
+        return functionHandle.getSignature().getName().equals(mangleOperatorName(NEGATION.name()));
     }
 
     public FunctionHandle arrayConstructor(List<? extends Type> argumentTypes)

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/StandardFunctionResolution.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/StandardFunctionResolution.java
@@ -60,6 +60,11 @@ public final class StandardFunctionResolution
         return functionManager.lookupFunction(QualifiedName.of("not"), fromTypes(BOOLEAN));
     }
 
+    public boolean isNotFunction(FunctionHandle functionHandle)
+    {
+        return notFunction().equals(functionHandle);
+    }
+
     public FunctionHandle likeVarcharFunction()
     {
         return functionManager.lookupFunction(QualifiedName.of("LIKE"), fromTypes(VARCHAR, LIKE_PATTERN));

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SymbolToChannelTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SymbolToChannelTranslator.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.Symbol;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Map;
+
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.field;
+
+public final class SymbolToChannelTranslator
+{
+    private SymbolToChannelTranslator() {}
+
+    /**
+     *
+     * Given an {@param expression} and a {@param layout}, translate the symbols in the expression to the corresponding channel.
+     */
+    public static RowExpression translate(RowExpression expression, Map<Symbol, Integer> layout)
+    {
+        return expression.accept(new Visitor(), layout);
+    }
+
+    private static class Visitor
+            implements RowExpressionVisitor<RowExpression, Map<Symbol, Integer>>
+    {
+        @Override
+        public RowExpression visitInputReference(InputReferenceExpression input, Map<Symbol, Integer> layout)
+        {
+            throw new UnsupportedOperationException("encountered already-translated symbols");
+        }
+
+        @Override
+        public RowExpression visitCall(CallExpression call, Map<Symbol, Integer> layout)
+        {
+            ImmutableList.Builder<RowExpression> arguments = ImmutableList.builder();
+            call.getArguments().forEach(argument -> arguments.add(argument.accept(this, layout)));
+            return call(call.getDisplayName(), call.getFunctionHandle(), call.getType(), arguments.build());
+        }
+
+        @Override
+        public RowExpression visitConstant(ConstantExpression literal, Map<Symbol, Integer> layout)
+        {
+            return literal;
+        }
+
+        @Override
+        public RowExpression visitLambda(LambdaDefinitionExpression lambda, Map<Symbol, Integer> layout)
+        {
+            return new LambdaDefinitionExpression(lambda.getArgumentTypes(), lambda.getArguments(), lambda.getBody().accept(this, layout));
+        }
+
+        @Override
+        public RowExpression visitVariableReference(VariableReferenceExpression reference, Map<Symbol, Integer> layout)
+        {
+            Symbol symbol = new Symbol(reference.getName());
+            if (layout.containsKey(symbol)) {
+                return field(layout.get(symbol), reference.getType());
+            }
+            // this is possible only for lambda
+            return reference;
+        }
+
+        @Override
+        public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Map<Symbol, Integer> layout)
+        {
+            ImmutableList.Builder<RowExpression> arguments = ImmutableList.builder();
+            specialForm.getArguments().forEach(argument -> arguments.add(argument.accept(this, layout)));
+            return new SpecialFormExpression(specialForm.getForm(), specialForm.getType(), arguments.build());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
@@ -19,7 +19,9 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.FixedWidthType;
+import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
@@ -103,6 +105,22 @@ public final class TypeUtils
     public static Type resolveType(TypeSignature typeName, TypeManager typeManager)
     {
         return typeManager.getType(typeName);
+    }
+
+    public static boolean isIntegralType(TypeSignature typeName, TypeManager typeManager)
+    {
+        switch (typeName.getBase()) {
+            case StandardTypes.BIGINT:
+            case StandardTypes.INTEGER:
+            case StandardTypes.SMALLINT:
+            case StandardTypes.TINYINT:
+                return true;
+            case StandardTypes.DECIMAL:
+                DecimalType decimalType = (DecimalType) resolveType(typeName, typeManager);
+                return decimalType.getScale() == 0;
+            default:
+                return false;
+        }
     }
 
     public static List<Type> resolveTypes(List<TypeSignature> typeNames, TypeManager typeManager)

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.util;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.sql.planner.Partitioning.ArgumentBinding;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.SubPlan;
@@ -53,6 +54,7 @@ import com.facebook.presto.sql.planner.plan.UnionNode;
 import com.facebook.presto.sql.planner.plan.UnnestNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.planner.planPrinter.RowExpressionFormatter;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.SymbolReference;
@@ -131,7 +133,7 @@ public final class GraphvizPrinter
 
     private GraphvizPrinter() {}
 
-    public static String printLogical(List<PlanFragment> fragments)
+    public static String printLogical(List<PlanFragment> fragments, Session session)
     {
         Map<PlanFragmentId, PlanFragment> fragmentsById = Maps.uniqueIndex(fragments, PlanFragment::getId);
         PlanNodeIdGenerator idGenerator = new PlanNodeIdGenerator();
@@ -140,7 +142,7 @@ public final class GraphvizPrinter
         output.append("digraph logical_plan {\n");
 
         for (PlanFragment fragment : fragments) {
-            printFragmentNodes(output, fragment, idGenerator);
+            printFragmentNodes(output, fragment, idGenerator, session);
         }
 
         for (PlanFragment fragment : fragments) {
@@ -152,7 +154,7 @@ public final class GraphvizPrinter
         return output.toString();
     }
 
-    public static String printDistributed(SubPlan plan)
+    public static String printDistributed(SubPlan plan, Session session)
     {
         List<PlanFragment> fragments = plan.getAllFragments();
         Map<PlanFragmentId, PlanFragment> fragmentsById = Maps.uniqueIndex(fragments, PlanFragment::getId);
@@ -161,25 +163,25 @@ public final class GraphvizPrinter
         StringBuilder output = new StringBuilder();
         output.append("digraph distributed_plan {\n");
 
-        printSubPlan(plan, fragmentsById, idGenerator, output);
+        printSubPlan(plan, fragmentsById, idGenerator, output, session);
 
         output.append("}\n");
 
         return output.toString();
     }
 
-    private static void printSubPlan(SubPlan plan, Map<PlanFragmentId, PlanFragment> fragmentsById, PlanNodeIdGenerator idGenerator, StringBuilder output)
+    private static void printSubPlan(SubPlan plan, Map<PlanFragmentId, PlanFragment> fragmentsById, PlanNodeIdGenerator idGenerator, StringBuilder output, Session session)
     {
         PlanFragment fragment = plan.getFragment();
-        printFragmentNodes(output, fragment, idGenerator);
+        printFragmentNodes(output, fragment, idGenerator, session);
         fragment.getRoot().accept(new EdgePrinter(output, fragmentsById, idGenerator), null);
 
         for (SubPlan child : plan.getChildren()) {
-            printSubPlan(child, fragmentsById, idGenerator, output);
+            printSubPlan(child, fragmentsById, idGenerator, output, session);
         }
     }
 
-    private static void printFragmentNodes(StringBuilder output, PlanFragment fragment, PlanNodeIdGenerator idGenerator)
+    private static void printFragmentNodes(StringBuilder output, PlanFragment fragment, PlanNodeIdGenerator idGenerator, Session session)
     {
         String clusterId = "cluster_" + fragment.getId();
         output.append("subgraph ")
@@ -191,7 +193,7 @@ public final class GraphvizPrinter
                 .append('\n');
 
         PlanNode plan = fragment.getRoot();
-        plan.accept(new NodePrinter(output, idGenerator), null);
+        plan.accept(new NodePrinter(output, idGenerator, session), null);
 
         output.append("}")
                 .append('\n');
@@ -203,11 +205,13 @@ public final class GraphvizPrinter
         private static final int MAX_NAME_WIDTH = 100;
         private final StringBuilder output;
         private final PlanNodeIdGenerator idGenerator;
+        private final RowExpressionFormatter formatter;
 
-        public NodePrinter(StringBuilder output, PlanNodeIdGenerator idGenerator)
+        public NodePrinter(StringBuilder output, PlanNodeIdGenerator idGenerator, Session session)
         {
             this.output = output;
             this.idGenerator = idGenerator;
+            this.formatter = new RowExpressionFormatter(session.toConnectorSession());
         }
 
         @Override
@@ -365,7 +369,7 @@ public final class GraphvizPrinter
         @Override
         public Void visitFilter(FilterNode node, Void context)
         {
-            String expression = node.getPredicate().toString();
+            String expression = formatter.formatRowExpression(node.getPredicate());
             printNode(node, "Filter", expression, NODE_COLORS.get(NodeType.FILTER));
             return node.getSource().accept(this, context);
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestingRowExpressionTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestingRowExpressionTranslator.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static java.util.Collections.emptyList;
 
-class TestingRowExpressionTranslator
+public class TestingRowExpressionTranslator
 {
     private final Metadata metadata;
     private final LiteralEncoder literalEncoder;
@@ -50,17 +50,17 @@ class TestingRowExpressionTranslator
         this(MetadataManager.createTestMetadataManager());
     }
 
-    RowExpression translateAndOptimize(Expression expression)
+    public RowExpression translateAndOptimize(Expression expression)
     {
         return translateAndOptimize(expression, getExpressionTypes(expression, TypeProvider.empty()));
     }
 
-    RowExpression translateAndOptimize(Expression expression, TypeProvider typeProvider)
+    public RowExpression translateAndOptimize(Expression expression, TypeProvider typeProvider)
     {
         return translateAndOptimize(expression, getExpressionTypes(expression, typeProvider));
     }
 
-    RowExpression translate(Expression expression, TypeProvider typeProvider)
+    public RowExpression translate(Expression expression, TypeProvider typeProvider)
     {
         return SqlToRowExpressionTranslator.translate(
                 expression,
@@ -72,7 +72,7 @@ class TestingRowExpressionTranslator
                 false);
     }
 
-    RowExpression translateAndOptimize(Expression expression, Map<NodeRef<Expression>, Type> types)
+    public RowExpression translateAndOptimize(Expression expression, Map<NodeRef<Expression>, Type> types)
     {
         return SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionManager(), metadata.getTypeManager(), TEST_SESSION, true);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -107,7 +107,7 @@ public class TestEffectivePredicateExtractor
     private static final Expression GE = G.toSymbolReference();
 
     private final Metadata metadata = MetadataManager.createTestMetadataManager();
-    private final EffectivePredicateExtractor effectivePredicateExtractor = new EffectivePredicateExtractor(new DomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde())));
+    private final EffectivePredicateExtractor effectivePredicateExtractor = new EffectivePredicateExtractor(new ExpressionDomainTranslator(new LiteralEncoder(metadata.getBlockEncodingSerde())));
 
     private Map<Symbol, ColumnHandle> scanAssignments;
     private TableScanNode baseTableScan;

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -78,6 +78,7 @@ import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.or;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.globalAggregation;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.singleGroupingSet;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static org.testng.Assert.assertEquals;
@@ -720,7 +721,7 @@ public class TestEffectivePredicateExtractor
 
     private static FilterNode filter(PlanNode source, Expression predicate)
     {
-        return new FilterNode(newId(), source, predicate);
+        return new FilterNode(newId(), source, castToRowExpression(predicate));
     }
 
     private static Expression bigintLiteral(long number)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestExpressionDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestExpressionDomainTranslator.java
@@ -21,7 +21,7 @@ import com.facebook.presto.spi.predicate.ValueSet;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
-import com.facebook.presto.sql.planner.DomainTranslator.ExtractionResult;
+import com.facebook.presto.sql.planner.ExpressionDomainTranslator.ExtractionResult;
 import com.facebook.presto.sql.tree.BetweenPredicate;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ComparisonExpression;
@@ -94,7 +94,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-public class TestDomainTranslator
+public class TestExpressionDomainTranslator
 {
     private static final Symbol C_BIGINT = new Symbol("c_bigint");
     private static final Symbol C_DOUBLE = new Symbol("c_double");
@@ -155,14 +155,14 @@ public class TestDomainTranslator
 
     private Metadata metadata;
     private LiteralEncoder literalEncoder;
-    private DomainTranslator domainTranslator;
+    private ExpressionDomainTranslator domainTranslator;
 
     @BeforeClass
     public void setup()
     {
         metadata = createTestMetadataManager();
         literalEncoder = new LiteralEncoder(metadata.getBlockEncodingSerde());
-        domainTranslator = new DomainTranslator(literalEncoder);
+        domainTranslator = new ExpressionDomainTranslator(literalEncoder);
     }
 
     @AfterClass(alwaysRun = true)
@@ -647,7 +647,7 @@ public class TestDomainTranslator
     void testNonImplictCastOnSymbolSide()
     {
         // we expect TupleDomain.all here().
-        // see comment in DomainTranslator.Visitor.visitComparisonExpression()
+        // see comment in ExpressionDomainTranslator.Visitor.visitComparisonExpression()
         assertUnsupportedPredicate(equal(
                 new Cast(C_TIMESTAMP.toSymbolReference(), DATE.toString()),
                 toExpression(DATE_VALUE, DATE)));
@@ -1169,7 +1169,7 @@ public class TestDomainTranslator
     {
         metadata = createTestMetadataManager(new FeaturesConfig().setLegacyCharToVarcharCoercion(true));
         literalEncoder = new LiteralEncoder(metadata.getBlockEncodingSerde());
-        domainTranslator = new DomainTranslator(literalEncoder);
+        domainTranslator = new ExpressionDomainTranslator(literalEncoder);
 
         String maxCodePoint = new String(Character.toChars(Character.MAX_CODE_POINT));
 
@@ -1251,7 +1251,7 @@ public class TestDomainTranslator
 
     private ExtractionResult fromPredicate(Expression originalPredicate)
     {
-        return DomainTranslator.fromPredicate(metadata, TEST_SESSION, originalPredicate, TYPES);
+        return ExpressionDomainTranslator.fromPredicate(metadata, TEST_SESSION, originalPredicate, TYPES);
     }
 
     private Expression toPredicate(TupleDomain<Symbol> tupleDomain)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
@@ -1,0 +1,1401 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.metadata.CastType;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.Range;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
+import com.facebook.presto.sql.relational.RowExpressionDomainTranslator.ExtractionResult;
+import com.facebook.presto.sql.relational.StandardFunctionResolution;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.CharType.createCharType;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
+import static com.facebook.presto.spi.type.Decimals.encodeScaledValue;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.HyperLogLogType.HYPER_LOG_LOG;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.LiteralEncoder.toRowExpression;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.constantNull;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.FALSE;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.and;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.or;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static com.facebook.presto.type.ColorType.COLOR;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.floatToIntBits;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestRowExpressionDomainTranslator
+{
+    private static final VariableReferenceExpression C_BIGINT = new VariableReferenceExpression("x1", BIGINT);
+    private static final VariableReferenceExpression C_DOUBLE = new VariableReferenceExpression("x2", DOUBLE);
+    private static final VariableReferenceExpression C_VARCHAR = new VariableReferenceExpression("x3", VARCHAR);
+    private static final VariableReferenceExpression C_BOOLEAN = new VariableReferenceExpression("x4", BOOLEAN);
+    private static final VariableReferenceExpression C_BIGINT_1 = new VariableReferenceExpression("x5", BIGINT);
+    private static final VariableReferenceExpression C_DOUBLE_1 = new VariableReferenceExpression("x6", DOUBLE);
+    private static final VariableReferenceExpression C_VARCHAR_1 = new VariableReferenceExpression("x7", VARCHAR);
+    private static final VariableReferenceExpression C_TIMESTAMP = new VariableReferenceExpression("x8", TIMESTAMP);
+    private static final VariableReferenceExpression C_DATE = new VariableReferenceExpression("x9", DATE);
+    private static final VariableReferenceExpression C_COLOR = new VariableReferenceExpression("x10", COLOR);
+    private static final VariableReferenceExpression C_HYPER_LOG_LOG = new VariableReferenceExpression("x11", HYPER_LOG_LOG);
+    private static final VariableReferenceExpression C_VARBINARY = new VariableReferenceExpression("x12", VARBINARY);
+    private static final VariableReferenceExpression C_DECIMAL_26_5 = new VariableReferenceExpression("x13", createDecimalType(26, 5));
+    private static final VariableReferenceExpression C_DECIMAL_23_4 = new VariableReferenceExpression("x14", createDecimalType(23, 4));
+    private static final VariableReferenceExpression C_INTEGER = new VariableReferenceExpression("x15", INTEGER);
+    private static final VariableReferenceExpression C_CHAR = new VariableReferenceExpression("x16", createCharType(10));
+    private static final VariableReferenceExpression C_DECIMAL_21_3 = new VariableReferenceExpression("x17", createDecimalType(21, 3));
+    private static final VariableReferenceExpression C_DECIMAL_12_2 = new VariableReferenceExpression("x18", createDecimalType(12, 2));
+    private static final VariableReferenceExpression C_DECIMAL_6_1 = new VariableReferenceExpression("x19", createDecimalType(6, 1));
+    private static final VariableReferenceExpression C_DECIMAL_3_0 = new VariableReferenceExpression("x20", createDecimalType(3, 0));
+    private static final VariableReferenceExpression C_DECIMAL_2_0 = new VariableReferenceExpression("x21", createDecimalType(2, 0));
+    private static final VariableReferenceExpression C_SMALLINT = new VariableReferenceExpression("x22", SMALLINT);
+    private static final VariableReferenceExpression C_TINYINT = new VariableReferenceExpression("x23", TINYINT);
+    private static final VariableReferenceExpression C_REAL = new VariableReferenceExpression("x24", REAL);
+
+    private static final long TIMESTAMP_VALUE = new DateTime(2013, 3, 30, 1, 5, 0, 0, DateTimeZone.UTC).getMillis();
+    private static final long DATE_VALUE = TimeUnit.MILLISECONDS.toDays(new DateTime(2001, 1, 22, 0, 0, 0, 0, DateTimeZone.UTC).getMillis());
+    private static final long COLOR_VALUE_1 = 1;
+    private static final long COLOR_VALUE_2 = 2;
+
+    private Metadata metadata;
+    private RowExpressionDomainTranslator domainTranslator;
+
+    @BeforeClass
+    public void setup()
+    {
+        metadata = createTestMetadataManager();
+        domainTranslator = new RowExpressionDomainTranslator(metadata.getFunctionManager());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        metadata = null;
+        domainTranslator = null;
+    }
+
+    @Test
+    public void testNoneRoundTrip()
+    {
+        TupleDomain<VariableReferenceExpression> tupleDomain = TupleDomain.none();
+        ExtractionResult result = fromPredicate(toPredicate(tupleDomain));
+        assertEquals(result.getRemainingExpression(), TRUE);
+        assertEquals(result.getTupleDomain(), tupleDomain);
+    }
+
+    @Test
+    public void testAllRoundTrip()
+    {
+        TupleDomain<VariableReferenceExpression> tupleDomain = TupleDomain.all();
+        ExtractionResult result = fromPredicate(toPredicate(tupleDomain));
+        assertEquals(result.getRemainingExpression(), TRUE);
+        assertEquals(result.getTupleDomain(), tupleDomain);
+    }
+
+    @Test
+    public void testRoundTrip()
+    {
+        TupleDomain<VariableReferenceExpression> tupleDomain = withColumnDomains(ImmutableMap.<VariableReferenceExpression, Domain>builder()
+                .put(C_BIGINT, Domain.singleValue(BIGINT, 1L))
+                .put(C_DOUBLE, Domain.onlyNull(DOUBLE))
+                .put(C_VARCHAR, Domain.notNull(VARCHAR))
+                .put(C_BOOLEAN, Domain.singleValue(BOOLEAN, true))
+                .put(C_BIGINT_1, Domain.singleValue(BIGINT, 2L))
+                .put(C_DOUBLE_1, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(DOUBLE, 1.1), Range.equal(DOUBLE, 2.0), Range.range(DOUBLE, 3.0, false, 3.5, true)), true))
+                .put(C_VARCHAR_1, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(VARCHAR, utf8Slice("2013-01-01")), Range.greaterThan(VARCHAR, utf8Slice("2013-10-01"))), false))
+                .put(C_TIMESTAMP, Domain.singleValue(TIMESTAMP, TIMESTAMP_VALUE))
+                .put(C_DATE, Domain.singleValue(DATE, DATE_VALUE))
+                .put(C_COLOR, Domain.singleValue(COLOR, COLOR_VALUE_1))
+                .put(C_HYPER_LOG_LOG, Domain.notNull(HYPER_LOG_LOG))
+                .build());
+
+        assertPredicateTranslates(toPredicate(tupleDomain), tupleDomain);
+    }
+
+    @Test
+    public void testInOptimization()
+    {
+        Domain testDomain = Domain.create(
+                ValueSet.all(BIGINT)
+                        .subtract(ValueSet.ofRanges(
+                                Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L))), false);
+
+        TupleDomain<VariableReferenceExpression> tupleDomain = withColumnDomains(ImmutableMap.<VariableReferenceExpression, Domain>builder().put(C_BIGINT, testDomain).build());
+        assertEquals(toPredicate(tupleDomain), not(bigintIn(C_BIGINT, ImmutableList.of(1L, 2L, 3L))));
+
+        testDomain = Domain.create(
+                ValueSet.ofRanges(
+                        Range.lessThan(BIGINT, 4L)).intersect(
+                        ValueSet.all(BIGINT)
+                                .subtract(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L)))), false);
+
+        tupleDomain = withColumnDomains(ImmutableMap.<VariableReferenceExpression, Domain>builder().put(C_BIGINT, testDomain).build());
+        assertEquals(toPredicate(tupleDomain), and(lessThan(C_BIGINT, bigintLiteral(4L)), not(bigintIn(C_BIGINT, ImmutableList.of(1L, 2L, 3L)))));
+
+        testDomain = Domain.create(ValueSet.ofRanges(
+                Range.range(BIGINT, 1L, true, 3L, true),
+                Range.range(BIGINT, 5L, true, 7L, true),
+                Range.range(BIGINT, 9L, true, 11L, true)),
+                false);
+
+        tupleDomain = withColumnDomains(ImmutableMap.<VariableReferenceExpression, Domain>builder().put(C_BIGINT, testDomain).build());
+        assertEquals(toPredicate(tupleDomain),
+                or(between(C_BIGINT, bigintLiteral(1L), bigintLiteral(3L)), (between(C_BIGINT, bigintLiteral(5L), bigintLiteral(7L))), (between(C_BIGINT, bigintLiteral(9L), bigintLiteral(11L)))));
+
+        testDomain = Domain.create(
+                ValueSet.ofRanges(
+                        Range.lessThan(BIGINT, 4L))
+                        .intersect(ValueSet.all(BIGINT)
+                                .subtract(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L))))
+                        .union(ValueSet.ofRanges(Range.range(BIGINT, 7L, true, 9L, true))), false);
+
+        tupleDomain = withColumnDomains(ImmutableMap.<VariableReferenceExpression, Domain>builder().put(C_BIGINT, testDomain).build());
+        assertEquals(toPredicate(tupleDomain), or(and(lessThan(C_BIGINT, bigintLiteral(4L)), not(bigintIn(C_BIGINT, ImmutableList.of(1L, 2L, 3L)))), between(C_BIGINT, bigintLiteral(7L), bigintLiteral(9L))));
+
+        testDomain = Domain.create(
+                ValueSet.ofRanges(Range.lessThan(BIGINT, 4L))
+                        .intersect(ValueSet.all(BIGINT)
+                                .subtract(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L))))
+                        .union(ValueSet.ofRanges(Range.range(BIGINT, 7L, false, 9L, false), Range.range(BIGINT, 11L, false, 13L, false))), false);
+
+        tupleDomain = withColumnDomains(ImmutableMap.<VariableReferenceExpression, Domain>builder().put(C_BIGINT, testDomain).build());
+        assertEquals(toPredicate(tupleDomain), or(
+                and(lessThan(C_BIGINT, bigintLiteral(4L)), not(bigintIn(C_BIGINT, ImmutableList.of(1L, 2L, 3L)))),
+                and(greaterThan(C_BIGINT, bigintLiteral(7L)), lessThan(C_BIGINT, bigintLiteral(9L))),
+                and(greaterThan(C_BIGINT, bigintLiteral(11L)), lessThan(C_BIGINT, bigintLiteral(13L)))));
+    }
+
+    @Test
+    public void testToPredicateNone()
+    {
+        TupleDomain<VariableReferenceExpression> tupleDomain = withColumnDomains(ImmutableMap.<VariableReferenceExpression, Domain>builder()
+                .put(C_BIGINT, Domain.singleValue(BIGINT, 1L))
+                .put(C_DOUBLE, Domain.onlyNull(DOUBLE))
+                .put(C_VARCHAR, Domain.notNull(VARCHAR))
+                .put(C_BOOLEAN, Domain.none(BOOLEAN))
+                .build());
+
+        assertEquals(toPredicate(tupleDomain), FALSE);
+    }
+
+    @Test
+    public void testToPredicateAllIgnored()
+    {
+        TupleDomain<VariableReferenceExpression> tupleDomain = withColumnDomains(ImmutableMap.<VariableReferenceExpression, Domain>builder()
+                .put(C_BIGINT, Domain.singleValue(BIGINT, 1L))
+                .put(C_DOUBLE, Domain.onlyNull(DOUBLE))
+                .put(C_VARCHAR, Domain.notNull(VARCHAR))
+                .put(C_BOOLEAN, Domain.all(BOOLEAN))
+                .build());
+
+        ExtractionResult result = fromPredicate(toPredicate(tupleDomain));
+        assertEquals(result.getRemainingExpression(), TRUE);
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.<VariableReferenceExpression, Domain>builder()
+                .put(C_BIGINT, Domain.singleValue(BIGINT, 1L))
+                .put(C_DOUBLE, Domain.onlyNull(DOUBLE))
+                .put(C_VARCHAR, Domain.notNull(VARCHAR))
+                .build()));
+    }
+
+    @Test
+    public void testToPredicate()
+    {
+        TupleDomain<VariableReferenceExpression> tupleDomain;
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT)));
+        assertEquals(toPredicate(tupleDomain), isNotNull(C_BIGINT));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.onlyNull(BIGINT)));
+        assertEquals(toPredicate(tupleDomain), isNull(C_BIGINT));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.none(BIGINT)));
+        assertEquals(toPredicate(tupleDomain), FALSE);
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.all(BIGINT)));
+        assertEquals(toPredicate(tupleDomain), TRUE);
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 1L)), false)));
+        assertEquals(toPredicate(tupleDomain), greaterThan(C_BIGINT, bigintLiteral(1L)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(BIGINT, 1L)), false)));
+        assertEquals(toPredicate(tupleDomain), greaterThanOrEqual(C_BIGINT, bigintLiteral(1L)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L)), false)));
+        assertEquals(toPredicate(tupleDomain), lessThan(C_BIGINT, bigintLiteral(1L)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 0L, false, 1L, true)), false)));
+        assertEquals(toPredicate(tupleDomain), and(greaterThan(C_BIGINT, bigintLiteral(0L)), lessThanOrEqual(C_BIGINT, bigintLiteral(1L))));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(BIGINT, 1L)), false)));
+        assertEquals(toPredicate(tupleDomain), lessThanOrEqual(C_BIGINT, bigintLiteral(1L)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.singleValue(BIGINT, 1L)));
+        assertEquals(toPredicate(tupleDomain), equal(C_BIGINT, bigintLiteral(1L)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L)), false)));
+        assertEquals(toPredicate(tupleDomain), bigintIn(C_BIGINT, ImmutableList.of(1L, 2L)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L)), true)));
+        assertEquals(toPredicate(tupleDomain), or(lessThan(C_BIGINT, bigintLiteral(1L)), isNull(C_BIGINT)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1), true)));
+        assertEquals(toPredicate(tupleDomain), or(equal(C_COLOR, colorLiteral(COLOR_VALUE_1)), isNull(C_COLOR)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1).complement(), true)));
+        assertEquals(toPredicate(tupleDomain), or(not(equal(C_COLOR, colorLiteral(COLOR_VALUE_1))), isNull(C_COLOR)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_HYPER_LOG_LOG, Domain.onlyNull(HYPER_LOG_LOG)));
+        assertEquals(toPredicate(tupleDomain), isNull(C_HYPER_LOG_LOG));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_HYPER_LOG_LOG, Domain.notNull(HYPER_LOG_LOG)));
+        assertEquals(toPredicate(tupleDomain), isNotNull(C_HYPER_LOG_LOG));
+    }
+
+    @Test
+    public void testFromUnknownPredicate()
+    {
+        assertUnsupportedPredicate(unprocessableExpression1(C_BIGINT));
+        assertUnsupportedPredicate(not(unprocessableExpression1(C_BIGINT)));
+    }
+
+    @Test
+    public void testFromAndPredicate()
+    {
+        RowExpression originalPredicate = and(
+                and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT)));
+        ExtractionResult result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), and(unprocessableExpression1(C_BIGINT), unprocessableExpression2(C_BIGINT)));
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 1L, false, 5L, false)), false))));
+
+        // Test complements
+        assertUnsupportedPredicate(not(and(
+                and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT)))));
+
+        originalPredicate = not(and(
+                not(and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT))),
+                not(and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT)))));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), originalPredicate);
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT))));
+    }
+
+    @Test
+    public void testFromOrPredicate()
+    {
+        RowExpression originalPredicate = or(
+                and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT)));
+        ExtractionResult result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), originalPredicate);
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT))));
+
+        originalPredicate = or(
+                and(equal(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(equal(C_BIGINT, bigintLiteral(2L)), unprocessableExpression2(C_BIGINT)));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), originalPredicate);
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L)), false))));
+
+        // Same unprocessableExpression means that we can do more extraction
+        // If both sides are operating on the same single symbol
+        originalPredicate = or(
+                and(equal(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(equal(C_BIGINT, bigintLiteral(2L)), unprocessableExpression1(C_BIGINT)));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), unprocessableExpression1(C_BIGINT));
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L)), false))));
+
+        // And not if they have different symbols
+        assertUnsupportedPredicate(or(
+                and(equal(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(equal(C_DOUBLE, doubleLiteral(2.0)), unprocessableExpression1(C_BIGINT))));
+
+        // We can make another optimization if one side is the super set of the other side
+        originalPredicate = or(
+                and(greaterThan(C_BIGINT, bigintLiteral(1L)), greaterThan(C_DOUBLE, doubleLiteral(1.0)), unprocessableExpression1(C_BIGINT)),
+                and(greaterThan(C_BIGINT, bigintLiteral(2L)), greaterThan(C_DOUBLE, doubleLiteral(2.0)), unprocessableExpression1(C_BIGINT)));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), unprocessableExpression1(C_BIGINT));
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(
+                C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 1L)), false),
+                C_DOUBLE, Domain.create(ValueSet.ofRanges(Range.greaterThan(DOUBLE, 1.0)), false))));
+
+        // We can't make those inferences if the unprocessableExpressions are non-deterministic
+        originalPredicate = or(
+                and(equal(C_BIGINT, bigintLiteral(1L)), randPredicate(C_BIGINT)),
+                and(equal(C_BIGINT, bigintLiteral(2L)), randPredicate(C_BIGINT)));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), originalPredicate);
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L)), false))));
+
+        // Test complements
+        originalPredicate = not(or(
+                and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT))));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), and(
+                not(and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT))),
+                not(and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT)))));
+        assertTrue(result.getTupleDomain().isAll());
+
+        originalPredicate = not(or(
+                not(and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT))),
+                not(and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT)))));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), and(unprocessableExpression1(C_BIGINT), unprocessableExpression2(C_BIGINT)));
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 1L, false, 5L, false)), false))));
+    }
+
+    @Test
+    public void testFromNotPredicate()
+    {
+        assertUnsupportedPredicate(not(and(equal(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT))));
+        assertUnsupportedPredicate(not(unprocessableExpression1(C_BIGINT)));
+
+        assertPredicateIsAlwaysFalse(not(TRUE));
+
+        assertPredicateTranslates(
+                not(equal(C_BIGINT, bigintLiteral(1L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L), Range.greaterThan(BIGINT, 1L)), false))));
+    }
+
+    @Test
+    public void testFromUnprocessableComparison()
+    {
+        assertUnsupportedPredicate(greaterThan(unprocessableExpression1(C_BIGINT), unprocessableExpression2(C_BIGINT)));
+        assertUnsupportedPredicate(not(greaterThan(unprocessableExpression1(C_BIGINT), unprocessableExpression2(C_BIGINT))));
+    }
+
+    @Test
+    public void testFromBasicComparisons()
+    {
+        // Test out the extraction of all basic comparisons
+        assertPredicateTranslates(
+                greaterThan(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                greaterThanOrEqual(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThan(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThanOrEqual(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                equal(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                notEqual(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L), Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                isDistinctFrom(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L), Range.greaterThan(BIGINT, 2L)), true))));
+
+        assertPredicateTranslates(
+                equal(C_COLOR, colorLiteral(COLOR_VALUE_1)),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1), false))));
+
+        assertPredicateTranslates(
+                in(C_COLOR, ImmutableList.of(colorLiteral(COLOR_VALUE_1), colorLiteral(COLOR_VALUE_2))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1, COLOR_VALUE_2), false))));
+
+        assertPredicateTranslates(
+                isDistinctFrom(C_COLOR, colorLiteral(COLOR_VALUE_1)),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1).complement(), true))));
+
+        // Test complement
+        assertPredicateTranslates(
+                not(greaterThan(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(greaterThanOrEqual(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(lessThan(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(lessThanOrEqual(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(equal(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L), Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(notEqual(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(isDistinctFrom(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(equal(C_COLOR, colorLiteral(COLOR_VALUE_1))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1).complement(), false))));
+
+        assertPredicateTranslates(
+                not(in(C_COLOR, ImmutableList.of(colorLiteral(COLOR_VALUE_1), colorLiteral(COLOR_VALUE_2)))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1, COLOR_VALUE_2).complement(), false))));
+
+        assertPredicateTranslates(
+                not(isDistinctFrom(C_COLOR, colorLiteral(COLOR_VALUE_1))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1), false))));
+    }
+
+    @Test
+    public void testFromFlippedBasicComparisons()
+    {
+        // Test out the extraction of all basic comparisons where the reference literal ordering is flipped
+        assertPredicateTranslates(
+                greaterThan(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                greaterThanOrEqual(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThan(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThanOrEqual(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(equal(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(equal(colorLiteral(COLOR_VALUE_1), C_COLOR),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1), false))));
+
+        assertPredicateTranslates(notEqual(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L), Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                notEqual(colorLiteral(COLOR_VALUE_1), C_COLOR),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1).complement(), false))));
+
+        assertPredicateTranslates(isDistinctFrom(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L), Range.greaterThan(BIGINT, 2L)), true))));
+
+        assertPredicateTranslates(
+                isDistinctFrom(colorLiteral(COLOR_VALUE_1), C_COLOR),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1).complement(), true))));
+
+        assertPredicateTranslates(
+                isDistinctFrom(nullLiteral(BIGINT), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT))));
+    }
+
+    @Test
+    public void testFromBasicComparisonsWithNulls()
+    {
+        // Test out the extraction of all basic comparisons with null literals
+        assertPredicateIsAlwaysFalse(greaterThan(C_BIGINT, nullLiteral(BIGINT)));
+
+        assertPredicateTranslates(
+                greaterThan(C_VARCHAR, nullLiteral(VARCHAR)),
+                withColumnDomains(ImmutableMap.of(C_VARCHAR, Domain.create(ValueSet.none(VARCHAR), false))));
+
+        assertPredicateIsAlwaysFalse(greaterThanOrEqual(C_BIGINT, nullLiteral(BIGINT)));
+        assertPredicateIsAlwaysFalse(lessThan(C_BIGINT, nullLiteral(BIGINT)));
+        assertPredicateIsAlwaysFalse(lessThanOrEqual(C_BIGINT, nullLiteral(BIGINT)));
+        assertPredicateIsAlwaysFalse(equal(C_BIGINT, nullLiteral(BIGINT)));
+        assertPredicateIsAlwaysFalse(equal(C_COLOR, nullLiteral(COLOR)));
+        assertPredicateIsAlwaysFalse(notEqual(C_BIGINT, nullLiteral(BIGINT)));
+        assertPredicateIsAlwaysFalse(notEqual(C_COLOR, nullLiteral(COLOR)));
+
+        assertPredicateTranslates(
+                isDistinctFrom(C_BIGINT, nullLiteral(BIGINT)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT))));
+
+        assertPredicateTranslates(
+                isDistinctFrom(C_COLOR, nullLiteral(COLOR)),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.notNull(COLOR))));
+
+        // Test complements
+        assertPredicateIsAlwaysFalse(not(greaterThan(C_BIGINT, nullLiteral(BIGINT))));
+        assertPredicateIsAlwaysFalse(not(greaterThanOrEqual(C_BIGINT, nullLiteral(BIGINT))));
+        assertPredicateIsAlwaysFalse(not(lessThan(C_BIGINT, nullLiteral(BIGINT))));
+        assertPredicateIsAlwaysFalse(not(lessThanOrEqual(C_BIGINT, nullLiteral(BIGINT))));
+        assertPredicateIsAlwaysFalse(not(equal(C_BIGINT, nullLiteral(BIGINT))));
+        assertPredicateIsAlwaysFalse(not(equal(C_COLOR, nullLiteral(COLOR))));
+        assertPredicateIsAlwaysFalse(not(notEqual(C_BIGINT, nullLiteral(BIGINT))));
+        assertPredicateIsAlwaysFalse(not(notEqual(C_COLOR, nullLiteral(COLOR))));
+
+        assertPredicateTranslates(
+                not(isDistinctFrom(C_BIGINT, nullLiteral(BIGINT))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.onlyNull(BIGINT))));
+
+        assertPredicateTranslates(
+                not(isDistinctFrom(C_COLOR, nullLiteral(COLOR))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.onlyNull(COLOR))));
+    }
+
+    @Test
+    void testNonImplictCastOnSymbolSide()
+    {
+        // we expect TupleDomain.all here().
+        // see comment in ExpressionDomainTranslator.Visitor.visitComparisonExpression()
+        assertUnsupportedPredicate(equal(
+                cast(C_TIMESTAMP, DATE),
+                toRowExpression(DATE_VALUE, DATE)));
+        assertUnsupportedPredicate(equal(
+                cast(C_DECIMAL_12_2, BIGINT),
+                bigintLiteral(135L)));
+    }
+
+    @Test
+    void testNoSaturatedFloorCastFromUnsupportedApproximateDomain()
+    {
+        assertUnsupportedPredicate(equal(
+                cast(C_DECIMAL_12_2, DOUBLE),
+                doubleLiteral(12345.56)));
+
+        assertUnsupportedPredicate(equal(
+                cast(C_BIGINT, DOUBLE),
+                doubleLiteral(12345.56)));
+
+        assertUnsupportedPredicate(equal(
+                cast(C_BIGINT, REAL),
+                realLiteral(12345.56f)));
+
+        assertUnsupportedPredicate(equal(
+                cast(C_INTEGER, REAL),
+                realLiteral(12345.56f)));
+    }
+
+    @Test
+    public void testFromComparisonsWithCoercions()
+    {
+        // B is a double column. Check that it can be compared against longs
+        assertPredicateTranslates(
+                greaterThan(C_DOUBLE, cast(bigintLiteral(2L), DOUBLE)),
+                withColumnDomains(ImmutableMap.of(C_DOUBLE, Domain.create(ValueSet.ofRanges(Range.greaterThan(DOUBLE, 2.0)), false))));
+
+        // C is a string column. Check that it can be compared.
+        assertPredicateTranslates(
+                greaterThan(C_VARCHAR, stringLiteral("test")),
+                withColumnDomains(ImmutableMap.of(C_VARCHAR, Domain.create(ValueSet.ofRanges(Range.greaterThan(VARCHAR, utf8Slice("test"))), false))));
+
+        // A is a integer column. Check that it can be compared against doubles
+        assertPredicateTranslates(
+                greaterThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                greaterThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                greaterThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                greaterThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                equal(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                equal(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.none(INTEGER))));
+
+        assertPredicateTranslates(
+                notEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThan(INTEGER, 2L), Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                notEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.notNull(INTEGER))));
+
+        assertPredicateTranslates(
+                isDistinctFrom(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThan(INTEGER, 2L), Range.greaterThan(INTEGER, 2L)), true))));
+
+        assertPredicateIsAlwaysTrue(isDistinctFrom(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)));
+
+        // Test complements
+
+        // B is a double column. Check that it can be compared against longs
+        assertPredicateTranslates(
+                not(greaterThan(C_DOUBLE, cast(bigintLiteral(2L), DOUBLE))),
+                withColumnDomains(ImmutableMap.of(C_DOUBLE, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(DOUBLE, 2.0)), false))));
+
+        // C is a string column. Check that it can be compared.
+        assertPredicateTranslates(
+                not(greaterThan(C_VARCHAR, stringLiteral("test"))),
+                withColumnDomains(ImmutableMap.of(C_VARCHAR, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(VARCHAR, utf8Slice("test"))), false))));
+
+        // A is a integer column. Check that it can be compared against doubles
+        assertPredicateTranslates(
+                not(greaterThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(greaterThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(greaterThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(greaterThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(lessThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(lessThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(lessThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(lessThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(equal(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThan(INTEGER, 2L), Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(equal(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.notNull(INTEGER))));
+
+        assertPredicateTranslates(
+                not(notEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(notEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.none(INTEGER))));
+
+        assertPredicateTranslates(
+                not(isDistinctFrom(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 2L)), false))));
+
+        assertPredicateIsAlwaysFalse(not(isDistinctFrom(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))));
+    }
+
+    @Test
+    public void testFromUnprocessableInPredicate()
+    {
+        assertUnsupportedPredicate(in(unprocessableExpression1(C_BIGINT), ImmutableList.of(TRUE)));
+        assertUnsupportedPredicate(in(C_BOOLEAN, ImmutableList.of(unprocessableExpression1(C_BOOLEAN))));
+        assertUnsupportedPredicate(
+                in(C_BOOLEAN, ImmutableList.of(TRUE, unprocessableExpression1(C_BOOLEAN))));
+        assertUnsupportedPredicate(not(in(C_BOOLEAN, ImmutableList.of(unprocessableExpression1(C_BOOLEAN)))));
+    }
+
+    @Test
+    public void testFromInPredicate()
+    {
+        assertPredicateTranslates(
+                bigintIn(C_BIGINT, ImmutableList.of(1L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.singleValue(BIGINT, 1L))));
+
+        assertPredicateTranslates(
+                in(C_COLOR, ImmutableList.of(colorLiteral(COLOR_VALUE_1))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.singleValue(COLOR, COLOR_VALUE_1))));
+
+        assertPredicateTranslates(
+                bigintIn(C_BIGINT, ImmutableList.of(1L, 2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                in(C_COLOR, ImmutableList.of(colorLiteral(COLOR_VALUE_1), colorLiteral(COLOR_VALUE_2))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1, COLOR_VALUE_2), false))));
+
+        assertPredicateTranslates(
+                not(bigintIn(C_BIGINT, ImmutableList.of(1L, 2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L), Range.range(BIGINT, 1L, false, 2L, false), Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(in(C_COLOR, ImmutableList.of(colorLiteral(COLOR_VALUE_1), colorLiteral(COLOR_VALUE_2)))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1, COLOR_VALUE_2).complement(), false))));
+    }
+
+    @Test
+    public void testFromBetweenPredicate()
+    {
+        assertPredicateTranslates(
+                between(C_BIGINT, bigintLiteral(1L), bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 1L, true, 2L, true)), false))));
+
+        assertPredicateTranslates(
+                between(cast(C_INTEGER, DOUBLE), cast(bigintLiteral(1L), DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.range(INTEGER, 1L, true, 2L, true)), false))));
+
+        assertPredicateIsAlwaysFalse(between(C_BIGINT, bigintLiteral(1L), nullLiteral(BIGINT)));
+
+        // Test complements
+        assertPredicateTranslates(
+                not(between(C_BIGINT, bigintLiteral(1L), bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L), Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(between(cast(C_INTEGER, DOUBLE), cast(bigintLiteral(1L), DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThan(INTEGER, 1L), Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(between(C_BIGINT, bigintLiteral(1L), nullLiteral(BIGINT))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L)), false))));
+    }
+
+    @Test
+    public void testFromIsNullPredicate()
+    {
+        assertPredicateTranslates(
+                isNull(C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.onlyNull(BIGINT))));
+
+        assertPredicateTranslates(
+                isNull(C_HYPER_LOG_LOG),
+                withColumnDomains(ImmutableMap.of(C_HYPER_LOG_LOG, Domain.onlyNull(HYPER_LOG_LOG))));
+
+        assertPredicateTranslates(
+                not(isNull(C_BIGINT)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT))));
+
+        assertPredicateTranslates(
+                not(isNull(C_HYPER_LOG_LOG)),
+                withColumnDomains(ImmutableMap.of(C_HYPER_LOG_LOG, Domain.notNull(HYPER_LOG_LOG))));
+    }
+
+    @Test
+    public void testFromIsNotNullPredicate()
+    {
+        assertPredicateTranslates(
+                isNotNull(C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT))));
+
+        assertPredicateTranslates(
+                isNotNull(C_HYPER_LOG_LOG),
+                withColumnDomains(ImmutableMap.of(C_HYPER_LOG_LOG, Domain.notNull(HYPER_LOG_LOG))));
+
+        assertPredicateTranslates(
+                not(isNotNull(C_BIGINT)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.onlyNull(BIGINT))));
+
+        assertPredicateTranslates(
+                not(isNotNull(C_HYPER_LOG_LOG)),
+                withColumnDomains(ImmutableMap.of(C_HYPER_LOG_LOG, Domain.onlyNull(HYPER_LOG_LOG))));
+    }
+
+    @Test
+    public void testFromBooleanLiteralPredicate()
+    {
+        assertPredicateIsAlwaysTrue(TRUE);
+        assertPredicateIsAlwaysFalse(not(TRUE));
+        assertPredicateIsAlwaysFalse(FALSE);
+        assertPredicateIsAlwaysTrue(not(FALSE));
+    }
+
+    @Test
+    public void testFromNullLiteralPredicate()
+    {
+        assertPredicateIsAlwaysFalse(nullLiteral(UNKNOWN));
+        assertPredicateIsAlwaysFalse(not(nullLiteral(UNKNOWN)));
+    }
+
+    @Test
+    public void testExpressionConstantFolding()
+    {
+        FunctionHandle hex = metadata.getFunctionManager().lookupFunction(QualifiedName.of("from_hex"), fromTypes(VARCHAR));
+        RowExpression originalExpression = greaterThan(C_VARBINARY, call("from_hex", hex, VARBINARY, stringLiteral("123456")));
+        ExtractionResult result = fromPredicate(originalExpression);
+        assertEquals(result.getRemainingExpression(), TRUE);
+        Slice value = Slices.wrappedBuffer(BaseEncoding.base16().decode("123456"));
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_VARBINARY, Domain.create(ValueSet.ofRanges(Range.greaterThan(VARBINARY, value)), false))));
+
+        RowExpression expression = toPredicate(result.getTupleDomain());
+        assertEquals(expression, greaterThan(C_VARBINARY, varbinaryLiteral(value)));
+    }
+
+    @Test
+    public void testConjunctExpression()
+    {
+        RowExpression expression = and(
+                greaterThan(C_DOUBLE, doubleLiteral(0)),
+                greaterThan(C_BIGINT, bigintLiteral(0)));
+        assertPredicateTranslates(
+                expression,
+                withColumnDomains(ImmutableMap.of(
+                        C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 0L)), false),
+                        C_DOUBLE, Domain.create(ValueSet.ofRanges(Range.greaterThan(DOUBLE, .0)), false))));
+
+        assertEquals(
+                toPredicate(fromPredicate(expression).getTupleDomain()),
+                and(
+                        greaterThan(C_BIGINT, bigintLiteral(0)),
+                        greaterThan(C_DOUBLE, doubleLiteral(0))));
+    }
+
+    @Test
+    void testMultipleCoercionsOnSymbolSide()
+    {
+        assertPredicateTranslates(
+                greaterThan(cast(cast(C_SMALLINT, REAL), DOUBLE), doubleLiteral(3.7)),
+                withColumnDomains(ImmutableMap.of(C_SMALLINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(SMALLINT, 3L)), false))));
+    }
+
+    @Test
+    public void testNumericTypeTranslation()
+    {
+        testNumericTypeTranslationChain(
+                new NumericValues<>(C_DECIMAL_26_5, longDecimal("-999999999999999999999.99999"), longDecimal("-22.00000"), longDecimal("-44.55569"), longDecimal("23.00000"), longDecimal("44.55567"), longDecimal("999999999999999999999.99999")),
+                new NumericValues<>(C_DECIMAL_23_4, longDecimal("-9999999999999999999.9999"), longDecimal("-22.0000"), longDecimal("-44.5557"), longDecimal("23.0000"), longDecimal("44.5556"), longDecimal("9999999999999999999.9999")),
+                new NumericValues<>(C_BIGINT, Long.MIN_VALUE, -22L, -45L, 23L, 44L, Long.MAX_VALUE),
+                new NumericValues<>(C_DECIMAL_21_3, longDecimal("-999999999999999999.999"), longDecimal("-22.000"), longDecimal("-44.556"), longDecimal("23.000"), longDecimal("44.555"), longDecimal("999999999999999999.999")),
+                new NumericValues<>(C_DECIMAL_12_2, shortDecimal("-9999999999.99"), shortDecimal("-22.00"), shortDecimal("-44.56"), shortDecimal("23.00"), shortDecimal("44.55"), shortDecimal("9999999999.99")),
+                new NumericValues<>(C_INTEGER, (long) Integer.MIN_VALUE, -22L, -45L, 23L, 44L, (long) Integer.MAX_VALUE),
+                new NumericValues<>(C_DECIMAL_6_1, shortDecimal("-99999.9"), shortDecimal("-22.0"), shortDecimal("-44.6"), shortDecimal("23.0"), shortDecimal("44.5"), shortDecimal("99999.9")),
+                new NumericValues<>(C_SMALLINT, (long) Short.MIN_VALUE, -22L, -45L, 23L, 44L, (long) Short.MAX_VALUE),
+                new NumericValues<>(C_DECIMAL_3_0, shortDecimal("-999"), shortDecimal("-22"), shortDecimal("-45"), shortDecimal("23"), shortDecimal("44"), shortDecimal("999")),
+                new NumericValues<>(C_TINYINT, (long) Byte.MIN_VALUE, -22L, -45L, 23L, 44L, (long) Byte.MAX_VALUE),
+                new NumericValues<>(C_DECIMAL_2_0, shortDecimal("-99"), shortDecimal("-22"), shortDecimal("-45"), shortDecimal("23"), shortDecimal("44"), shortDecimal("99")));
+
+        testNumericTypeTranslationChain(
+                new NumericValues<>(C_DOUBLE, -1.0 * Double.MAX_VALUE, -22.0, -44.5556836, 23.0, 44.5556789, Double.MAX_VALUE),
+                new NumericValues<>(C_REAL, realValue(-1.0f * Float.MAX_VALUE), realValue(-22.0f), realValue(-44.555687f), realValue(23.0f), realValue(44.555676f), realValue(Float.MAX_VALUE)));
+    }
+
+    private void testNumericTypeTranslationChain(NumericValues... translationChain)
+    {
+        for (int literalIndex = 0; literalIndex < translationChain.length; literalIndex++) {
+            for (int columnIndex = literalIndex + 1; columnIndex < translationChain.length; columnIndex++) {
+                NumericValues literal = translationChain[literalIndex];
+                NumericValues column = translationChain[columnIndex];
+                testNumericTypeTranslation(column, literal);
+            }
+        }
+    }
+
+    private void testNumericTypeTranslation(NumericValues columnValues, NumericValues literalValues)
+    {
+        Type columnType = columnValues.getInput().getType();
+        Type literalType = literalValues.getInput().getType();
+        Type superType = metadata.getTypeManager().getCommonSuperType(columnType, literalType).orElseThrow(() -> new IllegalArgumentException("incompatible types in test (" + columnType + ", " + literalType + ")"));
+
+        RowExpression max = toRowExpression(literalValues.getMax(), literalType);
+        RowExpression min = toRowExpression(literalValues.getMin(), literalType);
+        RowExpression integerPositive = toRowExpression(literalValues.getIntegerPositive(), literalType);
+        RowExpression integerNegative = toRowExpression(literalValues.getIntegerNegative(), literalType);
+        RowExpression fractionalPositive = toRowExpression(literalValues.getFractionalPositive(), literalType);
+        RowExpression fractionalNegative = toRowExpression(literalValues.getFractionalNegative(), literalType);
+
+        if (!literalType.equals(superType)) {
+            max = cast(max, superType);
+            min = cast(min, superType);
+            integerPositive = cast(integerPositive, superType);
+            integerNegative = cast(integerNegative, superType);
+            fractionalPositive = cast(fractionalPositive, superType);
+            fractionalNegative = cast(fractionalNegative, superType);
+        }
+
+        VariableReferenceExpression columnSymbol = columnValues.getInput();
+        RowExpression columnExpression = columnSymbol;
+
+        if (!columnType.equals(superType)) {
+            columnExpression = cast(columnExpression, superType);
+        }
+
+        // greater than or equal
+        testSimpleComparison(greaterThanOrEqual(columnExpression, integerPositive), columnSymbol, Range.greaterThanOrEqual(columnType, columnValues.getIntegerPositive()));
+        testSimpleComparison(greaterThanOrEqual(columnExpression, integerNegative), columnSymbol, Range.greaterThanOrEqual(columnType, columnValues.getIntegerNegative()));
+        testSimpleComparison(greaterThanOrEqual(columnExpression, max), columnSymbol, Range.greaterThan(columnType, columnValues.getMax()));
+        testSimpleComparison(greaterThanOrEqual(columnExpression, min), columnSymbol, Range.greaterThanOrEqual(columnType, columnValues.getMin()));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(greaterThanOrEqual(columnExpression, fractionalPositive), columnSymbol, Range.greaterThan(columnType, columnValues.getFractionalPositive()));
+            testSimpleComparison(greaterThanOrEqual(columnExpression, fractionalNegative), columnSymbol, Range.greaterThan(columnType, columnValues.getFractionalNegative()));
+        }
+
+        // greater than
+        testSimpleComparison(greaterThan(columnExpression, integerPositive), columnSymbol, Range.greaterThan(columnType, columnValues.getIntegerPositive()));
+        testSimpleComparison(greaterThan(columnExpression, integerNegative), columnSymbol, Range.greaterThan(columnType, columnValues.getIntegerNegative()));
+        testSimpleComparison(greaterThan(columnExpression, max), columnSymbol, Range.greaterThan(columnType, columnValues.getMax()));
+        testSimpleComparison(greaterThan(columnExpression, min), columnSymbol, Range.greaterThanOrEqual(columnType, columnValues.getMin()));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(greaterThan(columnExpression, fractionalPositive), columnSymbol, Range.greaterThan(columnType, columnValues.getFractionalPositive()));
+            testSimpleComparison(greaterThan(columnExpression, fractionalNegative), columnSymbol, Range.greaterThan(columnType, columnValues.getFractionalNegative()));
+        }
+
+        // less than or equal
+        testSimpleComparison(lessThanOrEqual(columnExpression, integerPositive), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getIntegerPositive()));
+        testSimpleComparison(lessThanOrEqual(columnExpression, integerNegative), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getIntegerNegative()));
+        testSimpleComparison(lessThanOrEqual(columnExpression, max), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getMax()));
+        testSimpleComparison(lessThanOrEqual(columnExpression, min), columnSymbol, Range.lessThan(columnType, columnValues.getMin()));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(lessThanOrEqual(columnExpression, fractionalPositive), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getFractionalPositive()));
+            testSimpleComparison(lessThanOrEqual(columnExpression, fractionalNegative), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getFractionalNegative()));
+        }
+
+        // less than
+        testSimpleComparison(lessThan(columnExpression, integerPositive), columnSymbol, Range.lessThan(columnType, columnValues.getIntegerPositive()));
+        testSimpleComparison(lessThan(columnExpression, integerNegative), columnSymbol, Range.lessThan(columnType, columnValues.getIntegerNegative()));
+        testSimpleComparison(lessThan(columnExpression, max), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getMax()));
+        testSimpleComparison(lessThan(columnExpression, min), columnSymbol, Range.lessThan(columnType, columnValues.getMin()));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(lessThan(columnExpression, fractionalPositive), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getFractionalPositive()));
+            testSimpleComparison(lessThan(columnExpression, fractionalNegative), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getFractionalNegative()));
+        }
+
+        // equal
+        testSimpleComparison(equal(columnExpression, integerPositive), columnSymbol, Range.equal(columnType, columnValues.getIntegerPositive()));
+        testSimpleComparison(equal(columnExpression, integerNegative), columnSymbol, Range.equal(columnType, columnValues.getIntegerNegative()));
+        testSimpleComparison(equal(columnExpression, max), columnSymbol, Domain.none(columnType));
+        testSimpleComparison(equal(columnExpression, min), columnSymbol, Domain.none(columnType));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(equal(columnExpression, fractionalPositive), columnSymbol, Domain.none(columnType));
+            testSimpleComparison(equal(columnExpression, fractionalNegative), columnSymbol, Domain.none(columnType));
+        }
+
+        // not equal
+        testSimpleComparison(notEqual(columnExpression, integerPositive), columnSymbol, Domain.create(ValueSet.ofRanges(Range.lessThan(columnType, columnValues.getIntegerPositive()), Range.greaterThan(columnType, columnValues.getIntegerPositive())), false));
+        testSimpleComparison(notEqual(columnExpression, integerNegative), columnSymbol, Domain.create(ValueSet.ofRanges(Range.lessThan(columnType, columnValues.getIntegerNegative()), Range.greaterThan(columnType, columnValues.getIntegerNegative())), false));
+        testSimpleComparison(notEqual(columnExpression, max), columnSymbol, Domain.notNull(columnType));
+        testSimpleComparison(notEqual(columnExpression, min), columnSymbol, Domain.notNull(columnType));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(notEqual(columnExpression, fractionalPositive), columnSymbol, Domain.notNull(columnType));
+            testSimpleComparison(notEqual(columnExpression, fractionalNegative), columnSymbol, Domain.notNull(columnType));
+        }
+
+        // is distinct from
+        testSimpleComparison(isDistinctFrom(columnExpression, integerPositive), columnSymbol, Domain.create(ValueSet.ofRanges(Range.lessThan(columnType, columnValues.getIntegerPositive()), Range.greaterThan(columnType, columnValues.getIntegerPositive())), true));
+        testSimpleComparison(isDistinctFrom(columnExpression, integerNegative), columnSymbol, Domain.create(ValueSet.ofRanges(Range.lessThan(columnType, columnValues.getIntegerNegative()), Range.greaterThan(columnType, columnValues.getIntegerNegative())), true));
+        testSimpleComparison(isDistinctFrom(columnExpression, max), columnSymbol, Domain.all(columnType));
+        testSimpleComparison(isDistinctFrom(columnExpression, min), columnSymbol, Domain.all(columnType));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(isDistinctFrom(columnExpression, fractionalPositive), columnSymbol, Domain.all(columnType));
+            testSimpleComparison(isDistinctFrom(columnExpression, fractionalNegative), columnSymbol, Domain.all(columnType));
+        }
+    }
+
+    @Test
+    public void testLegacyCharComparedToVarcharExpression()
+    {
+        metadata = createTestMetadataManager(new FeaturesConfig().setLegacyCharToVarcharCoercion(true));
+
+        String maxCodePoint = new String(Character.toChars(Character.MAX_CODE_POINT));
+
+        // greater than or equal
+        testSimpleComparison(greaterThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.greaterThan(createCharType(10), utf8Slice("123456788" + maxCodePoint)));
+        testSimpleComparison(greaterThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.greaterThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(greaterThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890")));
+
+        // greater than
+        testSimpleComparison(greaterThan(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.greaterThan(createCharType(10), utf8Slice("123456788" + maxCodePoint)));
+        testSimpleComparison(greaterThan(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(greaterThan(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890")));
+
+        // less than or equal
+        testSimpleComparison(lessThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.lessThanOrEqual(createCharType(10), utf8Slice("123456788" + maxCodePoint)));
+        testSimpleComparison(lessThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.lessThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(lessThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.lessThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")));
+
+        // less than
+        testSimpleComparison(lessThan(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.lessThanOrEqual(createCharType(10), utf8Slice("123456788" + maxCodePoint)));
+        testSimpleComparison(lessThan(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.lessThan(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(lessThan(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.lessThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")));
+
+        // equal
+        testSimpleComparison(equal(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Domain.none(createCharType(10)));
+        testSimpleComparison(equal(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.equal(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(equal(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Domain.none(createCharType(10)));
+
+        // not equal
+        testSimpleComparison(notEqual(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Domain.notNull(createCharType(10)));
+        testSimpleComparison(notEqual(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Domain.create(ValueSet.ofRanges(
+                Range.lessThan(createCharType(10), Slices.utf8Slice("1234567890")), Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890"))), false));
+        testSimpleComparison(notEqual(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Domain.notNull(createCharType(10)));
+
+        // is distinct from
+        testSimpleComparison(isDistinctFrom(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Domain.all(createCharType(10)));
+        testSimpleComparison(isDistinctFrom(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Domain.create(ValueSet.ofRanges(
+                Range.lessThan(createCharType(10), Slices.utf8Slice("1234567890")), Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890"))), true));
+        testSimpleComparison(isDistinctFrom(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Domain.all(createCharType(10)));
+    }
+
+    @Test
+    public void testCharComparedToVarcharExpression()
+    {
+        Type charType = createCharType(10);
+        // varchar literal is coerced to column (char) type
+        testSimpleComparison(equal(C_CHAR, cast(stringLiteral("abc"), charType)), C_CHAR, Range.equal(charType, Slices.utf8Slice("abc")));
+
+        // both sides got coerced to char(11)
+        charType = createCharType(11);
+        assertUnsupportedPredicate(equal(cast(C_CHAR, charType), cast(stringLiteral("abc12345678"), charType)));
+    }
+
+    private void assertPredicateTranslates(RowExpression expression, TupleDomain<VariableReferenceExpression> tupleDomain)
+    {
+        ExtractionResult result = fromPredicate(expression);
+        assertEquals(result.getRemainingExpression(), TRUE);
+        assertEquals(result.getTupleDomain(), tupleDomain);
+    }
+
+    private void assertPredicateIsAlwaysTrue(RowExpression expression)
+    {
+        assertPredicateTranslates(expression, TupleDomain.all());
+    }
+
+    private void assertPredicateIsAlwaysFalse(RowExpression expression)
+    {
+        ExtractionResult result = fromPredicate(expression);
+        assertEquals(result.getRemainingExpression(), TRUE);
+        assertTrue(result.getTupleDomain().isNone());
+    }
+
+    private RowExpression toPredicate(TupleDomain<VariableReferenceExpression> tupleDomain)
+    {
+        return domainTranslator.toPredicate(tupleDomain);
+    }
+
+    private ExtractionResult fromPredicate(RowExpression originalPredicate)
+    {
+        return RowExpressionDomainTranslator.fromPredicate(metadata, TEST_SESSION, originalPredicate);
+    }
+
+    private RowExpression nullLiteral(Type type)
+    {
+        return constantNull(type);
+    }
+
+    private RowExpression stringLiteral(String value)
+    {
+        return constant(Slices.utf8Slice(value), VARCHAR);
+    }
+
+    private RowExpression bigintLiteral(long value)
+    {
+        return constant(value, BIGINT);
+    }
+
+    private RowExpression doubleLiteral(double value)
+    {
+        return constant(value, DOUBLE);
+    }
+
+    private RowExpression varbinaryLiteral(Slice value)
+    {
+        return constant(value, VARBINARY);
+    }
+
+    private long realValue(float value)
+    {
+        return (long) floatToIntBits(value);
+    }
+
+    private RowExpression realLiteral(float value)
+    {
+        return constant(realValue(value), REAL);
+    }
+
+    private RowExpression colorLiteral(long value)
+    {
+        return constant(value, COLOR);
+    }
+
+    private static Long shortDecimal(String value)
+    {
+        return new BigDecimal(value).unscaledValue().longValueExact();
+    }
+
+    private static Slice longDecimal(String value)
+    {
+        return encodeScaledValue(new BigDecimal(value));
+    }
+
+    private static RowExpression isNull(RowExpression expression)
+    {
+        return new SpecialFormExpression(IS_NULL, BOOLEAN, expression);
+    }
+
+    private RowExpression cast(RowExpression expression, Type toType)
+    {
+        FunctionHandle cast = metadata.getFunctionManager().lookupCast(CastType.CAST, expression.getType().getTypeSignature(), toType.getTypeSignature());
+        return call(CastType.CAST.getCastName(), cast, toType, expression);
+    }
+
+    private RowExpression not(RowExpression expression)
+    {
+        return call("not", new StandardFunctionResolution(metadata.getFunctionManager()).notFunction(), expression.getType(), expression);
+    }
+
+    private RowExpression in(RowExpression value, List<RowExpression> inList)
+    {
+        return new SpecialFormExpression(IN, BOOLEAN, ImmutableList.<RowExpression>builder().add(value).addAll(inList).build());
+    }
+
+    private RowExpression isNotNull(RowExpression expression)
+    {
+        return not(isNull(expression));
+    }
+
+    private RowExpression bigintIn(RowExpression value, List<Long> inList)
+    {
+        List<RowExpression> arguments = inList.stream().map(argument -> constant(argument, BIGINT)).collect(toImmutableList());
+        return in(value, arguments);
+    }
+
+    private RowExpression binaryOperator(OperatorType operatorType, RowExpression left, RowExpression right)
+    {
+        return call(
+                operatorType.name(),
+                metadata.getFunctionManager().resolveOperator(operatorType, fromTypes(left.getType(), right.getType())),
+                BOOLEAN,
+                left,
+                right);
+    }
+
+    private RowExpression between(RowExpression value, RowExpression min, RowExpression max)
+    {
+        return call(
+                OperatorType.BETWEEN.name(),
+                metadata.getFunctionManager().resolveOperator(OperatorType.BETWEEN, fromTypes(value.getType(), min.getType(), max.getType())),
+                BOOLEAN,
+                value,
+                min,
+                max);
+    }
+
+    private RowExpression isDistinctFrom(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.IS_DISTINCT_FROM, left, right);
+    }
+
+    private RowExpression greaterThan(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.GREATER_THAN, left, right);
+    }
+
+    private RowExpression lessThan(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.LESS_THAN, left, right);
+    }
+
+    private RowExpression greaterThanOrEqual(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(GREATER_THAN_OR_EQUAL, left, right);
+    }
+
+    private RowExpression lessThanOrEqual(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(LESS_THAN_OR_EQUAL, left, right);
+    }
+
+    private RowExpression equal(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.EQUAL, left, right);
+    }
+
+    private RowExpression notEqual(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(NOT_EQUAL, left, right);
+    }
+
+    private RowExpression unprocessableExpression1(VariableReferenceExpression expression)
+    {
+        return greaterThan(expression, expression);
+    }
+
+    private RowExpression unprocessableExpression2(VariableReferenceExpression expression)
+    {
+        return lessThan(expression, expression);
+    }
+
+    private RowExpression randPredicate(VariableReferenceExpression expression)
+    {
+        RowExpression random = call("random", metadata.getFunctionManager().lookupFunction(QualifiedName.of("random"), fromTypes()), DOUBLE);
+        return greaterThan(
+                expression,
+                call(CastType.CAST.name(), metadata.getFunctionManager().lookupCast(CastType.CAST, DOUBLE.getTypeSignature(), expression.getType().getTypeSignature()), expression.getType(), random));
+    }
+
+    private void assertUnsupportedPredicate(RowExpression expression)
+    {
+        ExtractionResult result = fromPredicate(expression);
+        assertEquals(result.getRemainingExpression(), expression);
+        assertEquals(result.getTupleDomain(), TupleDomain.all());
+    }
+
+    private void testSimpleComparison(RowExpression expression, VariableReferenceExpression input, Range expectedDomainRange)
+    {
+        testSimpleComparison(expression, input, Domain.create(ValueSet.ofRanges(expectedDomainRange), false));
+    }
+
+    private void testSimpleComparison(RowExpression expression, VariableReferenceExpression input, Domain domain)
+    {
+        ExtractionResult result = fromPredicate(expression);
+        assertEquals(result.getRemainingExpression(), TRUE);
+        TupleDomain<VariableReferenceExpression> actual = result.getTupleDomain();
+        TupleDomain<VariableReferenceExpression> expected = withColumnDomains(ImmutableMap.of(input, domain));
+        if (!actual.equals(expected)) {
+            fail(format("for comparison [%s] expected %s but found %s", expression.toString(), expected.toString(SESSION), actual.toString(SESSION)));
+        }
+    }
+
+    private static class NumericValues<T>
+    {
+        private final VariableReferenceExpression input;
+        private final T min;
+        private final T integerNegative;
+        private final T fractionalNegative;
+        private final T integerPositive;
+        private final T fractionalPositive;
+        private final T max;
+
+        private NumericValues(VariableReferenceExpression input, T min, T integerNegative, T fractionalNegative, T integerPositive, T fractionalPositive, T max)
+        {
+            this.input = requireNonNull(input, "input is null");
+            this.min = requireNonNull(min, "min is null");
+            this.integerNegative = requireNonNull(integerNegative, "integerNegative is null");
+            this.fractionalNegative = requireNonNull(fractionalNegative, "fractionalNegative is null");
+            this.integerPositive = requireNonNull(integerPositive, "integerPositive is null");
+            this.fractionalPositive = requireNonNull(fractionalPositive, "fractionalPositive is null");
+            this.max = requireNonNull(max, "max is null");
+        }
+
+        public VariableReferenceExpression getInput()
+        {
+            return input;
+        }
+
+        public T getMin()
+        {
+            return min;
+        }
+
+        public T getIntegerNegative()
+        {
+            return integerNegative;
+        }
+
+        public T getFractionalNegative()
+        {
+            return fractionalNegative;
+        }
+
+        public T getIntegerPositive()
+        {
+            return integerPositive;
+        }
+
+        public T getFractionalPositive()
+        {
+            return fractionalPositive;
+        }
+
+        public T getMax()
+        {
+            return max;
+        }
+
+        public boolean isFractional()
+        {
+            return input.getType() == DOUBLE || input.getType() == REAL || (input.getType() instanceof DecimalType && ((DecimalType) input.getType()).getScale() > 0);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.planner.optimizations.RowExpressionCanonicalizer;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator.ExtractionResult;
 import com.facebook.presto.sql.relational.StandardFunctionResolution;
@@ -1155,7 +1156,7 @@ public class TestRowExpressionDomainTranslator
 
     private ExtractionResult fromPredicate(RowExpression originalPredicate)
     {
-        return RowExpressionDomainTranslator.fromPredicate(metadata, TEST_SESSION, originalPredicate);
+        return domainTranslator.fromPredicate(metadata, TEST_SESSION, originalPredicate);
     }
 
     private RowExpression nullLiteral(Type type)
@@ -1317,7 +1318,8 @@ public class TestRowExpressionDomainTranslator
     private void assertUnsupportedPredicate(RowExpression expression)
     {
         ExtractionResult result = fromPredicate(expression);
-        assertEquals(result.getRemainingExpression(), expression);
+        RowExpressionCanonicalizer canonicalizer = new RowExpressionCanonicalizer(metadata.getFunctionManager());
+        assertEquals(canonicalizer.canonicalize(result.getRemainingExpression()), canonicalizer.canonicalize(expression));
         assertEquals(result.getTupleDomain(), TupleDomain.all());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestSymbolExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestSymbolExtractor.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.TestingRowExpressionTranslator;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Expression;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
+import static com.facebook.presto.sql.planner.SymbolsExtractor.extractAll;
+import static com.facebook.presto.sql.planner.SymbolsExtractor.extractUnique;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.testng.Assert.assertEquals;
+
+public class TestSymbolExtractor
+{
+    private static final Metadata METADATA = MetadataManager.createTestMetadataManager();
+    private static final TestingRowExpressionTranslator TRANSLATOR = new TestingRowExpressionTranslator(METADATA);
+    private static final Map<Symbol, Type> SYMBOL_TYPES = ImmutableMap.of(new Symbol("a"), BIGINT, new Symbol("b"), BIGINT, new Symbol("c"), BIGINT);
+
+    @Test
+    public void testSimple()
+    {
+        assertSymbols("a > b");
+        assertSymbols("a + b > c");
+        assertSymbols("sin(a) - b");
+        assertSymbols("sin(a) + cos(a) - b");
+        assertSymbols("sin(a) + cos(a) + a - b");
+        assertSymbols("COALESCE(a, b, 1)");
+        assertSymbols("a IN (a, b, c)");
+        assertSymbols("transform(sequence(1, 5), a -> a + b)");
+        assertSymbols("bigint '1'");
+    }
+
+    private static void assertSymbols(String expression)
+    {
+        Expression expected = rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(expression, new ParsingOptions()));
+        RowExpression actual = TRANSLATOR.translate(expected, TypeProvider.copyOf(SYMBOL_TYPES));
+        assertEquals(extractUnique(expected), extractUnique(actual));
+        assertEquals(
+                extractAll(expected).stream().sorted().collect(toImmutableList()),
+                extractAll(actual).stream().map(variable -> new Symbol(variable.getName())).sorted().collect(toImmutableList()));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/FilterMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/FilterMatcher.java
@@ -20,6 +20,8 @@ import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
 import com.facebook.presto.sql.tree.Expression;
 
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.isExpression;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -46,8 +48,12 @@ final class FilterMatcher
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
 
         FilterNode filterNode = (FilterNode) node;
-        ExpressionVerifier verifier = new ExpressionVerifier(symbolAliases);
-        return new MatchResult(verifier.process(filterNode.getPredicate(), predicate));
+        if (isExpression(filterNode.getPredicate())) {
+            ExpressionVerifier verifier = new ExpressionVerifier(symbolAliases);
+            return new MatchResult(verifier.process(castToExpression(filterNode.getPredicate()), predicate));
+        }
+        RowExpressionVerifier verifier = new RowExpressionVerifier(symbolAliases, metadata, session);
+        return new MatchResult(verifier.process(predicate, filterNode.getPredicate()));
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
@@ -1,0 +1,512 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.FunctionMetadata;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.LiteralInterpreter;
+import com.facebook.presto.sql.relational.StandardFunctionResolution;
+import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
+import com.facebook.presto.sql.tree.AstVisitor;
+import com.facebook.presto.sql.tree.BetweenPredicate;
+import com.facebook.presto.sql.tree.BooleanLiteral;
+import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.CoalesceExpression;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DecimalLiteral;
+import com.facebook.presto.sql.tree.DoubleLiteral;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.GenericLiteral;
+import com.facebook.presto.sql.tree.InListExpression;
+import com.facebook.presto.sql.tree.InPredicate;
+import com.facebook.presto.sql.tree.IsNotNullPredicate;
+import com.facebook.presto.sql.tree.IsNullPredicate;
+import com.facebook.presto.sql.tree.Literal;
+import com.facebook.presto.sql.tree.LogicalBinaryExpression;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.NotExpression;
+import com.facebook.presto.sql.tree.NullLiteral;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.SimpleCaseExpression;
+import com.facebook.presto.sql.tree.StringLiteral;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.sql.tree.TryExpression;
+import com.facebook.presto.sql.tree.WhenClause;
+import io.airlift.slice.Slice;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.spi.function.OperatorType.ADD;
+import static com.facebook.presto.spi.function.OperatorType.DIVIDE;
+import static com.facebook.presto.spi.function.OperatorType.EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.MODULUS;
+import static com.facebook.presto.spi.function.OperatorType.MULTIPLY;
+import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.SUBTRACT;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.SWITCH;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.WHEN;
+import static com.facebook.presto.sql.planner.RowExpressionInterpreter.rowExpressionInterpreter;
+import static com.facebook.presto.sql.tree.LogicalBinaryExpression.Operator.AND;
+import static com.facebook.presto.sql.tree.LogicalBinaryExpression.Operator.OR;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * RowExpression visitor which verifies if given expression (actual) is matching other RowExpression given as context (expected).
+ */
+final class RowExpressionVerifier
+        extends AstVisitor<Boolean, RowExpression>
+{
+    // either use variable or input reference for symbol mapping
+    private final SymbolAliases symbolAliases;
+    private final Metadata metadata;
+    private final Session session;
+    private final StandardFunctionResolution functionResolution;
+
+    RowExpressionVerifier(SymbolAliases symbolAliases, Metadata metadata, Session session)
+    {
+        this.symbolAliases = requireNonNull(symbolAliases, "symbolLayout is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.session = requireNonNull(session, "session is null");
+        this.functionResolution = new StandardFunctionResolution(metadata.getFunctionManager());
+    }
+
+    @Override
+    protected Boolean visitNode(Node node, RowExpression context)
+    {
+        throw new IllegalStateException(format("Node %s is not supported", node));
+    }
+
+    @Override
+    protected Boolean visitTryExpression(TryExpression expected, RowExpression actual)
+    {
+        if (!(actual instanceof CallExpression) || !((CallExpression) actual).getFunctionHandle().getSignature().getName().equals("TRY")) {
+            return false;
+        }
+
+        return process(expected.getInnerExpression(), ((CallExpression) actual).getArguments().get(0));
+    }
+
+    @Override
+    protected Boolean visitCast(Cast expected, RowExpression actual)
+    {
+        // TODO: clean up cast path
+        if (actual instanceof ConstantExpression && expected.getExpression() instanceof Literal && expected.getType().equals(actual.getType().toString())) {
+            Literal literal = (Literal) expected.getExpression();
+            if (literal instanceof StringLiteral) {
+                Object value = LiteralInterpreter.evaluate(TEST_SESSION.toConnectorSession(), (ConstantExpression) actual);
+                String actualString = value instanceof Slice ? ((Slice) value).toStringUtf8() : String.valueOf(value);
+                return ((StringLiteral) literal).getValue().equals(actualString);
+            }
+            return getValueFromLiteral(literal).equals(String.valueOf(LiteralInterpreter.evaluate(TEST_SESSION.toConnectorSession(), (ConstantExpression) actual)));
+        }
+        if (actual instanceof VariableReferenceExpression && expected.getExpression() instanceof SymbolReference && expected.getType().equals(actual.getType().toString())) {
+            return visitSymbolReference((SymbolReference) expected.getExpression(), actual);
+        }
+        if (!(actual instanceof CallExpression) || !functionResolution.isCastFunction(((CallExpression) actual).getFunctionHandle())) {
+            return false;
+        }
+
+        if (!expected.getType().equals(actual.getType().toString())) {
+            return false;
+        }
+
+        return process(expected.getExpression(), ((CallExpression) actual).getArguments().get(0));
+    }
+
+    @Override
+    protected Boolean visitIsNullPredicate(IsNullPredicate expected, RowExpression actual)
+    {
+        if (!(actual instanceof SpecialFormExpression) || !((SpecialFormExpression) actual).getForm().equals(IS_NULL)) {
+            return false;
+        }
+
+        return process(expected.getValue(), ((SpecialFormExpression) actual).getArguments().get(0));
+    }
+
+    @Override
+    protected Boolean visitIsNotNullPredicate(IsNotNullPredicate expected, RowExpression actual)
+    {
+        if (!(actual instanceof CallExpression) || !functionResolution.notFunction().equals(((CallExpression) actual).getFunctionHandle())) {
+            return false;
+        }
+
+        RowExpression argument = ((CallExpression) actual).getArguments().get(0);
+
+        if (!(argument instanceof SpecialFormExpression) || !((SpecialFormExpression) argument).getForm().equals(IS_NULL)) {
+            return false;
+        }
+
+        return process(expected.getValue(), ((SpecialFormExpression) argument).getArguments().get(0));
+    }
+
+    @Override
+    protected Boolean visitInPredicate(InPredicate expected, RowExpression actual)
+    {
+        if (actual instanceof SpecialFormExpression && ((SpecialFormExpression) actual).getForm().equals(IN)) {
+            List<RowExpression> arguments = ((SpecialFormExpression) actual).getArguments();
+            if (expected.getValueList() instanceof InListExpression) {
+                return process(expected.getValue(), arguments.get(0)) && process(((InListExpression) expected.getValueList()).getValues(), arguments.subList(1, arguments.size()));
+            }
+            else {
+                /*
+                 * If the actual value is a value list, but the expected is e.g. a SymbolReference,
+                 * we need to unpack the value from the list so that when we hit visitSymbolReference, the
+                 * actual.toString() call returns something that the symbolAliases expectedly contains.
+                 * For example, InListExpression.toString returns "(onlyitem)" rather than "onlyitem".
+                 *
+                 * This is required because expected passes through the analyzer, planner, and possibly optimizers,
+                 * one of which sometimes takes the liberty of unpacking the InListExpression.
+                 *
+                 * Since the actual value doesn't go through all of that, we have to deal with the case
+                 * of the expected value being unpacked, but the actual value being an InListExpression.
+                 */
+                checkState(arguments.size() == 2, "Multiple expressions in actual value list %s, but expected value is not a list", arguments.subList(1, arguments.size()), expected.getValue());
+                return process(expected.getValue(), arguments.get(0)) && process(expected.getValueList(), arguments.get(1));
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitComparisonExpression(ComparisonExpression expected, RowExpression actual)
+    {
+        if (actual instanceof CallExpression) {
+            FunctionMetadata functionMetadata = metadata.getFunctionManager().getFunctionMetadata(((CallExpression) actual).getFunctionHandle());
+            if (!functionMetadata.getOperatorType().isPresent() || !functionMetadata.getOperatorType().get().isComparisonOperator()) {
+                return false;
+            }
+            OperatorType actualOperatorType = functionMetadata.getOperatorType().get();
+            OperatorType expectedOperatorType = getOperatorType(expected.getOperator());
+            if (expectedOperatorType.equals(actualOperatorType)) {
+                return process(expected.getLeft(), ((CallExpression) actual).getArguments().get(0)) && process(expected.getRight(), ((CallExpression) actual).getArguments().get(1));
+            }
+        }
+        return false;
+    }
+
+    private static OperatorType getOperatorType(ComparisonExpression.Operator operator)
+    {
+        OperatorType operatorType;
+        switch (operator) {
+            case EQUAL:
+                operatorType = EQUAL;
+                break;
+            case NOT_EQUAL:
+                operatorType = NOT_EQUAL;
+                break;
+            case LESS_THAN:
+                operatorType = LESS_THAN;
+                break;
+            case LESS_THAN_OR_EQUAL:
+                operatorType = LESS_THAN_OR_EQUAL;
+                break;
+            case GREATER_THAN:
+                operatorType = GREATER_THAN;
+                break;
+            case GREATER_THAN_OR_EQUAL:
+                operatorType = GREATER_THAN_OR_EQUAL;
+                break;
+            case IS_DISTINCT_FROM:
+                operatorType = IS_DISTINCT_FROM;
+                break;
+            default:
+                throw new IllegalStateException("Unsupported comparison operator type: " + operator);
+        }
+        return operatorType;
+    }
+
+    @Override
+    protected Boolean visitArithmeticBinary(ArithmeticBinaryExpression expected, RowExpression actual)
+    {
+        if (actual instanceof CallExpression) {
+            FunctionMetadata functionMetadata = metadata.getFunctionManager().getFunctionMetadata(((CallExpression) actual).getFunctionHandle());
+            if (!functionMetadata.getOperatorType().isPresent() || !functionMetadata.getOperatorType().get().isArithmeticOperator()) {
+                return false;
+            }
+            OperatorType actualOperatorType = functionMetadata.getOperatorType().get();
+            OperatorType expectedOperatorType = getOperatorType(expected.getOperator());
+            if (expectedOperatorType.equals(actualOperatorType)) {
+                return process(expected.getLeft(), ((CallExpression) actual).getArguments().get(0)) && process(expected.getRight(), ((CallExpression) actual).getArguments().get(1));
+            }
+        }
+        return false;
+    }
+
+    private static OperatorType getOperatorType(ArithmeticBinaryExpression.Operator operator)
+    {
+        OperatorType operatorType;
+        switch (operator) {
+            case ADD:
+                operatorType = ADD;
+                break;
+            case SUBTRACT:
+                operatorType = SUBTRACT;
+                break;
+            case MULTIPLY:
+                operatorType = MULTIPLY;
+                break;
+            case DIVIDE:
+                operatorType = DIVIDE;
+                break;
+            case MODULUS:
+                operatorType = MODULUS;
+                break;
+            default:
+                throw new IllegalStateException("Unknown arithmetic operator: " + operator);
+        }
+        return operatorType;
+    }
+
+    @Override
+    protected Boolean visitGenericLiteral(GenericLiteral expected, RowExpression actual)
+    {
+        return compareLiteral(expected, actual);
+    }
+
+    @Override
+    protected Boolean visitLongLiteral(LongLiteral expected, RowExpression actual)
+    {
+        return compareLiteral(expected, actual);
+    }
+
+    @Override
+    protected Boolean visitDoubleLiteral(DoubleLiteral expected, RowExpression actual)
+    {
+        return compareLiteral(expected, actual);
+    }
+
+    @Override
+    protected Boolean visitDecimalLiteral(DecimalLiteral expected, RowExpression actual)
+    {
+        return compareLiteral(expected, actual);
+    }
+
+    @Override
+    protected Boolean visitBooleanLiteral(BooleanLiteral expected, RowExpression actual)
+    {
+        return compareLiteral(expected, actual);
+    }
+
+    private static String getValueFromLiteral(Node expression)
+    {
+        if (expression instanceof LongLiteral) {
+            return String.valueOf(((LongLiteral) expression).getValue());
+        }
+        else if (expression instanceof BooleanLiteral) {
+            return String.valueOf(((BooleanLiteral) expression).getValue());
+        }
+        else if (expression instanceof DoubleLiteral) {
+            return String.valueOf(((DoubleLiteral) expression).getValue());
+        }
+        else if (expression instanceof DecimalLiteral) {
+            return String.valueOf(((DecimalLiteral) expression).getValue());
+        }
+        else if (expression instanceof GenericLiteral) {
+            return ((GenericLiteral) expression).getValue();
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported literal expression type: " + expression.getClass().getName());
+        }
+    }
+
+    private Boolean compareLiteral(Node expected, RowExpression actual)
+    {
+        if (actual instanceof CallExpression && functionResolution.isCastFunction(((CallExpression) actual).getFunctionHandle())) {
+            return getValueFromLiteral(expected).equals(String.valueOf(rowExpressionInterpreter(actual, metadata, session).evaluate()));
+        }
+        if (actual instanceof ConstantExpression) {
+            return getValueFromLiteral(expected).equals(String.valueOf(LiteralInterpreter.evaluate(TEST_SESSION.toConnectorSession(), (ConstantExpression) actual)));
+        }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitStringLiteral(StringLiteral expected, RowExpression actual)
+    {
+        if (actual instanceof ConstantExpression && actual.getType().getJavaType() == Slice.class) {
+            String actualString = (String) LiteralInterpreter.evaluate(TEST_SESSION.toConnectorSession(), (ConstantExpression) actual);
+            return expected.getValue().equals(actualString);
+        }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitLogicalBinaryExpression(LogicalBinaryExpression expected, RowExpression actual)
+    {
+        if (actual instanceof SpecialFormExpression) {
+            SpecialFormExpression actualLogicalBinary = (SpecialFormExpression) actual;
+            if ((expected.getOperator() == OR && actualLogicalBinary.getForm() == SpecialFormExpression.Form.OR) ||
+                    (expected.getOperator() == AND && actualLogicalBinary.getForm() == SpecialFormExpression.Form.AND)) {
+                return process(expected.getLeft(), actualLogicalBinary.getArguments().get(0)) &&
+                        process(expected.getRight(), actualLogicalBinary.getArguments().get(1));
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitBetweenPredicate(BetweenPredicate expected, RowExpression actual)
+    {
+        if (actual instanceof CallExpression && functionResolution.isBetweenFunction(((CallExpression) actual).getFunctionHandle())) {
+            return process(expected.getValue(), ((CallExpression) actual).getArguments().get(0)) &&
+                    process(expected.getMin(), ((CallExpression) actual).getArguments().get(1)) &&
+                    process(expected.getMax(), ((CallExpression) actual).getArguments().get(2));
+        }
+
+        return false;
+    }
+
+    @Override
+    protected Boolean visitNotExpression(NotExpression expected, RowExpression actual)
+    {
+        if (!(actual instanceof CallExpression) || !functionResolution.notFunction().equals(((CallExpression) actual).getFunctionHandle())) {
+            return false;
+        }
+        return process(expected.getValue(), ((CallExpression) actual).getArguments().get(0));
+    }
+
+    @Override
+    protected Boolean visitSymbolReference(SymbolReference expected, RowExpression actual)
+    {
+        if (!(actual instanceof VariableReferenceExpression)) {
+            return false;
+        }
+        return symbolAliases.get((expected).getName()).getName().equals(((VariableReferenceExpression) actual).getName());
+    }
+
+    @Override
+    protected Boolean visitCoalesceExpression(CoalesceExpression expected, RowExpression actual)
+    {
+        if (!(actual instanceof SpecialFormExpression) || !(((SpecialFormExpression) actual).getForm().equals(COALESCE))) {
+            return false;
+        }
+
+        SpecialFormExpression actualCoalesce = (SpecialFormExpression) actual;
+        if (expected.getOperands().size() == actualCoalesce.getArguments().size()) {
+            boolean verified = true;
+            for (int i = 0; i < expected.getOperands().size(); i++) {
+                verified &= process(expected.getOperands().get(i), actualCoalesce.getArguments().get(i));
+            }
+            return verified;
+        }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitSimpleCaseExpression(SimpleCaseExpression expected, RowExpression actual)
+    {
+        if (!(actual instanceof SpecialFormExpression && ((SpecialFormExpression) actual).getForm().equals(SWITCH))) {
+            return false;
+        }
+        SpecialFormExpression actualCase = (SpecialFormExpression) actual;
+        if (!process(expected.getOperand(), actualCase.getArguments().get(0))) {
+            return false;
+        }
+
+        List<RowExpression> whenClauses;
+        Optional<RowExpression> elseValue;
+        RowExpression last = actualCase.getArguments().get(actualCase.getArguments().size() - 1);
+        if (last instanceof SpecialFormExpression && ((SpecialFormExpression) last).getForm().equals(WHEN)) {
+            whenClauses = actualCase.getArguments().subList(1, actualCase.getArguments().size());
+            elseValue = Optional.empty();
+        }
+        else {
+            whenClauses = actualCase.getArguments().subList(1, actualCase.getArguments().size() - 1);
+            elseValue = Optional.of(last);
+        }
+
+        if (!process(expected.getWhenClauses(), whenClauses)) {
+            return false;
+        }
+
+        return process(expected.getDefaultValue(), elseValue);
+    }
+
+    @Override
+    protected Boolean visitWhenClause(WhenClause expected, RowExpression actual)
+    {
+        if (!(actual instanceof SpecialFormExpression && ((SpecialFormExpression) actual).getForm().equals(WHEN))) {
+            return false;
+        }
+        SpecialFormExpression actualWhenClause = (SpecialFormExpression) actual;
+
+        return process(expected.getOperand(), ((SpecialFormExpression) actual).getArguments().get(0)) &&
+                process(expected.getResult(), actualWhenClause.getArguments().get(1));
+    }
+
+    @Override
+    protected Boolean visitFunctionCall(FunctionCall expected, RowExpression actual)
+    {
+        if (!(actual instanceof CallExpression)) {
+            return false;
+        }
+        CallExpression actualFunction = (CallExpression) actual;
+
+        if (!expected.getName().equals(QualifiedName.of(actualFunction.getFunctionHandle().getSignature().getName()))) {
+            return false;
+        }
+
+        return process(expected.getArguments(), actualFunction.getArguments());
+    }
+
+    @Override
+    protected Boolean visitNullLiteral(NullLiteral node, RowExpression actual)
+    {
+        return actual instanceof ConstantExpression && ((ConstantExpression) actual).getValue() == null;
+    }
+
+    private <T extends Node> boolean process(List<T> expecteds, List<RowExpression> actuals)
+    {
+        if (expecteds.size() != actuals.size()) {
+            return false;
+        }
+        for (int i = 0; i < expecteds.size(); i++) {
+            if (!process(expecteds.get(i), actuals.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private <T extends Node> boolean process(Optional<T> expected, Optional<RowExpression> actual)
+    {
+        if (expected.isPresent() != actual.isPresent()) {
+            return false;
+        }
+        if (expected.isPresent()) {
+            return process(expected.get(), actual.get());
+        }
+        return true;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -99,6 +99,7 @@ import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HAS
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.constantNull;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.util.MoreLists.nElements;
@@ -242,6 +243,11 @@ public class PlanBuilder
     }
 
     public FilterNode filter(Expression predicate, PlanNode source)
+    {
+        return new FilterNode(idAllocator.getNextId(), source, castToRowExpression(predicate));
+    }
+
+    public FilterNode filter(RowExpression predicate, PlanNode source)
     {
         return new FilterNode(idAllocator.getNextId(), source, predicate);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/relational/TestDomainExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/relational/TestDomainExtractor.java
@@ -1,0 +1,1420 @@
+package com.facebook.presto.sql.relational;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.metadata.CastType;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.Range;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.CharType.createCharType;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
+import static com.facebook.presto.spi.type.Decimals.encodeScaledValue;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.HyperLogLogType.HYPER_LOG_LOG;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.LiteralEncoder.toRowExpression;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.constantNull;
+import static com.facebook.presto.sql.relational.Expressions.variable;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.FALSE;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.and;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.or;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static com.facebook.presto.type.ColorType.COLOR;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.floatToIntBits;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestDomainExtractor
+{
+    private RowExpression C_BIGINT;
+    private RowExpression C_DOUBLE;
+    private static final RowExpression C_VARCHAR = variable("x3", VARCHAR);
+    private static final RowExpression C_BOOLEAN = variable("x4", BOOLEAN);
+    private static final RowExpression C_BIGINT_1 = variable("x5", BIGINT);
+    private static final RowExpression C_DOUBLE_1 = variable("x6", DOUBLE);
+    private static final RowExpression C_VARCHAR_1 = variable("x7", VARCHAR);
+    private static final RowExpression C_TIMESTAMP = variable("x8", TIMESTAMP);
+    private static final RowExpression C_DATE = variable("x9", DATE);
+    private static final RowExpression C_COLOR = variable("x10", COLOR);
+    private static final RowExpression C_HYPER_LOG_LOG = variable("x11", HYPER_LOG_LOG);
+    private static final RowExpression C_VARBINARY = variable("x12", VARBINARY);
+    private static final RowExpression C_DECIMAL_26_5 = variable("x13", createDecimalType(26, 5));
+    private static final RowExpression C_DECIMAL_23_4 = variable("x14", createDecimalType(23, 4));
+    private static final RowExpression C_INTEGER = variable("x15", INTEGER);
+    private static final RowExpression C_CHAR = variable("x16", createCharType(10));
+    private static final RowExpression C_DECIMAL_21_3 = variable("x17", createDecimalType(21, 3));
+    private static final RowExpression C_DECIMAL_12_2 = variable("x18", createDecimalType(12, 2));
+    private static final RowExpression C_DECIMAL_6_1 = variable("x19", createDecimalType(6, 1));
+    private static final RowExpression C_DECIMAL_3_0 = variable("x20", createDecimalType(3, 0));
+    private static final RowExpression C_DECIMAL_2_0 = variable("x21", createDecimalType(2, 0));
+    private static final RowExpression C_SMALLINT = variable("x22", SMALLINT);
+    private static final RowExpression C_TINYINT = variable("x23", TINYINT);
+    private static final RowExpression C_REAL = variable("x24", REAL);
+
+    private static final long TIMESTAMP_VALUE = new DateTime(2013, 3, 30, 1, 5, 0, 0, DateTimeZone.UTC).getMillis();
+    private static final long DATE_VALUE = TimeUnit.MILLISECONDS.toDays(new DateTime(2001, 1, 22, 0, 0, 0, 0, DateTimeZone.UTC).getMillis());
+    private static final long COLOR_VALUE_1 = 1;
+    private static final long COLOR_VALUE_2 = 2;
+
+    private Metadata metadata;
+    private DomainExtractor domainTranslator;
+
+    @BeforeClass
+    public void setup()
+    {
+        metadata = createTestMetadataManager();
+        domainTranslator = new DomainExtractor(metadata.getFunctionManager());
+        C_BIGINT = add(variable("x1", BIGINT), constant(1, BIGINT));
+        C_DOUBLE = cast(variable("x2", BIGINT), DOUBLE);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        metadata = null;
+        domainTranslator = null;
+    }
+
+    @Test
+    public void testNoneRoundTrip()
+    {
+        TupleDomain<RowExpression> tupleDomain = TupleDomain.none();
+        DomainExtractor.ExtractionResult result = fromPredicate(toPredicate(tupleDomain));
+        assertEquals(result.getRemainingExpression(), TRUE);
+        assertEquals(result.getTupleDomain(), tupleDomain);
+    }
+
+    @Test
+    public void testAllRoundTrip()
+    {
+        TupleDomain<RowExpression> tupleDomain = TupleDomain.all();
+        DomainExtractor.ExtractionResult result = fromPredicate(toPredicate(tupleDomain));
+        assertEquals(result.getRemainingExpression(), TRUE);
+        assertEquals(result.getTupleDomain(), tupleDomain);
+    }
+
+    @Test
+    public void testRoundTrip()
+    {
+        TupleDomain<RowExpression> tupleDomain = withColumnDomains(ImmutableMap.<RowExpression, Domain>builder()
+                .put(C_BIGINT, Domain.singleValue(BIGINT, 1L))
+                .put(C_DOUBLE, Domain.onlyNull(DOUBLE))
+                .put(C_VARCHAR, Domain.notNull(VARCHAR))
+                .put(C_BOOLEAN, Domain.singleValue(BOOLEAN, true))
+                .put(C_BIGINT_1, Domain.singleValue(BIGINT, 2L))
+                .put(C_DOUBLE_1, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(DOUBLE, 1.1), Range.equal(DOUBLE, 2.0), Range.range(DOUBLE, 3.0, false, 3.5, true)), true))
+                .put(C_VARCHAR_1, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(VARCHAR, utf8Slice("2013-01-01")), Range.greaterThan(VARCHAR, utf8Slice("2013-10-01"))), false))
+                .put(C_TIMESTAMP, Domain.singleValue(TIMESTAMP, TIMESTAMP_VALUE))
+                .put(C_DATE, Domain.singleValue(DATE, DATE_VALUE))
+                .put(C_COLOR, Domain.singleValue(COLOR, COLOR_VALUE_1))
+                .put(C_HYPER_LOG_LOG, Domain.notNull(HYPER_LOG_LOG))
+                .build());
+
+        assertPredicateTranslates(toPredicate(tupleDomain), tupleDomain);
+    }
+
+    @Test
+    public void testInOptimization()
+    {
+        Domain testDomain = Domain.create(
+                ValueSet.all(BIGINT)
+                        .subtract(ValueSet.ofRanges(
+                                Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L))), false);
+
+        TupleDomain<RowExpression> tupleDomain = withColumnDomains(ImmutableMap.<RowExpression, Domain>builder().put(C_BIGINT, testDomain).build());
+        assertEquals(toPredicate(tupleDomain), not(bigintIn(C_BIGINT, ImmutableList.of(1L, 2L, 3L))));
+
+        testDomain = Domain.create(
+                ValueSet.ofRanges(
+                        Range.lessThan(BIGINT, 4L)).intersect(
+                        ValueSet.all(BIGINT)
+                                .subtract(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L)))), false);
+
+        tupleDomain = withColumnDomains(ImmutableMap.<RowExpression, Domain>builder().put(C_BIGINT, testDomain).build());
+        assertEquals(toPredicate(tupleDomain), and(lessThan(C_BIGINT, bigintLiteral(4L)), not(bigintIn(C_BIGINT, ImmutableList.of(1L, 2L, 3L)))));
+
+        testDomain = Domain.create(ValueSet.ofRanges(
+                Range.range(BIGINT, 1L, true, 3L, true),
+                Range.range(BIGINT, 5L, true, 7L, true),
+                Range.range(BIGINT, 9L, true, 11L, true)),
+                false);
+
+        tupleDomain = withColumnDomains(ImmutableMap.<RowExpression, Domain>builder().put(C_BIGINT, testDomain).build());
+        assertEquals(toPredicate(tupleDomain),
+                or(between(C_BIGINT, bigintLiteral(1L), bigintLiteral(3L)), (between(C_BIGINT, bigintLiteral(5L), bigintLiteral(7L))), (between(C_BIGINT, bigintLiteral(9L), bigintLiteral(11L)))));
+
+        testDomain = Domain.create(
+                ValueSet.ofRanges(
+                        Range.lessThan(BIGINT, 4L))
+                        .intersect(ValueSet.all(BIGINT)
+                                .subtract(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L))))
+                        .union(ValueSet.ofRanges(Range.range(BIGINT, 7L, true, 9L, true))), false);
+
+        tupleDomain = withColumnDomains(ImmutableMap.<RowExpression, Domain>builder().put(C_BIGINT, testDomain).build());
+        assertEquals(toPredicate(tupleDomain), or(and(lessThan(C_BIGINT, bigintLiteral(4L)), not(bigintIn(C_BIGINT, ImmutableList.of(1L, 2L, 3L)))), between(C_BIGINT, bigintLiteral(7L), bigintLiteral(9L))));
+
+        testDomain = Domain.create(
+                ValueSet.ofRanges(Range.lessThan(BIGINT, 4L))
+                        .intersect(ValueSet.all(BIGINT)
+                                .subtract(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L), Range.equal(BIGINT, 3L))))
+                        .union(ValueSet.ofRanges(Range.range(BIGINT, 7L, false, 9L, false), Range.range(BIGINT, 11L, false, 13L, false))), false);
+
+        tupleDomain = withColumnDomains(ImmutableMap.<RowExpression, Domain>builder().put(C_BIGINT, testDomain).build());
+        assertEquals(toPredicate(tupleDomain), or(
+                and(lessThan(C_BIGINT, bigintLiteral(4L)), not(bigintIn(C_BIGINT, ImmutableList.of(1L, 2L, 3L)))),
+                and(greaterThan(C_BIGINT, bigintLiteral(7L)), lessThan(C_BIGINT, bigintLiteral(9L))),
+                and(greaterThan(C_BIGINT, bigintLiteral(11L)), lessThan(C_BIGINT, bigintLiteral(13L)))));
+    }
+
+    @Test
+    public void testToPredicateNone()
+    {
+        TupleDomain<RowExpression> tupleDomain = withColumnDomains(ImmutableMap.<RowExpression, Domain>builder()
+                .put(C_BIGINT, Domain.singleValue(BIGINT, 1L))
+                .put(C_DOUBLE, Domain.onlyNull(DOUBLE))
+                .put(C_VARCHAR, Domain.notNull(VARCHAR))
+                .put(C_BOOLEAN, Domain.none(BOOLEAN))
+                .build());
+
+        assertEquals(toPredicate(tupleDomain), FALSE);
+    }
+
+    @Test
+    public void testToPredicateAllIgnored()
+    {
+        TupleDomain<RowExpression> tupleDomain = withColumnDomains(ImmutableMap.<RowExpression, Domain>builder()
+                .put(C_BIGINT, Domain.singleValue(BIGINT, 1L))
+                .put(C_DOUBLE, Domain.onlyNull(DOUBLE))
+                .put(C_VARCHAR, Domain.notNull(VARCHAR))
+                .put(C_BOOLEAN, Domain.all(BOOLEAN))
+                .build());
+
+        DomainExtractor.ExtractionResult result = fromPredicate(toPredicate(tupleDomain));
+        assertEquals(result.getRemainingExpression(), TRUE);
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.<RowExpression, Domain>builder()
+                .put(C_BIGINT, Domain.singleValue(BIGINT, 1L))
+                .put(C_DOUBLE, Domain.onlyNull(DOUBLE))
+                .put(C_VARCHAR, Domain.notNull(VARCHAR))
+                .build()));
+    }
+
+    @Test
+    public void testToPredicate()
+    {
+        TupleDomain<RowExpression> tupleDomain;
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT)));
+        assertEquals(toPredicate(tupleDomain), isNotNull(C_BIGINT));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.onlyNull(BIGINT)));
+        assertEquals(toPredicate(tupleDomain), isNull(C_BIGINT));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.none(BIGINT)));
+        assertEquals(toPredicate(tupleDomain), FALSE);
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.all(BIGINT)));
+        assertEquals(toPredicate(tupleDomain), TRUE);
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 1L)), false)));
+        assertEquals(toPredicate(tupleDomain), greaterThan(C_BIGINT, bigintLiteral(1L)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(BIGINT, 1L)), false)));
+        assertEquals(toPredicate(tupleDomain), greaterThanOrEqual(C_BIGINT, bigintLiteral(1L)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L)), false)));
+        assertEquals(toPredicate(tupleDomain), lessThan(C_BIGINT, bigintLiteral(1L)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 0L, false, 1L, true)), false)));
+        assertEquals(toPredicate(tupleDomain), and(greaterThan(C_BIGINT, bigintLiteral(0L)), lessThanOrEqual(C_BIGINT, bigintLiteral(1L))));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(BIGINT, 1L)), false)));
+        assertEquals(toPredicate(tupleDomain), lessThanOrEqual(C_BIGINT, bigintLiteral(1L)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.singleValue(BIGINT, 1L)));
+        assertEquals(toPredicate(tupleDomain), equal(C_BIGINT, bigintLiteral(1L)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L)), false)));
+        assertEquals(toPredicate(tupleDomain), bigintIn(C_BIGINT, ImmutableList.of(1L, 2L)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L)), true)));
+        assertEquals(toPredicate(tupleDomain), or(lessThan(C_BIGINT, bigintLiteral(1L)), isNull(C_BIGINT)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1), true)));
+        assertEquals(toPredicate(tupleDomain), or(equal(C_COLOR, colorLiteral(COLOR_VALUE_1)), isNull(C_COLOR)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1).complement(), true)));
+        assertEquals(toPredicate(tupleDomain), or(not(equal(C_COLOR, colorLiteral(COLOR_VALUE_1))), isNull(C_COLOR)));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_HYPER_LOG_LOG, Domain.onlyNull(HYPER_LOG_LOG)));
+        assertEquals(toPredicate(tupleDomain), isNull(C_HYPER_LOG_LOG));
+
+        tupleDomain = withColumnDomains(ImmutableMap.of(C_HYPER_LOG_LOG, Domain.notNull(HYPER_LOG_LOG)));
+        assertEquals(toPredicate(tupleDomain), isNotNull(C_HYPER_LOG_LOG));
+    }
+
+    @Test
+    public void testFromUnknownPredicate()
+    {
+        assertUnsupportedPredicate(unprocessableExpression1(C_BIGINT));
+        assertUnsupportedPredicate(not(unprocessableExpression1(C_BIGINT)));
+    }
+
+    @Test
+    public void testFromAndPredicate()
+    {
+        RowExpression originalPredicate = and(
+                and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT)));
+        DomainExtractor.ExtractionResult result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), and(unprocessableExpression1(C_BIGINT), unprocessableExpression2(C_BIGINT)));
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 1L, false, 5L, false)), false))));
+
+        // Test complements
+        assertUnsupportedPredicate(not(and(
+                and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT)))));
+
+        originalPredicate = not(and(
+                not(and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT))),
+                not(and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT)))));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), originalPredicate);
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT))));
+    }
+
+    @Test
+    public void testFromOrPredicate()
+    {
+        RowExpression originalPredicate = or(
+                and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT)));
+        DomainExtractor.ExtractionResult result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), originalPredicate);
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT))));
+
+        originalPredicate = or(
+                and(equal(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(equal(C_BIGINT, bigintLiteral(2L)), unprocessableExpression2(C_BIGINT)));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), originalPredicate);
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L)), false))));
+
+        // Same unprocessableExpression means that we can do more extraction
+        // If both sides are operating on the same single symbol
+        originalPredicate = or(
+                and(equal(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(equal(C_BIGINT, bigintLiteral(2L)), unprocessableExpression1(C_BIGINT)));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), unprocessableExpression1(C_BIGINT));
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L)), false))));
+
+        // And not if they have different symbols
+        assertUnsupportedPredicate(or(
+                and(equal(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(equal(C_DOUBLE, doubleLiteral(2.0)), unprocessableExpression1(C_BIGINT))));
+
+        // We can make another optimization if one side is the super set of the other side
+        originalPredicate = or(
+                and(greaterThan(C_BIGINT, bigintLiteral(1L)), greaterThan(C_DOUBLE, doubleLiteral(1.0)), unprocessableExpression1(C_BIGINT)),
+                and(greaterThan(C_BIGINT, bigintLiteral(2L)), greaterThan(C_DOUBLE, doubleLiteral(2.0)), unprocessableExpression1(C_BIGINT)));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), unprocessableExpression1(C_BIGINT));
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(
+                C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 1L)), false),
+                C_DOUBLE, Domain.create(ValueSet.ofRanges(Range.greaterThan(DOUBLE, 1.0)), false))));
+
+        // We can't make those inferences if the unprocessableExpressions are non-deterministic
+        originalPredicate = or(
+                and(equal(C_BIGINT, bigintLiteral(1L)), randPredicate(C_BIGINT)),
+                and(equal(C_BIGINT, bigintLiteral(2L)), randPredicate(C_BIGINT)));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), originalPredicate);
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L)), false))));
+
+        // Test complements
+        originalPredicate = not(or(
+                and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT)),
+                and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT))));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), and(
+                not(and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT))),
+                not(and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT)))));
+        assertTrue(result.getTupleDomain().isAll());
+
+        originalPredicate = not(or(
+                not(and(greaterThan(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT))),
+                not(and(lessThan(C_BIGINT, bigintLiteral(5L)), unprocessableExpression2(C_BIGINT)))));
+        result = fromPredicate(originalPredicate);
+        assertEquals(result.getRemainingExpression(), and(unprocessableExpression1(C_BIGINT), unprocessableExpression2(C_BIGINT)));
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 1L, false, 5L, false)), false))));
+    }
+
+    @Test
+    public void testFromNotPredicate()
+    {
+        assertUnsupportedPredicate(not(and(equal(C_BIGINT, bigintLiteral(1L)), unprocessableExpression1(C_BIGINT))));
+        assertUnsupportedPredicate(not(unprocessableExpression1(C_BIGINT)));
+
+        assertPredicateIsAlwaysFalse(not(TRUE));
+
+        assertPredicateTranslates(
+                not(equal(C_BIGINT, bigintLiteral(1L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L), Range.greaterThan(BIGINT, 1L)), false))));
+    }
+
+    @Test
+    public void testFromUnprocessableComparison()
+    {
+        assertUnsupportedPredicate(greaterThan(unprocessableExpression1(C_BIGINT), unprocessableExpression2(C_BIGINT)));
+        assertUnsupportedPredicate(not(greaterThan(unprocessableExpression1(C_BIGINT), unprocessableExpression2(C_BIGINT))));
+    }
+
+    @Test
+    public void testFromBasicComparisons()
+    {
+        // Test out the extraction of all basic comparisons
+        assertPredicateTranslates(
+                greaterThan(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                greaterThanOrEqual(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThan(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThanOrEqual(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                equal(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                notEqual(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L), Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                isDistinctFrom(C_BIGINT, bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L), Range.greaterThan(BIGINT, 2L)), true))));
+
+        assertPredicateTranslates(
+                equal(C_COLOR, colorLiteral(COLOR_VALUE_1)),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1), false))));
+
+        assertPredicateTranslates(
+                in(C_COLOR, ImmutableList.of(colorLiteral(COLOR_VALUE_1), colorLiteral(COLOR_VALUE_2))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1, COLOR_VALUE_2), false))));
+
+        assertPredicateTranslates(
+                not(in(C_COLOR, ImmutableList.of(colorLiteral(COLOR_VALUE_1), colorLiteral(COLOR_VALUE_2)))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1, COLOR_VALUE_2).complement(), false))));
+
+        assertPredicateTranslates(
+                in(C_COLOR, ImmutableList.of(colorLiteral(COLOR_VALUE_1), colorLiteral(COLOR_VALUE_2), constantNull(COLOR))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1, COLOR_VALUE_2), true))));
+
+        assertPredicateTranslates(
+                not(in(C_COLOR, ImmutableList.of(colorLiteral(COLOR_VALUE_1), colorLiteral(COLOR_VALUE_2), constantNull(COLOR)))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1, COLOR_VALUE_2).complement(), true))));
+
+        assertPredicateTranslates(
+                isDistinctFrom(C_COLOR, colorLiteral(COLOR_VALUE_1)),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1).complement(), true))));
+
+        // Test complement
+        assertPredicateTranslates(
+                not(greaterThan(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(greaterThanOrEqual(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(lessThan(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(lessThanOrEqual(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(equal(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L), Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(notEqual(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(isDistinctFrom(C_BIGINT, bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(equal(C_COLOR, colorLiteral(COLOR_VALUE_1))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1).complement(), false))));
+
+        assertPredicateTranslates(
+                not(in(C_COLOR, ImmutableList.of(colorLiteral(COLOR_VALUE_1), colorLiteral(COLOR_VALUE_2)))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1, COLOR_VALUE_2).complement(), false))));
+
+        assertPredicateTranslates(
+                not(isDistinctFrom(C_COLOR, colorLiteral(COLOR_VALUE_1))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1), false))));
+    }
+
+    @Test
+    public void testFromFlippedBasicComparisons()
+    {
+        // Test out the extraction of all basic comparisons where the reference literal ordering is flipped
+        assertPredicateTranslates(
+                greaterThan(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                greaterThanOrEqual(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThan(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThanOrEqual(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(equal(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(equal(colorLiteral(COLOR_VALUE_1), C_COLOR),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1), false))));
+
+        assertPredicateTranslates(notEqual(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L), Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                notEqual(colorLiteral(COLOR_VALUE_1), C_COLOR),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1).complement(), false))));
+
+        assertPredicateTranslates(isDistinctFrom(bigintLiteral(2L), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 2L), Range.greaterThan(BIGINT, 2L)), true))));
+
+        assertPredicateTranslates(
+                isDistinctFrom(colorLiteral(COLOR_VALUE_1), C_COLOR),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1).complement(), true))));
+
+        assertPredicateTranslates(
+                isDistinctFrom(nullLiteral(BIGINT), C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT))));
+    }
+
+    @Test
+    public void testFromBasicComparisonsWithNulls()
+    {
+        // Test out the extraction of all basic comparisons with null literals
+        assertPredicateIsAlwaysFalse(greaterThan(C_BIGINT, nullLiteral(BIGINT)));
+
+        assertPredicateTranslates(
+                greaterThan(C_VARCHAR, nullLiteral(VARCHAR)),
+                withColumnDomains(ImmutableMap.of(C_VARCHAR, Domain.create(ValueSet.none(VARCHAR), false))));
+
+        assertPredicateIsAlwaysFalse(greaterThanOrEqual(C_BIGINT, nullLiteral(BIGINT)));
+        assertPredicateIsAlwaysFalse(lessThan(C_BIGINT, nullLiteral(BIGINT)));
+        assertPredicateIsAlwaysFalse(lessThanOrEqual(C_BIGINT, nullLiteral(BIGINT)));
+        assertPredicateIsAlwaysFalse(equal(C_BIGINT, nullLiteral(BIGINT)));
+        assertPredicateIsAlwaysFalse(equal(C_COLOR, nullLiteral(COLOR)));
+        assertPredicateIsAlwaysFalse(notEqual(C_BIGINT, nullLiteral(BIGINT)));
+        assertPredicateIsAlwaysFalse(notEqual(C_COLOR, nullLiteral(COLOR)));
+
+        assertPredicateTranslates(
+                isDistinctFrom(C_BIGINT, nullLiteral(BIGINT)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT))));
+
+        assertPredicateTranslates(
+                isDistinctFrom(C_COLOR, nullLiteral(COLOR)),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.notNull(COLOR))));
+
+        // Test complements
+        assertPredicateIsAlwaysFalse(not(greaterThan(C_BIGINT, nullLiteral(BIGINT))));
+        assertPredicateIsAlwaysFalse(not(greaterThanOrEqual(C_BIGINT, nullLiteral(BIGINT))));
+        assertPredicateIsAlwaysFalse(not(lessThan(C_BIGINT, nullLiteral(BIGINT))));
+        assertPredicateIsAlwaysFalse(not(lessThanOrEqual(C_BIGINT, nullLiteral(BIGINT))));
+        assertPredicateIsAlwaysFalse(not(equal(C_BIGINT, nullLiteral(BIGINT))));
+        assertPredicateIsAlwaysFalse(not(equal(C_COLOR, nullLiteral(COLOR))));
+        assertPredicateIsAlwaysFalse(not(notEqual(C_BIGINT, nullLiteral(BIGINT))));
+        assertPredicateIsAlwaysFalse(not(notEqual(C_COLOR, nullLiteral(COLOR))));
+
+        assertPredicateTranslates(
+                not(isDistinctFrom(C_BIGINT, nullLiteral(BIGINT))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.onlyNull(BIGINT))));
+
+        assertPredicateTranslates(
+                not(isDistinctFrom(C_COLOR, nullLiteral(COLOR))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.onlyNull(COLOR))));
+    }
+
+    @Test
+    void testNonImplictCastOnSymbolSide()
+    {
+        // we expect TupleDomain.all here().
+        // see comment in ExpressionDomainTranslator.Visitor.visitComparisonExpression()
+        assertUnsupportedPredicate(equal(
+                cast(C_TIMESTAMP, DATE),
+                toRowExpression(DATE_VALUE, DATE)));
+        assertUnsupportedPredicate(equal(
+                cast(C_DECIMAL_12_2, BIGINT),
+                bigintLiteral(135L)));
+    }
+
+    @Test
+    void testNoSaturatedFloorCastFromUnsupportedApproximateDomain()
+    {
+        assertUnsupportedPredicate(equal(
+                cast(C_DECIMAL_12_2, DOUBLE),
+                doubleLiteral(12345.56)));
+
+        assertUnsupportedPredicate(equal(
+                cast(C_BIGINT, DOUBLE),
+                doubleLiteral(12345.56)));
+
+        assertUnsupportedPredicate(equal(
+                cast(C_BIGINT, REAL),
+                realLiteral(12345.56f)));
+
+        assertUnsupportedPredicate(equal(
+                cast(C_INTEGER, REAL),
+                realLiteral(12345.56f)));
+    }
+
+    @Test
+    public void testFromComparisonsWithCoercions()
+    {
+        // B is a double column. Check that it can be compared against longs
+        assertPredicateTranslates(
+                greaterThan(C_DOUBLE, cast(bigintLiteral(2L), DOUBLE)),
+                withColumnDomains(ImmutableMap.of(C_DOUBLE, Domain.create(ValueSet.ofRanges(Range.greaterThan(DOUBLE, 2.0)), false))));
+
+        // C is a string column. Check that it can be compared.
+        assertPredicateTranslates(
+                greaterThan(C_VARCHAR, stringLiteral("test")),
+                withColumnDomains(ImmutableMap.of(C_VARCHAR, Domain.create(ValueSet.ofRanges(Range.greaterThan(VARCHAR, utf8Slice("test"))), false))));
+
+        // A is a integer column. Check that it can be compared against doubles
+        assertPredicateTranslates(
+                greaterThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                greaterThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                greaterThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                greaterThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                lessThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                equal(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                equal(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.none(INTEGER))));
+
+        assertPredicateTranslates(
+                notEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThan(INTEGER, 2L), Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                notEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.notNull(INTEGER))));
+
+        assertPredicateTranslates(
+                isDistinctFrom(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThan(INTEGER, 2L), Range.greaterThan(INTEGER, 2L)), true))));
+
+        assertPredicateIsAlwaysTrue(isDistinctFrom(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1)));
+
+        // Test complements
+
+        // B is a double column. Check that it can be compared against longs
+        assertPredicateTranslates(
+                not(greaterThan(C_DOUBLE, cast(bigintLiteral(2L), DOUBLE))),
+                withColumnDomains(ImmutableMap.of(C_DOUBLE, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(DOUBLE, 2.0)), false))));
+
+        // C is a string column. Check that it can be compared.
+        assertPredicateTranslates(
+                not(greaterThan(C_VARCHAR, stringLiteral("test"))),
+                withColumnDomains(ImmutableMap.of(C_VARCHAR, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(VARCHAR, utf8Slice("test"))), false))));
+
+        // A is a integer column. Check that it can be compared against doubles
+        assertPredicateTranslates(
+                not(greaterThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(greaterThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(greaterThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(greaterThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(lessThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(lessThan(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(lessThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(lessThanOrEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(equal(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThan(INTEGER, 2L), Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(equal(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.notNull(INTEGER))));
+
+        assertPredicateTranslates(
+                not(notEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(notEqual(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.none(INTEGER))));
+
+        assertPredicateTranslates(
+                not(isDistinctFrom(cast(C_INTEGER, DOUBLE), doubleLiteral(2.0))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 2L)), false))));
+
+        assertPredicateIsAlwaysFalse(not(isDistinctFrom(cast(C_INTEGER, DOUBLE), doubleLiteral(2.1))));
+    }
+
+    @Test
+    public void testFromUnprocessableInPredicate()
+    {
+        assertUnsupportedPredicate(in(unprocessableExpression1(C_BIGINT), ImmutableList.of(TRUE)));
+        assertUnsupportedPredicate(in(C_BOOLEAN, ImmutableList.of(unprocessableExpression1(C_BOOLEAN))));
+        assertUnsupportedPredicate(
+                in(C_BOOLEAN, ImmutableList.of(TRUE, unprocessableExpression1(C_BOOLEAN))));
+        assertUnsupportedPredicate(not(in(C_BOOLEAN, ImmutableList.of(unprocessableExpression1(C_BOOLEAN)))));
+    }
+
+    @Test
+    public void testFromInPredicate()
+    {
+        assertPredicateTranslates(
+                bigintIn(C_BIGINT, ImmutableList.of(1L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.singleValue(BIGINT, 1L))));
+
+        assertPredicateTranslates(
+                in(C_COLOR, ImmutableList.of(colorLiteral(COLOR_VALUE_1))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.singleValue(COLOR, COLOR_VALUE_1))));
+
+        assertPredicateTranslates(
+                bigintIn(C_BIGINT, ImmutableList.of(1L, 2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                in(C_COLOR, ImmutableList.of(colorLiteral(COLOR_VALUE_1), colorLiteral(COLOR_VALUE_2))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1, COLOR_VALUE_2), false))));
+
+        assertPredicateTranslates(
+                not(bigintIn(C_BIGINT, ImmutableList.of(1L, 2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L), Range.range(BIGINT, 1L, false, 2L, false), Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(in(C_COLOR, ImmutableList.of(colorLiteral(COLOR_VALUE_1), colorLiteral(COLOR_VALUE_2)))),
+                withColumnDomains(ImmutableMap.of(C_COLOR, Domain.create(ValueSet.of(COLOR, COLOR_VALUE_1, COLOR_VALUE_2).complement(), false))));
+    }
+
+    @Test
+    public void testFromBetweenPredicate()
+    {
+        assertPredicateTranslates(
+                between(C_BIGINT, bigintLiteral(1L), bigintLiteral(2L)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 1L, true, 2L, true)), false))));
+
+        assertPredicateTranslates(
+                between(cast(C_INTEGER, DOUBLE), cast(bigintLiteral(1L), DOUBLE), doubleLiteral(2.1)),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.range(INTEGER, 1L, true, 2L, true)), false))));
+
+        assertPredicateIsAlwaysFalse(between(C_BIGINT, bigintLiteral(1L), nullLiteral(BIGINT)));
+
+        // Test complements
+        assertPredicateTranslates(
+                not(between(C_BIGINT, bigintLiteral(1L), bigintLiteral(2L))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L), Range.greaterThan(BIGINT, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(between(cast(C_INTEGER, DOUBLE), cast(bigintLiteral(1L), DOUBLE), doubleLiteral(2.1))),
+                withColumnDomains(ImmutableMap.of(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThan(INTEGER, 1L), Range.greaterThan(INTEGER, 2L)), false))));
+
+        assertPredicateTranslates(
+                not(between(C_BIGINT, bigintLiteral(1L), nullLiteral(BIGINT))),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L)), false))));
+    }
+
+    @Test
+    public void testFromIsNullPredicate()
+    {
+        assertPredicateTranslates(
+                isNull(C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.onlyNull(BIGINT))));
+
+        assertPredicateTranslates(
+                isNull(C_HYPER_LOG_LOG),
+                withColumnDomains(ImmutableMap.of(C_HYPER_LOG_LOG, Domain.onlyNull(HYPER_LOG_LOG))));
+
+        assertPredicateTranslates(
+                not(isNull(C_BIGINT)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT))));
+
+        assertPredicateTranslates(
+                not(isNull(C_HYPER_LOG_LOG)),
+                withColumnDomains(ImmutableMap.of(C_HYPER_LOG_LOG, Domain.notNull(HYPER_LOG_LOG))));
+    }
+
+    @Test
+    public void testFromIsNotNullPredicate()
+    {
+        assertPredicateTranslates(
+                isNotNull(C_BIGINT),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.notNull(BIGINT))));
+
+        assertPredicateTranslates(
+                isNotNull(C_HYPER_LOG_LOG),
+                withColumnDomains(ImmutableMap.of(C_HYPER_LOG_LOG, Domain.notNull(HYPER_LOG_LOG))));
+
+        assertPredicateTranslates(
+                not(isNotNull(C_BIGINT)),
+                withColumnDomains(ImmutableMap.of(C_BIGINT, Domain.onlyNull(BIGINT))));
+
+        assertPredicateTranslates(
+                not(isNotNull(C_HYPER_LOG_LOG)),
+                withColumnDomains(ImmutableMap.of(C_HYPER_LOG_LOG, Domain.onlyNull(HYPER_LOG_LOG))));
+    }
+
+    @Test
+    public void testFromBooleanLiteralPredicate()
+    {
+        assertPredicateIsAlwaysTrue(TRUE);
+        assertPredicateIsAlwaysFalse(not(TRUE));
+        assertPredicateIsAlwaysFalse(FALSE);
+        assertPredicateIsAlwaysTrue(not(FALSE));
+    }
+
+    @Test
+    public void testFromNullLiteralPredicate()
+    {
+        assertPredicateIsAlwaysFalse(nullLiteral(UNKNOWN));
+        assertPredicateIsAlwaysFalse(not(nullLiteral(UNKNOWN)));
+    }
+
+    @Test
+    public void testExpressionConstantFolding()
+    {
+        FunctionHandle hex = metadata.getFunctionManager().lookupFunction(QualifiedName.of("from_hex"), fromTypes(VARCHAR));
+        RowExpression originalExpression = greaterThan(C_VARBINARY, call(hex, VARBINARY, stringLiteral("123456")));
+        DomainExtractor.ExtractionResult result = fromPredicate(originalExpression);
+        assertEquals(result.getRemainingExpression(), TRUE);
+        Slice value = Slices.wrappedBuffer(BaseEncoding.base16().decode("123456"));
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(C_VARBINARY, Domain.create(ValueSet.ofRanges(Range.greaterThan(VARBINARY, value)), false))));
+
+        RowExpression expression = toPredicate(result.getTupleDomain());
+        assertEquals(expression, greaterThan(C_VARBINARY, varbinaryLiteral(value)));
+    }
+
+    @Test
+    public void testConjunctExpression()
+    {
+        RowExpression expression = and(
+                greaterThan(C_DOUBLE, doubleLiteral(0)),
+                greaterThan(C_BIGINT, bigintLiteral(0)));
+        assertPredicateTranslates(
+                expression,
+                withColumnDomains(ImmutableMap.of(
+                        C_BIGINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 0L)), false),
+                        C_DOUBLE, Domain.create(ValueSet.ofRanges(Range.greaterThan(DOUBLE, .0)), false))));
+
+        assertEquals(
+                toPredicate(fromPredicate(expression).getTupleDomain()),
+                and(
+                        greaterThan(C_BIGINT, bigintLiteral(0)),
+                        greaterThan(C_DOUBLE, doubleLiteral(0))));
+    }
+
+    @Test
+    void testMultipleCoercionsOnSymbolSide()
+    {
+        assertPredicateTranslates(
+                greaterThan(cast(cast(C_SMALLINT, REAL), DOUBLE), doubleLiteral(3.7)),
+                withColumnDomains(ImmutableMap.of(C_SMALLINT, Domain.create(ValueSet.ofRanges(Range.greaterThan(SMALLINT, 3L)), false))));
+    }
+
+    @Test
+    public void testNumericTypeTranslation()
+    {
+        testNumericTypeTranslationChain(
+                new NumericValues<>(C_DECIMAL_26_5, longDecimal("-999999999999999999999.99999"), longDecimal("-22.00000"), longDecimal("-44.55569"), longDecimal("23.00000"), longDecimal("44.55567"), longDecimal("999999999999999999999.99999")),
+                new NumericValues<>(C_DECIMAL_23_4, longDecimal("-9999999999999999999.9999"), longDecimal("-22.0000"), longDecimal("-44.5557"), longDecimal("23.0000"), longDecimal("44.5556"), longDecimal("9999999999999999999.9999")),
+                new NumericValues<>(C_BIGINT, Long.MIN_VALUE, -22L, -45L, 23L, 44L, Long.MAX_VALUE),
+                new NumericValues<>(C_DECIMAL_21_3, longDecimal("-999999999999999999.999"), longDecimal("-22.000"), longDecimal("-44.556"), longDecimal("23.000"), longDecimal("44.555"), longDecimal("999999999999999999.999")),
+                new NumericValues<>(C_DECIMAL_12_2, shortDecimal("-9999999999.99"), shortDecimal("-22.00"), shortDecimal("-44.56"), shortDecimal("23.00"), shortDecimal("44.55"), shortDecimal("9999999999.99")),
+                new NumericValues<>(C_INTEGER, (long) Integer.MIN_VALUE, -22L, -45L, 23L, 44L, (long) Integer.MAX_VALUE),
+                new NumericValues<>(C_DECIMAL_6_1, shortDecimal("-99999.9"), shortDecimal("-22.0"), shortDecimal("-44.6"), shortDecimal("23.0"), shortDecimal("44.5"), shortDecimal("99999.9")),
+                new NumericValues<>(C_SMALLINT, (long) Short.MIN_VALUE, -22L, -45L, 23L, 44L, (long) Short.MAX_VALUE),
+                new NumericValues<>(C_DECIMAL_3_0, shortDecimal("-999"), shortDecimal("-22"), shortDecimal("-45"), shortDecimal("23"), shortDecimal("44"), shortDecimal("999")),
+                new NumericValues<>(C_TINYINT, (long) Byte.MIN_VALUE, -22L, -45L, 23L, 44L, (long) Byte.MAX_VALUE),
+                new NumericValues<>(C_DECIMAL_2_0, shortDecimal("-99"), shortDecimal("-22"), shortDecimal("-45"), shortDecimal("23"), shortDecimal("44"), shortDecimal("99")));
+
+        testNumericTypeTranslationChain(
+                new NumericValues<>(C_DOUBLE, -1.0 * Double.MAX_VALUE, -22.0, -44.5556836, 23.0, 44.5556789, Double.MAX_VALUE),
+                new NumericValues<>(C_REAL, realValue(-1.0f * Float.MAX_VALUE), realValue(-22.0f), realValue(-44.555687f), realValue(23.0f), realValue(44.555676f), realValue(Float.MAX_VALUE)));
+    }
+
+    private void testNumericTypeTranslationChain(NumericValues... translationChain)
+    {
+        for (int literalIndex = 0; literalIndex < translationChain.length; literalIndex++) {
+            for (int columnIndex = literalIndex + 1; columnIndex < translationChain.length; columnIndex++) {
+                NumericValues literal = translationChain[literalIndex];
+                NumericValues column = translationChain[columnIndex];
+                testNumericTypeTranslation(column, literal);
+            }
+        }
+    }
+
+    private void testNumericTypeTranslation(NumericValues columnValues, NumericValues literalValues)
+    {
+        Type columnType = columnValues.getInput().getType();
+        Type literalType = literalValues.getInput().getType();
+        Type superType = metadata.getTypeManager().getCommonSuperType(columnType, literalType).orElseThrow(() -> new IllegalArgumentException("incompatible types in test (" + columnType + ", " + literalType + ")"));
+
+        RowExpression max = toRowExpression(literalValues.getMax(), literalType);
+        RowExpression min = toRowExpression(literalValues.getMin(), literalType);
+        RowExpression integerPositive = toRowExpression(literalValues.getIntegerPositive(), literalType);
+        RowExpression integerNegative = toRowExpression(literalValues.getIntegerNegative(), literalType);
+        RowExpression fractionalPositive = toRowExpression(literalValues.getFractionalPositive(), literalType);
+        RowExpression fractionalNegative = toRowExpression(literalValues.getFractionalNegative(), literalType);
+
+        if (!literalType.equals(superType)) {
+            max = cast(max, superType);
+            min = cast(min, superType);
+            integerPositive = cast(integerPositive, superType);
+            integerNegative = cast(integerNegative, superType);
+            fractionalPositive = cast(fractionalPositive, superType);
+            fractionalNegative = cast(fractionalNegative, superType);
+        }
+
+        RowExpression columnSymbol = columnValues.getInput();
+        RowExpression columnExpression = columnSymbol;
+
+        if (!columnType.equals(superType)) {
+            columnExpression = cast(columnExpression, superType);
+        }
+
+        // greater than or equal
+        testSimpleComparison(greaterThanOrEqual(columnExpression, integerPositive), columnSymbol, Range.greaterThanOrEqual(columnType, columnValues.getIntegerPositive()));
+        testSimpleComparison(greaterThanOrEqual(columnExpression, integerNegative), columnSymbol, Range.greaterThanOrEqual(columnType, columnValues.getIntegerNegative()));
+        testSimpleComparison(greaterThanOrEqual(columnExpression, max), columnSymbol, Range.greaterThan(columnType, columnValues.getMax()));
+        testSimpleComparison(greaterThanOrEqual(columnExpression, min), columnSymbol, Range.greaterThanOrEqual(columnType, columnValues.getMin()));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(greaterThanOrEqual(columnExpression, fractionalPositive), columnSymbol, Range.greaterThan(columnType, columnValues.getFractionalPositive()));
+            testSimpleComparison(greaterThanOrEqual(columnExpression, fractionalNegative), columnSymbol, Range.greaterThan(columnType, columnValues.getFractionalNegative()));
+        }
+
+        // greater than
+        testSimpleComparison(greaterThan(columnExpression, integerPositive), columnSymbol, Range.greaterThan(columnType, columnValues.getIntegerPositive()));
+        testSimpleComparison(greaterThan(columnExpression, integerNegative), columnSymbol, Range.greaterThan(columnType, columnValues.getIntegerNegative()));
+        testSimpleComparison(greaterThan(columnExpression, max), columnSymbol, Range.greaterThan(columnType, columnValues.getMax()));
+        testSimpleComparison(greaterThan(columnExpression, min), columnSymbol, Range.greaterThanOrEqual(columnType, columnValues.getMin()));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(greaterThan(columnExpression, fractionalPositive), columnSymbol, Range.greaterThan(columnType, columnValues.getFractionalPositive()));
+            testSimpleComparison(greaterThan(columnExpression, fractionalNegative), columnSymbol, Range.greaterThan(columnType, columnValues.getFractionalNegative()));
+        }
+
+        // less than or equal
+        testSimpleComparison(lessThanOrEqual(columnExpression, integerPositive), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getIntegerPositive()));
+        testSimpleComparison(lessThanOrEqual(columnExpression, integerNegative), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getIntegerNegative()));
+        testSimpleComparison(lessThanOrEqual(columnExpression, max), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getMax()));
+        testSimpleComparison(lessThanOrEqual(columnExpression, min), columnSymbol, Range.lessThan(columnType, columnValues.getMin()));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(lessThanOrEqual(columnExpression, fractionalPositive), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getFractionalPositive()));
+            testSimpleComparison(lessThanOrEqual(columnExpression, fractionalNegative), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getFractionalNegative()));
+        }
+
+        // less than
+        testSimpleComparison(lessThan(columnExpression, integerPositive), columnSymbol, Range.lessThan(columnType, columnValues.getIntegerPositive()));
+        testSimpleComparison(lessThan(columnExpression, integerNegative), columnSymbol, Range.lessThan(columnType, columnValues.getIntegerNegative()));
+        testSimpleComparison(lessThan(columnExpression, max), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getMax()));
+        testSimpleComparison(lessThan(columnExpression, min), columnSymbol, Range.lessThan(columnType, columnValues.getMin()));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(lessThan(columnExpression, fractionalPositive), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getFractionalPositive()));
+            testSimpleComparison(lessThan(columnExpression, fractionalNegative), columnSymbol, Range.lessThanOrEqual(columnType, columnValues.getFractionalNegative()));
+        }
+
+        // equal
+        testSimpleComparison(equal(columnExpression, integerPositive), columnSymbol, Range.equal(columnType, columnValues.getIntegerPositive()));
+        testSimpleComparison(equal(columnExpression, integerNegative), columnSymbol, Range.equal(columnType, columnValues.getIntegerNegative()));
+        testSimpleComparison(equal(columnExpression, max), columnSymbol, Domain.none(columnType));
+        testSimpleComparison(equal(columnExpression, min), columnSymbol, Domain.none(columnType));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(equal(columnExpression, fractionalPositive), columnSymbol, Domain.none(columnType));
+            testSimpleComparison(equal(columnExpression, fractionalNegative), columnSymbol, Domain.none(columnType));
+        }
+
+        // not equal
+        testSimpleComparison(notEqual(columnExpression, integerPositive), columnSymbol, Domain.create(ValueSet.ofRanges(Range.lessThan(columnType, columnValues.getIntegerPositive()), Range.greaterThan(columnType, columnValues.getIntegerPositive())), false));
+        testSimpleComparison(notEqual(columnExpression, integerNegative), columnSymbol, Domain.create(ValueSet.ofRanges(Range.lessThan(columnType, columnValues.getIntegerNegative()), Range.greaterThan(columnType, columnValues.getIntegerNegative())), false));
+        testSimpleComparison(notEqual(columnExpression, max), columnSymbol, Domain.notNull(columnType));
+        testSimpleComparison(notEqual(columnExpression, min), columnSymbol, Domain.notNull(columnType));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(notEqual(columnExpression, fractionalPositive), columnSymbol, Domain.notNull(columnType));
+            testSimpleComparison(notEqual(columnExpression, fractionalNegative), columnSymbol, Domain.notNull(columnType));
+        }
+
+        // is distinct from
+        testSimpleComparison(isDistinctFrom(columnExpression, integerPositive), columnSymbol, Domain.create(ValueSet.ofRanges(Range.lessThan(columnType, columnValues.getIntegerPositive()), Range.greaterThan(columnType, columnValues.getIntegerPositive())), true));
+        testSimpleComparison(isDistinctFrom(columnExpression, integerNegative), columnSymbol, Domain.create(ValueSet.ofRanges(Range.lessThan(columnType, columnValues.getIntegerNegative()), Range.greaterThan(columnType, columnValues.getIntegerNegative())), true));
+        testSimpleComparison(isDistinctFrom(columnExpression, max), columnSymbol, Domain.all(columnType));
+        testSimpleComparison(isDistinctFrom(columnExpression, min), columnSymbol, Domain.all(columnType));
+        if (literalValues.isFractional()) {
+            testSimpleComparison(isDistinctFrom(columnExpression, fractionalPositive), columnSymbol, Domain.all(columnType));
+            testSimpleComparison(isDistinctFrom(columnExpression, fractionalNegative), columnSymbol, Domain.all(columnType));
+        }
+    }
+
+    @Test
+    public void testLegacyCharComparedToVarcharExpression()
+    {
+        metadata = createTestMetadataManager(new FeaturesConfig().setLegacyCharToVarcharCoercion(true));
+
+        String maxCodePoint = new String(Character.toChars(Character.MAX_CODE_POINT));
+
+        // greater than or equal
+        testSimpleComparison(greaterThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.greaterThan(createCharType(10), utf8Slice("123456788" + maxCodePoint)));
+        testSimpleComparison(greaterThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.greaterThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(greaterThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890")));
+
+        // greater than
+        testSimpleComparison(greaterThan(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.greaterThan(createCharType(10), utf8Slice("123456788" + maxCodePoint)));
+        testSimpleComparison(greaterThan(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(greaterThan(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890")));
+
+        // less than or equal
+        testSimpleComparison(lessThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.lessThanOrEqual(createCharType(10), utf8Slice("123456788" + maxCodePoint)));
+        testSimpleComparison(lessThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.lessThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(lessThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.lessThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")));
+
+        // less than
+        testSimpleComparison(lessThan(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.lessThanOrEqual(createCharType(10), utf8Slice("123456788" + maxCodePoint)));
+        testSimpleComparison(lessThan(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.lessThan(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(lessThan(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.lessThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")));
+
+        // equal
+        testSimpleComparison(equal(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Domain.none(createCharType(10)));
+        testSimpleComparison(equal(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.equal(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(equal(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Domain.none(createCharType(10)));
+
+        // not equal
+        testSimpleComparison(notEqual(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Domain.notNull(createCharType(10)));
+        testSimpleComparison(notEqual(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Domain.create(ValueSet.ofRanges(
+                Range.lessThan(createCharType(10), Slices.utf8Slice("1234567890")), Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890"))), false));
+        testSimpleComparison(notEqual(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Domain.notNull(createCharType(10)));
+
+        // is distinct from
+        testSimpleComparison(isDistinctFrom(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Domain.all(createCharType(10)));
+        testSimpleComparison(isDistinctFrom(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Domain.create(ValueSet.ofRanges(
+                Range.lessThan(createCharType(10), Slices.utf8Slice("1234567890")), Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890"))), true));
+        testSimpleComparison(isDistinctFrom(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Domain.all(createCharType(10)));
+    }
+
+    @Test
+    public void testCharComparedToVarcharExpression()
+    {
+        Type charType = createCharType(10);
+        // varchar literal is coerced to column (char) type
+        testSimpleComparison(equal(C_CHAR, cast(stringLiteral("abc"), charType)), C_CHAR, Range.equal(charType, Slices.utf8Slice("abc")));
+
+        // both sides got coerced to char(11)
+        charType = createCharType(11);
+        assertUnsupportedPredicate(equal(cast(C_CHAR, charType), cast(stringLiteral("abc12345678"), charType)));
+    }
+
+    private void assertPredicateTranslates(RowExpression expression, TupleDomain<RowExpression> tupleDomain)
+    {
+        DomainExtractor.ExtractionResult result = fromPredicate(expression);
+        assertEquals(result.getRemainingExpression(), TRUE);
+        assertEquals(result.getTupleDomain(), tupleDomain);
+    }
+
+    private void assertPredicateIsAlwaysTrue(RowExpression expression)
+    {
+        assertPredicateTranslates(expression, TupleDomain.all());
+    }
+
+    private void assertPredicateIsAlwaysFalse(RowExpression expression)
+    {
+        DomainExtractor.ExtractionResult result = fromPredicate(expression);
+        assertEquals(result.getRemainingExpression(), TRUE);
+        assertTrue(result.getTupleDomain().isNone());
+    }
+
+    private RowExpression toPredicate(TupleDomain<? extends RowExpression> tupleDomain)
+    {
+        return domainTranslator.toPredicate(tupleDomain);
+    }
+
+    private DomainExtractor.ExtractionResult fromPredicate(RowExpression originalPredicate)
+    {
+        return domainTranslator.fromPredicate(metadata, TEST_SESSION, originalPredicate);
+    }
+
+    private RowExpression nullLiteral(Type type)
+    {
+        return constantNull(type);
+    }
+
+    private RowExpression stringLiteral(String value)
+    {
+        return constant(Slices.utf8Slice(value), VARCHAR);
+    }
+
+    private RowExpression bigintLiteral(long value)
+    {
+        return constant(value, BIGINT);
+    }
+
+    private RowExpression doubleLiteral(double value)
+    {
+        return constant(value, DOUBLE);
+    }
+
+    private RowExpression varbinaryLiteral(Slice value)
+    {
+        return constant(value, VARBINARY);
+    }
+
+    private long realValue(float value)
+    {
+        return (long) floatToIntBits(value);
+    }
+
+    private RowExpression realLiteral(float value)
+    {
+        return constant(realValue(value), REAL);
+    }
+
+    private RowExpression colorLiteral(long value)
+    {
+        return constant(value, COLOR);
+    }
+
+    private static Long shortDecimal(String value)
+    {
+        return new BigDecimal(value).unscaledValue().longValueExact();
+    }
+
+    private static Slice longDecimal(String value)
+    {
+        return encodeScaledValue(new BigDecimal(value));
+    }
+
+    private static RowExpression isNull(RowExpression expression)
+    {
+        return new SpecialFormExpression(IS_NULL, BOOLEAN, expression);
+    }
+
+    private RowExpression cast(RowExpression expression, Type toType)
+    {
+        FunctionHandle cast = metadata.getFunctionManager().lookupCast(CastType.CAST, expression.getType().getTypeSignature(), toType.getTypeSignature());
+        return call(cast, toType, expression);
+    }
+
+    private RowExpression not(RowExpression expression)
+    {
+        return call(new StandardFunctionResolution(metadata.getFunctionManager()).notFunction(), expression.getType(), expression);
+    }
+
+    private RowExpression in(RowExpression value, List<RowExpression> inList)
+    {
+        return new SpecialFormExpression(IN, BOOLEAN, ImmutableList.<RowExpression>builder().add(value).addAll(inList).build());
+    }
+
+    private RowExpression add(RowExpression left, RowExpression right)
+    {
+        return call(
+                new StandardFunctionResolution(metadata.getFunctionManager()).arithmeticFunction(ArithmeticBinaryExpression.Operator.ADD, left.getType(), right.getType()),
+                left.getType(),
+                ImmutableList.of(left, right));
+    }
+
+    private RowExpression isNotNull(RowExpression expression)
+    {
+        return not(isNull(expression));
+    }
+
+    private RowExpression bigintIn(RowExpression value, List<Long> inList)
+    {
+        List<RowExpression> arguments = inList.stream().map(argument -> constant(argument, BIGINT)).collect(toImmutableList());
+        return in(value, arguments);
+    }
+
+    private RowExpression binaryOperator(OperatorType operatorType, RowExpression left, RowExpression right)
+    {
+        return call(
+                metadata.getFunctionManager().resolveOperator(operatorType, fromTypes(left.getType(), right.getType())),
+                BOOLEAN,
+                left,
+                right);
+    }
+
+    private RowExpression between(RowExpression value, RowExpression min, RowExpression max)
+    {
+        return call(
+                metadata.getFunctionManager().resolveOperator(OperatorType.BETWEEN, fromTypes(value.getType(), min.getType(), max.getType())),
+                BOOLEAN,
+                value,
+                min,
+                max);
+    }
+
+    private RowExpression isDistinctFrom(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.IS_DISTINCT_FROM, left, right);
+    }
+
+    private RowExpression greaterThan(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.GREATER_THAN, left, right);
+    }
+
+    private RowExpression lessThan(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.LESS_THAN, left, right);
+    }
+
+    private RowExpression greaterThanOrEqual(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(GREATER_THAN_OR_EQUAL, left, right);
+    }
+
+    private RowExpression lessThanOrEqual(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(LESS_THAN_OR_EQUAL, left, right);
+    }
+
+    private RowExpression equal(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.EQUAL, left, right);
+    }
+
+    private RowExpression notEqual(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(NOT_EQUAL, left, right);
+    }
+
+    private RowExpression unprocessableExpression1(RowExpression expression)
+    {
+        return greaterThan(expression, expression);
+    }
+
+    private RowExpression unprocessableExpression2(RowExpression expression)
+    {
+        return lessThan(expression, expression);
+    }
+
+    private RowExpression randPredicate(RowExpression expression)
+    {
+        RowExpression random = call(metadata.getFunctionManager().lookupFunction(QualifiedName.of("random"), fromTypes()), DOUBLE);
+        return greaterThan(
+                expression,
+                call(metadata.getFunctionManager().lookupCast(CastType.CAST, DOUBLE.getTypeSignature(), expression.getType().getTypeSignature()), expression.getType(), random));
+    }
+
+    private void assertUnsupportedPredicate(RowExpression expression)
+    {
+        DomainExtractor.ExtractionResult result = fromPredicate(expression);
+        assertEquals(result.getRemainingExpression(), expression);
+        assertEquals(result.getTupleDomain(), TupleDomain.all());
+    }
+
+    private void testSimpleComparison(RowExpression expression, RowExpression input, Range expectedDomainRange)
+    {
+        testSimpleComparison(expression, input, Domain.create(ValueSet.ofRanges(expectedDomainRange), false));
+    }
+
+    private void testSimpleComparison(RowExpression expression, RowExpression input, Domain domain)
+    {
+        DomainExtractor.ExtractionResult result = fromPredicate(expression);
+        assertEquals(result.getRemainingExpression(), TRUE);
+        TupleDomain<RowExpression> actual = result.getTupleDomain();
+        TupleDomain<RowExpression> expected = withColumnDomains(ImmutableMap.of(input, domain));
+        if (!actual.equals(expected)) {
+            fail(format("for comparison [%s] expected %s but found %s", expression.toString(), expected.toString(SESSION), actual.toString(SESSION)));
+        }
+    }
+
+    private static class NumericValues<T>
+    {
+        private final RowExpression input;
+        private final T min;
+        private final T integerNegative;
+        private final T fractionalNegative;
+        private final T integerPositive;
+        private final T fractionalPositive;
+        private final T max;
+
+        private NumericValues(RowExpression input, T min, T integerNegative, T fractionalNegative, T integerPositive, T fractionalPositive, T max)
+        {
+            this.input = requireNonNull(input, "input is null");
+            this.min = requireNonNull(min, "min is null");
+            this.integerNegative = requireNonNull(integerNegative, "integerNegative is null");
+            this.fractionalNegative = requireNonNull(fractionalNegative, "fractionalNegative is null");
+            this.integerPositive = requireNonNull(integerPositive, "integerPositive is null");
+            this.fractionalPositive = requireNonNull(fractionalPositive, "fractionalPositive is null");
+            this.max = requireNonNull(max, "max is null");
+        }
+
+        public RowExpression getInput()
+        {
+            return input;
+        }
+
+        public T getMin()
+        {
+            return min;
+        }
+
+        public T getIntegerNegative()
+        {
+            return integerNegative;
+        }
+
+        public T getFractionalNegative()
+        {
+            return fractionalNegative;
+        }
+
+        public T getIntegerPositive()
+        {
+            return integerPositive;
+        }
+
+        public T getFractionalPositive()
+        {
+            return fractionalPositive;
+        }
+
+        public T getMax()
+        {
+            return max;
+        }
+
+        public boolean isFractional()
+        {
+            return input.getType() == DOUBLE || input.getType() == REAL || (input.getType() instanceof DecimalType && ((DecimalType) input.getType()).getScale() > 0);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/relational/TestDomainExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/relational/TestDomainExtractor.java
@@ -134,7 +134,7 @@ public class TestDomainExtractor
     private static final long COLOR_VALUE_2 = 2;
 
     private Metadata metadata;
-    private DomainExtractor domainTranslator;
+    private RowExpressionDomainTranslator domainTranslator;
     private RowExpressionCanonicalizer canonicalizer;
 
     private RowExpression opBigint;
@@ -145,7 +145,7 @@ public class TestDomainExtractor
     public void setup()
     {
         metadata = createTestMetadataManager();
-        domainTranslator = new DomainExtractor(metadata.getFunctionManager());
+        domainTranslator = new RowExpressionDomainTranslator(metadata.getFunctionManager());
         opBigint = add(C_BIGINT, constant(1, BIGINT));
         opDouble = dereference(DOUBLE, C_ROW, constant(1, INTEGER));
         opVarchar = regex_extract(C_VARCHAR, constant(Slices.utf8Slice("test"), JoniRegexpType.JONI_REGEXP));
@@ -1205,7 +1205,7 @@ public class TestDomainExtractor
 
     private DomainExtractor.ExtractionResult fromPredicate(RowExpression originalPredicate)
     {
-        return domainTranslator.fromPredicate(metadata, TEST_SESSION, originalPredicate);
+        return DomainExtractor.fromPredicate(metadata, TEST_SESSION, originalPredicate);
     }
 
     private RowExpression nullLiteral(Type type)

--- a/presto-main/src/test/java/com/facebook/presto/sql/relational/TestDomainExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/relational/TestDomainExtractor.java
@@ -1205,7 +1205,9 @@ public class TestDomainExtractor
 
     private DomainExtractor.ExtractionResult fromPredicate(RowExpression originalPredicate)
     {
-        return DomainExtractor.fromPredicate(metadata, TEST_SESSION, originalPredicate);
+        // metadata can be updated for testing legacy behaviors
+        DomainExtractor domainExtractor = new DomainExtractor(metadata.getFunctionManager(), metadata.getTypeManager(), new InterpretedPredicateOptimizer(metadata, TEST_SESSION));
+        return domainExtractor.extract(originalPredicate);
     }
 
     private RowExpression nullLiteral(Type type)

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/FileWriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/FileWriter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.storage;
+
+import com.facebook.presto.spi.Page;
+
+import java.io.Closeable;
+import java.util.List;
+
+public interface FileWriter
+        extends Closeable
+{
+    void appendPages(List<Page> pages);
+
+    void appendPages(List<Page> pages, int[] pageIndexes, int[] positionIndexes);
+
+    long getRowCount();
+
+    long getUncompressedSize();
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/OperatorType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/OperatorType.java
@@ -54,4 +54,20 @@ public enum OperatorType
     {
         return calledOnNullInput;
     }
+
+    public boolean isComparisonOperator()
+    {
+        return this.equals(EQUAL) ||
+                this.equals(NOT_EQUAL) ||
+                this.equals(LESS_THAN) ||
+                this.equals(LESS_THAN_OR_EQUAL) ||
+                this.equals(GREATER_THAN) ||
+                this.equals(GREATER_THAN_OR_EQUAL) ||
+                this.equals(IS_DISTINCT_FROM);
+    }
+
+    public boolean isArithmeticOperator()
+    {
+        return this.equals(ADD) || this.equals(SUBTRACT) || this.equals(MULTIPLY) || this.equals(DIVIDE) || this.equals(MODULUS);
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/Domain.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/Domain.java
@@ -214,6 +214,10 @@ public final class Domain
 
     public Domain complement()
     {
+        // we need to have following
+//        if (!values.isNone()) {
+//            return new Domain(values.complement(), nullAllowed);
+//        }
         return new Domain(values.complement(), !nullAllowed);
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4325,8 +4325,17 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT x IN (0) FROM (values 4294967296) t(x)", "values false");
         assertQuery("SELECT x IN (0, 4294967297 + CAST(rand() < 0 AS bigint)) FROM (values 4294967296, 4294967297) t(x)", "values false, true");
         assertQuery("SELECT NULL in (1, 2, 3)", "values null");
+        assertQuery("SELECT NULL not in (1, 2, 3)", "values null");
+        assertQuery("SELECT NULL in (NULL)", "values null");
+        assertQuery("SELECT NULL not in (NULL)", "values null");
+        assertQuery("SELECT 1 not in (NULL)", "values null");
+        assertQuery("SELECT 1 in (NULL)", "values null");
+        assertQuery("SELECT NULL in (1, NULL, 3)", "values null");
+        assertQuery("SELECT NULL not in (1, NULL, 3)", "values null");
         assertQuery("SELECT 1 in (1, NULL, 3)", "values true");
+        assertQuery("SELECT 1 NOT IN (1, NULL, 3)", "values false");
         assertQuery("SELECT 2 in (1, NULL, 3)", "values null");
+        assertQuery("SELECT 2 not in (1, NULL, 3)", "values null");
         assertQuery("SELECT x FROM (values DATE '1970-01-01', DATE '1970-01-03') t(x) WHERE x IN (DATE '1970-01-01')", "values DATE '1970-01-01'");
         assertEquals(
                 computeActual("SELECT x FROM (values TIMESTAMP '1970-01-01 00:01:00+00:00', TIMESTAMP '1970-01-01 08:01:00+08:00', TIMESTAMP '1970-01-01 00:01:00+08:00') t(x) WHERE x IN (TIMESTAMP '1970-01-01 00:01:00+00:00')")


### PR DESCRIPTION
On top of #12523, the purpose of this PR is:

For row expression such as:
```
(a+b) > 1 
a.b IN (1, 2, 3, 4)
``` 
We should be able to extract the domain for these parts:
```
(a+b) : range(1, +Inf)
a.b : (1,2,3,4)
```

This also allows if we have predicate comparator (useful for predicate pushdown), we can check if a predicate satisfies (is more specific than) another predicate:
```
a.b IN (1, 2,3)  a.b IN (1, 2, 3, 4)
...
```
