### PR TITLE
Add ExpressionOptimizer to RowExpressionService

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -51,6 +51,7 @@ import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.relational.ConnectorRowExpressionService;
 import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.sql.relational.RowExpressionOptimizer;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -326,7 +327,7 @@ public class ConnectorManager
                 new FunctionResolution(metadataManager.getFunctionManager()),
                 pageSorter,
                 pageIndexerFactory,
-                new ConnectorRowExpressionService(domainTranslator));
+                new ConnectorRowExpressionService(domainTranslator, new RowExpressionOptimizer(metadataManager)));
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(factory.getClass().getClassLoader())) {
             return factory.create(connectorId.getCatalogName(), properties, context);

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/ConnectorRowExpressionService.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/ConnectorRowExpressionService.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.relational;
 
 import com.facebook.presto.spi.relation.DomainTranslator;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.RowExpressionService;
 
 import static java.util.Objects.requireNonNull;
@@ -22,15 +23,23 @@ public final class ConnectorRowExpressionService
         implements RowExpressionService
 {
     private final DomainTranslator domainTranslator;
+    private final ExpressionOptimizer expressionOptimizer;
 
-    public ConnectorRowExpressionService(DomainTranslator domainTranslator)
+    public ConnectorRowExpressionService(DomainTranslator domainTranslator, ExpressionOptimizer expressionOptimizer)
     {
         this.domainTranslator = requireNonNull(domainTranslator, "domainTranslator is null");
+        this.expressionOptimizer = requireNonNull(expressionOptimizer, "expressionOptimizer is null");
     }
 
     @Override
     public DomainTranslator getDomainTranslator()
     {
         return domainTranslator;
+    }
+
+    @Override
+    public ExpressionOptimizer getExpressionOptimizer()
+    {
+        return expressionOptimizer;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionOptimizer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.sql.planner.RowExpressionInterpreter;
+
+import static com.facebook.presto.sql.planner.LiteralEncoder.toRowExpression;
+import static java.util.Objects.requireNonNull;
+
+public final class RowExpressionOptimizer
+        implements ExpressionOptimizer
+{
+    private final Metadata metadata;
+
+    public RowExpressionOptimizer(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session)
+    {
+        if (level == Level.SERIALIZABLE) {
+            return toRowExpression(RowExpressionInterpreter.rowExpressionInterpreter(rowExpression, metadata, session).evaluate(), rowExpression.getType());
+        }
+        if (level == Level.MOST_OPTIMIZED) {
+            return toRowExpression(new RowExpressionInterpreter(rowExpression, metadata, session, true).optimize(), rowExpression.getType());
+        }
+        throw new IllegalArgumentException("Unrecognized optimization level: " + level);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
@@ -30,12 +30,14 @@ import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.relation.DomainTranslator;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
+import com.facebook.presto.sql.relational.RowExpressionOptimizer;
 import com.facebook.presto.type.TypeRegistry;
 
 public class TestingConnectorContext
@@ -95,6 +97,12 @@ public class TestingConnectorContext
             public DomainTranslator getDomainTranslator()
             {
                 return domainTranslator;
+            }
+
+            @Override
+            public ExpressionOptimizer getExpressionOptimizer()
+            {
+                return new RowExpressionOptimizer(metadata);
             }
         };
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizer.java
@@ -13,12 +13,24 @@
  */
 package com.facebook.presto.spi.relation;
 
-/**
- * A set of services/utilities that are helpful for connectors to operate on row expressions
- */
-public interface RowExpressionService
-{
-    DomainTranslator getDomainTranslator();
+import com.facebook.presto.spi.ConnectorSession;
 
-    ExpressionOptimizer getExpressionOptimizer();
+public interface ExpressionOptimizer
+{
+    /**
+     * Optimize a RowExpression to
+     */
+    RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session);
+
+    enum Level
+    {
+        /**
+         * SERIALIZABLE guarantees the optimized RowExpression can be serialized and deserialized
+         */
+        SERIALIZABLE,
+        /**
+         * MOST_OPTIMIZED removes all redundancy in a RowExpression but can end up with non-serializable objects (e.g., Regex).
+         */
+        MOST_OPTIMIZED
+    }
 }


### PR DESCRIPTION
ExpressionOptimizer helps to simplify a RowExpression into a minimum
form. For example, `length(query) > 100` will be translated into
`GREATER_THAN(length(query), CAST(Slice{base=[B@47199eaa, address=47, length=3}))`;
After optimization, it will be `GREATER_THAN(length(query), 100)`