### PR TITLE
Detach Node from LateralJoinNode and ApplyNode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/SemanticExceptions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/SemanticExceptions.java
@@ -15,11 +15,13 @@ package com.facebook.presto.sql.analyzer;
 
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.NodeLocation;
 import com.facebook.presto.sql.tree.QualifiedName;
 
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.AMBIGUOUS_ATTRIBUTE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_ATTRIBUTE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
+import static java.lang.String.format;
 
 public final class SemanticExceptions
 {
@@ -47,5 +49,14 @@ public final class SemanticExceptions
     public static SemanticException notSupportedException(Node node, String notSupportedFeatureDescription)
     {
         throw new SemanticException(NOT_SUPPORTED, node, notSupportedFeatureDescription + " is not supported");
+    }
+
+    public static String subQueryNotSupportedError(Node node, String notSupportedFeatureDescription)
+    {
+        if (node.getLocation().isPresent()) {
+            NodeLocation nodeLocation = node.getLocation().get();
+            return format("line %s:%s: %s", nodeLocation.getLineNumber(), nodeLocation.getColumnNumber(), notSupportedFeatureDescription + " is not supported");
+        }
+        return notSupportedFeatureDescription + " is not supported";
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -57,6 +57,7 @@ import java.util.Set;
 
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.sql.analyzer.SemanticExceptions.notSupportedException;
+import static com.facebook.presto.sql.analyzer.SemanticExceptions.subQueryNotSupportedError;
 import static com.facebook.presto.sql.planner.ExpressionNodeInliner.replaceExpression;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
@@ -250,7 +251,7 @@ class SubqueryPlanner
                         subqueryNode,
                         ImmutableList.copyOf(SymbolsExtractor.extractUnique(correlation.values())),
                         type,
-                        query),
+                        subQueryNotSupportedError(query, "Given correlated subquery")),
                 analysis.getParameters());
     }
 
@@ -427,12 +428,7 @@ class SubqueryPlanner
                 .collect(toImmutableList());
     }
 
-    private PlanBuilder appendApplyNode(
-            PlanBuilder subPlan,
-            Node subquery,
-            PlanNode subqueryNode,
-            Assignments subqueryAssignments,
-            boolean correlationAllowed)
+    private PlanBuilder appendApplyNode(PlanBuilder subPlan, Node subquery, PlanNode subqueryNode, Assignments subqueryAssignments, boolean correlationAllowed)
     {
         Map<Expression, Expression> correlation = extractCorrelation(subPlan, subqueryNode);
         if (!correlationAllowed && !correlation.isEmpty()) {
@@ -449,7 +445,7 @@ class SubqueryPlanner
                         subqueryNode,
                         subqueryAssignments,
                         ImmutableList.copyOf(SymbolsExtractor.extractUnique(correlation.values())),
-                        subquery),
+                        subQueryNotSupportedError(subquery, "Given correlated subquery")),
                 analysis.getParameters());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
@@ -321,7 +321,7 @@ public class ExpressionRewriteRuleSet
                     applyNode.getSubquery(),
                     subqueryAssignments,
                     applyNode.getCorrelation(),
-                    applyNode.getOriginSubquery()));
+                    applyNode.getOriginSubqueryError()));
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
@@ -112,7 +112,7 @@ public class TransformCorrelatedScalarSubquery
                     rewrittenSubquery,
                     lateralJoinNode.getCorrelation(),
                     lateralJoinNode.getType(),
-                    lateralJoinNode.getOriginSubquery()));
+                    lateralJoinNode.getOriginSubqueryError()));
         }
 
         Symbol unique = context.getSymbolAllocator().newSymbol("unique", BigintType.BIGINT);
@@ -126,7 +126,7 @@ public class TransformCorrelatedScalarSubquery
                 rewrittenSubquery,
                 lateralJoinNode.getCorrelation(),
                 lateralJoinNode.getType(),
-                lateralJoinNode.getOriginSubquery());
+                lateralJoinNode.getOriginSubqueryError());
 
         Symbol isDistinct = context.getSymbolAllocator().newSymbol("is_distinct", BooleanType.BOOLEAN);
         MarkDistinctNode markDistinctNode = new MarkDistinctNode(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformExistsApplyToLateralNode.java
@@ -144,7 +144,7 @@ public class TransformExistsApplyToLateralNode
                         subquery,
                         applyNode.getCorrelation(),
                         LEFT,
-                        applyNode.getOriginSubquery()),
+                        applyNode.getOriginSubqueryError()),
                 assignments.build()));
     }
 
@@ -173,6 +173,6 @@ public class TransformExistsApplyToLateralNode
                         Assignments.of(exists, new ComparisonExpression(GREATER_THAN, count.toSymbolReference(), new Cast(new LongLiteral("0"), BIGINT.toString())))),
                 parent.getCorrelation(),
                 INNER,
-                parent.getOriginSubquery());
+                parent.getOriginSubqueryError());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -801,7 +801,7 @@ public class PruneUnreferencedOutputs
                     .addAll(subqueryAssignmentsSymbols) // need to include those: e.g: "expr" from "expr IN (SELECT 1)"
                     .build();
             PlanNode input = context.rewrite(node.getInput(), inputContext);
-            return new ApplyNode(node.getId(), input, subquery, subqueryAssignments.build(), newCorrelation, node.getOriginSubquery());
+            return new ApplyNode(node.getId(), input, subquery, subqueryAssignments.build(), newCorrelation, node.getOriginSubqueryError());
         }
 
         @Override
@@ -840,7 +840,7 @@ public class PruneUnreferencedOutputs
                 return subquery;
             }
 
-            return new LateralJoinNode(node.getId(), input, subquery, newCorrelation, node.getType(), node.getOriginSubquery());
+            return new LateralJoinNode(node.getId(), input, subquery, newCorrelation, node.getType(), node.getOriginSubqueryError());
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TransformQuantifiedComparisonApplyToLateralJoin.java
@@ -174,7 +174,7 @@ public class TransformQuantifiedComparisonApplyToLateralJoin
                     subqueryPlan,
                     node.getCorrelation(),
                     LateralJoinNode.Type.INNER,
-                    node.getOriginSubquery());
+                    node.getOriginSubqueryError());
 
             Expression valueComparedToSubquery = rewriteUsingBounds(quantifiedComparison, minValue, maxValue, countAllValue, countNonNullValue);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -455,7 +455,7 @@ public class UnaliasSymbolReferences
             PlanNode subquery = context.rewrite(node.getSubquery());
             List<Symbol> canonicalCorrelation = Lists.transform(node.getCorrelation(), this::canonicalize);
 
-            return new ApplyNode(node.getId(), source, subquery, canonicalize(node.getSubqueryAssignments()), canonicalCorrelation, node.getOriginSubquery());
+            return new ApplyNode(node.getId(), source, subquery, canonicalize(node.getSubqueryAssignments()), canonicalCorrelation, node.getOriginSubqueryError());
         }
 
         @Override
@@ -465,7 +465,7 @@ public class UnaliasSymbolReferences
             PlanNode subquery = context.rewrite(node.getSubquery());
             List<Symbol> canonicalCorrelation = canonicalizeAndDistinct(node.getCorrelation());
 
-            return new LateralJoinNode(node.getId(), source, subquery, canonicalCorrelation, node.getType(), node.getOriginSubquery());
+            return new LateralJoinNode(node.getId(), source, subquery, canonicalCorrelation, node.getType(), node.getOriginSubqueryError());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ApplyNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ApplyNode.java
@@ -17,7 +17,6 @@ import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.tree.ExistsPredicate;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.InPredicate;
-import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.QuantifiedComparisonExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -64,10 +63,9 @@ public class ApplyNode
     private final Assignments subqueryAssignments;
 
     /**
-     * HACK!
-     * Used for error reporting in case this ApplyNode is not supported
+     * This information is only used for sanity check.
      */
-    private final Node originSubquery;
+    private final String originSubqueryError;
 
     @JsonCreator
     public ApplyNode(
@@ -76,14 +74,14 @@ public class ApplyNode
             @JsonProperty("subquery") PlanNode subquery,
             @JsonProperty("subqueryAssignments") Assignments subqueryAssignments,
             @JsonProperty("correlation") List<Symbol> correlation,
-            @JsonProperty("originSubquery") Node originSubquery)
+            @JsonProperty("originSubqueryError") String originSubqueryError)
     {
         super(id);
         requireNonNull(input, "input is null");
         requireNonNull(subquery, "right is null");
         requireNonNull(subqueryAssignments, "assignments is null");
         requireNonNull(correlation, "correlation is null");
-        requireNonNull(originSubquery, "originSubquery is null");
+        requireNonNull(originSubqueryError, "originSubqueryError is null");
 
         checkArgument(input.getOutputSymbols().containsAll(correlation), "Input does not contain symbols from correlation");
         checkArgument(
@@ -94,7 +92,7 @@ public class ApplyNode
         this.subquery = subquery;
         this.subqueryAssignments = subqueryAssignments;
         this.correlation = ImmutableList.copyOf(correlation);
-        this.originSubquery = originSubquery;
+        this.originSubqueryError = originSubqueryError;
     }
 
     private static boolean isSupportedSubqueryExpression(Expression expression)
@@ -128,10 +126,10 @@ public class ApplyNode
         return correlation;
     }
 
-    @JsonProperty("originSubquery")
-    public Node getOriginSubquery()
+    @JsonProperty("originSubqueryError")
+    public String getOriginSubqueryError()
     {
-        return originSubquery;
+        return originSubqueryError;
     }
 
     @Override
@@ -160,6 +158,6 @@ public class ApplyNode
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         checkArgument(newChildren.size() == 2, "expected newChildren to contain 2 nodes");
-        return new ApplyNode(getId(), newChildren.get(0), newChildren.get(1), subqueryAssignments, correlation, originSubquery);
+        return new ApplyNode(getId(), newChildren.get(0), newChildren.get(1), subqueryAssignments, correlation, originSubqueryError);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/LateralJoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/LateralJoinNode.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.sql.planner.Symbol;
-import com.facebook.presto.sql.tree.Node;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -65,10 +64,9 @@ public class LateralJoinNode
     private final Type type;
 
     /**
-     * HACK!
-     * Used for error reporting in case this ApplyNode is not supported
+     * This information is only used for sanity check.
      */
-    private final Node originSubquery;
+    private final String originSubqueryError;
 
     @JsonCreator
     public LateralJoinNode(
@@ -77,13 +75,13 @@ public class LateralJoinNode
             @JsonProperty("subquery") PlanNode subquery,
             @JsonProperty("correlation") List<Symbol> correlation,
             @JsonProperty("type") Type type,
-            @JsonProperty("originSubquery") Node originSubquery)
+            @JsonProperty("originSubqueryError") String originSubqueryError)
     {
         super(id);
         requireNonNull(input, "input is null");
         requireNonNull(subquery, "right is null");
         requireNonNull(correlation, "correlation is null");
-        requireNonNull(originSubquery, "originSubquery is null");
+        requireNonNull(originSubqueryError, "originSubqueryError is null");
 
         checkArgument(input.getOutputSymbols().containsAll(correlation), "Input does not contain symbols from correlation");
 
@@ -91,7 +89,7 @@ public class LateralJoinNode
         this.subquery = subquery;
         this.correlation = ImmutableList.copyOf(correlation);
         this.type = type;
-        this.originSubquery = originSubquery;
+        this.originSubqueryError = originSubqueryError;
     }
 
     @JsonProperty("input")
@@ -118,10 +116,10 @@ public class LateralJoinNode
         return type;
     }
 
-    @JsonProperty("originSubquery")
-    public Node getOriginSubquery()
+    @JsonProperty("originSubqueryError")
+    public String getOriginSubqueryError()
     {
-        return originSubquery;
+        return originSubqueryError;
     }
 
     @Override
@@ -144,7 +142,7 @@ public class LateralJoinNode
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         checkArgument(newChildren.size() == 2, "expected newChildren to contain 2 nodes");
-        return new LateralJoinNode(getId(), newChildren.get(0), newChildren.get(1), correlation, type, originSubquery);
+        return new LateralJoinNode(getId(), newChildren.get(0), newChildren.get(1), correlation, type, originSubqueryError);
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -361,8 +361,7 @@ public class PlanBuilder
 
     public ApplyNode apply(Assignments subqueryAssignments, List<Symbol> correlation, PlanNode input, PlanNode subquery)
     {
-        NullLiteral originSubquery = new NullLiteral(); // does not matter for tests
-        return new ApplyNode(idAllocator.getNextId(), input, subquery, subqueryAssignments, correlation, originSubquery);
+        return new ApplyNode(idAllocator.getNextId(), input, subquery, subqueryAssignments, correlation, "");
     }
 
     public AssignUniqueId assignUniqueId(Symbol unique, PlanNode source)
@@ -373,7 +372,7 @@ public class PlanBuilder
     public LateralJoinNode lateral(List<Symbol> correlation, PlanNode input, PlanNode subquery)
     {
         NullLiteral originSubquery = new NullLiteral(); // does not matter for tests
-        return new LateralJoinNode(idAllocator.getNextId(), input, subquery, correlation, LateralJoinNode.Type.INNER, originSubquery);
+        return new LateralJoinNode(idAllocator.getNextId(), input, subquery, correlation, LateralJoinNode.Type.INNER, "");
     }
 
     public TableScanNode tableScan(List<Symbol> symbols, Map<Symbol, ColumnHandle> assignments)
@@ -761,6 +760,7 @@ public class PlanBuilder
                 unnestSymbols,
                 ordinalitySymbol);
     }
+
     public static Expression expression(String sql)
     {
         return ExpressionUtils.rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(sql));


### PR DESCRIPTION
Detach Node from LateralJoinNode and ApplyNode and use a error message instead to propagate position (line:column) information. 