### PR TITLE
Fix connector optimizer registration in PlanOptimizers

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -194,11 +194,6 @@ public class ConnectorManager
         return createConnection(catalogName, connectorFactory, properties);
     }
 
-    public ConnectorPlanOptimizerManager getConnectorPlanOptimizerManager()
-    {
-        return connectorPlanOptimizerManager;
-    }
-
     private synchronized ConnectorId createConnection(String catalogName, ConnectorFactory connectorFactory, Map<String, String> properties)
     {
         checkState(!stopped.get(), "ConnectorManager is stopped");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.sql.planner;
 
-import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.cost.CostCalculator;
 import com.facebook.presto.cost.CostCalculator.EstimatedExchanges;
 import com.facebook.presto.cost.CostComparator;
@@ -149,7 +148,7 @@ public class PlanOptimizers
             FeaturesConfig featuresConfig,
             MBeanExporter exporter,
             SplitManager splitManager,
-            ConnectorManager connectorManager,
+            ConnectorPlanOptimizerManager planOptimizerManager,
             PageSourceManager pageSourceManager,
             StatsCalculator statsCalculator,
             CostCalculator costCalculator,
@@ -163,7 +162,7 @@ public class PlanOptimizers
                 false,
                 exporter,
                 splitManager,
-                connectorManager.getConnectorPlanOptimizerManager(),
+                planOptimizerManager,
                 pageSourceManager,
                 statsCalculator,
                 costCalculator,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -524,7 +524,8 @@ public class PlanOptimizers
         // TODO: Do not move other PlanNode to SPI until this rule is moved to the end of logical planning (i.e., where AddExchanges lives)
         // TODO: The connector optimizer should not change plan shape (computations) at this point util #12960 is landed. (e.g., connector may pushdown filters to table scan but cannot add a new node)
         // TODO: Run RemoveRedundantIdentityProjections and PruneUnreferencedOutputs once (1) we can have ProjectNode in SPI and (2) have moved the connector optimization above HashGenerationOptimizer
-        builder.add(new ApplyConnectorOptimization(planOptimizerManager.getOptimizers()));
+        // Pass a supplier so that we pickup connector optimizers that are installed later
+        builder.add(new ApplyConnectorOptimization(planOptimizerManager::getOptimizers));
 
         builder.add(new MetadataDeleteOptimizer(metadata));
         builder.add(new BeginTableWrite(metadata)); // HACK! see comments in BeginTableWrite

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.sql.planner.SymbolAllocator;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.ValuesNode;
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -53,11 +54,11 @@ public class ApplyConnectorOptimization
     // for a leaf node that does not belong to any connector (e.g., ValuesNode)
     private static final ConnectorId EMPTY_CONNECTOR_ID = new ConnectorId("$internal$" + ApplyConnectorOptimization.class + "_CONNECTOR");
 
-    private final Map<ConnectorId, Set<ConnectorPlanOptimizer>> connectorOptimizers;
+    private final Supplier<Map<ConnectorId, Set<ConnectorPlanOptimizer>>> connectorOptimizersSupplier;
 
-    public ApplyConnectorOptimization(Map<ConnectorId, Set<ConnectorPlanOptimizer>> connectorOptimizers)
+    public ApplyConnectorOptimization(Supplier<Map<ConnectorId, Set<ConnectorPlanOptimizer>>> connectorOptimizersSupplier)
     {
-        this.connectorOptimizers = requireNonNull(connectorOptimizers, "connectorOptimizers is null");
+        this.connectorOptimizersSupplier = requireNonNull(connectorOptimizersSupplier, "connectorOptimizersSupplier is null");
     }
 
     @Override
@@ -69,6 +70,7 @@ public class ApplyConnectorOptimization
         requireNonNull(symbolAllocator, "symbolAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
+        Map<ConnectorId, Set<ConnectorPlanOptimizer>> connectorOptimizers = connectorOptimizersSupplier.get();
         if (connectorOptimizers.isEmpty()) {
             return plan;
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestConnectorOptimization.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestConnectorOptimization.java
@@ -284,7 +284,7 @@ public class TestConnectorOptimization
 
     private static PlanNode optimize(PlanNode plan, Map<ConnectorId, Set<ConnectorPlanOptimizer>> optimizers)
     {
-        ApplyConnectorOptimization optimizer = new ApplyConnectorOptimization(optimizers);
+        ApplyConnectorOptimization optimizer = new ApplyConnectorOptimization(() -> optimizers);
         return optimizer.optimize(plan, TEST_SESSION, TypeProvider.empty(), new SymbolAllocator(), new PlanNodeIdAllocator(), WarningCollector.NOOP);
     }
 


### PR DESCRIPTION
Use a supplier method instead of an object to initialize PlanOptimizers.