### PR TITLE
Fix equality inference for VARCHAR predicates

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/NullabilityAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/NullabilityAnalyzer.java
@@ -55,8 +55,12 @@ public final class NullabilityAnalyzer
         @Override
         protected Void visitCast(Cast node, AtomicBoolean result)
         {
-            // try_cast and cast(JSON 'null' AS ...) can return null
-            result.set(true);
+            // Certain casts (e.g., try_cast, cast(JSON 'null' AS ...)) can return
+            // null on non-null input.
+            // Type only casts are not evaluated by the execution, thus cannot return
+            // null on non-null input.
+            // TODO: This should be a part of a cast operator metadata
+            result.set(node.isSafe() || !node.isTypeOnly());
             return null;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
@@ -53,7 +53,7 @@ public class TestPredicatePushdown
                                 any(
                                         tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
                                 anyTree(
-                                        filter("cast(LINEITEM_LINENUMBER as varchar) = cast('2' as varchar)",
+                                        filter("cast('2' as varchar) = cast(LINEITEM_LINENUMBER as varchar)",
                                                 tableScan("lineitem", ImmutableMap.of(
                                                         "LINEITEM_OK", "orderkey",
                                                         "LINEITEM_LINENUMBER", "linenumber")))))));


### PR DESCRIPTION
Equality inference for VARCHAR predicates has been broken since the
introduction of the bounded VARCHAR type (e.g.: VARCHAR(2)).

The actual expression tree for the predicate like `c_varchar = 'abc'`
(assuming that the c_varchar column is of unbounded VARCHAR type) is
`c_varchar = CAST('abc' AS VARCHAR)`.

Equality cannot be inferred through a CAST in a generic case, as
casts like `cast(JSON 'null' AS ...)` and `try_cast` may return NULL
for a non null input.

However casts from VARCHAR(n) to VARCHAR(m) where m > n are type only.
Type only casts are not being evaluated by execution, thus cannot change
the input in any way.