### PR TITLE
Fix race condition in the SqlQueryScheduler

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -763,11 +763,11 @@ public class SqlQueryScheduler
             }
         }
         catch (Throwable t) {
+            scheduling.set(false);
             queryStateMachine.transitionToFailed(t);
             throw t;
         }
         finally {
-            scheduling.set(false);
             RuntimeException closeError = new RuntimeException();
             for (SqlStageExecution stage : stages) {
                 try {


### PR DESCRIPTION
The `scheduling` is supposed to ensure that only a single
scheduling happens at any moment of a time.

If the finally block is executed after the next streaming section
has already started scheduling, the "scheduling" flag will be set
to "false" despite the scheduling of the second streaming section
is still in process.