### PR TITLE
Change jar version to work with branch based release model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1269,6 +1269,30 @@
                     </excludes>
                 </configuration>
             </plugin>
+
+            <!-- Always build a jar with the test classes -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!-- do not build an empty jar if the project is
+                         e.g. a pom project -->
+                    <skipIfEmpty>true</skipIfEmpty>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                            <addClasspath>false</addClasspath>
+                        </manifest>
+                        <manifestEntries>
+                            <!-- This is actually the time when the build was done -->
+                            <Build-Time>${git.build.time}</Build-Time>
+                            <Git-Commit-Id>${git.commit.id}</Git-Commit-Id>
+                            <Implementation-Version>${project.version}-${git.commit.id.abbrev}</Implementation-Version>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
The previous model involved using git-describe which broke as we
moved to branch based releases since all of our tags are now on the
release branches rather than master.

Even before that, the versions generated used the previous version
number of the release rather than the current maven version.

Changed that to now use a combination of maven version and commit id.