### PR TITLE
Create test bucketed tables in ORC format

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -273,13 +273,13 @@ public final class HiveQueryRunner
                 sql = format("CREATE TABLE %s AS SELECT * FROM %s", table.getObjectName(), table);
                 break;
             case "lineitem":
-                sql = format("CREATE TABLE %s WITH (bucketed_by=array['orderkey'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
+                sql = format("CREATE TABLE %s WITH (format = 'ORC', bucketed_by=array['orderkey'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
                 break;
             case "customer":
-                sql = format("CREATE TABLE %s WITH (bucketed_by=array['custkey'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
+                sql = format("CREATE TABLE %s WITH (format = 'ORC', bucketed_by=array['custkey'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
                 break;
             case "orders":
-                sql = format("CREATE TABLE %s WITH (bucketed_by=array['custkey'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
+                sql = format("CREATE TABLE %s WITH (format = 'ORC', bucketed_by=array['custkey'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
                 break;
             default:
                 throw new UnsupportedOperationException();


### PR DESCRIPTION
Before this change HiveQueryRunner#copyTpchTablesBucketed created
tables in text format while HiveQueryRunner#copyTpchTables created tables in ORC format.