### PR TITLE
entropy udf

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/EntropyAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/EntropyAggregation.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.EntropyState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+
+@AggregationFunction("entropy")
+@Description("Returns the log-2 entropy of count inputs")
+public final class EntropyAggregation
+{
+    @InputFunction
+    public static void input(
+            @AggregationState EntropyState state,
+            @SqlType(StandardTypes.BIGINT) long count)
+    {
+        if (count == 0) {
+            return;
+        }
+        if (count < 0) {
+            state.setNull(true);
+            return;
+        }
+
+        final double countVal = count;
+        state.setSumC(state.getSumC() + countVal);
+        state.setSumCLogC(state.getSumCLogC() + countVal * Math.log(countVal));
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState EntropyState state, @AggregationState EntropyState otherState)
+    {
+        state.setSumC(state.getSumC() + otherState.getSumC());
+        state.setSumCLogC(state.getSumCLogC() + otherState.getSumCLogC());
+        state.setNull(state.getNull() || otherState.getNull());
+    }
+
+    @OutputFunction(StandardTypes.DOUBLE)
+    public static void output(@AggregationState EntropyState state, BlockBuilder out)
+    {
+        if (state.getNull()) {
+            out.appendNull();
+            return;
+        }
+        if (state.getSumC() == 0) {
+            DOUBLE.writeDouble(out, 0);
+            return;
+        }
+        double entropy = Math.max(
+                (-state.getSumCLogC() / state.getSumC() + Math.log(state.getSumC())) / Math.log(2),
+                0);
+        entropy = Math.max(entropy, 0);
+        DOUBLE.writeDouble(out, entropy);
+    }
+
+    private EntropyAggregation() {}
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/EntropyState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/EntropyState.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.function.AccumulatorState;
+
+public interface EntropyState
+        extends AccumulatorState
+{
+    void setNull(boolean isNull);
+
+    boolean getNull();
+
+    void setSumC(double sumC);
+
+    double getSumC();
+
+    void setSumCLogC(double sumCLogC);
+
+    double getSumCLogC();
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestEntropyAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestEntropyAggregation.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+
+public class TestEntropyAggregation
+        extends AbstractTestAggregationFunction
+{
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
+        for (int i = start; i < start + length; i++) {
+            BIGINT.writeLong(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        final ArrayList<Integer> counts = IntStream
+                .range(start, start + length)
+                .boxed()
+                .collect(Collectors.toCollection(ArrayList::new));
+        if (counts.stream().anyMatch(c -> c < 0)) {
+            return null;
+        }
+        final double sum = counts.stream()
+                .mapToDouble(c -> Math.max(c, 0.0))
+                .sum();
+        if (sum == 0) {
+            return 0.0;
+        }
+        final ArrayList<Double> entropies = counts.stream()
+                .filter(c -> c > 0)
+                .map(c -> (c / sum) * Math.log(sum / c))
+                .collect(Collectors.toCollection(ArrayList::new));
+        return entropies.isEmpty() ?
+                0 :
+                entropies.stream().mapToDouble(c -> c).sum() / Math.log(2);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "entropy";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTEGER);
+    }
+}


### PR DESCRIPTION
Following #12700  and talks with @rongrong, I'd like to ask to pull the entropy UDF.

Motivation
------------

[Entropy](https://en.wikipedia.org/wiki/Entropy_(information_theory)) is a measure of disorder and uncertainty. 

Say you have a number of web pages, each accessed by approximately 100 visits last month. The visits of one page might be "organized", in the sense that all 100 accesses came from a small number of users, while the visits of another page might be "disorganized", in the sense that the 100 accesses were distributed over many more users. In this case, entropy quantifies how "disorganized" the accesses are, by taking a column of counts per user (summing up to about 100, in this example), and giving a single number.

Entropy is also used as the basis of several other calculations in machine learning and statistics.

Possible inputs and output
------------------------------

  entropy(BIGINT) -> DOUBLE
  entropy(INT) -> DOUBLE

Description
------------

Compute the normalized entropy of a series of counts.  The input is assumed
 to be a column of counts of each value's occurrence . The entropy is normalized in the sense that
 the counts are first normalized so that the sum of all counts equals one
 (i.e., it is converted to a probability distribution).  Any NULLs in the
 column are ignored.  If the column contains negative values then NULL is
 returned.  If the total count of entries of in the column is zero then zero
 is returned.

 Note that the entropy is computed using base-2 log.