### PR TITLE
Support synthetic column names in Subfield

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/SubfieldTokenizer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SubfieldTokenizer.java
@@ -148,7 +148,7 @@ class SubfieldTokenizer
 
     private static boolean isUnquotedPathCharacter(char c)
     {
-        return c == ':' || isUnquotedSubscriptCharacter(c);
+        return c == ':' || c == '$' || isUnquotedSubscriptCharacter(c);
     }
 
     private Subfield.PathElement matchUnquotedSubscript()

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestSubfieldTokenizer.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestSubfieldTokenizer.java
@@ -33,6 +33,7 @@ public class TestSubfieldTokenizer
     {
         List<PathElement> elements = ImmutableList.of(
                 new NestedField("b"),
+                new NestedField("$bucket"),
                 new Subfield.LongSubscript(2),
                 new Subfield.StringSubscript("z"),
                 Subfield.allSubscripts(),


### PR DESCRIPTION
Make $-sign a valid character in subfield path to support filters on $bucket
and $path columns, e.g. SELECT * FROM t WHERE $bucket = 1.

CC: @oerling @yingsu00 @arhimondr @wenleix 