### PR TITLE
Replace all apiNote with Experimental annotation in SPI

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -658,8 +658,9 @@ public interface ConnectorMetadata
     /**
      * Commits partition for table creation.
      * To enable recoverable grouped execution, it is required that output connector supports partition commit.
-     * @apiNote This method is unstable and subject to change in the future.
+     * This method is unstable and subject to change in the future.
      */
+    @Experimental
     default void commitPartition(ConnectorSession session, ConnectorOutputTableHandle tableHandle, int partitionId, Collection<Slice> fragments)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support partition commit");
@@ -668,8 +669,9 @@ public interface ConnectorMetadata
     /**
      * Commits partition for table insertion.
      * To enable recoverable grouped execution, it is required that output connector supports partition commit.
-     * @apiNote This method is unstable and subject to change in the future.
+     * This method is unstable and subject to change in the future.
      */
+    @Experimental
     default void commitPartition(ConnectorSession session, ConnectorInsertTableHandle tableHandle, int partitionId, Collection<Slice> fragments)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support partition commit");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionHandle.java
@@ -14,12 +14,13 @@
 package com.facebook.presto.spi.function;
 
 import com.facebook.presto.spi.CatalogSchemaName;
+import com.facebook.presto.spi.api.Experimental;
 
 /**
- * @apiNote FunctionHandle is a unique handle to identify the function implementation from namespaces.
- *          However, currently it is still under changes, so please don't assume it is backward compatible.
+ * FunctionHandle is a unique handle to identify the function implementation from namespaces.
+ * However, currently it is still under changes, so please don't assume it is backward compatible.
  */
-
+@Experimental
 public interface FunctionHandle
 {
     CatalogSchemaName getCatalogSchemaName();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/PredicateCompiler.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/PredicateCompiler.java
@@ -13,12 +13,15 @@
  */
 package com.facebook.presto.spi.relation;
 
+import com.facebook.presto.spi.api.Experimental;
+
 import java.util.function.Supplier;
 
 /**
- * @apiNote An experimental API to allow Hive connector to implement smart
+ * An experimental API to allow Hive connector to implement smart
  * filtering on the encoded data to avoid materializing data unnecessarily.
  */
+@Experimental
 public interface PredicateCompiler
 {
     /**


### PR DESCRIPTION
apiNote is the legacy way to indicate an experimental interface. Replace
the usage with new Experimental annotation.