### PR TITLE
Improve performance for positioned reads on S3

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystemStats.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystemStats.java
@@ -251,15 +251,15 @@ public class PrestoS3FileSystemStats
         listObjectsCalls.update(1);
     }
 
-    public void newReadError(Exception e)
+    public void newReadError(Throwable t)
     {
-        if (e instanceof SocketException) {
+        if (t instanceof SocketException) {
             socketExceptions.update(1);
         }
-        else if (e instanceof SocketTimeoutException) {
+        else if (t instanceof SocketTimeoutException) {
             socketTimeoutExceptions.update(1);
         }
-        else if (e instanceof AbortedException) {
+        else if (t instanceof AbortedException) {
             awsAbortedExceptions.update(1);
         }
         else {


### PR DESCRIPTION
This is a backport of [prestosql/presto#142](https://github.com/prestosql/presto/pull/142). From the commit message:

> This eliminates reading extra data from S3 by always requesting the
exact range needed (rather than performing streaming reads). Also,
because all data is always read from connections, this allows
connection reuse via the HTTP client connection pool.