### PR TITLE
Enforce number of tasks per stage limit for grouped execution

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedBucketNodeMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedBucketNodeMap.java
@@ -58,4 +58,9 @@ public class FixedBucketNodeMap
     {
         return false;
     }
+
+    public List<InternalNode> getBucketToNode()
+    {
+        return bucketToNode;
+    }
 }


### PR DESCRIPTION
Test query:

```
presto:tpch_bucketed> select * from orders JOIN customer USING(custkey);
```
And set `max_tasks_per_stage=3` (introduced in https://github.com/prestodb/presto/commit/8f7449ab77fb8ef5701c253a839e743c7bbcb47b) 

Before: 

![Screen Shot 2019-04-23 at 2 49 41 PM](https://user-images.githubusercontent.com/799346/56621409-343d7280-65e1-11e9-8bc0-4c6f37caa91e.png)


After:

![Screen Shot 2019-04-23 at 3 58 35 PM](https://user-images.githubusercontent.com/799346/56621414-37386300-65e1-11e9-8e09-3951a9622727.png)


