### PR TITLE
Add PushdownSubfields optimizer rule

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
@@ -15,11 +15,14 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.Subfield;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -60,6 +63,7 @@ public class HiveColumnHandle
     private final int hiveColumnIndex;
     private final ColumnType columnType;
     private final Optional<String> comment;
+    private final List<Subfield> requiredSubfields;
 
     @JsonCreator
     public HiveColumnHandle(
@@ -68,7 +72,8 @@ public class HiveColumnHandle
             @JsonProperty("typeSignature") TypeSignature typeSignature,
             @JsonProperty("hiveColumnIndex") int hiveColumnIndex,
             @JsonProperty("columnType") ColumnType columnType,
-            @JsonProperty("comment") Optional<String> comment)
+            @JsonProperty("comment") Optional<String> comment,
+            @JsonProperty("requiredSubfields") List<Subfield> requiredSubfields)
     {
         this.name = requireNonNull(name, "name is null");
         checkArgument(hiveColumnIndex >= 0 || columnType == PARTITION_KEY || columnType == SYNTHESIZED, "hiveColumnIndex is negative");
@@ -77,6 +82,18 @@ public class HiveColumnHandle
         this.typeName = requireNonNull(typeSignature, "type is null");
         this.columnType = requireNonNull(columnType, "columnType is null");
         this.comment = requireNonNull(comment, "comment is null");
+        this.requiredSubfields = requireNonNull(requiredSubfields, "requiredSubfields is null");
+    }
+
+    public HiveColumnHandle(
+            String name,
+            HiveType hiveType,
+            TypeSignature typeSignature,
+            int hiveColumnIndex,
+            ColumnType columnType,
+            Optional<String> comment)
+    {
+        this(name, hiveType, typeSignature, hiveColumnIndex, columnType, comment, ImmutableList.of());
     }
 
     @JsonProperty
@@ -130,6 +147,18 @@ public class HiveColumnHandle
         return columnType;
     }
 
+    @JsonProperty
+    public List<Subfield> getRequiredSubfields()
+    {
+        return requiredSubfields;
+    }
+
+    @Override
+    public ColumnHandle withRequiredSubfields(List<Subfield> subfields)
+    {
+        return new HiveColumnHandle(name, hiveType, typeName, hiveColumnIndex, columnType, comment, subfields);
+    }
+
     @Override
     public int hashCode()
     {
@@ -150,13 +179,18 @@ public class HiveColumnHandle
                 Objects.equals(this.hiveColumnIndex, other.hiveColumnIndex) &&
                 Objects.equals(this.hiveType, other.hiveType) &&
                 Objects.equals(this.columnType, other.columnType) &&
-                Objects.equals(this.comment, other.comment);
+                Objects.equals(this.comment, other.comment) &&
+                Objects.equals(this.requiredSubfields, other.requiredSubfields);
     }
 
     @Override
     public String toString()
     {
-        return name + ":" + hiveType + ":" + hiveColumnIndex + ":" + columnType;
+        if (requiredSubfields.isEmpty()) {
+            return name + ":" + hiveType + ":" + hiveColumnIndex + ":" + columnType;
+        }
+
+        return name + ":" + hiveType + ":" + hiveColumnIndex + ":" + columnType + ":" + requiredSubfields;
     }
 
     public static HiveColumnHandle updateRowIdHandle()
@@ -167,12 +201,12 @@ public class HiveColumnHandle
         // plan-time support for row-by-row delete so that planning doesn't fail. This is why we need
         // rowid handle. Note that in Hive connector, rowid handle is not implemented beyond plan-time.
 
-        return new HiveColumnHandle(UPDATE_ROW_ID_COLUMN_NAME, HIVE_LONG, BIGINT.getTypeSignature(), -1, SYNTHESIZED, Optional.empty());
+        return new HiveColumnHandle(UPDATE_ROW_ID_COLUMN_NAME, HIVE_LONG, BIGINT.getTypeSignature(), -1, SYNTHESIZED, Optional.empty(), ImmutableList.of());
     }
 
     public static HiveColumnHandle pathColumnHandle()
     {
-        return new HiveColumnHandle(PATH_COLUMN_NAME, PATH_HIVE_TYPE, PATH_TYPE_SIGNATURE, PATH_COLUMN_INDEX, SYNTHESIZED, Optional.empty());
+        return new HiveColumnHandle(PATH_COLUMN_NAME, PATH_HIVE_TYPE, PATH_TYPE_SIGNATURE, PATH_COLUMN_INDEX, SYNTHESIZED, Optional.empty(), ImmutableList.of());
     }
 
     /**
@@ -182,7 +216,7 @@ public class HiveColumnHandle
      */
     public static HiveColumnHandle bucketColumnHandle()
     {
-        return new HiveColumnHandle(BUCKET_COLUMN_NAME, BUCKET_HIVE_TYPE, BUCKET_TYPE_SIGNATURE, BUCKET_COLUMN_INDEX, SYNTHESIZED, Optional.empty());
+        return new HiveColumnHandle(BUCKET_COLUMN_NAME, BUCKET_HIVE_TYPE, BUCKET_TYPE_SIGNATURE, BUCKET_COLUMN_INDEX, SYNTHESIZED, Optional.empty(), ImmutableList.of());
     }
 
     public static boolean isPathColumnHandle(HiveColumnHandle column)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -368,7 +368,8 @@ public class HivePageSourceProvider
                                 columnMapping.getCoercionFrom().get().getTypeSignature(),
                                 columnHandle.getHiveColumnIndex(),
                                 columnHandle.getColumnType(),
-                                Optional.empty());
+                                Optional.empty(),
+                                columnHandle.getRequiredSubfields());
                     })
                     .collect(toList());
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcPageSourceFactory.java
@@ -293,7 +293,7 @@ public class OrcPageSourceFactory
                 physicalOrdinal = nextMissingColumnIndex;
                 nextMissingColumnIndex++;
             }
-            physicalColumns.add(new HiveColumnHandle(column.getName(), column.getHiveType(), column.getTypeSignature(), physicalOrdinal, column.getColumnType(), column.getComment()));
+            physicalColumns.add(new HiveColumnHandle(column.getName(), column.getHiveType(), column.getTypeSignature(), physicalOrdinal, column.getColumnType(), column.getComment(), column.getRequiredSubfields()));
         }
         return physicalColumns.build();
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -14,8 +14,11 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.CastType;
 import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.Subfield;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.TupleDomain;
@@ -24,6 +27,13 @@ import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.assertions.MatchResult;
+import com.facebook.presto.sql.planner.assertions.Matcher;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.assertions.SymbolAliases;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.TableScanNode;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
@@ -49,14 +59,22 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
+import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictTableScan;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.tpch.TpchTable.LINE_ITEM;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -154,7 +172,7 @@ public class TestHiveLogicalPlanner
     private void assertTableLayout(Plan plan, String tableName, TupleDomain<Subfield> domainPredicate, RowExpression remainingPredicate, Set<String> predicateColumnNames)
     {
         TableScanNode tableScan = searchFrom(plan.getRoot())
-                .where(node -> node instanceof TableScanNode && ((HiveTableHandle) ((TableScanNode) node).getTable().getConnectorHandle()).getTableName().equals(tableName))
+                .where(node -> isTableScanNode(node, tableName))
                 .findOnlyElement();
 
         assertTrue(tableScan.getTable().getLayout().isPresent());
@@ -163,5 +181,377 @@ public class TestHiveLogicalPlanner
         assertEquals(layoutHandle.getPredicateColumns().keySet(), predicateColumnNames);
         assertEquals(layoutHandle.getDomainPredicate(), domainPredicate);
         assertEquals(layoutHandle.getRemainingPredicate(), remainingPredicate);
+    }
+
+    @Test
+    public void testPushdownArraySubscripts()
+    {
+        assertUpdate("CREATE TABLE test_pushdown_array_subscripts(id bigint, a array(bigint), b array(array(varchar)))");
+
+        assertPushdownSubscripts("test_pushdown_array_subscripts");
+
+        // Unnest
+        assertPushdownSubfields("SELECT t.b, a[1] FROM test_pushdown_array_subscripts CROSS JOIN UNNEST(b) as t(b)", "test_pushdown_array_subscripts",
+                ImmutableMap.of("a", toSubfields("a[1]")));
+
+        assertPushdownSubfields("SELECT t.b, a[1] FROM test_pushdown_array_subscripts CROSS JOIN UNNEST(b[1]) as t(b)", "test_pushdown_array_subscripts",
+                ImmutableMap.of("a", toSubfields("a[1]"), "b", toSubfields("b[1]")));
+
+        assertPushdownSubfields("SELECT t.b[2], a[1] FROM test_pushdown_array_subscripts CROSS JOIN UNNEST(b) as t(b)", "test_pushdown_array_subscripts",
+                ImmutableMap.of("a", toSubfields("a[1]"), "b", toSubfields("b[*][2]")));
+
+        assertPushdownSubfields("SELECT id, grouping(index), sum(length(b[1][2])) FROM test_pushdown_array_subscripts CROSS JOIN UNNEST(a) as t(index) GROUP BY grouping sets ((index, id), (index))", "test_pushdown_array_subscripts",
+                ImmutableMap.of("b", toSubfields("b[1][2]")));
+
+        assertPushdownSubfields("SELECT id, b[1] FROM test_pushdown_array_subscripts CROSS JOIN UNNEST(a) as t(unused)", "test_pushdown_array_subscripts",
+                ImmutableMap.of("b", toSubfields("b[1]")));
+
+        // No subfield pruning
+        assertPushdownSubfields("SELECT array_sort(a)[1] FROM test_pushdown_array_subscripts", "test_pushdown_array_subscripts",
+                ImmutableMap.of());
+
+        assertPushdownSubfields("SELECT id FROM test_pushdown_array_subscripts CROSS JOIN UNNEST(a) as t(index) WHERE a[1] > 10 AND cardinality(b[index]) = 2", "test_pushdown_array_subscripts",
+                ImmutableMap.of());
+
+        assertUpdate("DROP TABLE test_pushdown_array_subscripts");
+    }
+
+    @Test
+    public void testPushdownMapSubscripts()
+    {
+        assertUpdate("CREATE TABLE test_pushdown_map_subscripts(id bigint, a map(bigint, bigint), b map(bigint, map(bigint, varchar)), c map(varchar, bigint))");
+
+        assertPushdownSubscripts("test_pushdown_map_subscripts");
+
+        // Unnest
+        assertPushdownSubfields("SELECT t.b, a[1] FROM test_pushdown_map_subscripts CROSS JOIN UNNEST(b) as t(k, b)", "test_pushdown_map_subscripts",
+                ImmutableMap.of("a", toSubfields("a[1]")));
+
+        assertPushdownSubfields("SELECT t.b, a[1] FROM test_pushdown_map_subscripts CROSS JOIN UNNEST(b[1]) as t(k, b)", "test_pushdown_map_subscripts",
+                ImmutableMap.of("a", toSubfields("a[1]"), "b", toSubfields("b[1]")));
+
+        assertPushdownSubfields("SELECT t.b[2], a[1] FROM test_pushdown_map_subscripts CROSS JOIN UNNEST(b) as t(k, b)", "test_pushdown_map_subscripts",
+                ImmutableMap.of("a", toSubfields("a[1]"), "b", toSubfields("b[*][2]")));
+
+        assertPushdownSubfields("SELECT id, b[1] FROM test_pushdown_map_subscripts CROSS JOIN UNNEST(a) as t(unused_k, unused_v)", "test_pushdown_map_subscripts",
+                ImmutableMap.of("b", toSubfields("b[1]")));
+
+        // Map with varchar keys
+        assertPushdownSubfields("SELECT c['cat'] FROM test_pushdown_map_subscripts", "test_pushdown_map_subscripts",
+                ImmutableMap.of("c", toSubfields("c[\"cat\"]")));
+
+        assertPushdownSubfields("SELECT mod(c['cat'], 2) FROM test_pushdown_map_subscripts WHERE c['dog'] > 10", "test_pushdown_map_subscripts",
+                ImmutableMap.of("c", toSubfields("c[\"cat\"]", "c[\"dog\"]")));
+
+        // No subfield pruning
+        assertPushdownSubfields("SELECT map_keys(a)[1] FROM test_pushdown_map_subscripts", "test_pushdown_map_subscripts",
+                ImmutableMap.of());
+
+        assertUpdate("DROP TABLE test_pushdown_map_subscripts");
+    }
+
+    private void assertPushdownSubscripts(String tableName)
+    {
+        // Filter and project
+        assertPushdownSubfields(format("SELECT a[1] FROM %s", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]")));
+
+        assertPushdownSubfields(format("SELECT a[1] + 10 FROM %s", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]")));
+
+        assertPushdownSubfields(format("SELECT a[1] + mod(a[2], 3) FROM %s", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]", "a[2]")));
+
+        assertPushdownSubfields(format("SELECT a[1] FROM %s WHERE a[2] > 10", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]", "a[2]")));
+
+        assertPushdownSubfields(format("SELECT a[1] FROM %s WHERE mod(a[2], 3) = 1", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]", "a[2]")));
+
+        assertPushdownSubfields(format("SELECT a[1], b[2][3] FROM %s", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]"), "b", toSubfields("b[2][3]")));
+
+        assertPushdownSubfields(format("SELECT cardinality(b[1]), b[1][2] FROM %s", tableName), tableName,
+                ImmutableMap.of("b", toSubfields("b[1]")));
+
+        assertPushdownSubfields(format("CREATE TABLE x AS SELECT id, a[1] as a1 FROM %s", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]")));
+
+        assertPushdownSubfields(format("CREATE TABLE x AS SELECT id FROM %s WHERE a[1] > 10", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]")));
+
+        assertPushdownSubfields(format("SELECT a[1] FROM %s ORDER BY id LIMIT 1", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]")));
+
+        // Sort
+        assertPushdownSubfields(format("SELECT a[1] FROM %s ORDER BY a[2]", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]", "a[2]")));
+
+        // Join
+        assertPlan(format("SELECT l.orderkey, a.a[1] FROM lineitem l, %s a WHERE l.linenumber = a.id", tableName),
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(tableScan("lineitem", ImmutableMap.of())),
+                                anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[1]")))))));
+
+        assertPlan(format("SELECT l.orderkey, a.a[1] FROM lineitem l, %s a WHERE l.linenumber = a.id AND a.a[2] > 10", tableName),
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(tableScan("lineitem", ImmutableMap.of())),
+                                anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[1]", "a[2]")))))));
+
+        // Semi join
+        assertPlan(format("SELECT a[1] FROM %s WHERE a[2] IN (SELECT a[3] FROM %s)", tableName, tableName),
+                anyTree(node(SemiJoinNode.class,
+                        anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[1]", "a[2]")))),
+                        anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[3]")))))));
+
+        // Aggregation
+        assertPushdownSubfields(format("SELECT id, min(a[1]) FROM %s GROUP BY 1", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]")));
+
+        assertPushdownSubfields(format("SELECT id, min(a[1]) FROM %s GROUP BY 1, a[2]", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]", "a[2]")));
+
+        assertPushdownSubfields(format("SELECT id, min(a[1]) FROM %s GROUP BY 1 HAVING max(a[2]) > 10", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]", "a[2]")));
+
+        assertPushdownSubfields(format("SELECT id, min(mod(a[1], 3)) FROM %s GROUP BY 1", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]")));
+
+        assertPushdownSubfields(format("SELECT id, min(a[1]) FILTER (WHERE a[2] > 10) FROM %s GROUP BY 1", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]", "a[2]")));
+
+        assertPushdownSubfields(format("SELECT id, min(a[1] + length(b[2][3])) * avg(a[4]) FROM %s GROUP BY 1", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]", "a[4]"), "b", toSubfields("b[2][3]")));
+
+        assertPushdownSubfields(format("SELECT min(a[1]) FROM %s GROUP BY id", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]")));
+
+        // Union
+        assertPlan(format("SELECT a[1] FROM %s UNION ALL SELECT a[2] FROM %s", tableName, tableName),
+                anyTree(exchange(
+                        anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[1]")))),
+                        anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[2]")))))));
+
+        assertPlan(format("SELECT a[1] FROM (SELECT * FROM %s UNION ALL SELECT * FROM %s)", tableName, tableName),
+                anyTree(exchange(
+                        anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[1]")))),
+                        anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[1]")))))));
+
+        assertPlan(format("SELECT a[1] FROM (SELECT * FROM %s WHERE a[2] > 10 UNION ALL SELECT * FROM %s)", tableName, tableName),
+                anyTree(exchange(
+                        anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[1]", "a[2]")))),
+                        anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[1]")))))));
+
+        // Except
+        assertPlan(format("SELECT a[1] FROM %s EXCEPT SELECT a[2] FROM %s", tableName, tableName),
+                anyTree(exchange(
+                        anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[1]")))),
+                        anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[2]")))))));
+
+        // Intersect
+        assertPlan(format("SELECT a[1] FROM %s INTERSECT SELECT a[2] FROM %s", tableName, tableName),
+                anyTree(exchange(
+                        anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[1]")))),
+                        anyTree(tableScan(tableName, ImmutableMap.of("a", toSubfields("a[2]")))))));
+
+        // Window function
+        assertPushdownSubfields(format("SELECT id, first_value(a[1]) over (partition by a[2] order by b[1][2]) FROM %s", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]", "a[2]"), "b", toSubfields("b[1][2]")));
+
+        assertPushdownSubfields(format("SELECT count(*) over (partition by a[1] order by a[2] rows between a[3] preceding and a[4] preceding) FROM %s", tableName), tableName,
+                ImmutableMap.of("a", toSubfields("a[1]", "a[2]", "a[3]", "a[4]")));
+
+        // no subfield pruning
+        assertPushdownSubfields(format("SELECT a[id] FROM %s", tableName), tableName,
+                ImmutableMap.of());
+
+        assertPushdownSubfields(format("SELECT a[1] FROM (SELECT DISTINCT * FROM %s) LIMIT 10", tableName), tableName,
+                ImmutableMap.of());
+    }
+
+    @Test
+    public void testPushdownSubfields()
+    {
+        assertUpdate("CREATE TABLE test_pushdown_struct_subfields(id bigint, x row(a bigint, b varchar, c double, d row(d1 bigint, d2 double)), y array(row(a bigint, b varchar, c double, d row(d1 bigint, d2 double))))");
+
+        assertPushdownSubfields("SELECT t.a, t.d.d1, x.a FROM test_pushdown_struct_subfields CROSS JOIN UNNEST(y) as t(a, b, c, d)", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a"), "y", toSubfields("y[*].a", "y[*].d.d1")));
+
+        assertPushdownSubfields("SELECT x.a, mod(x.d.d1, 2) FROM test_pushdown_struct_subfields", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a", "x.d.d1")));
+
+        assertPushdownSubfields("SELECT x.d, mod(x.d.d1, 2), x.d.d2 FROM test_pushdown_struct_subfields", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.d")));
+
+        assertPushdownSubfields("SELECT x.a FROM test_pushdown_struct_subfields WHERE x.b LIKE 'abc%'", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a", "x.b")));
+
+        assertPushdownSubfields("SELECT x.a FROM test_pushdown_struct_subfields WHERE x.a > 10 AND x.b LIKE 'abc%'", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a", "x.b")));
+
+        // Join
+        Session session = getQueryRunner().getDefaultSession();
+        assertPlan("SELECT l.orderkey, x.a, mod(x.d.d1, 2) FROM lineitem l, test_pushdown_struct_subfields a WHERE l.linenumber = a.id",
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(tableScan("lineitem", ImmutableMap.of())),
+                                anyTree(tableScan("test_pushdown_struct_subfields", ImmutableMap.of("x", toSubfields("x.a", "x.d.d1")))))));
+
+        assertPlan("SELECT l.orderkey, x.a, mod(x.d.d1, 2) FROM lineitem l, test_pushdown_struct_subfields a WHERE l.linenumber = a.id AND x.a > 10",
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(tableScan("lineitem", ImmutableMap.of())),
+                                anyTree(tableScan("test_pushdown_struct_subfields", ImmutableMap.of("x", toSubfields("x.a", "x.d.d1")))))));
+
+        // Aggregation
+        assertPushdownSubfields("SELECT id, min(x.a) FROM test_pushdown_struct_subfields GROUP BY 1", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a")));
+
+        assertPushdownSubfields("SELECT id, min(mod(x.a, 3)) FROM test_pushdown_struct_subfields GROUP BY 1", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a")));
+
+        assertPushdownSubfields("SELECT id, min(x.a) FILTER (WHERE x.b LIKE 'abc%') FROM test_pushdown_struct_subfields GROUP BY 1", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a", "x.b")));
+
+        assertPushdownSubfields("SELECT id, min(x.a + length(y[2].b)) * avg(x.d.d1) FROM test_pushdown_struct_subfields GROUP BY 1", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a", "x.d.d1"), "y", toSubfields("y[2].b")));
+
+        // Unnest
+        assertPushdownSubfields("SELECT t.a, t.d.d1, x.a FROM test_pushdown_struct_subfields CROSS JOIN UNNEST(y) as t(a, b, c, d)", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a"), "y", toSubfields("y[*].a", "y[*].d.d1")));
+
+        assertPushdownSubfields("SELECT t.*, x.a FROM test_pushdown_struct_subfields CROSS JOIN UNNEST(y) as t(a, b, c, d)", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a"), "y", toSubfields("y[*].a", "y[*].b", "y[*].c", "y[*].d")));
+
+        assertPushdownSubfields("SELECT id, x.a FROM test_pushdown_struct_subfields CROSS JOIN UNNEST(y) as t(a, b, c, d)", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a")));
+
+        assertUpdate("DROP TABLE test_pushdown_struct_subfields");
+    }
+
+    @Test
+    public void testPushdownSubfieldsAssorted()
+    {
+        assertUpdate("CREATE TABLE test_pushdown_subfields(" +
+                "id bigint, " +
+                "a array(bigint), " +
+                "b map(bigint, bigint), " +
+                "c map(varchar, bigint), " +
+                "d row(d1 bigint, d2 array(bigint), d3 map(bigint, bigint), d4 row(x double, y double)))");
+
+        assertPushdownSubfields("SELECT id, a[1], mod(a[2], 3), b[10], c['cat'] + c['dog'], d.d1 * d.d2[5] / d.d3[2], d.d4.x FROM test_pushdown_subfields", "test_pushdown_subfields",
+                ImmutableMap.of(
+                        "a", toSubfields("a[1]", "a[2]"),
+                        "b", toSubfields("b[10]"),
+                        "c", toSubfields("c[\"cat\"]", "c[\"dog\"]"),
+                        "d", toSubfields("d.d1", "d.d2[5]", "d.d3[2]", "d.d4.x")));
+
+        assertPushdownSubfields("SELECT count(*) FROM test_pushdown_subfields WHERE a[1] > a[2] AND b[1] * c['cat'] = 5 AND d.d4.x IS NULL", "test_pushdown_subfields",
+                ImmutableMap.of(
+                        "a", toSubfields("a[1]", "a[2]"),
+                        "b", toSubfields("b[1]"),
+                        "c", toSubfields("c[\"cat\"]"),
+                        "d", toSubfields("d.d4.x")));
+
+        assertPushdownSubfields("SELECT a[1], cardinality(b), map_keys(c), k, v, d.d3[5] FROM test_pushdown_subfields CROSS JOIN UNNEST(c) as t(k, v)", "test_pushdown_subfields",
+                ImmutableMap.of(
+                        "a", toSubfields("a[1]"),
+                        "d", toSubfields("d.d3[5]")));
+
+        assertUpdate("DROP TABLE test_pushdown_subfields");
+    }
+
+    @Test
+    public void testPushdownFilterAndSubfields()
+    {
+        assertUpdate("CREATE TABLE test_pushdown_filter_and_subscripts(id bigint, a array(bigint), b array(array(varchar)))");
+
+        Session pushdownFilterEnabled = Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty(HIVE_CATALOG, PUSHDOWN_FILTER_ENABLED, "true")
+                .build();
+
+        assertPushdownSubfields("SELECT a[1] FROM test_pushdown_filter_and_subscripts WHERE a[2] > 10", "test_pushdown_filter_and_subscripts",
+                ImmutableMap.of("a", toSubfields("a[1]", "a[2]")));
+
+        assertPushdownSubfields(pushdownFilterEnabled, "SELECT a[1] FROM test_pushdown_filter_and_subscripts WHERE a[2] > 10", "test_pushdown_filter_and_subscripts",
+                ImmutableMap.of("a", toSubfields("a[1]")));
+
+        assertUpdate("DROP TABLE test_pushdown_filter_and_subscripts");
+    }
+
+    private static Set<Subfield> toSubfields(String... subfieldPaths)
+    {
+        return Arrays.stream(subfieldPaths)
+                .map(Subfield::new)
+                .collect(toImmutableSet());
+    }
+
+    private void assertPushdownSubfields(String query, String tableName, Map<String, Set<Subfield>> requiredSubfields)
+    {
+        assertPlan(query, anyTree(tableScan(tableName, requiredSubfields)));
+    }
+
+    private void assertPushdownSubfields(Session session, String query, String tableName, Map<String, Set<Subfield>> requiredSubfields)
+    {
+        assertPlan(session, query, anyTree(tableScan(tableName, requiredSubfields)));
+    }
+
+    private static PlanMatchPattern tableScan(String expectedTableName, Map<String, Set<Subfield>> expectedRequiredSubfields)
+    {
+        return PlanMatchPattern.tableScan(expectedTableName).with(new HiveTableScanMatcher(expectedRequiredSubfields));
+    }
+
+    private static boolean isTableScanNode(PlanNode node, String tableName)
+    {
+        return node instanceof TableScanNode && ((HiveTableHandle) ((TableScanNode) node).getTable().getConnectorHandle()).getTableName().equals(tableName);
+    }
+
+    private static final class HiveTableScanMatcher
+            implements Matcher
+    {
+        private final Map<String, Set<Subfield>> requiredSubfields;
+
+        private HiveTableScanMatcher(Map<String, Set<Subfield>> requiredSubfields)
+        {
+            this.requiredSubfields = requireNonNull(requiredSubfields, "requiredSubfields is null");
+        }
+
+        @Override
+        public boolean shapeMatches(PlanNode node)
+        {
+            return node instanceof TableScanNode;
+        }
+
+        @Override
+        public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+        {
+            TableScanNode tableScan = (TableScanNode) node;
+            for (ColumnHandle column : tableScan.getAssignments().values()) {
+                HiveColumnHandle hiveColumn = (HiveColumnHandle) column;
+                String columnName = hiveColumn.getName();
+                if (requiredSubfields.containsKey(columnName)) {
+                    if (!requiredSubfields.get(columnName).equals(ImmutableSet.copyOf(hiveColumn.getRequiredSubfields()))) {
+                        return NO_MATCH;
+                    }
+                }
+                else {
+                    if (!hiveColumn.getRequiredSubfields().isEmpty()) {
+                        return NO_MATCH;
+                    }
+                }
+            }
+
+            return match();
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("requiredSubfields", requiredSubfields)
+                    .toString();
+        }
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestJsonHiveHandles.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestJsonHiveHandles.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.ObjectMapperProvider;
 import org.testng.annotations.Test;
@@ -45,6 +46,7 @@ public class TestJsonHiveHandles
             .put("hiveColumnIndex", -1)
             .put("columnType", PARTITION_KEY.toString())
             .put("comment", "comment")
+            .put("requiredSubfields", ImmutableList.of())
             .build();
 
     private final ObjectMapper objectMapper = new ObjectMapperProvider().get();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -114,6 +114,7 @@ import com.facebook.presto.sql.planner.optimizations.OptimizeMixedDistinctAggreg
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.optimizations.PredicatePushDown;
 import com.facebook.presto.sql.planner.optimizations.PruneUnreferencedOutputs;
+import com.facebook.presto.sql.planner.optimizations.PushdownSubfields;
 import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinInDelete;
 import com.facebook.presto.sql.planner.optimizations.SetFlatteningOptimizer;
 import com.facebook.presto.sql.planner.optimizations.StatsRecordingPlanOptimizer;
@@ -407,6 +408,7 @@ public class PlanOptimizers
                         statsCalculator,
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(new RemoveRedundantIdentityProjections())),
+                new PushdownSubfields(metadata),
 
                 // Because ReorderJoins runs only once,
                 // PredicatePushDown, PruneUnreferenedOutputpus and RemoveRedundantIdentityProjections

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -1,0 +1,601 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.warnings.WarningCollector;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.TableHandle;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.Subfield;
+import com.facebook.presto.spi.Subfield.NestedField;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.RowType;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.facebook.presto.sql.planner.OrderingScheme;
+import com.facebook.presto.sql.planner.Symbol;
+import com.facebook.presto.sql.planner.SymbolAllocator;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.AggregationNode;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
+import com.facebook.presto.sql.planner.plan.DistinctLimitNode;
+import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
+import com.facebook.presto.sql.planner.plan.FilterNode;
+import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.facebook.presto.sql.planner.plan.IndexJoinNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.MarkDistinctNode;
+import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.PlanNode;
+import com.facebook.presto.sql.planner.plan.ProjectNode;
+import com.facebook.presto.sql.planner.plan.RowNumberNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.SortNode;
+import com.facebook.presto.sql.planner.plan.SpatialJoinNode;
+import com.facebook.presto.sql.planner.plan.TableScanNode;
+import com.facebook.presto.sql.planner.plan.TableWriterNode;
+import com.facebook.presto.sql.planner.plan.TopNNode;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
+import com.facebook.presto.sql.planner.plan.UnionNode;
+import com.facebook.presto.sql.planner.plan.UnnestNode;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.sql.relational.OriginalExpressionUtils;
+import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.DefaultExpressionTraversalVisitor;
+import com.facebook.presto.sql.tree.DereferenceExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.GenericLiteral;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.StringLiteral;
+import com.facebook.presto.sql.tree.SubscriptExpression;
+import com.facebook.presto.sql.tree.SymbolReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.spi.Subfield.allSubscripts;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class PushdownSubfields
+        implements PlanOptimizer
+{
+    private final Metadata metadata;
+
+    public PushdownSubfields(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        requireNonNull(plan, "plan is null");
+        requireNonNull(session, "session is null");
+        requireNonNull(types, "types is null");
+
+        return SimplePlanRewriter.rewriteWith(new Rewriter(session, metadata, types), plan, new Rewriter.Context());
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Rewriter.Context>
+    {
+        private final Session session;
+        private final Metadata metadata;
+        private final TypeProvider types;
+        private final SubfieldExtractor subfieldExtractor;
+
+        public Rewriter(Session session, Metadata metadata, TypeProvider types)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.metadata = requireNonNull(metadata, "metadata is null");
+            this.types = requireNonNull(types, "types is null");
+            this.subfieldExtractor = new SubfieldExtractor(types);
+        }
+
+        @Override
+        public PlanNode visitAggregation(AggregationNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getGroupingKeys());
+
+            for (AggregationNode.Aggregation aggregation : node.getAggregations().values()) {
+                aggregation.getArguments().forEach(expression -> subfieldExtractor.process(castToExpression(expression), context.get()));
+
+                aggregation.getFilter().ifPresent(expression -> subfieldExtractor.process(castToExpression(expression), context.get()));
+
+                aggregation.getOrderBy()
+                        .map(OrderingScheme::getOrderBy)
+                        .ifPresent(context.get().variables::addAll);
+
+                aggregation.getMask().ifPresent(context.get().variables::add);
+            }
+
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitApply(ApplyNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getCorrelation());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitDistinctLimit(DistinctLimitNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getDistinctVariables());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitExplainAnalyze(ExplainAnalyzeNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getSource().getOutputVariables());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitFilter(FilterNode node, RewriteContext<Context> context)
+        {
+            subfieldExtractor.process(castToExpression(node.getPredicate()), context.get());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitGroupId(GroupIdNode node, RewriteContext<Context> context)
+        {
+            for (Map.Entry<VariableReferenceExpression, VariableReferenceExpression> entry : node.getGroupingColumns().entrySet()) {
+                context.get().addAssignment(entry.getKey(), entry.getValue());
+            }
+
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitIndexJoin(IndexJoinNode node, RewriteContext<Context> context)
+        {
+            node.getCriteria().stream()
+                    .map(IndexJoinNode.EquiJoinClause::getProbe)
+                    .forEach(context.get().variables::add);
+            node.getCriteria().stream()
+                    .map(IndexJoinNode.EquiJoinClause::getIndex)
+                    .forEach(context.get().variables::add);
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitJoin(JoinNode node, RewriteContext<Context> context)
+        {
+            node.getCriteria().stream()
+                    .map(JoinNode.EquiJoinClause::getLeft)
+                    .forEach(context.get().variables::add);
+            node.getCriteria().stream()
+                    .map(JoinNode.EquiJoinClause::getRight)
+                    .forEach(context.get().variables::add);
+
+            node.getFilter()
+                    .map(OriginalExpressionUtils::castToExpression)
+                    .ifPresent(expression -> subfieldExtractor.process(expression, context.get()));
+
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitMarkDistinct(MarkDistinctNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getDistinctVariables());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitOutput(OutputNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getOutputVariables());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitProject(ProjectNode node, RewriteContext<Context> context)
+        {
+            for (Map.Entry<VariableReferenceExpression, Expression> entry : node.getAssignments().entrySet()) {
+                VariableReferenceExpression variable = entry.getKey();
+                Expression expression = entry.getValue();
+
+                if (expression instanceof SymbolReference) {
+                    context.get().addAssignment(variable, new VariableReferenceExpression(((SymbolReference) expression).getName(), types.get(Symbol.from(expression))));
+                    continue;
+                }
+
+                Optional<Subfield> subfield = toSubfield(expression);
+                if (subfield.isPresent()) {
+                    context.get().addAssignment(variable, subfield.get());
+                    continue;
+                }
+
+                subfieldExtractor.process(expression, context.get());
+            }
+
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitRowNumber(RowNumberNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.add(node.getRowNumberVariable());
+            context.get().variables.addAll(node.getPartitionBy());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitSemiJoin(SemiJoinNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.add(node.getSourceJoinVariable());
+            context.get().variables.add(node.getFilteringSourceJoinVariable());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitSort(SortNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getOrderingScheme().getOrderBy());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitSpatialJoin(SpatialJoinNode node, RewriteContext<Context> context)
+        {
+            subfieldExtractor.process(castToExpression(node.getFilter()), context.get());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitTableScan(TableScanNode node, RewriteContext<Context> context)
+        {
+            if (context.get().subfields.isEmpty()) {
+                return node;
+            }
+
+            ImmutableMap.Builder<VariableReferenceExpression, ColumnHandle> newAssignments = ImmutableMap.builder();
+
+            for (Map.Entry<VariableReferenceExpression, ColumnHandle> entry : node.getAssignments().entrySet()) {
+                VariableReferenceExpression variable = entry.getKey();
+                if (context.get().variables.contains(variable)) {
+                    newAssignments.put(entry);
+                    continue;
+                }
+
+                List<Subfield> subfields = context.get().findSubfields(variable.getName());
+
+                verify(!subfields.isEmpty(), "Missing variable: " + variable);
+
+                String columnName = getColumnName(session, metadata, node.getTable(), entry.getValue());
+
+                // Prune subfields: if one subfield is a prefix of another subfield, keep the shortest one.
+                // Example: {a.b.c, a.b} -> {a.b}
+                List<Subfield> columnSubfields = subfields.stream()
+                        .filter(subfield -> !prefixExists(subfield, subfields))
+                        .map(Subfield::getPath)
+                        .map(path -> new Subfield(columnName, path))
+                        .collect(toImmutableList());
+
+                newAssignments.put(variable, entry.getValue().withRequiredSubfields(columnSubfields));
+            }
+
+            return new TableScanNode(
+                    node.getId(),
+                    node.getTable(),
+                    node.getOutputVariables(),
+                    newAssignments.build(),
+                    node.getCurrentConstraint(),
+                    node.getEnforcedConstraint(),
+                    node.isTemporaryTable());
+        }
+
+        @Override
+        public PlanNode visitTableWriter(TableWriterNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getColumns());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitTopN(TopNNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getOrderingScheme().getOrderBy());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitTopNRowNumber(TopNRowNumberNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.add(node.getRowNumberVariable());
+            context.get().variables.addAll(node.getPartitionBy());
+            context.get().variables.addAll(node.getOrderingScheme().getOrderBy());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitUnion(UnionNode node, RewriteContext<Context> context)
+        {
+            for (Map.Entry<VariableReferenceExpression, Collection<VariableReferenceExpression>> entry : node.getVariableMapping().asMap().entrySet()) {
+                entry.getValue().forEach(variable -> context.get().addAssignment(entry.getKey(), variable));
+            }
+
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitUnnest(UnnestNode node, RewriteContext<Context> context)
+        {
+            ImmutableList.Builder<Subfield> newSubfields = ImmutableList.builder();
+            for (Map.Entry<VariableReferenceExpression, List<VariableReferenceExpression>> entry : node.getUnnestVariables().entrySet()) {
+                VariableReferenceExpression container = entry.getKey();
+                boolean found = false;
+
+                if (isRowType(container)) {
+                    for (VariableReferenceExpression field : entry.getValue()) {
+                        if (context.get().variables.contains(field)) {
+                            found = true;
+                            newSubfields.add(new Subfield(container.getName(), ImmutableList.of(allSubscripts(), new NestedField(field.getName()))));
+                        }
+                        else {
+                            List<Subfield> matchingSubfields = context.get().findSubfields(field.getName());
+                            if (!matchingSubfields.isEmpty()) {
+                                found = true;
+                                matchingSubfields.stream()
+                                        .map(Subfield::getPath)
+                                        .map(path -> new Subfield(container.getName(), ImmutableList.<Subfield.PathElement>builder()
+                                                .add(allSubscripts())
+                                                .add(new NestedField(field.getName()))
+                                                .addAll(path)
+                                                .build()))
+                                        .forEach(newSubfields::add);
+                            }
+                        }
+                    }
+                }
+                else {
+                    for (VariableReferenceExpression field : entry.getValue()) {
+                        if (context.get().variables.contains(field)) {
+                            found = true;
+                            context.get().variables.add(container);
+                        }
+                        else {
+                            List<Subfield> matchingSubfields = context.get().findSubfields(field.getName());
+
+                            if (!matchingSubfields.isEmpty()) {
+                                found = true;
+                                matchingSubfields.stream()
+                                        .map(Subfield::getPath)
+                                        .map(path -> new Subfield(container.getName(), ImmutableList.<Subfield.PathElement>builder()
+                                                .add(allSubscripts())
+                                                .addAll(path)
+                                                .build()))
+                                        .forEach(newSubfields::add);
+                            }
+                        }
+                    }
+                }
+                if (!found) {
+                    context.get().variables.add(container);
+                }
+            }
+            context.get().subfields.addAll(newSubfields.build());
+
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitWindow(WindowNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getSpecification().getPartitionBy());
+
+            node.getSpecification().getOrderingScheme()
+                    .map(OrderingScheme::getOrderBy)
+                    .ifPresent(context.get().variables::addAll);
+
+            node.getWindowFunctions().values().stream()
+                    .map(WindowNode.Function::getFunctionCall)
+                    .map(CallExpression::getArguments)
+                    .flatMap(List::stream)
+                    .map(OriginalExpressionUtils::castToExpression)
+                    .forEach(expression -> subfieldExtractor.process(expression, context.get()));
+
+            node.getWindowFunctions().values().stream()
+                    .map(WindowNode.Function::getFrame)
+                    .map(WindowNode.Frame::getStartValue)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .forEach(context.get().variables::add);
+
+            node.getWindowFunctions().values().stream()
+                    .map(WindowNode.Function::getFrame)
+                    .map(WindowNode.Frame::getEndValue)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .forEach(context.get().variables::add);
+
+            return context.defaultRewrite(node, context.get());
+        }
+
+        private boolean isRowType(VariableReferenceExpression variable)
+        {
+            return variable.getType() instanceof ArrayType && ((ArrayType) variable.getType()).getElementType() instanceof RowType;
+        }
+
+        private static boolean prefixExists(Subfield subfieldPath, Collection<Subfield> subfieldPaths)
+        {
+            return subfieldPaths.stream().anyMatch(path -> path.isPrefix(subfieldPath));
+        }
+
+        private static String getColumnName(Session session, Metadata metadata, TableHandle tableHandle, ColumnHandle columnHandle)
+        {
+            return metadata.getColumnMetadata(session, tableHandle, columnHandle).getName();
+        }
+
+        private static Optional<Subfield> toSubfield(Node expression)
+        {
+            ImmutableList.Builder<Subfield.PathElement> elements = ImmutableList.builder();
+            while (true) {
+                if (expression instanceof SymbolReference) {
+                    return Optional.of(new Subfield(((SymbolReference) expression).getName(), elements.build().reverse()));
+                }
+
+                if (expression instanceof DereferenceExpression) {
+                    DereferenceExpression dereference = (DereferenceExpression) expression;
+                    elements.add(new NestedField(dereference.getField().getValue()));
+                    expression = dereference.getBase();
+                }
+                else if (expression instanceof SubscriptExpression) {
+                    SubscriptExpression subscript = (SubscriptExpression) expression;
+                    Expression index = subscript.getIndex();
+                    if (index instanceof Cast) {
+                        index = ((Cast) index).getExpression();
+                    }
+                    if (index instanceof LongLiteral) {
+                        elements.add(new Subfield.LongSubscript(((LongLiteral) index).getValue()));
+                    }
+                    else if (index instanceof StringLiteral) {
+                        elements.add(new Subfield.StringSubscript(((StringLiteral) index).getValue()));
+                    }
+                    else if (index instanceof GenericLiteral) {
+                        GenericLiteral literal = (GenericLiteral) index;
+                        if (BIGINT.getTypeSignature().equals(TypeSignature.parseTypeSignature(literal.getType()))) {
+                            elements.add(new Subfield.LongSubscript(Long.valueOf(literal.getValue())));
+                        }
+                        else {
+                            return Optional.empty();
+                        }
+                    }
+                    else {
+                        return Optional.empty();
+                    }
+                    expression = subscript.getBase();
+                }
+                else {
+                    return Optional.empty();
+                }
+            }
+        }
+
+        private static final class SubfieldExtractor
+                extends DefaultExpressionTraversalVisitor<Void, Context>
+        {
+            private final TypeProvider typeProvider;
+
+            private SubfieldExtractor(TypeProvider typeProvider)
+            {
+                this.typeProvider = requireNonNull(typeProvider, "typeProvider is null");
+            }
+
+            @Override
+            protected Void visitSubscriptExpression(SubscriptExpression node, Context context)
+            {
+                Optional<Subfield> subfield = toSubfield(node);
+                if (subfield.isPresent()) {
+                    context.subfields.add(subfield.get());
+                }
+                else {
+                    process(node.getBase(), context);
+                    process(node.getIndex(), context);
+                }
+                return null;
+            }
+
+            @Override
+            protected Void visitDereferenceExpression(DereferenceExpression node, Context context)
+            {
+                Optional<Subfield> subfield = toSubfield(node);
+                if (subfield.isPresent()) {
+                    context.subfields.add(subfield.get());
+                }
+                else {
+                    process(node.getBase(), context);
+                    process(node.getField(), context);
+                }
+                return null;
+            }
+
+            @Override
+            protected Void visitSymbolReference(SymbolReference node, Context context)
+            {
+                context.variables.add(new VariableReferenceExpression(node.getName(), typeProvider.get(Symbol.from(node))));
+                return null;
+            }
+        }
+
+        private static final class Context
+        {
+            // Variables whose subfields cannot be pruned
+            private final Set<VariableReferenceExpression> variables = new HashSet<>();
+            private final Set<Subfield> subfields = new HashSet<>();
+
+            private void addAssignment(VariableReferenceExpression variable, VariableReferenceExpression otherVariable)
+            {
+                if (variables.contains(variable)) {
+                    variables.add(otherVariable);
+                    return;
+                }
+
+                List<Subfield> matchingSubfields = findSubfields(variable.getName());
+                verify(!matchingSubfields.isEmpty(), "Missing variable: " + variable);
+
+                matchingSubfields.stream()
+                        .map(Subfield::getPath)
+                        .map(path -> new Subfield(otherVariable.getName(), path))
+                        .forEach(subfields::add);
+            }
+
+            private void addAssignment(VariableReferenceExpression variable, Subfield subfield)
+            {
+                if (variables.contains(variable)) {
+                    subfields.add(subfield);
+                    return;
+                }
+
+                List<Subfield> matchingSubfields = findSubfields(variable.getName());
+                verify(!matchingSubfields.isEmpty(), "Missing variable: " + variable);
+
+                matchingSubfields.stream()
+                        .map(Subfield::getPath)
+                        .map(path -> new Subfield(subfield.getRootName(), ImmutableList.<Subfield.PathElement>builder()
+                                .addAll(subfield.getPath())
+                                .addAll(path)
+                                .build()))
+                        .forEach(subfields::add);
+            }
+
+            private List<Subfield> findSubfields(String rootName)
+            {
+                return subfields.stream()
+                        .filter(subfield -> rootName.equals(subfield.getRootName()))
+                        .collect(toImmutableList());
+            }
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ColumnHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ColumnHandle.java
@@ -13,6 +13,31 @@
  */
 package com.facebook.presto.spi;
 
+import com.facebook.presto.spi.api.Experimental;
+
+import java.util.List;
+
 public interface ColumnHandle
 {
+    /**
+     * Applies to columns of complex types: arrays, maps and structs. When a query
+     * uses only some of the subfields, the engine provides the complete list of
+     * required subfields and the connector is free to prune the rest.
+     * <p>
+     * Examples:
+     *  - SELECT a[1], b['x'], x.y.z FROM t
+     *  - SELECT a FROM t WHERE b['y'] > 10
+     * <p>
+     * Pruning must preserve the type of the values and support unmodified access.
+     * <p>
+     * - Pruning a struct means populating some of the members with null values.
+     * - Pruning a map means dropping keys not listed in the required subfields.
+     * - Pruning arrays means dropping values with indices larger than maximum
+     * required index and filling in remaining non-required indices with nulls.
+     */
+    @Experimental
+    default ColumnHandle withRequiredSubfields(List<Subfield> subfields)
+    {
+        return this;
+    }
 }


### PR DESCRIPTION
The new rule enables subfield pruning in the connectors by identifying
referenced subfields and passing them to the connector. The rule identifies
array subscripts, map keys, and nested fields in structs.

Depends on #12606.

CC: @aweisberg @rongrong @yingsu00 @wenleix 