### PR TITLE
Mark unpartitioned table in HiveWrittenPartitions

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -407,7 +407,7 @@ public class HiveMetadata
                 Iterable<List<Object>> records = () ->
                         stream(partitionManager.getPartitions(metastore, sourceTableHandle, targetConstraint, session).getPartitions())
                                 .map(hivePartition ->
-                                        (List<Object>) IntStream.range(0, partitionColumns.size())
+                                        IntStream.range(0, partitionColumns.size())
                                                 .mapToObj(fieldIdToColumnHandle::get)
                                                 .map(columnHandle -> hivePartition.getKeys().get(columnHandle).getValue())
                                                 .collect(toList()))


### PR DESCRIPTION
We already use "\<UNPARTITIONED\>" for unpartitioned table input, and
this commit would unify the representation of unpartitioned table in
output as well.