### PR TITLE
Print arithmetic and comparison expressions in human-readable format.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -144,10 +144,10 @@ public class QueryExplainer
         switch (planType) {
             case LOGICAL:
                 Plan plan = getLogicalPlan(session, statement, parameters, warningCollector);
-                return graphvizLogicalPlan(plan.getRoot(), plan.getTypes(), session);
+                return graphvizLogicalPlan(plan.getRoot(), plan.getTypes(), session, metadata.getFunctionManager());
             case DISTRIBUTED:
                 SubPlan subPlan = getDistributedPlan(session, statement, parameters, warningCollector);
-                return graphvizDistributedPlan(subPlan, session);
+                return graphvizDistributedPlan(subPlan, session, metadata.getFunctionManager());
         }
         throw new IllegalArgumentException("Unhandled plan type: " + planType);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -163,7 +163,7 @@ public class PlanPrinter
                 .sum(), MILLISECONDS));
 
         this.representation = new PlanRepresentation(planRoot, types, totalCpuTime, totalScheduledTime);
-        this.formatter = new RowExpressionFormatter(session.toConnectorSession());
+        this.formatter = new RowExpressionFormatter(session.toConnectorSession(), functionManager);
 
         Visitor visitor = new Visitor(stageExecutionStrategy, types, estimatedStatsAndCosts, session, stats);
         planRoot.accept(visitor, null);
@@ -312,7 +312,7 @@ public class PlanPrinter
         return builder.toString();
     }
 
-    public static String graphvizLogicalPlan(PlanNode plan, TypeProvider types, Session session)
+    public static String graphvizLogicalPlan(PlanNode plan, TypeProvider types, Session session, FunctionManager functionManager)
     {
         // TODO: This should move to something like GraphvizRenderer
         PlanFragment fragment = new PlanFragment(
@@ -325,12 +325,12 @@ public class PlanPrinter
                 StageExecutionDescriptor.ungroupedExecution(),
                 StatsAndCosts.empty(),
                 Optional.empty());
-        return GraphvizPrinter.printLogical(ImmutableList.of(fragment), session);
+        return GraphvizPrinter.printLogical(ImmutableList.of(fragment), session, functionManager);
     }
 
-    public static String graphvizDistributedPlan(SubPlan plan, Session session)
+    public static String graphvizDistributedPlan(SubPlan plan, Session session, FunctionManager functionManager)
     {
-        return GraphvizPrinter.printDistributed(plan, session);
+        return GraphvizPrinter.printDistributed(plan, session, functionManager);
     }
 
     private class Visitor


### PR DESCRIPTION
Previously, all functions (CallExpressions) would be printed as `$function_name$(ARG1, ARG2, ..., ARGN)` but now arithmetic and comparison expressions will print with the operand between arguments eg, `(#1) + (BIGINT 5)`. Additional changes were made to pass a `FunctionManager` instance to `RowExpressionFormatter` instead of instantiating one in the class.