### PR TITLE
Fixes for Classification ROC

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -338,11 +338,17 @@ Statistical Aggregate Functions
     an array of miss-rate values. ``y`` should be a boolean outcome value; ``x`` should be predictions, each
     between 0 and 1; ``weight`` should be non-negative values, indicating the weight of the instance.
 
+.. function:: classification_fall_out(buckets, y, x, weight) -> array<double>
+
+    Computes the fall-out part of the receiver operator curve with up to ``buckets`` number of buckets. Returns
+    an array of miss-rate values. ``y`` should be a boolean outcome value; ``x`` should be predictions, each
+    between 0 and 1; ``weight`` should be non-negative values, indicating the weight of the instance.
+
     To get an ROC map, use this in conjunction with :func:`classification_recall`:
 
     .. code-block:: none
 
-        MAP(classification_recall(200, outcome, prediction), classification_miss_rate(200, outcome, prediction))
+        MAP(classification_fall_out(1000, outcome, prediction), classification_recall(1000, outcome, prediction))
 
 .. function:: classification_precision(buckets, y, x) -> array<double>
 
@@ -359,7 +365,7 @@ Statistical Aggregate Functions
 
     .. code-block:: none
 
-        MAP(classification_recall(200, outcome, prediction), classification_precision(200, outcome, prediction))
+        MAP(classification_recall(1000, outcome, prediction), classification_precision(1000, outcome, prediction))
 
 .. function:: classification_precision(buckets, y, x) -> array<double>
 
@@ -377,7 +383,7 @@ Statistical Aggregate Functions
 
     .. code-block:: none
 
-        MAP(classification_recall(200, outcome, prediction), classification_precision(200, outcome, prediction))
+        MAP(classification_recall(1000, outcome, prediction), classification_precision(1000, outcome, prediction))
 
 .. function:: classification_recall(buckets, y, x) -> array<double>
 
@@ -394,13 +400,13 @@ Statistical Aggregate Functions
 
     .. code-block:: none
 
-        MAP(classification_thresholds(200, outcome, prediction), classification_precision(200, outcome, prediction))
+        MAP(classification_thresholds(1000, outcome, prediction), classification_precision(1000, outcome, prediction))
 
     To get a map of thresholds to recall, use this in conjunction with :func:`classification_recall`:
 
     .. code-block:: none
 
-        MAP(classification_thresholds(200, outcome, prediction), classification_recall(200, outcome, prediction))
+        MAP(classification_thresholds(1000, outcome, prediction), classification_recall(1000, outcome, prediction))
 
 .. function:: regr_intercept(y, x) -> double
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationFallOutAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationFallOutAggregation.java
@@ -23,12 +23,12 @@ import com.facebook.presto.spi.type.DoubleType;
 
 import java.util.Iterator;
 
-@AggregationFunction("classification_thresholds")
-@Description("Computes thresholds for metrics of binary classification")
-public final class ClassificationThresholdsAggregation
+@AggregationFunction("classification_fall_out")
+@Description("Computes fall-out (false-positive rate) for binary classification")
+public final class ClassificationFallOutAggregation
         extends PrecisionRecallAggregation
 {
-    private ClassificationThresholdsAggregation() {}
+    private ClassificationFallOutAggregation() {}
 
     @OutputFunction("array(double)")
     public static void output(@AggregationState PrecisionRecallState state, BlockBuilder out)
@@ -40,7 +40,7 @@ public final class ClassificationThresholdsAggregation
             BucketResult result = resultsIterator.next();
             DoubleType.DOUBLE.writeDouble(
                     entryBuilder,
-                    result.getThreshold());
+                    result.getFalsePositive() / result.getNegative());
         }
         out.closeEntry();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationMissRateAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationMissRateAggregation.java
@@ -24,7 +24,7 @@ import com.facebook.presto.spi.type.DoubleType;
 import java.util.Iterator;
 
 @AggregationFunction("classification_miss_rate")
-@Description("Computes miss-rate for precision-recall curves")
+@Description("Computes miss-rate (false-negative rate) for binary classification")
 public final class ClassificationMissRateAggregation
         extends PrecisionRecallAggregation
 {
@@ -37,10 +37,10 @@ public final class ClassificationMissRateAggregation
 
         BlockBuilder entryBuilder = out.beginBlockEntry();
         while (resultsIterator.hasNext()) {
-            final BucketResult result = resultsIterator.next();
+            BucketResult result = resultsIterator.next();
             DoubleType.DOUBLE.writeDouble(
                     entryBuilder,
-                    result.runningFalseWeight / result.totalTrueWeight);
+                    result.getFalseNegative() / result.getPositive());
         }
         out.closeEntry();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationPrecisionAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationPrecisionAggregation.java
@@ -37,12 +37,10 @@ public final class ClassificationPrecisionAggregation
 
         BlockBuilder entryBuilder = out.beginBlockEntry();
         while (resultsIterator.hasNext()) {
-            final BucketResult result = resultsIterator.next();
-            final double remainingTrueWeight = result.totalTrueWeight - result.runningTrueWeight;
-            final double remainingFalseWeight = result.totalFalseWeight - result.runningFalseWeight;
+            BucketResult result = resultsIterator.next();
             DoubleType.DOUBLE.writeDouble(
                     entryBuilder,
-                    remainingTrueWeight / (remainingTrueWeight + remainingFalseWeight));
+                    result.getTruePositive() / (result.getTruePositive() + result.getFalseNegative()));
         }
         out.closeEntry();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationRecallAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ClassificationRecallAggregation.java
@@ -24,7 +24,7 @@ import com.facebook.presto.spi.type.DoubleType;
 import java.util.Iterator;
 
 @AggregationFunction("classification_recall")
-@Description("Computes recall for precision-recall curves")
+@Description("Computes recall (true-positive rate) for binary classification")
 public final class ClassificationRecallAggregation
         extends PrecisionRecallAggregation
 {
@@ -37,11 +37,10 @@ public final class ClassificationRecallAggregation
 
         BlockBuilder entryBuilder = out.beginBlockEntry();
         while (resultsIterator.hasNext()) {
-            final BucketResult result = resultsIterator.next();
-            final double remainingTrueWeight = result.totalTrueWeight - result.runningTrueWeight;
+            BucketResult result = resultsIterator.next();
             DoubleType.DOUBLE.writeDouble(
                     entryBuilder,
-                    remainingTrueWeight / result.totalTrueWeight);
+                    result.getTruePositive() / result.getPositive());
         }
         out.closeEntry();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/PrecisionRecallAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/PrecisionRecallAggregation.java
@@ -113,27 +113,65 @@ public abstract class PrecisionRecallAggregation
 
     protected static class BucketResult
     {
-        public final double totalTrueWeight;
-        public final double totalFalseWeight;
-        public final double runningTrueWeight;
-        public final double runningFalseWeight;
-        public final double left;
-        public final double right;
+        private final double threshold;
+        private final double positive;
+        private final double negative;
+        private final double truePositive;
+        private final double trueNegative;
+        private final double falsePositive;
+        private final double falseNegative;
+
+        public double getThreshold()
+        {
+            return threshold;
+        }
+
+        public double getPositive()
+        {
+            return positive;
+        }
+
+        public double getNegative()
+        {
+            return negative;
+        }
+
+        public double getTruePositive()
+        {
+            return truePositive;
+        }
+
+        public double getTrueNegative()
+        {
+            return trueNegative;
+        }
+
+        public double getFalsePositive()
+        {
+            return falsePositive;
+        }
+
+        public double getFalseNegative()
+        {
+            return falseNegative;
+        }
 
         public BucketResult(
-                double left,
-                double right,
-                double totalTrueWeight,
-                double totalFalseWeight,
-                double runningTrueWeight,
-                double runningFalseWeight)
+                double threshold,
+                double positive,
+                double negative,
+                double truePositive,
+                double trueNegative,
+                double falsePositive,
+                double falseNegative)
         {
-            this.left = left;
-            this.right = right;
-            this.totalTrueWeight = totalTrueWeight;
-            this.totalFalseWeight = totalFalseWeight;
-            this.runningTrueWeight = runningTrueWeight;
-            this.runningFalseWeight = runningFalseWeight;
+            this.threshold = threshold;
+            this.positive = positive;
+            this.negative = negative;
+            this.truePositive = truePositive;
+            this.trueNegative = trueNegative;
+            this.falsePositive = falsePositive;
+            this.falseNegative = falseNegative;
         }
     }
 
@@ -174,11 +212,12 @@ public abstract class PrecisionRecallAggregation
 
                 final BucketResult result = new BucketResult(
                         trueResult.left,
-                        trueResult.right,
                         totalTrueWeight,
                         totalFalseWeight,
+                        totalTrueWeight - runningTrueWeight,
+                        runningFalseWeight,
                         runningTrueWeight,
-                        runningFalseWeight);
+                        totalFalseWeight - runningFalseWeight);
 
                 runningTrueWeight += trueResult.weight;
                 runningFalseWeight += falseResult.weight;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationMissRateAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationMissRateAggregation.java
@@ -34,7 +34,7 @@ public class TestClassificationMissRateAggregation
         final ArrayList<Double> expected = new ArrayList<>();
         while (iterator.hasNext()) {
             final BucketResult result = iterator.next();
-            final double missRate = (result.totalFalseWeight - result.remainingFalseWeight) / result.totalTrueWeight;
+            final double missRate = result.remainingFalseWeight / result.totalTrueWeight;
             expected.add(missRate);
         }
         return expected;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationPrecisionAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationPrecisionAggregation.java
@@ -34,7 +34,8 @@ public class TestClassificationPrecisionAggregation
         final ArrayList<Double> expected = new ArrayList<>();
         while (iterator.hasNext()) {
             final TestPrecisionRecallAggregation.BucketResult result = iterator.next();
-            final double precision = result.remainingTrueWeight / (result.remainingTrueWeight + result.remainingFalseWeight);
+            final double precision = result.remainingTrueWeight /
+                    (result.remainingTrueWeight + result.remainingFalseWeight);
             expected.add(precision);
         }
         return expected;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationThresholdAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationThresholdAggregation.java
@@ -34,7 +34,7 @@ public class TestClassificationThresholdAggregation
         final ArrayList<Double> expected = new ArrayList<>();
         while (iterator.hasNext()) {
             final BucketResult result = iterator.next();
-            expected.add((result.left + result.right) / 2);
+            expected.add(result.left);
         }
         return expected;
     }


### PR DESCRIPTION
Minor fixes for Classification ROC related UDFs

1. Use fall-out for ROC
2. Fixed miss-rate
3. Improved docs

UDFs:

classification_miss_rate
classification_fall_out
classification_precision
classification_recall
classification_thresholds