### PR TITLE
Entropy UDF

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -308,6 +308,19 @@ Statistical Aggregate Functions
 
     Returns the sample covariance of input values.
 
+.. function:: entropy(c) -> double
+
+    Returns the log-2 entropy of count input-values.
+
+    .. code-block:: none
+
+        entropy(c) = \sum_i [ c_i / \sum_j [c_j] \log_2(\sum_j [c_j] / c_i) ]
+
+    ``c`` must be a ``bigint`` column of non-negative values.
+
+    The function ignores any ``NULL`` count. If the sum of non-``NULL`` counts is 0,
+    it returns 0.
+
 .. function:: kurtosis(x) -> double
 
     Returns the excess kurtosis of all input values. Unbiased estimate using

--- a/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespace.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespace.java
@@ -36,6 +36,7 @@ import com.facebook.presto.operator.aggregation.DoubleCovarianceAggregation;
 import com.facebook.presto.operator.aggregation.DoubleHistogramAggregation;
 import com.facebook.presto.operator.aggregation.DoubleRegressionAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
+import com.facebook.presto.operator.aggregation.EntropyAggregation;
 import com.facebook.presto.operator.aggregation.GeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.facebook.presto.operator.aggregation.IntervalDayToSecondAverageAggregation;
@@ -450,6 +451,7 @@ class StaticFunctionNamespace
                 .function(REAL_AVERAGE_AGGREGATION)
                 .aggregates(IntervalDayToSecondAverageAggregation.class)
                 .aggregates(IntervalYearToMonthAverageAggregation.class)
+                .aggregates(EntropyAggregation.class)
                 .aggregates(GeometricMeanAggregations.class)
                 .aggregates(RealGeometricMeanAggregations.class)
                 .aggregates(MergeHyperLogLogAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/EntropyAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/EntropyAggregation.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.EntropyState;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+
+/**
+ *  Calculates the log-2 entropy of count inputs.
+ *
+ *  Given counts $c_1, c_2, ..., cn$ ($c_i \geq 0)$, this aggregation calculates $\sum_i [ p_i log_2(-p_i) ]$,
+ *      where $p_i = {c_i \over \sum_i [ c_i ]}$. If $\sum_i [ c_i ] = 0$, the entropy is defined to be 0.
+ */
+@AggregationFunction("entropy")
+@Description("Takes non-negative count inputs, and computes the log-2 entropy of their fractions when normalized to sum to 1.")
+public final class EntropyAggregation
+{
+    private EntropyAggregation() {}
+
+    /**
+     * @note If count is negative, the value of the aggregation will be null; if
+     * count is 0, this is a no-op (since, in the context of entropy, 0 log(0) = 0; if count is null,
+     * this is a no op.
+     */
+    @InputFunction
+    public static void input(
+            @AggregationState EntropyState state,
+            @SqlType(StandardTypes.BIGINT) long count)
+    {
+        if (count < 0) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    "Entropy count argument must be non-negative");
+        }
+
+        if (count == 0) {
+            return;
+        }
+        state.setSumC(state.getSumC() + count);
+        state.setSumCLogC(state.getSumCLogC() + count * Math.log(count));
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState EntropyState state, @AggregationState EntropyState otherState)
+    {
+        state.setSumC(state.getSumC() + otherState.getSumC());
+        state.setSumCLogC(state.getSumCLogC() + otherState.getSumCLogC());
+    }
+
+    @OutputFunction(StandardTypes.DOUBLE)
+    public static void output(@AggregationState EntropyState state, BlockBuilder out)
+    {
+        Double entropy = 0.0;
+        if (state.getSumC() > 0.0) {
+            entropy = Math.max(
+                    (Math.log(state.getSumC()) - state.getSumCLogC() / state.getSumC()) / Math.log(2.0),
+                    0.0);
+        }
+
+        DOUBLE.writeDouble(out, entropy);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/EntropyState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/EntropyState.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.function.AccumulatorState;
+
+/**
+ * This is a state class for calculating the log-2 entropy of counts.
+ *
+ *  Given counts $c_1, c_2, ..., cn$ ($c_i \geq 0)$, this aggregation calculates $\sum_i [ p_i log(-p_i) ]$,
+ *      where $p_i = {c_i \over \sum_i [c_i]}$. Note that
+ *      $$
+ *      \sum_i [ p_i log( -p_i ) ] =
+ *      \sum_i [ {c_i \over \sum_j [c_j]} \log( {\sum_j [c_j] \over c_i} ) ] =
+ *      {
+ *          \sum_i [ c_i \log( \sum_j [c_j] ) - c_i \log( c_i )]
+ *          \over
+ *          \sum_j [c_j]
+ *      } =
+ *      {
+ *          \sum_i [ c_i ] \log( \sum_i [c_i] )  -
+ *          \sum_i [ c_i \log( c_i ) ]
+ *          \over
+ *          \sum_i [c_i]
+ *      } =
+ *      \log( \sum_i [c_i] )  -
+ *      { \sum_i [ c_i \log( c_i ) ] \over \sum_i [c_i] }
+ *      .
+ *      $$
+ *      This shows that we just need to accumulate $\sum_i [c_i]$ and $\sum_i [ c_i \log( c_i ) ]$.
+ *      In the following, they are termed sumC and sumCLogC, respectively (technically,
+ *      the latter is $\sum_i [ c_i \ln( c_i ) ]$, and we change bases only at the end of the calculation).
+ */
+public interface EntropyState
+        extends AccumulatorState
+{
+    // $\sum_i [c_i]$
+    void setSumC(double sumC);
+
+    // $\sum_i [c_i]$
+    double getSumC();
+
+    // $\sum_i [ c_i \log (c_i) ]$
+    void setSumCLogC(double sumCLogC);
+
+    // $\sum_i [ c_i \log (c_i) ]$
+    double getSumCLogC();
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestEntropyAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestEntropyAggregation.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static org.testng.Assert.assertTrue;
+
+public class TestEntropyAggregation
+        extends AbstractTestAggregationFunction
+{
+    private static final String FUNCTION_NAME = "entropy";
+
+    private InternalAggregationFunction entropyFunction;
+
+    @BeforeClass
+    public void setUp()
+    {
+        FunctionManager functionManager = MetadataManager.createTestMetadataManager().getFunctionManager();
+        entropyFunction = functionManager.getAggregateFunctionImplementation(
+                functionManager.lookupFunction(TestEntropyAggregation.FUNCTION_NAME, fromTypes(BIGINT)));
+    }
+
+    @Test
+    public void entropyOfASingle()
+    {
+        assertAggregation(entropyFunction,
+                0.0,
+                createLongsBlock(Long.valueOf(1)));
+    }
+
+    @Test
+    public void entropyOfTwoEquals()
+    {
+        Long x;
+
+        x = Long.valueOf(1);
+        assertAggregation(entropyFunction,
+                1.0,
+                createLongsBlock(x, x));
+
+        x = Long.valueOf(20);
+        assertAggregation(entropyFunction,
+                1.0,
+                createLongsBlock(x, x));
+    }
+
+    @Test
+    public void entropyOfTwoEqualsWithNulls()
+    {
+        Long x;
+
+        x = Long.valueOf(1);
+        assertAggregation(entropyFunction,
+                1.0,
+                createLongsBlock(x, null, x));
+
+        x = Long.valueOf(10);
+        assertAggregation(entropyFunction,
+                1.0,
+                createLongsBlock(null, null, x, x));
+    }
+
+    @Test
+    public void entropyOfTwoSkewed()
+    {
+        Long lower = Long.valueOf(30);
+        Long higher = Long.valueOf(70);
+        Double expected = 0.8812908992306931;
+
+        assertAggregation(entropyFunction,
+                expected,
+                createLongsBlock(lower, higher));
+        assertAggregation(entropyFunction,
+                expected,
+                createLongsBlock(higher, lower));
+    }
+
+    @Test
+    public void entropyOfOnlyNulls()
+    {
+        assertAggregation(entropyFunction,
+                0.0,
+                createLongsBlock(null, null));
+    }
+
+    @Test
+    public void entropyOfNegativeCount()
+    {
+        String error = "";
+        try {
+            assertAggregation(entropyFunction,
+                    0.0,
+                    createLongsBlock(Long.valueOf(-1)));
+        }
+        catch (PrestoException e) {
+            error = e.getMessage();
+        }
+        assertTrue(error.toLowerCase(Locale.ENGLISH).contains("negative"));
+    }
+
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, length);
+        for (int i = start; i < start + length; i++) {
+            BIGINT.writeLong(blockBuilder, Math.abs(i));
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Override
+    public Number getExpectedValue(int start, int length)
+    {
+        final ArrayList<Integer> counts = IntStream
+                .range(start, start + length)
+                .map(c -> Math.abs(c))
+                .boxed()
+                .collect(Collectors.toCollection(ArrayList::new));
+        if (counts.stream().anyMatch(c -> c < 0)) {
+            return null;
+        }
+        final double sum = counts.stream()
+                .mapToDouble(c -> Math.max(c, 0.0))
+                .sum();
+        if (sum == 0) {
+            return 0.0;
+        }
+        final ArrayList<Double> entropies = counts.stream()
+                .filter(c -> c > 0)
+                .map(c -> (c / sum) * Math.log(sum / c))
+                .collect(Collectors.toCollection(ArrayList::new));
+        return entropies.isEmpty() ?
+                0 :
+                entropies.stream().mapToDouble(c -> c).sum() / Math.log(2);
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return TestEntropyAggregation.FUNCTION_NAME;
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTEGER);
+    }
+}


### PR DESCRIPTION
Following #12700  and talks with @rongrong, I'd like to ask to pull the entropy UDF.

Motivation
------------

[Entropy](https://en.wikipedia.org/wiki/Entropy_(information_theory)) is a measure of disorder and uncertainty. 

Say you have a number of web pages, each accessed by approximately 100 visits last month. The visits of one page might be "organized", in the sense that all 100 accesses came from a small number of users, while the visits of another page might be "disorganized", in the sense that the 100 accesses were distributed over many more users. In this case, entropy quantifies how "disorganized" the accesses are, by taking a column of counts per user (summing up to about 100, in this example), and giving a single number.

Entropy is also used as the basis of several other calculations in machine learning and statistics.

Possible inputs and output
------------------------------

  entropy(BIGINT) -> DOUBLE
  entropy(INT) -> DOUBLE

Description
------------

Compute the normalized entropy of a series of counts.  The input is assumed
 to be a column of counts of each value's occurrence . The entropy is normalized in the sense that
 the counts are first normalized so that the sum of all counts equals one
 (i.e., it is converted to a probability distribution).  Any NULLs in the
 column are ignored.  If the column contains negative values then NULL is
 returned.  If the total count of entries of in the column is zero then zero
 is returned.

 Note that the entropy is computed using base-2 log.