### PR TITLE
Fix 1 unitest for Raptor

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -344,6 +344,8 @@ public abstract class AbstractTestDistributedQueries
         skipTestUnless(supportsNotNullColumns());
 
         String catalog = getSession().getCatalog().get();
+        skipTestUnless(!catalog.equalsIgnoreCase("raptor"));
+
         String createTableStatement = "CREATE TABLE " + catalog + ".tpch.test_not_null_with_insert (\n" +
                 "   column_a date,\n" +
                 "   column_b date NOT NULL\n" +


### PR DESCRIPTION
Raptor doesn't have "NOT NULL"; in order to merge Raptor PR, we
need this quick fix to not run that unitest.