### PR TITLE
Remove the SubType list from JsonTypeInfo on PlanNode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/PlanNode.java
@@ -15,55 +15,13 @@ package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.sql.planner.Symbol;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
-@JsonTypeInfo(
-        use = JsonTypeInfo.Id.NAME,
-        include = JsonTypeInfo.As.PROPERTY,
-        property = "@type")
-@JsonSubTypes({
-        @JsonSubTypes.Type(value = OutputNode.class, name = "output"),
-        @JsonSubTypes.Type(value = ProjectNode.class, name = "project"),
-        @JsonSubTypes.Type(value = TableScanNode.class, name = "tablescan"),
-        @JsonSubTypes.Type(value = ValuesNode.class, name = "values"),
-        @JsonSubTypes.Type(value = AggregationNode.class, name = "aggregation"),
-        @JsonSubTypes.Type(value = MarkDistinctNode.class, name = "markDistinct"),
-        @JsonSubTypes.Type(value = FilterNode.class, name = "filter"),
-        @JsonSubTypes.Type(value = WindowNode.class, name = "window"),
-        @JsonSubTypes.Type(value = RowNumberNode.class, name = "rowNumber"),
-        @JsonSubTypes.Type(value = TopNRowNumberNode.class, name = "topnRowNumber"),
-        @JsonSubTypes.Type(value = LimitNode.class, name = "limit"),
-        @JsonSubTypes.Type(value = DistinctLimitNode.class, name = "distinctlimit"),
-        @JsonSubTypes.Type(value = TopNNode.class, name = "topn"),
-        @JsonSubTypes.Type(value = SampleNode.class, name = "sample"),
-        @JsonSubTypes.Type(value = SortNode.class, name = "sort"),
-        @JsonSubTypes.Type(value = RemoteSourceNode.class, name = "remoteSource"),
-        @JsonSubTypes.Type(value = JoinNode.class, name = "join"),
-        @JsonSubTypes.Type(value = SemiJoinNode.class, name = "semijoin"),
-        @JsonSubTypes.Type(value = SpatialJoinNode.class, name = "spatialjoin"),
-        @JsonSubTypes.Type(value = IndexJoinNode.class, name = "indexjoin"),
-        @JsonSubTypes.Type(value = IndexSourceNode.class, name = "indexsource"),
-        @JsonSubTypes.Type(value = TableWriterNode.class, name = "tablewriter"),
-        @JsonSubTypes.Type(value = DeleteNode.class, name = "delete"),
-        @JsonSubTypes.Type(value = MetadataDeleteNode.class, name = "metadatadelete"),
-        @JsonSubTypes.Type(value = TableFinishNode.class, name = "tablecommit"),
-        @JsonSubTypes.Type(value = UnnestNode.class, name = "unnest"),
-        @JsonSubTypes.Type(value = ExchangeNode.class, name = "exchange"),
-        @JsonSubTypes.Type(value = UnionNode.class, name = "union"),
-        @JsonSubTypes.Type(value = IntersectNode.class, name = "intersect"),
-        @JsonSubTypes.Type(value = EnforceSingleRowNode.class, name = "scalar"),
-        @JsonSubTypes.Type(value = GroupIdNode.class, name = "groupid"),
-        @JsonSubTypes.Type(value = ExplainAnalyzeNode.class, name = "explainAnalyze"),
-        @JsonSubTypes.Type(value = ApplyNode.class, name = "apply"),
-        @JsonSubTypes.Type(value = AssignUniqueId.class, name = "assignUniqueId"),
-        @JsonSubTypes.Type(value = LateralJoinNode.class, name = "lateralJoin"),
-        @JsonSubTypes.Type(value = StatisticsWriterNode.class, name = "statisticsWriterNode"),
-})
+@JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS, property = "@type")
 public abstract class PlanNode
 {
     private final PlanNodeId id;


### PR DESCRIPTION
This type list is only for making sure name serialized is same as given
shortened readable names. However, it makes expanding PlanNode types 
very difficult. 

Test seems OK but need to confirm if there is something else outside presto depends on plan json (which shouldn't). 