### PR TITLE
Classification Metric UDFs

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -317,6 +317,76 @@ Statistical Aggregate Functions
 
         kurtosis(x) = n(n+1)/((n-1)(n-2)(n-3))sum[(x_i-mean)^4]/stddev(x)^4-3(n-1)^2/((n-2)(n-3))
 
+.. function:: classification_miss_rate(buckets, y, x, weight) -> array<double>
+
+    Computes the miss-rate part of the receiver operator curve with up to ``buckets`` number of buckets. Returns
+    an array of miss-rate values. ``y`` should be a boolean outcome value; ``x`` should be predictions, each
+    between 0 and 1; ``weight`` should be non-negative values, indicating the weight of the instance.
+
+    To get an ROC map, use this in conjunction with :func:`classification_recall`:
+
+    .. code-block:: none
+
+        MAP(classification_recall(200, outcome, prediction), classification_miss_rate(200, outcome, prediction))
+
+.. function:: classification_precision(buckets, y, x) -> array<double>
+
+    This function is equivalent to the variant of
+    :func:`classification_precision` that takes a ``weight``, with a per-item weight of ``1``.
+
+.. function:: classification_precision(buckets, y, x, weight) -> array<double>
+
+    Computes the precision part of the precision-recall curve with up to ``buckets`` number of buckets. Returns
+    an array of precision values. ``y`` should be a boolean outcome value; ``x`` should be predictions, each
+    between 0 and 1; ``weight`` should be non-negative values, indicating the weight of the instance.
+
+    To get a map of recall to precision, use this in conjunction with :func:`classification_recall`:
+
+    .. code-block:: none
+
+        MAP(classification_recall(200, outcome, prediction), classification_precision(200, outcome, prediction))
+
+.. function:: classification_precision(buckets, y, x) -> array<double>
+
+    This function is equivalent to the variant of
+    :func:`classification_precision` that takes a ``weight``, with a per-item weight of ``1``.
+
+.. function:: classification_recall(buckets, y, x, weight) -> array<double>
+
+    Computes the recall part of the precision-recall curve or the receiver operator charateristic curve
+    with up to ``buckets`` number of buckets. Returns an array of recall values.
+    ``y`` should be a boolean outcome value; ``x`` should be predictions, each
+    between 0 and 1; ``weight`` should be non-negative values, indicating the weight of the instance.
+
+    To get a map of recall to precision, use this in conjunction with :func:`classification_recall`:
+
+    .. code-block:: none
+
+        MAP(classification_recall(200, outcome, prediction), classification_precision(200, outcome, prediction))
+
+.. function:: classification_recall(buckets, y, x) -> array<double>
+
+    This function is equivalent to the variant of
+    :func:`classification_recall` that takes a ``weight``, with a per-item weight of ``1``.
+
+.. function:: classification_thresholds(buckets, y, x) -> array<double>
+
+    Computes the thresholds part of the precision-recall curve with up to ``buckets`` number of buckets. Returns
+    an array of thresholds. ``y`` should be a boolean outcome value; ``x`` should be predictions, each
+    between 0 and 1.
+
+    To get a map of thresholds to precision, use this in conjunction with :func:`classification_precision`:
+
+    .. code-block:: none
+
+        MAP(classification_thresholds(200, outcome, prediction), classification_precision(200, outcome, prediction))
+
+    To get a map of thresholds to recall, use this in conjunction with :func:`classification_recall`:
+
+    .. code-block:: none
+
+        MAP(classification_thresholds(200, outcome, prediction), classification_recall(200, outcome, prediction))
+
 .. function:: regr_intercept(y, x) -> double
 
     Returns linear regression intercept of input values. ``y`` is the dependent

--- a/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespace.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespace.java
@@ -28,6 +28,10 @@ import com.facebook.presto.operator.aggregation.BitwiseOrAggregation;
 import com.facebook.presto.operator.aggregation.BooleanAndAggregation;
 import com.facebook.presto.operator.aggregation.BooleanOrAggregation;
 import com.facebook.presto.operator.aggregation.CentralMomentsAggregation;
+import com.facebook.presto.operator.aggregation.ClassificationMissRateAggregation;
+import com.facebook.presto.operator.aggregation.ClassificationPrecisionAggregation;
+import com.facebook.presto.operator.aggregation.ClassificationRecallAggregation;
+import com.facebook.presto.operator.aggregation.ClassificationThresholdsAggregation;
 import com.facebook.presto.operator.aggregation.CountAggregation;
 import com.facebook.presto.operator.aggregation.CountIfAggregation;
 import com.facebook.presto.operator.aggregation.DefaultApproximateCountDistinctAggregation;
@@ -466,6 +470,10 @@ class StaticFunctionNamespace
                 .aggregates(RealCorrelationAggregation.class)
                 .aggregates(BitwiseOrAggregation.class)
                 .aggregates(BitwiseAndAggregation.class)
+                .aggregates(ClassificationMissRateAggregation.class)
+                .aggregates(ClassificationPrecisionAggregation.class)
+                .aggregates(ClassificationRecallAggregation.class)
+                .aggregates(ClassificationThresholdsAggregation.class)
                 .scalar(RepeatFunction.class)
                 .scalars(SequenceFunction.class)
                 .scalars(SessionFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationMissRateAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationMissRateAggregation.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.PrecisionRecallState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.type.DoubleType;
+
+import java.util.Iterator;
+
+@AggregationFunction("classification_miss_rate")
+@Description("Computes miss-rate for precision-recall curves")
+public final class ClassificationMissRateAggregation
+        extends PrecisionRecallAggregation
+{
+    private ClassificationMissRateAggregation() {}
+
+    @OutputFunction("array(double)")
+    public static void output(@AggregationState PrecisionRecallState state, BlockBuilder out)
+    {
+        Iterator<BucketResult> resultsIterator = getResultsIterator(state);
+
+        BlockBuilder entryBuilder = out.beginBlockEntry();
+        while (resultsIterator.hasNext()) {
+            final BucketResult result = resultsIterator.next();
+            DoubleType.DOUBLE.writeDouble(
+                    entryBuilder,
+                    result.runningFalseWeight / result.totalTrueWeight);
+        }
+        out.closeEntry();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationPrecisionAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationPrecisionAggregation.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.PrecisionRecallState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.type.DoubleType;
+
+import java.util.Iterator;
+
+@AggregationFunction("classification_precision")
+@Description("Computes precision for precision-recall curves")
+public final class ClassificationPrecisionAggregation
+        extends PrecisionRecallAggregation
+{
+    private ClassificationPrecisionAggregation() {}
+
+    @OutputFunction("array(double)")
+    public static void output(@AggregationState PrecisionRecallState state, BlockBuilder out)
+    {
+        Iterator<PrecisionRecallAggregation.BucketResult> resultsIterator = getResultsIterator(state);
+
+        BlockBuilder entryBuilder = out.beginBlockEntry();
+        while (resultsIterator.hasNext()) {
+            final BucketResult result = resultsIterator.next();
+            final double remainingTrueWeight = result.totalTrueWeight - result.runningTrueWeight;
+            final double remainingFalseWeight = result.totalFalseWeight - result.runningFalseWeight;
+            DoubleType.DOUBLE.writeDouble(
+                    entryBuilder,
+                    remainingTrueWeight / (remainingTrueWeight + remainingFalseWeight));
+        }
+        out.closeEntry();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationRecallAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationRecallAggregation.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.PrecisionRecallState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.type.DoubleType;
+
+import java.util.Iterator;
+
+@AggregationFunction("classification_recall")
+@Description("Computes recall for precision-recall curves")
+public final class ClassificationRecallAggregation
+        extends PrecisionRecallAggregation
+{
+    private ClassificationRecallAggregation() {}
+
+    @OutputFunction("array(double)")
+    public static void output(@AggregationState PrecisionRecallState state, BlockBuilder out)
+    {
+        Iterator<BucketResult> resultsIterator = getResultsIterator(state);
+
+        BlockBuilder entryBuilder = out.beginBlockEntry();
+        while (resultsIterator.hasNext()) {
+            final BucketResult result = resultsIterator.next();
+            final double remainingTrueWeight = result.totalTrueWeight - result.runningTrueWeight;
+            DoubleType.DOUBLE.writeDouble(
+                    entryBuilder,
+                    remainingTrueWeight / result.totalTrueWeight);
+        }
+        out.closeEntry();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationThresholdsAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationThresholdsAggregation.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.PrecisionRecallState;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.type.DoubleType;
+
+import java.util.Iterator;
+
+@AggregationFunction("classification_thresholds")
+@Description("Computes thresholds for precision-recall curves")
+public final class ClassificationThresholdsAggregation
+        extends PrecisionRecallAggregation
+{
+    private ClassificationThresholdsAggregation() {}
+
+    @OutputFunction("array(double)")
+    public static void output(@AggregationState PrecisionRecallState state, BlockBuilder out)
+    {
+        Iterator<BucketResult> resultsIterator = getResultsIterator(state);
+
+        BlockBuilder entryBuilder = out.beginBlockEntry();
+        while (resultsIterator.hasNext()) {
+            final BucketResult result = resultsIterator.next();
+            DoubleType.DOUBLE.writeDouble(
+                    entryBuilder,
+                    (result.left + result.right) / 2);
+        }
+        out.closeEntry();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FixedDoubleHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/FixedDoubleHistogram.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class FixedDoubleHistogram
+        implements Cloneable, Iterable<FixedDoubleHistogram.Bin>
+{
+    private static final byte FORMAT_TAG = 0;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(FixedDoubleHistogram.class).instanceSize();
+
+    private final int bucketCount;
+    private final double min;
+    private final double max;
+    private final double[] weights;
+
+    public class Bin
+    {
+        public final double left;
+        public final double right;
+        public final double weight;
+
+        public Bin(double left, double right, double weight)
+        {
+            this.left = left;
+            this.right = right;
+            this.weight = weight;
+        }
+    }
+
+    public FixedDoubleHistogram(int bucketCount, double min, double max)
+    {
+        checkArgument(bucketCount >= 2, "bucketCount %s must be >= 2", bucketCount);
+        checkArgument(min < max, "min %s must be greater than max %s ", min, max);
+
+        this.bucketCount = bucketCount;
+        this.min = min;
+        this.max = max;
+        this.weights = new double[bucketCount];
+    }
+
+    public FixedDoubleHistogram(SliceInput input)
+    {
+        checkArgument(input.readByte() == FORMAT_TAG, "Unsupported format tag");
+        bucketCount = input.readInt();
+        checkArgument(bucketCount >= 2, "bucketCount %s must be >= 2", bucketCount);
+        min = input.readDouble();
+        max = input.readDouble();
+        checkArgument(min < max, "min %s must be greater than max %s ", min, max);
+        weights = new double[bucketCount];
+        input.readBytes(Slices.wrappedDoubleArray(weights), bucketCount * SizeOf.SIZE_OF_DOUBLE);
+    }
+
+    protected FixedDoubleHistogram(FixedDoubleHistogram other)
+    {
+        this(other.bucketCount, other.min, other.max);
+        for (int i = 0; i < bucketCount; ++i) {
+            weights[i] = other.weights[i];
+        }
+    }
+
+    public FixedDoubleHistogram clone()
+    {
+        return new FixedDoubleHistogram(this);
+    }
+
+    int getBucketCount()
+    {
+        return bucketCount;
+    }
+
+    double getMin()
+    {
+        return min;
+    }
+
+    double getMax()
+    {
+        return max;
+    }
+
+    public int getRequiredBytesForSerialization()
+    {
+        return SizeOf.SIZE_OF_BYTE + // format
+                SizeOf.SIZE_OF_INT + // num buckets
+                SizeOf.SIZE_OF_DOUBLE + // min
+                SizeOf.SIZE_OF_DOUBLE + // max
+                SizeOf.SIZE_OF_DOUBLE * bucketCount; // weights
+    }
+
+    public void serialize(SliceOutput out)
+    {
+        out.appendByte(FORMAT_TAG)
+            .appendInt(bucketCount)
+            .appendDouble(min)
+            .appendDouble(max)
+            .appendBytes(Slices.wrappedDoubleArray(weights, 0, bucketCount));
+    }
+
+    public long estimatedInMemorySize()
+    {
+        return INSTANCE_SIZE + SizeOf.sizeOf(weights);
+    }
+
+    public void set(double value, double weight)
+    {
+        checkArgument(
+                value >= min && value <= max,
+                "value must be within range [%s, %s]", min, max);
+        weights[getIndexForValue(value)] = weight;
+    }
+
+    public void add(double value)
+    {
+        add(value, 1);
+    }
+
+    public void add(double value, double weight)
+    {
+        weights[getIndexForValue(value)] += weight;
+    }
+
+    public void mergeWith(FixedDoubleHistogram other)
+    {
+        checkArgument(min == other.min, "min %s must be equal to other min %s", min, other.min);
+        checkArgument(max == other.max, "max %s must be equal to other max %s", max, other.max);
+        checkArgument(
+                bucketCount == other.bucketCount,
+                "bucketCount %s must be equal to other bucketCount %s", bucketCount, other.bucketCount);
+
+        for (int i = 0; i < bucketCount; ++i) {
+            weights[i] += other.weights[i];
+        }
+    }
+
+    @Override
+    public Iterator<Bin> iterator()
+    {
+        return new Iterator<Bin>()
+        {
+            private int currentIndex;
+
+            @Override
+            public boolean hasNext()
+            {
+                return currentIndex < bucketCount;
+            }
+
+            @Override
+            public Bin next()
+            {
+                if (currentIndex == bucketCount) {
+                    throw new NoSuchElementException();
+                }
+
+                return new Bin(
+                    currentIndex * (max - min) / bucketCount,
+                    (currentIndex + 1) * (max - min) / bucketCount,
+                    weights[currentIndex++]);
+            }
+
+            @Override
+            public void remove()
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    private int getIndexForValue(double value)
+    {
+        checkArgument(
+                value >= min && value <= max,
+                "value must be within range [%s, %s]", min, max);
+        return Math.min(
+                (int) (bucketCount * (value - min) / (max - min)),
+                bucketCount - 1);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/PrecisionRecallAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/PrecisionRecallAggregation.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.PrecisionRecallState;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.Streams;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+
+public abstract class PrecisionRecallAggregation
+{
+    private static final double DEFAULT_WEIGHT = 1.0;
+    private static final double MIN_PREDICTION_VALUE = 0.0;
+    private static final double MAX_PREDICTION_VALUE = 1.0;
+    private static final String ILLEGAL_PREDICTION_VALUE_MESSAGE = String.format(
+            "Prediction value must be between %s and %s",
+            PrecisionRecallAggregation.MIN_PREDICTION_VALUE,
+            PrecisionRecallAggregation.MAX_PREDICTION_VALUE);
+    private static final String NEGATIVE_WEIGHT_MESSAGE = "Weights must be non-negative";
+    private static final String INCONSISTENT_BUCKET_COUNT_MESSAGE = "Bucket count must be constant";
+
+    protected PrecisionRecallAggregation() {}
+
+    @InputFunction
+    public static void input(
+            @AggregationState PrecisionRecallState state,
+            @SqlType(StandardTypes.BIGINT) long bucketCount,
+            @SqlType(StandardTypes.BOOLEAN) boolean outcome,
+            @SqlType(StandardTypes.DOUBLE) double pred,
+            @SqlType(StandardTypes.DOUBLE) double weight)
+    {
+        if (state.getTrueWeights() == null) {
+            state.setTrueWeights(new FixedDoubleHistogram(
+                    (int) (bucketCount),
+                    PrecisionRecallAggregation.MIN_PREDICTION_VALUE,
+                    PrecisionRecallAggregation.MAX_PREDICTION_VALUE));
+            state.setFalseWeights(new FixedDoubleHistogram(
+                    (int) (bucketCount),
+                    PrecisionRecallAggregation.MIN_PREDICTION_VALUE,
+                    PrecisionRecallAggregation.MAX_PREDICTION_VALUE));
+        }
+
+        if (pred < MIN_PREDICTION_VALUE || pred > PrecisionRecallAggregation.MAX_PREDICTION_VALUE) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    PrecisionRecallAggregation.ILLEGAL_PREDICTION_VALUE_MESSAGE);
+        }
+        if (weight < 0) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    PrecisionRecallAggregation.NEGATIVE_WEIGHT_MESSAGE);
+        }
+        if (bucketCount != state.getTrueWeights().getBucketCount()) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    PrecisionRecallAggregation.INCONSISTENT_BUCKET_COUNT_MESSAGE);
+        }
+
+        if (outcome) {
+            state.getTrueWeights().add(pred, weight);
+        }
+        else {
+            state.getFalseWeights().add(pred, weight);
+        }
+    }
+
+    @InputFunction
+    public static void input(
+            @AggregationState PrecisionRecallState state,
+            @SqlType(StandardTypes.BIGINT) long bucketCount,
+            @SqlType(StandardTypes.BOOLEAN) boolean outcome,
+            @SqlType(StandardTypes.DOUBLE) double pred)
+    {
+        PrecisionRecallAggregation.input(state, bucketCount, outcome, pred, PrecisionRecallAggregation.DEFAULT_WEIGHT);
+    }
+
+    @CombineFunction
+    public static void combine(
+            @AggregationState PrecisionRecallState state,
+            @AggregationState PrecisionRecallState otherState)
+    {
+        if (state.getTrueWeights() == null && otherState.getTrueWeights() != null) {
+            state.setTrueWeights(new FixedDoubleHistogram(otherState.getTrueWeights().clone()));
+            state.setFalseWeights(new FixedDoubleHistogram(otherState.getFalseWeights().clone()));
+            return;
+        }
+        if (state.getTrueWeights() != null && otherState.getTrueWeights() != null) {
+            state.getTrueWeights().mergeWith(otherState.getTrueWeights());
+            state.getFalseWeights().mergeWith(otherState.getFalseWeights());
+        }
+    }
+
+    protected static class BucketResult
+    {
+        public final double totalTrueWeight;
+        public final double totalFalseWeight;
+        public final double runningTrueWeight;
+        public final double runningFalseWeight;
+        public final double left;
+        public final double right;
+
+        public BucketResult(
+                double left,
+                double right,
+                double totalTrueWeight,
+                double totalFalseWeight,
+                double runningTrueWeight,
+                double runningFalseWeight)
+        {
+            this.left = left;
+            this.right = right;
+            this.totalTrueWeight = totalTrueWeight;
+            this.totalFalseWeight = totalFalseWeight;
+            this.runningTrueWeight = runningTrueWeight;
+            this.runningFalseWeight = runningFalseWeight;
+        }
+    }
+
+    protected static Iterator<BucketResult> getResultsIterator(@AggregationState PrecisionRecallState state)
+    {
+        if (state.getTrueWeights() == null) {
+            return Collections.<BucketResult>emptyList().iterator();
+        }
+
+        final double totalTrueWeight = Streams.stream(state.getTrueWeights().iterator())
+                .mapToDouble(c -> c.weight)
+                .sum();
+        final double totalFalseWeight = Streams.stream(state.getFalseWeights().iterator())
+                .mapToDouble(c -> c.weight)
+                .sum();
+
+        return new Iterator<BucketResult>()
+        {
+            Iterator<FixedDoubleHistogram.Bin> trueIt = state.getTrueWeights().iterator();
+            Iterator<FixedDoubleHistogram.Bin> falseIt = state.getFalseWeights().iterator();
+            double runningFalseWeight;
+            double runningTrueWeight;
+
+            @Override
+            public boolean hasNext()
+            {
+                return trueIt.hasNext() && totalTrueWeight > runningTrueWeight;
+            }
+
+            @Override
+            public BucketResult next()
+            {
+                if (!trueIt.hasNext() || !falseIt.hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                final FixedDoubleHistogram.Bin trueResult = trueIt.next();
+                final FixedDoubleHistogram.Bin falseResult = falseIt.next();
+
+                final BucketResult result = new BucketResult(
+                        trueResult.left,
+                        trueResult.right,
+                        totalTrueWeight,
+                        totalFalseWeight,
+                        runningTrueWeight,
+                        runningFalseWeight);
+
+                runningTrueWeight += trueResult.weight;
+                runningFalseWeight += falseResult.weight;
+
+                return result;
+            }
+
+            @Override
+            public void remove()
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/PrecisionRecallState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/PrecisionRecallState.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.operator.aggregation.FixedDoubleHistogram;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+
+@AccumulatorStateMetadata(
+        stateSerializerClass = PrecisionRecallStateSerializer.class,
+        stateFactoryClass = PrecisionRecallStateFactory.class)
+public interface PrecisionRecallState
+        extends AccumulatorState
+{
+    void setTrueWeights(FixedDoubleHistogram hist);
+
+    FixedDoubleHistogram getTrueWeights();
+
+    void setFalseWeights(FixedDoubleHistogram hist);
+
+    FixedDoubleHistogram getFalseWeights();
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/PrecisionRecallStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/PrecisionRecallStateFactory.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.operator.aggregation.FixedDoubleHistogram;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrecisionRecallStateFactory
+        implements AccumulatorStateFactory<PrecisionRecallState>
+{
+    @Override
+    public PrecisionRecallState createSingleState()
+    {
+        return new SingleState();
+    }
+
+    @Override
+    public Class<? extends PrecisionRecallState> getSingleStateClass()
+    {
+        return SingleState.class;
+    }
+
+    @Override
+    public PrecisionRecallState createGroupedState()
+    {
+        return new GroupedState();
+    }
+
+    @Override
+    public Class<? extends PrecisionRecallState> getGroupedStateClass()
+    {
+        return GroupedState.class;
+    }
+
+    public static class GroupedState
+            extends AbstractGroupedAccumulatorState
+            implements PrecisionRecallState
+    {
+        private final ObjectBigArray<FixedDoubleHistogram> trueWeights = new ObjectBigArray<>();
+        private final ObjectBigArray<FixedDoubleHistogram> falseWeights = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            trueWeights.ensureCapacity(size);
+            falseWeights.ensureCapacity(size);
+        }
+
+        @Override
+        public void setTrueWeights(FixedDoubleHistogram histogram)
+        {
+            requireNonNull(histogram, "histogram is null");
+
+            FixedDoubleHistogram previous = getTrueWeights();
+            if (previous != null) {
+                size -= previous.estimatedInMemorySize();
+            }
+
+            trueWeights.set(getGroupId(), histogram);
+            size += histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public FixedDoubleHistogram getTrueWeights()
+        {
+            return trueWeights.get(getGroupId());
+        }
+
+        @Override
+        public void setFalseWeights(FixedDoubleHistogram histogram)
+        {
+            requireNonNull(histogram, "histogram is null");
+
+            FixedDoubleHistogram previous = getFalseWeights();
+            if (previous != null) {
+                size -= previous.estimatedInMemorySize();
+            }
+
+            falseWeights.set(getGroupId(), histogram);
+            size += histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public FixedDoubleHistogram getFalseWeights()
+        {
+            return falseWeights.get(getGroupId());
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + trueWeights.sizeOf() + falseWeights.sizeOf();
+        }
+    }
+
+    public static class SingleState
+            implements PrecisionRecallState
+    {
+        private boolean nullSet;
+        private FixedDoubleHistogram trueWeights;
+        private FixedDoubleHistogram falseWeights;
+
+        @Override
+        public void setTrueWeights(FixedDoubleHistogram histogram)
+        {
+            requireNonNull(histogram, "histogram is null");
+            trueWeights = histogram;
+        }
+
+        @Override
+        public FixedDoubleHistogram getTrueWeights()
+        {
+            return trueWeights;
+        }
+
+        @Override
+        public void setFalseWeights(FixedDoubleHistogram histogram)
+        {
+            requireNonNull(histogram, "histogram is null");
+            falseWeights = histogram;
+        }
+
+        @Override
+        public FixedDoubleHistogram getFalseWeights()
+        {
+            return falseWeights;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            if (trueWeights == null) {
+                return 0;
+            }
+            return trueWeights.estimatedInMemorySize() + falseWeights.estimatedInMemorySize();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/PrecisionRecallStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/PrecisionRecallStateSerializer.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.operator.aggregation.FixedDoubleHistogram;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class PrecisionRecallStateSerializer
+        implements AccumulatorStateSerializer<PrecisionRecallState>
+{
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(PrecisionRecallState state, BlockBuilder out)
+    {
+        int requiredBytes = SizeOf.SIZE_OF_BYTE; // has histograms;
+        if (state.getTrueWeights() != null) {
+            requiredBytes += state.getTrueWeights().getRequiredBytesForSerialization();
+            requiredBytes += state.getFalseWeights().getRequiredBytesForSerialization();
+        }
+
+        SliceOutput sliceOut = Slices.allocate(requiredBytes).getOutput();
+        sliceOut.appendByte(state.getTrueWeights() == null ? 0 : 1);
+        if (state.getTrueWeights() != null) {
+            state.getTrueWeights().serialize(sliceOut);
+            state.getFalseWeights().serialize(sliceOut);
+        }
+
+        VARBINARY.writeSlice(out, sliceOut.getUnderlyingSlice());
+    }
+
+    @Override
+    public void deserialize(
+            Block block,
+            int index,
+            PrecisionRecallState state)
+    {
+        final SliceInput input = VARBINARY.getSlice(block, index).getInput();
+
+        final byte hasHistograms = input.readByte();
+        checkArgument(
+                hasHistograms == 0 || hasHistograms == 1,
+                "hasHistogram %s should be boolean-convertible", hasHistograms);
+        if (hasHistograms == 1) {
+            state.setTrueWeights(new FixedDoubleHistogram(input));
+            state.setFalseWeights(new FixedDoubleHistogram(input));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationMissRateAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationMissRateAggregation.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.operator.aggregation.TestPrecisionRecallAggregation;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class TestClassificationMissRateAggregation
+        extends TestPrecisionRecallAggregation
+{
+    public TestClassificationMissRateAggregation()
+    {
+        super("classification_miss_rate");
+    }
+
+    @Override
+    public ArrayList<Double> getExpectedValue(int start, int length)
+    {
+        final Iterator<BucketResult> iterator =
+                TestPrecisionRecallAggregation.getResultsIterator(start, length);
+        final ArrayList<Double> expected = new ArrayList<>();
+        while (iterator.hasNext()) {
+            final BucketResult result = iterator.next();
+            final double missRate = (result.totalFalseWeight - result.remainingFalseWeight) / result.totalTrueWeight;
+            expected.add(missRate);
+        }
+        return expected;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationPrecisionAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationPrecisionAggregation.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.operator.aggregation.TestPrecisionRecallAggregation;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class TestClassificationPrecisionAggregation
+        extends TestPrecisionRecallAggregation
+{
+    public TestClassificationPrecisionAggregation()
+    {
+        super("classification_precision");
+    }
+
+    @Override
+    public ArrayList<Double> getExpectedValue(int start, int length)
+    {
+        final Iterator<TestPrecisionRecallAggregation.BucketResult> iterator =
+                TestPrecisionRecallAggregation.getResultsIterator(start, length);
+        final ArrayList<Double> expected = new ArrayList<>();
+        while (iterator.hasNext()) {
+            final TestPrecisionRecallAggregation.BucketResult result = iterator.next();
+            final double precision = result.remainingTrueWeight / (result.remainingTrueWeight + result.remainingFalseWeight);
+            expected.add(precision);
+        }
+        return expected;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationRecallAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationRecallAggregation.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.operator.aggregation.TestPrecisionRecallAggregation;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class TestClassificationRecallAggregation
+        extends TestPrecisionRecallAggregation
+{
+    public TestClassificationRecallAggregation()
+    {
+        super("classification_recall");
+    }
+
+    @Override
+    public ArrayList<Double> getExpectedValue(int start, int length)
+    {
+        final Iterator<BucketResult> iterator =
+                TestPrecisionRecallAggregation.getResultsIterator(start, length);
+        final ArrayList<Double> expected = new ArrayList<>();
+        while (iterator.hasNext()) {
+            final BucketResult result = iterator.next();
+            final double recall = result.remainingTrueWeight / result.totalTrueWeight;
+            expected.add(recall);
+        }
+        return expected;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationThresholdAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationThresholdAggregation.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.operator.aggregation.TestPrecisionRecallAggregation;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class TestClassificationThresholdAggregation
+        extends TestPrecisionRecallAggregation
+{
+    public TestClassificationThresholdAggregation()
+    {
+        super("classification_thresholds");
+    }
+
+    @Override
+    public ArrayList<Double> getExpectedValue(int start, int length)
+    {
+        final Iterator<BucketResult> iterator =
+                TestPrecisionRecallAggregation.getResultsIterator(start, length);
+        final ArrayList<Double> expected = new ArrayList<>();
+        while (iterator.hasNext()) {
+            final BucketResult result = iterator.next();
+            expected.add((result.left + result.right) / 2);
+        }
+        return expected;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFixedDoubleHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFixedDoubleHistogram.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.google.common.collect.Streams;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestFixedDoubleHistogram
+{
+    @Test
+    public void getters()
+    {
+        final FixedDoubleHistogram histogram = new FixedDoubleHistogram(200, 3.0, 4.0);
+
+        assertEquals(histogram.getMin(), 3.0);
+        assertEquals(histogram.getMax(), 4.0);
+    }
+
+    @Test
+    public void illegalBucketCount()
+    {
+        try {
+            new FixedDoubleHistogram(-200, 3.0, 4.0);
+            fail("Expected Exception");
+        }
+        catch (IllegalArgumentException e) {
+        }
+    }
+
+    @Test
+    public void illegalMinMax()
+    {
+        try {
+            new FixedDoubleHistogram(-200, 3.0, 3.0);
+            fail("Expected Exception");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("bucketCount"));
+        }
+    }
+
+    @Test
+    public void basicOps()
+    {
+        final FixedDoubleHistogram histogram = new FixedDoubleHistogram(200, 3.0, 4.0);
+
+        histogram.add(3.1, 100.0);
+        histogram.add(3.8, 200.0);
+        assertEquals(
+                Streams.stream(histogram.iterator()).mapToDouble(c -> c.weight).sum(),
+                300.0);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPrecisionRecallAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPrecisionRecallAggregation.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+
+import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public abstract class TestPrecisionRecallAggregation
+        extends AbstractTestAggregationFunction
+{
+    private static final Integer NUM_BINS = 3;
+    private static final double MIN_FALSE_PRED = 0.2;
+    private static final double MAX_FALSE_PRED = 0.5;
+
+    private final String functionName;
+    private InternalAggregationFunction precisionRecallFunction;
+
+    @BeforeClass
+    public void setUp()
+    {
+        FunctionManager functionManager = MetadataManager.createTestMetadataManager().getFunctionManager();
+        precisionRecallFunction = functionManager.getAggregateFunctionImplementation(
+                functionManager.lookupFunction(
+                        this.functionName,
+                        fromTypes(BIGINT, BOOLEAN, DOUBLE, DOUBLE)));
+    }
+
+    @Test
+    public void testNegativeWeight()
+    {
+        try {
+            assertAggregation(
+                    precisionRecallFunction,
+                    0.0,
+                    createLongsBlock(Long.valueOf(200)),
+                    createBooleansBlock(Boolean.valueOf(true)),
+                    createDoublesBlock(Double.valueOf(0.2)),
+                    createDoublesBlock(Double.valueOf(-0.2)));
+            fail("Expected PrestoException");
+        }
+        catch (PrestoException e) {
+            assertTrue(e.getMessage().toLowerCase(Locale.ENGLISH).contains("weight"));
+            assertTrue(e.getMessage().toLowerCase(Locale.ENGLISH).contains("negative"));
+        }
+    }
+
+    @Test
+    public void testTooHighPrediction()
+    {
+        try {
+            assertAggregation(
+                    precisionRecallFunction,
+                    0.0,
+                    createLongsBlock(Long.valueOf(200)),
+                    createBooleansBlock(Boolean.valueOf(true)),
+                    createDoublesBlock(Double.valueOf(1.2)),
+                    createDoublesBlock(Double.valueOf(0.2)));
+            fail("Expected PrestoException");
+        }
+        catch (PrestoException e) {
+            assertTrue(e.getMessage().toLowerCase(Locale.ENGLISH).contains("prediction"));
+        }
+    }
+
+    @Test
+    public void testTooLowPrediction()
+    {
+        try {
+            assertAggregation(
+                    precisionRecallFunction,
+                    0.0,
+                    createLongsBlock(Long.valueOf(200)),
+                    createBooleansBlock(Boolean.valueOf(true)),
+                    createDoublesBlock(Double.valueOf(-1.2)),
+                    createDoublesBlock(Double.valueOf(0.2)));
+            fail("Expected PrestoException");
+        }
+        catch (PrestoException e) {
+            assertTrue(e.getMessage().toLowerCase(Locale.ENGLISH).contains("prediction"));
+        }
+    }
+
+    @Test
+    public void testNonConstantBuckets()
+    {
+        try {
+            assertAggregation(
+                    precisionRecallFunction,
+                    0.0,
+                    createLongsBlock(Long.valueOf(200), Long.valueOf(300)),
+                    createBooleansBlock(Boolean.valueOf(true), Boolean.valueOf(false)),
+                    createDoublesBlock(Double.valueOf(0.2), Double.valueOf(0.3)),
+                    createDoublesBlock(Double.valueOf(1), Double.valueOf(1)));
+            fail("Expected PrestoException");
+        }
+        catch (PrestoException e) {
+            assertTrue(e.getMessage().toLowerCase(Locale.ENGLISH).contains("bucket"));
+        }
+    }
+
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        start = Math.abs(start);
+
+        BlockBuilder bucketCountBlockBuilder = BIGINT.createBlockBuilder(null, length);
+        BlockBuilder outcomeBlockBuilder = BOOLEAN.createBlockBuilder(null, length);
+        BlockBuilder predBlockBuilder = DOUBLE.createBlockBuilder(null, length);
+        for (int i = start; i < start + length; i++) {
+            BIGINT.writeLong(bucketCountBlockBuilder, TestPrecisionRecallAggregation.NUM_BINS);
+            final Result result =
+                    TestPrecisionRecallAggregation.getResult(start, length, i);
+            BOOLEAN.writeBoolean(outcomeBlockBuilder, result.outcome);
+            DOUBLE.writeDouble(predBlockBuilder, result.prediction);
+        }
+
+        return new Block[] {
+                bucketCountBlockBuilder.build(),
+                outcomeBlockBuilder.build(),
+                predBlockBuilder.build(),
+        };
+    }
+
+    private static class Result
+    {
+        public final Boolean outcome;
+        public final Double prediction;
+
+        public Result(Boolean outcome, Double prediction)
+        {
+            this.outcome = outcome;
+            this.prediction = prediction;
+        }
+    }
+
+    protected static class BucketResult
+    {
+        public final Double left;
+        public final Double right;
+        public final Double totalTrueWeight;
+        public final Double totalFalseWeight;
+        public final Double remainingTrueWeight;
+        public final Double remainingFalseWeight;
+
+        public BucketResult(
+                Double left,
+                Double right,
+                Double totalTrueWeight,
+                Double totalFalseWeight,
+                Double remainingTrueWeight,
+                Double remainingFalseWeight)
+        {
+            this.left = left;
+            this.right = right;
+            this.totalTrueWeight = totalTrueWeight;
+            this.totalFalseWeight = totalFalseWeight;
+            this.remainingTrueWeight = remainingTrueWeight;
+            this.remainingFalseWeight = remainingFalseWeight;
+        }
+    }
+
+    protected static Iterator<BucketResult> getResultsIterator(int start, int length)
+    {
+        final int effectiveStart = Math.abs(start);
+
+        return new Iterator<BucketResult>()
+        {
+            int i;
+
+            @Override
+            public boolean hasNext()
+            {
+                final Double left = (double) (i) / TestPrecisionRecallAggregation.NUM_BINS;
+                for (int j = start; j < effectiveStart + length; j++) {
+                    final Result result =
+                            TestPrecisionRecallAggregation.getResult(effectiveStart, length, j);
+                    if (result.outcome && result.prediction >= left) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public BucketResult next()
+            {
+                final Double left = (double) (i) / TestPrecisionRecallAggregation.NUM_BINS;
+                final Double right = (double) (i + 1) / TestPrecisionRecallAggregation.NUM_BINS;
+                Double totalTrue = 0.0;
+                Double totalFalse = 0.0;
+                Double remainingTrue = 0.0;
+                Double remainingFalse = 0.0;
+                for (int j = start; j < start + length; j++) {
+                    final Result result =
+                            TestPrecisionRecallAggregation.getResult(start, length, j);
+                    if (result.outcome) {
+                        totalTrue += 1.0;
+                        if (result.prediction >= left) {
+                            remainingTrue += 1.0;
+                        }
+                    }
+                    else {
+                        totalFalse += 1.0;
+                        if (result.prediction >= left) {
+                            remainingFalse += 1.0;
+                        }
+                    }
+                }
+                i++;
+                return new BucketResult(left, right, totalTrue, totalFalse, remainingTrue, remainingFalse);
+            }
+
+            @Override
+            public void remove()
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    protected TestPrecisionRecallAggregation(String functionName)
+    {
+        this.functionName = functionName;
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return functionName;
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(
+                StandardTypes.INTEGER,
+                StandardTypes.BOOLEAN,
+                StandardTypes.DOUBLE);
+    }
+
+    protected static Result getResult(int start, int length, int i)
+    {
+        final Double prediction = Double.valueOf(i - start) / (length + 1);
+        final Boolean outcome = prediction < TestPrecisionRecallAggregation.MIN_FALSE_PRED ||
+                prediction > TestPrecisionRecallAggregation.MAX_FALSE_PRED;
+        return new Result(outcome, prediction);
+    }
+}


### PR DESCRIPTION
Following #12732 and talks with @rongrong, I'd like to request pulling a Precision/Recall UDF.

```
.. function:: classification_miss_rate(buckets, y, x, weight) -> array<double>

     Computes the miss-rate part of the receiver operator curve with up to ``buckets`` number of buckets. Returns
    an array of miss-rate values. ``y`` should be a boolean outcome value; ``x`` should be predictions, each
    between 0 and 1; ``weight`` should be non-negative values, indicating the weight of the instance.

     To get an ROC map, use this in conjunction with :func:`classification_recall`:

     .. code-block:: none

         MAP(classification_recall(200, outcome, prediction), classification_miss_rate(200, outcome, prediction))

 .. function:: classification_precision(buckets, y, x) -> array<double>

     This function is equivalent to the variant of
    :func:`classification_precision` that takes a ``weight``, with a per-item weight of ``1``.

 .. function:: classification_precision(buckets, y, x, weight) -> array<double>

     Computes the precision part of the precision-recall curve with up to ``buckets`` number of buckets. Returns
    an array of precision values. ``y`` should be a boolean outcome value; ``x`` should be predictions, each
    between 0 and 1; ``weight`` should be non-negative values, indicating the weight of the instance.

     To get a map of recall to precision, use this in conjunction with :func:`classification_recall`:

     .. code-block:: none

         MAP(classification_recall(200, outcome, prediction), classification_precision(200, outcome, prediction))

 .. function:: classification_precision(buckets, y, x) -> array<double>

     This function is equivalent to the variant of
    :func:`classification_precision` that takes a ``weight``, with a per-item weight of ``1``.

 .. function:: classification_recall(buckets, y, x, weight) -> array<double>

     Computes the recall part of the precision-recall curve or the receiver operator charateristic curve
    with up to ``buckets`` number of buckets. Returns an array of recall values.
    ``y`` should be a boolean outcome value; ``x`` should be predictions, each
    between 0 and 1; ``weight`` should be non-negative values, indicating the weight of the instance.

     To get a map of recall to precision, use this in conjunction with :func:`classification_recall`:

     .. code-block:: none

         MAP(classification_recall(200, outcome, prediction), classification_precision(200, outcome, prediction))

 .. function:: classification_recall(buckets, y, x) -> array<double>

     This function is equivalent to the variant of
    :func:`classification_recall` that takes a ``weight``, with a per-item weight of ``1``.

 .. function:: classification_thresholds(buckets, y, x) -> array<double>

     Computes the thresholds part of the precision-recall curve with up to ``buckets`` number of buckets. Returns
    an array of thresholds. ``y`` should be a boolean outcome value; ``x`` should be predictions, each
    between 0 and 1.

     To get a map of thresholds to precision, use this in conjunction with :func:`classification_precision`:

     .. code-block:: none

         MAP(classification_thresholds(200, outcome, prediction), classification_precision(200, outcome, prediction))

     To get a map of thresholds to recall, use this in conjunction with :func:`classification_recall`:

     .. code-block:: none

         MAP(classification_thresholds(200, outcome, prediction), classification_recall(200, outcome, prediction))
```