### PR TITLE
s/hostAddress/host in Elasticsearch connector docs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/presto-docs/src/main/sphinx/connector/elasticsearch.rst
@@ -222,7 +222,7 @@ A table definition file describes a table in JSON format.
     {
         "tableName": ...,
         "schemaName": ...,
-        "hostAddress": ...,
+        "host": ...,
         "port": ...,
         "clusterName": ...,
         "index": ...,


### PR DESCRIPTION
This PR is a small change, but it tripped me up and took a good few minutes to figure it out. Especially useful for people who copy, paste, and then edit snippets of code from the documentation :wink:.