### PR TITLE
Fix spatial join on top of colocated right join

### DIFF
--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoinOperator.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoinOperator.java
@@ -346,6 +346,9 @@ public class TestSpatialJoinOperator
                 .row(stPoint(10, 1), "10_1");
         OperatorFactory joinOperatorFactory = new SpatialJoinOperatorFactory(2, new PlanNodeId("test"), INNER, probePages.getTypes(), Ints.asList(1), 0, Optional.empty(), pagesSpatialIndexFactory);
 
+        // Make sure that spatial index reference counting works with duplicate factories
+        joinOperatorFactory.duplicate().noMoreOperators();
+
         MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.of(VARCHAR, VARCHAR))
                 .row("0_1", "0_0")
                 .row("0_1", "1_0")
@@ -452,6 +455,9 @@ public class TestSpatialJoinOperator
         while (!pagesSpatialIndex.isDone()) {
             driver.process();
         }
+
+        // Release the spatial index reference
+        pagesSpatialIndexFactory.probeOperatorFinished();
 
         runDriverInThread(executor, driver);
         return pagesSpatialIndexFactory;

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndexFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndexFactory.java
@@ -112,6 +112,16 @@ public class PagesSpatialIndexFactory
     }
 
     /**
+     * Called by SpatialJoinOperatorFactory to indicate that a duplicate factory will be created
+     * and this class should wait for an extra {@link noMoreProbeOperators} call before
+     * releasing spatial index.
+     */
+    public synchronized void addProbeOperatorFactory()
+    {
+        activeProbeOperators.retain();
+    }
+
+    /**
      * Called by SpatialJoinOperatorFactory to indicate that all
      * {@link SpatialJoinOperator} have been created.
      */

--- a/presto-main/src/main/java/com/facebook/presto/operator/SpatialJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SpatialJoinOperator.java
@@ -107,6 +107,8 @@ public class SpatialJoinOperator
         @Override
         public OperatorFactory duplicate()
         {
+            checkState(!closed, "Factory is already closed");
+            pagesSpatialIndexFactory.addProbeOperatorFactory();
             return new SpatialJoinOperatorFactory(operatorId, planNodeId, joinType, probeTypes, probeOutputChannels, probeGeometryChannel, partitionChannel, pagesSpatialIndexFactory);
         }
     }


### PR DESCRIPTION
Reference counting for the spatial index didn't take into account a possibility
of having multiple SpatialJoinOperatorFactories. This caused the index to be
deleted before all the probe operators were done processing.

The fix is to increment reference count by 1 for each duplicate factory.

Fixes #12672