### PR TITLE
Remove redundant offset parameter in primitive type getter

### DIFF
--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/BingTileType.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/BingTileType.java
@@ -42,6 +42,6 @@ public class BingTileType
             return null;
         }
 
-        return BingTile.decode(block.getLong(position, 0));
+        return BingTile.decode(block.getLong(position));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
@@ -346,7 +346,7 @@ public class HivePageSink
 
             OptionalInt bucketNumber = OptionalInt.empty();
             if (bucketBlock != null) {
-                bucketNumber = OptionalInt.of(bucketBlock.getInt(position, 0));
+                bucketNumber = OptionalInt.of(bucketBlock.getInt(position));
             }
             HiveWriter writer = writerFactory.createWriter(partitionColumns, position, bucketNumber);
             writers.set(writerIndex, writer);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/Statistics.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/Statistics.java
@@ -447,7 +447,7 @@ public final class Statistics
     private static OptionalLong getTimestampValue(DateTimeZone timeZone, Block block)
     {
         // TODO #7122
-        return block.isNull(0) ? OptionalLong.empty() : OptionalLong.of(MILLISECONDS.toSeconds(timeZone.convertUTCToLocal(block.getLong(0, 0))));
+        return block.isNull(0) ? OptionalLong.empty() : OptionalLong.of(MILLISECONDS.toSeconds(timeZone.convertUTCToLocal(block.getLong(0))));
     }
 
     private static Optional<BigDecimal> getDecimalValue(ConnectorSession session, Type type, Block block)

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -80,21 +80,21 @@ public class GroupByIdBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
-        return block.getByte(position, offset);
+        return block.getByte(position);
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
-        return block.getShort(position, offset);
+        return block.getShort(position);
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
-        return block.getInt(position, offset);
+        return block.getInt(position);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -98,6 +98,12 @@ public class GroupByIdBlock
     }
 
     @Override
+    public long getLong(int position)
+    {
+        return block.getLong(position);
+    }
+
+    @Override
     public long getLong(int position, int offset)
     {
         return block.getLong(position, offset);

--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -425,7 +425,7 @@ public class MultiChannelGroupByHash
 
     private long getRawHash(int sliceIndex, int position)
     {
-        return channelBuilders.get(precomputedHashChannel.getAsInt()).get(sliceIndex).getLong(position, 0);
+        return channelBuilders.get(precomputedHashChannel.getAsInt()).get(sliceIndex).getLong(position);
     }
 
     private boolean positionNotDistinctFromCurrentRow(long address, int hashPosition, int position, Page page, byte rawHash, int[] hashChannels)

--- a/presto-main/src/main/java/com/facebook/presto/type/ColorType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/ColorType.java
@@ -49,7 +49,7 @@ public class ColorType
             return null;
         }
 
-        int color = block.getInt(position, 0);
+        int color = block.getInt(position);
         if (color < 0) {
             return ColorFunctions.SystemColor.valueOf(-(color + 1)).getName();
         }

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalInequalityOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalInequalityOperators.java
@@ -217,8 +217,8 @@ public class DecimalInequalityOperators
             return false;
         }
 
-        long leftValue = left.getLong(leftPosition, 0);
-        long rightValue = right.getLong(rightPosition, 0);
+        long leftValue = left.getLong(leftPosition);
+        long rightValue = right.getLong(rightPosition);
         return Long.compare(leftValue, rightValue) != 0;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/IntervalDayTimeType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IntervalDayTimeType.java
@@ -36,7 +36,7 @@ public final class IntervalDayTimeType
         if (block.isNull(position)) {
             return null;
         }
-        return new SqlIntervalDayTime(block.getLong(position, 0));
+        return new SqlIntervalDayTime(block.getLong(position));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/type/IntervalYearMonthType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IntervalYearMonthType.java
@@ -36,7 +36,7 @@ public final class IntervalYearMonthType
         if (block.isNull(position)) {
             return null;
         }
-        return new SqlIntervalYearMonth(block.getInt(position, 0));
+        return new SqlIntervalYearMonth(block.getInt(position));
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -291,10 +291,8 @@ public abstract class AbstractTestBlock
                 assertEquals(block.getInt(position), expectedSliceValue.getInt(0));
             }
 
-            if (isLongAccessSupported()) {
-                for (int offset = 0; offset <= expectedSliceValue.length() - SIZE_OF_LONG; offset++) {
-                    assertEquals(block.getLong(position, offset), expectedSliceValue.getLong(offset));
-                }
+            if (isIntAccessSupported() && expectedSliceValue.length() >= SIZE_OF_LONG) {
+                assertEquals(block.getLong(position), expectedSliceValue.getLong(0));
             }
 
             if (isAlignedLongAccessSupported()) {

--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -279,22 +279,16 @@ public abstract class AbstractTestBlock
         if (expectedValue instanceof Slice) {
             Slice expectedSliceValue = (Slice) expectedValue;
 
-            if (isByteAccessSupported()) {
-                for (int offset = 0; offset <= expectedSliceValue.length() - SIZE_OF_BYTE; offset++) {
-                    assertEquals(block.getByte(position, offset), expectedSliceValue.getByte(offset));
-                }
+            if (isByteAccessSupported() && expectedSliceValue.length() >= SIZE_OF_BYTE) {
+                assertEquals(block.getByte(position), expectedSliceValue.getByte(0));
             }
 
-            if (isShortAccessSupported()) {
-                for (int offset = 0; offset <= expectedSliceValue.length() - SIZE_OF_SHORT; offset++) {
-                    assertEquals(block.getShort(position, offset), expectedSliceValue.getShort(offset));
-                }
+            if (isShortAccessSupported() && expectedSliceValue.length() >= SIZE_OF_SHORT) {
+                assertEquals(block.getShort(position), expectedSliceValue.getShort(0));
             }
 
-            if (isIntAccessSupported()) {
-                for (int offset = 0; offset <= expectedSliceValue.length() - SIZE_OF_INT; offset++) {
-                    assertEquals(block.getInt(position, offset), expectedSliceValue.getInt(offset));
-                }
+            if (isIntAccessSupported() && expectedSliceValue.length() >= SIZE_OF_INT) {
+                assertEquals(block.getInt(position), expectedSliceValue.getInt(0));
             }
 
             if (isLongAccessSupported()) {

--- a/presto-main/src/test/java/com/facebook/presto/block/TestBlockBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestBlockBuilder.java
@@ -130,7 +130,7 @@ public class TestBlockBuilder
     private static void assertInvalidGetPositions(Block block, int[] positions, int offset, int length)
     {
         try {
-            block.getPositions(positions, offset, length).getLong(0, 0);
+            block.getPositions(positions, offset, length).getLong(0);
             fail("Expected to fail");
         }
         catch (IllegalArgumentException e) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
@@ -151,7 +151,7 @@ public class BenchmarkGroupByHash
             Block block = page.getBlock(0);
             int positionCount = block.getPositionCount();
             for (int position = 0; position < positionCount; position++) {
-                long value = block.getLong(position, 0);
+                long value = block.getLong(position);
 
                 int tablePosition = (int) (value & mask);
                 while (table[tablePosition] != -1 && table[tablePosition] != value) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -402,7 +402,7 @@ public class TestHashAggregationOperator
             // value + hash + aggregation result
             assertEquals(page.getChannelCount(), 3);
             for (int i = 0; i < page.getPositionCount(); i++) {
-                assertEquals(page.getBlock(2).getLong(i, 0), 1);
+                assertEquals(page.getBlock(2).getLong(i), 1);
                 count++;
             }
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestLookupJoinPageBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestLookupJoinPageBuilder.java
@@ -63,13 +63,13 @@ public class TestLookupJoinPageBuilder
         for (int i = 0; i < output.getPositionCount(); i++) {
             assertFalse(output.getBlock(0).isNull(i));
             assertFalse(output.getBlock(1).isNull(i));
-            assertEquals(output.getBlock(0).getLong(i, 0), i / 2);
-            assertEquals(output.getBlock(1).getLong(i, 0), i / 2);
+            assertEquals(output.getBlock(0).getLong(i), i / 2);
+            assertEquals(output.getBlock(1).getLong(i), i / 2);
             if (i % 2 == 0) {
                 assertFalse(output.getBlock(2).isNull(i));
                 assertFalse(output.getBlock(3).isNull(i));
-                assertEquals(output.getBlock(2).getLong(i, 0), i / 2);
-                assertEquals(output.getBlock(3).getLong(i, 0), i / 2);
+                assertEquals(output.getBlock(2).getLong(i), i / 2);
+                assertEquals(output.getBlock(3).getLong(i), i / 2);
             }
             else {
                 assertTrue(output.getBlock(2).isNull(i));
@@ -117,8 +117,8 @@ public class TestLookupJoinPageBuilder
         assertTrue(output.getBlock(0) instanceof DictionaryBlock);
         assertEquals(output.getPositionCount(), entries / 2);
         for (int i = 0; i < entries / 2; i++) {
-            assertEquals(output.getBlock(0).getLong(i, 0), i * 2);
-            assertEquals(output.getBlock(1).getLong(i, 0), i * 2);
+            assertEquals(output.getBlock(0).getLong(i), i * 2);
+            assertEquals(output.getBlock(1).getLong(i), i * 2);
         }
         lookupJoinPageBuilder.reset();
 
@@ -132,8 +132,8 @@ public class TestLookupJoinPageBuilder
         assertFalse(output.getBlock(0) instanceof DictionaryBlock);
         assertEquals(output.getPositionCount(), entries);
         for (int i = 0; i < entries; i++) {
-            assertEquals(output.getBlock(0).getLong(i, 0), i);
-            assertEquals(output.getBlock(1).getLong(i, 0), i);
+            assertEquals(output.getBlock(0).getLong(i), i);
+            assertEquals(output.getBlock(1).getLong(i), i);
         }
         lookupJoinPageBuilder.reset();
 
@@ -150,8 +150,8 @@ public class TestLookupJoinPageBuilder
         assertFalse(output.getBlock(0) instanceof DictionaryBlock);
         assertEquals(output.getPositionCount(), 40);
         for (int i = 10; i < 50; i++) {
-            assertEquals(output.getBlock(0).getLong(i - 10, 0), i);
-            assertEquals(output.getBlock(1).getLong(i - 10, 0), i);
+            assertEquals(output.getBlock(0).getLong(i - 10), i);
+            assertEquals(output.getBlock(1).getLong(i - 10), i);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMarkDistinctOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMarkDistinctOperator.java
@@ -122,7 +122,7 @@ public class TestMarkDistinctOperator
         for (Page page : result.getOutput()) {
             assertEquals(page.getChannelCount(), 3);
             for (int i = 0; i < page.getPositionCount(); i++) {
-                assertEquals(page.getBlock(2).getByte(i, 0), 1);
+                assertEquals(page.getBlock(2).getByte(i), 1);
                 count++;
             }
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMergeHashSort.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMergeHashSort.java
@@ -61,7 +61,7 @@ public class TestMergeHashSort
         Page actualPage = mergedPage.getResult();
         assertEquals(actualPage.getPositionCount(), 1);
         assertEquals(actualPage.getChannelCount(), 1);
-        assertEquals(actualPage.getBlock(0).getLong(0, 0), 42);
+        assertEquals(actualPage.getBlock(0).getLong(0), 42);
 
         assertFinishes(mergedPage);
     }
@@ -84,7 +84,7 @@ public class TestMergeHashSort
         Page actualPage = mergedPage.getResult();
         assertEquals(actualPage.getPositionCount(), 1);
         assertEquals(actualPage.getChannelCount(), 1);
-        assertEquals(actualPage.getBlock(0).getLong(0, 0), 42);
+        assertEquals(actualPage.getBlock(0).getLong(0), 42);
 
         assertFinishes(mergedPage);
     }
@@ -110,10 +110,10 @@ public class TestMergeHashSort
         assertTrue(mergedPages.process());
         Page resultPage = mergedPages.getResult();
         assertEquals(resultPage.getPositionCount(), 4);
-        assertEquals(resultPage.getBlock(0).getLong(0, 0), 42);
-        assertEquals(resultPage.getBlock(0).getLong(1, 0), 42);
-        assertEquals(resultPage.getBlock(0).getLong(2, 0), 52);
-        assertEquals(resultPage.getBlock(0).getLong(3, 0), 60);
+        assertEquals(resultPage.getBlock(0).getLong(0), 42);
+        assertEquals(resultPage.getBlock(0).getLong(1), 42);
+        assertEquals(resultPage.getBlock(0).getLong(2), 52);
+        assertEquals(resultPage.getBlock(0).getLong(3), 60);
 
         assertFinishes(mergedPages);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestRowNumberOperator.java
@@ -176,7 +176,7 @@ public class TestRowNumberOperator
         for (Page page : result.getOutput()) {
             assertEquals(page.getChannelCount(), 3);
             for (int i = 0; i < page.getPositionCount(); i++) {
-                assertEquals(page.getBlock(2).getLong(i, 0), 1);
+                assertEquals(page.getBlock(2).getLong(i), 1);
                 count++;
             }
         }
@@ -305,7 +305,7 @@ public class TestRowNumberOperator
         assertEquals(rowNumberColumn.getPositionCount(), 8);
         // Check that all row numbers generated are <= 3
         for (int i = 0; i < rowNumberColumn.getPositionCount(); i++) {
-            assertTrue(rowNumberColumn.getLong(i, 0) <= 3);
+            assertTrue(rowNumberColumn.getLong(i) <= 3);
         }
 
         pages = stripRowNumberColumn(pages);
@@ -381,7 +381,7 @@ public class TestRowNumberOperator
         for (Page page : pages) {
             int rowNumberChannel = page.getChannelCount() - 1;
             for (int i = 0; i < page.getPositionCount(); i++) {
-                BIGINT.writeLong(builder, page.getBlock(rowNumberChannel).getLong(i, 0));
+                BIGINT.writeLong(builder, page.getBlock(rowNumberChannel).getLong(i));
             }
         }
         return builder.build();

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTopNRowNumberOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTopNRowNumberOperator.java
@@ -224,7 +224,7 @@ public class TestTopNRowNumberOperator
         for (Page page : result.getOutput()) {
             assertEquals(page.getChannelCount(), 2);
             for (int i = 0; i < page.getPositionCount(); i++) {
-                assertEquals(page.getBlock(1).getByte(i, 0), 1);
+                assertEquals(page.getBlock(1).getByte(i), 1);
                 count++;
             }
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStateCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStateCompiler.java
@@ -235,8 +235,8 @@ public class TestStateCompiler
         assertEquals(deserializedState.getSlice(), singleState.getSlice());
         assertEquals(deserializedState.getAnotherSlice(), singleState.getAnotherSlice());
         assertEquals(deserializedState.getYetAnotherSlice(), singleState.getYetAnotherSlice());
-        assertEquals(deserializedState.getBlock().getLong(0, 0), singleState.getBlock().getLong(0, 0));
-        assertEquals(deserializedState.getAnotherBlock().getLong(0, 0), singleState.getAnotherBlock().getLong(0, 0));
+        assertEquals(deserializedState.getBlock().getLong(0), singleState.getBlock().getLong(0));
+        assertEquals(deserializedState.getAnotherBlock().getLong(0), singleState.getAnotherBlock().getLong(0));
         assertEquals(deserializedState.getAnotherBlock().getSlice(1, 0, 9), singleState.getAnotherBlock().getSlice(1, 0, 9));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageFilter.java
@@ -187,7 +187,7 @@ public class TestDictionaryAwarePageFilter
 
         IntSet expectedSelectedPositions = new IntArraySet(block.getPositionCount());
         for (int position = 0; position < block.getPositionCount(); position++) {
-            if (isSelected(filterRange, block.getLong(position, 0))) {
+            if (isSelected(filterRange, block.getLong(position))) {
                 expectedSelectedPositions.add(position);
             }
         }
@@ -271,7 +271,7 @@ public class TestDictionaryAwarePageFilter
             boolean sequential = true;
             IntArrayList selectedPositions = new IntArrayList();
             for (int position = 0; position < block.getPositionCount(); position++) {
-                long value = block.getLong(position, 0);
+                long value = block.getLong(position);
                 verifyPositive(value);
 
                 boolean selected = isSelected(filterRange, value);

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
@@ -340,7 +340,7 @@ public class TestDictionaryAwarePageProjection
                     int offset = selectedPositions.getOffset();
                     int[] positions = selectedPositions.getPositions();
                     for (int index = nextIndexOrPosition + offset; index < offset + selectedPositions.size(); index++) {
-                        blockBuilder.writeLong(verifyPositive(block.getLong(positions[index], 0)));
+                        blockBuilder.writeLong(verifyPositive(block.getLong(positions[index])));
                         if (yieldSignal.isSet()) {
                             nextIndexOrPosition = index + 1 - offset;
                             return false;
@@ -350,7 +350,7 @@ public class TestDictionaryAwarePageProjection
                 else {
                     int offset = selectedPositions.getOffset();
                     for (int position = nextIndexOrPosition + offset; position < offset + selectedPositions.size(); position++) {
-                        blockBuilder.writeLong(verifyPositive(block.getLong(position, 0)));
+                        blockBuilder.writeLong(verifyPositive(block.getLong(position)));
                         if (yieldSignal.isSet()) {
                             nextIndexOrPosition = position + 1 - offset;
                             return false;

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestGenericPartitioningSpiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestGenericPartitioningSpiller.java
@@ -246,7 +246,7 @@ public class TestGenericPartitioningSpiller
         @Override
         public int getPartition(Page page, int position)
         {
-            long value = page.getBlock(valueChannel).getLong(position, 0);
+            long value = page.getBlock(valueChannel).getLong(position);
             if (value >= FOURTH_PARTITION_START) {
                 return 3;
             }
@@ -282,7 +282,7 @@ public class TestGenericPartitioningSpiller
         @Override
         public int getPartition(Page page, int position)
         {
-            long value = page.getBlock(valueChannel).getLong(position, 0);
+            long value = page.getBlock(valueChannel).getLong(position);
             return toIntExact(Math.abs(value) % partitionCount);
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -138,9 +138,9 @@ public class TestRowExpressionSerde
         assertTrue(value instanceof IntArrayBlock);
         IntArrayBlock block = (IntArrayBlock) value;
         assertEquals(block.getPositionCount(), 3);
-        assertEquals(block.getInt(0, 0), 1);
-        assertEquals(block.getInt(1, 0), 2);
-        assertEquals(block.getInt(2, 0), 3);
+        assertEquals(block.getInt(0), 1);
+        assertEquals(block.getInt(1), 2);
+        assertEquals(block.getInt(2), 3);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestSimpleRowType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestSimpleRowType.java
@@ -67,7 +67,7 @@ public class TestSimpleRowType
 
         Block block = (Block) value;
         singleRowBlockWriter = blockBuilder.beginBlockEntry();
-        BIGINT.writeLong(singleRowBlockWriter, block.getSingleValueBlock(0).getLong(0, 0) + 1);
+        BIGINT.writeLong(singleRowBlockWriter, block.getSingleValueBlock(0).getLong(0) + 1);
         VARCHAR.writeSlice(singleRowBlockWriter, block.getSingleValueBlock(1).getSlice(0, 0, 1));
         blockBuilder.closeEntry();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
@@ -63,6 +63,13 @@ public abstract class AbstractSingleArrayBlock
     }
 
     @Override
+    public long getLong(int position)
+    {
+        checkReadablePosition(position);
+        return getBlock().getLong(position + start);
+    }
+
+    @Override
     public long getLong(int position, int offset)
     {
         checkReadablePosition(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
@@ -42,24 +42,24 @@ public abstract class AbstractSingleArrayBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        return getBlock().getByte(position + start, offset);
+        return getBlock().getByte(position + start);
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        return getBlock().getShort(position + start, offset);
+        return getBlock().getShort(position + start);
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        return getBlock().getInt(position + start, offset);
+        return getBlock().getInt(position + start);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
@@ -85,6 +85,18 @@ public abstract class AbstractSingleMapBlock
     }
 
     @Override
+    public long getLong(int position)
+    {
+        position = getAbsolutePosition(position);
+        if (position % 2 == 0) {
+            return getRawKeyBlock().getLong(position / 2);
+        }
+        else {
+            return getRawValueBlock().getLong(position / 2);
+        }
+    }
+
+    @Override
     public long getLong(int position, int offset)
     {
         position = getAbsolutePosition(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
@@ -49,38 +49,38 @@ public abstract class AbstractSingleMapBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         position = getAbsolutePosition(position);
         if (position % 2 == 0) {
-            return getRawKeyBlock().getByte(position / 2, offset);
+            return getRawKeyBlock().getByte(position / 2);
         }
         else {
-            return getRawValueBlock().getByte(position / 2, offset);
+            return getRawValueBlock().getByte(position / 2);
         }
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         position = getAbsolutePosition(position);
         if (position % 2 == 0) {
-            return getRawKeyBlock().getShort(position / 2, offset);
+            return getRawKeyBlock().getShort(position / 2);
         }
         else {
-            return getRawValueBlock().getShort(position / 2, offset);
+            return getRawValueBlock().getShort(position / 2);
         }
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         position = getAbsolutePosition(position);
         if (position % 2 == 0) {
-            return getRawKeyBlock().getInt(position / 2, offset);
+            return getRawKeyBlock().getInt(position / 2);
         }
         else {
-            return getRawValueBlock().getInt(position / 2, offset);
+            return getRawValueBlock().getInt(position / 2);
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
@@ -43,24 +43,24 @@ public abstract class AbstractSingleRowBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).getByte(rowIndex, offset);
+        return getRawFieldBlock(position).getByte(rowIndex);
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).getShort(rowIndex, offset);
+        return getRawFieldBlock(position).getShort(rowIndex);
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).getInt(rowIndex, offset);
+        return getRawFieldBlock(position).getInt(rowIndex);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
@@ -64,6 +64,13 @@ public abstract class AbstractSingleRowBlock
     }
 
     @Override
+    public long getLong(int position)
+    {
+        checkFieldIndex(position);
+        return getRawFieldBlock(position).getLong(rowIndex);
+    }
+
+    @Override
     public long getLong(int position, int offset)
     {
         checkFieldIndex(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
@@ -36,24 +36,24 @@ public abstract class AbstractVariableWidthBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        return getRawSlice(position).getByte(getPositionOffset(position) + offset);
+        return getRawSlice(position).getByte(getPositionOffset(position));
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        return getRawSlice(position).getShort(getPositionOffset(position) + offset);
+        return getRawSlice(position).getShort(getPositionOffset(position));
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        return getRawSlice(position).getInt(getPositionOffset(position) + offset);
+        return getRawSlice(position).getInt(getPositionOffset(position));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
@@ -57,6 +57,13 @@ public abstract class AbstractVariableWidthBlock
     }
 
     @Override
+    public long getLong(int position)
+    {
+        checkReadablePosition(position);
+        return getRawSlice(position).getLong(getPositionOffset(position));
+    }
+
+    @Override
     public long getLong(int position, int offset)
     {
         checkReadablePosition(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -56,6 +56,14 @@ public interface Block
     }
 
     /**
+     * Gets a little endian long in the value at {@code position}.
+     */
+    default long getLong(int position)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    /**
      * Gets a little endian long at {@code offset} in the value at {@code position}.
      */
     default long getLong(int position, int offset)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -32,25 +32,25 @@ public interface Block
     }
 
     /**
-     * Gets a byte at {@code offset} in the value at {@code position}.
+     * Gets a byte in the value at {@code position}.
      */
-    default byte getByte(int position, int offset)
+    default byte getByte(int position)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
 
     /**
-     * Gets a little endian short at {@code offset} in the value at {@code position}.
+     * Gets a little endian short at in the value at {@code position}.
      */
-    default short getShort(int position, int offset)
+    default short getShort(int position)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
 
     /**
-     * Gets a little endian int at {@code offset} in the value at {@code position}.
+     * Gets a little endian int in the value at {@code position}.
      */
-    default int getInt(int position, int offset)
+    default int getInt(int position)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
@@ -117,12 +117,9 @@ public class ByteArrayBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position + arrayOffset];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
@@ -180,12 +180,9 @@ public class ByteArrayBlockBuilder
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockEncoding.java
@@ -40,7 +40,7 @@ public class ByteArrayBlockEncoding
 
         for (int position = 0; position < positionCount; position++) {
             if (!block.isNull(position)) {
-                sliceOutput.writeByte(block.getByte(position, 0));
+                sliceOutput.writeByte(block.getByte(position));
             }
         }
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -105,21 +105,21 @@ public class DictionaryBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
-        return dictionary.getByte(getId(position), offset);
+        return dictionary.getByte(getId(position));
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
-        return dictionary.getShort(getId(position), offset);
+        return dictionary.getShort(getId(position));
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
-        return dictionary.getInt(getId(position), offset);
+        return dictionary.getInt(getId(position));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -123,6 +123,12 @@ public class DictionaryBlock
     }
 
     @Override
+    public long getLong(int position)
+    {
+        return dictionary.getLong(getId(position));
+    }
+
+    @Override
     public long getLong(int position, int offset)
     {
         return dictionary.getLong(getId(position), offset);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
@@ -117,12 +117,9 @@ public class IntArrayBlock
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position + arrayOffset];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -180,12 +180,9 @@ public class IntArrayBlockBuilder
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockEncoding.java
@@ -40,7 +40,7 @@ public class IntArrayBlockEncoding
 
         for (int position = 0; position < positionCount; position++) {
             if (!block.isNull(position)) {
-                sliceOutput.writeInt(block.getInt(position, 0));
+                sliceOutput.writeInt(block.getInt(position));
             }
         }
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -50,24 +50,24 @@ public class LazyBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         assureLoaded();
-        return block.getByte(position, offset);
+        return block.getByte(position);
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         assureLoaded();
-        return block.getShort(position, offset);
+        return block.getShort(position);
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         assureLoaded();
-        return block.getInt(position, offset);
+        return block.getInt(position);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -71,6 +71,13 @@ public class LazyBlock
     }
 
     @Override
+    public long getLong(int position)
+    {
+        assureLoaded();
+        return block.getLong(position);
+    }
+
+    @Override
     public long getLong(int position, int offset)
     {
         assureLoaded();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
@@ -130,24 +130,18 @@ public class LongArrayBlock
     @Override
     @Deprecated
     // TODO: Remove when we fix intermediate types on aggregations.
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return toIntExact(values[position + arrayOffset]);
     }
 
     @Override
     @Deprecated
     // TODO: Remove when we fix intermediate types on aggregations.
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
 
         short value = (short) (values[position + arrayOffset]);
         if (value != values[position + arrayOffset]) {
@@ -159,12 +153,9 @@ public class LongArrayBlock
     @Override
     @Deprecated
     // TODO: Remove when we fix intermediate types on aggregations.
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
 
         byte value = (byte) (values[position + arrayOffset]);
         if (value != values[position + arrayOffset]) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
@@ -118,12 +118,9 @@ public class LongArrayBlock
     }
 
     @Override
-    public long getLong(int position, int offset)
+    public long getLong(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position + arrayOffset];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -181,12 +181,9 @@ public class LongArrayBlockBuilder
     }
 
     @Override
-    public long getLong(int position, int offset)
+    public long getLong(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -193,24 +193,18 @@ public class LongArrayBlockBuilder
     @Override
     @Deprecated
     // TODO: Remove when we fix intermediate types on aggregations.
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return toIntExact(values[position]);
     }
 
     @Override
     @Deprecated
     // TODO: Remove when we fix intermediate types on aggregations.
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
 
         short value = (short) (values[position]);
         if (value != values[position]) {
@@ -222,12 +216,9 @@ public class LongArrayBlockBuilder
     @Override
     @Deprecated
     // TODO: Remove when we fix intermediate types on aggregations.
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
 
         byte value = (byte) (values[position]);
         if (value != values[position]) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockEncoding.java
@@ -40,7 +40,7 @@ public class LongArrayBlockEncoding
 
         for (int position = 0; position < positionCount; position++) {
             if (!block.isNull(position)) {
-                sliceOutput.writeLong(block.getLong(position, 0));
+                sliceOutput.writeLong(block.getLong(position));
             }
         }
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -166,24 +166,24 @@ public class RunLengthEncodedBlock
     }
 
     @Override
-    public byte getByte(int position, int offset)
+    public byte getByte(int position)
     {
         checkReadablePosition(position);
-        return value.getByte(0, offset);
+        return value.getByte(0);
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        return value.getShort(0, offset);
+        return value.getShort(0);
     }
 
     @Override
-    public int getInt(int position, int offset)
+    public int getInt(int position)
     {
         checkReadablePosition(position);
-        return value.getInt(0, offset);
+        return value.getInt(0);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -187,6 +187,13 @@ public class RunLengthEncodedBlock
     }
 
     @Override
+    public long getLong(int position)
+    {
+        checkReadablePosition(position);
+        return value.getLong(0);
+    }
+
+    @Override
     public long getLong(int position, int offset)
     {
         checkReadablePosition(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
@@ -117,12 +117,9 @@ public class ShortArrayBlock
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position + arrayOffset];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -180,12 +180,9 @@ public class ShortArrayBlockBuilder
     }
 
     @Override
-    public short getShort(int position, int offset)
+    public short getShort(int position)
     {
         checkReadablePosition(position);
-        if (offset != 0) {
-            throw new IllegalArgumentException("offset must be zero");
-        }
         return values[position];
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockEncoding.java
@@ -40,7 +40,7 @@ public class ShortArrayBlockEncoding
 
         for (int position = 0; position < positionCount; position++) {
             if (!block.isNull(position)) {
-                sliceOutput.writeShort(block.getShort(position, 0));
+                sliceOutput.writeShort(block.getShort(position));
             }
         }
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
@@ -52,7 +52,7 @@ public abstract class AbstractIntType
     @Override
     public final long getLong(Block block, int position)
     {
-        return block.getInt(position, 0);
+        return block.getInt(position);
     }
 
     @Override
@@ -74,22 +74,22 @@ public abstract class AbstractIntType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeInt(block.getInt(position, 0)).closeEntry();
+            blockBuilder.writeInt(block.getInt(position)).closeEntry();
         }
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        int leftValue = leftBlock.getInt(leftPosition, 0);
-        int rightValue = rightBlock.getInt(rightPosition, 0);
+        int leftValue = leftBlock.getInt(leftPosition);
+        int rightValue = rightBlock.getInt(rightPosition);
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return hash(block.getInt(position, 0));
+        return hash(block.getInt(position));
     }
 
     @Override
@@ -97,8 +97,8 @@ public abstract class AbstractIntType
     {
         // WARNING: the correctness of InCodeGenerator is dependent on the implementation of this
         // function being the equivalence of internal long representation.
-        int leftValue = leftBlock.getInt(leftPosition, 0);
-        int rightValue = rightBlock.getInt(rightPosition, 0);
+        int leftValue = leftBlock.getInt(leftPosition);
+        int rightValue = rightBlock.getInt(rightPosition);
         return Integer.compare(leftValue, rightValue);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
@@ -52,7 +52,7 @@ public abstract class AbstractLongType
     @Override
     public final long getLong(Block block, int position)
     {
-        return block.getLong(position, 0);
+        return block.getLong(position);
     }
 
     @Override
@@ -74,29 +74,29 @@ public abstract class AbstractLongType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeLong(block.getLong(position, 0)).closeEntry();
+            blockBuilder.writeLong(block.getLong(position)).closeEntry();
         }
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = leftBlock.getLong(leftPosition, 0);
-        long rightValue = rightBlock.getLong(rightPosition, 0);
+        long leftValue = leftBlock.getLong(leftPosition);
+        long rightValue = rightBlock.getLong(rightPosition);
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return hash(block.getLong(position, 0));
+        return hash(block.getLong(position));
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = leftBlock.getLong(leftPosition, 0);
-        long rightValue = rightBlock.getLong(rightPosition, 0);
+        long leftValue = leftBlock.getLong(leftPosition);
+        long rightValue = rightBlock.getLong(rightPosition);
         return Long.compare(leftValue, rightValue);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/BigintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/BigintType.java
@@ -35,7 +35,7 @@ public final class BigintType
             return null;
         }
 
-        return block.getLong(position, 0);
+        return block.getLong(position);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
@@ -85,29 +85,29 @@ public final class BooleanType
             return null;
         }
 
-        return block.getByte(position, 0) != 0;
+        return block.getByte(position) != 0;
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        boolean leftValue = leftBlock.getByte(leftPosition, 0) != 0;
-        boolean rightValue = rightBlock.getByte(rightPosition, 0) != 0;
+        boolean leftValue = leftBlock.getByte(leftPosition) != 0;
+        boolean rightValue = rightBlock.getByte(rightPosition) != 0;
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        boolean value = block.getByte(position, 0) != 0;
+        boolean value = block.getByte(position) != 0;
         return value ? 1231 : 1237;
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        boolean leftValue = leftBlock.getByte(leftPosition, 0) != 0;
-        boolean rightValue = rightBlock.getByte(rightPosition, 0) != 0;
+        boolean leftValue = leftBlock.getByte(leftPosition) != 0;
+        boolean rightValue = rightBlock.getByte(rightPosition) != 0;
         return Boolean.compare(leftValue, rightValue);
     }
 
@@ -118,14 +118,14 @@ public final class BooleanType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeByte(block.getByte(position, 0)).closeEntry();
+            blockBuilder.writeByte(block.getByte(position)).closeEntry();
         }
     }
 
     @Override
     public boolean getBoolean(Block block, int position)
     {
-        return block.getByte(position, 0) != 0;
+        return block.getByte(position) != 0;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DateType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DateType.java
@@ -43,7 +43,7 @@ public final class DateType
             return null;
         }
 
-        int days = block.getInt(position, 0);
+        int days = block.getInt(position);
         return new SqlDate(days);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
@@ -59,14 +59,14 @@ public final class DoubleType
         if (block.isNull(position)) {
             return null;
         }
-        return longBitsToDouble(block.getLong(position, 0));
+        return longBitsToDouble(block.getLong(position));
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        double leftValue = longBitsToDouble(leftBlock.getLong(leftPosition, 0));
-        double rightValue = longBitsToDouble(rightBlock.getLong(rightPosition, 0));
+        double leftValue = longBitsToDouble(leftBlock.getLong(leftPosition));
+        double rightValue = longBitsToDouble(rightBlock.getLong(rightPosition));
 
         // direct equality is correct here
         // noinspection FloatingPointEquality
@@ -77,14 +77,14 @@ public final class DoubleType
     public long hash(Block block, int position)
     {
         // convert to canonical NaN if necessary
-        return AbstractLongType.hash(doubleToLongBits(longBitsToDouble(block.getLong(position, 0))));
+        return AbstractLongType.hash(doubleToLongBits(longBitsToDouble(block.getLong(position))));
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        double leftValue = longBitsToDouble(leftBlock.getLong(leftPosition, 0));
-        double rightValue = longBitsToDouble(rightBlock.getLong(rightPosition, 0));
+        double leftValue = longBitsToDouble(leftBlock.getLong(leftPosition));
+        double rightValue = longBitsToDouble(rightBlock.getLong(rightPosition));
         return Double.compare(leftValue, rightValue);
     }
 
@@ -95,14 +95,14 @@ public final class DoubleType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeLong(block.getLong(position, 0)).closeEntry();
+            blockBuilder.writeLong(block.getLong(position)).closeEntry();
         }
     }
 
     @Override
     public double getDouble(Block block, int position)
     {
-        return longBitsToDouble(block.getLong(position, 0));
+        return longBitsToDouble(block.getLong(position));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/IntegerType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/IntegerType.java
@@ -38,7 +38,7 @@ public final class IntegerType
             return null;
         }
 
-        return block.getInt(position, 0);
+        return block.getInt(position);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/RealType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/RealType.java
@@ -41,14 +41,14 @@ public final class RealType
         if (block.isNull(position)) {
             return null;
         }
-        return intBitsToFloat(block.getInt(position, 0));
+        return intBitsToFloat(block.getInt(position));
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        float leftValue = intBitsToFloat(leftBlock.getInt(leftPosition, 0));
-        float rightValue = intBitsToFloat(rightBlock.getInt(rightPosition, 0));
+        float leftValue = intBitsToFloat(leftBlock.getInt(leftPosition));
+        float rightValue = intBitsToFloat(rightBlock.getInt(rightPosition));
 
         // direct equality is correct here
         // noinspection FloatingPointEquality
@@ -59,7 +59,7 @@ public final class RealType
     public long hash(Block block, int position)
     {
         // convert to canonical NaN if necessary
-        return hash(floatToIntBits(intBitsToFloat(block.getInt(position, 0))));
+        return hash(floatToIntBits(intBitsToFloat(block.getInt(position))));
     }
 
     @Override
@@ -67,8 +67,8 @@ public final class RealType
     {
         // WARNING: the correctness of InCodeGenerator is dependent on the implementation of this
         // function being the equivalence of internal long representation.
-        float leftValue = intBitsToFloat(leftBlock.getInt(leftPosition, 0));
-        float rightValue = intBitsToFloat(rightBlock.getInt(rightPosition, 0));
+        float leftValue = intBitsToFloat(leftBlock.getInt(leftPosition));
+        float rightValue = intBitsToFloat(rightBlock.getInt(rightPosition));
         return Float.compare(leftValue, rightValue);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
@@ -73,29 +73,29 @@ final class ShortDecimalType
         if (block.isNull(position)) {
             return null;
         }
-        long unscaledValue = block.getLong(position, 0);
+        long unscaledValue = block.getLong(position);
         return new SqlDecimal(BigInteger.valueOf(unscaledValue), getPrecision(), getScale());
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = leftBlock.getLong(leftPosition, 0);
-        long rightValue = rightBlock.getLong(rightPosition, 0);
+        long leftValue = leftBlock.getLong(leftPosition);
+        long rightValue = rightBlock.getLong(rightPosition);
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return block.getLong(position, 0);
+        return block.getLong(position);
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = leftBlock.getLong(leftPosition, 0);
-        long rightValue = rightBlock.getLong(rightPosition, 0);
+        long leftValue = leftBlock.getLong(leftPosition);
+        long rightValue = rightBlock.getLong(rightPosition);
         return Long.compare(leftValue, rightValue);
     }
 
@@ -106,14 +106,14 @@ final class ShortDecimalType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeLong(block.getLong(position, 0)).closeEntry();
+            blockBuilder.writeLong(block.getLong(position)).closeEntry();
         }
     }
 
     @Override
     public long getLong(Block block, int position)
     {
-        return block.getLong(position, 0);
+        return block.getLong(position);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
@@ -88,21 +88,21 @@ public final class SmallintType
             return null;
         }
 
-        return block.getShort(position, 0);
+        return block.getShort(position);
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        int leftValue = leftBlock.getShort(leftPosition, 0);
-        int rightValue = rightBlock.getShort(rightPosition, 0);
+        int leftValue = leftBlock.getShort(leftPosition);
+        int rightValue = rightBlock.getShort(rightPosition);
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return hash(block.getShort(position, 0));
+        return hash(block.getShort(position));
     }
 
     @Override
@@ -110,8 +110,8 @@ public final class SmallintType
     {
         // WARNING: the correctness of InCodeGenerator is dependent on the implementation of this
         // function being the equivalence of internal long representation.
-        short leftValue = leftBlock.getShort(leftPosition, 0);
-        short rightValue = rightBlock.getShort(rightPosition, 0);
+        short leftValue = leftBlock.getShort(leftPosition);
+        short rightValue = rightBlock.getShort(rightPosition);
         return Short.compare(leftValue, rightValue);
     }
 
@@ -122,14 +122,14 @@ public final class SmallintType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeShort(block.getShort(position, 0)).closeEntry();
+            blockBuilder.writeShort(block.getShort(position)).closeEntry();
         }
     }
 
     @Override
     public long getLong(Block block, int position)
     {
-        return (long) block.getShort(position, 0);
+        return (long) block.getShort(position);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeType.java
@@ -40,10 +40,10 @@ public final class TimeType
         }
 
         if (session.isLegacyTimestamp()) {
-            return new SqlTime(block.getLong(position, 0), session.getTimeZoneKey());
+            return new SqlTime(block.getLong(position), session.getTimeZoneKey());
         }
         else {
-            return new SqlTime(block.getLong(position, 0));
+            return new SqlTime(block.getLong(position));
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeWithTimeZoneType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimeWithTimeZoneType.java
@@ -36,27 +36,27 @@ public final class TimeWithTimeZoneType
             return null;
         }
 
-        return new SqlTimeWithTimeZone(block.getLong(position, 0));
+        return new SqlTimeWithTimeZone(block.getLong(position));
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition, 0));
-        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition, 0));
+        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition));
+        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition));
         return leftValue == rightValue;
     }
 
     public long hash(Block block, int position)
     {
-        return AbstractLongType.hash(unpackMillisUtc(block.getLong(position, 0)));
+        return AbstractLongType.hash(unpackMillisUtc(block.getLong(position)));
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition, 0));
-        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition, 0));
+        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition));
+        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition));
         return Long.compare(leftValue, rightValue);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampType.java
@@ -40,10 +40,10 @@ public final class TimestampType
         }
 
         if (session.isLegacyTimestamp()) {
-            return new SqlTimestamp(block.getLong(position, 0), session.getTimeZoneKey());
+            return new SqlTimestamp(block.getLong(position), session.getTimeZoneKey());
         }
         else {
-            return new SqlTimestamp(block.getLong(position, 0));
+            return new SqlTimestamp(block.getLong(position));
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampWithTimeZoneType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TimestampWithTimeZoneType.java
@@ -36,28 +36,28 @@ public final class TimestampWithTimeZoneType
             return null;
         }
 
-        return new SqlTimestampWithTimeZone(block.getLong(position, 0));
+        return new SqlTimestampWithTimeZone(block.getLong(position));
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition, 0));
-        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition, 0));
+        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition));
+        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition));
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return AbstractLongType.hash(unpackMillisUtc(block.getLong(position, 0)));
+        return AbstractLongType.hash(unpackMillisUtc(block.getLong(position)));
     }
 
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition, 0));
-        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition, 0));
+        long leftValue = unpackMillisUtc(leftBlock.getLong(leftPosition));
+        long rightValue = unpackMillisUtc(rightBlock.getLong(rightPosition));
         return Long.compare(leftValue, rightValue);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
@@ -88,21 +88,21 @@ public final class TinyintType
             return null;
         }
 
-        return block.getByte(position, 0);
+        return block.getByte(position);
     }
 
     @Override
     public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        int leftValue = leftBlock.getByte(leftPosition, 0);
-        int rightValue = rightBlock.getByte(rightPosition, 0);
+        int leftValue = leftBlock.getByte(leftPosition);
+        int rightValue = rightBlock.getByte(rightPosition);
         return leftValue == rightValue;
     }
 
     @Override
     public long hash(Block block, int position)
     {
-        return hash(block.getByte(position, 0));
+        return hash(block.getByte(position));
     }
 
     @Override
@@ -110,8 +110,8 @@ public final class TinyintType
     {
         // WARNING: the correctness of InCodeGenerator is dependent on the implementation of this
         // function being the equivalence of internal long representation.
-        byte leftValue = leftBlock.getByte(leftPosition, 0);
-        byte rightValue = rightBlock.getByte(rightPosition, 0);
+        byte leftValue = leftBlock.getByte(leftPosition);
+        byte rightValue = rightBlock.getByte(rightPosition);
         return Byte.compare(leftValue, rightValue);
     }
 
@@ -122,14 +122,14 @@ public final class TinyintType
             blockBuilder.appendNull();
         }
         else {
-            blockBuilder.writeByte(block.getByte(position, 0)).closeEntry();
+            blockBuilder.writeByte(block.getByte(position)).closeEntry();
         }
     }
 
     @Override
     public long getLong(Block block, int position)
     {
-        return (long) block.getByte(position, 0);
+        return (long) block.getByte(position);
     }
 
     @Override

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestPage.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestPage.java
@@ -114,11 +114,11 @@ public class TestPage
         Page page = new Page(block, block, block).getPositions(new int[] {0, 1, 1, 1, 2, 5, 5}, 1, 5);
         assertEquals(page.getPositionCount(), 5);
         for (int i = 0; i < 3; i++) {
-            assertEquals(page.getBlock(i).getLong(0, 0), 1);
-            assertEquals(page.getBlock(i).getLong(1, 0), 1);
-            assertEquals(page.getBlock(i).getLong(2, 0), 1);
-            assertEquals(page.getBlock(i).getLong(3, 0), 2);
-            assertEquals(page.getBlock(i).getLong(4, 0), 5);
+            assertEquals(page.getBlock(i).getLong(0), 1);
+            assertEquals(page.getBlock(i).getLong(1), 1);
+            assertEquals(page.getBlock(i).getLong(2), 1);
+            assertEquals(page.getBlock(i).getLong(3), 2);
+            assertEquals(page.getBlock(i).getLong(4), 5);
         }
     }
 

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingIdType.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestingIdType.java
@@ -42,7 +42,7 @@ public class TestingIdType
             return null;
         }
 
-        return block.getLong(position, 0);
+        return block.getLong(position);
     }
 
     @Override

--- a/presto-thrift-connector-api/src/test/java/com/facebook/presto/connector/thrift/api/datatypes/TestPrestoThriftBigint.java
+++ b/presto-thrift-connector-api/src/test/java/com/facebook/presto/connector/thrift/api/datatypes/TestPrestoThriftBigint.java
@@ -156,7 +156,7 @@ public class TestPrestoThriftBigint
                 assertTrue(block.isNull(i));
             }
             else {
-                assertEquals(block.getLong(i, 0), expected.get(i).longValue());
+                assertEquals(block.getLong(i), expected.get(i).longValue());
             }
         }
     }

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftIndexPageSource.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftIndexPageSource.java
@@ -119,7 +119,7 @@ public class TestThriftIndexPageSource
         assertEquals((long) stats.getIndexPageSize().getAllTime().getTotal(), pageSizeReceived);
         assertNotNull(page);
         assertEquals(page.getPositionCount(), 1);
-        assertEquals(page.getBlock(0).getInt(0, 0), 20);
+        assertEquals(page.getBlock(0).getInt(0), 20);
         // not complete yet
         assertFalse(pageSource.isFinished());
 
@@ -134,7 +134,7 @@ public class TestThriftIndexPageSource
         pageSizeReceived += page.getSizeInBytes();
         assertEquals((long) stats.getIndexPageSize().getAllTime().getTotal(), pageSizeReceived);
         assertEquals(page.getPositionCount(), 1);
-        assertEquals(page.getBlock(0).getInt(0, 0), 10);
+        assertEquals(page.getBlock(0).getInt(0), 10);
         // still not complete
         assertFalse(pageSource.isFinished());
 
@@ -145,7 +145,7 @@ public class TestThriftIndexPageSource
         pageSizeReceived += page.getSizeInBytes();
         assertEquals((long) stats.getIndexPageSize().getAllTime().getTotal(), pageSizeReceived);
         assertEquals(page.getPositionCount(), 1);
-        assertEquals(page.getBlock(0).getInt(0, 0), 30);
+        assertEquals(page.getBlock(0).getInt(0), 30);
         // finished now
         assertTrue(pageSource.isFinished());
 
@@ -205,7 +205,7 @@ public class TestThriftIndexPageSource
             if (page != null) {
                 Block block = page.getBlock(0);
                 for (int position = 0; position < block.getPositionCount(); position++) {
-                    actual.add(block.getInt(position, 0));
+                    actual.add(block.getInt(position));
                 }
             }
         }


### PR DESCRIPTION
Historically, the offset parameter in block primitive type
getter method (getByte, getShort, getInt, getLong) are mainly
used for encode/decode complex types before
`InterleavedBlock` is introduced.

Now we have natural columnar representations for complex types,
the offset parameter is no longer used except in `LongDecimalType`,
where `getLong(position, SIZE_OF_LONG)` is used to retrieve
the high 64 bit int a 128 bit unscaled decimal value.

WIP to revive https://github.com/prestodb/presto/pull/9477 . `getLong` requires a different solution. 