### PR TITLE
[Geospatial] WIP Initial work on simpler RTrees.

### DIFF
--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
@@ -160,4 +160,16 @@ public final class GeometryUtils
 
         return true;
     }
+
+    public static Rectangle getRectangle(Envelope envelope)
+    {
+        Point minPoint = envelope.getLowerLeft();
+        Point maxPoint = envelope.getUpperRight();
+        return new Rectangle(minPoint.getX(), minPoint.getY(), maxPoint.getX(), maxPoint.getY());
+    }
+
+    public static Rectangle getRectangle(OGCGeometry geometry)
+    {
+        return getRectangle(getEnvelope(geometry));
+    }
 }

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/Rectangle.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/Rectangle.java
@@ -77,6 +77,7 @@ public final class Rectangle
     {
         return xMax - xMin;
     }
+
     public double getHeight()
     {
         return yMax - yMin;
@@ -101,6 +102,21 @@ public final class Rectangle
     public Rectangle merge(Rectangle other)
     {
         return new Rectangle(min(this.xMin, other.xMin), min(this.yMin, other.yMin), max(this.xMax, other.xMax), max(this.yMax, other.yMax));
+    }
+
+    /**
+     * Return the minimum euclidean distance squared to another envelope.
+     * <p>
+     * If they intersect, return 0.0.
+     *
+     * @param other
+     * @return distance squared
+     */
+    public double distance2(Rectangle other)
+    {
+        double dx = max(xMin - other.xMax, 0) + max(other.xMin - xMax, 0);
+        double dy = max(yMin - other.yMax, 0) + max(other.yMin - yMax, 0);
+        return dx * dx + dy * dy;
     }
 
     public int estimateMemorySize()

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/rtree/IntersectionIterator.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/rtree/IntersectionIterator.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.geospatial.rtree;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.facebook.presto.geospatial.Rectangle;
+import com.facebook.presto.geospatial.rtree.StrRTree.Node;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.Optional;
+
+/**
+ * Iterate over all entries in the RTree with envelope intersection.
+ *
+ * This only checks that the envelopes intersect; the caller must filter by
+ * actual intersection if desired.  There is no guarantee of order.
+ */
+public class IntersectionIterator
+        implements Iterator<OGCGeometry>
+{
+    private final Deque<Node> stack = new ArrayDeque<Node>();
+    private final Rectangle queryEnvelope;
+    private Optional<OGCGeometry> nextCandidate = Optional.empty();
+
+    public IntersectionIterator(Rectangle queryEnvelope, Node root)
+    {
+        stack.addFirst(root);
+        this.queryEnvelope = queryEnvelope;
+        advance();
+    }
+
+    public boolean hasNext()
+    {
+        return nextCandidate.isPresent();
+    }
+
+    public OGCGeometry next()
+    {
+        OGCGeometry next = nextCandidate.get();
+        nextCandidate = Optional.empty();
+        advance();
+        return next;
+    }
+
+    private void advance()
+    {
+        // ??? Check that nextCandidate is empty?
+        while (stack.size() > 0) {
+            Node node = stack.removeFirst();
+            if (!queryEnvelope.intersects(node.getExtent())) {
+                continue;
+            }
+            if (node.isLeaf()) {
+                nextCandidate = node.getGeometry();
+                break;
+            }
+            else {
+                node.getChildren().get().stream().forEach(child -> stack.addFirst(child));
+            }
+        }
+    }
+}
+

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/rtree/NeighborIterator.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/rtree/NeighborIterator.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.geospatial.rtree;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.facebook.presto.geospatial.GeometryUtils;
+import com.facebook.presto.geospatial.Rectangle;
+import com.facebook.presto.geospatial.rtree.StrRTree.Neighbor;
+import com.facebook.presto.geospatial.rtree.StrRTree.Node;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.PriorityQueue;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Iterate over the entries in an RTree in order of increasing distance.
+ *
+ * All entries will be iterated over if the iterator is exhausted.
+ *
+ * It works by using a min-heap sorted by distance-squared.  The key
+ * observation is that distance(a.envelope, b.envelope) <= distance(a, b).
+ * For RTree nodes, we can calculate relatively cheap envelope-envelope
+ * distances.  Each node is expanded into their children, which are re-inserted
+ * into the heap.  When a Leaf node is pulled from the heap, the distance
+ * between the actual query geometry and the geometry contained in the leaf
+ * node is calculated; the `actualDistance` flag is set to indicate this the true
+ * distance and not the envelope lower-bound.  Thus when an entry with
+ * `actualDistance` is pulled, it must be the nearest geometry, and it can
+ * be yielded.
+ */
+public class NeighborIterator
+        implements Iterator<Neighbor>
+{
+    public static final Comparator<Entry> entryComparator = (first, second) -> Double.compare(first.distance2, second.distance2);
+    private final PriorityQueue<Entry> heap = new PriorityQueue(1, entryComparator);
+    private final Rectangle queryEnvelope;
+    private final OGCGeometry queryGeometry;
+    private Optional<Neighbor> nextCandidate = Optional.empty();
+
+    public NeighborIterator(OGCGeometry geometry, Node root)
+    {
+        queryEnvelope = GeometryUtils.getRectangle(geometry);
+        queryGeometry = geometry;
+        heap.add(new Entry(queryEnvelope.distance2(root.getExtent()), root));
+        advance();
+    }
+
+    public boolean hasNext()
+    {
+        return nextCandidate.isPresent();
+    }
+
+    public Neighbor next()
+    {
+        Neighbor neighbor = nextCandidate.get();
+        nextCandidate = Optional.empty();
+        advance();
+        return neighbor;
+    }
+
+    private void advance()
+    {
+        while (!heap.isEmpty()) {
+            Entry entry = heap.poll();
+            Node node = entry.getNode();
+            if (entry.isActualDistance()) {
+                checkArgument(node.isLeaf(), "Non-leaf node has actual distance set.");
+                nextCandidate = Optional.of(new Neighbor(Math.sqrt(entry.getDistance2()), node.getGeometry().get()));
+                break;
+            }
+            if (node.isLeaf()) {
+                double distance = queryGeometry.distance(node.getGeometry().get());
+                entry.setDistance2(distance * distance);
+                entry.setActualDistance(true);
+                heap.add(entry);
+            }
+            else {
+                node.getChildren().get().stream().forEach(c -> heap.add(new Entry(
+                        queryEnvelope.distance2(c.getExtent()), c
+                )));
+            }
+        }
+    }
+
+    public static final class Entry
+    {
+        private final Node node;
+        private double distance2;
+        // Leaf nodes will first be inserted with Envelope distance, then actual distance.
+        private boolean actualDistance = false;
+
+        public Entry(double distance2, Node node)
+        {
+            this.distance2 = distance2;
+            this.node = node;
+        }
+
+        public double getDistance2()
+        {
+            return distance2;
+        }
+
+        public void setDistance2(double distance2)
+        {
+            this.distance2 = distance2;
+        }
+
+        public boolean isActualDistance()
+        {
+            return actualDistance;
+        }
+
+        public void setActualDistance(boolean actualDistance)
+        {
+            this.actualDistance = actualDistance;
+        }
+
+        public Node getNode()
+        {
+            return node;
+        }
+    }
+}

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/rtree/RTreeUtils.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/rtree/RTreeUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.geospatial.rtree;
+
+import com.facebook.presto.geospatial.Rectangle;
+import com.facebook.presto.geospatial.rtree.StrRTree.Node;
+import com.google.common.collect.ComparisonChain;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class RTreeUtils
+{
+    private static final Comparator<StrRTree.Node> xComparator = (first, second) -> ComparisonChain.start()
+            .compare(first.getExtent().getXMin(), second.getExtent().getXMin())
+            .compare(first.getExtent().getXMax(), second.getExtent().getXMax())
+            .result();
+    private static final Comparator<StrRTree.Node> yComparator = (first, second) -> ComparisonChain.start()
+            .compare(first.getExtent().getYMin(), second.getExtent().getYMin())
+            .compare(first.getExtent().getYMax(), second.getExtent().getYMax())
+            .result();
+
+    public static Node bulkLoad(List<Node> leaves, int maxChildren)
+    {
+        checkArgument(leaves.size() > 0, "Must have at least one leaf node.");
+        List<Node> nodes = leaves;
+        while (nodes.size() > maxChildren) {
+            nodes = tileOneLevel(nodes, maxChildren);
+        }
+        return Node.newInternal(mergeRectangles(nodes), nodes);
+    }
+
+    private static List<Node> tileOneLevel(List<Node> children, int maxChildren)
+    {
+        List<Node> parents = new ArrayList<Node>();
+        Collections.sort(children, xComparator);
+        // First we slice children into vertical slices
+        int sliceSize = (int) Math.ceil(Math.sqrt(1.0 * children.size() / maxChildren));
+        for (int sliceStart = 0; sliceStart < children.size(); sliceStart += sliceSize) {
+            int sliceEnd = Math.min(sliceStart + sliceSize, children.size());
+            List<Node> verticalSlice = children.subList(sliceStart, sliceEnd);
+            verticalSlice.sort(yComparator);
+            // Now slice them into blocks with horizontal slices
+            for (int blockStart = 0; blockStart < verticalSlice.size(); blockStart += sliceSize) {
+                int blockEnd = Math.min(blockStart + sliceSize, verticalSlice.size());
+                List<Node> blockNodes = verticalSlice.subList(blockStart, blockEnd);
+                parents.add(Node.newInternal(mergeRectangles(blockNodes), blockNodes));
+            }
+        }
+        return parents;
+    }
+
+    private static Rectangle mergeRectangles(List<Node> nodes)
+    {
+        checkArgument(nodes.size() > 0, "Must have at least one node.");
+        Rectangle rectangle = null;
+        for (Node node : nodes) {
+            rectangle = rectangle == null ? node.getExtent() : rectangle.merge(node.getExtent());
+        }
+        return rectangle;
+    }
+}

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/rtree/StrRTree.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/rtree/StrRTree.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.geospatial.rtree;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.facebook.presto.geospatial.GeometryUtils;
+import com.facebook.presto.geospatial.Rectangle;
+import com.google.common.collect.Streams;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * 2-dimensional Rtree created with STR bulk loading.
+ * <p>
+ * STR (Sort-Tile-Recurse) Rtrees are bulk-loaded query-only Rtrees that support very efficient
+ * queries.  Intuitively, they "tile" the 2d space such that each tile contains
+ * no more than max_children objects, and make a parent node for each tile.
+ * This procedure is performed recursively on those parent nodes, and so on,
+ * until a root node is reached.
+ * <p>
+ * Rtrees: https://en.wikipedia.org/wiki/R-tree
+ * STR loading: https://www.researchgate.net/publication/3686660_STR_A_Simple_and_Efficient_Algorithm_for_R-Tree_Packing
+ */
+public class StrRTree
+{
+
+    private final int maxChildren;
+    private final Node root;
+
+    public StrRTree(List<OGCGeometry> geometries, int maxChildren)
+    {
+        this.maxChildren = maxChildren;
+        List<Node> leaves = geometries.stream()
+                .map(geom -> Node.newLeaf(GeometryUtils.getRectangle(geom), geom))
+                .collect(Collectors.toList());
+        this.root = RTreeUtils.bulkLoad(leaves, maxChildren);
+    }
+
+    public int getMaxChildren()
+    {
+        return maxChildren;
+    }
+
+    public Node getRoot()
+    {
+        return root;
+    }
+
+    public Stream<OGCGeometry> findEnvelopeIntersections(Rectangle envelope)
+    {
+        return Streams.stream(new IntersectionIterator(envelope, root));
+    }
+
+    public Stream<Neighbor> findNeighbors(OGCGeometry geometry)
+    {
+        return Streams.stream(new NeighborIterator(geometry, root));
+    }
+
+    public List<Neighbor> findNearestNeighbors(OGCGeometry geometry, int numNeighbors)
+    {
+        return findNeighbors(geometry).limit(numNeighbors).collect(Collectors.toList());
+    }
+
+    public List<Neighbor> findNeighborsWithin(OGCGeometry geometry, double distance)
+    {
+        // There's really no takeWhile function?
+        List<Neighbor> neighborsWithin = new ArrayList<Neighbor>();
+        Iterator<Neighbor> allNeighbors = new NeighborIterator(geometry, root);
+        while (allNeighbors.hasNext()) {
+            Neighbor neighbor = allNeighbors.next();
+            if (neighbor.getDistance() > distance) {
+                break;
+            }
+            neighborsWithin.add(neighbor);
+        }
+        return neighborsWithin;
+    }
+
+    public static final class Node
+    {
+        private final Rectangle extent;
+        private final Optional<OGCGeometry> geometry;
+        private final Optional<List<Node>> children;
+
+        public Node(
+                Rectangle extent,
+                Optional<OGCGeometry> geometry,
+                Optional<List<StrRTree.Node>> children)
+        {
+            this.extent = requireNonNull(extent, "extent is null");
+            this.geometry = requireNonNull(geometry, "geometry is null");
+            this.children = requireNonNull(children, "children is null");
+            if (geometry.isPresent()) {
+                checkArgument(!children.isPresent(), "Leaf node cannot have children");
+            }
+            else {
+                checkArgument(children.isPresent(), "Internal node must have children");
+            }
+        }
+
+        public static Node newLeaf(Rectangle extent, OGCGeometry geometry)
+        {
+            return new Node(extent, Optional.of(geometry), Optional.empty());
+        }
+
+        public static Node newInternal(Rectangle extent, List<Node> children)
+        {
+            return new Node(extent, Optional.empty(), Optional.of(children));
+        }
+
+        public Rectangle getExtent()
+        {
+            return extent;
+        }
+
+        public Optional<OGCGeometry> getGeometry()
+        {
+            return geometry;
+        }
+
+        public Optional<List<StrRTree.Node>> getChildren()
+        {
+            return children;
+        }
+
+        public boolean isLeaf()
+        {
+            return geometry.isPresent();
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (obj == null) {
+                return false;
+            }
+
+            if (!(obj instanceof StrRTree.Node)) {
+                return false;
+            }
+
+            StrRTree.Node other = (StrRTree.Node) obj;
+            return this.extent.equals(other.extent)
+                    && Objects.equals(this.geometry, other.geometry)
+                    && Objects.equals(this.children, other.children);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(extent, geometry, children);
+        }
+    }
+
+    public static final class Neighbor
+    {
+        private final double distance;
+        private final OGCGeometry geometry;
+
+        public Neighbor(double distance, OGCGeometry geometry)
+        {
+            this.distance = distance;
+            this.geometry = geometry;
+        }
+
+        public double getDistance()
+        {
+            return distance;
+        }
+
+        public OGCGeometry getGeometry()
+        {
+            return geometry;
+        }
+    }
+}


### PR DESCRIPTION
This is some initial work on more efficient, GC-friendly RTrees.

Step 1 (this one) creates a relatively simple bulk-loaded STR Rtree.
It does create some objects on the heap, but its intended use will
only be to efficiently create a flat RTree.  It's intended that all the
objects created by this tree won't make it past the new generation.

Step 2 (to come) will create a flat RTree, which has only three members:
  * `int maxNumChildren`: Max num children per node.
  * `double[] nodes`: Flattened array of bounding boxes of nodes.
  * `OGCGeometry[] geometries`: Array of leaf geometries, in compatible order with the
tail of `nodes`.

Things I don't like:
* I don't like how tightly the implementation is tied to OGCGeometry.
  I'd rather have an interface that allowed querying an envelope, but Java
  doesn't let me force an Interface post-facto onto existing classes.
* Streams seem clumsy here, but I think it's nice to be able to
  map/filter the query results.

cc @mbasmanova @arhimondr 