### PR TITLE
Fix a time format string in the tests.

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
@@ -875,7 +875,7 @@ public abstract class TestDateTimeFunctionsBase
         assertInvalidFunction("date_parse('', '%X')", "%X not supported in date format string");
 
         assertInvalidFunction("date_parse('3.0123456789', '%s.%f')", "Invalid format: \"3.0123456789\" is malformed at \"9\"");
-        assertInvalidFunction("date_parse('%Y-%M-%d', '')", "Both printing and parsing not supported");
+        assertInvalidFunction("date_parse('%Y-%m-%d', '')", "Both printing and parsing not supported");
     }
 
     @Test


### PR DESCRIPTION
`%M` is the code for the current minute; `%m` is the month. `%Y-%M` is thus never a format string you want.

This isn't actually a bug since this is testing that the code errors, and won't actually examine the contents of the format, but I found it in a large-scale grep for this common bug; fixing it resolves the slim chance of someone cargo-culting it, or doing the same grep and having to do the same work I did to ignore it.