### PR TITLE
Limit query submition threads

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -68,6 +68,8 @@ public class QueryManagerConfig
     private int requiredWorkers = 1;
     private Duration requiredWorkersMaxWait = new Duration(5, TimeUnit.MINUTES);
 
+    private int querySubmissionMaxThreads = Runtime.getRuntime().availableProcessors() * 2;
+
     @Min(1)
     public int getScheduleSplitBatchSize()
     {
@@ -407,6 +409,19 @@ public class QueryManagerConfig
     public QueryManagerConfig setRequiredWorkersMaxWait(Duration requiredWorkersMaxWait)
     {
         this.requiredWorkersMaxWait = requiredWorkersMaxWait;
+        return this;
+    }
+
+    @Min(1)
+    public int getQuerySubmissionMaxThreads()
+    {
+        return querySubmissionMaxThreads;
+    }
+
+    @Config("query-manager.query-submission-max-threads")
+    public QueryManagerConfig setQuerySubmissionMaxThreads(int querySubmissionMaxThreads)
+    {
+        this.querySubmissionMaxThreads = querySubmissionMaxThreads;
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -52,7 +52,8 @@ public class TestQueryManagerConfig
                 .setInitializationRequiredWorkers(1)
                 .setInitializationTimeout(new Duration(5, TimeUnit.MINUTES))
                 .setRequiredWorkers(1)
-                .setRequiredWorkersMaxWait(new Duration(5, TimeUnit.MINUTES)));
+                .setRequiredWorkersMaxWait(new Duration(5, TimeUnit.MINUTES))
+                .setQuerySubmissionMaxThreads(Runtime.getRuntime().availableProcessors() * 2));
     }
 
     @Test
@@ -84,6 +85,7 @@ public class TestQueryManagerConfig
                 .put("query-manager.initialization-timeout", "1m")
                 .put("query-manager.required-workers", "333")
                 .put("query-manager.required-workers-max-wait", "33m")
+                .put("query-manager.query-submission-max-threads", "5")
                 .build();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -111,7 +113,8 @@ public class TestQueryManagerConfig
                 .setInitializationRequiredWorkers(200)
                 .setInitializationTimeout(new Duration(1, TimeUnit.MINUTES))
                 .setRequiredWorkers(333)
-                .setRequiredWorkersMaxWait(new Duration(33, TimeUnit.MINUTES));
+                .setRequiredWorkersMaxWait(new Duration(33, TimeUnit.MINUTES))
+                .setQuerySubmissionMaxThreads(5);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Analysis is the part of the submission and when analysing Presto communicates
with the metastore using the blocking IO. Thus the maximum number of threads
that handle submission remains high (twice the number of CPUs).

Callbacks of the FailedQueryExecution and the ResourceGroupManager are supposed
to be lightweight and low latency. That why the unbounded executor remains to be
used to handle those.