### PR TITLE
Add TableStatistics in QueryInputMetadata for Join Query

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -319,7 +319,8 @@ public class QueryMonitor
                     input.getTable(),
                     input.getColumns().stream()
                             .map(Column::getName).collect(Collectors.toList()),
-                    input.getConnectorInfo()));
+                    input.getConnectorInfo(),
+                    input.getStatistics()));
         }
 
         Optional<QueryOutputMetadata> output = Optional.empty();

--- a/presto-main/src/main/java/com/facebook/presto/execution/Input.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/Input.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.statistics.TableStatistics;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -35,6 +36,7 @@ public final class Input
     private final String table;
     private final List<Column> columns;
     private final Optional<Object> connectorInfo;
+    private final Optional<TableStatistics> statistics;
 
     @JsonCreator
     public Input(
@@ -42,19 +44,15 @@ public final class Input
             @JsonProperty("schema") String schema,
             @JsonProperty("table") String table,
             @JsonProperty("connectorInfo") Optional<Object> connectorInfo,
-            @JsonProperty("columns") List<Column> columns)
+            @JsonProperty("columns") List<Column> columns,
+            @JsonProperty("statistics") Optional<TableStatistics> statistics)
     {
-        requireNonNull(connectorId, "connectorId is null");
-        requireNonNull(schema, "schema is null");
-        requireNonNull(table, "table is null");
-        requireNonNull(connectorInfo, "connectorInfo is null");
-        requireNonNull(columns, "columns is null");
-
-        this.connectorId = connectorId;
-        this.schema = schema;
-        this.table = table;
-        this.connectorInfo = connectorInfo;
-        this.columns = ImmutableList.copyOf(columns);
+        this.connectorId = requireNonNull(connectorId, "connectorId is null");
+        this.schema = requireNonNull(schema, "schema is null");
+        this.table = requireNonNull(table, "table is null");
+        this.connectorInfo = requireNonNull(connectorInfo, "connectorInfo is null");
+        this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
+        this.statistics = requireNonNull(statistics, "table statistics is null");
     }
 
     @JsonProperty
@@ -87,6 +85,12 @@ public final class Input
         return columns;
     }
 
+    @JsonProperty
+    public Optional<TableStatistics> getStatistics()
+    {
+        return statistics;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -101,13 +105,14 @@ public final class Input
                 Objects.equals(schema, input.schema) &&
                 Objects.equals(table, input.table) &&
                 Objects.equals(columns, input.columns) &&
-                Objects.equals(connectorInfo, input.connectorInfo);
+                Objects.equals(connectorInfo, input.connectorInfo) &&
+                Objects.equals(statistics, input.statistics);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(connectorId, schema, table, columns, connectorInfo);
+        return Objects.hash(connectorId, schema, table, columns, connectorInfo, statistics);
     }
 
     @Override
@@ -118,6 +123,7 @@ public final class Input
                 .addValue(schema)
                 .addValue(table)
                 .addValue(columns)
+                .addValue(statistics)
                 .toString();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestInput.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestInput.java
@@ -32,7 +32,8 @@ public class TestInput
         Input expected = new Input(new ConnectorId("connectorId"), "schema", "table", Optional.empty(), ImmutableList.of(
                 new Column("column1", "string"),
                 new Column("column2", "string"),
-                new Column("column3", "string")));
+                new Column("column3", "string")),
+                Optional.empty());
 
         String json = codec.toJson(expected);
         Input actual = codec.fromJson(json);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -75,7 +75,7 @@ public class TestQueryStateMachine
     private static final String QUERY = "sql";
     private static final URI LOCATION = URI.create("fake://fake-query");
     private static final SQLException FAILED_CAUSE = new SQLException("FAILED");
-    private static final List<Input> INPUTS = ImmutableList.of(new Input(new ConnectorId("connector"), "schema", "table", Optional.empty(), ImmutableList.of(new Column("a", "varchar"))));
+    private static final List<Input> INPUTS = ImmutableList.of(new Input(new ConnectorId("connector"), "schema", "table", Optional.empty(), ImmutableList.of(new Column("a", "varchar")), Optional.empty()));
     private static final Optional<Output> OUTPUT = Optional.empty();
     private static final List<String> OUTPUT_FIELD_NAMES = ImmutableList.of("a", "b", "c");
     private static final List<Type> OUTPUT_FIELD_TYPES = ImmutableList.of(BIGINT, BIGINT, BIGINT);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryInputMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryInputMetadata.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.eventlistener;
 
+import com.facebook.presto.spi.statistics.TableStatistics;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -27,14 +28,16 @@ public class QueryInputMetadata
     private final String table;
     private final List<String> columns;
     private final Optional<Object> connectorInfo;
+    private final Optional<TableStatistics> statistics;
 
-    public QueryInputMetadata(String catalogName, String schema, String table, List<String> columns, Optional<Object> connectorInfo)
+    public QueryInputMetadata(String catalogName, String schema, String table, List<String> columns, Optional<Object> connectorInfo, Optional<TableStatistics> statistics)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
         this.columns = requireNonNull(columns, "columns is null");
         this.connectorInfo = requireNonNull(connectorInfo, "connectorInfo is null");
+        this.statistics = requireNonNull(statistics, "table statistics is null");
     }
 
     @JsonProperty
@@ -65,5 +68,11 @@ public class QueryInputMetadata
     public Optional<Object> getConnectorInfo()
     {
         return connectorInfo;
+    }
+
+    @JsonProperty
+    public Optional<TableStatistics> getStatistics()
+    {
+        return statistics;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.spi.statistics;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Objects;
 import java.util.Optional;
 
@@ -56,21 +58,25 @@ public final class ColumnStatistics
         this.range = requireNonNull(range, "range is null");
     }
 
+    @JsonProperty
     public Estimate getNullsFraction()
     {
         return nullsFraction;
     }
 
+    @JsonProperty
     public Estimate getDistinctValuesCount()
     {
         return distinctValuesCount;
     }
 
+    @JsonProperty
     public Estimate getDataSize()
     {
         return dataSize;
     }
 
+    @JsonProperty
     public Optional<DoubleRange> getRange()
     {
         return range;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/DoubleRange.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/DoubleRange.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.spi.statistics;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Objects;
 
 import static java.lang.Double.isNaN;
@@ -41,11 +43,13 @@ public class DoubleRange
         this.max = max;
     }
 
+    @JsonProperty
     public double getMin()
     {
         return min;
     }
 
+    @JsonProperty
     public double getMax()
     {
         return max;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/Estimate.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/Estimate.java
@@ -14,6 +14,8 @@
 
 package com.facebook.presto.spi.statistics;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Objects;
 
 import static java.lang.Double.NaN;
@@ -62,6 +64,7 @@ public final class Estimate
         return isNaN(value);
     }
 
+    @JsonProperty
     public double getValue()
     {
         return value;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatistics.java
@@ -15,6 +15,7 @@
 package com.facebook.presto.spi.statistics;
 
 import com.facebook.presto.spi.ColumnHandle;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -45,11 +46,13 @@ public final class TableStatistics
         this.columnStatistics = unmodifiableMap(requireNonNull(columnStatistics, "columnStatistics can not be null"));
     }
 
+    @JsonProperty
     public Estimate getRowCount()
     {
         return rowCount;
     }
 
+    @JsonProperty
     public Map<ColumnHandle, ColumnStatistics> getColumnStatistics()
     {
         return columnStatistics;

--- a/presto-tpcds/pom.xml
+++ b/presto-tpcds/pom.xml
@@ -33,6 +33,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>joda-to-java-time-bridge</artifactId>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
Table stats availablity is important for cost-based optimization
of join query. Add it to QueryInputMetadata class.

Test is added to show example of TableStatisitcs in json format.