### PR TITLE
[WIP] Differential Entropy UDF

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -327,6 +327,79 @@ Statistical Aggregate Functions
     Returns linear regression slope of input values. ``y`` is the dependent
     value. ``x`` is the independent value.
 
+.. function:: sample_adjusted_mutual_information_score(bucketCount, min, max, outcome, sample, weight, 'histogram_mle') -> double
+
+    Returns the [adjusted mutual information score](https://en.wikipedia.org/wiki/Mutual_information#Adjusted_mutual_information) between samples of
+   `outcome`, a categorical `int` column, and `sample`, a `double` column. The samples have weight
+   `weight`, a non-negative weight column. The mutual information is non-negative.
+
+    The mutual information is calculated by estimating the reduction in entropy by outcome.
+    See :func:`differential_entropy` for the meaning of `bucketCount`, `weight`, and `'histogram_mle`.
+
+.. function:: sample_adjusted_mutual_information_score(bucketCount, min, max, outcome, sample, weight) -> double
+
+    Same as :func:`sample_adjusted_mutual_information_score(bucketCount, min, max, outcome, sample, weight, 'histogram_mle')``
+
+.. function:: sample_adjusted_mutual_information_score(bucketCount, min, max, outcome, sample) -> double
+
+    Same as :func:`sample_adjusted_mutual_information_score(bucketCount, min, max, outcome, sample, 1.0, 'histogram_mle')``
+
+.. function:: sample_adjusted_mutual_information_score(bucketCount, min, max, outcome, sample, weight, 'fixed_histogram_mle', min, max) -> double
+
+    Returns the [adjusted mutual information score](https://en.wikipedia.org/wiki/Mutual_information#Adjusted_mutual_information) between samples of
+   `outcome`, a categorical `int` column, and `sample`, a `double` column. The samples have weight
+   `weight`, a non-negative weight column. The mutual information is non-negative.
+
+    The mutual information is calculated by estimating the reduction in entropy by outcome.
+    See :func:`differential_entropy` for the meaning of `bucketCount`, `weight`, `'fixed_histogram_mle`, `min`
+    and `max`.
+
+.. function:: sample_adjusted_mutual_information_score(bucketCount, min, max, outcome, sample, weight, 'fixed_histogram_jacknife', min, max) -> double
+
+    Returns the [adjusted mutual information score](https://en.wikipedia.org/wiki/Mutual_information#Adjusted_mutual_information) between samples of
+   `outcome`, a categorical `int` column, and `sample`, a `double` column. The samples have weight
+   `weight`, a non-negative weight column. The mutual information is non-negative.
+
+    The mutual information is calculated by estimating the reduction in entropy by outcome.
+    See :func:`differential_entropy` for the meaning of `bucketCount`, `weight`, `'fixed_histogram_jacknife`, `min`
+    and `max`.
+
+.. function :: differential_entropy(bucketCount, sample, weight, 'histogram_mle') -> double
+
+    Returns the approximate log-2 entropy from a random variable's sample outcomes based on the
+    maximal-likelihood estimation of a histogram of the data using `bucketCount`
+    buckets (see :func:`numeric_histogram` for a description of the histogram used). The `histogram_mle`
+    variant of sample entropy estimation is convenient for use, but might be inexact for small numbers of
+    samples.
+
+.. function :: differential_entropy(bucketCount, sample, weight) -> double
+
+    Same as :func:`differential_entropy(bucketCount, sample, weight, 'histogram_mle').
+
+.. function :: differential_entropy(bucketCount, sample) -> double
+
+    Same as :func:`differential_entropy(bucketCount, sample, 1.0, 'histogram_mle').
+
+.. function :: differential_entropy(bucketCount, sample, weight, 'fixed_histogram_mle', min, max) -> double
+
+    Returns the approximate log-2 entropy from a random variable's sample outcomes based on the
+    maximal-likelihood estimation of a fixed-bin histogram of the data using `bucketCount`
+    buckets between `min` and `max`. The `fixed_histogram_mle`
+    variant of sample entropy estimation is convenient for use, but might be less exact for small numbers of
+    samples.
+
+.. function :: differential_entropy(bucketCount, sample, weight, 'fixed_histogram_jacknife', min, max) -> double
+
+    Returns the approximate log-2 entropy from a random variable's sample outcomes based on the
+    maximal-likelihood estimation of a fixed-bin histogram of the data using `bucketCount`
+    buckets between `min` and `max`. The `fixed_histogram_jacknife`
+    variant of sample entropy estimation, is more exact than maximum likelihood estimates. See
+
+    .. code-block:: none
+
+        Beirlant, Dudewicz, Gyorfi, and van der Meulen,
+       "Nonparametric entropy estimation: an overview", (2001)
+
 .. function:: skewness(x) -> double
 
     Returns the skewness of all input values.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespace.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespace.java
@@ -55,6 +55,7 @@ import com.facebook.presto.operator.aggregation.RealSumAggregation;
 import com.facebook.presto.operator.aggregation.SumDataSizeForStats;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
 import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggregationFunction;
+import com.facebook.presto.operator.aggregation.differentialentropy.DifferentialEntropyAggregation;
 import com.facebook.presto.operator.aggregation.histogram.Histogram;
 import com.facebook.presto.operator.aggregation.multimapagg.MultimapAggregationFunction;
 import com.facebook.presto.operator.scalar.ArrayCardinalityFunction;
@@ -464,6 +465,7 @@ class StaticFunctionNamespace
                 .aggregates(RealRegressionAggregation.class)
                 .aggregates(DoubleCorrelationAggregation.class)
                 .aggregates(RealCorrelationAggregation.class)
+                .aggregates(DifferentialEntropyAggregation.class)
                 .aggregates(BitwiseOrAggregation.class)
                 .aggregates(BitwiseAndAggregation.class)
                 .scalar(RepeatFunction.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/DifferentialEntropyAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/DifferentialEntropyAggregation.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+
+@AggregationFunction("differential_entropy")
+@Description("Computes differential entropy based on random-variable samples")
+public final class DifferentialEntropyAggregation
+{
+    private DifferentialEntropyAggregation() {}
+
+    @InputFunction
+    public static void input(
+            @AggregationState State state,
+            @SqlType(StandardTypes.BIGINT) long size,
+            @SqlType(StandardTypes.DOUBLE) double sample,
+            @SqlType(StandardTypes.DOUBLE) double weight,
+            @SqlType(StandardTypes.VARCHAR) Slice method,
+            @SqlType(StandardTypes.DOUBLE) double arg0,
+            @SqlType(StandardTypes.DOUBLE) double arg1)
+    {
+        input(
+                state,
+                size,
+                sample,
+                Double.valueOf(weight),
+                method,
+                Double.valueOf(arg0),
+                Double.valueOf(arg1));
+    }
+
+    @InputFunction
+    public static void input(
+            @AggregationState State state,
+            @SqlType(StandardTypes.BIGINT) long size,
+            @SqlType(StandardTypes.DOUBLE) double sample,
+            @SqlType(StandardTypes.DOUBLE) double weight,
+            @SqlType(StandardTypes.VARCHAR) Slice method)
+    {
+        input(
+                state,
+                size,
+                sample,
+                Double.valueOf(weight),
+                method,
+                (Double) null,
+                (Double) null);
+    }
+
+    @InputFunction
+    public static void input(
+            @AggregationState State state,
+            @SqlType(StandardTypes.BIGINT) long size,
+            @SqlType(StandardTypes.DOUBLE) double sample,
+            @SqlType(StandardTypes.DOUBLE) double weight)
+    {
+        input(
+                state,
+                size,
+                sample,
+                Double.valueOf(weight),
+                null,
+                (Double) null,
+                (Double) null);
+    }
+
+    @InputFunction
+    public static void input(
+            @AggregationState State state,
+            @SqlType(StandardTypes.BIGINT) long size,
+            @SqlType(StandardTypes.DOUBLE) double sample)
+    {
+        input(
+                state,
+                size,
+                sample,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    protected static void input(
+            State state,
+            long size,
+            double sample,
+            Double weight,
+            Slice method,
+            Double arg0,
+            Double arg1)
+    {
+        final String requestedMethod = method == null ? null : method.toStringUtf8();
+        if (state.getStrategy() == null) {
+            state.setStrategy(StateSerializer.create(
+                    size, requestedMethod, arg0, arg1));
+        }
+        if (weight == null) {
+            weight = Double.valueOf(1.0);
+        }
+        final StateStrategy strategy = state.getStrategy();
+        StateSerializer.validate(requestedMethod, strategy);
+        strategy.validateParams(size, sample, weight, arg0, arg1);
+        strategy.add(sample, weight);
+    }
+
+    @CombineFunction
+    public static void combine(
+            @AggregationState State state,
+            @AggregationState State otherState)
+    {
+        final StateStrategy strategy = state.getStrategy();
+        final StateStrategy otherStrategy = otherState.getStrategy();
+        if (strategy == null && otherStrategy != null) {
+            state.setStrategy(otherStrategy.clone());
+            return;
+        }
+        if (strategy != null && otherStrategy != null) {
+            StateSerializer.combine(strategy, otherStrategy);
+        }
+    }
+
+    @OutputFunction("double")
+    public static void output(@AggregationState State state, BlockBuilder out)
+    {
+        final StateStrategy strategy = state.getStrategy();
+        if (strategy == null) {
+            DOUBLE.writeDouble(out, 0.0);
+            return;
+        }
+        DOUBLE.writeDouble(
+                out,
+                strategy == null ? 0.0 : strategy.calculateEntropy());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/FixedHistogramJacknifeStateStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/FixedHistogramJacknifeStateStrategy.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.operator.aggregation.fixedhistogram.FixedDoubleBreakdownHistogram;
+import com.google.common.collect.Streams;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+Calculates sample entropy using jacknife estimates on a fixed histogram.
+See http://cs.brown.edu/~pvaliant/unseen_nips.pdf.
+ */
+public class FixedHistogramJacknifeStateStrategy
+        implements StateStrategy
+{
+    protected final FixedDoubleBreakdownHistogram histogram;
+
+    public FixedHistogramJacknifeStateStrategy(long bucketCount, double min, double max)
+    {
+        histogram = new FixedDoubleBreakdownHistogram((int) bucketCount, min, max);
+    }
+
+    protected FixedHistogramJacknifeStateStrategy(FixedHistogramJacknifeStateStrategy other)
+    {
+        histogram = other.getBreakdownHistogram().clone();
+    }
+
+    public FixedHistogramJacknifeStateStrategy(SliceInput input)
+    {
+        histogram = new FixedDoubleBreakdownHistogram(input);
+    }
+
+    @Override
+    public void validateParams(
+            long bucketCount,
+            double sample,
+            Double weight,
+            Double min,
+            Double max)
+    {
+        FixedHistogramStateStrategyUtils.validateParams(
+                histogram.getBucketCount(),
+                histogram.getMin(),
+                histogram.getMax(),
+                bucketCount,
+                sample,
+                weight,
+                min,
+                max);
+    }
+
+    @Override
+    public void mergeWith(StateStrategy other)
+    {
+        getBreakdownHistogram()
+                .mergeWith(((FixedHistogramJacknifeStateStrategy) other).getBreakdownHistogram());
+    }
+
+    @Override
+    public void add(double value, double weight)
+    {
+        getBreakdownHistogram().add(value, weight);
+    }
+
+    @Override
+    public double calculateEntropy()
+    {
+        Map<Double, Double> bucketWeights = new HashMap<Double, Double>();
+        Streams.stream(getBreakdownHistogram().iterator()).forEach(
+                e -> {
+                    bucketWeights.put(
+                            e.left,
+                            Streams.stream(e.breakdown.iterator()).mapToDouble(w -> w.weight * w.count).sum());
+                });
+        System.out.println("bucketWeights " + Arrays.toString(bucketWeights.entrySet().toArray()));
+        double sumW =
+                bucketWeights.values().stream().mapToDouble(w -> w).sum();
+        if (sumW == 0.0) {
+            return 0.0;
+        }
+        long n = Streams.stream(getBreakdownHistogram())
+                .mapToLong(e -> Streams.stream(e.breakdown.iterator()).mapToLong(w -> w.count).sum())
+                .sum();
+        double sumWLogW =
+                bucketWeights.values().stream().mapToDouble(w -> w == 0.0 ? 0.0 : w * Math.log(w)).sum();
+
+        double entropy = n * calculateEntropy(histogram.getWidth(), sumW, sumWLogW);
+        entropy -= Streams.stream(getBreakdownHistogram().iterator()).mapToDouble(
+                e -> {
+                    double bucketWeight = bucketWeights.get(e.left);
+                    if (bucketWeight == 0.0) {
+                        return 0.0;
+                    }
+                    return Streams.stream(e.breakdown.iterator()).mapToDouble(
+                            bucketE -> FixedHistogramJacknifeStateStrategy.getHoldOutEntropy(
+                                    n,
+                                    histogram.getWidth(),
+                                    sumW,
+                                    sumWLogW,
+                                    bucketWeight,
+                                    bucketE.weight,
+                                    bucketE.count))
+                            .sum();
+                })
+                .sum();
+        return entropy;
+    }
+
+    private static double getHoldOutEntropy(
+            long n,
+            double width,
+            double sumW,
+            double sumWLogW,
+            double bucketWeight,
+            double entryWeight,
+            long entryMultiplicity)
+    {
+        double holdoutBucketWeight = Math.max(bucketWeight - entryWeight, 0);
+        double holdoutSumW =
+                sumW - bucketWeight + holdoutBucketWeight;
+        double holdoutSumWLogW =
+                sumWLogW - FixedHistogramStateStrategyUtils.getXLogX(bucketWeight) +
+                        FixedHistogramStateStrategyUtils.getXLogX(holdoutBucketWeight);
+        double holdoutEntropy = entryMultiplicity * (n - 1) *
+                calculateEntropy(width, holdoutSumW, holdoutSumWLogW) /
+                n;
+        return holdoutEntropy;
+    }
+
+    private static double calculateEntropy(double width, double sumW, double sumWLogW)
+    {
+        if (sumW == 0.0) {
+            return 0.0;
+        }
+        double entropy = Math.max(
+                (Math.log(width * sumW) - sumWLogW / sumW) / Math.log(2.0),
+                0.0);
+        return entropy;
+    }
+
+    @Override
+    public long estimatedInMemorySize()
+    {
+        return getBreakdownHistogram().estimatedInMemorySize();
+    }
+
+    @Override
+    public int getRequiredBytesForSerialization()
+    {
+        return getBreakdownHistogram().getRequiredBytesForSerialization();
+    }
+
+    @Override
+    public void serialize(SliceOutput out)
+    {
+        getBreakdownHistogram().serialize(out);
+    }
+
+    public FixedDoubleBreakdownHistogram getBreakdownHistogram()
+    {
+        return histogram;
+    }
+
+    @Override
+    public StateStrategy clone()
+    {
+        return new FixedHistogramJacknifeStateStrategy(this);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/FixedHistogramMLEStateStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/FixedHistogramMLEStateStrategy.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.operator.aggregation.fixedhistogram.FixedDoubleHistogram;
+import com.google.common.collect.Streams;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+/*
+Calculates sample entropy using MLE (maximum likelihood estimates) on a NumericHistogram.
+ */
+public class FixedHistogramMLEStateStrategy
+        implements StateStrategy
+{
+    protected final FixedDoubleHistogram histogram;
+
+    public FixedHistogramMLEStateStrategy(long bucketCount, double min, double max)
+    {
+        histogram = new FixedDoubleHistogram((int) bucketCount, min, max);
+    }
+
+    protected FixedHistogramMLEStateStrategy(FixedHistogramMLEStateStrategy other)
+    {
+        histogram = other.getWeightHistogram().clone();
+    }
+
+    public FixedHistogramMLEStateStrategy(SliceInput input)
+    {
+        histogram = new FixedDoubleHistogram(input);
+    }
+
+    @Override
+    public void validateParams(
+            long bucketCount,
+            double sample,
+            Double weight,
+            Double min,
+            Double max)
+    {
+        FixedHistogramStateStrategyUtils.validateParams(
+                histogram.getBucketCount(),
+                histogram.getMin(),
+                histogram.getMax(),
+                bucketCount,
+                sample,
+                weight,
+                min,
+                max);
+    }
+
+    @Override
+    public void add(double sample, double weight)
+    {
+        getWeightHistogram().add(sample, weight);
+    }
+
+    @Override
+    public double calculateEntropy()
+    {
+        final double sum = Streams.stream(getWeightHistogram().iterator())
+                .mapToDouble(w -> w.weight)
+                .sum();
+        if (sum == 0) {
+            return 0.0;
+        }
+
+        final double rawEntropy = Streams.stream(getWeightHistogram().iterator())
+                .mapToDouble(w -> {
+                    final double prob = w.weight / sum;
+                    return -FixedHistogramStateStrategyUtils.getXLogX(prob);
+                })
+                .sum() / Math.log(2);
+        return rawEntropy + Math.log(getWeightHistogram().getWidth()) / Math.log(2);
+    }
+
+    @Override
+    public long estimatedInMemorySize()
+    {
+        return getWeightHistogram().estimatedInMemorySize();
+    }
+
+    @Override
+    public int getRequiredBytesForSerialization()
+    {
+        return getWeightHistogram().getRequiredBytesForSerialization();
+    }
+
+    @Override
+    public void mergeWith(StateStrategy other)
+    {
+        getWeightHistogram()
+                .mergeWith(((FixedHistogramMLEStateStrategy) other).getWeightHistogram());
+    }
+
+    @Override
+    public void serialize(SliceOutput out)
+    {
+        getWeightHistogram().serialize(out);
+    }
+
+    public FixedDoubleHistogram getWeightHistogram()
+    {
+        return histogram;
+    }
+
+    @Override
+    public StateStrategy clone()
+    {
+        return new FixedHistogramMLEStateStrategy(this);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/FixedHistogramStateStrategyUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/FixedHistogramStateStrategyUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.operator.aggregation.fixedhistogram.FixedDoubleHistogram;
+import com.facebook.presto.operator.aggregation.fixedhistogram.FixedHistogram;
+import com.facebook.presto.spi.PrestoException;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+
+/*
+Utility class for different strategies for calculating entropy based on fixed histograms.
+ */
+public class FixedHistogramStateStrategyUtils
+{
+    private FixedHistogramStateStrategyUtils() {}
+
+    public static void validateParams(
+            long histogramBucketCount,
+            double histogramMin,
+            double HistogramMax,
+            long bucketCount,
+            double sample,
+            Double weight,
+            Double min,
+            Double max)
+    {
+        if (weight != null && weight < 0.0) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    "Weight must be non-negative");
+        }
+
+        if (histogramBucketCount != bucketCount) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    "Inconsistent bucket count");
+        }
+        if (histogramMin != min) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    "Inconsistent min");
+        }
+        if (HistogramMax != max) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    "Inconsistent max");
+        }
+        if (sample < min) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    "Sample must be at least min");
+        }
+        if (sample > max) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    "Sample must be at most max");
+        }
+    }
+
+    public static double getXLogX(double x)
+    {
+        return x <= 0.0 ? 0.0 : x * Math.log(x);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/State.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/State.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+
+@AccumulatorStateMetadata(
+        stateSerializerClass = StateSerializer.class,
+        stateFactoryClass = StateFactory.class)
+public interface State
+        extends AccumulatorState
+{
+    void setStrategy(StateStrategy strategy);
+
+    StateStrategy getStrategy();
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/StateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/StateFactory.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.operator.aggregation.state.AbstractGroupedAccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+
+import static java.util.Objects.requireNonNull;
+
+public class StateFactory
+        implements AccumulatorStateFactory<State>
+{
+    @Override
+    public State createSingleState()
+    {
+        return new SingleState();
+    }
+
+    @Override
+    public Class<? extends State> getSingleStateClass()
+    {
+        return SingleState.class;
+    }
+
+    @Override
+    public State createGroupedState()
+    {
+        return new GroupedState();
+    }
+
+    @Override
+    public Class<? extends State> getGroupedStateClass()
+    {
+        return GroupedState.class;
+    }
+
+    public static class GroupedState
+            extends AbstractGroupedAccumulatorState
+            implements State
+    {
+        private final ObjectBigArray<StateStrategy> strategies = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            strategies.ensureCapacity(size);
+        }
+
+        @Override
+        public void setStrategy(StateStrategy strategy)
+        {
+            requireNonNull(strategy, "strategy is null");
+
+            StateStrategy previous = getStrategy();
+            if (previous != null) {
+                size -= previous.estimatedInMemorySize();
+            }
+
+            strategies.set(getGroupId(), strategy);
+            size += strategy.estimatedInMemorySize();
+        }
+
+        @Override
+        public StateStrategy getStrategy()
+        {
+            return strategies.get(getGroupId());
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + strategies.sizeOf();
+        }
+    }
+
+    public static class SingleState
+            implements State
+    {
+        private StateStrategy strategy;
+
+        @Override
+        public void setStrategy(StateStrategy strategy)
+        {
+            requireNonNull(strategy, "strategy is null");
+
+            this.strategy = strategy;
+        }
+
+        @Override
+        public StateStrategy getStrategy()
+        {
+            return strategy;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            if (strategy == null) {
+                return 0;
+            }
+            return strategy.estimatedInMemorySize();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/StateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/StateSerializer.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+
+import java.security.InvalidParameterException;
+
+import static com.facebook.presto.spi.StandardErrorCode.CONSTRAINT_VIOLATION;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+
+/*
+Serializes sample-entropy states.
+ */
+public class StateSerializer
+        implements AccumulatorStateSerializer<State>
+{
+    public static StateStrategy create(
+            long size,
+            String method,
+            Double arg0,
+            Double arg1)
+    {
+        if (method.equalsIgnoreCase("fixed_histogram_mle")) {
+            return new FixedHistogramMLEStateStrategy(size, arg0, arg1);
+        }
+
+        if (method.equalsIgnoreCase("fixed_histogram_jacknife")) {
+            return new FixedHistogramJacknifeStateStrategy(size, arg0, arg1);
+        }
+
+        throw new InvalidParameterException(String.format("unknown method %s", method));
+    }
+
+    public static void validate(String method, StateStrategy strategy)
+    {
+        if (method.equalsIgnoreCase("fixed_histogram_mle")) {
+            if (!(strategy instanceof FixedHistogramMLEStateStrategy)) {
+                throw new PrestoException(
+                        INVALID_FUNCTION_ARGUMENT,
+                        "Inconsistent method");
+            }
+
+            return;
+        }
+
+        if (method.equalsIgnoreCase("fixed_histogram_jacknife")) {
+            if (!(strategy instanceof FixedHistogramJacknifeStateStrategy)) {
+                throw new PrestoException(
+                        INVALID_FUNCTION_ARGUMENT,
+                        "Inconsistent method");
+            }
+
+            return;
+        }
+
+        throw new InvalidParameterException("unknown method");
+    }
+
+    public static void combine(StateStrategy target, StateStrategy source)
+    {
+        if (target instanceof FixedHistogramMLEStateStrategy) {
+            if (!(source instanceof FixedHistogramMLEStateStrategy)) {
+                throw new PrestoException(
+                        INVALID_FUNCTION_ARGUMENT,
+                        "Inconsistent strategy");
+            }
+            ((FixedHistogramMLEStateStrategy) target).mergeWith((FixedHistogramMLEStateStrategy) source);
+            return;
+        }
+
+        if (target instanceof FixedHistogramJacknifeStateStrategy) {
+            if (!(source instanceof FixedHistogramJacknifeStateStrategy)) {
+                throw new PrestoException(
+                        INVALID_FUNCTION_ARGUMENT,
+                        "Inconsistent strategy");
+            }
+            ((FixedHistogramJacknifeStateStrategy) target).mergeWith((FixedHistogramJacknifeStateStrategy) source);
+            return;
+        }
+
+        throw new InvalidParameterException("unknown strategy combination");
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(State state, BlockBuilder out)
+    {
+        final int requiredBytes =
+                SizeOf.SIZE_OF_INT + // Method
+                        (state.getStrategy() == null ? 0 : state.getStrategy().getRequiredBytesForSerialization());
+
+        final StateStrategy strategy = state.getStrategy();
+
+        SliceOutput sliceOut = Slices.allocate(requiredBytes).getOutput();
+
+        if (strategy == null) {
+            sliceOut.appendInt(0);
+        }
+        else if (strategy instanceof FixedHistogramMLEStateStrategy) {
+            sliceOut.appendInt(2);
+        }
+        else if (strategy instanceof FixedHistogramJacknifeStateStrategy) {
+            sliceOut.appendInt(3);
+        }
+        else {
+            throw new InvalidParameterException("unknown method in serialize");
+        }
+
+        if (strategy != null) {
+            strategy.serialize(sliceOut);
+        }
+
+        VARBINARY.writeSlice(out, sliceOut.getUnderlyingSlice());
+    }
+
+    @Override
+    public void deserialize(
+            Block block,
+            int index,
+            State state)
+    {
+        StateSerializer.deserialize(
+                VARBINARY.getSlice(block, index).getInput(),
+                state);
+    }
+
+    public static void deserialize(
+            SliceInput input,
+            State state)
+    {
+        final StateStrategy strategy =
+                StateSerializer.deserializeStrategy(input);
+        if (strategy == null && state.getStrategy() != null) {
+            throw new PrestoException(
+                    CONSTRAINT_VIOLATION,
+                    "strategy is not null for null method");
+        }
+        if (strategy != null) {
+            state.setStrategy(strategy);
+        }
+    }
+
+    public static StateStrategy deserializeStrategy(SliceInput input)
+    {
+        final int method = input.readInt();
+        if (method == 0) {
+            return null;
+        }
+        if (method == 2) {
+            return new FixedHistogramMLEStateStrategy(input);
+        }
+        if (method == 3) {
+            return new FixedHistogramJacknifeStateStrategy(input);
+        }
+        throw new InvalidParameterException("unknown method in deserialize");
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/StateStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/StateStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import io.airlift.slice.SliceOutput;
+
+/*
+Abstract base class for different strategies for calculating entropy: MLE (maximum likelihood
+estimator) using NumericHistogram, jacknife estimates using a fixed histogram, compressed
+counting and Renyi entropy, and so forth.
+ */
+public interface StateStrategy
+        extends Cloneable
+{
+    void add(double sample, double weight);
+
+    double calculateEntropy();
+
+    long estimatedInMemorySize();
+
+    int getRequiredBytesForSerialization();
+
+    void serialize(SliceOutput out);
+
+    void mergeWith(StateStrategy other);
+
+    StateStrategy clone();
+
+    void validateParams(
+            long bucketCount,
+            double sample,
+            Double weight,
+            Double arg0,
+            Double arg1);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/fixedhistogram/DoubleBreakdownMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/fixedhistogram/DoubleBreakdownMap.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.fixedhistogram;
+
+import io.airlift.slice.SliceInput;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class DoubleBreakdownMap
+        implements Iterable<DoubleBreakdownMap.Entry>
+{
+    protected double[] weights;
+    protected long[] counts;
+    int nextIndex;
+    int size;
+
+    public static class Entry
+    {
+        public final double weight;
+        public final long count;
+
+        public Entry(double weight, long count)
+        {
+            this.weight = weight;
+            this.count = count;
+        }
+    }
+
+    protected DoubleBreakdownMap()
+    {
+        nextIndex = 0;
+        size = 1;
+        weights = new double[size];
+        counts = new long[size];
+    }
+
+    protected DoubleBreakdownMap(SliceInput input)
+    {
+        nextIndex = input.readInt();
+        size = 2 * nextIndex;
+        weights = new double[size];
+        counts = new long[size];
+        for (int i = 0; i < nextIndex; ++i) {
+            weights[i] = input.readDouble();
+            counts[i] = input.readLong();
+        }
+    }
+
+    protected DoubleBreakdownMap(DoubleBreakdownMap other)
+    {
+        nextIndex = other.nextIndex;
+        size = other.size;
+        weights = new double[size];
+        counts = new long[size];
+        for (int i = 0; i < nextIndex; ++i) {
+            weights[i] = other.weights[i];
+            counts[i] = other.counts[i];
+        }
+    }
+
+    int getSize()
+    {
+        return this.nextIndex;
+    }
+
+    public void add(double weight, long count)
+    {
+        for (int i = 0; i < nextIndex; ++i) {
+            if (weights[i] == weight) {
+                counts[i] += count;
+                System.out.println(this + " Found " + weight);
+                return;
+            }
+        }
+        System.out.println(this + " inserting " + weight);
+        ++nextIndex;
+        if (nextIndex == size) {
+            double weights[] = new double[2 * size];
+            long counts[] = new long[2 * size];
+            for (int i = 0; i < nextIndex; ++i) {
+                weights[i] = this.weights[i];
+                counts[i] = this.counts[i];
+            }
+            this.size *= 2;
+            this.weights = weights;
+            this.counts = counts;
+        }
+        weights[nextIndex] = weight;
+        counts[nextIndex] = count;
+    }
+
+    public Iterator<Entry> iterator()
+    {
+        return new Iterator<Entry>()
+        {
+            private int index;
+
+            @Override
+            public boolean hasNext()
+            {
+                return index < nextIndex;
+            }
+
+            @Override
+            public Entry next()
+            {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+
+                final Entry entry = new Entry(weights[index], counts[index]);
+                ++index;
+                return entry;
+            }
+
+            @Override
+            public void remove()
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/fixedhistogram/FixedDoubleBreakdownHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/fixedhistogram/FixedDoubleBreakdownHistogram.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.fixedhistogram;
+
+import com.google.common.collect.Streams;
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class FixedDoubleBreakdownHistogram
+        extends FixedHistogram
+        implements Iterable<FixedDoubleBreakdownHistogram.Bucket>
+{
+    protected DoubleBreakdownMap breakdowns[];
+
+    public static class Bucket
+    {
+        public final double left;
+        public final double right;
+        public final DoubleBreakdownMap breakdown;
+
+        public Bucket(double left, double right, DoubleBreakdownMap breakdown)
+        {
+            this.left = left;
+            this.right = right;
+            this.breakdown = breakdown;
+        }
+    }
+
+    public FixedDoubleBreakdownHistogram(int bucketCount, double min, double max)
+    {
+        super(bucketCount, min, max);
+        breakdowns = new DoubleBreakdownMap[bucketCount];
+        for (int i = 0; i < getBucketCount(); ++i) {
+            breakdowns[i] = new DoubleBreakdownMap();
+        }
+    }
+
+    public FixedDoubleBreakdownHistogram(SliceInput input)
+    {
+        super(input);
+        breakdowns = new DoubleBreakdownMap[getBucketCount()];
+        System.out.println("Read in " + super.getBucketCount() + " buckets");
+        for (int i = 0; i < super.getBucketCount(); ++i) {
+            System.out.println("Reading bucket " + i);
+            breakdowns[i] = new DoubleBreakdownMap();
+            final long numInBucket = input.readLong();
+            for (int j = 0; j < numInBucket; ++j) {
+                final double weight = input.readDouble();
+                final long multiplicity = input.readLong();
+                System.out.println("Read in " + weight + "," + multiplicity);
+                breakdowns[i].add(weight, multiplicity);
+            }
+        }
+    }
+
+    public FixedDoubleBreakdownHistogram(FixedDoubleBreakdownHistogram other)
+    {
+        super(other.getBucketCount(), other.getMin(), other.getMax());
+        breakdowns = new DoubleBreakdownMap[other.getBucketCount()];
+        for (int i = 0; i < super.getBucketCount(); ++i) {
+            breakdowns[i] = new DoubleBreakdownMap(other.breakdowns[i]) ;
+        }        int size = super.getRequiredBytesForSerialization();
+
+    }
+
+    public int getRequiredBytesForSerialization()
+    {
+        int size = super.getRequiredBytesForSerialization();
+        System.out.println("Bytes for " + size);
+        for (int i = 0; i < super.getBucketCount(); ++i) {
+            size += SizeOf.SIZE_OF_LONG;
+            size += Streams.stream(breakdowns[i].iterator())
+                    .mapToInt(e -> SizeOf.SIZE_OF_DOUBLE + SizeOf.SIZE_OF_LONG)
+                    .sum();
+            System.out.println("Bytes for bucket " + i + " " + size);
+        }
+        return size;
+    }
+
+    public void serialize(SliceOutput out)
+    {
+        super.serialize(out);
+        for (int i = 0; i < super.getBucketCount(); ++i) {
+            out.appendLong(breakdowns[i].getSize());
+            System.out.println("ser " + i + ": " + breakdowns[i].getSize());
+            Streams.stream(breakdowns[i].iterator())
+                    .forEach(e -> {
+                        System.out.println("ser " + e.weight + "; " + e.count);
+                        out.appendDouble(e.weight);
+                        out.appendLong(e.count);
+                    });
+        }
+    }
+
+    public long estimatedInMemorySize()
+    {
+        long size = super.estimatedInMemorySize();
+        for (int i = 0; i < super.getBucketCount(); ++i) {
+            size += SizeOf.SIZE_OF_LONG + breakdowns[i].size * (Long.SIZE + Double.SIZE);
+        }
+        return size;
+    }
+
+    public void add(double value)
+    {
+        add(value, 1.0);
+    }
+
+    public void add(double value, double weight)
+    {
+        System.out.println(this + " adding " + value + " -> " + weight + "; " + getIndexForValue(value));
+        breakdowns[getIndexForValue(value)].add(weight, 1);
+    }
+
+    public void mergeWith(FixedDoubleBreakdownHistogram other)
+    {
+        System.out.println("Merging " + this + " -< " + other);
+        super.mergeWith(other);
+        for (int i = 0; i < super.getBucketCount(); ++i) {
+            final int index = i;
+            Streams.stream(other.breakdowns[i].iterator()).forEach(
+                    e -> breakdowns[index].add(e.weight, e.count));
+            }
+    }
+
+    @Override
+    public Iterator<Bucket> iterator()
+    {
+        final int bucketCount = super.getBucketCount();
+        final double min = super.getMin();
+        final double max = super.getMax();
+
+        Iterator<FixedHistogram.Bucket> baseIterator = super.getIterator();
+
+        return new Iterator<Bucket>()
+        {
+            final Iterator<FixedHistogram.Bucket> iterator = baseIterator;
+
+            @Override
+            public boolean hasNext()
+            {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public Bucket next()
+            {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+
+                final FixedHistogram.Bucket baseValue = iterator.next();
+
+                return new Bucket(baseValue.left, baseValue.right, breakdowns[baseValue.index]);
+            }
+
+            @Override
+            public void remove()
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    public FixedDoubleBreakdownHistogram clone()
+    {
+        FixedDoubleBreakdownHistogram cloned = new FixedDoubleBreakdownHistogram(
+                getBucketCount(),
+                getMin(),
+                getMax());
+        for (int i = 0; i < getBucketCount(); ++i) {
+            cloned.breakdowns[i] = new DoubleBreakdownMap(breakdowns[i]);
+        }
+        return cloned;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/fixedhistogram/FixedDoubleHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/fixedhistogram/FixedDoubleHistogram.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.fixedhistogram;
+
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class FixedDoubleHistogram
+        implements Cloneable, Iterable<FixedDoubleHistogram.Bucket>
+{
+    private static final byte FORMAT_TAG = 0;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(FixedHistogram.class).instanceSize();
+
+    protected final double[] weights;
+
+    private int bucketCount;
+    private double min;
+    private double max;
+
+    public FixedDoubleHistogram(int bucketCount, double min, double max)
+    {
+        this.bucketCount = bucketCount;
+        checkArgument(bucketCount >= 2, "bucketCount %s must be >= 2", bucketCount);
+        this.min = min;
+        this.max = max;
+        checkArgument(min < max, "min %s must be greater than max %s ", min, max);
+        this.weights = new double[bucketCount];
+    }
+
+    public FixedDoubleHistogram(SliceInput input)
+    {
+        checkArgument(input.readByte() == FORMAT_TAG, "Unsupported format tag");
+        this.bucketCount = input.readInt();
+        checkArgument(bucketCount >= 2, "bucketCount %s must be >= 2", bucketCount);
+        this.min = input.readDouble();
+        this.max = input.readDouble();
+        checkArgument(min < max, "min %s must be greater than max %s ", min, max);
+        this.weights = new double[bucketCount];
+        input.readBytes(
+                Slices.wrappedDoubleArray(weights),
+                bucketCount * SizeOf.SIZE_OF_DOUBLE);
+    }
+
+    public int getBucketCount()
+    {
+        return bucketCount;
+    }
+
+    public double getMin()
+    {
+        return min;
+    }
+
+    public double getMax()
+    {
+        return max;
+    }
+
+    public double getWidth()
+    {
+        return (max - min) / bucketCount;
+    }
+
+    protected int getIndexForValue(Double value)
+    {
+        checkArgument(
+                value >= min && value <= max,
+                "value must be within range [%s, %s]", min, max);
+        return Math.min(
+                (int) (bucketCount * (value - min) / (max - min)),
+                bucketCount - 1);
+    }
+
+    protected Iterator<Bucket> getIterator()
+    {
+        final int bucketCount = getBucketCount();
+        final double min = getMin();
+        final double max = getMax();
+
+        return new Iterator<Bucket>()
+        {
+            private int currentIndex;
+
+            @Override
+            public boolean hasNext()
+            {
+                return currentIndex < bucketCount;
+            }
+
+            @Override
+            public Bucket next()
+            {
+                final Bucket value = new Bucket(
+                        currentIndex * (max - min) / bucketCount,
+                        (currentIndex + 1) * (max - min) / bucketCount,
+                        weights[currentIndex]);
+                ++currentIndex;
+                return value;
+            }
+
+            @Override
+            public void remove()
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    public static class Bucket
+    {
+        public final Double left;
+        public final Double right;
+        public final Double weight;
+
+        public Bucket(Double left, Double right, Double weight)
+        {
+            this.left = left;
+            this.right = right;
+            this.weight = weight;
+        }
+    }
+
+    protected FixedDoubleHistogram(FixedDoubleHistogram other)
+    {
+        bucketCount = other.bucketCount;
+        min = other.min;
+        max = other.max;
+        weights = new double[bucketCount];
+        for (int i = 0; i < bucketCount; ++i) {
+            weights[i] = other.weights[i];
+        }
+    }
+
+    public int getRequiredBytesForSerialization()
+    {
+        return SizeOf.SIZE_OF_BYTE + // format
+                SizeOf.SIZE_OF_INT + // num buckets
+                SizeOf.SIZE_OF_DOUBLE + // min
+                SizeOf.SIZE_OF_DOUBLE + // max
+                SizeOf.SIZE_OF_DOUBLE * bucketCount; // weights
+    }
+
+    public void serialize(SliceOutput out)
+    {
+        out.appendByte(FORMAT_TAG)
+                .appendInt(bucketCount)
+                .appendDouble(min)
+                .appendDouble(max)
+                .appendBytes(Slices.wrappedDoubleArray(weights, 0, bucketCount));
+    }
+
+    public long estimatedInMemorySize()
+    {
+        return INSTANCE_SIZE + SizeOf.sizeOf(weights);
+    }
+
+    public void set(double value, double weight)
+    {
+        weights[getIndexForValue(value)] = weight;
+    }
+
+    public void add(double value)
+    {
+        add(value, 1.0);
+    }
+
+    public void add(double value, double weight)
+    {
+        weights[getIndexForValue(value)] += weight;
+    }
+
+    public void mergeWith(FixedDoubleHistogram other)
+    {
+        checkArgument(min == other.min, "min %s must be equal to other min %s", min, other.min);
+        checkArgument(max == other.max, "max %s must be equal to other max %s", max, other.max);
+        checkArgument(
+                bucketCount == other.bucketCount,
+                "bucketCount %s must be equal to other bucketCount %s", bucketCount, other.bucketCount);
+        for (int i = 0; i < bucketCount; ++i) {
+            weights[i] += other.weights[i];
+        }
+    }
+
+    @Override
+    public Iterator<Bucket> iterator()
+    {
+        final int bucketCount = getBucketCount();
+        final double min = getMin();
+        final double max = getMax();
+
+        return new Iterator<Bucket>()
+        {
+            private int currentIndex;
+
+            @Override
+            public boolean hasNext()
+            {
+                return currentIndex < bucketCount;
+            }
+
+            @Override
+            public Bucket next()
+            {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+
+                final Bucket bucket = new Bucket(
+                        currentIndex * (max - min) / bucketCount,
+                        (currentIndex + 1) * (max - min) / bucketCount,
+                        (currentIndex + 1) * (max - min) / bucketCount);
+                ++currentIndex;
+                return bucket;
+            }
+
+            @Override
+            public void remove()
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    public FixedDoubleHistogram clone()
+    {
+        return new FixedDoubleHistogram(this);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/fixedhistogram/FixedHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/fixedhistogram/FixedHistogram.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.fixedhistogram;
+
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Iterator;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class FixedHistogram
+{
+    private static final byte FORMAT_TAG = 0;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(FixedHistogram.class).instanceSize();
+
+    private int bucketCount;
+    private double min;
+    private double max;
+
+    public class Bucket
+    {
+        public final int index;
+        public final Double left;
+        public final Double right;
+
+        public Bucket(int index, Double left, Double right)
+        {
+            this.index = index;
+            this.left = left;
+            this.right = right;
+        }
+    }
+
+    protected FixedHistogram(int bucketCount, double min, double max)
+    {
+        checkArgument(bucketCount >= 2, "bucketCount %s must be >= 2", bucketCount);
+        checkArgument(min < max, "min %s must be greater than max %s ", min, max);
+
+        this.bucketCount = bucketCount;
+        this.min = min;
+        this.max = max;
+    }
+
+    protected FixedHistogram(SliceInput input)
+    {
+        checkArgument(input.readByte() == FORMAT_TAG, "Unsupported format tag");
+        bucketCount = input.readInt();
+        checkArgument(bucketCount >= 2, "bucketCount %s must be >= 2", bucketCount);
+        min = input.readDouble();
+        max = input.readDouble();
+        checkArgument(min < max, "min %s must be greater than max %s ", min, max);
+    }
+
+    public int getBucketCount()
+    {
+        return bucketCount;
+    }
+
+    public double getMin()
+    {
+        return min;
+    }
+
+    public double getMax()
+    {
+        return max;
+    }
+
+    public double getWidth()
+    {
+        return (max - min) / bucketCount;
+    }
+
+    public void mergeWith(FixedHistogram other)
+    {
+        checkArgument(min == other.min, "min %s must be equal to other min %s", min, other.min);
+        checkArgument(max == other.max, "max %s must be equal to other max %s", max, other.max);
+        checkArgument(
+                bucketCount == other.bucketCount,
+                "bucketCount %s must be equal to other bucketCount %s", bucketCount, other.bucketCount);
+    }
+
+    protected int getRequiredBytesForSerialization()
+    {
+        return SizeOf.SIZE_OF_BYTE + // format
+                SizeOf.SIZE_OF_INT + // num buckets
+                SizeOf.SIZE_OF_DOUBLE + // min
+                SizeOf.SIZE_OF_DOUBLE; // max
+    }
+
+    protected void serialize(SliceOutput out)
+    {
+        out.appendByte(FORMAT_TAG)
+                .appendInt(bucketCount)
+                .appendDouble(min)
+                .appendDouble(max);
+    }
+
+    protected long estimatedInMemorySize()
+    {
+        return INSTANCE_SIZE;
+    }
+
+    protected int getIndexForValue(Double value)
+    {
+        checkArgument(
+                value >= min && value <= max,
+                "value must be within range [%s, %s]", min, max);
+        return Math.min(
+                (int) (bucketCount * (value - min) / (max - min)),
+                bucketCount - 1);
+    }
+
+    protected Iterator<Bucket> getIterator()
+    {
+        final int bucketCount = getBucketCount();
+        final double min = getMin();
+        final double max = getMax();
+
+        return new Iterator<Bucket>()
+        {
+            private int currentIndex;
+
+            @Override
+            public boolean hasNext()
+            {
+                return currentIndex < bucketCount;
+            }
+
+            @Override
+            public Bucket next()
+            {
+                final Bucket value = new Bucket(
+                        currentIndex,
+                        currentIndex * (max - min) / bucketCount,
+                        (currentIndex + 1) * (max - min) / bucketCount);
+                ++currentIndex;
+                return value;
+            }
+
+            @Override
+            public void remove()
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TesFixedHistogramJacknifeAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TesFixedHistogramJacknifeAggregation.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import java.util.ArrayList;
+
+public class TesFixedHistogramJacknifeAggregation
+        extends TestFixedHistogramAggregation
+{
+    public TesFixedHistogramJacknifeAggregation()
+    {
+        super("fixed_histogram_jacknife");
+    }
+
+    @Override
+    public Double getExpectedValue(int start, int length)
+    {
+        final ArrayList<Double> samples = new ArrayList<Double>();
+        final ArrayList<Double> weights = new ArrayList<Double>();
+        super.getSamplesAndWeights(start, length, samples, weights);
+        return getEntropyFromSamplesAndWeights(samples, weights);
+    }
+
+    protected double getEntropyFromSamplesAndWeights(
+            ArrayList<Double> samples,
+            ArrayList<Double> weights)
+    {
+        double entropy = samples.size() *
+                super.getEntropyFromSamplesAndWeights(samples, weights);
+
+        for (int i = 0; i < samples.size(); ++i) {
+            final ArrayList<Double> subSamples = new ArrayList<Double>(samples);
+            subSamples.remove(i);
+            final ArrayList<Double> subWeights = new ArrayList<Double>(weights);
+            subWeights.remove(i);
+
+            entropy -= (samples.size() - 1) *
+                    super.getEntropyFromSamplesAndWeights(subSamples, subWeights) /
+                    samples.size();
+        }
+
+        return entropy;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestAggregation.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.aggregation.AbstractTestAggregationFunction;
+import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import com.google.common.math.DoubleMath;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public abstract class TestAggregation
+        extends AbstractTestAggregationFunction
+{
+    private static final String functionName = "differential_entropy";
+    protected static final Integer SIZE = 12;
+    private final String method;
+    private final Double arg0;
+    private final Double arg1;
+    private InternalAggregationFunction aggregationFunction;
+
+    @BeforeClass
+    public void setUp()
+    {
+        FunctionManager functionManager = MetadataManager.createTestMetadataManager().getFunctionManager();
+        if (arg1 != null) {
+            aggregationFunction = functionManager.getAggregateFunctionImplementation(
+                    functionManager.lookupFunction(
+                            TestAggregation.functionName,
+                            fromTypes(BIGINT, DOUBLE, DOUBLE, VARCHAR, DOUBLE, DOUBLE)));
+        }
+        else if (arg0 != null) {
+            aggregationFunction = functionManager.getAggregateFunctionImplementation(
+                    functionManager.lookupFunction(
+                            TestAggregation.functionName,
+                            fromTypes(BIGINT, DOUBLE, DOUBLE, VARCHAR, DOUBLE)));
+        }
+        else {
+            aggregationFunction = functionManager.getAggregateFunctionImplementation(
+                    functionManager.lookupFunction(
+                            TestAggregation.functionName,
+                            fromTypes(BIGINT, DOUBLE, DOUBLE, VARCHAR)));
+        }
+    }
+
+    @Test
+    public void negativeSize()
+    {
+        try {
+            assertSingleAggregation(0.0, -200, 1.0, 1.0);
+            fail("Expected Exception");
+        }
+        catch (Exception e) {
+        }
+    }
+
+    @Test
+    public void negativeWeight()
+    {
+        try {
+            assertSingleAggregation(0.0, 200, 1.0, -1.0);
+            fail("Expected Exception");
+        }
+        catch (Exception e) {
+            assertTrue(e.getMessage().toLowerCase(Locale.ENGLISH).contains("weight"));
+            assertTrue(e.getMessage().toLowerCase(Locale.ENGLISH).contains("negative"));
+        }
+    }
+
+    @Test
+    public void testUniform()
+    {
+        final int length = 99999;
+        final Random random = new Random(13);
+        final double min = arg0 == null ? 0.0 : arg0;
+        final double max = arg1 == null ? 10.0 : arg1;
+        ArrayList<Double> samples = new ArrayList<Double>();
+        for (int i = 0; i < length; i++) {
+            samples.add(
+                    Double.valueOf(min + (max - min) * random.nextDouble()));
+        }
+        final double expected = Math.log(max - min) / Math.log(2);
+        testSequence(samples, expected);
+    }
+
+    @Test
+    public void testNormal()
+    {
+        final int length = 99999;
+        final Random random = new Random(13);
+        final double min = arg0 == null ? 0.0 : arg0;
+        final double max = arg1 == null ? 10.0 : arg1;
+        ArrayList<Double> samples = new ArrayList<Double>();
+        for (int i = 0; i < length; i++) {
+            samples.add(
+                    clip((max - min) / 2 + random.nextGaussian(), (double) min, (double) max));
+        }
+        final double expected = 0.5 * Math.log(2 * Math.PI * Math.E) / Math.log(2);
+        testSequence(samples, expected);
+    }
+
+    protected void testSequence(ArrayList<Double> samples, double expected)
+    {
+        final Random random = new Random(13);
+        final int length = samples.size();
+        BlockBuilder sizeBlockBuilder = BIGINT.createBlockBuilder(null, length);
+        BlockBuilder sampleBlockBuilder = DOUBLE.createBlockBuilder(null, length);
+        BlockBuilder weightBlockBuilder = DOUBLE.createBlockBuilder(null, length);
+        BlockBuilder methodBlockBuilder = VARCHAR.createBlockBuilder(null, length);
+        BlockBuilder arg0BlockBuilder = null;
+        BlockBuilder arg1BlockBuilder = null;
+        if (this.arg1 != null) {
+            arg0BlockBuilder = DOUBLE.createBlockBuilder(null, length);
+            arg1BlockBuilder = DOUBLE.createBlockBuilder(null, length);
+        }
+        else if (this.arg0 != null) {
+            arg0BlockBuilder = DOUBLE.createBlockBuilder(null, length);
+        }
+        for (double s : samples) {
+            BIGINT.writeLong(sizeBlockBuilder, 200);
+            DOUBLE.writeDouble(sampleBlockBuilder, s);
+            VARCHAR.writeSlice(methodBlockBuilder, wrappedBuffer(this.method.getBytes()));
+            DOUBLE.writeDouble(weightBlockBuilder, Double.valueOf(1.0));
+            if (this.arg1 != null) {
+                DOUBLE.writeDouble(arg0BlockBuilder, this.arg0);
+                DOUBLE.writeDouble(arg1BlockBuilder, this.arg1);
+            }
+            else if (this.arg0 != null) {
+                DOUBLE.writeDouble(arg0BlockBuilder, this.arg0);
+            }
+        }
+        Page page;
+        if (this.arg1 != null) {
+            page = new Page(
+                    sizeBlockBuilder.build(),
+                    sampleBlockBuilder.build(),
+                    weightBlockBuilder.build(),
+                    methodBlockBuilder.build(),
+                    arg0BlockBuilder.build(),
+                    arg1BlockBuilder.build());
+        }
+        else if (this.arg0 != null) {
+            page = new Page(
+                    sizeBlockBuilder.build(),
+                    sampleBlockBuilder.build(),
+                    weightBlockBuilder.build(),
+                    methodBlockBuilder.build(),
+                    arg0BlockBuilder.build());
+        }
+        else {
+            page = new Page(
+                    sizeBlockBuilder.build(),
+                    sampleBlockBuilder.build(),
+                    weightBlockBuilder.build(),
+                    methodBlockBuilder.build());
+        }
+        assertAggregation(
+                aggregationFunction,
+                (l, r) -> DoubleMath.fuzzyCompare((Double) l, (Double) r, 0.01) == 0,
+                "sequence",
+                page,
+                expected);
+    }
+
+    private void assertSingleAggregation(double expected, long size, double sample, double weight)
+    {
+        if (arg1 != null) {
+            assertAggregation(
+                    aggregationFunction,
+                    expected,
+                    createLongsBlock(Long.valueOf(size)),
+                    createDoublesBlock(Double.valueOf(sample)),
+                    createDoublesBlock(Double.valueOf(weight)),
+                    createStringsBlock(method),
+                    createDoublesBlock(Double.valueOf(arg0)),
+                    createDoublesBlock(Double.valueOf(arg1)));
+        }
+        else if (arg0 != null) {
+            assertAggregation(
+                    aggregationFunction,
+                    expected,
+                    createLongsBlock(Long.valueOf(size)),
+                    createDoublesBlock(Double.valueOf(sample)),
+                    createDoublesBlock(Double.valueOf(weight)),
+                    createStringsBlock(method),
+                    createDoublesBlock(Double.valueOf(arg0)));
+        }
+        else {
+            assertAggregation(
+                    aggregationFunction,
+                    expected,
+                    createLongsBlock(Long.valueOf(size)),
+                    createDoublesBlock(Double.valueOf(sample)),
+                    createDoublesBlock(Double.valueOf(weight)),
+                    createStringsBlock(method));
+        }
+    }
+
+    protected TestAggregation(String method, Double arg0, Double arg1)
+    {
+        this.method = method;
+        this.arg0 = arg0;
+        this.arg1 = arg1;
+    }
+
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        BlockBuilder sizeBlockBuilder = BIGINT.createBlockBuilder(null, 2 * length);
+        BlockBuilder sampleBlockBuilder = DOUBLE.createBlockBuilder(null, 2 * length);
+        BlockBuilder weightBlockBuilder = DOUBLE.createBlockBuilder(null, 2 * length);
+        BlockBuilder methodBlockBuilder = VARCHAR.createBlockBuilder(null, 2 * length);
+        BlockBuilder arg0BlockBuilder = null;
+        BlockBuilder arg1BlockBuilder = null;
+        if (this.arg1 != null) {
+            arg0BlockBuilder = DOUBLE.createBlockBuilder(null, 2 * length);
+            arg1BlockBuilder = DOUBLE.createBlockBuilder(null, 2 * length);
+        }
+        else if (this.arg0 != null) {
+            arg0BlockBuilder = DOUBLE.createBlockBuilder(null, 2 * length);
+        }
+        for (int weight = 1; weight < 3; ++weight) {
+            for (int i = start; i < start + length; i++) {
+                BIGINT.writeLong(sizeBlockBuilder, TestAggregation.SIZE);
+                DOUBLE.writeDouble(
+                        sampleBlockBuilder,
+                        Double.valueOf(
+                                clip((double) i, 0.0, (double) TestAggregation.SIZE)));
+                VARCHAR.writeSlice(methodBlockBuilder, wrappedBuffer(this.method.getBytes()));
+                DOUBLE.writeDouble(weightBlockBuilder, Double.valueOf(weight));
+                if (this.arg1 != null) {
+                    DOUBLE.writeDouble(arg0BlockBuilder, this.arg0);
+                    DOUBLE.writeDouble(arg1BlockBuilder, this.arg1);
+                }
+                else if (this.arg0 != null) {
+                    DOUBLE.writeDouble(arg0BlockBuilder, this.arg0);
+                }
+            }
+        }
+
+        if (this.arg1 != null) {
+            return new Block[]{
+                    sizeBlockBuilder.build(),
+                    sampleBlockBuilder.build(),
+                    weightBlockBuilder.build(),
+                    methodBlockBuilder.build(),
+                    arg0BlockBuilder.build(),
+                    arg1BlockBuilder.build()
+            };
+        }
+        if (this.arg0 != null) {
+            return new Block[]{
+                    sizeBlockBuilder.build(),
+                    sampleBlockBuilder.build(),
+                    weightBlockBuilder.build(),
+                    methodBlockBuilder.build(),
+                    arg0BlockBuilder.build()
+            };
+        }
+        return new Block[]{
+                sizeBlockBuilder.build(),
+                sampleBlockBuilder.build(),
+                weightBlockBuilder.build(),
+                methodBlockBuilder.build()
+        };
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "differential_entropy";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        if (this.arg1 != null) {
+            return ImmutableList.of(
+                    StandardTypes.INTEGER,
+                    StandardTypes.DOUBLE,
+                    StandardTypes.DOUBLE,
+                    StandardTypes.VARCHAR,
+                    StandardTypes.DOUBLE,
+                    StandardTypes.DOUBLE);
+        }
+
+        if (this.arg0 != null) {
+            return ImmutableList.of(
+                    StandardTypes.INTEGER,
+                    StandardTypes.DOUBLE,
+                    StandardTypes.DOUBLE,
+                    StandardTypes.VARCHAR,
+                    StandardTypes.DOUBLE);
+        }
+
+        return ImmutableList.of(
+                StandardTypes.INTEGER,
+                StandardTypes.DOUBLE,
+                StandardTypes.DOUBLE,
+                StandardTypes.VARCHAR);
+    }
+
+    protected void getSamplesAndWeights(
+            int start,
+            int length,
+            ArrayList<Double> samples,
+            ArrayList<Double> weights)
+    {
+        for (int weight = 1; weight < 3; ++weight) {
+            for (int i = start; i < start + length; ++i) {
+                final int bin = clip(i, 0, TestAggregation.SIZE - 1);
+                samples.add(Double.valueOf(bin));
+                weights.add(Double.valueOf(weight));
+            }
+        }
+    }
+
+    protected static double clip(double value, double min, double max)
+    {
+        return Math.min(Math.max(value, min), max);
+    }
+
+    protected static int clip(int value, int min, int max)
+    {
+        return Math.min(Math.max(value, min), max);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestFixedHistogramAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestFixedHistogramAggregation.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class TestFixedHistogramAggregation
+        extends TestAggregation
+{
+    private static final double min = 0;
+    private static final double max = (double) TestAggregation.SIZE;
+
+    protected TestFixedHistogramAggregation(String method)
+    {
+        super(
+                method,
+                TestFixedHistogramAggregation.min,
+                TestFixedHistogramAggregation.max);
+    }
+
+    protected double getEntropyFromSamplesAndWeights(ArrayList<Double> samples, ArrayList<Double> weights)
+    {
+        final double weight = weights.stream().mapToDouble(c -> c).sum();
+        if (weight == 0.0) {
+            return 0.0;
+        }
+        final Map<Double, Double> bucketWeights = new HashMap<Double, Double>();
+        for (int i = 0; i < samples.size(); ++i) {
+            final Double s = samples.get(i);
+            final Double w = weights.get(i);
+            bucketWeights.put(
+                    s,
+                    bucketWeights.getOrDefault(s, Double.valueOf(0.0)) + w);
+        }
+        final double rawEntropy = bucketWeights.values().stream()
+                .mapToDouble(w -> w == 0.0 ? 0.0 : w / weight * Math.log(weight / w))
+                .sum() / Math.log(2.0);
+        final double width =
+                (TestFixedHistogramAggregation.max - TestFixedHistogramAggregation.min) /
+                        TestAggregation.SIZE;
+        return rawEntropy + Math.log(width) / Math.log(2);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestFixedHistogramMLEAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestFixedHistogramMLEAggregation.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import java.util.ArrayList;
+
+public class TestFixedHistogramMLEAggregation
+        extends TestFixedHistogramAggregation
+{
+    public TestFixedHistogramMLEAggregation()
+    {
+        super("fixed_histogram_mle");
+    }
+
+    @Override
+    public Double getExpectedValue(int start, int length)
+    {
+        final ArrayList<Double> samples = new ArrayList<Double>();
+        final ArrayList<Double> weights = new ArrayList<Double>();
+        super.getSamplesAndWeights(start, length, samples, weights);
+        return super.getEntropyFromSamplesAndWeights(samples, weights);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/fixedhistogram/TestFixedDoubleBreakdownHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/fixedhistogram/TestFixedDoubleBreakdownHistogram.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.fixedhistogram;
+
+import com.google.common.collect.Streams;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestFixedDoubleBreakdownHistogram
+{
+    @Test
+    public void getters()
+    {
+        final FixedDoubleBreakdownHistogram histogram = new FixedDoubleBreakdownHistogram(200, 3.0, 4.0);
+
+        assertEquals(histogram.getBucketCount(), 200);
+        assertEquals(histogram.getMin(), 3.0);
+        assertEquals(histogram.getMax(), 4.0);
+    }
+
+    @Test
+    public void illegalBucketCount()
+    {
+        try {
+            new FixedDoubleBreakdownHistogram(-200, 3.0, 4.0);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("bucketCount"));
+        }
+    }
+
+    @Test
+    public void illegalMinMax()
+    {
+        try {
+            new FixedDoubleBreakdownHistogram(-200, 3.0, 3.0);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("bucketCount"));
+        }
+    }
+
+    @Test
+    public void basicOps()
+    {
+        final FixedDoubleBreakdownHistogram histogram = new FixedDoubleBreakdownHistogram(200, 3.0, 4.0);
+
+        histogram.add(3.1, 100.0);
+        histogram.add(3.8, 200.0);
+        histogram.add(3.1, 100.0);
+        assertEquals(
+                Streams.stream(histogram.iterator())
+                        .mapToDouble(
+                                c ->
+                                        Streams.stream(c.breakdown.iterator())
+                                                .mapToDouble(e -> e.weight * e.count)
+                                                .sum())
+                        .sum(),
+                400.0);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/fixedhistogram/TestFixedDoubleHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/fixedhistogram/TestFixedDoubleHistogram.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.fixedhistogram;
+
+import com.google.common.collect.Streams;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestFixedDoubleHistogram
+{
+    @Test
+    public void getters()
+    {
+        final FixedDoubleHistogram histogram = new FixedDoubleHistogram(200, 3.0, 4.0);
+
+        assertEquals(histogram.getBucketCount(), 200);
+        assertEquals(histogram.getMin(), 3.0);
+        assertEquals(histogram.getMax(), 4.0);
+    }
+
+    @Test
+    public void illegalBucketCount()
+    {
+        try {
+            new FixedDoubleHistogram(-200, 3.0, 4.0);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("bucketCount"));
+        }
+    }
+
+    @Test
+    public void illegalMinMax()
+    {
+        try {
+            new FixedDoubleHistogram(-200, 3.0, 3.0);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("bucketCount"));
+        }
+    }
+
+    @Test
+    public void basicOps()
+    {
+        final FixedDoubleHistogram histogram = new FixedDoubleHistogram(200, 3.0, 4.0);
+
+        histogram.add(3.1, 100.0);
+        histogram.add(3.8, 200.0);
+        assertEquals(
+                Streams.stream(histogram.iterator()).mapToDouble(c -> c.weight).sum(),
+                300.0);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/fixedhistogram/TestFixedDoubleWeightsHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/fixedhistogram/TestFixedDoubleWeightsHistogram.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.fixedhistogram;
+
+import com.google.common.collect.Streams;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestFixedDoubleWeightsHistogram
+{
+    @Test
+    public void getters()
+    {
+        final FixedDoubleBreakdownHistogram histogram =
+                new FixedDoubleBreakdownHistogram(200, 3.0, 4.0);
+
+        assertEquals(histogram.getBucketCount(), 200);
+        assertEquals(histogram.getMin(), 3.0);
+        assertEquals(histogram.getMax(), 4.0);
+    }
+
+    @Test
+    public void illegalBucketCount()
+    {
+        try {
+            new FixedDoubleBreakdownHistogram(-200, 3.0, 4.0);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("bucketCount"));
+        }
+    }
+
+    @Test
+    public void illegalMinMax()
+    {
+        try {
+            new FixedDoubleBreakdownHistogram(-200, 3.0, 3.0);
+            fail("exception expected");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("bucketCount"));
+        }
+    }
+
+    @Test
+    public void basicOps()
+    {
+        final FixedDoubleBreakdownHistogram histogram =
+                new FixedDoubleBreakdownHistogram(200, 3.0, 4.0);
+
+        histogram.add(3.1, 100.0);
+        histogram.add(3.8, 200.0);
+        assertEquals(
+                Streams.stream(histogram.iterator())
+                        .mapToLong(c ->
+                                Streams.stream(c.breakdown.iterator()).mapToLong(w -> w.count).sum())
+                        .sum(),
+                2);
+        assertEquals(
+                Streams.stream(histogram.iterator())
+                        .mapToDouble(c ->
+                                Streams.stream(c.breakdown.iterator()).mapToDouble(w -> w.weight).sum())
+                        .sum(),
+                300.0);
+    }
+}


### PR DESCRIPTION
Following #12872 and talks with @tdcmeehan, I'd like to ask to pull sample-entropy UDFs.

This PR is part of a series of UDFs, whose main payload is mutual-information classification scores, allowing easy determination of features' relevance to classification. 

In order to calculate the mutual information score, it is necessary to calculate the entropy of random-variable samples. This PR introduces two such methods: using a MLE (maximum-likelihood estimate) on a fixed histogram, and using jacknife estimation on a fixed histogram. The API is future proofed to allow less constrained versions of sample entropy (that don't require specifying the minimum and maximum), but these require reservoir sampling, which is part of a [different PR](https://github.com/prestodb/presto/pull/12915).