### PR TITLE
Improve testIllegalStorageFormatDuringTableScan

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -2979,7 +2979,7 @@ public abstract class AbstractTestHiveClient
         // to make sure it can still be retrieved instead of throwing exception.
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
-            Map<SchemaTableName, List<ColumnMetadata>> allColumns = metadata.listTableColumns(newSession(), new SchemaTablePrefix(schemaTableName.getSchemaName()));
+            Map<SchemaTableName, List<ColumnMetadata>> allColumns = metadata.listTableColumns(newSession(), new SchemaTablePrefix(schemaTableName.getSchemaName(), schemaTableName.getTableName()));
             assertTrue(allColumns.containsKey(schemaTableName));
         }
         finally {


### PR DESCRIPTION
Provide both schema name and table name when listing columns. It
is not necessary to list all tables to achieve the goal of the test.