### PR TITLE
Make max error in approx_set tunable

### DIFF
--- a/presto-docs/src/main/sphinx/functions/hyperloglog.rst
+++ b/presto-docs/src/main/sphinx/functions/hyperloglog.rst
@@ -54,8 +54,17 @@ Functions
 
 .. function:: approx_set(x) -> HyperLogLog
 
-    Returns the ``HyperLogLog`` sketch of the input data set of ``x``. This
-    data sketch underlies :func:`approx_distinct` and can be stored and
+    Returns the ``HyperLogLog`` sketch of the input data set of ``x``.
+    The value of the maximum standard error is defaulted to ``0.01625``.
+    This data sketch underlies :func:`approx_distinct` and can be stored and
+    used later by calling ``cardinality()``.
+
+.. function:: approx_set(x, e) -> HyperLogLog
+
+    Returns the ``HyperLogLog`` sketch of the input data set of ``x``, with
+    a maximum standard error of ``e``. The current implementation of this
+    function requires that ``e`` be in the range of ``[0.0040625, 0.26000]``.
+    This data sketch underlies :func:`approx_distinct` and can be stored and
     used later by calling ``cardinality()``.
 
 .. function:: cardinality(hll) -> bigint
@@ -67,6 +76,13 @@ Functions
 .. function:: empty_approx_set() -> HyperLogLog
 
     Returns an empty ``HyperLogLog``.
+    The value of the maximum standard error is defaulted to ``0.01625``.
+
+.. function:: empty_approx_set(e) -> HyperLogLog
+
+    Returns an empty ``HyperLogLog`` with a maximum standard error of ``e``.
+    The current implementation of this function requires that ``e`` be in
+    the range of ``[0.0040625, 0.26000]``.
 
 .. function:: merge(HyperLogLog) -> HyperLogLog
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountDistinctAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateCountDistinctAggregation.java
@@ -28,24 +28,18 @@ import com.facebook.presto.spi.function.OutputFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.StandardTypes;
-import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.Slice;
 import io.airlift.stats.cardinality.HyperLogLog;
 
 import java.lang.invoke.MethodHandle;
 
-import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
-import static com.facebook.presto.util.Failures.checkCondition;
 import static com.facebook.presto.util.Failures.internalError;
 
 @AggregationFunction("approx_distinct")
 public final class ApproximateCountDistinctAggregation
 {
-    private static final double LOWEST_MAX_STANDARD_ERROR = 0.0040625;
-    private static final double HIGHEST_MAX_STANDARD_ERROR = 0.26000;
-
     private ApproximateCountDistinctAggregation() {}
 
     @InputFunction
@@ -66,7 +60,7 @@ public final class ApproximateCountDistinctAggregation
             @SqlType("T") long value,
             @SqlType(StandardTypes.DOUBLE) double maxStandardError)
     {
-        HyperLogLog hll = getOrCreateHyperLogLog(state, maxStandardError);
+        HyperLogLog hll = HyperLogLogUtils.getOrCreateHyperLogLog(state, maxStandardError);
         state.addMemoryUsage(-hll.estimatedInMemorySize());
         long hash;
         try {
@@ -87,7 +81,7 @@ public final class ApproximateCountDistinctAggregation
             @SqlType("T") double value,
             @SqlType(StandardTypes.DOUBLE) double maxStandardError)
     {
-        HyperLogLog hll = getOrCreateHyperLogLog(state, maxStandardError);
+        HyperLogLog hll = HyperLogLogUtils.getOrCreateHyperLogLog(state, maxStandardError);
         state.addMemoryUsage(-hll.estimatedInMemorySize());
         long hash;
         try {
@@ -108,7 +102,7 @@ public final class ApproximateCountDistinctAggregation
             @SqlType("T") Slice value,
             @SqlType(StandardTypes.DOUBLE) double maxStandardError)
     {
-        HyperLogLog hll = getOrCreateHyperLogLog(state, maxStandardError);
+        HyperLogLog hll = HyperLogLogUtils.getOrCreateHyperLogLog(state, maxStandardError);
         state.addMemoryUsage(-hll.estimatedInMemorySize());
         long hash;
         try {
@@ -127,46 +121,10 @@ public final class ApproximateCountDistinctAggregation
         state.setByte((byte) (state.getByte() | (value ? 1 : 2)));
     }
 
-    private static HyperLogLog getOrCreateHyperLogLog(HyperLogLogState state, double maxStandardError)
-    {
-        HyperLogLog hll = state.getHyperLogLog();
-        if (hll == null) {
-            hll = HyperLogLog.newInstance(standardErrorToBuckets(maxStandardError));
-            state.setHyperLogLog(hll);
-            state.addMemoryUsage(hll.estimatedInMemorySize());
-        }
-        return hll;
-    }
-
-    @VisibleForTesting
-    static int standardErrorToBuckets(double maxStandardError)
-    {
-        checkCondition(maxStandardError >= LOWEST_MAX_STANDARD_ERROR && maxStandardError <= HIGHEST_MAX_STANDARD_ERROR,
-                INVALID_FUNCTION_ARGUMENT,
-                "Max standard error must be in [%s, %s]: %s", LOWEST_MAX_STANDARD_ERROR, HIGHEST_MAX_STANDARD_ERROR, maxStandardError);
-        return log2Ceiling((int) Math.ceil(1.0816 / (maxStandardError * maxStandardError)));
-    }
-
-    private static int log2Ceiling(int value)
-    {
-        return Integer.highestOneBit(value - 1) << 1;
-    }
-
     @CombineFunction
     public static void combineState(@AggregationState HyperLogLogState state, @AggregationState HyperLogLogState otherState)
     {
-        HyperLogLog input = otherState.getHyperLogLog();
-
-        HyperLogLog previous = state.getHyperLogLog();
-        if (previous == null) {
-            state.setHyperLogLog(input);
-            state.addMemoryUsage(input.estimatedInMemorySize());
-        }
-        else {
-            state.addMemoryUsage(-previous.estimatedInMemorySize());
-            previous.mergeWith(input);
-            state.addMemoryUsage(previous.estimatedInMemorySize());
-        }
+        HyperLogLogUtils.mergeState(state, otherState.getHyperLogLog());
     }
 
     @CombineFunction

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/HyperLogLogUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/HyperLogLogUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.HyperLogLogState;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AggregationState;
+import io.airlift.stats.cardinality.HyperLogLog;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.util.Failures.checkCondition;
+
+public final class HyperLogLogUtils
+{
+    private static final double LOWEST_MAX_STANDARD_ERROR = 0.0040625;
+    private static final double HIGHEST_MAX_STANDARD_ERROR = 0.26000;
+
+    private HyperLogLogUtils()
+    {
+    }
+
+    public static int standardErrorToBuckets(double maxStandardError)
+    {
+        checkCondition(maxStandardError >= LOWEST_MAX_STANDARD_ERROR && maxStandardError <= HIGHEST_MAX_STANDARD_ERROR,
+                INVALID_FUNCTION_ARGUMENT,
+                "Max standard error must be in [%s, %s]: %s", LOWEST_MAX_STANDARD_ERROR, HIGHEST_MAX_STANDARD_ERROR, maxStandardError);
+        return log2Ceiling((int) Math.ceil(1.0816 / (maxStandardError * maxStandardError)));
+    }
+
+    public static HyperLogLog getOrCreateHyperLogLog(HyperLogLogState state, double maxStandardError)
+    {
+        HyperLogLog hll = state.getHyperLogLog();
+        if (hll == null) {
+            hll = HyperLogLog.newInstance(standardErrorToBuckets(maxStandardError));
+            state.setHyperLogLog(hll);
+            state.addMemoryUsage(hll.estimatedInMemorySize());
+        }
+        return hll;
+    }
+
+    public static void mergeState(@AggregationState HyperLogLogState state, HyperLogLog input)
+    {
+        HyperLogLog previous = state.getHyperLogLog();
+        if (previous == null) {
+            state.setHyperLogLog(input);
+            state.addMemoryUsage(input.estimatedInMemorySize());
+        }
+        else {
+            state.addMemoryUsage(-previous.estimatedInMemorySize());
+            try {
+                // Throws if the bucket counts are different.
+                // We currently cannot access these counts from HLL so we must
+                // catch and rethrow a more useful exception
+                previous.mergeWith(input);
+            }
+            catch (IllegalArgumentException e) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+            }
+            state.addMemoryUsage(previous.estimatedInMemorySize());
+        }
+    }
+
+    private static int log2Ceiling(int value)
+    {
+        return Integer.highestOneBit(value - 1) << 1;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MergeHyperLogLogAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MergeHyperLogLogAggregation.java
@@ -38,27 +38,13 @@ public final class MergeHyperLogLogAggregation
     public static void input(@AggregationState HyperLogLogState state, @SqlType(StandardTypes.HYPER_LOG_LOG) Slice value)
     {
         HyperLogLog input = HyperLogLog.newInstance(value);
-        merge(state, input);
+        HyperLogLogUtils.mergeState(state, input);
     }
 
     @CombineFunction
     public static void combine(@AggregationState HyperLogLogState state, @AggregationState HyperLogLogState otherState)
     {
-        merge(state, otherState.getHyperLogLog());
-    }
-
-    private static void merge(@AggregationState HyperLogLogState state, HyperLogLog input)
-    {
-        HyperLogLog previous = state.getHyperLogLog();
-        if (previous == null) {
-            state.setHyperLogLog(input);
-            state.addMemoryUsage(input.estimatedInMemorySize());
-        }
-        else {
-            state.addMemoryUsage(-previous.estimatedInMemorySize());
-            previous.mergeWith(input);
-            state.addMemoryUsage(previous.estimatedInMemorySize());
-        }
+        HyperLogLogUtils.mergeState(state, otherState.getHyperLogLog());
     }
 
     @OutputFunction(StandardTypes.HYPER_LOG_LOG)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/HyperLogLogFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/HyperLogLogFunctions.java
@@ -13,13 +13,15 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.operator.aggregation.ApproximateSetAggregation;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
 import io.airlift.stats.cardinality.HyperLogLog;
+
+import static com.facebook.presto.operator.aggregation.ApproximateSetAggregation.DEFAULT_STANDARD_ERROR;
+import static com.facebook.presto.operator.aggregation.HyperLogLogUtils.standardErrorToBuckets;
 
 public final class HyperLogLogFunctions
 {
@@ -38,6 +40,14 @@ public final class HyperLogLogFunctions
     @SqlType(StandardTypes.HYPER_LOG_LOG)
     public static Slice emptyApproxSet()
     {
-        return ApproximateSetAggregation.newHyperLogLog().serialize();
+        return HyperLogLog.newInstance(standardErrorToBuckets(DEFAULT_STANDARD_ERROR)).serialize();
+    }
+
+    @ScalarFunction
+    @Description("an empty HyperLogLog instance with the specified max standard error")
+    @SqlType(StandardTypes.HYPER_LOG_LOG)
+    public static Slice emptyApproxSet(@SqlType(StandardTypes.DOUBLE) double maxStandardError)
+    {
+        return HyperLogLog.newInstance(standardErrorToBuckets(maxStandardError)).serialize();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestHyperLogLogUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestHyperLogLogUtils.java
@@ -16,12 +16,12 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.spi.PrestoException;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.operator.aggregation.ApproximateCountDistinctAggregation.standardErrorToBuckets;
+import static com.facebook.presto.operator.aggregation.HyperLogLogUtils.standardErrorToBuckets;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
-public class TestApproximateCountDistinctAggregations
+public class TestHyperLogLogUtils
 {
     @Test
     public void testStandardErrorToBuckets()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/CreateHll.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/CreateHll.java
@@ -19,6 +19,9 @@ import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.slice.Slice;
 import io.airlift.stats.cardinality.HyperLogLog;
 
+import static com.facebook.presto.operator.aggregation.ApproximateSetAggregation.DEFAULT_STANDARD_ERROR;
+import static com.facebook.presto.operator.aggregation.HyperLogLogUtils.standardErrorToBuckets;
+
 public final class CreateHll
 {
     private CreateHll() {}
@@ -27,7 +30,16 @@ public final class CreateHll
     @SqlType(StandardTypes.HYPER_LOG_LOG)
     public static Slice createHll(@SqlType(StandardTypes.BIGINT) long value)
     {
-        HyperLogLog hll = HyperLogLog.newInstance(4096);
+        HyperLogLog hll = HyperLogLog.newInstance(standardErrorToBuckets(DEFAULT_STANDARD_ERROR));
+        hll.add(value);
+        return hll.serialize();
+    }
+
+    @ScalarFunction
+    @SqlType(StandardTypes.HYPER_LOG_LOG)
+    public static Slice createHll(@SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.DOUBLE) double maxStandardError)
+    {
+        HyperLogLog hll = HyperLogLog.newInstance(standardErrorToBuckets(maxStandardError));
         hll.add(value);
         return hll.serialize();
     }


### PR DESCRIPTION
Adds a new version: approx_set(x, e)
Also for empty_approx_set(e)

This brings it in line with the approx_distinct functionality, although I kept the existing difference in default max standard error (0.01625 vs 0.023 i.e. 4096 vs 2048 buckets).

Issue: #12506