### PR TITLE
Reorder the lookup RecordSet in ThriftIndexedTpchService

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/tpch/TpchIndexedData.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/tpch/TpchIndexedData.java
@@ -82,6 +82,9 @@ public class TpchIndexedData
         indexedTables = indexedTablesBuilder.build();
     }
 
+    /**
+     * @apiNote this method returns a cached index table that is ordered in a certain order.
+     */
     public Optional<IndexedTable> getIndexedTable(String tableName, double scaleFactor, Set<String> indexColumnNames)
     {
         TpchScaledTable table = new TpchScaledTable(tableName, scaleFactor);
@@ -185,6 +188,7 @@ public class TpchIndexedData
 
         public RecordSet lookupKeys(RecordSet recordSet)
         {
+            // Since we only return a cached copy of IndexedTable, please make sure you reorder the input to same order of keyColumns
             checkArgument(recordSet.getColumnTypes().equals(keyTypes), "Input RecordSet keys do not match expected key type");
 
             Iterable<RecordSet> outputRecordSets = Iterables.transform(tupleIterable(recordSet), key -> {
@@ -196,10 +200,11 @@ public class TpchIndexedData
                 return lookupKey(key);
             });
 
+            // We will return result same order as outputColumns
             return new ConcatRecordSet(outputRecordSets, outputTypes);
         }
 
-        public RecordSet lookupKey(MaterializedTuple tupleKey)
+        private RecordSet lookupKey(MaterializedTuple tupleKey)
         {
             return new MaterializedTupleRecordSet(keyToValues.get(tupleKey), outputTypes);
         }

--- a/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftIndexedTpchService.java
+++ b/presto-thrift-testing-server/src/main/java/com/facebook/presto/connector/thrift/server/ThriftIndexedTpchService.java
@@ -97,7 +97,7 @@ public class ThriftIndexedTpchService
                 ImmutableSet.copyOf(splitInfo.getLookupColumnNames()))
                 .orElseThrow(() -> new IllegalArgumentException(String.format("No such index: %s%s", splitInfo.getTableName(), splitInfo.getLookupColumnNames())));
         List<Type> lookupColumnTypes = types(splitInfo.getTableName(), splitInfo.getLookupColumnNames());
-        RecordSet keyRecordSet = new ListBasedRecordSet(splitInfo.getKeys(), lookupColumnTypes);
+        RecordSet keyRecordSet = new MappedRecordSet(new ListBasedRecordSet(splitInfo.getKeys(), lookupColumnTypes), computeRemap(splitInfo.getLookupColumnNames(), indexedTable.getKeyColumns()));
         RecordSet outputRecordSet = lookupIndexKeys(keyRecordSet, indexedTable, outputColumnNames);
         return new RecordPageSource(outputRecordSet);
     }


### PR DESCRIPTION
IndexedTable is cached with a fixed order. To do a lookup, we should
always reorder input RecordSet to match with it.