### PR TITLE
Add rewind API for SplitSource

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -157,6 +157,7 @@ public class HiveClientConfig
     private boolean writingStagingFilesEnabled;
     private String temporaryTableSchema = "default";
     private HiveStorageFormat temporaryTableStorageFormat = ORC;
+    private boolean useRewindableSplitSource;
 
     public int getMaxInitialSplits()
     {
@@ -1290,6 +1291,19 @@ public class HiveClientConfig
     public HiveClientConfig setTemporaryTableStorageFormat(HiveStorageFormat temporaryTableStorageFormat)
     {
         this.temporaryTableStorageFormat = temporaryTableStorageFormat;
+        return this;
+    }
+
+    public boolean isUseRewindableSplitSource()
+    {
+        return useRewindableSplitSource;
+    }
+
+    @Config("hive.use-rewindable-split-source")
+    @ConfigDescription("Use rewindable hive split source")
+    public HiveClientConfig setUseRewindableSplitSource(boolean useRewindableSplitSource)
+    {
+        this.useRewindableSplitSource = useRewindableSplitSource;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -154,8 +154,6 @@ public class HiveClientConfig
     private boolean isTemporaryStagingDirectoryEnabled = true;
     private String temporaryStagingDirectoryPath = "/tmp/presto-${USER}";
 
-    private boolean preloadSplitsForGroupedExecution;
-
     private boolean writingStagingFilesEnabled;
     private String temporaryTableSchema = "default";
     private HiveStorageFormat temporaryTableStorageFormat = ORC;
@@ -1253,19 +1251,6 @@ public class HiveClientConfig
     public HiveClientConfig setTemporaryStagingDirectoryPath(String temporaryStagingDirectoryPath)
     {
         this.temporaryStagingDirectoryPath = temporaryStagingDirectoryPath;
-        return this;
-    }
-
-    public boolean isPreloadSplitsForGroupedExecution()
-    {
-        return preloadSplitsForGroupedExecution;
-    }
-
-    @Config("hive.preload-splits-for-grouped-execution")
-    @ConfigDescription("Preload splits before scheduling for grouped execution")
-    public HiveClientConfig setPreloadSplitsForGroupedExecution(boolean preloadSplitsForGroupedExecution)
-    {
-        this.preloadSplitsForGroupedExecution = preloadSplitsForGroupedExecution;
         return this;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -79,7 +79,6 @@ public final class HiveSessionProperties
     private static final String S3_SELECT_PUSHDOWN_ENABLED = "s3_select_pushdown_enabled";
     private static final String TEMPORARY_STAGING_DIRECTORY_ENABLED = "temporary_staging_directory_enabled";
     private static final String TEMPORARY_STAGING_DIRECTORY_PATH = "temporary_staging_directory_path";
-    private static final String PRELOAD_SPLITS_FOR_GROUPED_EXECUTION = "preload_splits_for_grouped_execution";
     public static final String WRITING_STAGING_FILES_ENABLED = "writing_staging_files_enabled";
     private static final String TEMPORARY_TABLE_SCHEMA = "temporary_table_schema";
     private static final String TEMPORARY_TABLE_STORAGE_FORMAT = "temporary_table_storage_format";
@@ -320,11 +319,6 @@ public final class HiveSessionProperties
                         hiveClientConfig.getTemporaryStagingDirectoryPath(),
                         false),
                 booleanProperty(
-                        PRELOAD_SPLITS_FOR_GROUPED_EXECUTION,
-                        "Preload splits before scheduling for grouped execution",
-                        hiveClientConfig.isPreloadSplitsForGroupedExecution(),
-                        false),
-                booleanProperty(
                         WRITING_STAGING_FILES_ENABLED,
                         "Experimental: Write table to staging files and rename to target files when commit",
                         hiveClientConfig.isWritingStagingFilesEnabled(),
@@ -554,11 +548,6 @@ public final class HiveSessionProperties
     public static String getTemporaryStagingDirectoryPath(ConnectorSession session)
     {
         return session.getProperty(TEMPORARY_STAGING_DIRECTORY_PATH, String.class);
-    }
-
-    public static boolean isPreloadSplitsForGroupedExecution(ConnectorSession session)
-    {
-        return session.getProperty(PRELOAD_SPLITS_FOR_GROUPED_EXECUTION, Boolean.class);
     }
 
     public static boolean isWritingStagingFilesEnabled(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -82,6 +82,7 @@ public final class HiveSessionProperties
     public static final String WRITING_STAGING_FILES_ENABLED = "writing_staging_files_enabled";
     private static final String TEMPORARY_TABLE_SCHEMA = "temporary_table_schema";
     private static final String TEMPORARY_TABLE_STORAGE_FORMAT = "temporary_table_storage_format";
+    public static final String USE_REWINDABLE_SPLIT_SOURCE = "use_rewindable_split_source";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -336,7 +337,12 @@ public final class HiveSessionProperties
                         hiveClientConfig.getTemporaryTableStorageFormat(),
                         false,
                         value -> HiveStorageFormat.valueOf(((String) value).toUpperCase()),
-                        HiveStorageFormat::name));
+                        HiveStorageFormat::name),
+                booleanProperty(
+                        USE_REWINDABLE_SPLIT_SOURCE,
+                        "Use rewindable hive split source",
+                        hiveClientConfig.isUseRewindableSplitSource(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -563,6 +569,11 @@ public final class HiveSessionProperties
     public static HiveStorageFormat getTemporaryTableStorageFormat(ConnectorSession session)
     {
         return session.getProperty(TEMPORARY_TABLE_STORAGE_FORMAT, HiveStorageFormat.class);
+    }
+
+    public static boolean isUseRewindableSplitSource(ConnectorSession session)
+    {
+        return session.getProperty(USE_REWINDABLE_SPLIT_SOURCE, Boolean.class);
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
@@ -27,7 +27,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.log.Logger;
 import io.airlift.stats.CounterStat;
 import io.airlift.units.DataSize;
@@ -51,7 +50,6 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILE_NOT_FOUND;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNKNOWN_ERROR;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxSplitSize;
-import static com.facebook.presto.hive.HiveSessionProperties.isPreloadSplitsForGroupedExecution;
 import static com.facebook.presto.hive.HiveSplitSource.StateKind.CLOSED;
 import static com.facebook.presto.hive.HiveSplitSource.StateKind.FAILED;
 import static com.facebook.presto.hive.HiveSplitSource.StateKind.INITIAL;
@@ -201,8 +199,6 @@ class HiveSplitSource
                 {
                     private final Map<Integer, AsyncQueue<InternalHiveSplit>> queues = new ConcurrentHashMap<>();
                     private final AtomicBoolean finished = new AtomicBoolean();
-                    private final boolean preloadSplitsForGroupedExecution = isPreloadSplitsForGroupedExecution(session);
-                    private final SettableFuture<?> allSplitsLoaded = SettableFuture.create();
 
                     @Override
                     public ListenableFuture<?> offer(OptionalInt bucketNumber, InternalHiveSplit connectorSplit)
@@ -217,10 +213,6 @@ class HiveSplitSource
                     @Override
                     public ListenableFuture<List<ConnectorSplit>> borrowBatchAsync(OptionalInt bucketNumber, int maxSize, Function<List<InternalHiveSplit>, BorrowResult<InternalHiveSplit, List<ConnectorSplit>>> function)
                     {
-                        // The call to borrowBatchAsync() is blocked until allSplitsLoaded is complete, which is set in finish(), then it would call borrowBatchAsync() again.
-                        if (preloadSplitsForGroupedExecution && !finished.get()) {
-                            return allSplitsLoaded.transformAsync(ignored -> borrowBatchAsync(bucketNumber, maxSize, function), executor);
-                        }
                         return queueFor(bucketNumber).borrowBatchAsync(maxSize, function);
                     }
 
@@ -229,7 +221,6 @@ class HiveSplitSource
                     {
                         if (finished.compareAndSet(false, true)) {
                             queues.values().forEach(AsyncQueue::finish);
-                            allSplitsLoaded.set(null);
                         }
                     }
 
@@ -239,7 +230,7 @@ class HiveSplitSource
                         return queueFor(bucketNumber).isFinished();
                     }
 
-                    private AsyncQueue<InternalHiveSplit> queueFor(OptionalInt bucketNumber)
+                    public AsyncQueue<InternalHiveSplit> queueFor(OptionalInt bucketNumber)
                     {
                         checkArgument(bucketNumber.isPresent());
                         AtomicBoolean isNew = new AtomicBoolean();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
@@ -27,11 +27,16 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.log.Logger;
 import io.airlift.stats.CounterStat;
 import io.airlift.units.DataSize;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
@@ -50,6 +55,7 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILE_NOT_FOUND;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNKNOWN_ERROR;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxSplitSize;
+import static com.facebook.presto.hive.HiveSessionProperties.isUseRewindableSplitSource;
 import static com.facebook.presto.hive.HiveSplitSource.StateKind.CLOSED;
 import static com.facebook.presto.hive.HiveSplitSource.StateKind.FAILED;
 import static com.facebook.presto.hive.HiveSplitSource.StateKind.INITIAL;
@@ -57,6 +63,7 @@ import static com.facebook.presto.hive.HiveSplitSource.StateKind.NO_MORE_SPLITS;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Maps.transformValues;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -83,6 +90,7 @@ class HiveSplitSource
 
     private final DataSize maxSplitSize;
     private final DataSize maxInitialSplitSize;
+    private final boolean useRewindableSplitSource;
     private final AtomicInteger remainingInitialSplits;
 
     private final HiveSplitLoader splitLoader;
@@ -118,6 +126,7 @@ class HiveSplitSource
 
         this.maxSplitSize = getMaxSplitSize(session);
         this.maxInitialSplitSize = getMaxInitialSplitSize(session);
+        this.useRewindableSplitSource = isUseRewindableSplitSource(session);
         this.remainingInitialSplits = new AtomicInteger(maxInitialSplits);
     }
 
@@ -168,6 +177,12 @@ class HiveSplitSource
                     {
                         checkArgument(!bucketNumber.isPresent());
                         return queue.isFinished();
+                    }
+
+                    @Override
+                    public int rewind(OptionalInt bucketNumber)
+                    {
+                        throw new UnsupportedOperationException("rewind is not supported for non bucketed split source");
                     }
                 },
                 maxInitialSplits,
@@ -230,7 +245,13 @@ class HiveSplitSource
                         return queueFor(bucketNumber).isFinished();
                     }
 
-                    public AsyncQueue<InternalHiveSplit> queueFor(OptionalInt bucketNumber)
+                    @Override
+                    public int rewind(OptionalInt bucketNumber)
+                    {
+                        throw new UnsupportedOperationException("rewind is not supported for unrewindable split source");
+                    }
+
+                    private AsyncQueue<InternalHiveSplit> queueFor(OptionalInt bucketNumber)
                     {
                         checkArgument(bucketNumber.isPresent());
                         AtomicBoolean isNew = new AtomicBoolean();
@@ -244,6 +265,91 @@ class HiveSplitSource
                             queue.finish();
                         }
                         return queue;
+                    }
+                },
+                maxInitialSplits,
+                maxOutstandingSplitsSize,
+                splitLoader,
+                stateReference,
+                highMemorySplitSourceCounter);
+    }
+
+    public static HiveSplitSource bucketedRewindable(
+            ConnectorSession session,
+            String databaseName,
+            String tableName,
+            TupleDomain<? extends ColumnHandle> compactEffectivePredicate,
+            int maxInitialSplits,
+            DataSize maxOutstandingSplitsSize,
+            HiveSplitLoader splitLoader,
+            Executor executor,
+            CounterStat highMemorySplitSourceCounter)
+    {
+        AtomicReference<State> stateReference = new AtomicReference<>(State.initial());
+        return new HiveSplitSource(
+                session,
+                databaseName,
+                tableName,
+                compactEffectivePredicate,
+                new PerBucket()
+                {
+                    @GuardedBy("this")
+                    private final Map<Integer, List<InternalHiveSplit>> splits = new HashMap<>();
+                    private final SettableFuture<?> allSplitLoaded = SettableFuture.create();
+
+                    @Override
+                    public synchronized ListenableFuture<?> offer(OptionalInt bucketNumber, InternalHiveSplit connectorSplit)
+                    {
+                        checkArgument(bucketNumber.isPresent(), "bucketNumber must be present");
+                        splits.computeIfAbsent(bucketNumber.getAsInt(), ignored -> new ArrayList<>()).add(connectorSplit);
+                        // Do not block "offer" when running split discovery in bucketed mode.
+                        return immediateFuture(null);
+                    }
+
+                    @Override
+                    public synchronized ListenableFuture<List<ConnectorSplit>> borrowBatchAsync(OptionalInt bucketNumber, int maxSize, Function<List<InternalHiveSplit>, BorrowResult<InternalHiveSplit, List<ConnectorSplit>>> function)
+                    {
+                        checkArgument(bucketNumber.isPresent(), "bucketNumber must be present");
+                        if (!allSplitLoaded.isDone()) {
+                            return allSplitLoaded.transform(ignored -> ImmutableList.of(), executor);
+                        }
+                        return immediateFuture(function.apply(getSplits(bucketNumber.getAsInt(), maxSize)).getResult());
+                    }
+
+                    private List<InternalHiveSplit> getSplits(int bucketNumber, int batchSize)
+                    {
+                        return splits.getOrDefault(bucketNumber, ImmutableList.of()).stream()
+                                .filter(split -> !split.isDone())
+                                .limit(batchSize)
+                                .collect(toImmutableList());
+                    }
+
+                    @Override
+                    public void noMoreSplits()
+                    {
+                        allSplitLoaded.set(null);
+                    }
+
+                    @Override
+                    public boolean isFinished(OptionalInt bucketNumber)
+                    {
+                        checkArgument(bucketNumber.isPresent(), "bucketNumber must be present");
+                        return allSplitLoaded.isDone() && splits.get(bucketNumber.getAsInt()).stream().allMatch(InternalHiveSplit::isDone);
+                    }
+
+                    @Override
+                    public synchronized int rewind(OptionalInt bucketNumber)
+                    {
+                        checkArgument(bucketNumber.isPresent(), "bucketNumber must be present");
+                        checkState(allSplitLoaded.isDone(), "splits cannot be rewound before splits enumeration is finished");
+                        int revivedSplitCount = 0;
+                        for (InternalHiveSplit split : splits.getOrDefault(bucketNumber.getAsInt(), ImmutableList.of())) {
+                            if (split.isDone()) {
+                                revivedSplitCount++;
+                            }
+                            split.reset();
+                        }
+                        return revivedSplitCount;
                     }
                 },
                 maxInitialSplits,
@@ -389,7 +495,11 @@ class HiveSplitSource
                     splitsToInsertBuilder.add(internalSplit);
                 }
             }
-            estimatedSplitSizeInBytes.addAndGet(-removedEstimatedSizeInBytes);
+
+            // For rewindable split source, we keep all the splits in memory.
+            if (!useRewindableSplitSource) {
+                estimatedSplitSizeInBytes.addAndGet(-removedEstimatedSizeInBytes);
+            }
 
             List<InternalHiveSplit> splitsToInsert = splitsToInsertBuilder.build();
             List<ConnectorSplit> result = resultBuilder.build();
@@ -419,6 +529,12 @@ class HiveSplitSource
         }, directExecutor());
 
         return toCompletableFuture(transform);
+    }
+
+    @Override
+    public void rewind(ConnectorPartitionHandle partitionHandle)
+    {
+        bufferedInternalSplitCount.addAndGet(queues.rewind(toBucketNumber(partitionHandle)));
     }
 
     @Override
@@ -493,6 +609,9 @@ class HiveSplitSource
         void noMoreSplits();
 
         boolean isFinished(OptionalInt bucketNumber);
+
+        // returns the number of finished InternalHiveSplits that are rewound
+        int rewind(OptionalInt bucketNumber);
     }
 
     static class State

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
@@ -158,7 +158,7 @@ class HiveSplitSource
                     }
 
                     @Override
-                    public void finish()
+                    public void noMoreSplits()
                     {
                         queue.finish();
                     }
@@ -217,7 +217,7 @@ class HiveSplitSource
                     }
 
                     @Override
-                    public void finish()
+                    public void noMoreSplits()
                     {
                         if (finished.compareAndSet(false, true)) {
                             queues.values().forEach(AsyncQueue::finish);
@@ -302,13 +302,13 @@ class HiveSplitSource
             // Once the queue is finished, it will always return a completed future to avoid blocking any caller.
             // This could lead to a short period of busy loop in splitLoader (although unlikely in general setup).
             splitLoader.stop();
-            queues.finish();
+            queues.noMoreSplits();
         }
     }
 
     void fail(Throwable e)
     {
-        // The error must be recorded before setting the finish marker to make sure
+        // The error must be recorded before setting the noMoreSplits marker to make sure
         // isFinished will observe failure instead of successful completion.
         // Only record the first error message.
         if (setIf(stateReference, State.failed(e), state -> state.getKind() == INITIAL)) {
@@ -316,7 +316,7 @@ class HiveSplitSource
             // Once the queue is finished, it will always return a completed future to avoid blocking any caller.
             // This could lead to a short period of busy loop in splitLoader (although unlikely in general setup).
             splitLoader.stop();
-            queues.finish();
+            queues.noMoreSplits();
         }
     }
 
@@ -448,7 +448,7 @@ class HiveSplitSource
             // Once the queue is finished, it will always return a completed future to avoid blocking any caller.
             // This could lead to a short period of busy loop in splitLoader (although unlikely in general setup).
             splitLoader.stop();
-            queues.finish();
+            queues.noMoreSplits();
         }
     }
 
@@ -490,7 +490,7 @@ class HiveSplitSource
 
         ListenableFuture<List<ConnectorSplit>> borrowBatchAsync(OptionalInt bucketNumber, int maxSize, Function<List<InternalHiveSplit>, BorrowResult<InternalHiveSplit, List<ConnectorSplit>>> function);
 
-        void finish();
+        void noMoreSplits();
 
         boolean isFinished(OptionalInt bucketNumber);
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
@@ -203,6 +203,12 @@ public class InternalHiveSplit
         }
     }
 
+    public void reset()
+    {
+        currentBlockIndex = 0;
+        start = 0;
+    }
+
     public int getEstimatedSizeInBytes()
     {
         int result = INSTANCE_SIZE;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.SystemSessionProperties.EXCHANGE_MATERIALIZATI
 import static com.facebook.presto.SystemSessionProperties.GROUPED_EXECUTION_FOR_AGGREGATION;
 import static com.facebook.presto.SystemSessionProperties.HASH_PARTITION_COUNT;
 import static com.facebook.presto.SystemSessionProperties.PARTITIONING_PROVIDER_CATALOG;
+import static com.facebook.presto.hive.HiveSessionProperties.USE_REWINDABLE_SPLIT_SOURCE;
 import static com.facebook.presto.spi.security.SelectedRole.Type.ROLE;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
@@ -225,6 +226,22 @@ public final class HiveQueryRunner
                 .setSystemProperty(GROUPED_EXECUTION_FOR_AGGREGATION, "true")
                 .setCatalog(HIVE_CATALOG)
                 .setSchema(TPCH_SCHEMA)
+                .build();
+    }
+
+    public static Session createRewindableSplitSourceSession(Optional<SelectedRole> role)
+    {
+        return testSessionBuilder()
+                .setIdentity(new Identity(
+                        "hive",
+                        Optional.empty(),
+                        role.map(selectedRole -> ImmutableMap.of("hive", selectedRole))
+                                .orElse(ImmutableMap.of())))
+                .setSystemProperty(COLOCATED_JOIN, "true")
+                .setSystemProperty(GROUPED_EXECUTION_FOR_AGGREGATION, "true")
+                .setCatalogSessionProperty(HIVE_CATALOG, USE_REWINDABLE_SPLIT_SOURCE, "true")
+                .setCatalog(HIVE_CATALOG)
+                .setSchema(TPCH_BUCKETED_SCHEMA)
                 .build();
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -122,7 +122,6 @@ public class TestHiveClientConfig
                 .setS3SelectPushdownMaxConnections(500)
                 .setTemporaryStagingDirectoryEnabled(true)
                 .setTemporaryStagingDirectoryPath("/tmp/presto-${USER}")
-                .setPreloadSplitsForGroupedExecution(false)
                 .setWritingStagingFilesEnabled(false)
                 .setTemporaryTableSchema("default")
                 .setTemporaryTableStorageFormat(ORC));
@@ -213,7 +212,6 @@ public class TestHiveClientConfig
                 .put("hive.s3select-pushdown.max-connections", "1234")
                 .put("hive.temporary-staging-directory-enabled", "false")
                 .put("hive.temporary-staging-directory-path", "updated")
-                .put("hive.preload-splits-for-grouped-execution", "true")
                 .put("hive.writing-staging-files-enabled", "true")
                 .put("hive.temporary-table-schema", "other")
                 .put("hive.temporary-table-storage-format", "DWRF")
@@ -302,7 +300,6 @@ public class TestHiveClientConfig
                 .setS3SelectPushdownMaxConnections(1234)
                 .setTemporaryStagingDirectoryEnabled(false)
                 .setTemporaryStagingDirectoryPath("updated")
-                .setPreloadSplitsForGroupedExecution(true)
                 .setWritingStagingFilesEnabled(true)
                 .setTemporaryTableSchema("other")
                 .setTemporaryTableStorageFormat(DWRF);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -124,7 +124,8 @@ public class TestHiveClientConfig
                 .setTemporaryStagingDirectoryPath("/tmp/presto-${USER}")
                 .setWritingStagingFilesEnabled(false)
                 .setTemporaryTableSchema("default")
-                .setTemporaryTableStorageFormat(ORC));
+                .setTemporaryTableStorageFormat(ORC)
+                .setUseRewindableSplitSource(false));
     }
 
     @Test
@@ -215,6 +216,7 @@ public class TestHiveClientConfig
                 .put("hive.writing-staging-files-enabled", "true")
                 .put("hive.temporary-table-schema", "other")
                 .put("hive.temporary-table-storage-format", "DWRF")
+                .put("hive.use-rewindable-split-source", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -302,7 +304,8 @@ public class TestHiveClientConfig
                 .setTemporaryStagingDirectoryPath("updated")
                 .setWritingStagingFilesEnabled(true)
                 .setTemporaryTableSchema("other")
-                .setTemporaryTableStorageFormat(DWRF);
+                .setTemporaryTableStorageFormat(DWRF)
+                .setUseRewindableSplitSource(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -13,10 +13,12 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.SettableFuture;
@@ -41,6 +43,7 @@ import static java.lang.Math.toIntExact;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -251,6 +254,141 @@ public class TestHiveSplitSource
         assertEquals(getSplits(hiveSplitSource, OptionalInt.of(1), 10).size(), 0);
         assertEquals(getSplits(hiveSplitSource, OptionalInt.of(2), 10).size(), 1);
         assertEquals(getSplits(hiveSplitSource, OptionalInt.of(3), 10).size(), 0);
+    }
+
+    @Test
+    public void testPreloadSplitsForRewindableSplitSource()
+            throws Exception
+    {
+        // TODO: Use Session::builder after HiveTestUtils::SESSION is refactored to Session.
+        ConnectorSession session = new TestingConnectorSession(
+                new HiveSessionProperties(
+                        new HiveClientConfig().setUseRewindableSplitSource(true),
+                        new OrcFileWriterConfig(),
+                        new ParquetFileWriterConfig()).getSessionProperties());
+        HiveSplitSource hiveSplitSource = HiveSplitSource.bucketedRewindable(
+                session,
+                "database",
+                "table",
+                TupleDomain.all(),
+                10,
+                new DataSize(1, MEGABYTE),
+                new TestingHiveSplitLoader(),
+                EXECUTOR,
+                new CounterStat());
+        for (int i = 0; i < 10; i++) {
+            hiveSplitSource.addToQueue(new TestSplit(i, OptionalInt.of(0)));
+            assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), i + 1);
+        }
+
+        SettableFuture<List<ConnectorSplit>> splits = SettableFuture.create();
+
+        // create a thread that will get the splits
+        CountDownLatch started = new CountDownLatch(1);
+        Thread getterThread = new Thread(() -> {
+            try {
+                started.countDown();
+                List<ConnectorSplit> batch = getSplits(hiveSplitSource, OptionalInt.of(0), 10);
+                splits.set(batch);
+            }
+            catch (Throwable e) {
+                splits.setException(e);
+            }
+        });
+        getterThread.start();
+
+        try {
+            // wait for the thread to be started
+            assertTrue(started.await(10, SECONDS));
+
+            // scheduling will not start before noMoreSplits is called to ensure we preload all splits.
+            MILLISECONDS.sleep(200);
+            assertFalse(splits.isDone());
+
+            // wait for thread to get the splits after noMoreSplit signal is sent
+            hiveSplitSource.noMoreSplits();
+            List<ConnectorSplit> connectorSplits = splits.get(10, SECONDS);
+            assertEquals(connectorSplits.size(), 0);
+            assertFalse(hiveSplitSource.isFinished());
+
+            connectorSplits = getSplits(hiveSplitSource, OptionalInt.of(0), 10);
+            for (int i = 0; i < 10; i++) {
+                assertEquals(((HiveSplit) connectorSplits.get(i)).getSchema().getProperty("id"), Integer.toString(i));
+            }
+            assertTrue(hiveSplitSource.isFinished());
+        }
+        finally {
+            getterThread.interrupt();
+        }
+    }
+
+    @Test
+    public void testRewindOneBucket()
+    {
+        HiveSplitSource hiveSplitSource = HiveSplitSource.bucketedRewindable(
+                SESSION,
+                "database",
+                "table",
+                TupleDomain.all(),
+                10,
+                new DataSize(1, MEGABYTE),
+                new TestingHiveSplitLoader(),
+                EXECUTOR,
+                new CounterStat());
+        for (int i = 0; i < 10; i++) {
+            hiveSplitSource.addToQueue(new TestSplit(i, OptionalInt.of(0)));
+            assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), i + 1);
+        }
+        hiveSplitSource.noMoreSplits();
+
+        // Rewind when split is not retrieved.
+        hiveSplitSource.rewind(new HivePartitionHandle(0));
+        assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), 10);
+
+        // Rewind when split is partially retrieved.
+        assertEquals(getSplits(hiveSplitSource, OptionalInt.of(0), 5).size(), 5);
+        assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), 5);
+        hiveSplitSource.rewind(new HivePartitionHandle(0));
+        assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), 10);
+
+        // Rewind when split is fully retrieved
+        assertEquals(getSplits(hiveSplitSource, OptionalInt.of(0), 10).size(), 10);
+        assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), 0);
+        hiveSplitSource.rewind(new HivePartitionHandle(0));
+        assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), 10);
+    }
+
+    @Test
+    public void testRewindMultipleBuckets()
+    {
+        HiveSplitSource hiveSplitSource = HiveSplitSource.bucketedRewindable(
+                SESSION,
+                "database",
+                "table",
+                TupleDomain.all(),
+                10,
+                new DataSize(1, MEGABYTE),
+                new TestingHiveSplitLoader(),
+                EXECUTOR,
+                new CounterStat());
+        for (int i = 0; i < 10; i++) {
+            hiveSplitSource.addToQueue(new TestSplit(i, OptionalInt.of(1)));
+            hiveSplitSource.addToQueue(new TestSplit(i, OptionalInt.of(2)));
+            assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), 2 * (i + 1));
+        }
+        hiveSplitSource.noMoreSplits();
+        assertEquals(getSplits(hiveSplitSource, OptionalInt.of(1), 1).size(), 1);
+        assertEquals(getSplits(hiveSplitSource, OptionalInt.of(2), 2).size(), 2);
+        assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), 17);
+
+        // Rewind bucket 1 and test only bucket 1 is rewinded.
+        hiveSplitSource.rewind(new HivePartitionHandle(1));
+        assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), 18);
+        assertEquals(getSplits(hiveSplitSource, OptionalInt.of(1), 1).size(), 1);
+
+        // Rewind bucket 2 and test only bucket 2 is rewinded.
+        hiveSplitSource.rewind(new HivePartitionHandle(2));
+        assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), 19);
     }
 
     private static List<ConnectorSplit> getSplits(ConnectorSplitSource source, int maxSize)

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -561,7 +561,7 @@ public final class Session
             this.clientTags = ImmutableSet.copyOf(session.clientTags);
             this.startTime = session.startTime;
             this.systemProperties.putAll(session.systemProperties);
-            this.catalogSessionProperties.putAll(session.unprocessedCatalogProperties);
+            session.unprocessedCatalogProperties.forEach((key, value) -> this.catalogSessionProperties.put(key, new HashMap<>(value)));
             this.preparedStatements.putAll(session.preparedStatements);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/split/BufferingSplitSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/BufferingSplitSource.java
@@ -61,6 +61,12 @@ public class BufferingSplitSource
     }
 
     @Override
+    public void rewind(ConnectorPartitionHandle partitionHandle)
+    {
+        source.rewind(partitionHandle);
+    }
+
+    @Override
     public void close()
     {
         source.close();

--- a/presto-main/src/main/java/com/facebook/presto/split/ConnectorAwareSplitSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/ConnectorAwareSplitSource.java
@@ -72,6 +72,12 @@ public class ConnectorAwareSplitSource
     }
 
     @Override
+    public void rewind(ConnectorPartitionHandle partitionHandle)
+    {
+        source.rewind(partitionHandle);
+    }
+
+    @Override
     public void close()
     {
         source.close();

--- a/presto-main/src/main/java/com/facebook/presto/split/SampledSplitSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/SampledSplitSource.java
@@ -65,6 +65,12 @@ public class SampledSplitSource
     }
 
     @Override
+    public void rewind(ConnectorPartitionHandle partitionHandle)
+    {
+        splitSource.rewind(partitionHandle);
+    }
+
+    @Override
     public void close()
     {
         splitSource.close();

--- a/presto-main/src/main/java/com/facebook/presto/split/SplitSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/SplitSource.java
@@ -34,6 +34,8 @@ public interface SplitSource
 
     ListenableFuture<SplitBatch> getNextBatch(ConnectorPartitionHandle partitionHandle, Lifespan lifespan, int maxSize);
 
+    void rewind(ConnectorPartitionHandle partitionHandle);
+
     @Override
     void close();
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LazySplitSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LazySplitSource.java
@@ -61,6 +61,12 @@ public class LazySplitSource
     }
 
     @Override
+    public void rewind(ConnectorPartitionHandle partitionHandle)
+    {
+        getDelegate().rewind(partitionHandle);
+    }
+
+    @Override
     public boolean isFinished()
     {
         return getDelegate().isFinished();

--- a/presto-main/src/test/java/com/facebook/presto/split/MockSplitSource.java
+++ b/presto-main/src/test/java/com/facebook/presto/split/MockSplitSource.java
@@ -138,6 +138,12 @@ public class MockSplitSource
     }
 
     @Override
+    public void rewind(ConnectorPartitionHandle partitionHandle)
+    {
+        throw new UnsupportedOperationException("rewind is not supported in MockSplitSource");
+    }
+
+    @Override
     public void close()
     {
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplitSource.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplitSource.java
@@ -26,6 +26,11 @@ public interface ConnectorSplitSource
 {
     CompletableFuture<ConnectorSplitBatch> getNextBatch(ConnectorPartitionHandle partitionHandle, int maxSize);
 
+    default void rewind(ConnectorPartitionHandle partitionHandle)
+    {
+        throw new UnsupportedOperationException("rewind is not supported in this ConnectorSplitSource");
+    }
+
     @Override
     void close();
 


### PR DESCRIPTION
This is a prerequisite API for recoverable grouped execution

Extracted from https://github.com/prestodb/presto/pull/12529 to avoid blocking other changes on `HiveSplitSource`  . Required by https://github.com/prestodb/presto/issues/12124