### PR TITLE
Mark HIVE_WRITER_OPEN_ERROR and THRIFT_SERVICE_CONNECTION_ERROR as retryable in Verifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -454,6 +454,12 @@
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-thrift-connector</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-thrift-connector</artifactId>
+                <version>${project.version}</version>
                 <type>zip</type>
             </dependency>
 

--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -54,6 +54,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-thrift-connector</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/PrestoExceptionClassifier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/PrestoExceptionClassifier.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.verifier.framework;
 
+import com.facebook.presto.connector.thrift.ThriftErrorCode;
 import com.facebook.presto.hive.HiveErrorCode;
 import com.facebook.presto.jdbc.QueryStats;
 import com.facebook.presto.plugin.jdbc.JdbcErrorCode;
@@ -30,6 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
+import static com.facebook.presto.connector.thrift.ThriftErrorCode.THRIFT_SERVICE_CONNECTION_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
@@ -60,6 +62,7 @@ public class PrestoExceptionClassifier
             .addAll(asList(StandardErrorCode.values()))
             .addAll(asList(HiveErrorCode.values()))
             .addAll(asList(JdbcErrorCode.values()))
+            .addAll(asList(ThriftErrorCode.values()))
             .build();
 
     private static final Set<ErrorCodeSupplier> DEFAULT_RETRYABLE_ERRORS = ImmutableSet.of(
@@ -84,7 +87,9 @@ public class PrestoExceptionClassifier
             HIVE_CANNOT_OPEN_SPLIT,
             HIVE_METASTORE_ERROR,
             // From JdbcErrorCode
-            JDBC_ERROR);
+            JDBC_ERROR,
+            // From ThriftErrorCode
+            THRIFT_SERVICE_CONNECTION_ERROR);
 
     private final Map<Integer, ErrorCodeSupplier> errorByCode;
     private final Set<ErrorCodeSupplier> retryableErrors;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/PrestoExceptionClassifier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/PrestoExceptionClassifier.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_TOO_MANY_OPEN_PARTITIONS;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.ABANDONED_TASK;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
@@ -76,8 +77,9 @@ public class PrestoExceptionClassifier
             HIVE_CURSOR_ERROR,
             HIVE_FILE_NOT_FOUND,
             HIVE_TOO_MANY_OPEN_PARTITIONS,
-            HIVE_WRITER_DATA_ERROR,
+            HIVE_WRITER_OPEN_ERROR,
             HIVE_WRITER_CLOSE_ERROR,
+            HIVE_WRITER_DATA_ERROR,
             HIVE_FILESYSTEM_ERROR,
             HIVE_CANNOT_OPEN_SPLIT,
             HIVE_METASTORE_ERROR,


### PR DESCRIPTION
We have seen those 2 types of transient failures in nightly Verifier runs.