### PR TITLE
Fix incorrect partitioned join after PredicatePushDown

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -84,6 +84,8 @@ import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionT
 import static com.facebook.presto.sql.planner.EqualityInference.createEqualityInference;
 import static com.facebook.presto.sql.planner.ExpressionDeterminismEvaluator.isDeterministic;
 import static com.facebook.presto.sql.planner.ExpressionSymbolInliner.inlineSymbols;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
@@ -517,6 +519,18 @@ public class PredicatePushDown
                 leftSource = new ProjectNode(idAllocator.getNextId(), leftSource, leftProjections.build());
                 rightSource = new ProjectNode(idAllocator.getNextId(), rightSource, rightProjections.build());
 
+                // if the distribution type is already set, make sure that changes from PredicatePushDown
+                // don't make the join node invalid.
+                Optional<JoinNode.DistributionType> distributionType = node.getDistributionType();
+                if (node.getDistributionType().isPresent()) {
+                    if (node.getType().mustPartition()) {
+                        distributionType = Optional.of(PARTITIONED);
+                    }
+                    if (node.getType().mustReplicate(equiJoinClauses)) {
+                        distributionType = Optional.of(REPLICATED);
+                    }
+                }
+
                 output = new JoinNode(
                         node.getId(),
                         node.getType(),
@@ -530,7 +544,7 @@ public class PredicatePushDown
                         newJoinFilter.map(OriginalExpressionUtils::castToRowExpression),
                         node.getLeftHashSymbol(),
                         node.getRightHashSymbol(),
-                        node.getDistributionType());
+                        distributionType);
             }
 
             if (!postJoinPredicate.equals(TRUE_LITERAL)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -223,8 +223,8 @@ public class PredicatePushDown
             // pre-projected symbols.
             Predicate<Expression> isSupported = conjunct ->
                     ExpressionDeterminismEvaluator.isDeterministic(conjunct) &&
-                    SymbolsExtractor.extractUnique(conjunct).stream()
-                            .allMatch(partitionSymbols::contains);
+                            SymbolsExtractor.extractUnique(conjunct).stream()
+                                    .allMatch(partitionSymbols::contains);
 
             Map<Boolean, List<Expression>> conjuncts = extractConjuncts(context.get()).stream().collect(Collectors.partitioningBy(isSupported));
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPredicatePushdown.java
@@ -15,14 +15,20 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
+import com.facebook.presto.sql.planner.optimizations.PredicatePushDown;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.JoinNode.EquiJoinClause;
 import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.LongLiteral;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.any;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
@@ -38,8 +44,11 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.projec
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.PARTITIONED;
+import static com.facebook.presto.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.EQUAL;
 
 public class TestPredicatePushdown
         extends BasePlanTest
@@ -411,5 +420,36 @@ public class TestPredicatePushdown
                                                         tableScan(
                                                                 "orders",
                                                                 ImmutableMap.of("CUST_KEY", "custkey"))))))));
+    }
+
+    @Test
+    public void testPredicatePushDownCreatesValidJoin()
+    {
+        RuleTester tester = new RuleTester();
+        tester.assertThat(new PredicatePushDown(tester.getMetadata(), tester.getSqlParser()))
+                .on(p ->
+                        p.join(INNER,
+                                p.filter(new ComparisonExpression(EQUAL, p.symbol("a1").toSymbolReference(), new LongLiteral("1")),
+                                        p.values(p.symbol("a1"))),
+                                p.values(p.symbol("b1")),
+                                ImmutableList.of(new EquiJoinClause(p.symbol("a1"), p.symbol("b1"))),
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.of(PARTITIONED)))
+                .matches(
+                        project(
+                                join(
+                                        INNER,
+                                        ImmutableList.of(),
+                                        Optional.empty(),
+                                        Optional.of(REPLICATED),
+                                        project(
+                                                filter("a1=1",
+                                                        values("a1"))),
+                                        project(
+                                                filter("1=b1",
+                                                        values("b1"))))));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/OptimizerAssert.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsAndCosts;
+import com.facebook.presto.cost.StatsCalculator;
+import com.facebook.presto.execution.warnings.WarningCollector;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleAssert.TestingStatsCalculator;
+import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.function.Function;
+
+import static com.facebook.presto.sql.planner.assertions.PlanAssert.assertPlan;
+import static com.facebook.presto.transaction.TransactionBuilder.transaction;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.fail;
+
+public class OptimizerAssert
+{
+    private final Metadata metadata;
+    private final TestingStatsCalculator statsCalculator;
+    private final Session session;
+    private final PlanOptimizer optimizer;
+    private final PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+    private final TransactionManager transactionManager;
+    private final AccessControl accessControl;
+
+    private TypeProvider types;
+    private PlanNode plan;
+
+    public OptimizerAssert(Metadata metadata, StatsCalculator statsCalculator, Session session, PlanOptimizer optimizer, TransactionManager transactionManager, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.statsCalculator = new TestingStatsCalculator(requireNonNull(statsCalculator, "statsCalculator is null"));
+        this.session = requireNonNull(session, "session is null");
+        this.optimizer = requireNonNull(optimizer, "optimizer is null");
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.accessControl = requireNonNull(accessControl, "access control is null");
+    }
+
+    public OptimizerAssert on(Function<PlanBuilder, PlanNode> planProvider)
+    {
+        checkState(plan == null, "plan has already been set");
+
+        PlanBuilder builder = new PlanBuilder(idAllocator, metadata);
+        plan = planProvider.apply(builder);
+        types = builder.getTypes();
+        return this;
+    }
+
+    public void matches(PlanMatchPattern pattern)
+    {
+        PlanNode actual = optimizer.optimize(plan, session, types, new SymbolAllocator(), idAllocator, WarningCollector.NOOP);
+
+        if (!ImmutableSet.copyOf(plan.getOutputSymbols()).equals(ImmutableSet.copyOf(actual.getOutputSymbols()))) {
+            fail(String.format(
+                    "%s: output schema of transformed and original plans are not equivalent\n" +
+                            "\texpected: %s\n" +
+                            "\tactual:   %s",
+                    optimizer.getClass().getName(),
+                    plan.getOutputSymbols(),
+                    actual.getOutputSymbols()));
+        }
+
+        inTransaction(session -> {
+            assertPlan(session, metadata, statsCalculator, new Plan(actual, types, StatsAndCosts.empty()), pattern);
+            return null;
+        });
+    }
+
+    private <T> void inTransaction(Function<Session, T> transactionSessionConsumer)
+    {
+        transaction(transactionManager, accessControl)
+                .singleStatement()
+                .execute(session, session -> {
+                    // metadata.getCatalogHandle() registers the catalog for the transaction
+                    session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
+                    return transactionSessionConsumer.apply(session);
+                });
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -49,34 +49,33 @@ import java.util.stream.Stream;
 import static com.facebook.presto.sql.planner.assertions.PlanAssert.assertPlan;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.textLogicalPlan;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.fail;
 
 public class RuleAssert
 {
     private final Metadata metadata;
-    private TestingStatsCalculator statsCalculator;
+    private final TestingStatsCalculator statsCalculator;
     private final CostCalculator costCalculator;
-    private Session session;
     private final Rule<?> rule;
-
     private final PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
-
-    private TypeProvider types;
-    private PlanNode plan;
     private final TransactionManager transactionManager;
     private final AccessControl accessControl;
 
+    private Session session;
+    private TypeProvider types;
+    private PlanNode plan;
+
     public RuleAssert(Metadata metadata, StatsCalculator statsCalculator, CostCalculator costCalculator, Session session, Rule rule, TransactionManager transactionManager, AccessControl accessControl)
     {
-        this.metadata = metadata;
-        this.statsCalculator = new TestingStatsCalculator(statsCalculator);
-        this.costCalculator = costCalculator;
-        this.session = session;
-        this.rule = rule;
-        this.transactionManager = transactionManager;
-        this.accessControl = accessControl;
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.statsCalculator = new TestingStatsCalculator(requireNonNull(statsCalculator, "statsCalculator is null"));
+        this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
+        this.session = requireNonNull(session, "session is null");
+        this.rule = requireNonNull(rule, "rule is null");
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
     }
 
     public RuleAssert setSystemProperty(String key, String value)
@@ -100,7 +99,7 @@ public class RuleAssert
 
     public RuleAssert on(Function<PlanBuilder, PlanNode> planProvider)
     {
-        checkArgument(plan == null, "plan has already been set");
+        checkState(plan == null, "plan has already been set");
 
         PlanBuilder builder = new PlanBuilder(idAllocator, metadata);
         plan = planProvider.apply(builder);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -281,13 +281,13 @@ public class RuleAssert
         }
     }
 
-    private static class TestingStatsCalculator
+    public static class TestingStatsCalculator
             implements StatsCalculator
     {
         private final StatsCalculator delegate;
         private final Map<PlanNodeId, PlanNodeStatsEstimate> stats = new HashMap<>();
 
-        TestingStatsCalculator(StatsCalculator delegate)
+        public TestingStatsCalculator(StatsCalculator delegate)
         {
             this.delegate = requireNonNull(delegate, "delegate is null");
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleTester.java
@@ -21,7 +21,9 @@ import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.assertions.OptimizerAssert;
 import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.tpch.TpchConnectorFactory;
 import com.facebook.presto.transaction.TransactionManager;
@@ -97,6 +99,11 @@ public class RuleTester
     public RuleAssert assertThat(Rule rule)
     {
         return new RuleAssert(metadata, queryRunner.getStatsCalculator(), queryRunner.getEstimatedExchangesCostCalculator(), session, rule, transactionManager, accessControl);
+    }
+
+    public OptimizerAssert assertThat(PlanOptimizer optimizer)
+    {
+        return new OptimizerAssert(metadata, queryRunner.getStatsCalculator(), session, optimizer, transactionManager, accessControl);
     }
 
     @Override


### PR DESCRIPTION
PredicatePushDown used the original join distribution type when it
creates a new join node.  However, if predicate push down removed all
equijoin criteria after DetermineJoinDistributionType already ran, then
the join type could be invalid leading to an assertion failure in the
join node.

Fixes #12354 

I still need to figure out how to test it because none of our test tables have small int types and i'm not sure how to reproduce it with the existing tables. We either need to
1. create a new test table (and not run for tpch?)
2. find another way to reproduce. 
3. just have a product test