### PR TITLE
Remove TODO in TranslateExpressions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TranslateExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TranslateExpressions.java
@@ -89,7 +89,6 @@ public class TranslateExpressions
 
     public Set<Rule<?>> rules()
     {
-        // TODO: finish all other PlanNodes that have Expression
         return ImmutableSet.of(
                 new ValuesExpressionTranslation(),
                 new FilterExpressionTranslation(),


### PR DESCRIPTION
PlanNode has been completely migrated from Expression to RowExpression.
The TODO is no longer needed.