### PR TITLE
Revert "Trigger bucket balancer after cluster restart"

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/BucketBalancer.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/BucketBalancer.java
@@ -81,7 +81,6 @@ public class BucketBalancer
     private final ShardManager shardManager;
     private final boolean enabled;
     private final Duration interval;
-    private final Duration initialDelay;
     private final boolean backupAvailable;
     private final boolean coordinator;
     private final int minimumNodeCount;
@@ -106,7 +105,6 @@ public class BucketBalancer
                 shardManager,
                 balancerConfig.isBalancerEnabled(),
                 balancerConfig.getBalancerInterval(),
-                metadataConfig.getStartupGracePeriod(),
                 metadataConfig.getMinimumNodeCount(),
                 backupService.isBackupAvailable(),
                 nodeManager.getCurrentNode().isCoordinator(),
@@ -118,7 +116,6 @@ public class BucketBalancer
             ShardManager shardManager,
             boolean enabled,
             Duration interval,
-            Duration initialDelay,
             int minimumNodeCount,
             boolean backupAvailable,
             boolean coordinator,
@@ -128,7 +125,6 @@ public class BucketBalancer
         this.shardManager = requireNonNull(shardManager, "shardManager is null");
         this.enabled = enabled;
         this.interval = requireNonNull(interval, "interval is null");
-        this.initialDelay = requireNonNull(initialDelay, "initialDelay is null");
         this.minimumNodeCount = minimumNodeCount;
         this.backupAvailable = backupAvailable;
         this.coordinator = coordinator;
@@ -139,7 +135,7 @@ public class BucketBalancer
     public void start()
     {
         if (enabled && backupAvailable && coordinator && !started.getAndSet(true)) {
-            executor.scheduleWithFixedDelay(this::runBalanceJob, initialDelay.toMillis(), interval.toMillis(), MILLISECONDS);
+            executor.scheduleWithFixedDelay(this::runBalanceJob, interval.toMillis(), interval.toMillis(), MILLISECONDS);
         }
     }
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestBucketBalancer.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestBucketBalancer.java
@@ -80,7 +80,7 @@ public class TestBucketBalancer
 
         NodeSupplier nodeSupplier = nodeManager::getWorkerNodes;
         shardManager = createShardManager(dbi, nodeSupplier);
-        balancer = new BucketBalancer(nodeSupplier, shardManager, true, new Duration(1, DAYS), new Duration(1, DAYS), 0, true, true, "test");
+        balancer = new BucketBalancer(nodeSupplier, shardManager, true, new Duration(1, DAYS), 0, true, true, "test");
     }
 
     @AfterMethod(alwaysRun = true)


### PR DESCRIPTION
A forced rebalance can have unexpected outcome when restarting cluster
to mitigate issues.