### PR TITLE
Move removeRemoteSource from RemoteTaskFactory to RemoteTask

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryTrackingRemoteTaskFactory.java
@@ -22,7 +22,6 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.Multimap;
-import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.OptionalInt;
 
@@ -63,12 +62,6 @@ public class MemoryTrackingRemoteTaskFactory
 
         task.addStateChangeListener(new UpdatePeakMemory(stateMachine));
         return task;
-    }
-
-    @Override
-    public ListenableFuture<?> removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId)
-    {
-        return remoteTaskFactory.removeRemoteSource(taskId, remoteSourceTaskId);
     }
 
     private static final class UpdatePeakMemory

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
@@ -40,6 +40,8 @@ public interface RemoteTask
 
     void setOutputBuffers(OutputBuffers outputBuffers);
 
+    ListenableFuture<?> removeRemoteSource(TaskId remoteSourceTaskId);
+
     /**
      * Listener is always notified asynchronously using a dedicated notification thread pool so, care should
      * be taken to avoid leaking {@code this} when adding a listener in a constructor. Additionally, it is

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
@@ -21,7 +21,6 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.Multimap;
-import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.OptionalInt;
 
@@ -36,6 +35,4 @@ public interface RemoteTaskFactory
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             boolean summarizeTaskInfo);
-
-    ListenableFuture<?> removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId);
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -31,45 +31,29 @@ import com.facebook.presto.server.InternalCommunicationConfig;
 import com.facebook.presto.server.TaskUpdateRequest;
 import com.facebook.presto.server.smile.Codec;
 import com.facebook.presto.server.smile.SmileCodec;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.PlanNodeId;
 import com.google.common.collect.Multimap;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.concurrent.ThreadPoolExecutorMBean;
 import io.airlift.http.client.HttpClient;
-import io.airlift.http.client.Request;
-import io.airlift.http.client.StatusResponseHandler.StatusResponse;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
-import javax.annotation.Nullable;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
-import java.net.URI;
 import java.util.OptionalInt;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import static com.facebook.presto.server.smile.JsonCodecWrapper.wrapJsonCodec;
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static com.google.common.util.concurrent.Futures.addCallback;
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.airlift.http.client.HttpStatus.OK;
-import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
-import static io.airlift.http.client.Request.Builder.prepareDelete;
-import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
@@ -183,75 +167,5 @@ public class HttpRemoteTaskFactory
                 partitionedSplitCountTracker,
                 stats,
                 isBinaryTransportEnabled);
-    }
-
-    @Override
-    public ListenableFuture<?> removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId)
-    {
-        URI remoteSourceUri = uriBuilderFrom(locationFactory.createLocalTaskLocation(taskId))
-                .appendPath("remote-source")
-                .appendPath(remoteSourceTaskId.toString())
-                .build();
-
-        Request request = prepareDelete()
-                .setUri(remoteSourceUri)
-                .build();
-        RequestErrorTracker errorTracker = new RequestErrorTracker(
-                taskId,
-                remoteSourceUri,
-                maxErrorDuration,
-                errorScheduledExecutor,
-                "Remove exchange remote source");
-
-        SettableFuture<?> future = SettableFuture.create();
-        removeRemoteSourceHelper(errorTracker, request, future);
-        return future;
-    }
-
-    private void removeRemoteSourceHelper(RequestErrorTracker errorTracker, Request request, SettableFuture<?> future)
-    {
-        errorTracker.startRequest();
-
-        FutureCallback<StatusResponse> callback = new FutureCallback<StatusResponse>() {
-            @Override
-            public void onSuccess(@Nullable StatusResponse response)
-            {
-                if (response == null) {
-                    throw new PrestoException(GENERIC_INTERNAL_ERROR, "Request failed with null response");
-                }
-                if (response.getStatusCode() != OK.code()) {
-                    throw new PrestoException(GENERIC_INTERNAL_ERROR, "Request failed with HTTP status " + response.getStatusCode());
-                }
-                future.set(null);
-            }
-
-            @Override
-            public void onFailure(Throwable failedReason)
-            {
-                if (failedReason instanceof RejectedExecutionException && httpClient.isClosed()) {
-                    LOG.error("Unable to destroy exchange source at %s. HTTP client is closed", request.getUri());
-                    future.setException(failedReason);
-                    return;
-                }
-                // record failure
-                try {
-                    errorTracker.requestFailed(failedReason);
-                }
-                catch (PrestoException e) {
-                    future.setException(e);
-                    return;
-                }
-                // if throttled due to error, asynchronously wait for timeout and try again
-                ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
-                if (errorRateLimit.isDone()) {
-                    removeRemoteSourceHelper(errorTracker, request, future);
-                }
-                else {
-                    errorRateLimit.addListener(() -> removeRemoteSourceHelper(errorTracker, request, future), errorScheduledExecutor);
-                }
-            }
-        };
-
-        addCallback(httpClient.executeAsync(request, createStatusResponseHandler()), callback, directExecutor());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -143,12 +143,6 @@ public class MockRemoteTaskFactory
         return new MockRemoteTask(taskId, fragment, node.getNodeIdentifier(), executor, scheduledExecutor, initialSplits, totalPartitions, partitionedSplitCountTracker);
     }
 
-    @Override
-    public ListenableFuture<?> removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId)
-    {
-        throw new UnsupportedOperationException();
-    }
-
     public static final class MockRemoteTask
             implements RemoteTask
     {
@@ -372,6 +366,12 @@ public class MockRemoteTaskFactory
         public void setOutputBuffers(OutputBuffers outputBuffers)
         {
             outputBuffer.setOutputBuffers(outputBuffers);
+        }
+
+        @Override
+        public ListenableFuture<?> removeRemoteSource(TaskId remoteSourceTaskId)
+        {
+            throw new UnsupportedOperationException();
         }
 
         @Override


### PR DESCRIPTION
Loose ends as discussed in https://github.com/prestodb/presto/pull/12488#discussion_r271532854 ; required by recoverable grouped execution (https://github.com/prestodb/presto/issues/12124)