### PR TITLE
[GeoSpatial] Add xxHash64 operator to Bing Tiles

### DIFF
--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/BingTileOperators.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/BingTileOperators.java
@@ -19,11 +19,13 @@ import com.facebook.presto.spi.function.SqlNullable;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.AbstractLongType;
 import com.facebook.presto.spi.type.StandardTypes;
+import io.airlift.slice.XxHash64;
 
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.HASH_CODE;
 import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.function.OperatorType.XX_HASH_64;
 
 public final class BingTileOperators
 {
@@ -67,5 +69,12 @@ public final class BingTileOperators
     public static long hashCode(@SqlType(BingTileType.NAME) long value)
     {
         return AbstractLongType.hash(value);
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(BingTileType.NAME) long value)
+    {
+        return XxHash64.hash(value);
     }
 }


### PR DESCRIPTION
In particular, this enables operators like approx_distinct which
requires the object to be xxHashable.

Fixes #12822 