### PR TITLE
Add block flattening

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -232,4 +232,64 @@ public class GroupByIdBlock
     {
         return block.getLoadedBlock();
     }
+
+    @Override
+    public byte getByteUnchecked(int internalPosition)
+    {
+        return block.getByte(internalPosition);
+    }
+
+    @Override
+    public short getShortUnchecked(int internalPosition)
+    {
+        return block.getShort(internalPosition);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        return block.getInt(internalPosition);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        return block.getLong(internalPosition);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        return block.getLong(internalPosition, offset);
+    }
+
+    @Override
+    public Slice getSliceUnchecked(int internalPosition, int offset, int length)
+    {
+        return block.getSlice(internalPosition, offset, length);
+    }
+
+    @Override
+    public int getSliceLengthUnchecked(int internalPosition)
+    {
+        return block.getSliceLength(internalPosition);
+    }
+
+    @Override
+    public Block getBlockUnchecked(int internalPosition)
+    {
+        return block.getObject(internalPosition, Block.class);
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        return block.isNull(internalPosition);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimpleArrayAllocator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimpleArrayAllocator.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.ArrayAllocator;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.util.Collections.newSetFromMap;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A simple {@link ArrayAllocator} that caches returned arrays.  When retrieving an array which is
+ * cached, this implementation will first discard all smaller arrays encountered to ensure amortized
+ * constant time access to the appropriately sized array.
+ */
+@NotThreadSafe
+class SimpleArrayAllocator
+        implements ArrayAllocator
+{
+    private static final int DEFAULT_MAX_OUTSTANDING = 1000;
+    private final int maxOutstandingArrays;
+
+    private final Deque<int[]> intArrays = new ArrayDeque<>();
+    private final Set<int[]> borrowedIntArrays = newSetFromMap(new IdentityHashMap<>());
+    private long estimatedSizeInBytes;
+
+    public SimpleArrayAllocator()
+    {
+        this(DEFAULT_MAX_OUTSTANDING);
+    }
+
+    public SimpleArrayAllocator(int maxOutstandingArrays)
+    {
+        checkArgument(maxOutstandingArrays > 0, "maxOutstandingArrays must be positive");
+        this.maxOutstandingArrays = maxOutstandingArrays;
+    }
+
+    @Override
+    public int[] borrowIntArray(int positionCount)
+    {
+        checkState(borrowedIntArrays.size() < maxOutstandingArrays, "Requested too many arrays: %s", borrowedIntArrays.size());
+        int[] array;
+        while (!intArrays.isEmpty() && intArrays.peek().length < positionCount) {
+            array = intArrays.pop();
+            estimatedSizeInBytes -= sizeOf(array);
+        }
+        if (intArrays.isEmpty()) {
+            array = new int[positionCount];
+            estimatedSizeInBytes += sizeOf(array);
+        }
+        else {
+            array = intArrays.pop();
+        }
+        verify(borrowedIntArrays.add(array), "Attempted to borrow array which was already borrowed");
+        return array;
+    }
+
+    @Override
+    public void returnArray(int[] array)
+    {
+        requireNonNull(array, "array is null");
+        checkArgument(borrowedIntArrays.remove(array), "Returned int array which was not borrowed");
+        intArrays.push(array);
+    }
+
+    @Override
+    public int getBorrowedArrayCount()
+    {
+        return borrowedIntArrays.size();
+    }
+
+    @Override
+    public long getEstimatedSizeInBytes()
+    {
+        return estimatedSizeInBytes;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkBlockFlattener.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkBlockFlattener.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.ArrayAllocator;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockFlattener;
+import com.facebook.presto.spi.block.BlockLease;
+import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.IntArrayBlock;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(3)
+@Warmup(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkBlockFlattener
+{
+    private static class ThrowawayArrayAllocator
+            implements ArrayAllocator
+    {
+        @Override
+        public int[] borrowIntArray(int positionCount)
+        {
+            return new int[positionCount];
+        }
+
+        @Override
+        public void returnArray(int[] array)
+        {
+            // no op
+        }
+
+        @Override
+        public int getBorrowedArrayCount()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getEstimatedSizeInBytes()
+        {
+            return 0;
+        }
+    }
+
+    @State(Thread)
+    public static class BaseContext
+    {
+        protected Block block;
+
+        @Param({"1000", "10000", "100000", "1000000"})
+        protected int blockSize;
+
+        @Param({"1", "2", "3", "4", "5"})
+        protected int nestedLevel;
+
+        @Param({"1", "10", "100", "1000"})
+        protected int numberOfIterations;
+
+        @Setup
+        public void setUp()
+        {
+            Random r = ThreadLocalRandom.current();
+            int[] data = new int[blockSize];
+
+            for (int i = 0; i < blockSize; i++) {
+                data[i] = r.nextInt(blockSize);
+            }
+
+            block = new IntArrayBlock(blockSize, Optional.empty(), data);
+            for (int i = 1; i < nestedLevel; i++) {
+                int[] ids = IntStream.range(0, blockSize).toArray();
+                Collections.shuffle(Arrays.asList(ids));
+                block = new DictionaryBlock(block, ids);
+            }
+        }
+    }
+
+    @State(Thread)
+    public static class FlattenContext
+            extends BaseContext
+    {
+        private BlockFlattener flattener;
+
+        @Param({"false", "true"})
+        private boolean reuseArrays;
+
+        @Setup
+        public void setUp()
+        {
+            super.setUp();
+
+            if (reuseArrays) {
+                flattener = new BlockFlattener(new SimpleArrayAllocator());
+            }
+            else {
+                flattener = new BlockFlattener(new ThrowawayArrayAllocator());
+            }
+        }
+    }
+
+    @Benchmark
+    public long benchmarkWithFlatten(FlattenContext context)
+    {
+        long sum = 0;
+        for (int i = 0; i < context.numberOfIterations; i++) {
+            try (BlockLease lease = context.flattener.flatten(context.block)) {
+                Block block = lease.get();
+
+                for (int j = 0; j < context.blockSize; j++) {
+                    sum += block.getInt(j);
+                }
+            }
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long benchmarkWithoutFlatten(BaseContext context)
+    {
+        int sum = 0;
+        Block block = context.block;
+
+        for (int i = 0; i < context.numberOfIterations; i++) {
+            for (int j = 0; j < context.blockSize; j++) {
+                sum += block.getInt(j);
+            }
+        }
+
+        return sum;
+    }
+
+    @Test
+    public void testBenchmarkWithFlatten()
+    {
+        FlattenContext context = new FlattenContext();
+        context.setUp();
+        benchmarkWithFlatten(context);
+    }
+
+    @Test
+    public void testBenchmarkWithoutFlatten()
+    {
+        BaseContext context = new BaseContext();
+        context.setUp();
+        benchmarkWithoutFlatten(context);
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkBlockFlattener.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestSimpleArrayAllocator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestSimpleArrayAllocator.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import org.testng.annotations.Test;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import static io.airlift.slice.SizeOf.sizeOfIntArray;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class TestSimpleArrayAllocator
+{
+    @Test
+    public void testNewLease()
+    {
+        SimpleArrayAllocator allocator = new SimpleArrayAllocator(5);
+
+        Deque<int[]> arrayList = new ArrayDeque<>();
+        for (int i = 0; i < 5; i++) {
+            arrayList.push(allocator.borrowIntArray(10));
+        }
+        assertEquals(allocator.getBorrowedArrayCount(), 5);
+        assertEquals(allocator.getEstimatedSizeInBytes(), sizeOfIntArray(10) * 5);
+
+        for (int i = 0; i < 5; i++) {
+            allocator.returnArray(arrayList.pop());
+        }
+        assertEquals(allocator.getBorrowedArrayCount(), 0);
+        assertEquals(allocator.getEstimatedSizeInBytes(), sizeOfIntArray(10) * 5);
+
+        int[] borrowed = allocator.borrowIntArray(101);
+        assertEquals(allocator.getEstimatedSizeInBytes(), sizeOfIntArray(101));
+        allocator.returnArray(borrowed);
+        assertEquals(allocator.getEstimatedSizeInBytes(), sizeOfIntArray(101));
+    }
+
+    @Test
+    public void testOverAllocateLeases()
+    {
+        SimpleArrayAllocator allocator = new SimpleArrayAllocator(2);
+
+        allocator.borrowIntArray(10);
+        allocator.borrowIntArray(10);
+        assertThrows(IllegalStateException.class, () -> allocator.borrowIntArray(10));
+    }
+
+    @Test
+    public void testReturnArrayNotBorrowed()
+    {
+        SimpleArrayAllocator allocator = new SimpleArrayAllocator(2);
+
+        int[] array = allocator.borrowIntArray(10);
+        allocator.returnArray(array);
+        assertThrows(IllegalArgumentException.class, () -> allocator.returnArray(array));
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractRowBlock.java
@@ -19,6 +19,7 @@ import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.compactOffsets;
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
 import static com.facebook.presto.spi.block.RowBlock.createRowBlockInternal;
 
 public abstract class AbstractRowBlock
@@ -30,7 +31,7 @@ public abstract class AbstractRowBlock
 
     protected abstract int[] getFieldBlockOffsets();
 
-    protected abstract int getOffsetBase();
+    public abstract int getOffsetBase();
 
     protected abstract boolean[] getRowIsNull();
 
@@ -228,5 +229,20 @@ public abstract class AbstractRowBlock
         if (position < 0 || position >= getPositionCount()) {
             throw new IllegalArgumentException("position is not valid");
         }
+    }
+
+    @Override
+    public Block getBlockUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return new SingleRowBlock(getFieldBlockOffsets()[internalPosition], getRawFieldBlocks());
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getRowIsNull()[internalPosition];
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleArrayBlock.java
@@ -15,6 +15,8 @@ package com.facebook.presto.spi.block;
 
 import io.airlift.slice.Slice;
 
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
+
 public abstract class AbstractSingleArrayBlock
         implements Block
 {
@@ -195,5 +197,74 @@ public abstract class AbstractSingleArrayBlock
     public Block copyRegion(int position, int length)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getSliceLengthUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getBlock().getSliceLength(internalPosition);
+    }
+
+    @Override
+    public byte getByteUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getBlock().getByte(internalPosition);
+    }
+
+    @Override
+    public short getShortUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getBlock().getShort(internalPosition);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getBlock().getInt(internalPosition);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getBlock().getLong(internalPosition);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getBlock().getLong(internalPosition, offset);
+    }
+
+    @Override
+    public Slice getSliceUnchecked(int internalPosition, int offset, int length)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getBlock().getSlice(internalPosition, offset, length);
+    }
+
+    @Override
+    public Block getBlockUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getBlock().getBlockUnchecked(internalPosition);
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return start;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getBlock().isNullUnchecked(internalPosition);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleMapBlock.java
@@ -16,6 +16,8 @@ package com.facebook.presto.spi.block;
 
 import io.airlift.slice.Slice;
 
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
+
 public abstract class AbstractSingleMapBlock
         implements Block
 {
@@ -51,85 +53,43 @@ public abstract class AbstractSingleMapBlock
     @Override
     public byte getByte(int position)
     {
-        position = getAbsolutePosition(position);
-        if (position % 2 == 0) {
-            return getRawKeyBlock().getByte(position / 2);
-        }
-        else {
-            return getRawValueBlock().getByte(position / 2);
-        }
+        return getByteUnchecked(getAbsolutePosition(position));
     }
 
     @Override
     public short getShort(int position)
     {
-        position = getAbsolutePosition(position);
-        if (position % 2 == 0) {
-            return getRawKeyBlock().getShort(position / 2);
-        }
-        else {
-            return getRawValueBlock().getShort(position / 2);
-        }
+        return getShortUnchecked(getAbsolutePosition(position));
     }
 
     @Override
     public int getInt(int position)
     {
-        position = getAbsolutePosition(position);
-        if (position % 2 == 0) {
-            return getRawKeyBlock().getInt(position / 2);
-        }
-        else {
-            return getRawValueBlock().getInt(position / 2);
-        }
+        return getIntUnchecked(getAbsolutePosition(position));
     }
 
     @Override
     public long getLong(int position)
     {
-        position = getAbsolutePosition(position);
-        if (position % 2 == 0) {
-            return getRawKeyBlock().getLong(position / 2);
-        }
-        else {
-            return getRawValueBlock().getLong(position / 2);
-        }
+        return getLongUnchecked(getAbsolutePosition(position));
     }
 
     @Override
     public long getLong(int position, int offset)
     {
-        position = getAbsolutePosition(position);
-        if (position % 2 == 0) {
-            return getRawKeyBlock().getLong(position / 2, offset);
-        }
-        else {
-            return getRawValueBlock().getLong(position / 2, offset);
-        }
+        return getLongUnchecked(getAbsolutePosition(position), offset);
     }
 
     @Override
     public Slice getSlice(int position, int offset, int length)
     {
-        position = getAbsolutePosition(position);
-        if (position % 2 == 0) {
-            return getRawKeyBlock().getSlice(position / 2, offset, length);
-        }
-        else {
-            return getRawValueBlock().getSlice(position / 2, offset, length);
-        }
+        return getSliceUnchecked(getAbsolutePosition(position), offset, length);
     }
 
     @Override
     public int getSliceLength(int position)
     {
-        position = getAbsolutePosition(position);
-        if (position % 2 == 0) {
-            return getRawKeyBlock().getSliceLength(position / 2);
-        }
-        else {
-            return getRawValueBlock().getSliceLength(position / 2);
-        }
+        return getSliceLengthUnchecked(getAbsolutePosition(position));
     }
 
     @Override
@@ -280,5 +240,103 @@ public abstract class AbstractSingleMapBlock
     public Block copyRegion(int position, int length)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte getByteUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        if (internalPosition % 2 == 0) {
+            return getRawKeyBlock().getByte(internalPosition / 2);
+        }
+        return getRawValueBlock().getByte(internalPosition / 2);
+    }
+
+    @Override
+    public short getShortUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        if (internalPosition % 2 == 0) {
+            return getRawKeyBlock().getShort(internalPosition / 2);
+        }
+        return getRawValueBlock().getShort(internalPosition / 2);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        if (internalPosition % 2 == 0) {
+            return getRawKeyBlock().getInt(internalPosition / 2);
+        }
+        return getRawValueBlock().getInt(internalPosition / 2);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        if (internalPosition % 2 == 0) {
+            return getRawKeyBlock().getLong(internalPosition / 2);
+        }
+        return getRawValueBlock().getLong(internalPosition / 2);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        if (internalPosition % 2 == 0) {
+            return getRawKeyBlock().getLong(internalPosition / 2, offset);
+        }
+        return getRawValueBlock().getLong(internalPosition / 2, offset);
+    }
+
+    @Override
+    public Slice getSliceUnchecked(int internalPosition, int offset, int length)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        if (internalPosition % 2 == 0) {
+            return getRawKeyBlock().getSlice(internalPosition / 2, offset, length);
+        }
+        return getRawValueBlock().getSlice(internalPosition / 2, offset, length);
+    }
+
+    @Override
+    public int getSliceLengthUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        if (internalPosition % 2 == 0) {
+            return getRawKeyBlock().getSliceLength(internalPosition / 2);
+        }
+        return getRawValueBlock().getSliceLength(internalPosition / 2);
+    }
+
+    @Override
+    public Block getBlockUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        if (internalPosition % 2 == 0) {
+            return getRawKeyBlock().getObject(internalPosition / 2, Block.class);
+        }
+        return getRawValueBlock().getObject(internalPosition / 2, Block.class);
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return getOffset();
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffset(), getPositionCount());
+        // Keys are presumed to be non-null
+        if (internalPosition % 2 == 0) {
+            return false;
+        }
+        return getRawValueBlock().isNull(internalPosition / 2);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractSingleRowBlock.java
@@ -16,6 +16,8 @@ package com.facebook.presto.spi.block;
 
 import io.airlift.slice.Slice;
 
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
+
 public abstract class AbstractSingleRowBlock
         implements Block
 {
@@ -189,5 +191,67 @@ public abstract class AbstractSingleRowBlock
     public Block copyRegion(int position, int length)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte getByteUnchecked(int internalPosition)
+    {
+        return getRawFieldBlock(internalPosition).getByte(rowIndex);
+    }
+
+    @Override
+    public short getShortUnchecked(int internalPosition)
+    {
+        return getRawFieldBlock(internalPosition).getShort(rowIndex);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        return getRawFieldBlock(internalPosition).getInt(rowIndex);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        return getRawFieldBlock(internalPosition).getLong(rowIndex);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        return getRawFieldBlock(internalPosition).getLong(rowIndex, offset);
+    }
+
+    @Override
+    public Slice getSliceUnchecked(int internalPosition, int offset, int length)
+    {
+        return getRawFieldBlock(internalPosition).getSlice(rowIndex, offset, length);
+    }
+
+    @Override
+    public int getSliceLengthUnchecked(int internalPosition)
+    {
+        return getRawFieldBlock(internalPosition).getSliceLength(rowIndex);
+    }
+
+    @Override
+    public Block getBlockUnchecked(int internalPosition)
+    {
+        return getRawFieldBlock(internalPosition).getObject(rowIndex, Block.class);
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getRawFieldBlock(internalPosition).isNull(rowIndex);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayAllocator.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayAllocator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.block;
+
+import com.facebook.presto.spi.api.Experimental;
+
+/**
+ * Manages the creation and return of primitive arrays, to be used within an operator to avoid repeated array allocation.
+ * Typically this will be used within {@link BlockFlattener}.
+ *
+ * The arrays which are returned may have a size which exceeds the specified {@code positionCount}, and they are not
+ * guaranteed to be filled with the type's default value.
+ */
+@Experimental
+public interface ArrayAllocator
+{
+    int[] borrowIntArray(int positionCount);
+
+    void returnArray(int[] array);
+
+    /**
+     * @return the number of borrowed arrays which have not been returned
+     */
+    int getBorrowedArrayCount();
+
+    long getEstimatedSizeInBytes();
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlock.java
@@ -157,7 +157,7 @@ public class ArrayBlock
     }
 
     @Override
-    protected int getOffsetBase()
+    public int getOffsetBase()
     {
         return arrayOffset;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
@@ -128,7 +128,7 @@ public class ArrayBlockBuilder
     }
 
     @Override
-    protected int getOffsetBase()
+    public int getOffsetBase()
     {
         return 0;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Block.java
@@ -21,6 +21,7 @@ import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.DictionaryId.randomDictionaryId;
 
 public interface Block
+        extends UncheckedBlock
 {
     /**
      * Gets the length of the value at the {@code position}.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockFlattener.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockFlattener.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import com.facebook.presto.spi.api.Experimental;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.spi.block.ClosingBlockLease.newLease;
+import static java.util.Objects.requireNonNull;
+
+@Experimental
+public class BlockFlattener
+{
+    private final ArrayAllocator allocator;
+
+    public BlockFlattener(ArrayAllocator allocator)
+    {
+        this.allocator = requireNonNull(allocator, "allocator is null");
+    }
+
+    /**
+     * Flattens {@code RunLengthEncodedBlock} and {@code DictionaryBlock} into the top-level type
+     * such that the inner block is not itself a run length encoded block or dictionary block.
+     * For example, a dictionary block which consists of another dictionary block would be flattened
+     * to just a dictionary block which has an inner data block of the child dictionary, with all of
+     * the ids remapped accordingly.
+     */
+    public BlockLease flatten(Block block)
+    {
+        requireNonNull(block, "block is null");
+        if (block instanceof DictionaryBlock) {
+            return flattenDictionaryBlock((DictionaryBlock) block);
+        }
+        if (block instanceof RunLengthEncodedBlock) {
+            return flattenRunLengthEncodedBlock((RunLengthEncodedBlock) block);
+        }
+        return newLease(block);
+    }
+
+    private BlockLease flattenDictionaryBlock(DictionaryBlock dictionaryBlock)
+    {
+        Block dictionary = dictionaryBlock.getDictionary();
+        int positionCount = dictionaryBlock.getPositionCount();
+        int[] currentRemappedIds = (int[]) dictionaryBlock.getIds().getBase();
+        // Initially, the below variable is null.  After the first pass of the loop, it will be a borrowed array from the allocator,
+        // and it will have reference equality with currentRemappedIds
+        int[] newRemappedIds = null;
+
+        while (true) {
+            if (dictionary instanceof DictionaryBlock) {
+                dictionaryBlock = (DictionaryBlock) dictionary;
+                int[] ids = (int[]) dictionaryBlock.getIds().getBase();
+
+                if (newRemappedIds == null) {
+                    newRemappedIds = allocator.borrowIntArray(positionCount);
+                }
+
+                for (int i = 0; i < positionCount; ++i) {
+                    newRemappedIds[i] = ids[currentRemappedIds[i] + dictionaryBlock.getOffsetBase()];
+                }
+
+                currentRemappedIds = newRemappedIds;
+                dictionary = dictionaryBlock.getDictionary();
+            }
+            else if (dictionary instanceof RunLengthEncodedBlock) {
+                RunLengthEncodedBlock rle = (RunLengthEncodedBlock) dictionary;
+                if (newRemappedIds == null) {
+                    newRemappedIds = allocator.borrowIntArray(positionCount);
+                }
+                Arrays.fill(newRemappedIds, 0, positionCount, 0);
+                currentRemappedIds = newRemappedIds;
+
+                dictionary = rle.getValue();
+            }
+            else {
+                // We have reached a data block, break to return the flattened dictionary
+                break;
+            }
+        }
+
+        if (newRemappedIds == null) {
+            return newLease(dictionaryBlock);
+        }
+
+        dictionary = new DictionaryBlock(positionCount, dictionary, currentRemappedIds);
+        int[] leasedMapToReturn = newRemappedIds; // effectively final
+        return newLease(dictionary, () -> allocator.returnArray(leasedMapToReturn));
+    }
+
+    private static BlockLease flattenRunLengthEncodedBlock(RunLengthEncodedBlock rleBLock)
+    {
+        Block block = rleBLock;
+        while (true) {
+            if (block instanceof RunLengthEncodedBlock) {
+                RunLengthEncodedBlock rle = (RunLengthEncodedBlock) block;
+                block = rle.getValue();
+            }
+            else if (block instanceof DictionaryBlock) {
+                DictionaryBlock dictionaryBlock = (DictionaryBlock) block;
+                block = dictionaryBlock.getDictionary().copyRegion(dictionaryBlock.getId(0), 1);
+            }
+            else {
+                // We have reached a data block, break to return the flattened run length encoded block
+                break;
+            }
+        }
+        return newLease(new RunLengthEncodedBlock(block, rleBLock.getPositionCount()));
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockLease.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockLease.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import com.facebook.presto.spi.api.Experimental;
+
+import java.util.function.Supplier;
+
+/**
+ * Represents a Block backed by a closeable resource.  The Block is retrieved via the {@link #get()}
+ * method, which must only be called once.  The {@link #close()} method must be called unconditionally
+ * when use of the Block is complete.
+ */
+@Experimental
+public interface BlockLease
+        extends Supplier<Block>, AutoCloseable
+{
+    void close();
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockUtil.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockUtil.java
@@ -180,6 +180,7 @@ final class BlockUtil
         }
         return Arrays.copyOfRange(array, index, index + length);
     }
+
     static int countUsedPositions(boolean[] positions)
     {
         int used = 0;
@@ -207,5 +208,12 @@ final class BlockUtil
             }
         }
         return true;
+    }
+
+    public static boolean internalPositionInRange(int internalPosition, int offset, int positionCount)
+    {
+        boolean withinRange = internalPosition >= offset && internalPosition < positionCount + offset;
+        assert withinRange : format("internalPosition %s is not within range [%s, %s)", internalPosition, offset, positionCount + offset);
+        return withinRange;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlock.java
@@ -24,6 +24,7 @@ import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class ByteArrayBlock
@@ -120,7 +121,7 @@ public class ByteArrayBlock
     public byte getByte(int position)
     {
         checkReadablePosition(position);
-        return values[position + arrayOffset];
+        return getByteUnchecked(position + arrayOffset);
     }
 
     @Override
@@ -133,7 +134,7 @@ public class ByteArrayBlock
     public boolean isNull(int position)
     {
         checkReadablePosition(position);
-        return valueIsNull != null && valueIsNull[position + arrayOffset];
+        return valueIsNull != null && isNullUnchecked(position + arrayOffset);
     }
 
     @Override
@@ -219,5 +220,26 @@ public class ByteArrayBlock
         if (position < 0 || position >= getPositionCount()) {
             throw new IllegalArgumentException("position is not valid");
         }
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return arrayOffset;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public byte getByteUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return values[internalPosition];
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ByteArrayBlockBuilder.java
@@ -24,6 +24,7 @@ import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 
@@ -289,5 +290,26 @@ public class ByteArrayBlockBuilder
         if (position < 0 || position >= getPositionCount()) {
             throw new IllegalArgumentException("position is not valid");
         }
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public byte getByteUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return values[internalPosition];
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ClosingBlockLease.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ClosingBlockLease.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import com.facebook.presto.spi.api.Experimental;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+
+@Experimental
+@NotThreadSafe
+public final class ClosingBlockLease
+        implements BlockLease
+{
+    private final Block block;
+    private final List<Closer> closers;
+    private boolean closed;
+    private boolean retrieved;
+
+    public ClosingBlockLease(Block block, Closer... closers)
+    {
+        requireNonNull(block, "block is null");
+        requireNonNull(closers, "closers is null");
+        this.block = block;
+        this.closers = closers.length == 0 ? emptyList() : unmodifiableList(asList(closers.clone()));
+    }
+
+    public static BlockLease newLease(Block block, Closer... closers)
+    {
+        return new ClosingBlockLease(block, closers);
+    }
+
+    @Override
+    public Block get()
+    {
+        checkState(!closed, "block lease is closed");
+        checkState(!retrieved, "block lease already retrieved");
+        retrieved = true;
+        return block;
+    }
+
+    // Implementations of Closer should not throw, but in theory they could.  If they do,
+    // make a best-effort attempt to preserve the exception history and close all resources.
+    @Override
+    public void close()
+    {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        Throwable innerException = null;
+        for (Closer closer : closers) {
+            try {
+                closer.close();
+            }
+            catch (Throwable t) {
+                if (innerException == null) {
+                    innerException = t;
+                }
+                else if (innerException != t) {
+                    // Self-suppression not permitted
+                    innerException.addSuppressed(t);
+                }
+            }
+        }
+        if (innerException != null) {
+            // Convert to unchecked exception
+            throw new RuntimeException(innerException);
+        }
+    }
+
+    private static void checkState(boolean state, String message)
+    {
+        if (!state) {
+            throw new IllegalStateException(message);
+        }
+    }
+
+    // Implementations of Closer should not throw
+    public interface Closer
+            extends AutoCloseable
+    {
+        @Override
+        void close();
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -27,6 +27,7 @@ import static com.facebook.presto.spi.block.BlockUtil.checkValidPosition;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPositions;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
 import static com.facebook.presto.spi.block.DictionaryId.randomDictionaryId;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.min;
@@ -463,5 +464,75 @@ public class DictionaryBlock
             // ignore if copy positions is not supported for the dictionary block
             return this;
         }
+    }
+
+    @Override
+    public byte getByteUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return dictionary.getByte(ids[internalPosition]);
+    }
+
+    @Override
+    public short getShortUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return dictionary.getShort(ids[internalPosition]);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return dictionary.getInt(ids[internalPosition]);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return dictionary.getLong(ids[internalPosition]);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return dictionary.getLong(ids[internalPosition], offset);
+    }
+
+    @Override
+    public Slice getSliceUnchecked(int internalPosition, int offset, int length)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return dictionary.getSlice(ids[internalPosition], offset, length);
+    }
+
+    @Override
+    public int getSliceLengthUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return dictionary.getSliceLength(ids[internalPosition]);
+    }
+
+    @Override
+    public Block getBlockUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return dictionary.getObject(ids[internalPosition], Block.class);
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return idsOffset;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, idsOffset, positionCount);
+        return dictionary.isNull(ids[internalPosition]);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/Int128ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/Int128ArrayBlockBuilder.java
@@ -25,9 +25,11 @@ import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
 import static com.facebook.presto.spi.block.Int128ArrayBlock.INT128_BYTES;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Integer.bitCount;
 import static java.lang.Math.max;
 
 public class Int128ArrayBlockBuilder
@@ -313,5 +315,27 @@ public class Int128ArrayBlockBuilder
         if (position < 0 || position >= getPositionCount()) {
             throw new IllegalArgumentException("position is not valid");
         }
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        assert offset == 0 || offset == 8 : "offset must be 0 or 8";
+        return values[internalPosition * 2 + bitCount(offset)];
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlock.java
@@ -24,6 +24,7 @@ import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class IntArrayBlock
@@ -120,7 +121,7 @@ public class IntArrayBlock
     public int getInt(int position)
     {
         checkReadablePosition(position);
-        return values[position + arrayOffset];
+        return getIntUnchecked(position + arrayOffset);
     }
 
     @Override
@@ -133,7 +134,7 @@ public class IntArrayBlock
     public boolean isNull(int position)
     {
         checkReadablePosition(position);
-        return valueIsNull != null && valueIsNull[position + arrayOffset];
+        return valueIsNull != null && isNullUnchecked(position + arrayOffset);
     }
 
     @Override
@@ -219,5 +220,26 @@ public class IntArrayBlock
         if (position < 0 || position >= getPositionCount()) {
             throw new IllegalArgumentException("position is not valid");
         }
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return arrayOffset;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return values[internalPosition];
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/IntArrayBlockBuilder.java
@@ -24,6 +24,7 @@ import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 
@@ -289,5 +290,26 @@ public class IntArrayBlockBuilder
         if (position < 0 || position >= getPositionCount()) {
             throw new IllegalArgumentException("position is not valid");
         }
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return values[internalPosition];
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LazyBlock.java
@@ -289,4 +289,73 @@ public class LazyBlock
         // clear reference to loader to free resources, since load was successful
         loader = null;
     }
+
+    @Override
+    public byte getByteUnchecked(int internalPosition)
+    {
+        assert block != null : "block is not loaded";
+        return block.getByte(internalPosition);
+    }
+
+    @Override
+    public short getShortUnchecked(int internalPosition)
+    {
+        assert block != null : "block is not loaded";
+        return block.getShort(internalPosition);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert block != null : "block is not loaded";
+        return block.getInt(internalPosition);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        assert block != null : "block is not loaded";
+        return block.getLong(internalPosition);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert block != null : "block is not loaded";
+        return block.getLong(internalPosition, offset);
+    }
+
+    @Override
+    public Slice getSliceUnchecked(int internalPosition, int offset, int length)
+    {
+        assert block != null : "block is not loaded";
+        return block.getSlice(internalPosition, offset, length);
+    }
+
+    @Override
+    public int getSliceLengthUnchecked(int internalPosition)
+    {
+        assert block != null : "block is not loaded";
+        return block.getSliceLength(internalPosition);
+    }
+
+    @Override
+    public Block getBlockUnchecked(int internalPosition)
+    {
+        assert block != null : "block is not loaded";
+        return block.getObject(internalPosition, Block.class);
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert block != null : "block is not loaded";
+        return block.isNull(internalPosition);
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlock.java
@@ -24,6 +24,7 @@ import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.toIntExact;
 
@@ -121,7 +122,7 @@ public class LongArrayBlock
     public long getLong(int position)
     {
         checkReadablePosition(position);
-        return values[position + arrayOffset];
+        return getLongUnchecked(position + arrayOffset);
     }
 
     @Override
@@ -171,7 +172,7 @@ public class LongArrayBlock
     public boolean isNull(int position)
     {
         checkReadablePosition(position);
-        return valueIsNull != null && valueIsNull[position + arrayOffset];
+        return valueIsNull != null && isNullUnchecked(position + arrayOffset);
     }
 
     @Override
@@ -257,5 +258,26 @@ public class LongArrayBlock
         if (position < 0 || position >= getPositionCount()) {
             throw new IllegalArgumentException("position is not valid");
         }
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return arrayOffset;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return values[internalPosition];
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/LongArrayBlockBuilder.java
@@ -24,6 +24,7 @@ import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 import static java.lang.Math.toIntExact;
@@ -327,5 +328,26 @@ public class LongArrayBlockBuilder
         if (position < 0 || position >= getPositionCount()) {
             throw new IllegalArgumentException("position is not valid");
         }
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return values[internalPosition];
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlock.java
@@ -32,6 +32,7 @@ import static java.util.Objects.requireNonNull;
 
 public class MapBlock
         extends AbstractMapBlock
+        implements Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapBlock.class).instanceSize();
 
@@ -229,7 +230,7 @@ public class MapBlock
     }
 
     @Override
-    protected int getOffsetBase()
+    public int getOffsetBase()
     {
         return startOffset;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlockBuilder.java
@@ -127,7 +127,7 @@ public class MapBlockBuilder
     }
 
     @Override
-    protected int getOffsetBase()
+    public int getOffsetBase()
     {
         return 0;
     }
@@ -395,7 +395,7 @@ public class MapBlockBuilder
             }
         }
 
-        closeEntry(singleMapBlock.getHashTable(), singleMapBlock.getOffset() / 2 * HASH_MULTIPLIER);
+        closeEntry(singleMapBlock.getHashTable(), singleMapBlock.getOffsetBase() / 2 * HASH_MULTIPLIER);
         return this;
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlock.java
@@ -26,6 +26,7 @@ import static java.util.Objects.requireNonNull;
 
 public class RowBlock
         extends AbstractRowBlock
+        implements Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(RowBlock.class).instanceSize();
 
@@ -129,7 +130,7 @@ public class RowBlock
     }
 
     @Override
-    protected int getOffsetBase()
+    public int getOffsetBase()
     {
         return startOffset;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RowBlockBuilder.java
@@ -88,7 +88,7 @@ public class RowBlockBuilder
     }
 
     @Override
-    protected int getOffsetBase()
+    public int getOffsetBase()
     {
         return 0;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/RunLengthEncodedBlock.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidPosition;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -303,5 +304,75 @@ public class RunLengthEncodedBlock
         if (position < 0 || position >= positionCount) {
             throw new IllegalArgumentException("position is not valid");
         }
+    }
+
+    @Override
+    public byte getByteUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return value.getByte(0);
+    }
+
+    @Override
+    public short getShortUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return value.getShort(0);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return value.getInt(0);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return value.getLong(0);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return value.getLong(0, offset);
+    }
+
+    @Override
+    public Slice getSliceUnchecked(int internalPosition, int offset, int length)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return value.getSlice(0, offset, length);
+    }
+
+    @Override
+    public int getSliceLengthUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return value.getSliceLength(0);
+    }
+
+    @Override
+    public Block getBlockUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return value.getObject(0, Block.class);
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, 0, getPositionCount());
+        return value.isNull(0);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlock.java
@@ -24,6 +24,7 @@ import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 
 public class ShortArrayBlock
@@ -120,7 +121,7 @@ public class ShortArrayBlock
     public short getShort(int position)
     {
         checkReadablePosition(position);
-        return values[position + arrayOffset];
+        return getShortUnchecked(position + arrayOffset);
     }
 
     @Override
@@ -133,7 +134,7 @@ public class ShortArrayBlock
     public boolean isNull(int position)
     {
         checkReadablePosition(position);
-        return valueIsNull != null && valueIsNull[position + arrayOffset];
+        return valueIsNull != null && isNullUnchecked(position + arrayOffset);
     }
 
     @Override
@@ -219,5 +220,26 @@ public class ShortArrayBlock
         if (position < 0 || position >= getPositionCount()) {
             throw new IllegalArgumentException("position is not valid");
         }
+    }
+
+    @Override
+    public short getShortUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return values[internalPosition];
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return arrayOffset;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ShortArrayBlockBuilder.java
@@ -24,6 +24,7 @@ import static com.facebook.presto.spi.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.spi.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.countUsedPositions;
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 
@@ -289,5 +290,26 @@ public class ShortArrayBlockBuilder
         if (position < 0 || position >= getPositionCount()) {
             throw new IllegalArgumentException("position is not valid");
         }
+    }
+
+    @Override
+    public short getShortUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return values[internalPosition];
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/SingleMapBlockEncoding.java
@@ -58,7 +58,7 @@ public class SingleMapBlockEncoding
         SingleMapBlock singleMapBlock = (SingleMapBlock) block;
         TypeSerde.writeType(sliceOutput, singleMapBlock.getKeyType());
 
-        int offset = singleMapBlock.getOffset();
+        int offset = singleMapBlock.getOffsetBase();
         int positionCount = singleMapBlock.getPositionCount();
         blockEncodingSerde.writeBlock(sliceOutput, singleMapBlock.getRawKeyBlock().getRegion(offset / 2, positionCount / 2));
         blockEncodingSerde.writeBlock(sliceOutput, singleMapBlock.getRawValueBlock().getRegion(offset / 2, positionCount / 2));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/UncheckedBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/UncheckedBlock.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import com.facebook.presto.spi.api.Experimental;
+import io.airlift.slice.Slice;
+
+/**
+ * Accessors for Block which provide for raw indexing into the underlying data structure of the Block.
+ * It is intended for hot path use cases where the speed of the boundary checks on Block is a performance
+ * bottleneck.  Methods in this case must be used with more care, as they may return invalid data if the
+ * indexing is not performed with respect to {@link #getOffsetBase} and {@code getPositionCount()}.
+ * Implementations of UncheckedBlock should perform any boundary checks within assert statements so they can
+ * be disabled in performance critical deployments by disabling assertions.
+ *
+ * Example usage:
+ *
+ * <pre>
+ * {@code
+ *  UncheckedBlock block = ...
+ *  int sum = 0;
+ *  for (int i = block.getOffsetBase(); i < block.getOffsetBase() + block.getPositionCount(); i++) {
+ *      sum += block.getIntUnchecked(i);
+ *  }
+ * }
+ * </pre>
+ *
+ * For nested structures, such as dictionaries and RLEs, the indexing is unchecked with respect to the top
+ * level block, but not with respect to the inner blocks.  If, for performance reasons, it is desired to
+ * use unchecked indexing also for the inner blocks, you may unpeel the blocks using existing utilities
+ * such as {@link ColumnarArray}, {@link ColumnarMap}, {@link ColumnarRow} and {@link BlockFlattener}.
+ */
+@Experimental
+public interface UncheckedBlock
+{
+    /**
+     * Gets a byte value at {@code internalPosition - getOffsetBase()}.
+     */
+    default byte getByteUnchecked(int internalPosition)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    /**
+     * Gets a little endian short at value at {@code internalPosition - getOffsetBase()}.
+     */
+    default short getShortUnchecked(int internalPosition)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    /**
+     * Gets a little endian int value at {@code internalPosition - getOffsetBase()}.
+     */
+    default int getIntUnchecked(int internalPosition)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    /**
+     * Gets a little endian long value at {@code internalPosition - getOffsetBase()}.
+     */
+    default long getLongUnchecked(int internalPosition)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    /**
+     * Gets a little endian long at {@code offset} in the value at {@code internalPosition - getOffsetBase()}.
+     */
+    default long getLongUnchecked(int internalPosition, int offset)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    /**
+     * Gets the length of the slice value at {@code internalPosition - getOffsetBase()}.
+     * This method must be implemented if {@code getSliceUnchecked} is implemented.
+     */
+    default int getSliceLengthUnchecked(int internalPosition)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    /**
+     * Gets a slice with offset {@code offset} at {@code internalPosition - getOffsetBase()}.
+     */
+    default Slice getSliceUnchecked(int internalPosition, int offset, int length)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    /**
+     * Gets a Block value at {@code internalPosition - getOffsetBase()}.
+     */
+    default Block getBlockUnchecked(int internalPosition)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    /**
+     * @return true if value at {@code internalPosition - getOffsetBase()} is null
+     */
+    boolean isNullUnchecked(int internalPosition);
+
+    /**
+     * @return the internal offset of the underlying data structure of this block
+     */
+    int getOffsetBase();
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -17,6 +17,7 @@ import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
+import io.airlift.slice.UnsafeSlice;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -34,6 +35,7 @@ import static com.facebook.presto.spi.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.spi.block.BlockUtil.compactArray;
 import static com.facebook.presto.spi.block.BlockUtil.compactOffsets;
 import static com.facebook.presto.spi.block.BlockUtil.compactSlice;
+import static com.facebook.presto.spi.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
@@ -365,5 +367,68 @@ public class VariableWidthBlockBuilder
         sb.append(", size=").append(sliceOutput.size());
         sb.append('}');
         return sb.toString();
+    }
+
+    @Override
+    public byte getByteUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return UnsafeSlice.getByteUnchecked(getRawSlice(internalPosition), offsets[internalPosition]);
+    }
+
+    @Override
+    public short getShortUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return UnsafeSlice.getShortUnchecked(getRawSlice(internalPosition), offsets[internalPosition]);
+    }
+
+    @Override
+    public int getIntUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return UnsafeSlice.getIntUnchecked(getRawSlice(internalPosition), offsets[internalPosition]);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return UnsafeSlice.getLongUnchecked(getRawSlice(internalPosition), offsets[internalPosition]);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return UnsafeSlice.getLongUnchecked(getRawSlice(internalPosition), offsets[internalPosition] + offset);
+    }
+
+    @Override
+    public Slice getSliceUnchecked(int internalPosition, int offset, int length)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return getRawSlice(internalPosition).slice(offsets[internalPosition] + offset, length);
+    }
+
+    @Override
+    public int getSliceLengthUnchecked(int internalPosition)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return offsets[internalPosition + 1] - offsets[internalPosition];
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractIntType.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.IntArrayBlockBuilder;
 import com.facebook.presto.spi.block.PageBuilderStatus;
+import com.facebook.presto.spi.block.UncheckedBlock;
 import io.airlift.slice.Slice;
 
 import static java.lang.Long.rotateLeft;
@@ -53,6 +54,12 @@ public abstract class AbstractIntType
     public final long getLong(Block block, int position)
     {
         return block.getInt(position);
+    }
+
+    @Override
+    public final long getLongUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return block.getIntUnchecked(internalPosition);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractLongType.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.LongArrayBlockBuilder;
 import com.facebook.presto.spi.block.PageBuilderStatus;
+import com.facebook.presto.spi.block.UncheckedBlock;
 import io.airlift.slice.Slice;
 
 import static java.lang.Long.rotateLeft;
@@ -53,6 +54,12 @@ public abstract class AbstractLongType
     public final long getLong(Block block, int position)
     {
         return block.getLong(position);
+    }
+
+    @Override
+    public final long getLongUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return block.getLongUnchecked(internalPosition);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/AbstractType.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.type;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.UncheckedBlock;
 import io.airlift.slice.Slice;
 
 import java.util.ArrayList;
@@ -94,6 +95,12 @@ public abstract class AbstractType
     }
 
     @Override
+    public boolean getBooleanUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    @Override
     public void writeBoolean(BlockBuilder blockBuilder, boolean value)
     {
         throw new UnsupportedOperationException(getClass().getName());
@@ -101,6 +108,12 @@ public abstract class AbstractType
 
     @Override
     public long getLong(Block block, int position)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    @Override
+    public long getLongUnchecked(UncheckedBlock block, int internalPosition)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -118,6 +131,12 @@ public abstract class AbstractType
     }
 
     @Override
+    public double getDoubleUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    @Override
     public void writeDouble(BlockBuilder blockBuilder, double value)
     {
         throw new UnsupportedOperationException(getClass().getName());
@@ -125,6 +144,12 @@ public abstract class AbstractType
 
     @Override
     public Slice getSlice(Block block, int position)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    @Override
+    public Slice getSliceUnchecked(Block block, int internalPosition)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -143,6 +168,12 @@ public abstract class AbstractType
 
     @Override
     public Object getObject(Block block, int position)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    @Override
+    public Block getBlockUnchecked(Block block, int internalPosition)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ArrayType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ArrayType.java
@@ -184,6 +184,12 @@ public class ArrayType
     }
 
     @Override
+    public Block getBlockUnchecked(Block block, int internalPosition)
+    {
+        return block.getBlockUnchecked(internalPosition);
+    }
+
+    @Override
     public void writeObject(BlockBuilder blockBuilder, Object value)
     {
         blockBuilder.appendStructure((Block) value);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/BooleanType.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.ByteArrayBlockBuilder;
 import com.facebook.presto.spi.block.PageBuilderStatus;
+import com.facebook.presto.spi.block.UncheckedBlock;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 
@@ -126,6 +127,12 @@ public final class BooleanType
     public boolean getBoolean(Block block, int position)
     {
         return block.getByte(position) != 0;
+    }
+
+    @Override
+    public boolean getBooleanUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return block.getByteUnchecked(internalPosition) != 0;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/DoubleType.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.LongArrayBlockBuilder;
 import com.facebook.presto.spi.block.PageBuilderStatus;
+import com.facebook.presto.spi.block.UncheckedBlock;
 
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static java.lang.Double.doubleToLongBits;
@@ -103,6 +104,12 @@ public final class DoubleType
     public double getDouble(Block block, int position)
     {
         return longBitsToDouble(block.getLong(position));
+    }
+
+    @Override
+    public double getDoubleUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return longBitsToDouble(block.getLongUnchecked(internalPosition));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/FunctionType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/FunctionType.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.UncheckedBlock;
 import io.airlift.slice.Slice;
 
 import java.util.ArrayList;
@@ -132,6 +133,12 @@ public class FunctionType
     }
 
     @Override
+    public boolean getBooleanUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    @Override
     public void writeBoolean(BlockBuilder blockBuilder, boolean value)
     {
         throw new UnsupportedOperationException(getClass().getName());
@@ -139,6 +146,12 @@ public class FunctionType
 
     @Override
     public long getLong(Block block, int position)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    @Override
+    public long getLongUnchecked(UncheckedBlock block, int internalPosition)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -156,6 +169,12 @@ public class FunctionType
     }
 
     @Override
+    public double getDoubleUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    @Override
     public void writeDouble(BlockBuilder blockBuilder, double value)
     {
         throw new UnsupportedOperationException(getClass().getName());
@@ -163,6 +182,12 @@ public class FunctionType
 
     @Override
     public Slice getSlice(Block block, int position)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    @Override
+    public Slice getSliceUnchecked(Block block, int internalPosition)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }
@@ -181,6 +206,12 @@ public class FunctionType
 
     @Override
     public Object getObject(Block block, int position)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    @Override
+    public Block getBlockUnchecked(Block block, int internalPosition)
     {
         throw new UnsupportedOperationException(getClass().getName());
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
@@ -232,6 +232,12 @@ public class MapType
     }
 
     @Override
+    public Block getBlockUnchecked(Block block, int internalPosition)
+    {
+        return block.getBlockUnchecked(internalPosition);
+    }
+
+    @Override
     public void writeObject(BlockBuilder blockBuilder, Object value)
     {
         if (!(value instanceof SingleMapBlock)) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
@@ -170,6 +170,12 @@ public class RowType
     }
 
     @Override
+    public Block getBlockUnchecked(Block block, int internalPosition)
+    {
+        return block.getBlockUnchecked(internalPosition);
+    }
+
+    @Override
     public void writeObject(BlockBuilder blockBuilder, Object value)
     {
         blockBuilder.appendStructure((Block) value);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.LongArrayBlockBuilder;
 import com.facebook.presto.spi.block.PageBuilderStatus;
+import com.facebook.presto.spi.block.UncheckedBlock;
 
 import java.math.BigInteger;
 
@@ -114,6 +115,12 @@ final class ShortDecimalType
     public long getLong(Block block, int position)
     {
         return block.getLong(position);
+    }
+
+    @Override
+    public long getLongUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return block.getLongUnchecked(internalPosition);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/SmallintType.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.PageBuilderStatus;
 import com.facebook.presto.spi.block.ShortArrayBlockBuilder;
+import com.facebook.presto.spi.block.UncheckedBlock;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
@@ -130,6 +131,12 @@ public final class SmallintType
     public long getLong(Block block, int position)
     {
         return (long) block.getShort(position);
+    }
+
+    @Override
+    public long getLongUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return (long) block.getShortUnchecked(internalPosition);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TinyintType.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.ByteArrayBlockBuilder;
 import com.facebook.presto.spi.block.PageBuilderStatus;
+import com.facebook.presto.spi.block.UncheckedBlock;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
@@ -130,6 +131,12 @@ public final class TinyintType
     public long getLong(Block block, int position)
     {
         return (long) block.getByte(position);
+    }
+
+    @Override
+    public long getLongUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return (long) block.getByteUnchecked(internalPosition);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/Type.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/Type.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
+import com.facebook.presto.spi.block.UncheckedBlock;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.airlift.slice.Slice;
 
@@ -84,9 +85,21 @@ public interface Type
     boolean getBoolean(Block block, int position);
 
     /**
+     * Gets the value at the {@code block} {@code internalPosition - offsetBase} as a boolean
+     * without boundary checks.
+     */
+    boolean getBooleanUnchecked(UncheckedBlock block, int internalPosition);
+
+    /**
      * Gets the value at the {@code block} {@code position} as a long.
      */
     long getLong(Block block, int position);
+
+    /**
+     * Gets the value at the {@code block} {@code internalPosition - offsetBase} as a long
+     * without boundary checks.
+     */
+    long getLongUnchecked(UncheckedBlock block, int internalPosition);
 
     /**
      * Gets the value at the {@code block} {@code position} as a double.
@@ -94,14 +107,32 @@ public interface Type
     double getDouble(Block block, int position);
 
     /**
+     * Gets the value at the {@code block} {@code internalPosition - offsetBase} as a double
+     * without boundary checks.
+     */
+    double getDoubleUnchecked(UncheckedBlock block, int internalPosition);
+
+    /**
      * Gets the value at the {@code block} {@code position} as a Slice.
      */
     Slice getSlice(Block block, int position);
 
     /**
+     * Gets the value at the {@code block} {@code position} as a Slice
+     * without boundary checks
+     */
+    Slice getSliceUnchecked(Block block, int internalPosition);
+
+    /**
      * Gets the value at the {@code block} {@code position} as an Object.
      */
     Object getObject(Block block, int position);
+
+    /**
+     * Gets the value at the {@code block} {@code internalPosition - offsetBase} as a block
+     * without boundary checks.
+     */
+    Block getBlockUnchecked(Block block, int internalPosition);
 
     /**
      * Writes the boolean value into the {@code BlockBuilder}.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/VarcharType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/VarcharType.java
@@ -149,6 +149,12 @@ public final class VarcharType
         return block.getSlice(position, 0, block.getSliceLength(position));
     }
 
+    @Override
+    public Slice getSliceUnchecked(Block block, int internalPosition)
+    {
+        return block.getSliceUnchecked(internalPosition, 0, block.getSliceLengthUnchecked(internalPosition));
+    }
+
     public void writeString(BlockBuilder blockBuilder, String value)
     {
         writeSlice(blockBuilder, Slices.utf8Slice(value));

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/CountingArrayAllocator.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/CountingArrayAllocator.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+/**
+ * Test class which always allocates a new array but keeps track of the number
+ * of borrowed arrays.
+ */
+class CountingArrayAllocator
+        implements ArrayAllocator
+{
+    private int borrowedArrays;
+
+    @Override
+    public int[] borrowIntArray(int positionCount)
+    {
+        borrowedArrays++;
+        return new int[positionCount];
+    }
+
+    @Override
+    public void returnArray(int[] array)
+    {
+        borrowedArrays--;
+    }
+
+    @Override
+    public int getBorrowedArrayCount()
+    {
+        return borrowedArrays;
+    }
+
+    @Override
+    public long getEstimatedSizeInBytes()
+    {
+        return 0;
+    }
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestBlockFlattenner.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestBlockFlattenner.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+public class TestBlockFlattenner
+{
+    private ArrayAllocator allocator;
+    private BlockFlattener flattener;
+
+    @BeforeClass
+    public void setup()
+    {
+        this.allocator = new CountingArrayAllocator();
+        this.flattener = new BlockFlattener(allocator);
+    }
+
+    @Test
+    public void testLongArrayIdentityDecode()
+    {
+        Block block = createLongArrayBlock(1, 2, 3, 4);
+        try (BlockLease blockLease = flattener.flatten(block)) {
+            Block flattenedBlock = blockLease.get();
+            assertSame(flattenedBlock, block);
+        }
+    }
+
+    @Test
+    public void testNestedDictionaryRLELongArray()
+    {
+        DictionaryBlock block = createTestDictionaryBlock(createTestRleBlock(createLongArrayBlock(4), 3));
+        assertFlatten(
+                block,
+                flattenedBlock -> {
+                    assertEquals(allocator.getBorrowedArrayCount(), 1);
+
+                    assertEquals(flattenedBlock.getPositionCount(), block.getPositionCount());
+                    for (int i = 0; i < block.getPositionCount(); i++) {
+                        assertEquals(BIGINT.getLong(block, i), BIGINT.getLong(flattenedBlock, i));
+                    }
+                    assertEquals(flattenedBlock.getClass(), DictionaryBlock.class);
+                    DictionaryBlock decodedDictionary = (DictionaryBlock) flattenedBlock;
+                    assertEquals(decodedDictionary.getDictionary().getClass(), LongArrayBlock.class);
+                    assertEquals(1, decodedDictionary.getDictionary().getPositionCount());
+                });
+    }
+
+    @Test
+    public void testIntArrayIdentityDecode()
+    {
+        Block block = createIntArrayBlock(1, 2, 3, 4);
+        try (BlockLease blockLease = flattener.flatten(block)) {
+            Block flattenedBlock = blockLease.get();
+            assertSame(flattenedBlock, block);
+        }
+    }
+
+    @Test
+    public void testNestedDictionaryRLEIntArray()
+    {
+        DictionaryBlock block = createTestDictionaryBlock(createTestRleBlock(createIntArrayBlock(4), 3));
+        assertFlatten(
+                block,
+                flattenedBlock -> {
+                    assertEquals(allocator.getBorrowedArrayCount(), 1);
+
+                    assertEquals(flattenedBlock.getPositionCount(), block.getPositionCount());
+                    for (int i = 0; i < block.getPositionCount(); i++) {
+                        assertEquals(INTEGER.getLong(block, i), INTEGER.getLong(flattenedBlock, i));
+                    }
+                    assertEquals(flattenedBlock.getClass(), DictionaryBlock.class);
+                    DictionaryBlock decodedDictionary = (DictionaryBlock) flattenedBlock;
+                    assertEquals(decodedDictionary.getDictionary().getClass(), IntArrayBlock.class);
+                    assertEquals(1, decodedDictionary.getDictionary().getPositionCount());
+                });
+    }
+
+    @Test
+    public void testShortArrayIdentityDecode()
+    {
+        Block block = createShortArrayBlock(1, 2, 3, 4);
+        try (BlockLease blockLease = flattener.flatten(block)) {
+            Block flattenedBlock = blockLease.get();
+            assertSame(flattenedBlock, block);
+        }
+    }
+
+    @Test
+    public void testNestedDictionaryRLEShortArray()
+    {
+        DictionaryBlock block = createTestDictionaryBlock(createTestRleBlock(createShortArrayBlock(4), 3));
+        assertFlatten(
+                block,
+                flattenedBlock -> {
+                    assertEquals(allocator.getBorrowedArrayCount(), 1);
+
+                    assertEquals(flattenedBlock.getPositionCount(), block.getPositionCount());
+                    for (int i = 0; i < block.getPositionCount(); i++) {
+                        assertEquals(SMALLINT.getLong(block, i), SMALLINT.getLong(flattenedBlock, i));
+                    }
+                    assertEquals(flattenedBlock.getClass(), DictionaryBlock.class);
+                    DictionaryBlock decodedDictionary = (DictionaryBlock) flattenedBlock;
+                    assertEquals(decodedDictionary.getDictionary().getClass(), ShortArrayBlock.class);
+                    assertEquals(1, decodedDictionary.getDictionary().getPositionCount());
+                });
+    }
+
+    @Test
+    public void testByteArrayIdentityDecode()
+    {
+        Block block = createByteArrayBlock(1, 2, 3, 4);
+        try (BlockLease blockLease = flattener.flatten(block)) {
+            Block flattenedBlock = blockLease.get();
+            assertSame(flattenedBlock, block);
+        }
+    }
+
+    @Test
+    public void testNestedDictionaryRLEByteArray()
+    {
+        DictionaryBlock block = createTestDictionaryBlock(createTestRleBlock(createByteArrayBlock(4), 3));
+        assertFlatten(
+                block,
+                flattenedBlock -> {
+                    assertEquals(allocator.getBorrowedArrayCount(), 1);
+                    assertNotNull(flattenedBlock);
+
+                    assertEquals(flattenedBlock.getPositionCount(), block.getPositionCount());
+                    for (int i = 0; i < block.getPositionCount(); i++) {
+                        assertEquals(TINYINT.getLong(flattenedBlock, i), TINYINT.getLong(block, i));
+                        assertEquals(BOOLEAN.getBoolean(flattenedBlock, i), BOOLEAN.getBoolean(block, i));
+                    }
+                    assertEquals(flattenedBlock.getClass(), DictionaryBlock.class);
+                    DictionaryBlock decodedDictionary = (DictionaryBlock) flattenedBlock;
+                    assertEquals(decodedDictionary.getDictionary().getClass(), ByteArrayBlock.class);
+                    assertEquals(1, decodedDictionary.getDictionary().getPositionCount());
+                });
+    }
+
+    @Test
+    public void testNestedRLEs()
+    {
+        Block block = createTestRleBlock(createTestRleBlock(createTestRleBlock(createLongArrayBlock(5), 1), 1), 4);
+        assertEquals(block.getPositionCount(), 4);
+        try (BlockLease blockLease = flattener.flatten(block)) {
+            Block flattenedBlock = blockLease.get();
+            assertEquals(flattenedBlock.getClass(), RunLengthEncodedBlock.class);
+            assertEquals(flattenedBlock.getPositionCount(), block.getPositionCount());
+            assertEquals(flattenedBlock.getClass(), RunLengthEncodedBlock.class);
+            assertEquals(((RunLengthEncodedBlock) flattenedBlock).getValue().getClass(), LongArrayBlock.class);
+
+            Block innerBlock = ((RunLengthEncodedBlock) flattenedBlock).getValue();
+            assertEquals(innerBlock.getPositionCount(), 1);
+        }
+    }
+
+    @Test
+    public void testCardinalityIncreasingNestedDictionaryBlock()
+    {
+        Block block = new DictionaryBlock(
+                new DictionaryBlock(
+                        new DictionaryBlock(
+                            createLongArrayBlock(5, 6),
+                            new int[] {0, 1}),
+                        new int[] {0, 1, 0, 0, 1}),
+                new int[] {0, 1, 0, 0, 1, 1, 0});
+        assertFlatten(
+                block,
+                flattenedBlock -> {
+                    assertEquals(flattenedBlock.getPositionCount(), block.getPositionCount());
+                    assertEquals(((DictionaryBlock) flattenedBlock).getDictionary().getClass(), LongArrayBlock.class);
+
+                    for (int i = 0; i < block.getPositionCount(); i++) {
+                        assertEquals(flattenedBlock.getLong(i), block.getLong(i));
+                    }
+                });
+    }
+
+    @Test
+    public void testCardinalityDecreasingNestedDictionaryBlock()
+    {
+        Block block = new DictionaryBlock(
+                new DictionaryBlock(
+                        new DictionaryBlock(
+                                createLongArrayBlock(5, 6),
+                                new int[] {0, 1, 0, 0, 1, 1, 0}),
+                        new int[] {0, 1, 0}),
+                new int[] {0, 1});
+        assertFlatten(
+                block,
+                flattenedBlock -> {
+                    assertEquals(flattenedBlock.getPositionCount(), block.getPositionCount());
+                    assertEquals(((DictionaryBlock) flattenedBlock).getDictionary().getClass(), LongArrayBlock.class);
+
+                    for (int i = 0; i < block.getPositionCount(); i++) {
+                        assertEquals(flattenedBlock.getLong(i), block.getLong(i));
+                    }
+                });
+    }
+
+    @Test
+    public void testNestedDictionaryWithRLEWithLeftoverData()
+    {
+        Random random = ThreadLocalRandom.current();
+        Deque<int[]> leasedArrays = new ArrayDeque<>();
+        for (int i = 0; i < 10; i++) {
+            int[] randomInts = IntStream.range(0, 100).map(j -> random.nextInt()).toArray();
+            int[] array = allocator.borrowIntArray(100);
+            System.arraycopy(randomInts, 0, array, 0, randomInts.length);
+            leasedArrays.push(array);
+        }
+        while (!leasedArrays.isEmpty()) {
+            allocator.returnArray(leasedArrays.pop());
+        }
+        DictionaryBlock block = createTestDictionaryBlock(createTestRleBlock(createIntArrayBlock(4), 3));
+        assertFlatten(
+                block,
+                flattenedBlock -> {
+                    assertEquals(flattenedBlock.getClass(), DictionaryBlock.class);
+                    assertEquals(((DictionaryBlock) flattenedBlock).getDictionary().getClass(), IntArrayBlock.class);
+                    assertEquals(flattenedBlock.getPositionCount(), block.getPositionCount());
+                    for (int i = 0; i < block.getPositionCount(); i++) {
+                        assertEquals(INTEGER.getLong(flattenedBlock, i), INTEGER.getLong(block, i));
+                    }
+                });
+    }
+
+    private void assertFlatten(Block block, Consumer<Block> blockConsumer)
+    {
+        assertEquals(allocator.getBorrowedArrayCount(), 0);
+        try (BlockLease blockLease = flattener.flatten(block)) {
+            assertTrue(allocator.getBorrowedArrayCount() > 0);
+            Block retrievedBlock = blockLease.get();
+            assertNotNull(retrievedBlock);
+            blockConsumer.accept(retrievedBlock);
+            assertThrows(IllegalStateException.class, blockLease::get);
+        }
+        assertEquals(allocator.getBorrowedArrayCount(), 0);
+    }
+
+    private static Block createLongArrayBlock(long... values)
+    {
+        return new LongArrayBlock(values.length, Optional.empty(), values);
+    }
+
+    private static Block createIntArrayBlock(int... values)
+    {
+        return new IntArrayBlock(values.length, Optional.empty(), values);
+    }
+
+    private static Block createShortArrayBlock(int... values)
+    {
+        short[] shorts = new short[values.length];
+        for (int i = 0; i < values.length; i++) {
+            shorts[i] = (short) values[i];
+        }
+        return new ShortArrayBlock(shorts.length, Optional.empty(), shorts);
+    }
+
+    private static Block createByteArrayBlock(int... values)
+    {
+        byte[] bytes = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            bytes[i] = (byte) values[i];
+        }
+        return new ByteArrayBlock(bytes.length, Optional.empty(), bytes);
+    }
+
+    private static DictionaryBlock createTestDictionaryBlock(Block block)
+    {
+        int[] dictionaryIndexes = createTestDictionaryIndexes(block.getPositionCount());
+        return new DictionaryBlock(dictionaryIndexes.length, block, dictionaryIndexes);
+    }
+
+    private static int[] createTestDictionaryIndexes(int valueCount)
+    {
+        int[] dictionaryIndexes = new int[valueCount * 2];
+        for (int i = 0; i < valueCount; i++) {
+            dictionaryIndexes[i] = valueCount - i - 1;
+            dictionaryIndexes[i + valueCount] = i;
+        }
+        return dictionaryIndexes;
+    }
+
+    private static RunLengthEncodedBlock createTestRleBlock(Block block, int position)
+    {
+        return new RunLengthEncodedBlock(block, position);
+    }
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestClosingBlockLease.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestClosingBlockLease.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.block;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.block.ClosingBlockLease.newLease;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestClosingBlockLease
+{
+    private final Block dummyBlock = RunLengthEncodedBlock.create(BIGINT, 1L, 100);
+
+    @Test
+    public void testArrayAllocations()
+    {
+        CountingArrayAllocator allocator = new CountingArrayAllocator();
+
+        assertEquals(allocator.getBorrowedArrayCount(), 0);
+        int[] array = allocator.borrowIntArray(1);
+        try (BlockLease ignored = newLease(dummyBlock, () -> allocator.returnArray(array))) {
+            assertEquals(allocator.getBorrowedArrayCount(), 1);
+        }
+        assertEquals(allocator.getBorrowedArrayCount(), 0);
+    }
+
+    @Test
+    public void testArrayOverReturn()
+    {
+        CountingArrayAllocator allocator = new CountingArrayAllocator();
+
+        assertEquals(allocator.getBorrowedArrayCount(), 0);
+        int[] array = allocator.borrowIntArray(1);
+        BlockLease lease = newLease(dummyBlock, () -> allocator.returnArray(array));
+        assertEquals(allocator.getBorrowedArrayCount(), 1);
+        lease.close();
+        assertEquals(allocator.getBorrowedArrayCount(), 0);
+        lease.close();
+        assertEquals(allocator.getBorrowedArrayCount(), 0);
+    }
+
+    @Test
+    public void testClosingErrors()
+    {
+        BlockLease lease = newLease(
+                dummyBlock,
+                () -> {
+                    throw new IllegalStateException("1");
+                },
+                () -> {
+                    throw new IllegalArgumentException("2");
+                },
+                () -> {
+                    throw new StringIndexOutOfBoundsException("3");
+                });
+        try {
+            lease.close();
+            fail("expected RuntimeException");
+        }
+        catch (RuntimeException e) {
+            assertEquals(e.getCause().getClass(), IllegalStateException.class);
+            assertEquals(e.getCause().getSuppressed().length, 2);
+            assertEquals(e.getCause().getSuppressed()[0].getClass(), IllegalArgumentException.class);
+            assertEquals(e.getCause().getSuppressed()[1].getClass(), StringIndexOutOfBoundsException.class);
+        }
+    }
+}

--- a/src/checkstyle/presto-checks.xml
+++ b/src/checkstyle/presto-checks.xml
@@ -204,10 +204,6 @@
             <property name="allowLineBreaks" value="false" />
         </module>
 
-        <module name="IllegalToken">
-            <property name="tokens" value="LITERAL_ASSERT" />
-        </module>
-
         <module name="IllegalImport">
             <property name="illegalPkgs" value="org.weakref.jmx.internal" />
             <property name="illegalPkgs" value="jersey.repackaged" />


### PR DESCRIPTION
# High level goal

Join, repartitioning, and other future enhancements, need data access with minimal overhead for efficient access.  Experiments have shown nontrivial overhead from accessing deeply nested blocks and boundary checks over data which is not elided by the JVM.  We want "fast track" data access which trades safety for speed, with the idea that this API may require more care and testing.

# New components

## BlockFlattener

Returns a Block structure which is nested at most one level.  Nested structures, for the time being, are considered Dictionary and RLE blocks.  The idea is to flatten nested structures so that they are at most one level deep.  This promises better efficiency when operating over tight loops due to a lower cache miss rate.

## BlockLease

Repeated array allocation has nontrivial overhead, in particular when combined with block decoding/flattening, as this requires repeated array allocation when rewriting the nested ids map.  BlockLease is introduced as an `AutoCloseable` resources that is designed to return arrays for later reuse when finished, and `Supplier<Block>` to access the Block from within the try-with-resources.

## ArrayAllocator

A simple interface for creating and returning primitive arrays.  It may be used with a `BlockLease` to return an array for reuse when the lease has expired.  This class is designed to live at the operator level to avoid repeated array allocation over several iterations of calls to an operator.

## UncheckedBlock

Access over primitive types over blocks incurs nontrivial overhead from boundary checks which are not elided by the JVM.  Access over primitive arrays proves to have the best performance, as for example the JVM will elide most boundary checks in loops to the end of the loops.  We would like a compromise where we can get the performance of raw primitive arrays but with the encapsulation and convenience of Blocks.

The idea of UncheckedBlock is to hoist out boundary checks, so we pay the cost once in a loop rather than per item of the loop.  To accomplish this, we expose the offset of the block in UncheckedBlock--this provides the start of the iteration.  Once the offset is exposed, which is where the initial data lives in the underlying array, we exposed `getXXXUnchecked` methods to provide quick access which is strictly limited to underlying array access.  These methods will be inlined by the JVM into direct array access, giving us a good compromise of performance, with the slight inconvenience of a downcast to `UncheckedBlock`.

When complete, any block which is not RLE or Dictionary could be cast to UncheckedBlock, where a parallel API could be used to provide fast track access to the data in the Blocks.

## Decisions made

1. A decision was made that the Block interface is already heavily polluted, and adding unsafe accessor methods will further pollute this interface.
2. A decision was made to have a clear delineation of the "safe" word of Block into the "Unsafe" world of UncheckedBlock.  Meaning, you must do something inconvenient in order to obtain the necessary methods on UncheckedBlock, which signals that you're aware of the risks of coding errors or other issues.  i.e. UcheckedBlock is a "sharp instrument" which requires particular care.

