### PR TITLE
Avoid using containsAll for tasks in SqlStageExecution

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -232,7 +232,7 @@ public final class SqlStageExecution
         if (getAllTasks().stream().anyMatch(task -> getState() == StageState.RUNNING)) {
             stateMachine.transitionToRunning();
         }
-        if (finishedTasks.containsAll(allTasks)) {
+        if (finishedTasks.size() == allTasks.size()) {
             stateMachine.transitionToFinished();
         }
 
@@ -509,7 +509,7 @@ public final class SqlStageExecution
                 if (taskState == TaskState.RUNNING) {
                     stateMachine.transitionToRunning();
                 }
-                if (finishedTasks.containsAll(allTasks)) {
+                if (finishedTasks.size() == allTasks.size()) {
                     stateMachine.transitionToFinished();
                 }
             }


### PR DESCRIPTION
`containsAll()` is `O(n)`. This causes lock contention on coordinator and cause potential reliability issues. 

 Since `finishedTasks` is a subset of `allTasks`, we can simply compare the size.