### PR TITLE
[Raptorx] a quick fix of TransactionRollback to unblock RaptorV2

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -56,7 +56,7 @@ import static java.util.Objects.requireNonNull;
 public final class Session
 {
     private final QueryId queryId;
-    private final Optional<TransactionId> transactionId;
+    private Optional<TransactionId> transactionId;
     private final boolean clientTransactionSupport;
     private final Identity identity;
     private final Optional<String> source;
@@ -284,6 +284,11 @@ public final class Session
         String sql = preparedStatements.get(name);
         checkCondition(sql != null, NOT_FOUND, "Prepared statement not found: " + name);
         return sql;
+    }
+
+    public void setTransactionId(TransactionId transactionId)
+    {
+        this.transactionId = Optional.of(transactionId);
     }
 
     public Session beginTransactionId(TransactionId transactionId, TransactionManager transactionManager, AccessControl accessControl)

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -218,16 +218,18 @@ public class QueryStateMachine
             Metadata metadata,
             WarningCollector warningCollector)
     {
+        Session newSession = null;
         // If there is not an existing transaction, begin an auto commit transaction
         if (!session.getTransactionId().isPresent() && !transactionControl) {
             // TODO: make autocommit isolation level a session parameter
             TransactionId transactionId = transactionManager.beginTransaction(true);
-            session = session.beginTransactionId(transactionId, transactionManager, accessControl);
+            newSession = session.beginTransactionId(transactionId, transactionManager, accessControl);
+            session.setTransactionId(transactionId);
         }
 
         QueryStateMachine queryStateMachine = new QueryStateMachine(
                 query,
-                session,
+                newSession,
                 self,
                 Optional.of(resourceGroup),
                 queryType,


### PR DESCRIPTION
Presto doesn't end a query correctly on some condition.
It affects RaptorV1 too, but not that critical.
This quick fix is for unlock testing.

This PR only serves as a starting point of the issue, https://github.com/prestodb/presto/issues/12675. Consider not landing the PR, instead, discuss out a thorough fix of Presto Transaction layer, then abandon this PR.