### PR TITLE
Fix Bug with ElasticSearchQueryBuilder, Column Name are not preserving case sensivity

### DIFF
--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchQueryBuilder.java
@@ -102,7 +102,7 @@ public class ElasticsearchQueryBuilder
     {
         String indices = index != null && !index.isEmpty() ? index : "_all";
         List<String> fields = columns.stream()
-                .map(ElasticsearchColumnHandle::getColumnName)
+                .map(ElasticsearchColumnHandle::getColumnJsonPath)
                 .collect(toList());
         SearchRequestBuilder searchRequestBuilder = client.prepareSearch(indices)
                 .setTypes(type)

--- a/presto-elasticsearch/src/test/resources/queryrunner/elastic.telemetry.json
+++ b/presto-elasticsearch/src/test/resources/queryrunner/elastic.telemetry.json
@@ -1,0 +1,26 @@
+{
+    "tableName": "machine",
+    "schemaName": "telemetry",
+    "host": "localhost",
+    "port": "9300",
+    "clusterName": "test",
+    "index": "machine",
+    "type": "doc",
+    "columns": [
+
+            {
+                "name": "Name",
+                "type": "varchar",
+                "jsonPath": "Name",
+                "jsonType": "varchar",
+                "ordinalPosition": "0"
+            },
+            {
+              "name": "ProductionCount",
+              "type": "bigint",
+              "jsonPath": "ProductionCount",
+              "jsonType": "bigint",
+              "ordinalPosition": "1"
+            }
+        ]
+}


### PR DESCRIPTION
Hi, I was testing presto agains an ElasticSearch cluster for a internal project at my company and after having an hard time to retrieve data, I found an issue in the ElasticSearchQueryBuilder.

The FetchSource field in the SearchQueryBuilder object must preserve the case the field, otherwise the SearchHit.getSourceAsMap() function won't contains any values.

