### PR TITLE
Reduce Hive split memory usage to prevent EXCEEDED_SPLIT_BUFFERING_LIMIT errors

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloSplitManager.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloSplitManager.java
@@ -57,7 +57,11 @@ public class AccumuloSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         AccumuloTableLayoutHandle layoutHandle = (AccumuloTableLayoutHandle) layout;
         AccumuloTableHandle tableHandle = layoutHandle.getTable();

--- a/presto-atop/src/main/java/com/facebook/presto/atop/AtopSplitManager.java
+++ b/presto-atop/src/main/java/com/facebook/presto/atop/AtopSplitManager.java
@@ -53,7 +53,11 @@ public class AtopSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layoutHandle, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layoutHandle,
+            SplitSchedulingContext splitSchedulingContext)
     {
         AtopTableLayoutHandle handle = (AtopTableLayoutHandle) layoutHandle;
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplitManager.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplitManager.java
@@ -35,7 +35,11 @@ public class JdbcSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         JdbcTableLayoutHandle layoutHandle = (JdbcTableLayoutHandle) layout;
         return jdbcClient.getSplits(layoutHandle);

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleSplitManager.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleSplitManager.java
@@ -25,7 +25,11 @@ public final class BlackHoleSplitManager
         implements ConnectorSplitManager
 {
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layoutHandle, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layoutHandle,
+            SplitSchedulingContext splitSchedulingContext)
     {
         BlackHoleTableLayoutHandle layout = (BlackHoleTableLayoutHandle) layoutHandle;
 

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSplitManager.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSplitManager.java
@@ -61,7 +61,11 @@ public class CassandraSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         CassandraTableLayoutHandle layoutHandle = (CassandraTableLayoutHandle) layout;
         CassandraTableHandle cassandraTableHandle = layoutHandle.getTable();

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingContext;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.testing.TestingConnectorContext;
@@ -176,7 +177,7 @@ public class TestCassandraConnector
 
         List<ConnectorTableLayoutResult> layouts = metadata.getTableLayouts(SESSION, tableHandle, Constraint.alwaysTrue(), Optional.empty());
         ConnectorTableLayoutHandle layout = getOnlyElement(layouts).getTableLayout().getHandle();
-        List<ConnectorSplit> splits = getAllSplits(splitManager.getSplits(transaction, SESSION, layout, UNGROUPED_SCHEDULING));
+        List<ConnectorSplit> splits = getAllSplits(splitManager.getSplits(transaction, SESSION, layout, new SplitSchedulingContext(UNGROUPED_SCHEDULING, false)));
 
         long rowNumber = 0;
         for (ConnectorSplit split : splits) {

--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchSplitManager.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchSplitManager.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.FixedSplitSource;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
-import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.common.collect.ImmutableList;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsGroup;
@@ -45,7 +44,11 @@ public class ElasticsearchSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         ElasticsearchTableLayoutHandle layoutHandle = (ElasticsearchTableLayoutHandle) layout;
         ElasticsearchTableHandle tableHandle = layoutHandle.getTable();

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleSplitManager.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleSplitManager.java
@@ -45,7 +45,11 @@ public class ExampleSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle handle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle handle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         ExampleTableLayoutHandle layoutHandle = (ExampleTableLayoutHandle) layout;
         ExampleTableHandle tableHandle = layoutHandle.getTable();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -312,7 +312,7 @@ public class BackgroundHiveSplitLoader
                         effectivePredicate,
                         isForceLocalScheduling(session),
                         s3SelectPushdownEnabled,
-                        new HiveSplitPartitionInfo(schema, partitionKeys, partitionName, partition.getColumnCoercions(), Optional.empty()),
+                        new HiveSplitPartitionInfo(schema, path.toUri(), partitionKeys, partitionName, partition.getColumnCoercions(), Optional.empty()),
                         schedulerUsesHostAddresses);
                 lastResult = addSplitsToSource(targetSplits, splitFactory);
                 if (stopped) {
@@ -347,6 +347,7 @@ public class BackgroundHiveSplitLoader
                 s3SelectPushdownEnabled,
                 new HiveSplitPartitionInfo(
                         schema,
+                        path.toUri(),
                         partitionKeys,
                         partitionName,
                         partition.getColumnCoercions(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -591,7 +591,7 @@ public class BackgroundHiveSplitLoader
          * <ul>
          * <li>Filter on "$bucket" column. e.g. {@code "$bucket" between 0 and 100}
          * <li>Single-value equality filter on all bucket columns. e.g. for a table with two bucketing columns,
-         *     {@code bucketCol1 = 'a' AND bucketCol2 = 123}
+         * {@code bucketCol1 = 'a' AND bucketCol2 = 123}
          * </ul>
          */
         public boolean isTableBucketEnabled(int tableBucketNumber)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -214,7 +214,8 @@ public class HiveSplitManager
                 directoryLister,
                 executor,
                 splitLoaderConcurrency,
-                recursiveDfsWalkerEnabled);
+                recursiveDfsWalkerEnabled,
+                splitSchedulingContext.schedulerUsesHostAddresses());
 
         HiveSplitSource splitSource;
         switch (splitSchedulingContext.getSplitSchedulingStrategy()) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -152,7 +152,11 @@ public class HiveSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorTableLayoutHandle layoutHandle, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layoutHandle,
+            SplitSchedulingContext splitSchedulingContext)
     {
         HiveTableLayoutHandle layout = (HiveTableLayoutHandle) layoutHandle;
         SchemaTableName tableName = layout.getSchemaTableName();
@@ -182,7 +186,7 @@ public class HiveSplitManager
 
         // validate bucket bucketed execution
         Optional<HiveBucketHandle> bucketHandle = layout.getBucketHandle();
-        if ((splitSchedulingStrategy == GROUPED_SCHEDULING) && !bucketHandle.isPresent()) {
+        if ((splitSchedulingContext.getSplitSchedulingStrategy() == GROUPED_SCHEDULING) && !bucketHandle.isPresent()) {
             throw new PrestoException(GENERIC_INTERNAL_ERROR, "SchedulingPolicy is bucketed, but BucketHandle is not present");
         }
 
@@ -213,7 +217,7 @@ public class HiveSplitManager
                 recursiveDfsWalkerEnabled);
 
         HiveSplitSource splitSource;
-        switch (splitSchedulingStrategy) {
+        switch (splitSchedulingContext.getSplitSchedulingStrategy()) {
             case UNGROUPED_SCHEDULING:
                 splitSource = HiveSplitSource.allAtOnce(
                         session,
@@ -241,7 +245,7 @@ public class HiveSplitManager
                         new CounterStat());
                 break;
             default:
-                throw new IllegalArgumentException("Unknown splitSchedulingStrategy: " + splitSchedulingStrategy);
+                throw new IllegalArgumentException("Unknown splitSchedulingStrategy: " + splitSchedulingContext.getSplitSchedulingStrategy());
         }
         hiveSplitLoader.start(splitSource);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -197,7 +197,7 @@ public class HiveSplitManager
         // sort partitions
         partitions = Ordering.natural().onResultOf(HivePartition::getPartitionId).reverse().sortedCopy(partitions);
 
-        Iterable<HivePartitionMetadata> hivePartitions = getPartitionMetadata(metastore, table, tableName, partitions, bucketHandle.map(HiveBucketHandle::toTableBucketProperty), session);
+        Iterable<HivePartitionMetadata> hivePartitions = getPartitionMetadata(metastore, table, tableName, partitions, bucketHandle.map(HiveBucketHandle::toTableBucketProperty));
 
         HiveSplitLoader hiveSplitLoader = new BackgroundHiveSplitLoader(
                 table,
@@ -255,7 +255,7 @@ public class HiveSplitManager
         return highMemorySplitSourceCounter;
     }
 
-    private Iterable<HivePartitionMetadata> getPartitionMetadata(SemiTransactionalHiveMetastore metastore, Table table, SchemaTableName tableName, List<HivePartition> hivePartitions, Optional<HiveBucketProperty> bucketProperty, ConnectorSession session)
+    private Iterable<HivePartitionMetadata> getPartitionMetadata(SemiTransactionalHiveMetastore metastore, Table table, SchemaTableName tableName, List<HivePartition> hivePartitions, Optional<HiveBucketProperty> bucketProperty)
     {
         if (hivePartitions.isEmpty()) {
             return ImmutableList.of();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitPartitionInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitPartitionInfo.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive;
+
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.airlift.slice.SizeOf.sizeOfObjectArray;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * HiveSplitPartitionInfo is a class for fields that are shared between all InternalHiveSplits
+ * of the same partition. It allows the memory usage to only be counted once per partition
+ */
+public class HiveSplitPartitionInfo
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(HiveSplitPartitionInfo.class).instanceSize();
+    private static final int INTEGER_INSTANCE_SIZE = ClassLayout.parseClass(Integer.class).instanceSize();
+
+    private final Properties schema;
+    private final List<HivePartitionKey> partitionKeys;
+    private final String partitionName;
+    private final Map<Integer, HiveTypeName> columnCoercions;
+    private final Optional<HiveSplit.BucketConversion> bucketConversion;
+
+    // keep track of how many InternalHiveSplits reference this PartitionInfo.
+    private final AtomicInteger references = new AtomicInteger(0);
+
+    public HiveSplitPartitionInfo(
+            Properties schema,
+            List<HivePartitionKey> partitionKeys,
+            String partitionName,
+            Map<Integer, HiveTypeName> columnCoercions,
+            Optional<HiveSplit.BucketConversion> bucketConversion)
+    {
+        this.schema = requireNonNull(schema, "schema is null");
+        this.partitionKeys = requireNonNull(partitionKeys, "partitionKeys is null");
+        this.partitionName = requireNonNull(partitionName, "partitionName is null");
+        this.columnCoercions = requireNonNull(columnCoercions, "columnCoersions is null");
+        this.bucketConversion = requireNonNull(bucketConversion, "bucketConversion is null");
+    }
+
+    public Properties getSchema()
+    {
+        return schema;
+    }
+
+    public List<HivePartitionKey> getPartitionKeys()
+    {
+        return partitionKeys;
+    }
+
+    public String getPartitionName()
+    {
+        return partitionName;
+    }
+
+    public Map<Integer, HiveTypeName> getColumnCoercions()
+    {
+        return columnCoercions;
+    }
+
+    public Optional<HiveSplit.BucketConversion> getBucketConversion()
+    {
+        return bucketConversion;
+    }
+
+    public int getEstimatedSizeInBytes()
+    {
+        int result = INSTANCE_SIZE;
+        result += sizeOfObjectArray(partitionKeys.size());
+        for (HivePartitionKey partitionKey : partitionKeys) {
+            result += partitionKey.getEstimatedSizeInBytes();
+        }
+
+        result += partitionName.length() * Character.BYTES;
+        result += sizeOfObjectArray(columnCoercions.size());
+        for (HiveTypeName hiveTypeName : columnCoercions.values()) {
+            result += INTEGER_INSTANCE_SIZE + hiveTypeName.getEstimatedSizeInBytes();
+        }
+        return result;
+    }
+
+    public int incrementAndGetReferences()
+    {
+        return references.incrementAndGet();
+    }
+
+    public int decrementAndGetReferences()
+    {
+        return references.decrementAndGet();
+    }
+
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
@@ -55,7 +55,6 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILE_NOT_FOUND;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNKNOWN_ERROR;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxSplitSize;
-import static com.facebook.presto.hive.HiveSessionProperties.isUseRewindableSplitSource;
 import static com.facebook.presto.hive.HiveSplitSource.StateKind.CLOSED;
 import static com.facebook.presto.hive.HiveSplitSource.StateKind.FAILED;
 import static com.facebook.presto.hive.HiveSplitSource.StateKind.INITIAL;
@@ -110,7 +109,8 @@ class HiveSplitSource
             int maxInitialSplits,
             DataSize maxOutstandingSplitsSize,
             HiveSplitLoader splitLoader,
-            CounterStat highMemorySplitSourceCounter)
+            CounterStat highMemorySplitSourceCounter,
+            boolean useRewindableSplitSource)
     {
         requireNonNull(session, "session is null");
         this.queryId = session.getQueryId();
@@ -124,7 +124,7 @@ class HiveSplitSource
 
         this.maxSplitSize = getMaxSplitSize(session);
         this.maxInitialSplitSize = getMaxInitialSplitSize(session);
-        this.useRewindableSplitSource = isUseRewindableSplitSource(session);
+        this.useRewindableSplitSource = useRewindableSplitSource;
         this.remainingInitialSplits = new AtomicInteger(maxInitialSplits);
     }
 
@@ -185,7 +185,8 @@ class HiveSplitSource
                 maxInitialSplits,
                 maxOutstandingSplitsSize,
                 splitLoader,
-                highMemorySplitSourceCounter);
+                highMemorySplitSourceCounter,
+                false);
     }
 
     public static HiveSplitSource bucketed(
@@ -265,7 +266,8 @@ class HiveSplitSource
                 maxInitialSplits,
                 maxOutstandingSplitsSize,
                 splitLoader,
-                highMemorySplitSourceCounter);
+                highMemorySplitSourceCounter,
+                false);
     }
 
     public static HiveSplitSource bucketedRewindable(
@@ -348,7 +350,8 @@ class HiveSplitSource
                 maxInitialSplits,
                 maxOutstandingSplitsSize,
                 splitLoader,
-                highMemorySplitSourceCounter);
+                highMemorySplitSourceCounter,
+                true);
     }
 
     /**

--- a/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
@@ -29,7 +29,6 @@ import java.util.Properties;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOfObjectArray;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -71,7 +70,7 @@ public class InternalHiveSplit
             HiveSplitPartitionInfo partitionInfo)
     {
         checkArgument(start >= 0, "start must be positive");
-        checkArgument(end >= 0, "length must be positive");
+        checkArgument(end >= 0, "end must be positive");
         checkArgument(fileSize >= 0, "fileSize must be positive");
         requireNonNull(path, "path is null");
         requireNonNull(blocks, "blocks is null");
@@ -178,10 +177,6 @@ public class InternalHiveSplit
         start += value;
         if (start == currentBlock().getEnd()) {
             currentBlockIndex++;
-            if (isDone()) {
-                return;
-            }
-            verify(start == currentBlock().getStart());
         }
     }
 
@@ -229,21 +224,14 @@ public class InternalHiveSplit
         private static final int HOST_ADDRESS_INSTANCE_SIZE = ClassLayout.parseClass(HostAddress.class).instanceSize() +
                 ClassLayout.parseClass(String.class).instanceSize();
 
-        private final long start;
         private final long end;
         private final List<HostAddress> addresses;
 
-        public InternalHiveBlock(long start, long end, List<HostAddress> addresses)
+        public InternalHiveBlock(long end, List<HostAddress> addresses)
         {
-            checkArgument(start <= end, "block end cannot be before block start");
-            this.start = start;
+            checkArgument(end >= 0, "block end must be >= 0");
             this.end = end;
             this.addresses = ImmutableList.copyOf(addresses);
-        }
-
-        public long getStart()
-        {
-            return start;
         }
 
         public long getEnd()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
@@ -31,6 +31,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOfObjectArray;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 @NotThreadSafe
@@ -42,7 +43,7 @@ public class InternalHiveSplit
             ClassLayout.parseClass(String.class).instanceSize() +
             ClassLayout.parseClass(OptionalInt.class).instanceSize();
 
-    private final String path;
+    private final byte[] path;
     private final long end;
     private final long fileSize;
     private final List<InternalHiveBlock> blocks;
@@ -78,7 +79,7 @@ public class InternalHiveSplit
         requireNonNull(tableBucketNumber, "tableBucketNumber is null");
         requireNonNull(partitionInfo, "partitionInfo is null");
 
-        this.path = path;
+        this.path = path.getBytes(UTF_8);
         this.start = start;
         this.end = end;
         this.fileSize = fileSize;
@@ -93,7 +94,7 @@ public class InternalHiveSplit
 
     public String getPath()
     {
-        return path;
+        return new String(path, UTF_8);
     }
 
     public long getStart()
@@ -203,7 +204,7 @@ public class InternalHiveSplit
     public int getEstimatedSizeInBytes()
     {
         int result = INSTANCE_SIZE;
-        result += path.length() * Character.BYTES;
+        result += path.length;
         result += sizeOfObjectArray(blocks.size());
         for (InternalHiveBlock block : blocks) {
             result += block.getEstimatedSizeInBytes();
@@ -215,7 +216,7 @@ public class InternalHiveSplit
     public String toString()
     {
         return toStringHelper(this)
-                .add("path", path)
+                .add("path", new String(relativeUri, UTF_8))
                 .add("start", start)
                 .add("end", end)
                 .add("fileSize", fileSize)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
@@ -54,8 +54,11 @@ public class InternalHiveSplit
     private final long[] blockEndOffsets;
     private final List<List<HostAddress>> blockAddresses;
 
-    private final OptionalInt readBucketNumber;
-    private final OptionalInt tableBucketNumber;
+    // stored as ints rather than Optionals to save memory
+    // -1 indicates an absent value
+    private final int readBucketNumber;
+    private final int tableBucketNumber;
+
     private final boolean splittable;
     private final boolean forceLocalScheduling;
     private final boolean s3SelectPushdownEnabled;
@@ -89,8 +92,8 @@ public class InternalHiveSplit
         this.start = start;
         this.end = end;
         this.fileSize = fileSize;
-        this.readBucketNumber = readBucketNumber;
-        this.tableBucketNumber = tableBucketNumber;
+        this.readBucketNumber = readBucketNumber.orElse(-1);
+        this.tableBucketNumber = tableBucketNumber.orElse(-1);
         this.splittable = splittable;
         this.forceLocalScheduling = forceLocalScheduling;
         this.s3SelectPushdownEnabled = s3SelectPushdownEnabled;
@@ -151,12 +154,12 @@ public class InternalHiveSplit
 
     public OptionalInt getReadBucketNumber()
     {
-        return readBucketNumber;
+        return readBucketNumber >= 0 ? OptionalInt.of(readBucketNumber) : OptionalInt.empty();
     }
 
     public OptionalInt getTableBucketNumber()
     {
-        return tableBucketNumber;
+        return tableBucketNumber >= 0 ? OptionalInt.of(tableBucketNumber) : OptionalInt.empty();
     }
 
     public boolean isSplittable()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.mapred.InputFormat;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -170,8 +171,9 @@ public class InternalHiveSplitFactory
             blocks = ImmutableList.of(new InternalHiveBlock(start + length, addresses));
         }
 
+        URI relativePath = partitionInfo.getPath().relativize(path.toUri());
         return Optional.of(new InternalHiveSplit(
-                pathString,
+                relativePath.toString(),
                 start,
                 start + length,
                 length,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
@@ -152,14 +152,14 @@ public class InternalHiveSplitFactory
                 // skip zero-width block, except in the special circumstance: slice is empty, and the block covers the empty slice interval.
                 continue;
             }
-            blockBuilder.add(new InternalHiveBlock(blockStart, blockEnd, getHostAddresses(blockLocation)));
+            blockBuilder.add(new InternalHiveBlock(blockEnd, getHostAddresses(blockLocation)));
         }
         List<InternalHiveBlock> blocks = blockBuilder.build();
         checkBlocks(blocks, start, length);
 
         if (!splittable) {
             // not splittable, use the hosts from the first block if it exists
-            blocks = ImmutableList.of(new InternalHiveBlock(start, start + length, blocks.get(0).getAddresses()));
+            blocks = ImmutableList.of(new InternalHiveBlock(start + length, blocks.get(0).getAddresses()));
         }
 
         return Optional.of(new InternalHiveSplit(
@@ -180,11 +180,7 @@ public class InternalHiveSplitFactory
     {
         checkArgument(length >= 0);
         checkArgument(!blocks.isEmpty());
-        checkArgument(start == blocks.get(0).getStart());
         checkArgument(start + length == blocks.get(blocks.size() - 1).getEnd());
-        for (int i = 1; i < blocks.size(); i++) {
-            checkArgument(blocks.get(i - 1).getEnd() == blocks.get(i).getStart());
-        }
     }
 
     private static boolean allBlocksHaveRealAddress(List<InternalHiveBlock> blocks)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -46,6 +46,7 @@ import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingContext;
 import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.JoinCompiler;
@@ -107,6 +108,7 @@ import static org.testng.Assert.assertTrue;
 public abstract class AbstractTestHiveFileSystem
 {
     private static final HdfsContext TESTING_CONTEXT = new HdfsContext(new ConnectorIdentity("test", Optional.empty(), Optional.empty()));
+    public static final SplitSchedulingContext SPLIT_SCHEDULING_CONTEXT = new SplitSchedulingContext(UNGROUPED_SCHEDULING, false);
 
     protected String database;
     protected SchemaTableName table;
@@ -243,7 +245,7 @@ public abstract class AbstractTestHiveFileSystem
             List<ConnectorTableLayoutResult> tableLayoutResults = metadata.getTableLayouts(session, table, Constraint.alwaysTrue(), Optional.empty());
             HiveTableLayoutHandle layoutHandle = (HiveTableLayoutHandle) getOnlyElement(tableLayoutResults).getTableLayout().getHandle();
             assertEquals(layoutHandle.getPartitions().get().size(), 1);
-            ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, layoutHandle, UNGROUPED_SCHEDULING);
+            ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, layoutHandle, SPLIT_SCHEDULING_CONTEXT);
 
             long sum = 0;
 
@@ -410,7 +412,7 @@ public abstract class AbstractTestHiveFileSystem
             List<ConnectorTableLayoutResult> tableLayoutResults = metadata.getTableLayouts(session, tableHandle, Constraint.alwaysTrue(), Optional.empty());
             HiveTableLayoutHandle layoutHandle = (HiveTableLayoutHandle) getOnlyElement(tableLayoutResults).getTableLayout().getHandle();
             assertEquals(layoutHandle.getPartitions().get().size(), 1);
-            ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, layoutHandle, UNGROUPED_SCHEDULING);
+            ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, layoutHandle, SPLIT_SCHEDULING_CONTEXT);
             ConnectorSplit split = getOnlyElement(getAllSplits(splitSource));
 
             try (ConnectorPageSource pageSource = pageSourceProvider.createPageSource(transaction.getTransactionHandle(), session, split, columnHandles)) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -261,6 +261,7 @@ public class TestBackgroundHiveSplitLoader
                 new TestingDirectoryLister(files),
                 EXECUTOR,
                 2,
+                false,
                 false);
     }
 
@@ -280,6 +281,7 @@ public class TestBackgroundHiveSplitLoader
                 new TestingDirectoryLister(TEST_FILES),
                 directExecutor(),
                 2,
+                false,
                 false);
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.stats.CounterStat;
 import io.airlift.units.DataSize;
+import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -443,7 +444,7 @@ public class TestHiveSplitSource
                     true,
                     false,
                     false,
-                    new HiveSplitPartitionInfo(properties("id", String.valueOf(id)), ImmutableList.of(), "partition-name", ImmutableMap.of(), Optional.empty()));
+                    new HiveSplitPartitionInfo(properties("id", String.valueOf(id)), new Path("path").toUri(), ImmutableList.of(), "partition-name", ImmutableMap.of(), Optional.empty()));
         }
 
         private static Properties properties(String key, String value)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -211,7 +211,9 @@ public class TestHiveSplitSource
                 new TestingHiveSplitLoader(),
                 EXECUTOR,
                 new CounterStat());
-        int testSplitSizeInBytes = new TestSplit(0).getEstimatedSizeInBytes();
+
+        TestSplit testSplit = new TestSplit(0);
+        int testSplitSizeInBytes = testSplit.getEstimatedSizeInBytes() + testSplit.getPartitionInfo().getEstimatedSizeInBytes();
 
         int maxSplitCount = toIntExact(maxOutstandingSplitsSize.toBytes()) / testSplitSizeInBytes;
         for (int i = 0; i < maxSplitCount; i++) {
@@ -431,21 +433,17 @@ public class TestHiveSplitSource
         private TestSplit(int id, OptionalInt bucketNumber)
         {
             super(
-                    "partition-name",
                     "path",
                     0,
                     100,
                     100,
-                    properties("id", String.valueOf(id)),
-                    ImmutableList.of(),
                     ImmutableList.of(new InternalHiveBlock(0, 100, ImmutableList.of())),
                     bucketNumber,
                     bucketNumber,
                     true,
                     false,
-                    ImmutableMap.of(),
-                    Optional.empty(),
-                    false);
+                    false,
+                    new HiveSplitPartitionInfo(properties("id", String.valueOf(id)), ImmutableList.of(), "partition-name", ImmutableMap.of(), Optional.empty()));
         }
 
         private static Properties properties(String key, String value)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -437,7 +437,7 @@ public class TestHiveSplitSource
                     0,
                     100,
                     100,
-                    ImmutableList.of(new InternalHiveBlock(0, 100, ImmutableList.of())),
+                    ImmutableList.of(new InternalHiveBlock(100, ImmutableList.of())),
                     bucketNumber,
                     bucketNumber,
                     true,

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxSplitManager.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxSplitManager.java
@@ -52,7 +52,11 @@ public class JmxSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         JmxTableLayoutHandle jmxLayout = (JmxTableLayoutHandle) layout;
         JmxTableHandle tableHandle = jmxLayout.getTable();

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxSplitManager.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxSplitManager.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingContext;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
@@ -106,7 +107,7 @@ public class TestJmxSplitManager
             TupleDomain<ColumnHandle> nodeTupleDomain = TupleDomain.fromFixedValues(ImmutableMap.of(columnHandle, NullableValue.of(createUnboundedVarcharType(), utf8Slice(nodeIdentifier))));
             ConnectorTableLayoutHandle layout = new JmxTableLayoutHandle(tableHandle, nodeTupleDomain);
 
-            ConnectorSplitSource splitSource = splitManager.getSplits(JmxTransactionHandle.INSTANCE, SESSION, layout, UNGROUPED_SCHEDULING);
+            ConnectorSplitSource splitSource = splitManager.getSplits(JmxTransactionHandle.INSTANCE, SESSION, layout, new SplitSchedulingContext(UNGROUPED_SCHEDULING, false));
             List<ConnectorSplit> allSplits = getAllSplits(splitSource);
 
             assertEquals(allSplits.size(), 1);
@@ -120,7 +121,7 @@ public class TestJmxSplitManager
             throws Exception
     {
         ConnectorTableLayoutHandle layout = new JmxTableLayoutHandle(tableHandle, TupleDomain.all());
-        ConnectorSplitSource splitSource = splitManager.getSplits(JmxTransactionHandle.INSTANCE, SESSION, layout, UNGROUPED_SCHEDULING);
+        ConnectorSplitSource splitSource = splitManager.getSplits(JmxTransactionHandle.INSTANCE, SESSION, layout, new SplitSchedulingContext(UNGROUPED_SCHEDULING, false));
         List<ConnectorSplit> allSplits = getAllSplits(splitSource);
         assertEquals(allSplits.size(), nodes.size());
 
@@ -197,7 +198,7 @@ public class TestJmxSplitManager
         List<ColumnHandle> columnHandles = ImmutableList.copyOf(metadata.getColumnHandles(SESSION, tableHandle).values());
 
         ConnectorTableLayoutHandle layout = new JmxTableLayoutHandle(tableHandle, TupleDomain.all());
-        ConnectorSplitSource splitSource = splitManager.getSplits(JmxTransactionHandle.INSTANCE, SESSION, layout, UNGROUPED_SCHEDULING);
+        ConnectorSplitSource splitSource = splitManager.getSplits(JmxTransactionHandle.INSTANCE, SESSION, layout, new SplitSchedulingContext(UNGROUPED_SCHEDULING, false));
         List<ConnectorSplit> allSplits = getAllSplits(splitSource);
         assertEquals(allSplits.size(), nodes.size());
         ConnectorSplit split = allSplits.get(0);

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSplitManager.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSplitManager.java
@@ -85,7 +85,11 @@ public class KafkaSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         KafkaTableHandle kafkaTableHandle = convertLayout(layout).getTable();
         try {

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduSplitManager.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduSplitManager.java
@@ -40,9 +40,11 @@ public class KuduSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle,
-            ConnectorSession session, ConnectorTableLayoutHandle layout,
-            SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         KuduTableLayoutHandle layoutHandle = (KuduTableLayoutHandle) layout;
 

--- a/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileSplitManager.java
+++ b/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileSplitManager.java
@@ -42,7 +42,11 @@ public class LocalFileSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         LocalFileTableLayoutHandle layoutHandle = (LocalFileTableLayoutHandle) layout;
         LocalFileTableHandle tableHandle = layoutHandle.getTable();

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplitManager.java
@@ -39,7 +39,11 @@ public class InformationSchemaSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         InformationSchemaTableLayoutHandle handle = (InformationSchemaTableLayoutHandle) layout;
 

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/GlobalSystemConnector.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/GlobalSystemConnector.java
@@ -130,7 +130,7 @@ public class GlobalSystemConnector
     @Override
     public ConnectorSplitManager getSplitManager()
     {
-        return (transactionHandle, session, layout, splitSchedulingStrategy) -> {
+        return (transactionHandle, session, layout, splitSchedulingContext) -> {
             throw new UnsupportedOperationException();
         };
     }

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplitManager.java
@@ -54,7 +54,11 @@ public class SystemSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         SystemTableLayoutHandle layoutHandle = (SystemTableLayoutHandle) layout;
         SystemTableHandle tableHandle = layoutHandle.getTable();

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -311,7 +311,7 @@ public class LocalQueryRunner
                 new ColumnPropertyManager(),
                 new AnalyzePropertyManager(),
                 transactionManager);
-        this.splitManager = new SplitManager(metadata, new QueryManagerConfig());
+        this.splitManager = new SplitManager(metadata, new QueryManagerConfig(), nodeSchedulerConfig);
         this.planFragmenter = new PlanFragmenter(this.metadata, this.nodePartitioningManager, new QueryManagerConfig(), sqlParser);
         this.joinCompiler = new JoinCompiler(metadata, featuresConfig);
         this.pageIndexerFactory = new GroupByHashPageIndexerFactory(joinCompiler);

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingSplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingSplitManager.java
@@ -37,7 +37,11 @@ public class TestingSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         return new FixedSplitSource(splits);
     }

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplitManager.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplitManager.java
@@ -38,7 +38,11 @@ public final class MemorySplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layoutHandle, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layoutHandle,
+            SplitSchedulingContext splitSchedulingContext)
     {
         MemoryTableLayoutHandle layout = (MemoryTableLayoutHandle) layoutHandle;
 

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSplitManager.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSplitManager.java
@@ -43,7 +43,11 @@ public class MongoSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         MongoTableLayoutHandle tableLayout = (MongoTableLayoutHandle) layout;
         MongoTableHandle tableHandle = tableLayout.getTable();

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplitManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplitManager.java
@@ -96,7 +96,11 @@ public class RaptorSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         RaptorTableLayoutHandle handle = (RaptorTableLayoutHandle) layout;
         RaptorTableHandle table = handle.getTable();

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorSplitManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorSplitManager.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.ConnectorTableLayoutResult;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingContext;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.testing.TestingNodeManager;
@@ -206,7 +207,7 @@ public class TestRaptorSplitManager
     private static ConnectorSplitSource getSplits(RaptorSplitManager splitManager, ConnectorTableLayoutResult layout)
     {
         ConnectorTransactionHandle transaction = new RaptorTransactionHandle();
-        return splitManager.getSplits(transaction, SESSION, layout.getTableLayout().getHandle(), UNGROUPED_SCHEDULING);
+        return splitManager.getSplits(transaction, SESSION, layout.getTableLayout().getHandle(), new SplitSchedulingContext(UNGROUPED_SCHEDULING, true));
     }
 
     private static List<ConnectorSplit> getSplits(ConnectorSplitSource source, int maxSize)

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisSplitManager.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisSplitManager.java
@@ -59,7 +59,11 @@ public class RedisSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         RedisTableHandle redisTableHandle = convertLayout(layout).getTable();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorSplitManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorSplitManager.java
@@ -17,17 +17,49 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 
+import static java.util.Objects.requireNonNull;
+
 public interface ConnectorSplitManager
 {
     ConnectorSplitSource getSplits(
             ConnectorTransactionHandle transactionHandle,
             ConnectorSession session,
             ConnectorTableLayoutHandle layout,
-            SplitSchedulingStrategy splitSchedulingStrategy);
+            SplitSchedulingContext splitSchedulingContext);
 
     enum SplitSchedulingStrategy
     {
         UNGROUPED_SCHEDULING,
         GROUPED_SCHEDULING,
+    }
+
+    class SplitSchedulingContext
+    {
+        private final SplitSchedulingStrategy splitSchedulingStrategy;
+        private final boolean schedulerUsesHostAddresses;
+
+        /**
+         * @param splitSchedulingStrategy the method by which splits are scheduled
+         * @param schedulerUsesHostAddresses whether host addresses are take into account
+         * when choosing where to schedule remotely accessible splits. If this is false,
+         * the connector can return an empty list of addresses for remotely accessible
+         * splits without any performance loss.  Non-remotely accessible splits always
+         * need to provide host addresses.
+         */
+        public SplitSchedulingContext(SplitSchedulingStrategy splitSchedulingStrategy, boolean schedulerUsesHostAddresses)
+        {
+            this.splitSchedulingStrategy = requireNonNull(splitSchedulingStrategy, "splitSchedulingStrategy is null");
+            this.schedulerUsesHostAddresses = schedulerUsesHostAddresses;
+        }
+
+        public SplitSchedulingStrategy getSplitSchedulingStrategy()
+        {
+            return splitSchedulingStrategy;
+        }
+
+        public boolean schedulerUsesHostAddresses()
+        {
+            return schedulerUsesHostAddresses;
+        }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorSplitManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorSplitManager.java
@@ -35,10 +35,10 @@ public final class ClassLoaderSafeConnectorSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingContext splitSchedulingContext)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getSplits(transactionHandle, session, layout, splitSchedulingStrategy);
+            return delegate.getSplits(transactionHandle, session, layout, splitSchedulingContext);
         }
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftSplitManager.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftSplitManager.java
@@ -71,7 +71,11 @@ public class ThriftSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         ThriftTableLayoutHandle layoutHandle = (ThriftTableLayoutHandle) layout;
         return new ThriftSplitSource(

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsSplitManager.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsSplitManager.java
@@ -48,7 +48,11 @@ public class TpcdsSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         TpcdsTableHandle tableHandle = ((TpcdsTableLayoutHandle) layout).getTable();
 

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchSplitManager.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchSplitManager.java
@@ -42,7 +42,11 @@ public class TpchSplitManager
     }
 
     @Override
-    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
     {
         TpchTableLayoutHandle tableLayoutHandle = (TpchTableLayoutHandle) layout;
         TpchTableHandle tableHandle = tableLayoutHandle.getTable();


### PR DESCRIPTION
During grouped execution for queries with lots of buckets/partitions, we can encounter EXCEEDED_SPLIT_BUFFERING_LIMIT errors for the Hive connector because all splits get created at once.  This PR reduces the memory usage of each split by
1. extracting partition level information and counting it only once
2. storing just the end of each block rather than both start and end
3. not storing block addresses unless its required for scheduling


See https://github.com/prestodb/presto/wiki/HiveSplitSource-and-Grouped-Execution for more details and background

----------------------------

Split schedule notes can be found in https://github.com/prestodb/presto/pull/12780#pullrequestreview-236183935