### PR TITLE
Rename LogicalRowExpressions::TRUE/FALSE to TRUE/FALSE_CONSTANT

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -217,7 +217,7 @@ import static com.facebook.presto.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
-import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.spi.security.PrincipalType.USER;
 import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -1753,8 +1753,8 @@ public class HiveMetadata
     @Override
     public ConnectorPushdownFilterResult pushdownFilter(ConnectorSession session, ConnectorTableHandle tableHandle, RowExpression filter, Optional<ConnectorTableLayoutHandle> currentLayoutHandle)
     {
-        if (TRUE.equals(filter) && currentLayoutHandle.isPresent()) {
-            return new ConnectorPushdownFilterResult(getTableLayout(session, currentLayoutHandle.get()), TRUE);
+        if (TRUE_CONSTANT.equals(filter) && currentLayoutHandle.isPresent()) {
+            return new ConnectorPushdownFilterResult(getTableLayout(session, currentLayoutHandle.get()), TRUE_CONSTANT);
         }
 
         if (currentLayoutHandle.isPresent()) {
@@ -1812,7 +1812,7 @@ public class HiveMetadata
                                 hivePartitionResult.getEnforcedConstraint(),
                                 hivePartitionResult.getBucketHandle(),
                                 hivePartitionResult.getBucketFilter())),
-                TRUE);
+                TRUE_CONSTANT);
     }
 
     private static Set<VariableReferenceExpression> extractAll(RowExpression expression)
@@ -1858,7 +1858,7 @@ public class HiveMetadata
                                 ImmutableList.copyOf(hivePartitionResult.getPartitionColumns()),
                                 getPartitionsAsList(hivePartitionResult),
                                 hivePartitionResult.getEffectivePredicate().transform(HiveMetadata::toSubfield),
-                                TRUE,
+                                TRUE_CONSTANT,
                                 predicateColumns,
                                 hivePartitionResult.getEnforcedConstraint(),
                                 hivePartitionResult.getBucketHandle(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -205,7 +205,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.TRANSACTION_CONFLICT;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
-import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.spi.security.PrincipalType.USER;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -658,7 +658,7 @@ public abstract class AbstractTestHiveClient
                 ImmutableList.of(),
                 ImmutableList.of(new HivePartition(invalidTable, "unknown", ImmutableMap.of())),
                 TupleDomain.all(),
-                TRUE,
+                TRUE_CONSTANT,
                 ImmutableMap.of(),
                 TupleDomain.all(),
                 Optional.empty(),
@@ -706,7 +706,7 @@ public abstract class AbstractTestHiveClient
         TupleDomain<Subfield> domainPredicate = tupleDomain.transform(HiveColumnHandle.class::cast)
                 .transform(column -> new Subfield(column.getName(), ImmutableList.of()));
         tableLayout = new ConnectorTableLayout(
-                new HiveTableLayoutHandle(tablePartitionFormat, partitionColumns, partitions, domainPredicate, TRUE, ImmutableMap.of(dsColumn.getName(), dsColumn), tupleDomain, Optional.empty(), Optional.empty()),
+                new HiveTableLayoutHandle(tablePartitionFormat, partitionColumns, partitions, domainPredicate, TRUE_CONSTANT, ImmutableMap.of(dsColumn.getName(), dsColumn), tupleDomain, Optional.empty(), Optional.empty()),
                 Optional.empty(),
                 TupleDomain.withColumnDomains(ImmutableMap.of(
                         dsColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("2012-12-29"))), false),
@@ -733,7 +733,7 @@ public abstract class AbstractTestHiveClient
                                 dummyColumn, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 4L)), false)))))),
                 ImmutableList.of());
         List<HivePartition> unpartitionedPartitions = ImmutableList.of(new HivePartition(tableUnpartitioned));
-        unpartitionedTableLayout = new ConnectorTableLayout(new HiveTableLayoutHandle(tableUnpartitioned, ImmutableList.of(), unpartitionedPartitions, TupleDomain.all(), TRUE, ImmutableMap.of(), TupleDomain.all(), Optional.empty(), Optional.empty()));
+        unpartitionedTableLayout = new ConnectorTableLayout(new HiveTableLayoutHandle(tableUnpartitioned, ImmutableList.of(), unpartitionedPartitions, TupleDomain.all(), TRUE_CONSTANT, ImmutableMap.of(), TupleDomain.all(), Optional.empty(), Optional.empty()));
         timeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(timeZoneId));
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -61,7 +61,7 @@ import static com.facebook.presto.hive.HiveUtil.getRegularColumnHandles;
 import static com.facebook.presto.hive.metastore.PrestoTableType.MANAGED_TABLE;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
 import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
-import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -326,7 +326,7 @@ public class TestBackgroundHiveSplitLoader
                 SIMPLE_TABLE.getDatabaseName(),
                 SIMPLE_TABLE.getTableName(),
                 effectivePredicate,
-                TRUE,
+                TRUE_CONSTANT,
                 predicateColumns,
                 1,
                 1,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
@@ -43,7 +43,7 @@ import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.spi.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
-import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.DEREFERENCE;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IN;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -163,7 +163,7 @@ public class TestDomainTranslator
     private void assertPredicateTranslates(RowExpression predicate, String subfield, Domain domain)
     {
         ExtractionResult<Subfield> result = domainTranslator.fromPredicate(TEST_SESSION.toConnectorSession(), predicate, columnExtractor);
-        assertEquals(result.getRemainingExpression(), TRUE);
+        assertEquals(result.getRemainingExpression(), TRUE_CONSTANT);
         assertEquals(result.getTupleDomain(), withColumnDomains(ImmutableMap.of(new Subfield(subfield), domain)));
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -44,7 +44,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.PUSHDOWN_FILTER_ENA
 import static com.facebook.presto.spi.function.OperatorType.CAST;
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
 import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
-import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
@@ -84,12 +84,12 @@ public class TestHiveLogicalPlanner
         assertPlan(pushdownFilterEnabled, "SELECT linenumber FROM lineitem WHERE partkey = 10",
                 output(exchange(
                         strictTableScan("lineitem", identityMap("linenumber")))),
-                plan -> assertTableLayout(plan, "lineitem", withColumnDomains(ImmutableMap.of(new Subfield("partkey", ImmutableList.of()), Domain.singleValue(BIGINT, 10L))), TRUE, ImmutableSet.of("partkey")));
+                plan -> assertTableLayout(plan, "lineitem", withColumnDomains(ImmutableMap.of(new Subfield("partkey", ImmutableList.of()), Domain.singleValue(BIGINT, 10L))), TRUE_CONSTANT, ImmutableSet.of("partkey")));
 
         assertPlan(pushdownFilterEnabled, "SELECT partkey, linenumber FROM lineitem WHERE partkey = 10",
                 output(exchange(
                         strictTableScan("lineitem", identityMap("partkey", "linenumber")))),
-                plan -> assertTableLayout(plan, "lineitem", withColumnDomains(ImmutableMap.of(new Subfield("partkey", ImmutableList.of()), Domain.singleValue(BIGINT, 10L))), TRUE, ImmutableSet.of("partkey")));
+                plan -> assertTableLayout(plan, "lineitem", withColumnDomains(ImmutableMap.of(new Subfield("partkey", ImmutableList.of()), Domain.singleValue(BIGINT, 10L))), TRUE_CONSTANT, ImmutableSet.of("partkey")));
 
         // Only remaining predicate
         assertPlan("SELECT linenumber FROM lineitem WHERE mod(orderkey, 2) = 1",

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -71,7 +71,7 @@ import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.hive.LocationHandle.TableType.NEW;
 import static com.facebook.presto.hive.LocationHandle.WriteMode.DIRECT_TO_TARGET_NEW_DIRECTORY;
 import static com.facebook.presto.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
-import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
@@ -231,7 +231,7 @@ public class TestHivePageSink
                 OptionalInt.empty(),
                 false,
                 TupleDomain.all(),
-                TRUE,
+                TRUE_CONSTANT,
                 ImmutableMap.of(),
                 ImmutableMap.of(),
                 Optional.empty(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
@@ -45,7 +45,7 @@ import java.util.Properties;
 
 import static com.facebook.presto.hive.HiveType.HIVE_LONG;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
-import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -80,7 +80,7 @@ public class TestHiveSplit
                 OptionalInt.empty(),
                 true,
                 TupleDomain.all(),
-                TRUE,
+                TRUE_CONSTANT,
                 ImmutableMap.of(),
                 ImmutableMap.of(1, HIVE_STRING),
                 Optional.of(new HiveSplit.BucketConversion(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -35,7 +35,7 @@ import java.util.concurrent.Executors;
 
 import static com.facebook.presto.hive.HiveTestUtils.SESSION;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
-import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE_CONSTANT;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.testing.Assertions.assertContains;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -59,7 +59,7 @@ public class TestHiveSplitSource
                 "database",
                 "table",
                 TupleDomain.all(),
-                TRUE,
+                TRUE_CONSTANT,
                 ImmutableMap.of(),
                 10,
                 10,
@@ -95,7 +95,7 @@ public class TestHiveSplitSource
                 "database",
                 "table",
                 TupleDomain.all(),
-                TRUE,
+                TRUE_CONSTANT,
                 ImmutableMap.of(),
                 10,
                 10,
@@ -155,7 +155,7 @@ public class TestHiveSplitSource
                 "database",
                 "table",
                 TupleDomain.all(),
-                TRUE,
+                TRUE_CONSTANT,
                 ImmutableMap.of(),
                 10,
                 10,
@@ -211,7 +211,7 @@ public class TestHiveSplitSource
                 "database",
                 "table",
                 TupleDomain.all(),
-                TRUE,
+                TRUE_CONSTANT,
                 ImmutableMap.of(),
                 10,
                 10000,
@@ -252,7 +252,7 @@ public class TestHiveSplitSource
                 "database",
                 "table",
                 TupleDomain.all(),
-                TRUE,
+                TRUE_CONSTANT,
                 ImmutableMap.of(),
                 10,
                 10,
@@ -277,7 +277,7 @@ public class TestHiveSplitSource
                 "database",
                 "table",
                 TupleDomain.all(),
-                TRUE,
+                TRUE_CONSTANT,
                 ImmutableMap.of(),
                 10,
                 new DataSize(1, MEGABYTE),
@@ -338,7 +338,7 @@ public class TestHiveSplitSource
                 "database",
                 "table",
                 TupleDomain.all(),
-                TRUE,
+                TRUE_CONSTANT,
                 ImmutableMap.of(),
                 10,
                 new DataSize(1, MEGABYTE),
@@ -376,7 +376,7 @@ public class TestHiveSplitSource
                 "database",
                 "table",
                 TupleDomain.all(),
-                TRUE,
+                TRUE_CONSTANT,
                 ImmutableMap.of(),
                 10,
                 new DataSize(1, MEGABYTE),

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -106,7 +106,7 @@ import static com.facebook.presto.spi.function.OperatorType.HASH_CODE;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
-import static com.facebook.presto.spi.relation.LogicalRowExpressions.FALSE;
+import static com.facebook.presto.spi.relation.LogicalRowExpressions.FALSE_CONSTANT;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -430,7 +430,7 @@ public class MetadataManager
     @Override
     public PushdownFilterResult pushdownFilter(Session session, TableHandle tableHandle, RowExpression filter)
     {
-        checkArgument(!FALSE.equals(filter), "Cannot pushdown filter that is always false");
+        checkArgument(!FALSE_CONSTANT.equals(filter), "Cannot pushdown filter that is always false");
 
         ConnectorId connectorId = tableHandle.getConnectorId();
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -240,7 +240,7 @@ import static com.facebook.presto.operator.TableWriterOperator.TableWriterOperat
 import static com.facebook.presto.operator.UnnestOperator.UnnestOperatorFactory;
 import static com.facebook.presto.operator.WindowFunctionDefinition.window;
 import static com.facebook.presto.spi.StandardErrorCode.COMPILER_ERROR;
-import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.TypeUtils.writeNativeValue;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
@@ -1704,8 +1704,8 @@ public class LocalExecutionPlanner
 
         private Optional<RowExpression> removeExpressionFromFilter(RowExpression filter, RowExpression expression)
         {
-            RowExpression updatedJoinFilter = replaceExpression(filter, ImmutableMap.of(expression, TRUE));
-            return updatedJoinFilter == TRUE ? Optional.empty() : Optional.of(updatedJoinFilter);
+            RowExpression updatedJoinFilter = replaceExpression(filter, ImmutableMap.of(expression, TRUE_CONSTANT));
+            return updatedJoinFilter == TRUE_CONSTANT ? Optional.empty() : Optional.of(updatedJoinFilter);
         }
 
         private SpatialPredicate spatialTest(CallExpression functionCall, boolean probeFirst, Optional<OperatorType> comparisonOperator)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
@@ -63,7 +63,7 @@ import java.util.Set;
 import static com.facebook.presto.SystemSessionProperties.isNewOptimizerEnabled;
 import static com.facebook.presto.matching.Capture.newCapture;
 import static com.facebook.presto.metadata.TableLayoutResult.computeEnforced;
-import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE;
+import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.sql.ExpressionUtils.combineConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.filterDeterministicConjuncts;
 import static com.facebook.presto.sql.ExpressionUtils.filterNonDeterministicConjuncts;
@@ -232,7 +232,7 @@ public class PickTableLayout
 
             Session session = context.getSession();
             if (metadata.isPushdownFilterSupported(session, tableHandle)) {
-                PushdownFilterResult pushdownFilterResult = metadata.pushdownFilter(session, tableHandle, TRUE);
+                PushdownFilterResult pushdownFilterResult = metadata.pushdownFilter(session, tableHandle, TRUE_CONSTANT);
                 if (pushdownFilterResult.getLayout().getPredicate().isNone()) {
                     return Result.ofPlanNode(new ValuesNode(context.getIdAllocator().getNextId(), tableScanNode.getOutputVariables(), ImmutableList.of()));
                 }
@@ -312,7 +312,7 @@ public class PickTableLayout
                     TupleDomain.all());
 
             RowExpression unenforcedFilter = pushdownFilterResult.getUnenforcedFilter();
-            if (!TRUE.equals(unenforcedFilter)) {
+            if (!TRUE_CONSTANT.equals(unenforcedFilter)) {
                 return new FilterNode(idAllocator.getNextId(), tableScan, replaceExpression(unenforcedFilter, symbolToColumnMapping.inverse()));
             }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/LogicalRowExpressions.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/LogicalRowExpressions.java
@@ -37,8 +37,8 @@ import static java.util.stream.Collectors.toList;
 
 public final class LogicalRowExpressions
 {
-    public static final ConstantExpression TRUE = new ConstantExpression(true, BOOLEAN);
-    public static final ConstantExpression FALSE = new ConstantExpression(false, BOOLEAN);
+    public static final ConstantExpression TRUE_CONSTANT = new ConstantExpression(true, BOOLEAN);
+    public static final ConstantExpression FALSE_CONSTANT = new ConstantExpression(false, BOOLEAN);
 
     private final DeterminismEvaluator determinismEvaluator;
     private final StandardFunctionResolution functionResolution;
@@ -115,9 +115,9 @@ public final class LogicalRowExpressions
         if (expressions.isEmpty()) {
             switch (form) {
                 case AND:
-                    return TRUE;
+                    return TRUE_CONSTANT;
                 case OR:
-                    return FALSE;
+                    return FALSE_CONSTANT;
                 default:
                     throw new IllegalArgumentException("Unsupported binary expression operator");
             }
@@ -199,13 +199,13 @@ public final class LogicalRowExpressions
 
         List<RowExpression> conjuncts = expressions.stream()
                 .flatMap(e -> extractConjuncts(e).stream())
-                .filter(e -> !e.equals(TRUE))
+                .filter(e -> !e.equals(TRUE_CONSTANT))
                 .collect(toList());
 
         conjuncts = removeDuplicates(conjuncts);
 
-        if (conjuncts.contains(FALSE)) {
-            return FALSE;
+        if (conjuncts.contains(FALSE_CONSTANT)) {
+            return FALSE_CONSTANT;
         }
 
         return and(conjuncts);
@@ -218,7 +218,7 @@ public final class LogicalRowExpressions
 
     public RowExpression combineDisjuncts(Collection<RowExpression> expressions)
     {
-        return combineDisjunctsWithDefault(expressions, FALSE);
+        return combineDisjunctsWithDefault(expressions, FALSE_CONSTANT);
     }
 
     public RowExpression combineDisjunctsWithDefault(Collection<RowExpression> expressions, RowExpression emptyDefault)
@@ -227,13 +227,13 @@ public final class LogicalRowExpressions
 
         List<RowExpression> disjuncts = expressions.stream()
                 .flatMap(e -> extractDisjuncts(e).stream())
-                .filter(e -> !e.equals(FALSE))
+                .filter(e -> !e.equals(FALSE_CONSTANT))
                 .collect(toList());
 
         disjuncts = removeDuplicates(disjuncts);
 
-        if (disjuncts.contains(TRUE)) {
-            return TRUE;
+        if (disjuncts.contains(TRUE_CONSTANT)) {
+            return TRUE_CONSTANT;
         }
 
         return disjuncts.isEmpty() ? emptyDefault : or(disjuncts);


### PR DESCRIPTION
TRUE/FALSE collide with java.lang.Boolean.TRUE/FALSE

This goes after #12606