### PR TITLE
Move getPathDomain to HiveSplitManager

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -24,11 +24,10 @@ import com.facebook.presto.hive.util.HiveFileIterator.NestedDirectoryNotAllowedE
 import com.facebook.presto.hive.util.InternalHiveSplitFactory;
 import com.facebook.presto.hive.util.ResumableTask;
 import com.facebook.presto.hive.util.ResumableTasks;
-import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
-import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.predicate.Domain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Streams;
@@ -96,7 +95,7 @@ public class BackgroundHiveSplitLoader
     private static final ListenableFuture<?> COMPLETED_FUTURE = immediateFuture(null);
 
     private final Table table;
-    private final TupleDomain<? extends ColumnHandle> compactEffectivePredicate;
+    private final Optional<Domain> pathDomain;
     private final Optional<BucketSplitInfo> tableBucketInfo;
     private final HdfsEnvironment hdfsEnvironment;
     private final HdfsContext hdfsContext;
@@ -133,7 +132,7 @@ public class BackgroundHiveSplitLoader
     public BackgroundHiveSplitLoader(
             Table table,
             Iterable<HivePartitionMetadata> partitions,
-            TupleDomain<? extends ColumnHandle> compactEffectivePredicate,
+            Optional<Domain> pathDomain,
             Optional<BucketSplitInfo> tableBucketInfo,
             ConnectorSession session,
             HdfsEnvironment hdfsEnvironment,
@@ -145,7 +144,7 @@ public class BackgroundHiveSplitLoader
             boolean schedulerUsesHostAddresses)
     {
         this.table = table;
-        this.compactEffectivePredicate = compactEffectivePredicate;
+        this.pathDomain = pathDomain;
         this.tableBucketInfo = tableBucketInfo;
         this.loaderConcurrency = loaderConcurrency;
         this.session = session;
@@ -279,7 +278,6 @@ public class BackgroundHiveSplitLoader
         String partitionName = partition.getHivePartition().getPartitionId();
         Properties schema = getPartitionSchema(table, partition.getPartition());
         List<HivePartitionKey> partitionKeys = getPartitionKeys(table, partition.getPartition());
-        TupleDomain<HiveColumnHandle> effectivePredicate = (TupleDomain<HiveColumnHandle>) compactEffectivePredicate;
 
         Path path = new Path(getPartitionLocation(table, partition.getPartition()));
         Configuration configuration = hdfsEnvironment.getConfiguration(hdfsContext, path);
@@ -309,7 +307,7 @@ public class BackgroundHiveSplitLoader
                 InternalHiveSplitFactory splitFactory = new InternalHiveSplitFactory(
                         targetFilesystem,
                         inputFormat,
-                        effectivePredicate,
+                        pathDomain,
                         isForceLocalScheduling(session),
                         s3SelectPushdownEnabled,
                         new HiveSplitPartitionInfo(schema, path.toUri(), partitionKeys, partitionName, partition.getColumnCoercions(), Optional.empty()),
@@ -342,7 +340,7 @@ public class BackgroundHiveSplitLoader
         InternalHiveSplitFactory splitFactory = new InternalHiveSplitFactory(
                 fs,
                 inputFormat,
-                effectivePredicate,
+                pathDomain,
                 isForceLocalScheduling(session),
                 s3SelectPushdownEnabled,
                 new HiveSplitPartitionInfo(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -143,17 +143,17 @@ public class BackgroundHiveSplitLoader
             boolean recursiveDirWalkerEnabled,
             boolean schedulerUsesHostAddresses)
     {
-        this.table = table;
-        this.pathDomain = pathDomain;
-        this.tableBucketInfo = tableBucketInfo;
-        this.loaderConcurrency = loaderConcurrency;
-        this.session = session;
-        this.hdfsEnvironment = hdfsEnvironment;
-        this.namenodeStats = namenodeStats;
-        this.directoryLister = directoryLister;
+        this.table = requireNonNull(table, "table is null");
+        this.pathDomain = requireNonNull(pathDomain, "pathDomain is null");
+        this.tableBucketInfo = requireNonNull(tableBucketInfo, "tableBucketInfo is null");
+        this.loaderConcurrency = requireNonNull(loaderConcurrency, "loaderConcurrency is null");
+        this.session = requireNonNull(session, "session is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.namenodeStats = requireNonNull(namenodeStats, "namenodeStats is null");
+        this.directoryLister = requireNonNull(directoryLister, "directoryLister is null");
         this.recursiveDirWalkerEnabled = recursiveDirWalkerEnabled;
-        this.executor = executor;
-        this.partitions = new ConcurrentLazyQueue<>(partitions);
+        this.executor = requireNonNull(executor, "executor is null");
+        this.partitions = new ConcurrentLazyQueue<>(requireNonNull(partitions, "partitions is null"));
         this.hdfsContext = new HdfsContext(session, table.getDatabaseName(), table.getTableName());
         this.schedulerUsesHostAddresses = schedulerUsesHostAddresses;
     }


### PR DESCRIPTION
Filter pushdown implementation in Hive connector involves changing HiveTableLayoutHandle to replace `TupleDomain<? extends ColumnHandle> compactEffectivePredicate` with 3 new fields:

```
// Range filters on entire columns and subfields extracted from the filter (non-compacted)
TupleDomain<Subfield> domainPredicate;

// The remaining filter. AND-ing this with domainPredicate give full filter.
RowExpression remainingPredicate;

// Columns referenced in domainPredicate or remainingPredicate. 
// These columns may overlap columns that will be projected out (e.g. columns listed in the TableScanNode).
Map<String, HiveColumnHandle> predicateColumns;
```

Extracting range filters on $path column will be more involved and would be more convenient to do in HiveSplitManager as opposed to InternalHiveSplitFactory. This change makes InternalHiveSplitFactory accept `Optional<Domain> pathDomain` instead of more opaque `TupleDomain<? extends ColumnHandle> compactEffectivePredicate`.