### PR TITLE
return create table or create view statements in spite of user error

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -438,7 +438,9 @@ final class ShowQueriesRewrite
 
             if (node.getType() == TABLE) {
                 if (viewDefinition.isPresent()) {
-                    throw new SemanticException(NOT_SUPPORTED, node, "Relation '%s' is a view, not a table", objectName);
+                    Query query = parseView(viewDefinition.get().getOriginalSql(), objectName, node);
+                    String sql = formatSql(new CreateView(createQualifiedName(objectName), query, false), Optional.of(parameters)).trim();
+                    return singleValueQuery("Create View", sql);
                 }
 
                 Optional<TableHandle> tableHandle = metadata.getTableHandle(session, objectName);


### PR DESCRIPTION
There is no reason not return the create view statement here. if the users type show create table instead of show create view, the mistake has been made, but if there's a view by that name, why not just show the create statement instead of throwing an error.