### PR TITLE
Make StageScheduler notify all tasks are scheduled

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedCountScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedCountScheduler.java
@@ -61,6 +61,8 @@ public class FixedCountScheduler
                 .map(Optional::get)
                 .collect(toImmutableList());
 
+        // no need to call stage.transitionToSchedulingSplits() since there is no table splits
+
         return ScheduleResult.nonBlocked(true, newTasks, 0);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -173,6 +173,9 @@ public class FixedSourcePartitionedScheduler
                     .map(Optional::get)
                     .collect(toImmutableList());
             scheduledTasks = true;
+
+            // notify listeners that we have scheduled all tasks so they can set no more buffers or exchange splits
+            stage.transitionToSchedulingSplits();
         }
 
         boolean allBlocked = true;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
@@ -335,7 +335,7 @@ public class SourcePartitionedScheduler
             return ScheduleResult.nonBlocked(false, overallNewTasks.build(), overallSplitAssignmentCount);
         }
 
-        if (anyBlockedOnPlacements || groupedExecution) {
+        if (anyBlockedOnPlacements) {
             // In a broadcast join, output buffers of the tasks in build source stage have to
             // hold onto all data produced before probe side task scheduling finishes,
             // even if the data is acknowledged by all known consumers. This is because
@@ -346,6 +346,9 @@ public class SourcePartitionedScheduler
             // The build side blocks due to a full output buffer.
             // In the meantime the probe side split cannot be consumed since
             // builder side hash table construction has not finished.
+            //
+            // TODO: When SourcePartitionedScheduler is used as a SourceScheduler, it shouldn't need to worry about
+            //  task scheduling and creation -- these are done by the StageScheduler.
             overallNewTasks.addAll(finalizeTaskCreationIfNecessary());
         }
 


### PR DESCRIPTION
There are three major responsibilities for `SourcePartitionedScheduler`:
- Split schedule
- Task schedule and stage management
- Lifespan schedule

Note `SourcePartitionedScheduler` can be used either as a `StageScheduler` or `SourceScheduler`. In both case it needs to take care about split schedule. 

- When it's used as a `StageScheduler`, it's always used for unpartitioned stage (i.e. JOIN/AGGREGATE over *remote* source. 
  - It needs to take care about task schedule
  - It doesn't need to take care about lifespan schedule

- When it's used as a `SourceScheduler`, it's used by a `FixedSourcePartitionedScheduler` to schedule table scan sources.
   * It doesn't need to take care about task schedule (although today it still do so) 
   * It need to take care about lifespan schedule (behemoth warning!)

Historically, `FixedSourcePartitionedScheduler` doesn't call `stage.transitionToSchedulingSplits()`. And it  relies on `SourcePartitionedScheduler` to do this stage management,  even `SourcePartitionedScheduler` is used as a `SourceScheduler`.  This is confusing and error-prone, as it should be `StageScheduler`'s responsibility to do stage management .

This commit makes `FixedSourcePartitionedScheduler` to call `stage.transitionToSchedulingSplits()`. As a result, it release the needs for `SourcePartitionedScheduler` from doing this for grouped execution (In the context of grouped execution, `SourcePartitionedScheduler` is guaranteed to be used as a `SourceScheduler`). 

In principle, `SourcePartitionedScheduler`  doesn't need to do stage management at all  as long as it's used as a `SourceScheduler` (even for ungrouped execution).  This is not done in this commit. 

`FixedCountScheduler` doesn't need to  call `stage.transitionToSchedulingSplits()`  since it there will be no table splits to schedule.