### PR TITLE
Improve download speed of records by the CLI and jdbc client

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/AlignedTablePrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/AlignedTablePrinter.java
@@ -63,6 +63,71 @@ public class AlignedTablePrinter
     }
 
     @Override
+    public void printRow(List<?> row, boolean complete)
+            throws IOException
+    {
+        rowCount++;
+        int columns = fieldNames.size();
+
+        int[] maxWidth = new int[columns];
+        for (int i = 0; i < columns; i++) {
+            maxWidth[i] = max(1, consoleWidth(fieldNames.get(i)));
+        }
+
+        for (int i = 0; i < row.size(); i++) {
+            String s = formatValue(row.get(i));
+            maxWidth[i] = max(maxWidth[i], maxLineLength(s));
+        }
+
+        if (!headerOutput) {
+            headerOutput = true;
+
+            for (int i = 0; i < columns; i++) {
+                if (i > 0) {
+                    writer.append('|');
+                }
+                String name = fieldNames.get(i);
+                writer.append(center(name, maxWidth[i], 1));
+            }
+            writer.append('\n');
+
+            for (int i = 0; i < columns; i++) {
+                if (i > 0) {
+                    writer.append('+');
+                }
+                writer.append(repeat("-", maxWidth[i] + 2));
+            }
+            writer.append('\n');
+        }
+
+        List<List<String>> columnLines = new ArrayList<>(columns);
+        int maxLines = 1;
+        for (int i = 0; i < columns; i++) {
+            String s = formatValue(row.get(i));
+            ImmutableList<String> lines = ImmutableList.copyOf(LINE_SPLITTER.split(s));
+            columnLines.add(lines);
+            maxLines = max(maxLines, lines.size());
+        }
+
+        for (int line = 0; line < maxLines; line++) {
+            for (int column = 0; column < columns; column++) {
+                if (column > 0) {
+                    writer.append('|');
+                }
+                List<String> lines = columnLines.get(column);
+                String s = (line < lines.size()) ? lines.get(line) : "";
+                boolean numeric = row.get(column) instanceof Number;
+                String out = align(s, maxWidth[column], 1, numeric);
+                if ((!complete || (rowCount > 1)) && ((line + 1) < lines.size())) {
+                    out = out.substring(0, out.length() - 1) + "+";
+                }
+                writer.append(out);
+            }
+            writer.append('\n');
+        }
+    }
+
+    @Override
     public void printRows(List<List<?>> rows, boolean complete)
             throws IOException
     {

--- a/presto-cli/src/main/java/com/facebook/presto/cli/CsvPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/CsvPrinter.java
@@ -56,6 +56,18 @@ public class CsvPrinter
     }
 
     @Override
+    public void printRow(List<?> row, boolean complete) throws IOException
+    {
+        if (needHeader) {
+            needHeader = false;
+            writer.writeNext(toStrings(fieldNames));
+        }
+
+        writer.writeNext(toStrings(row));
+        checkError();
+    }
+
+    @Override
     public void finish()
             throws IOException
     {

--- a/presto-cli/src/main/java/com/facebook/presto/cli/NullPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/NullPrinter.java
@@ -24,6 +24,11 @@ public class NullPrinter
     }
 
     @Override
+    public void printRow(List<?> row, boolean complete)
+    {
+    }
+
+    @Override
     public void finish()
     {
     }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/OutputPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/OutputPrinter.java
@@ -21,6 +21,12 @@ public interface OutputPrinter
     void printRows(List<List<?>> rows, boolean complete)
             throws IOException;
 
+    default void printRow(List<?> row, boolean complete)
+            throws IOException
+    {
+        throw new UnsupportedOperationException();
+    }
+
     void finish()
             throws IOException;
 }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -29,6 +29,7 @@ import org.fusesource.jansi.Ansi;
 import sun.misc.Signal;
 import sun.misc.SignalHandler;
 
+import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -319,7 +320,7 @@ public class Query
 
     private static Writer createWriter(OutputStream out)
     {
-        return new OutputStreamWriter(out, UTF_8);
+        return new BufferedWriter(new OutputStreamWriter(out, UTF_8), 16384);
     }
 
     @Override

--- a/presto-cli/src/main/java/com/facebook/presto/cli/TsvPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/TsvPrinter.java
@@ -53,6 +53,18 @@ public class TsvPrinter
     }
 
     @Override
+    public void printRow(List<?> row, boolean complete)
+            throws IOException
+    {
+        if (needHeader) {
+            needHeader = false;
+            printRows(ImmutableList.of(fieldNames), false);
+        }
+
+        writer.write(formatRow(row));
+    }
+
+    @Override
     public void finish()
             throws IOException
     {

--- a/presto-cli/src/main/java/com/facebook/presto/cli/VerticalRecordPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/VerticalRecordPrinter.java
@@ -56,6 +56,37 @@ public class VerticalRecordPrinter
     }
 
     @Override
+    public void printRow(List<?> row, boolean complete)
+            throws IOException
+    {
+        int valuesWidth = 0;
+        for (Object o : row) {
+            valuesWidth = max(valuesWidth, maxLineLength(formatValue(o)));
+        }
+        rowCount++;
+
+        String header = "-[ RECORD " + rowCount + " ]";
+        if ((namesWidth + 1) >= header.length()) {
+            header += repeat("-", (namesWidth + 1) - header.length()) + "+";
+        }
+        header += repeat("-", max(0, (namesWidth + valuesWidth + 3) - header.length()));
+        writer.append(header).append('\n');
+
+        for (int i = 0; i < row.size(); i++) {
+            String name = fieldNames.get(i);
+            String column = formatValue(row.get(i));
+            for (String line : LINE_SPLITTER.split(column)) {
+                writer.append(name)
+                        .append(repeat(" ", namesWidth - consoleWidth(name)))
+                        .append(" | ")
+                        .append(formatValue(line))
+                        .append("\n");
+                name = repeat(" ", consoleWidth(name));
+            }
+        }
+    }
+
+    @Override
     public void printRows(List<List<?>> rows, boolean complete)
             throws IOException
     {

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoStatement.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoStatement.java
@@ -249,12 +249,14 @@ public class PrestoStatement
             currentWarningsManager.set(Optional.of(warningsManager));
             resultSet = new PrestoResultSet(client, maxRows.get(), progressConsumer, warningsManager);
 
+            String updateType = client.isFinished() ? client.finalStatusInfo().getUpdateType() : client.currentStatusInfo().getUpdateType();
+
             for (Map.Entry<String, SelectedRole> entry : client.getSetRoles().entrySet()) {
                 connection.get().setRole(entry.getKey(), entry.getValue());
             }
 
             // check if this is a query
-            if (client.currentStatusInfo().getUpdateType() == null) {
+            if (updateType == null) {
                 currentResult.set(resultSet);
                 return true;
             }


### PR DESCRIPTION
The sequential read by the client makes the download really slow. Split it into two threads, with one thread downloading the data and buffering while the other thread renders it to stdout (CLI) or returns it to the user (jdbc)