### PR TITLE
Add subfield support to DomainTranslator

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -258,6 +258,13 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-parser</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.Subfield;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.DomainTranslator;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.RowType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.DEREFERENCE;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+
+public final class SubfieldExtractor
+        implements DomainTranslator.ColumnExtractor<Subfield>
+{
+    private final StandardFunctionResolution functionResolution;
+
+    public SubfieldExtractor(StandardFunctionResolution functionResolution)
+    {
+        this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
+    }
+
+    @Override
+    public Optional<Subfield> extract(RowExpression expression)
+    {
+        return toSubfield(expression, functionResolution);
+    }
+
+    private static Optional<Subfield> toSubfield(RowExpression expression, StandardFunctionResolution functionResolution)
+    {
+        List<Subfield.PathElement> elements = new ArrayList<>();
+        while (true) {
+            if (expression instanceof VariableReferenceExpression) {
+                Collections.reverse(elements);
+                return Optional.of(new Subfield(((VariableReferenceExpression) expression).getName(), unmodifiableList(elements)));
+            }
+
+            if (expression instanceof SpecialFormExpression && ((SpecialFormExpression) expression).getForm() == DEREFERENCE) {
+                SpecialFormExpression dereferenceExpression = (SpecialFormExpression) expression;
+                RowExpression base = dereferenceExpression.getArguments().get(0);
+                RowType baseType = (RowType) base.getType();
+
+                RowExpression indexExpression = dereferenceExpression.getArguments().get(1);
+                if (indexExpression instanceof ConstantExpression) {
+                    Object index = ((ConstantExpression) indexExpression).getValue();
+                    if (index instanceof Number) {
+                        Optional<String> fieldName = baseType.getFields().get(((Number) index).intValue()).getName();
+                        if (fieldName.isPresent()) {
+                            elements.add(new Subfield.NestedField(fieldName.get()));
+                            expression = base;
+                            continue;
+                        }
+                    }
+                }
+                return Optional.empty();
+            }
+
+            if (expression instanceof CallExpression && functionResolution.isSubscriptFunction(((CallExpression) expression).getFunctionHandle())) {
+                List<RowExpression> arguments = ((CallExpression) expression).getArguments();
+                RowExpression indexExpression = arguments.get(1);
+                if (indexExpression instanceof ConstantExpression) {
+                    Object index = ((ConstantExpression) indexExpression).getValue();
+                    if (index instanceof Number) {
+                        elements.add(new Subfield.LongSubscript(((Number) index).longValue()));
+                        expression = arguments.get(0);
+                        continue;
+                    }
+
+                    if (isVarcharType(indexExpression.getType())) {
+                        elements.add(new Subfield.StringSubscript(String.valueOf(index)));
+                        expression = arguments.get(0);
+                        continue;
+                    }
+                }
+                return Optional.empty();
+            }
+
+            return Optional.empty();
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.Subfield;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.Range;
+import com.facebook.presto.spi.predicate.ValueSet;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.DomainTranslator.ExtractionResult;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.RowType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.spi.function.OperatorType.SUBSCRIPT;
+import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.DEREFERENCE;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.specialForm;
+import static com.facebook.presto.sql.relational.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.testng.Assert.assertEquals;
+
+public class TestDomainTranslator
+{
+    private static final VariableReferenceExpression C_BIGINT = new VariableReferenceExpression("c_bigint", BIGINT);
+    private static final VariableReferenceExpression C_BIGINT_ARRAY = new VariableReferenceExpression("c_bigint_array", new ArrayType(BIGINT));
+    private static final VariableReferenceExpression C_BIGINT_TO_BIGINT_MAP = new VariableReferenceExpression("c_bigint_to_bigint_map", mapType(BIGINT, BIGINT));
+    private static final VariableReferenceExpression C_VARCHAR_TO_BIGINT_MAP = new VariableReferenceExpression("c_varchar_to_bigint_map", mapType(VARCHAR, BIGINT));
+    private static final VariableReferenceExpression C_STRUCT = new VariableReferenceExpression("c_struct", RowType.from(ImmutableList.of(
+            RowType.field("a", BIGINT),
+            RowType.field("b", RowType.from(ImmutableList.of(RowType.field("x", BIGINT)))),
+            RowType.field("c", new ArrayType(BIGINT)),
+            RowType.field("d", mapType(BIGINT, BIGINT)),
+            RowType.field("e", mapType(VARCHAR, BIGINT)))));
+
+    private Metadata metadata;
+    private RowExpressionDomainTranslator domainTranslator;
+    private SubfieldExtractor columnExtractor;
+
+    @BeforeClass
+    public void setup()
+    {
+        metadata = createTestMetadataManager();
+        domainTranslator = new RowExpressionDomainTranslator(metadata);
+        columnExtractor = new SubfieldExtractor(new FunctionResolution(metadata.getFunctionManager()));
+    }
+
+    @Test
+    public void testSubfields()
+    {
+        Map<String, RowExpression> expressions = ImmutableMap.<String, RowExpression>builder()
+                .put("c_bigint", C_BIGINT)
+                .put("c_bigint_array[5]", arraySubscript(C_BIGINT_ARRAY, 5))
+                .put("c_bigint_to_bigint_map[5]", mapSubscript(C_BIGINT_TO_BIGINT_MAP, constant(5, BIGINT)))
+                .put("c_varchar_to_bigint_map[\"foo\"]", mapSubscript(C_VARCHAR_TO_BIGINT_MAP, constant("foo", VARCHAR)))
+                .put("c_struct.a", dereference(C_STRUCT, 0))
+                .put("c_struct.b.x", dereference(dereference(C_STRUCT, 1), 0))
+                .put("c_struct.c[5]", arraySubscript(dereference(C_STRUCT, 2), 5))
+                .put("c_struct.d[5]", mapSubscript(dereference(C_STRUCT, 3), constant(5, BIGINT)))
+                .put("c_struct.e[\"foo\"]", mapSubscript(dereference(C_STRUCT, 4), constant("foo", VARCHAR)))
+                .build();
+
+        for (Map.Entry<String, RowExpression> entry : expressions.entrySet()) {
+            String subfield = entry.getKey();
+            RowExpression expression = entry.getValue();
+
+            assertPredicateTranslates(greaterThan(expression, bigintLiteral(2L)), subfield, Domain.create(ValueSet.ofRanges(Range.greaterThan(BIGINT, 2L)), false));
+
+            assertPredicateTranslates(equal(expression, bigintLiteral(2L)), subfield, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 2L)), false));
+
+            assertPredicateTranslates(between(expression, bigintLiteral(1L), bigintLiteral(2L)), subfield, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 1L, true, 2L, true)), false));
+
+            assertPredicateTranslates(bigintIn(expression, ImmutableList.of(1L)), subfield, Domain.singleValue(BIGINT, 1L));
+
+            assertPredicateTranslates(bigintIn(expression, ImmutableList.of(1L, 2L)), subfield, Domain.create(ValueSet.ofRanges(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L)), false));
+        }
+    }
+
+    private RowExpression dereference(RowExpression base, int field)
+    {
+        Type fieldType = base.getType().getTypeParameters().get(field);
+        return specialForm(DEREFERENCE, fieldType, ImmutableList.of(base, new ConstantExpression(field, INTEGER)));
+    }
+
+    private RowExpression arraySubscript(RowExpression arrayExpression, int index)
+    {
+        ArrayType arrayType = (ArrayType) arrayExpression.getType();
+        Type elementType = arrayType.getElementType();
+        return call(SUBSCRIPT.name(),
+                operator(SUBSCRIPT, arrayType, elementType),
+                elementType,
+                ImmutableList.of(arrayExpression, constant(index, INTEGER)));
+    }
+
+    private RowExpression mapSubscript(RowExpression mapExpression, RowExpression keyExpression)
+    {
+        MapType mapType = (MapType) mapExpression.getType();
+        return call(SUBSCRIPT.name(),
+                operator(SUBSCRIPT, mapType(mapType.getKeyType(), mapType.getValueType()), mapType.getKeyType()),
+                mapType.getValueType(),
+                ImmutableList.of(mapExpression, keyExpression));
+    }
+
+    private static MapType mapType(Type keyType, Type valueType)
+    {
+        return new MapType(
+                keyType,
+                valueType,
+                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"),
+                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"),
+                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"),
+                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"));
+    }
+
+    public static void throwUnsupportedOperationException()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    private FunctionHandle operator(OperatorType operatorType, Type... types)
+    {
+        return metadata.getFunctionManager().resolveOperator(operatorType, fromTypes(types));
+    }
+
+    private void assertPredicateTranslates(RowExpression predicate, String subfield, Domain domain)
+    {
+        ExtractionResult<Subfield> result = domainTranslator.fromPredicate(TEST_SESSION.toConnectorSession(), predicate, columnExtractor);
+        assertEquals(result.getRemainingExpression(), TRUE);
+        assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(new Subfield(subfield), domain)));
+    }
+
+    private RowExpression greaterThan(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.GREATER_THAN, left, right);
+    }
+
+    private RowExpression equal(RowExpression left, RowExpression right)
+    {
+        return binaryOperator(OperatorType.EQUAL, left, right);
+    }
+
+    private RowExpression between(RowExpression value, RowExpression min, RowExpression max)
+    {
+        return call(
+                OperatorType.BETWEEN.name(),
+                metadata.getFunctionManager().resolveOperator(OperatorType.BETWEEN, fromTypes(value.getType(), min.getType(), max.getType())),
+                BOOLEAN,
+                value,
+                min,
+                max);
+    }
+
+    private RowExpression bigintIn(RowExpression value, List<Long> inList)
+    {
+        List<RowExpression> arguments = inList.stream().map(argument -> constant(argument, BIGINT)).collect(toImmutableList());
+        return in(value, arguments);
+    }
+
+    private RowExpression in(RowExpression value, List<RowExpression> inList)
+    {
+        return new SpecialFormExpression(IN, BOOLEAN, ImmutableList.<RowExpression>builder().add(value).addAll(inList).build());
+    }
+
+    private RowExpression binaryOperator(OperatorType operatorType, RowExpression left, RowExpression right)
+    {
+        return call(
+                operatorType.name(),
+                metadata.getFunctionManager().resolveOperator(operatorType, fromTypes(left.getType(), right.getType())),
+                BOOLEAN,
+                left,
+                right);
+    }
+
+    private RowExpression bigintLiteral(long value)
+    {
+        return constant(value, BIGINT);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestSubfieldExtractor.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestSubfieldExtractor.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.spi.Subfield;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.RowType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.spi.function.OperatorType.SUBSCRIPT;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.DEREFERENCE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.specialForm;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public class TestSubfieldExtractor
+{
+    private static final VariableReferenceExpression C_BIGINT = new VariableReferenceExpression("c_bigint", BIGINT);
+    private static final VariableReferenceExpression C_BIGINT_ARRAY = new VariableReferenceExpression("c_bigint_array", new ArrayType(BIGINT));
+    private static final VariableReferenceExpression C_BIGINT_TO_BIGINT_MAP = new VariableReferenceExpression("c_bigint_to_bigint_map", mapType(BIGINT, BIGINT));
+    private static final VariableReferenceExpression C_VARCHAR_TO_BIGINT_MAP = new VariableReferenceExpression("c_varchar_to_bigint_map", mapType(VARCHAR, BIGINT));
+    private static final VariableReferenceExpression C_STRUCT = new VariableReferenceExpression("c_struct", RowType.from(ImmutableList.of(
+            RowType.field("a", BIGINT),
+            RowType.field("b", RowType.from(ImmutableList.of(RowType.field("x", BIGINT)))),
+            RowType.field("c", new ArrayType(BIGINT)),
+            RowType.field("d", mapType(BIGINT, BIGINT)),
+            RowType.field("e", mapType(VARCHAR, BIGINT)))));
+
+    private FunctionManager functionManager;
+    private SubfieldExtractor subfieldExtractor;
+
+    @BeforeClass
+    public void setup()
+    {
+        functionManager = createTestMetadataManager().getFunctionManager();
+        subfieldExtractor = new SubfieldExtractor(new FunctionResolution(functionManager));
+    }
+
+    @Test
+    public void test()
+    {
+        assertSubfieldExtract(C_BIGINT, "c_bigint");
+        assertSubfieldExtract(arraySubscript(C_BIGINT_ARRAY, 5), "c_bigint_array[5]");
+        assertSubfieldExtract(mapSubscript(C_BIGINT_TO_BIGINT_MAP, constant(5, BIGINT)), "c_bigint_to_bigint_map[5]");
+        assertSubfieldExtract(mapSubscript(C_VARCHAR_TO_BIGINT_MAP, constant("foo", VARCHAR)), "c_varchar_to_bigint_map[\"foo\"]");
+        assertSubfieldExtract(dereference(C_STRUCT, 0), "c_struct.a");
+        assertSubfieldExtract(dereference(dereference(C_STRUCT, 1), 0), "c_struct.b.x");
+        assertSubfieldExtract(arraySubscript(dereference(C_STRUCT, 2), 5), "c_struct.c[5]");
+        assertSubfieldExtract(mapSubscript(dereference(C_STRUCT, 3), constant(5, BIGINT)), "c_struct.d[5]");
+        assertSubfieldExtract(mapSubscript(dereference(C_STRUCT, 4), constant("foo", VARCHAR)), "c_struct.e[\"foo\"]");
+
+        assertEquals(subfieldExtractor.extract(constant(2, INTEGER)), Optional.empty());
+    }
+
+    private void assertSubfieldExtract(RowExpression expression, String subfield)
+    {
+        assertEquals(subfieldExtractor.extract(expression), Optional.of(new Subfield(subfield)));
+    }
+
+    private RowExpression dereference(RowExpression base, int field)
+    {
+        Type fieldType = base.getType().getTypeParameters().get(field);
+        return specialForm(DEREFERENCE, fieldType, ImmutableList.of(base, new ConstantExpression(field, INTEGER)));
+    }
+
+    private RowExpression arraySubscript(RowExpression arrayExpression, int index)
+    {
+        ArrayType arrayType = (ArrayType) arrayExpression.getType();
+        Type elementType = arrayType.getElementType();
+        return call(SUBSCRIPT.name(),
+                operator(SUBSCRIPT, arrayType, elementType),
+                elementType,
+                ImmutableList.of(arrayExpression, constant(index, INTEGER)));
+    }
+
+    private RowExpression mapSubscript(RowExpression mapExpression, RowExpression keyExpression)
+    {
+        MapType mapType = (MapType) mapExpression.getType();
+        return call(SUBSCRIPT.name(),
+                operator(SUBSCRIPT, mapType(mapType.getKeyType(), mapType.getValueType()), mapType.getKeyType()),
+                mapType.getValueType(),
+                ImmutableList.of(mapExpression, keyExpression));
+    }
+
+    private static MapType mapType(Type keyType, Type valueType)
+    {
+        return new MapType(
+                keyType,
+                valueType,
+                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"),
+                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"),
+                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"),
+                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"));
+    }
+
+    public static void throwUnsupportedOperationException()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    private FunctionHandle operator(OperatorType operatorType, Type... types)
+    {
+        return functionManager.resolveOperator(operatorType, fromTypes(types));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -90,6 +90,7 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.planWithTableNodePartitioning;
 import static com.facebook.presto.spi.predicate.TupleDomain.extractFixedValues;
+import static com.facebook.presto.spi.relation.DomainTranslator.BASIC_COLUMN_EXTRACTOR;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.ARBITRARY_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.optimizations.ActualProperties.Global.arbitraryPartition;
@@ -600,7 +601,7 @@ public class PropertyDerivations
                 tupleDomain = ExpressionDomainTranslator.fromPredicate(metadata, session, castToExpression(node.getPredicate()), types).getTupleDomain();
             }
             else {
-                tupleDomain = new RowExpressionDomainTranslator(metadata).fromPredicate(session.toConnectorSession(), node.getPredicate())
+                tupleDomain = new RowExpressionDomainTranslator(metadata).fromPredicate(session.toConnectorSession(), node.getPredicate(), BASIC_COLUMN_EXTRACTOR)
                         .getTupleDomain()
                         .transform(column -> new Symbol(column.getName()));
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -94,6 +94,7 @@ public final class FunctionResolution
         return functionManager.lookupFunction("LIKE_PATTERN", fromTypes(VARCHAR, VARCHAR));
     }
 
+    @Override
     public boolean isCastFunction(FunctionHandle functionHandle)
     {
         return functionManager.getFunctionMetadata(functionHandle).getName().equals(mangleOperatorName(OperatorType.CAST.name()));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
@@ -51,6 +51,7 @@ import static com.facebook.presto.spi.function.OperatorType.GREATER_THAN_OR_EQUA
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
+import static com.facebook.presto.spi.relation.DomainTranslator.BASIC_COLUMN_EXTRACTOR;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -1074,46 +1075,47 @@ public class TestRowExpressionDomainTranslator
     @Test
     public void testLegacyCharComparedToVarcharExpression()
     {
-        RowExpressionDomainTranslator domainTranslator = new RowExpressionDomainTranslator(createTestMetadataManager(new FeaturesConfig().setLegacyCharToVarcharCoercion(true)));
+        metadata = createTestMetadataManager(new FeaturesConfig().setLegacyCharToVarcharCoercion(true));
+        domainTranslator = new RowExpressionDomainTranslator(metadata);
 
         String maxCodePoint = new String(Character.toChars(Character.MAX_CODE_POINT));
 
         // greater than or equal
-        testSimpleComparison(greaterThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.greaterThan(createCharType(10), utf8Slice("123456788" + maxCodePoint)), domainTranslator);
-        testSimpleComparison(greaterThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.greaterThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")), domainTranslator);
-        testSimpleComparison(greaterThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890")), domainTranslator);
+        testSimpleComparison(greaterThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.greaterThan(createCharType(10), utf8Slice("123456788" + maxCodePoint)));
+        testSimpleComparison(greaterThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.greaterThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(greaterThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890")));
 
         // greater than
-        testSimpleComparison(greaterThan(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.greaterThan(createCharType(10), utf8Slice("123456788" + maxCodePoint)), domainTranslator);
-        testSimpleComparison(greaterThan(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890")), domainTranslator);
-        testSimpleComparison(greaterThan(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890")), domainTranslator);
+        testSimpleComparison(greaterThan(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.greaterThan(createCharType(10), utf8Slice("123456788" + maxCodePoint)));
+        testSimpleComparison(greaterThan(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(greaterThan(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890")));
 
         // less than or equal
-        testSimpleComparison(lessThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.lessThanOrEqual(createCharType(10), utf8Slice("123456788" + maxCodePoint)), domainTranslator);
-        testSimpleComparison(lessThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.lessThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")), domainTranslator);
-        testSimpleComparison(lessThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.lessThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")), domainTranslator);
+        testSimpleComparison(lessThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.lessThanOrEqual(createCharType(10), utf8Slice("123456788" + maxCodePoint)));
+        testSimpleComparison(lessThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.lessThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(lessThanOrEqual(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.lessThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")));
 
         // less than
-        testSimpleComparison(lessThan(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.lessThanOrEqual(createCharType(10), utf8Slice("123456788" + maxCodePoint)), domainTranslator);
-        testSimpleComparison(lessThan(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.lessThan(createCharType(10), Slices.utf8Slice("1234567890")), domainTranslator);
-        testSimpleComparison(lessThan(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.lessThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")), domainTranslator);
+        testSimpleComparison(lessThan(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Range.lessThanOrEqual(createCharType(10), utf8Slice("123456788" + maxCodePoint)));
+        testSimpleComparison(lessThan(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.lessThan(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(lessThan(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Range.lessThanOrEqual(createCharType(10), Slices.utf8Slice("1234567890")));
 
         // equal
-        testSimpleComparison(equal(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Domain.none(createCharType(10)), domainTranslator);
-        testSimpleComparison(equal(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.equal(createCharType(10), Slices.utf8Slice("1234567890")), domainTranslator);
-        testSimpleComparison(equal(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Domain.none(createCharType(10)), domainTranslator);
+        testSimpleComparison(equal(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Domain.none(createCharType(10)));
+        testSimpleComparison(equal(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Range.equal(createCharType(10), Slices.utf8Slice("1234567890")));
+        testSimpleComparison(equal(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Domain.none(createCharType(10)));
 
         // not equal
-        testSimpleComparison(notEqual(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Domain.notNull(createCharType(10)), domainTranslator);
+        testSimpleComparison(notEqual(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Domain.notNull(createCharType(10)));
         testSimpleComparison(notEqual(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Domain.create(ValueSet.ofRanges(
-                Range.lessThan(createCharType(10), Slices.utf8Slice("1234567890")), Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890"))), false), domainTranslator);
-        testSimpleComparison(notEqual(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Domain.notNull(createCharType(10)), domainTranslator);
+                Range.lessThan(createCharType(10), Slices.utf8Slice("1234567890")), Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890"))), false));
+        testSimpleComparison(notEqual(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Domain.notNull(createCharType(10)));
 
         // is distinct from
-        testSimpleComparison(isDistinctFrom(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Domain.all(createCharType(10)), domainTranslator);
+        testSimpleComparison(isDistinctFrom(cast(C_CHAR, VARCHAR), stringLiteral("123456789")), C_CHAR, Domain.all(createCharType(10)));
         testSimpleComparison(isDistinctFrom(cast(C_CHAR, VARCHAR), stringLiteral("1234567890")), C_CHAR, Domain.create(ValueSet.ofRanges(
-                Range.lessThan(createCharType(10), Slices.utf8Slice("1234567890")), Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890"))), true), domainTranslator);
-        testSimpleComparison(isDistinctFrom(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Domain.all(createCharType(10)), domainTranslator);
+                Range.lessThan(createCharType(10), Slices.utf8Slice("1234567890")), Range.greaterThan(createCharType(10), Slices.utf8Slice("1234567890"))), true));
+        testSimpleComparison(isDistinctFrom(cast(C_CHAR, VARCHAR), stringLiteral("12345678901")), C_CHAR, Domain.all(createCharType(10)));
     }
 
     @Test
@@ -1154,12 +1156,7 @@ public class TestRowExpressionDomainTranslator
 
     private ExtractionResult fromPredicate(RowExpression originalPredicate)
     {
-        return fromPredicate(originalPredicate, domainTranslator);
-    }
-
-    private ExtractionResult fromPredicate(RowExpression originalPredicate, RowExpressionDomainTranslator domainTranslator)
-    {
-        return domainTranslator.fromPredicate(TEST_SESSION.toConnectorSession(), originalPredicate);
+        return domainTranslator.fromPredicate(TEST_SESSION.toConnectorSession(), originalPredicate, BASIC_COLUMN_EXTRACTOR);
     }
 
     private RowExpression nullLiteral(Type type)
@@ -1330,19 +1327,9 @@ public class TestRowExpressionDomainTranslator
         testSimpleComparison(expression, input, Domain.create(ValueSet.ofRanges(expectedDomainRange), false));
     }
 
-    private void testSimpleComparison(RowExpression expression, VariableReferenceExpression input, Range expectedDomainRange, RowExpressionDomainTranslator domainTranslator)
-    {
-        testSimpleComparison(expression, input, Domain.create(ValueSet.ofRanges(expectedDomainRange), false), domainTranslator);
-    }
-
     private void testSimpleComparison(RowExpression expression, VariableReferenceExpression input, Domain domain)
     {
-        testSimpleComparison(expression, input, domain, domainTranslator);
-    }
-
-    private void testSimpleComparison(RowExpression expression, VariableReferenceExpression input, Domain domain, RowExpressionDomainTranslator domainTranslator)
-    {
-        ExtractionResult result = fromPredicate(expression, domainTranslator);
+        ExtractionResult result = fromPredicate(expression);
         assertEquals(result.getRemainingExpression(), TRUE);
         TupleDomain<VariableReferenceExpression> actual = result.getTupleDomain();
         TupleDomain<VariableReferenceExpression> expected = withColumnDomains(ImmutableMap.of(input, domain));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Subfield.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Subfield.java
@@ -1,0 +1,300 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public class Subfield
+{
+    public interface PathElement
+    {
+        boolean isSubscript();
+    }
+
+    public static final class AllSubscripts
+            implements PathElement
+    {
+        private static final AllSubscripts ALL_SUBSCRIPTS = new AllSubscripts();
+
+        private AllSubscripts() {}
+
+        public static AllSubscripts getInstance()
+        {
+            return ALL_SUBSCRIPTS;
+        }
+
+        @Override
+        public boolean isSubscript()
+        {
+            return true;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "[*]";
+        }
+    }
+
+    public static final class NestedField
+            implements PathElement
+    {
+        private final String name;
+
+        public NestedField(String name)
+        {
+            this.name = requireNonNull(name, "name is null");
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            NestedField that = (NestedField) o;
+            return Objects.equals(name, that.name);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(name);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "." + name;
+        }
+
+        @Override
+        public boolean isSubscript()
+        {
+            return false;
+        }
+    }
+
+    public static final class LongSubscript
+            implements PathElement
+    {
+        private final long index;
+
+        public LongSubscript(long index)
+        {
+            this.index = index;
+        }
+
+        public long getIndex()
+        {
+            return index;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            LongSubscript that = (LongSubscript) o;
+            return index == that.index;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(index);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "[" + index + "]";
+        }
+
+        @Override
+        public boolean isSubscript()
+        {
+            return true;
+        }
+    }
+
+    public static final class StringSubscript
+            implements PathElement
+    {
+        private final String index;
+
+        public StringSubscript(String index)
+        {
+            this.index = requireNonNull(index, "index is null");
+        }
+
+        public String getIndex()
+        {
+            return index;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            StringSubscript that = (StringSubscript) o;
+            return Objects.equals(index, that.index);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(index);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "[\"" + index.replace("\"", "\\\"") + "\"]";
+        }
+
+        @Override
+        public boolean isSubscript()
+        {
+            return true;
+        }
+    }
+
+    private final String name;
+    private final List<PathElement> path;
+
+    public static PathElement allSubscripts()
+    {
+        return AllSubscripts.getInstance();
+    }
+
+    @JsonCreator
+    public Subfield(String path)
+    {
+        requireNonNull(path, "path is null");
+
+        SubfieldTokenizer tokenizer = new SubfieldTokenizer(path);
+        checkArgument(tokenizer.hasNext(), "Column name is missing: " + path);
+
+        PathElement firstElement = tokenizer.next();
+        checkArgument(firstElement instanceof NestedField, "Subfield path must start with a name: " + path);
+
+        this.name = ((NestedField) firstElement).getName();
+
+        List<PathElement> pathElements = new ArrayList<>();
+        tokenizer.forEachRemaining(pathElements::add);
+        this.path = Collections.unmodifiableList(pathElements);
+    }
+
+    private static void checkArgument(boolean expression, String errorMessage)
+    {
+        if (!expression) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+    }
+
+    public Subfield(String name, List<PathElement> path)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.path = requireNonNull(path, "path is null");
+    }
+
+    public String getRootName()
+    {
+        return name;
+    }
+
+    public List<PathElement> getPath()
+    {
+        return path;
+    }
+
+    public boolean isPrefix(Subfield other)
+    {
+        if (!other.name.equals(name)) {
+            return false;
+        }
+
+        if (path.size() < other.path.size()) {
+            return Objects.equals(path, other.path.subList(0, path.size()));
+        }
+
+        return false;
+    }
+
+    @JsonValue
+    public String serialize()
+    {
+        return name + path.stream()
+                .map(PathElement::toString)
+                .collect(Collectors.joining());
+    }
+
+    @Override
+    public String toString()
+    {
+        return serialize();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Subfield other = (Subfield) o;
+        return Objects.equals(name, other.name) &&
+                Objects.equals(path, other.path);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, path);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/SubfieldTokenizer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SubfieldTokenizer.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static java.lang.Character.isLetterOrDigit;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+class SubfieldTokenizer
+        implements Iterator<Subfield.PathElement>
+{
+    private static final char QUOTE = '\"';
+    private static final char BACKSLASH = '\\';
+    private static final char DOT = '.';
+    private static final char OPEN_BRACKET = '[';
+    private static final char CLOSE_BRACKET = ']';
+    private static final char UNICODE_CARET = '\u2038';
+    private static final char WILDCARD = '*';
+
+    private final String path;
+    private State state = State.NOT_READY;
+    private int index;
+    private boolean firstSegment = true;
+    private Subfield.PathElement next;
+
+    public SubfieldTokenizer(String path)
+    {
+        this.path = requireNonNull(path, "path is null");
+
+        if (path.isEmpty()) {
+            throw invalidSubfieldPath();
+        }
+    }
+
+    @Override
+    public final boolean hasNext()
+    {
+        if (state == State.FAILED) {
+            throw new IllegalStateException();
+        }
+        switch (state) {
+            case DONE:
+                return false;
+            case READY:
+                return true;
+            default:
+        }
+        return tryToComputeNext();
+    }
+
+    private boolean tryToComputeNext()
+    {
+        state = State.FAILED; // temporary pessimism
+        next = computeNext();
+        if (state != State.DONE) {
+            state = State.READY;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public final Subfield.PathElement next()
+    {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        state = State.NOT_READY;
+        Subfield.PathElement result = next;
+        next = null;
+        return result;
+    }
+
+    @Override
+    public final void remove()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    private Subfield.PathElement computeNext()
+    {
+        if (!hasNextCharacter()) {
+            state = State.DONE;
+            return null;
+        }
+
+        if (tryMatch(DOT)) {
+            Subfield.PathElement token = matchPathSegment();
+            firstSegment = false;
+            return token;
+        }
+
+        if (tryMatch(OPEN_BRACKET)) {
+            Subfield.PathElement token = tryMatch(QUOTE) ? matchQuotedSubscript() : tryMatch(WILDCARD) ? matchWildcardSubscript() : matchUnquotedSubscript();
+
+            match(CLOSE_BRACKET);
+            firstSegment = false;
+            return token;
+        }
+
+        if (firstSegment) {
+            Subfield.PathElement token = matchPathSegment();
+            firstSegment = false;
+            return token;
+        }
+
+        throw invalidSubfieldPath();
+    }
+
+    private Subfield.PathElement matchPathSegment()
+    {
+        // seek until we see a special character or whitespace
+        int start = index;
+        while (hasNextCharacter() && isUnquotedPathCharacter(peekCharacter())) {
+            nextCharacter();
+        }
+        int end = index;
+
+        String token = path.substring(start, end);
+
+        // an empty unquoted token is not allowed
+        if (token.isEmpty()) {
+            throw invalidSubfieldPath();
+        }
+
+        return new Subfield.NestedField(token);
+    }
+
+    private Subfield.PathElement matchWildcardSubscript()
+    {
+        return Subfield.allSubscripts();
+    }
+
+    private static boolean isUnquotedPathCharacter(char c)
+    {
+        return c == ':' || isUnquotedSubscriptCharacter(c);
+    }
+
+    private Subfield.PathElement matchUnquotedSubscript()
+    {
+        // seek until we see a special character or whitespace
+        int start = index;
+        while (hasNextCharacter() && isUnquotedSubscriptCharacter(peekCharacter())) {
+            nextCharacter();
+        }
+        int end = index;
+
+        String token = path.substring(start, end);
+
+        // an empty unquoted token is not allowed
+        if (token.isEmpty()) {
+            throw invalidSubfieldPath();
+        }
+
+        long index;
+        try {
+            index = Long.valueOf(token);
+        }
+        catch (NumberFormatException e) {
+            throw invalidSubfieldPath();
+        }
+
+        return new Subfield.LongSubscript(index);
+    }
+
+    private static boolean isUnquotedSubscriptCharacter(char c)
+    {
+        return c == '_' || isLetterOrDigit(c);
+    }
+
+    private Subfield.PathElement matchQuotedSubscript()
+    {
+        // quote has already been matched
+
+        // seek until we see the close quote
+        StringBuilder token = new StringBuilder();
+        boolean escaped = false;
+
+        while (hasNextCharacter() && (escaped || peekCharacter() != QUOTE)) {
+            if (escaped) {
+                switch (peekCharacter()) {
+                    case QUOTE:
+                    case BACKSLASH:
+                        token.append(peekCharacter());
+                        break;
+                    default:
+                        throw invalidSubfieldPath();
+                }
+                escaped = false;
+            }
+            else {
+                if (peekCharacter() == BACKSLASH) {
+                    escaped = true;
+                }
+                else {
+                    token.append(peekCharacter());
+                }
+            }
+            nextCharacter();
+        }
+        if (escaped) {
+            throw invalidSubfieldPath();
+        }
+
+        match(QUOTE);
+
+        String index = token.toString();
+        if (index.equals(String.valueOf(WILDCARD))) {
+            return Subfield.allSubscripts();
+        }
+        return new Subfield.StringSubscript(index);
+    }
+
+    private boolean hasNextCharacter()
+    {
+        return index < path.length();
+    }
+
+    private void match(char expected)
+    {
+        if (!tryMatch(expected)) {
+            throw invalidSubfieldPath();
+        }
+    }
+
+    private boolean tryMatch(char expected)
+    {
+        if (!hasNextCharacter() || peekCharacter() != expected) {
+            return false;
+        }
+        index++;
+        return true;
+    }
+
+    private void nextCharacter()
+    {
+        index++;
+    }
+
+    private char peekCharacter()
+    {
+        return path.charAt(index);
+    }
+
+    private PrestoException invalidSubfieldPath()
+    {
+        return new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Invalid subfield path: '%s'", this));
+    }
+
+    @Override
+    public String toString()
+    {
+        return path.substring(0, index) + UNICODE_CARET + path.substring(index);
+    }
+
+    private enum State {
+        /** We have computed the next element and haven't returned it yet. */
+        READY,
+
+        /** We haven't yet computed or have already returned the element. */
+        NOT_READY,
+
+        /** We have reached the end of the data and are finished. */
+        DONE,
+
+        /** We've suffered an exception and are kaput. */
+        FAILED,
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
@@ -48,4 +48,6 @@ public interface StandardFunctionResolution
     FunctionHandle subscriptFunction(Type baseType, Type indexType);
 
     boolean isSubscriptFunction(FunctionHandle functionHandle);
+
+    boolean isCastFunction(FunctionHandle functionHandle);
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestSubfieldTokenizer.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestSubfieldTokenizer.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import com.facebook.presto.spi.Subfield.NestedField;
+import com.facebook.presto.spi.Subfield.PathElement;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestSubfieldTokenizer
+{
+    @Test
+    public void test()
+    {
+        List<PathElement> elements = ImmutableList.of(
+                new NestedField("b"),
+                new Subfield.LongSubscript(2),
+                new Subfield.StringSubscript("z"),
+                Subfield.allSubscripts(),
+                new Subfield.StringSubscript("34"),
+                new Subfield.StringSubscript("b \"test\""),
+                new Subfield.StringSubscript("\"abc"),
+                new Subfield.StringSubscript("abc\""),
+                new Subfield.StringSubscript("ab\"cde"),
+                new Subfield.StringSubscript("a.b[\"hello\uDBFF\"]"));
+
+        for (PathElement element : elements) {
+            assertPath(new Subfield("a", ImmutableList.of(element)));
+        }
+
+        for (PathElement element : elements) {
+            for (PathElement secondElement : elements) {
+                assertPath(new Subfield("a", ImmutableList.of(element, secondElement)));
+            }
+        }
+
+        for (PathElement element : elements) {
+            for (PathElement secondElement : elements) {
+                for (PathElement thirdElement : elements) {
+                    assertPath(new Subfield("a", ImmutableList.of(element, secondElement, thirdElement)));
+                }
+            }
+        }
+    }
+
+    private static void assertPath(Subfield path)
+    {
+        SubfieldTokenizer tokenizer = new SubfieldTokenizer(path.serialize());
+        assertTrue(tokenizer.hasNext());
+        assertEquals(new Subfield(((NestedField) tokenizer.next()).getName(), Streams.stream(tokenizer).collect(toImmutableList())), path);
+    }
+
+    @Test
+    public void testInvalidPaths()
+    {
+        assertInvalidPath("a[b]");
+        assertInvalidPath("a[2");
+        assertInvalidPath("a.*");
+        assertInvalidPath("a[2].[3].");
+    }
+
+    private void assertInvalidPath(String path)
+    {
+        SubfieldTokenizer tokenizer = new SubfieldTokenizer(path);
+
+        try {
+            Streams.stream(tokenizer).collect(toImmutableList());
+            fail("Expected failure");
+        }
+        catch (PrestoException e) {
+            // this is expected
+            assertTrue(e.getMessage().startsWith("Invalid subfield path: "));
+        }
+    }
+}


### PR DESCRIPTION
Modify DomainTranslator to support subfields, e.g. `a[2] > 10`.

Part of #12585