### PR TITLE
Make Aggregation use RowExpression instead

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionExtractor.java
@@ -92,11 +92,8 @@ public class ExpressionExtractor
         {
             node.getAggregations().values()
                     .forEach(aggregation -> {
-                        aggregation.getArguments()
-                                .stream()
-                                .map(OriginalExpressionUtils::castToRowExpression)
-                                .forEach(context::add);
-                        aggregation.getFilter().map(OriginalExpressionUtils::castToRowExpression).ifPresent(context::add);
+                        aggregation.getArguments().forEach(context::add);
+                        aggregation.getFilter().ifPresent(context::add);
                         aggregation.getOrderBy()
                                 .map(OrderingScheme::getOrderBy)
                                 .orElse(ImmutableList.of())

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
@@ -15,16 +15,19 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.spi.block.SortOrder;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.facebook.presto.sql.relational.Expressions.variable;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class PlannerUtils
 {
@@ -44,18 +47,26 @@ public class PlannerUtils
         return SortOrder.DESC_NULLS_LAST;
     }
 
-    public static OrderingScheme toOrderingScheme(List<SortItem> sortItems, TypeProvider typeProvider)
+    public static OrderingScheme toOrderingScheme(OrderBy orderBy, TypeProvider types)
     {
-        // The logic is similar to QueryPlanner::sort
+        return toOrderingScheme(
+                orderBy.getSortItems().stream()
+                        .map(SortItem::getSortKey)
+                        .map(item -> {
+                            checkArgument(item instanceof SymbolReference, "must be symbol reference");
+                            Symbol symbol = Symbol.from(item);
+                            return variable(symbol.getName(), types.get(symbol));
+                        }).collect(toImmutableList()),
+                orderBy.getSortItems().stream()
+                        .map(PlannerUtils::toSortOrder)
+                        .collect(toImmutableList()));
+    }
+
+    public static OrderingScheme toOrderingScheme(List<VariableReferenceExpression> orderingSymbols, List<SortOrder> sortOrders)
+    {
         Map<VariableReferenceExpression, SortOrder> orderings = new LinkedHashMap<>();
-        for (SortItem item : sortItems) {
-            Expression sortKey = item.getSortKey();
-            checkArgument(sortKey instanceof SymbolReference, "must be symbol reference");
-            Symbol symbol = Symbol.from(sortKey);
-            VariableReferenceExpression variable = new VariableReferenceExpression(symbol.getName(), typeProvider.get(symbol));
-            // don't override existing keys, i.e. when "ORDER BY a ASC, a DESC" is specified
-            orderings.putIfAbsent(variable, toSortOrder(item));
-        }
+        // don't override existing keys, i.e. when "ORDER BY a ASC, a DESC" is specified
+        Streams.forEachPair(orderingSymbols.stream(), sortOrders.stream(), orderings::putIfAbsent);
         return new OrderingScheme(ImmutableList.copyOf(orderings.keySet()), orderings);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionVariableInliner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionVariableInliner.java
@@ -26,27 +26,27 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
-public final class RowExpressionSymbolInliner
+public final class RowExpressionVariableInliner
         extends RowExpressionRewriter<Void>
 {
     private final Set<String> excludedNames = new HashSet<>();
-    private final Map<Symbol, Symbol> mapping;
+    private final Map<VariableReferenceExpression, RowExpression> mapping;
 
-    private RowExpressionSymbolInliner(Map<Symbol, Symbol> mapping)
+    private RowExpressionVariableInliner(Map<VariableReferenceExpression, RowExpression> mapping)
     {
         this.mapping = mapping;
     }
 
-    public static RowExpression inlineSymbols(Map<Symbol, Symbol> mapping, RowExpression expression)
+    public static RowExpression inlineVariables(Map<VariableReferenceExpression, RowExpression> mapping, RowExpression expression)
     {
-        return RowExpressionTreeRewriter.rewriteWith(new RowExpressionSymbolInliner(mapping), expression);
+        return RowExpressionTreeRewriter.rewriteWith(new RowExpressionVariableInliner(mapping), expression);
     }
 
     @Override
     public RowExpression rewriteVariableReference(VariableReferenceExpression node, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
     {
         if (!excludedNames.contains(node.getName())) {
-            RowExpression result = new VariableReferenceExpression(mapping.get(new Symbol(node.getName())).getName(), node.getType());
+            RowExpression result = mapping.get(node);
             checkState(result != null, "Cannot resolve symbol %s", node.getName());
             return result;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultipleDistinctAggregationToMarkDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultipleDistinctAggregationToMarkDistinct.java
@@ -23,6 +23,7 @@ import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
 import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
 import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.relational.OriginalExpressionUtils;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -123,6 +124,7 @@ public class MultipleDistinctAggregationToMarkDistinct
 
             if (aggregation.isDistinct() && !aggregation.getFilter().isPresent() && !aggregation.getMask().isPresent()) {
                 Set<VariableReferenceExpression> inputs = aggregation.getArguments().stream()
+                        .map(OriginalExpressionUtils::castToExpression)
                         .map(Symbol::from)
                         .map(context.getSymbolAllocator()::toVariableReference)
                         .collect(toSet());
@@ -148,8 +150,7 @@ public class MultipleDistinctAggregationToMarkDistinct
                 // remove the distinct flag and set the distinct marker
                 newAggregations.put(entry.getKey(),
                         new Aggregation(
-                                aggregation.getFunctionHandle(),
-                                aggregation.getArguments(),
+                                aggregation.getCall(),
                                 aggregation.getFilter(),
                                 aggregation.getOrderBy(),
                                 false,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationSourceColumns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneAggregationSourceColumns.java
@@ -58,7 +58,7 @@ public class PruneAggregationSourceColumns
     private static Stream<VariableReferenceExpression> getAggregationInputs(AggregationNode.Aggregation aggregation, TypeProvider types)
     {
         return Streams.concat(
-                AggregationNodeUtils.extractUniqueVariables(aggregation, types).stream(),
+                AggregationNodeUtils.extractAggregationUniqueVariables(aggregation, types).stream(),
                 aggregation.getMask().map(Stream::of).orElse(Stream.empty()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneOrderByInAggregation.java
@@ -67,8 +67,7 @@ public class PruneOrderByInAggregation
                 anyRewritten = true;
 
                 aggregations.put(entry.getKey(), new Aggregation(
-                        aggregation.getFunctionHandle(),
-                        aggregation.getArguments(),
+                        aggregation.getCall(),
                         aggregation.getFilter(),
                         Optional.empty(),
                         aggregation.isDistinct(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyCountOverConstant.java
@@ -18,6 +18,8 @@ import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.iterative.Rule;
@@ -37,9 +39,11 @@ import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
 import static com.facebook.presto.sql.planner.plan.Patterns.project;
 import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
 import static java.util.Objects.requireNonNull;
 
 public class SimplifyCountOverConstant
@@ -79,8 +83,11 @@ public class SimplifyCountOverConstant
             if (isCountOverConstant(aggregation, child.getAssignments())) {
                 changed = true;
                 aggregations.put(variable, new AggregationNode.Aggregation(
-                        functionResolution.countFunction(),
-                        ImmutableList.of(),
+                        new CallExpression(
+                                "count",
+                                functionResolution.countFunction(),
+                                BIGINT,
+                                ImmutableList.of()),
                         Optional.empty(),
                         Optional.empty(),
                         false,
@@ -109,11 +116,12 @@ public class SimplifyCountOverConstant
             return false;
         }
 
-        Expression argument = aggregation.getArguments().get(0);
-        if (argument instanceof SymbolReference) {
-            argument = inputs.get(Symbol.from(argument));
+        RowExpression argument = aggregation.getArguments().get(0);
+        Expression assigned = null;
+        if (castToExpression(argument) instanceof SymbolReference) {
+            assigned = inputs.get(Symbol.from(castToExpression(argument)));
         }
 
-        return argument instanceof Literal && !(argument instanceof NullLiteral);
+        return assigned instanceof Literal && !(assigned instanceof NullLiteral);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedInPredicateToJoin.java
@@ -18,6 +18,7 @@ import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.SymbolAllocator;
@@ -255,9 +256,12 @@ public class TransformCorrelatedInPredicateToJoin
     private AggregationNode.Aggregation countWithFilter(Expression condition)
     {
         return new AggregationNode.Aggregation(
-                functionResolution.countFunction(),
-                ImmutableList.of(),
-                Optional.of(condition),
+                new CallExpression(
+                        "count",
+                        functionResolution.countFunction(),
+                        BIGINT,
+                        ImmutableList.of()),
+                Optional.of(castToRowExpression(condition)),
                 Optional.empty(),
                 false,
                 Optional.empty()); /* mask */

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ImplementIntersectAndExceptAsUnion.java
@@ -18,6 +18,7 @@ import com.facebook.presto.execution.warnings.WarningCollector;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
@@ -55,6 +56,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.Step;
 import static com.facebook.presto.sql.planner.plan.AggregationNode.singleGroupingSet;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.asSymbolReference;
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.facebook.presto.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.EQUAL;
@@ -248,8 +250,11 @@ public class ImplementIntersectAndExceptAsUnion
             for (int i = 0; i < markers.size(); i++) {
                 VariableReferenceExpression output = aggregationOutputs.get(i);
                 aggregations.put(output, new Aggregation(
-                        functionResolution.countFunction(BIGINT),
-                        ImmutableList.of(new SymbolReference(markers.get(i).getName())),
+                        new CallExpression(
+                                "count",
+                                functionResolution.countFunction(markers.get(i).getType()),
+                                BIGINT,
+                                ImmutableList.of(castToRowExpression(asSymbolReference(markers.get(i))))),
                         Optional.empty(),
                         Optional.empty(),
                         false,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TranslateExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TranslateExpressions.java
@@ -14,28 +14,42 @@
 
 package com.facebook.presto.sql.planner.optimizations;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.FunctionType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.FilterNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.SpatialJoinNode;
+import com.facebook.presto.sql.planner.plan.StatisticAggregations;
+import com.facebook.presto.sql.planner.plan.TableFinishNode;
+import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.planner.plan.WindowNode.Function;
+import com.facebook.presto.sql.relational.OriginalExpressionUtils;
 import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
+import com.facebook.presto.sql.tree.LambdaExpression;
 import com.facebook.presto.sql.tree.NodeRef;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -44,15 +58,22 @@ import java.util.Set;
 
 import static com.facebook.presto.execution.warnings.WarningCollector.NOOP;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
+import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
 import static com.facebook.presto.sql.planner.plan.Patterns.filter;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
 import static com.facebook.presto.sql.planner.plan.Patterns.spatialJoin;
+import static com.facebook.presto.sql.planner.plan.Patterns.tableFinish;
+import static com.facebook.presto.sql.planner.plan.Patterns.tableWriterNode;
 import static com.facebook.presto.sql.planner.plan.Patterns.values;
 import static com.facebook.presto.sql.planner.plan.Patterns.window;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.isExpression;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.builder;
+import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
 public class TranslateExpressions
@@ -74,7 +95,10 @@ public class TranslateExpressions
                 new FilterExpressionTranslation(),
                 new WindowExpressionTranslation(),
                 new JoinExpressionTranslation(),
-                new SpatialJoinExpressionTranslation());
+                new SpatialJoinExpressionTranslation(),
+                new AggregationExpressionTranslation(),
+                new TableFinishExpressionTranslation(),
+                new TableWriterExpressionTranslation());
     }
 
     private final class SpatialJoinExpressionTranslation
@@ -90,13 +114,7 @@ public class TranslateExpressions
         public Result apply(SpatialJoinNode spatialJoinNode, Captures captures, Context context)
         {
             RowExpression filter = spatialJoinNode.getFilter();
-            RowExpression rewritten;
-            if (isExpression(filter)) {
-                rewritten = toRowExpression(castToExpression(filter), context);
-            }
-            else {
-                rewritten = filter;
-            }
+            RowExpression rewritten = removeOriginalExpression(filter, context);
 
             if (filter.equals(rewritten)) {
                 return Result.empty();
@@ -126,18 +144,12 @@ public class TranslateExpressions
         @Override
         public Result apply(JoinNode joinNode, Captures captures, Context context)
         {
-            RowExpression rewritten;
             if (!joinNode.getFilter().isPresent()) {
                 return Result.empty();
             }
 
             RowExpression filter = joinNode.getFilter().get();
-            if (isExpression(filter)) {
-                rewritten = toRowExpression(castToExpression(filter), context);
-            }
-            else {
-                rewritten = filter;
-            }
+            RowExpression rewritten = removeOriginalExpression(filter, context);
 
             if (filter.equals(rewritten)) {
                 return Result.empty();
@@ -175,14 +187,11 @@ public class TranslateExpressions
                 ImmutableList.Builder<RowExpression> newArguments = ImmutableList.builder();
                 CallExpression callExpression = entry.getValue().getFunctionCall();
                 for (RowExpression argument : callExpression.getArguments()) {
-                    if (isExpression(argument)) {
-                        RowExpression rewritten = toRowExpression(castToExpression(argument), context);
+                    RowExpression rewritten = removeOriginalExpression(argument, context);
+                    if (rewritten != argument) {
                         anyRewritten = true;
-                        newArguments.add(rewritten);
                     }
-                    else {
-                        newArguments.add(argument);
-                    }
+                    newArguments.add(rewritten);
                 }
                 functions.put(
                         entry.getKey(),
@@ -221,13 +230,7 @@ public class TranslateExpressions
         public Result apply(FilterNode filterNode, Captures captures, Context context)
         {
             checkState(filterNode.getSource() != null);
-            RowExpression rewritten;
-            if (isExpression(filterNode.getPredicate())) {
-                rewritten = toRowExpression(castToExpression(filterNode.getPredicate()), context);
-            }
-            else {
-                rewritten = filterNode.getPredicate();
-            }
+            RowExpression rewritten = removeOriginalExpression(filterNode.getPredicate(), context);
 
             if (filterNode.getPredicate().equals(rewritten)) {
                 return Result.empty();
@@ -253,14 +256,11 @@ public class TranslateExpressions
             for (List<RowExpression> row : valuesNode.getRows()) {
                 ImmutableList.Builder<RowExpression> newRow = ImmutableList.builder();
                 for (RowExpression rowExpression : row) {
-                    if (isExpression(rowExpression)) {
-                        RowExpression rewritten = toRowExpression(castToExpression(rowExpression), context);
+                    RowExpression rewritten = removeOriginalExpression(rowExpression, context);
+                    if (rowExpression != rewritten) {
                         anyRewritten = true;
-                        newRow.add(rewritten);
                     }
-                    else {
-                        newRow.add(rowExpression);
-                    }
+                    newRow.add(rewritten);
                 }
                 rows.add(newRow.build());
             }
@@ -271,18 +271,256 @@ public class TranslateExpressions
         }
     }
 
-    private RowExpression toRowExpression(Expression expression, Rule.Context context)
+    private final class AggregationExpressionTranslation
+            implements Rule<AggregationNode>
     {
-        Map<NodeRef<Expression>, Type> types = getExpressionTypes(
-                context.getSession(),
+        @Override
+        public Pattern<AggregationNode> getPattern()
+        {
+            return aggregation();
+        }
+
+        @Override
+        public Result apply(AggregationNode node, Captures captures, Context context)
+        {
+            checkState(node.getSource() != null);
+
+            boolean changed = false;
+            ImmutableMap.Builder<VariableReferenceExpression, AggregationNode.Aggregation> rewrittenAggregation = builder();
+            for (Map.Entry<VariableReferenceExpression, AggregationNode.Aggregation> entry : node.getAggregations().entrySet()) {
+                AggregationNode.Aggregation rewritten = translateAggregation(entry.getValue(), context.getSession(), context.getSymbolAllocator().getTypes());
+                rewrittenAggregation.put(entry.getKey(), rewritten);
+                if (!rewritten.equals(entry.getValue())) {
+                    changed = true;
+                }
+            }
+
+            if (changed) {
+                AggregationNode aggregationNode = new AggregationNode(
+                        node.getId(),
+                        node.getSource(),
+                        rewrittenAggregation.build(),
+                        node.getGroupingSets(),
+                        node.getPreGroupedVariables(),
+                        node.getStep(),
+                        node.getHashVariable(),
+                        node.getGroupIdVariable());
+                return Result.ofPlanNode(aggregationNode);
+            }
+            return Result.empty();
+        }
+    }
+
+    private final class TableFinishExpressionTranslation
+            implements Rule<TableFinishNode>
+    {
+        @Override
+        public Pattern<TableFinishNode> getPattern()
+        {
+            return tableFinish();
+        }
+
+        @Override
+        public Result apply(TableFinishNode node, Captures captures, Context context)
+        {
+            checkState(node.getSource() != null);
+
+            if (!node.getStatisticsAggregation().isPresent()) {
+                return Result.empty();
+            }
+
+            Optional<StatisticAggregations> rewrittenStatisticsAggregation = translateStatisticAggregation(node.getStatisticsAggregation().get(), context);
+
+            if (rewrittenStatisticsAggregation.isPresent()) {
+                return Result.ofPlanNode(new TableFinishNode(
+                        node.getId(),
+                        node.getSource(),
+                        node.getTarget(),
+                        node.getRowCountVariable(),
+                        rewrittenStatisticsAggregation,
+                        node.getStatisticsAggregationDescriptor()));
+            }
+            return Result.empty();
+        }
+    }
+
+    private final class TableWriterExpressionTranslation
+            implements Rule<TableWriterNode>
+    {
+        @Override
+        public Pattern<TableWriterNode> getPattern()
+        {
+            return tableWriterNode();
+        }
+
+        @Override
+        public Result apply(TableWriterNode node, Captures captures, Context context)
+        {
+            checkState(node.getSource() != null);
+
+            if (!node.getStatisticsAggregation().isPresent()) {
+                return Result.empty();
+            }
+
+            Optional<StatisticAggregations> rewrittenStatisticsAggregation = translateStatisticAggregation(node.getStatisticsAggregation().get(), context);
+
+            if (rewrittenStatisticsAggregation.isPresent()) {
+                return Result.ofPlanNode(new TableWriterNode(
+                        node.getId(),
+                        node.getSource(),
+                        node.getTarget(),
+                        node.getRowCountVariable(),
+                        node.getFragmentVariable(),
+                        node.getTableCommitContextVariable(),
+                        node.getColumns(),
+                        node.getColumnNames(),
+                        node.getPartitioningScheme(),
+                        rewrittenStatisticsAggregation,
+                        node.getStatisticsAggregationDescriptor()));
+            }
+            return Result.empty();
+        }
+    }
+
+    private Optional<StatisticAggregations> translateStatisticAggregation(StatisticAggregations statisticAggregations, Rule.Context context)
+    {
+        ImmutableMap.Builder<VariableReferenceExpression, AggregationNode.Aggregation> rewrittenAggregation = builder();
+        boolean changed = false;
+        for (Map.Entry<VariableReferenceExpression, AggregationNode.Aggregation> entry : statisticAggregations.getAggregations().entrySet()) {
+            AggregationNode.Aggregation rewritten = translateAggregation(entry.getValue(), context.getSession(), context.getSymbolAllocator().getTypes());
+            rewrittenAggregation.put(entry.getKey(), rewritten);
+            if (!rewritten.equals(entry.getValue())) {
+                changed = true;
+            }
+        }
+        if (changed) {
+            return Optional.of(new StatisticAggregations(rewrittenAggregation.build(), statisticAggregations.getGroupingVariables()));
+        }
+        return Optional.empty();
+    }
+
+    @VisibleForTesting
+    public AggregationNode.Aggregation translateAggregation(AggregationNode.Aggregation aggregation, Session session, TypeProvider typeProvider)
+    {
+        Map<NodeRef<Expression>, Type> types = analyzeAggregationExpressionTypes(aggregation, session, typeProvider);
+
+        return new AggregationNode.Aggregation(
+                new CallExpression(
+                        aggregation.getCall().getDisplayName(),
+                        aggregation.getCall().getFunctionHandle(),
+                        aggregation.getCall().getType(),
+                        aggregation.getArguments().stream().map(argument -> removeOriginalExpression(argument, session, types)).collect(toImmutableList())),
+                aggregation.getFilter().map(filter -> removeOriginalExpression(filter, session, types)),
+                aggregation.getOrderBy(),
+                aggregation.isDistinct(),
+                aggregation.getMask());
+    }
+
+    private Map<NodeRef<Expression>, Type> analyzeAggregationExpressionTypes(AggregationNode.Aggregation aggregation, Session session, TypeProvider typeProvider)
+    {
+        List<LambdaExpression> lambdaExpressions = aggregation.getArguments().stream()
+                .filter(OriginalExpressionUtils::isExpression)
+                .map(OriginalExpressionUtils::castToExpression)
+                .filter(LambdaExpression.class::isInstance)
+                .map(LambdaExpression.class::cast)
+                .collect(toImmutableList());
+        ImmutableMap.Builder<NodeRef<Expression>, Type> builder = ImmutableMap.<NodeRef<Expression>, Type>builder();
+        if (!lambdaExpressions.isEmpty()) {
+            List<FunctionType> functionTypes = metadata.getFunctionManager().getFunctionMetadata(aggregation.getFunctionHandle()).getArgumentTypes().stream()
+                    .filter(typeSignature -> typeSignature.getBase().equals(FunctionType.NAME))
+                    .map(typeSignature -> (FunctionType) (metadata.getTypeManager().getType(typeSignature)))
+                    .collect(toImmutableList());
+            InternalAggregationFunction internalAggregationFunction = metadata.getFunctionManager().getAggregateFunctionImplementation(aggregation.getFunctionHandle());
+            List<Class> lambdaInterfaces = internalAggregationFunction.getLambdaInterfaces();
+            verify(lambdaExpressions.size() == functionTypes.size());
+            verify(lambdaExpressions.size() == lambdaInterfaces.size());
+
+            for (int i = 0; i < lambdaExpressions.size(); i++) {
+                LambdaExpression lambdaExpression = lambdaExpressions.get(i);
+                FunctionType functionType = functionTypes.get(i);
+
+                // To compile lambda, LambdaDefinitionExpression needs to be generated from LambdaExpression,
+                // which requires the types of all sub-expressions.
+                //
+                // In project and filter expression compilation, ExpressionAnalyzer.getExpressionTypesFromInput
+                // is used to generate the types of all sub-expressions. (see visitScanFilterAndProject and visitFilter)
+                //
+                // This does not work here since the function call representation in final aggregation node
+                // is currently a hack: it takes intermediate type as input, and may not be a valid
+                // function call in Presto.
+                //
+                // TODO: Once the final aggregation function call representation is fixed,
+                // the same mechanism in project and filter expression should be used here.
+                verify(lambdaExpression.getArguments().size() == functionType.getArgumentTypes().size());
+                Map<NodeRef<Expression>, Type> lambdaArgumentExpressionTypes = new HashMap<>();
+                Map<Symbol, Type> lambdaArgumentSymbolTypes = new HashMap<>();
+                for (int j = 0; j < lambdaExpression.getArguments().size(); j++) {
+                    LambdaArgumentDeclaration argument = lambdaExpression.getArguments().get(j);
+                    Type type = functionType.getArgumentTypes().get(j);
+                    lambdaArgumentExpressionTypes.put(NodeRef.of(argument), type);
+                    lambdaArgumentSymbolTypes.put(new Symbol(argument.getName().getValue()), type);
+                }
+                // the lambda expression itself
+                builder.put(NodeRef.of(lambdaExpression), functionType)
+                        // expressions from lambda arguments
+                        .putAll(lambdaArgumentExpressionTypes)
+                        // expressions from lambda body
+                        .putAll(getExpressionTypes(
+                                session,
+                                metadata,
+                                sqlParser,
+                                TypeProvider.copyOf(lambdaArgumentSymbolTypes),
+                                lambdaExpression.getBody(),
+                                emptyList(),
+                                NOOP));
+            }
+        }
+        for (RowExpression argument : aggregation.getArguments()) {
+            if (!isExpression(argument) || castToExpression(argument) instanceof LambdaExpression) {
+                continue;
+            }
+            builder.putAll(analyze(castToExpression(argument), session, typeProvider));
+        }
+        if (aggregation.getFilter().isPresent() && isExpression(aggregation.getFilter().get())) {
+            builder.putAll(analyze(castToExpression(aggregation.getFilter().get()), session, typeProvider));
+        }
+        return builder.build();
+    }
+
+    private Map<NodeRef<Expression>, Type> analyze(Expression expression, Session session, TypeProvider typeProvider)
+    {
+        return getExpressionTypes(
+                session,
                 metadata,
                 sqlParser,
-                context.getSymbolAllocator().getTypes(),
-                ImmutableList.of(expression),
-                ImmutableList.of(),
-                NOOP,
-                false);
+                typeProvider,
+                expression,
+                emptyList(),
+                NOOP);
+    }
 
-        return SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionManager(), metadata.getTypeManager(), context.getSession(), false);
+    private RowExpression toRowExpression(Expression expression, Session session, Map<NodeRef<Expression>, Type> types)
+    {
+        return SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionManager(), metadata.getTypeManager(), session, false);
+    }
+
+    private RowExpression removeOriginalExpression(RowExpression expression, Rule.Context context)
+    {
+        if (isExpression(expression)) {
+            return toRowExpression(
+                    castToExpression(expression),
+                    context.getSession(),
+                    analyze(castToExpression(expression), context.getSession(), context.getSymbolAllocator().getTypes()));
+        }
+        return expression;
+    }
+
+    private RowExpression removeOriginalExpression(RowExpression rowExpression, Session session, Map<NodeRef<Expression>, Type> types)
+    {
+        if (isExpression(rowExpression)) {
+            Expression expression = castToExpression(rowExpression);
+            return toRowExpression(expression, session, types);
+        }
+        return rowExpression;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AggregationNode.java
@@ -17,9 +17,10 @@ import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.OrderingScheme;
-import com.facebook.presto.sql.tree.Expression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -357,24 +358,21 @@ public class AggregationNode
 
     public static class Aggregation
     {
-        private final FunctionHandle functionHandle;
-        private final List<Expression> arguments;
-        private final Optional<Expression> filter;
+        private final CallExpression call;
+        private final Optional<RowExpression> filter;
         private final Optional<OrderingScheme> orderingScheme;
         private final boolean isDistinct;
         private final Optional<VariableReferenceExpression> mask;
 
         @JsonCreator
         public Aggregation(
-                @JsonProperty("functionHandle") FunctionHandle functionHandle,
-                @JsonProperty("arguments") List<Expression> arguments,
-                @JsonProperty("filter") Optional<Expression> filter,
+                @JsonProperty("call") CallExpression call,
+                @JsonProperty("filter") Optional<RowExpression> filter,
                 @JsonProperty("orderBy") Optional<OrderingScheme> orderingScheme,
                 @JsonProperty("distinct") boolean isDistinct,
                 @JsonProperty("mask") Optional<VariableReferenceExpression> mask)
         {
-            this.functionHandle = requireNonNull(functionHandle, "functionHandle is null");
-            this.arguments = requireNonNull(arguments, "arguments is null");
+            this.call = requireNonNull(call, "call is null");
             this.filter = requireNonNull(filter, "filter is null");
             this.orderingScheme = requireNonNull(orderingScheme, "orderingScheme is null");
             this.isDistinct = isDistinct;
@@ -382,15 +380,21 @@ public class AggregationNode
         }
 
         @JsonProperty
-        public FunctionHandle getFunctionHandle()
+        public CallExpression getCall()
         {
-            return functionHandle;
+            return call;
         }
 
         @JsonProperty
-        public List<Expression> getArguments()
+        public FunctionHandle getFunctionHandle()
         {
-            return arguments;
+            return call.getFunctionHandle();
+        }
+
+        @JsonProperty
+        public List<RowExpression> getArguments()
+        {
+            return call.getArguments();
         }
 
         @JsonProperty
@@ -400,7 +404,7 @@ public class AggregationNode
         }
 
         @JsonProperty
-        public Optional<Expression> getFilter()
+        public Optional<RowExpression> getFilter()
         {
             return filter;
         }
@@ -428,17 +432,28 @@ public class AggregationNode
             }
             Aggregation that = (Aggregation) o;
             return isDistinct == that.isDistinct &&
-                    Objects.equals(functionHandle, that.functionHandle) &&
-                    Objects.equals(arguments, that.arguments) &&
+                    Objects.equals(call, that.call) &&
                     Objects.equals(filter, that.filter) &&
                     Objects.equals(orderingScheme, that.orderingScheme) &&
                     Objects.equals(mask, that.mask);
         }
 
         @Override
+        public String toString()
+        {
+            return "Aggregation{" +
+                    "call=" + call +
+                    ", filter=" + filter +
+                    ", orderingScheme=" + orderingScheme +
+                    ", isDistinct=" + isDistinct +
+                    ", mask=" + mask +
+                    '}';
+        }
+
+        @Override
         public int hashCode()
         {
-            return Objects.hash(functionHandle, arguments, filter, orderingScheme, isDistinct, mask);
+            return Objects.hash(call, filter, orderingScheme, isDistinct, mask);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -509,10 +509,10 @@ public class PlanPrinter
                 builder.append("*");
             }
             else {
-                builder.append(Joiner.on(",").join(aggregation.getArguments().stream().map(Object::toString).collect(toImmutableList())));
+                builder.append("(" + Joiner.on(",").join(aggregation.getArguments().stream().map(formatter::formatRowExpression).collect(toImmutableList())) + ")");
             }
             builder.append(")");
-            aggregation.getFilter().ifPresent(filter -> builder.append(" WHERE " + filter));
+            aggregation.getFilter().ifPresent(filter -> builder.append(" WHERE " + formatter.formatRowExpression(filter)));
             aggregation.getOrderBy().ifPresent(orderingScheme -> builder.append(" ORDER BY " + orderingScheme.toString()));
             aggregation.getMask().ifPresent(mask -> builder.append(" (mask = " + mask + ")"));
             return builder.toString();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -74,7 +74,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.sql.planner.optimizations.AggregationNodeUtils.extractUniqueVariables;
+import static com.facebook.presto.sql.planner.optimizations.AggregationNodeUtils.extractAggregationUniqueVariables;
 import static com.facebook.presto.sql.planner.optimizations.IndexJoinOptimizer.IndexKeyTracer;
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.isExpression;
@@ -135,7 +135,7 @@ public final class ValidateDependenciesChecker
             checkDependencies(inputs, node.getGroupingKeys(), "Invalid node. Grouping key variables (%s) not in source plan output (%s)", node.getGroupingKeys(), node.getSource().getOutputVariables());
 
             for (Aggregation aggregation : node.getAggregations().values()) {
-                Set<VariableReferenceExpression> dependencies = extractUniqueVariables(aggregation, types);
+                Set<VariableReferenceExpression> dependencies = extractAggregationUniqueVariables(aggregation, types);
                 checkDependencies(inputs, dependencies, "Invalid node. Aggregation dependencies (%s) not in source plan output (%s)", dependencies, node.getSource().getOutputVariables());
                 aggregation.getMask().ifPresent(mask -> {
                     checkDependencies(inputs, ImmutableSet.of(mask), "Invalid node. Aggregation mask symbol (%s) not in source plan output (%s)", mask, node.getSource().getOutputVariables());

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/OriginalExpressionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/OriginalExpressionUtils.java
@@ -15,8 +15,10 @@ package com.facebook.presto.sql.relational;
 
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.SymbolReference;
 
 import java.util.Objects;
 
@@ -37,6 +39,11 @@ public final class OriginalExpressionUtils
     public static RowExpression castToRowExpression(Expression expression)
     {
         return new OriginalExpression(expression);
+    }
+
+    public static Expression asSymbolReference(VariableReferenceExpression variable)
+    {
+        return new SymbolReference(variable.getName());
     }
 
     /**

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SymbolToSymbolTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SymbolToSymbolTranslator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.Symbol;
+
+import java.util.function.Function;
+
+public class SymbolToSymbolTranslator
+        extends RowExpressionRewriter<Function<Symbol, Symbol>>
+{
+    private SymbolToSymbolTranslator()
+    {
+    }
+
+    public static RowExpression rewriteWith(RowExpression input, Function<Symbol, Symbol> mapping)
+    {
+        return RowExpressionTreeRewriter.rewriteWith(new SymbolToSymbolTranslator(), input, mapping);
+    }
+
+    @Override
+    public RowExpression rewriteVariableReference(VariableReferenceExpression node, Function<Symbol, Symbol> context, RowExpressionTreeRewriter<Function<Symbol, Symbol>> treeRewriter)
+    {
+        Symbol transformed = context.apply(new Symbol(node.getName()));
+        if (!transformed.getName().equals(node.getName())) {
+            return new VariableReferenceExpression(transformed.getName(), node.getType());
+        }
+        return null;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GraphvizPrinter.java
@@ -15,6 +15,7 @@ package com.facebook.presto.util;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.SubPlan;
@@ -213,14 +214,12 @@ public final class GraphvizPrinter
         private final StringBuilder output;
         private final PlanNodeIdGenerator idGenerator;
         private final RowExpressionFormatter formatter;
-        private final FunctionManager functionManager;
 
         public NodePrinter(StringBuilder output, PlanNodeIdGenerator idGenerator, Session session, FunctionManager functionManager)
         {
             this.output = output;
             this.idGenerator = idGenerator;
             this.formatter = new RowExpressionFormatter(session.toConnectorSession(), functionManager);
-            this.functionManager = functionManager;
         }
 
         @Override
@@ -359,8 +358,8 @@ public final class GraphvizPrinter
         private String formatAggregation(AggregationNode.Aggregation aggregation)
         {
             return String.format("%s(%s)%s%s%s",
-                    functionManager.getFunctionMetadata(aggregation.getFunctionHandle()).getName(),
-                    Joiner.on(",").join(aggregation.getArguments().stream().map(Expression::toString).collect(toImmutableList())),
+                    aggregation.getCall().getDisplayName(),
+                    Joiner.on(",").join(aggregation.getArguments().stream().map(RowExpression::toString).collect(toImmutableList())),
                     aggregation.getFilter().map(filter -> format(" WHERE %s", filter)).orElse(""),
                     aggregation.getOrderBy().map(orderingScheme -> format(" ORDER BY %s", orderingScheme)).orElse(""),
                     aggregation.getMask().map(mask -> format(" (mask = %s)", mask)).orElse(""));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionVariableInliner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionVariableInliner.java
@@ -24,17 +24,17 @@ import org.testng.annotations.Test;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static org.testng.Assert.assertEquals;
 
-public class TestRowExpressionSymbolInliner
+public class TestRowExpressionVariableInliner
 {
     private static final FunctionHandle TEST_FUNCTION = () -> null;
 
     @Test
     public void testInlineVariable()
     {
-        assertEquals(RowExpressionSymbolInliner.inlineSymbols(
+        assertEquals(RowExpressionVariableInliner.inlineVariables(
                 ImmutableMap.of(
-                        symbol("a"),
-                        symbol("b")),
+                        variable("a"),
+                        variable("b")),
                 variable("a")),
                 variable("b"));
     }
@@ -42,12 +42,12 @@ public class TestRowExpressionSymbolInliner
     @Test
     public void testInlineLambda()
     {
-        assertEquals(RowExpressionSymbolInliner.inlineSymbols(
+        assertEquals(RowExpressionVariableInliner.inlineVariables(
                 ImmutableMap.of(
-                        symbol("a"),
-                        symbol("b"),
-                        symbol("lambda_argument"),
-                        symbol("c")),
+                        variable("a"),
+                        variable("b"),
+                        variable("lambda_argument"),
+                        variable("c")),
                 new CallExpression("apply", TEST_FUNCTION, BIGINT, ImmutableList.of(
                         variable("a"),
                         new LambdaDefinitionExpression(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -249,8 +249,7 @@ public class TestTypeValidator
         assertTypesValid(node);
     }
 
-    // This test will be disable temporarily until we converted Aggregation to use CallExpression
-    @Test(enabled = false, expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "type of variable 'sum(_[0-9]+)?' is expected to be double, but the actual type is bigint")
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Expected input types are \\[double\\] but getting \\[bigint\\]")
     public void testInvalidAggregationFunctionCall()
     {
         VariableReferenceExpression aggregationVariable = symbolAllocator.newVariable("sum", DOUBLE);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.VarcharType;
@@ -65,6 +66,7 @@ import static com.facebook.presto.sql.planner.plan.WindowNode.Frame.BoundType.UN
 import static com.facebook.presto.sql.planner.plan.WindowNode.Frame.BoundType.UNBOUNDED_PRECEDING;
 import static com.facebook.presto.sql.planner.plan.WindowNode.Frame.WindowType.RANGE;
 import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.variable;
 
 @Test(singleThreaded = true)
 public class TestTypeValidator
@@ -77,6 +79,7 @@ public class TestTypeValidator
     private static final SqlParser SQL_PARSER = new SqlParser();
     private static final TypeValidator TYPE_VALIDATOR = new TypeValidator();
     private static final FunctionManager FUNCTION_MANAGER = createTestMetadataManager().getFunctionManager();
+    private static final FunctionHandle SUM = FUNCTION_MANAGER.lookupFunction("sum", fromTypes(DOUBLE));
 
     private SymbolAllocator symbolAllocator;
     private TableScanNode baseTableScan;
@@ -174,7 +177,7 @@ public class TestTypeValidator
                 Optional.empty(),
                 Optional.empty());
 
-        WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, DOUBLE, new VariableReferenceExpression(columnC.getName(), DOUBLE)), frame);
+        WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, DOUBLE, variable(columnC.getName(), DOUBLE)), frame);
 
         WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), Optional.empty());
 
@@ -199,8 +202,10 @@ public class TestTypeValidator
                 newId(),
                 baseTableScan,
                 ImmutableMap.of(aggregationVariable, new Aggregation(
-                        FUNCTION_MANAGER.lookupFunction("sum", fromTypes(DOUBLE)),
-                        ImmutableList.of(columnC.toSymbolReference()),
+                        new CallExpression("sum",
+                                SUM,
+                                DOUBLE,
+                                ImmutableList.of(variable(columnC.getName(), DOUBLE))),
                         Optional.empty(),
                         Optional.empty(),
                         false,
@@ -254,8 +259,11 @@ public class TestTypeValidator
                 newId(),
                 baseTableScan,
                 ImmutableMap.of(aggregationVariable, new Aggregation(
-                        FUNCTION_MANAGER.lookupFunction("sum", fromTypes(DOUBLE)),
-                        ImmutableList.of(columnA.toSymbolReference()),
+                        new CallExpression(
+                                "sum",
+                                SUM,
+                                DOUBLE,
+                                ImmutableList.of(variable(columnA.getName(), BIGINT))),
                         Optional.empty(),
                         Optional.empty(),
                         false,
@@ -278,8 +286,11 @@ public class TestTypeValidator
                 newId(),
                 baseTableScan,
                 ImmutableMap.of(aggregationVariable, new Aggregation(
-                        FUNCTION_MANAGER.lookupFunction("sum", fromTypes(BIGINT)), // should be DOUBLE
-                        ImmutableList.of(columnC.toSymbolReference()),
+                        new CallExpression(
+                                "sum",
+                                FUNCTION_MANAGER.lookupFunction("sum", fromTypes(BIGINT)), // should be DOUBLE
+                                DOUBLE,
+                                ImmutableList.of(variable(columnC.getName(), BIGINT))),
                         Optional.empty(),
                         Optional.empty(),
                         false,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.type.Type;
@@ -299,9 +300,12 @@ public class PlanBuilder
             FunctionCall call = (FunctionCall) expression;
             FunctionHandle functionHandle = metadata.getFunctionManager().resolveFunction(session, call.getName(), TypeSignatureProvider.fromTypes(inputTypes));
             return addAggregation(output, new Aggregation(
-                    functionHandle,
-                    call.getArguments(),
-                    call.getFilter(),
+                    new CallExpression(
+                            call.getName().getSuffix(),
+                            functionHandle,
+                            metadata.getType(metadata.getFunctionManager().getFunctionMetadata(functionHandle).getReturnType()),
+                            call.getArguments().stream().map(OriginalExpressionUtils::castToRowExpression).collect(toImmutableList())),
+                    call.getFilter().map(OriginalExpressionUtils::castToRowExpression),
                     call.getOrderBy().map(orderBy -> toOrderingScheme(orderBy, types)),
                     call.isDistinct(),
                     mask));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -73,7 +73,6 @@ import com.facebook.presto.sql.planner.plan.WindowNode;
 import com.facebook.presto.sql.relational.OriginalExpressionUtils;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
-import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
 import com.facebook.presto.testing.TestingTransactionHandle;
 import com.google.common.base.Functions;
@@ -277,6 +276,7 @@ public class PlanBuilder
         {
             this.types = types;
         }
+
         public AggregationBuilder source(PlanNode source)
         {
             this.source = source;
@@ -302,7 +302,7 @@ public class PlanBuilder
                     functionHandle,
                     call.getArguments(),
                     call.getFilter(),
-                    call.getOrderBy().map(OrderBy::getSortItems).map(sortItems -> toOrderingScheme(sortItems, types)),
+                    call.getOrderBy().map(orderBy -> toOrderingScheme(orderBy, types)),
                     call.isDistinct(),
                     mask));
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestTranslateExpressions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestTranslateExpressions.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.type.FunctionType;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.sql.relational.OriginalExpressionUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static com.facebook.presto.sql.planner.plan.AggregationNode.Aggregation;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.variable;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class TestTranslateExpressions
+{
+    private static final Metadata METADATA = createTestMetadataManager();
+    private static final FunctionManager FUNCTION_MANAGER = METADATA.getFunctionManager();
+    private static final FunctionResolution FUNCTION_RESOLUTION = new FunctionResolution(FUNCTION_MANAGER);
+    private static final FunctionHandle REDUCE_AGG = FUNCTION_MANAGER.lookupFunction(
+            "reduce_agg",
+            fromTypes(
+                    INTEGER,
+                    INTEGER,
+                    new FunctionType(ImmutableList.of(INTEGER, INTEGER), INTEGER),
+                    new FunctionType(ImmutableList.of(INTEGER, INTEGER), INTEGER)));
+
+    @Test
+    public void testTranslateAggregationWithLambda()
+    {
+        TranslateExpressions translator = new TranslateExpressions(METADATA, new SqlParser());
+        Aggregation aggregation = new Aggregation(
+                new CallExpression(
+                        "reduce_agg",
+                        REDUCE_AGG,
+                        INTEGER,
+                        ImmutableList.of(
+                                castToRowExpression(expression("input")),
+                                castToRowExpression(expression("0")),
+                                castToRowExpression(expression("(x,y) -> x*y")),
+                                castToRowExpression(expression("(a,b) -> a*b")))),
+                Optional.of(castToRowExpression(expression("input > 10"))),
+                Optional.empty(),
+                false,
+                Optional.empty());
+        Aggregation translated = translator.translateAggregation(aggregation, TEST_SESSION, TypeProvider.viewOf(ImmutableMap.of(new Symbol("input"), INTEGER)));
+        assertEquals(translated, new Aggregation(
+                new CallExpression(
+                        "reduce_agg",
+                        REDUCE_AGG,
+                        INTEGER,
+                        ImmutableList.of(
+                                variable("input", INTEGER),
+                                constant(0L, INTEGER),
+                                new LambdaDefinitionExpression(
+                                        ImmutableList.of(INTEGER, INTEGER),
+                                        ImmutableList.of("x", "y"),
+                                        multiply(variable("x", INTEGER), variable("y", INTEGER))),
+                                new LambdaDefinitionExpression(
+                                        ImmutableList.of(INTEGER, INTEGER),
+                                        ImmutableList.of("a", "b"),
+                                        multiply(variable("a", INTEGER), variable("b", INTEGER))))),
+                Optional.of(greaterThan(variable("input", INTEGER), constant(10L, INTEGER))),
+                Optional.empty(),
+                false,
+                Optional.empty()));
+        assertFalse(isUntranslated(translated));
+    }
+
+    @Test
+    public void testTranslateIntermediateAggregationWithLambda()
+    {
+        TranslateExpressions translator = new TranslateExpressions(METADATA, new SqlParser());
+        Aggregation aggregation = new Aggregation(
+                new CallExpression(
+                        "reduce_agg",
+                        REDUCE_AGG,
+                        INTEGER,
+                        ImmutableList.of(
+                                castToRowExpression(expression("input")),
+                                castToRowExpression(expression("(x,y) -> x*y")),
+                                castToRowExpression(expression("(a,b) -> a*b")))),
+                Optional.of(castToRowExpression(expression("input > 10"))),
+                Optional.empty(),
+                false,
+                Optional.empty());
+        Aggregation translated = translator.translateAggregation(aggregation, TEST_SESSION, TypeProvider.viewOf(ImmutableMap.of(new Symbol("input"), INTEGER)));
+        assertEquals(translated, new Aggregation(
+                new CallExpression(
+                        "reduce_agg",
+                        REDUCE_AGG,
+                        INTEGER,
+                        ImmutableList.of(
+                                variable("input", INTEGER),
+                                new LambdaDefinitionExpression(
+                                        ImmutableList.of(INTEGER, INTEGER),
+                                        ImmutableList.of("x", "y"),
+                                        multiply(variable("x", INTEGER), variable("y", INTEGER))),
+                                new LambdaDefinitionExpression(
+                                        ImmutableList.of(INTEGER, INTEGER),
+                                        ImmutableList.of("a", "b"),
+                                        multiply(variable("a", INTEGER), variable("b", INTEGER))))),
+                Optional.of(greaterThan(variable("input", INTEGER), constant(10L, INTEGER))),
+                Optional.empty(),
+                false,
+                Optional.empty()));
+        assertFalse(isUntranslated(translated));
+    }
+
+    private CallExpression greaterThan(RowExpression left, RowExpression right)
+    {
+        return call("GREATER_THAN", FUNCTION_RESOLUTION.comparisonFunction(OperatorType.GREATER_THAN, left.getType(), right.getType()), BOOLEAN, ImmutableList.of(left, right));
+    }
+
+    private CallExpression multiply(RowExpression left, RowExpression right)
+    {
+        return call("MULTIPLY", FUNCTION_RESOLUTION.arithmeticFunction(OperatorType.MULTIPLY, left.getType(), right.getType()), left.getType(), ImmutableList.of(left, right));
+    }
+
+    private static boolean isUntranslated(AggregationNode.Aggregation aggregation)
+    {
+        return aggregation.getCall().getArguments().stream().anyMatch(OriginalExpressionUtils::isExpression) ||
+                aggregation.getFilter().map(OriginalExpressionUtils::isExpression).orElse(false);
+    }
+}


### PR DESCRIPTION
This will remove the dependency to Expression in following plan nodes:
```
AggregationNode
TableWriterNode
TableFinishNode
```
It is splitted to small commits  that may need to squash together later. 
