### PR TITLE
Prevent type change in RowEpxression optimization phase

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
@@ -69,6 +69,7 @@ import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.addStatsAndSumD
 import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.capStats;
 import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.subtractSubsetStats;
 import static com.facebook.presto.cost.StatsUtil.toStatsRepresentation;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level;
 import static com.facebook.presto.spi.relation.LogicalRowExpressions.and;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -153,7 +154,7 @@ public class FilterStatsCalculator
 
     private RowExpression simplifyExpression(Session session, RowExpression predicate)
     {
-        RowExpressionInterpreter interpreter = new RowExpressionInterpreter(predicate, metadata, session.toConnectorSession(), true);
+        RowExpressionInterpreter interpreter = new RowExpressionInterpreter(predicate, metadata, session.toConnectorSession(), Level.MOST_OPTIMIZED);
         Object value = interpreter.optimize();
 
         if (value == null) {

--- a/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
@@ -59,6 +59,7 @@ import java.util.OptionalDouble;
 import static com.facebook.presto.cost.StatsUtil.toStatsRepresentation;
 import static com.facebook.presto.spi.function.OperatorType.DIVIDE;
 import static com.facebook.presto.spi.function.OperatorType.MODULUS;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
 import static com.facebook.presto.sql.planner.LiteralInterpreter.evaluate;
 import static com.facebook.presto.util.MoreMath.max;
@@ -122,7 +123,7 @@ public class ScalarStatsCalculator
                 return computeArithmeticBinaryStatistics(call, context);
             }
 
-            Object value = new RowExpressionInterpreter(call, metadata, session.toConnectorSession(), true).optimize();
+            Object value = new RowExpressionInterpreter(call, metadata, session.toConnectorSession(), Level.MOST_OPTIMIZED).optimize();
 
             if (value == null) {
                 return nullStatsEstimate();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -233,6 +233,7 @@ import static com.facebook.presto.operator.TableWriterOperator.TableWriterOperat
 import static com.facebook.presto.operator.UnnestOperator.UnnestOperatorFactory;
 import static com.facebook.presto.operator.WindowFunctionDefinition.window;
 import static com.facebook.presto.spi.StandardErrorCode.COMPILER_ERROR;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level;
 import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.spi.relation.RowExpressionNodeInliner.replaceExpression;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -1251,7 +1252,7 @@ public class LocalExecutionPlanner
         private RowExpression bindChannels(RowExpression expression, Map<VariableReferenceExpression, Integer> sourceLayout)
         {
             Type type = expression.getType();
-            Object value = new RowExpressionInterpreter(expression, metadata, session.toConnectorSession(), true).optimize();
+            Object value = new RowExpressionInterpreter(expression, metadata, session.toConnectorSession(), Level.MOST_OPTIMIZED).optimize();
             if (value instanceof RowExpression) {
                 RowExpression optimized = (RowExpression) value;
                 // building channel info

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -171,6 +171,7 @@ public class RowExpressionInterpreter
             // constant folding
             return result;
         }
+        // TODO deprecate ExpressionOptimizer since it overlaps with RowExpressionInterpreter and is less efficient.
         return new ExpressionOptimizer(metadata.getFunctionManager(), session).optimize((RowExpression) result);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PickTableLayout.java
@@ -294,7 +294,7 @@ public class PickTableLayout
                     .collect(toImmutableBiMap(
                             entry -> new VariableReferenceExpression(entry.getKey().getName(), types.get(new Symbol(entry.getKey().getName()))),
                             entry -> new VariableReferenceExpression(getColumnName(session, metadata, node.getTable(), entry.getValue()), types.get(new Symbol(entry.getKey().getName())))));
-            RowExpression translatedPredicate = replaceExpression(SqlToRowExpressionTranslator.translate(predicate, predicateTypes, ImmutableMap.of(), metadata.getFunctionManager(), metadata.getTypeManager(), session, false), symbolToColumnMapping);
+            RowExpression translatedPredicate = replaceExpression(SqlToRowExpressionTranslator.translate(predicate, predicateTypes, ImmutableMap.of(), metadata.getFunctionManager(), metadata.getTypeManager(), session), symbolToColumnMapping);
 
             PushdownFilterResult pushdownFilterResult = metadata.pushdownFilter(session, node.getTable(), translatedPredicate);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ExpressionEquivalence.java
@@ -113,7 +113,7 @@ public class ExpressionEquivalence
                 WarningCollector.NOOP);
 
         // convert to row expression
-        return translate(expression, expressionTypes, variableInput, metadata.getFunctionManager(), metadata.getTypeManager(), session, false);
+        return translate(expression, expressionTypes, variableInput, metadata.getFunctionManager(), metadata.getTypeManager(), session);
     }
 
     private static class CanonicalizationVisitor

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -94,6 +94,7 @@ import java.util.stream.Collectors;
 import static com.facebook.presto.SystemSessionProperties.planWithTableNodePartitioning;
 import static com.facebook.presto.spi.predicate.TupleDomain.extractFixedValuesToConstantExpressions;
 import static com.facebook.presto.spi.relation.DomainTranslator.BASIC_COLUMN_EXTRACTOR;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
 import static com.facebook.presto.sql.planner.PlannerUtils.toVariableReference;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.ARBITRARY_DISTRIBUTION;
@@ -655,7 +656,7 @@ public class PropertyDerivations
                     }
                 }
                 else {
-                    Object value = new RowExpressionInterpreter(expression, metadata, session.toConnectorSession(), true).optimize();
+                    Object value = new RowExpressionInterpreter(expression, metadata, session.toConnectorSession(), Level.MOST_OPTIMIZED).optimize();
 
                     if (value instanceof VariableReferenceExpression) {
                         ConstantExpression existingConstantValue = constants.get(value);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TranslateExpressions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/TranslateExpressions.java
@@ -557,7 +557,7 @@ public class TranslateExpressions
 
     private RowExpression toRowExpression(Expression expression, Session session, Map<NodeRef<Expression>, Type> types)
     {
-        return SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionManager(), metadata.getTypeManager(), session, false);
+        return SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionManager(), metadata.getTypeManager(), session);
     }
 
     private RowExpression removeOriginalExpression(RowExpression expression, Rule.Context context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.SymbolsExtractor;
 import com.facebook.presto.sql.planner.TypeProvider;
@@ -93,24 +92,22 @@ public final class ValidateDependenciesChecker
     @Override
     public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
     {
-        validate(plan, types, metadata.getTypeManager());
+        validate(plan, types);
     }
 
-    public static void validate(PlanNode plan, TypeProvider types, TypeManager typeManager)
+    public static void validate(PlanNode plan, TypeProvider types)
     {
-        plan.accept(new Visitor(types, typeManager), ImmutableSet.of());
+        plan.accept(new Visitor(types), ImmutableSet.of());
     }
 
     private static class Visitor
             extends InternalPlanVisitor<Void, Set<VariableReferenceExpression>>
     {
         private final TypeProvider types;
-        private final TypeManager typeManager;
 
-        public Visitor(TypeProvider types, TypeManager typeManager)
+        public Visitor(TypeProvider types)
         {
             this.types = requireNonNull(types, "types is null");
-            this.typeManager = requireNonNull(typeManager, "typeManager is null");
         }
 
         @Override
@@ -727,17 +724,7 @@ public final class ValidateDependenciesChecker
 
         private void checkDependencies(Collection<VariableReferenceExpression> inputs, Collection<VariableReferenceExpression> required, String message, Object... parameters)
         {
-            // If a variable can be assigned into another type directly, CAST is usually implicitly removed.
-            // For example, we can assign input VARCHAR(3) to output VARCHAR(5)
-            // the reference variable in the assignment will have type VARCHAR(5) while the input is VARCHAR(3).
-            for (VariableReferenceExpression target : required) {
-                checkArgument(
-                        inputs.stream()
-                                .anyMatch(input -> input.getName().equalsIgnoreCase(target.getName()) &&
-                                        typeManager.isTypeOnlyCoercion(input.getType(), target.getType())),
-                        message,
-                        parameters);
-            }
+            checkArgument(ImmutableSet.copyOf(inputs).containsAll(required), message, parameters);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -722,9 +722,14 @@ public final class ValidateDependenciesChecker
                     .build();
         }
 
-        private void checkDependencies(Collection<VariableReferenceExpression> inputs, Collection<VariableReferenceExpression> required, String message, Object... parameters)
+        private void checkDependencies(List<VariableReferenceExpression> inputs, Collection<VariableReferenceExpression> required, String message, Object... parameters)
         {
-            checkArgument(ImmutableSet.copyOf(inputs).containsAll(required), message, parameters);
+            checkDependencies(ImmutableSet.copyOf(inputs), required, message, parameters);
+        }
+
+        private void checkDependencies(Set<VariableReferenceExpression> inputs, Collection<VariableReferenceExpression> required, String message, Object... parameters)
+        {
+            checkArgument(inputs.containsAll(required), message, parameters);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionDomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionDomainTranslator.java
@@ -69,6 +69,7 @@ import static com.facebook.presto.spi.function.OperatorType.IS_DISTINCT_FROM;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.spi.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level;
 import static com.facebook.presto.spi.relation.LogicalRowExpressions.FALSE_CONSTANT;
 import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.spi.relation.LogicalRowExpressions.and;
@@ -636,13 +637,13 @@ public final class RowExpressionDomainTranslator
                 left = leftExpression;
             }
             else {
-                left = new RowExpressionInterpreter(leftExpression, metadata, session, true).optimize();
+                left = new RowExpressionInterpreter(leftExpression, metadata, session, Level.MOST_OPTIMIZED).optimize();
             }
             if (rightExpression instanceof VariableReferenceExpression) {
                 right = rightExpression;
             }
             else {
-                right = new RowExpressionInterpreter(rightExpression, metadata, session, true).optimize();
+                right = new RowExpressionInterpreter(rightExpression, metadata, session, Level.MOST_OPTIMIZED).optimize();
             }
 
             if (left instanceof RowExpression == right instanceof RowExpression) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionOptimizer.java
@@ -35,11 +35,8 @@ public final class RowExpressionOptimizer
     @Override
     public RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session)
     {
-        if (level == Level.SERIALIZABLE) {
-            return toRowExpression(RowExpressionInterpreter.rowExpressionInterpreter(rowExpression, metadata, session).evaluate(), rowExpression.getType());
-        }
-        if (level == Level.MOST_OPTIMIZED) {
-            return toRowExpression(new RowExpressionInterpreter(rowExpression, metadata, session, true).optimize(), rowExpression.getType());
+        if (level.ordinal() <= Level.MOST_OPTIMIZED.ordinal()) {
+            return toRowExpression(new RowExpressionInterpreter(rowExpression, metadata, session, level).optimize(), rowExpression.getType());
         }
         throw new IllegalArgumentException("Unrecognized optimization level: " + level);
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionTypeChanger.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionTypeChanger.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.Type;
+
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.field;
+import static com.facebook.presto.sql.relational.Expressions.specialForm;
+
+public class RowExpressionTypeChanger
+{
+    private RowExpressionTypeChanger() {}
+
+    public static RowExpression changeType(RowExpression value, Type targetType)
+    {
+        //TODO make it private in RowExpressionInterpreter once ExpressionOptimizer is deprecated.
+        ChangeTypeVisitor visitor = new ChangeTypeVisitor(targetType);
+        return value.accept(visitor, null);
+    }
+
+    private static class ChangeTypeVisitor
+            implements RowExpressionVisitor<RowExpression, Void>
+    {
+        private final Type targetType;
+
+        private ChangeTypeVisitor(Type targetType)
+        {
+            this.targetType = targetType;
+        }
+
+        @Override
+        public RowExpression visitCall(CallExpression call, Void context)
+        {
+            return new CallExpression(call.getDisplayName(), call.getFunctionHandle(), targetType, call.getArguments());
+        }
+
+        @Override
+        public RowExpression visitInputReference(InputReferenceExpression reference, Void context)
+        {
+            return field(reference.getField(), targetType);
+        }
+
+        @Override
+        public RowExpression visitConstant(ConstantExpression literal, Void context)
+        {
+            return constant(literal.getValue(), targetType);
+        }
+
+        @Override
+        public RowExpression visitLambda(LambdaDefinitionExpression lambda, Void context)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RowExpression visitVariableReference(VariableReferenceExpression reference, Void context)
+        {
+            return new VariableReferenceExpression(reference.getName(), targetType);
+        }
+
+        @Override
+        public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Void context)
+        {
+            return specialForm(specialForm.getForm(), targetType, specialForm.getArguments());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -29,7 +29,6 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.analyzer.TypeSignatureProvider;
-import com.facebook.presto.sql.relational.optimizer.ExpressionOptimizer;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.ArithmeticUnaryExpression;
 import com.facebook.presto.sql.tree.ArrayConstructor;
@@ -147,8 +146,7 @@ public final class SqlToRowExpressionTranslator
             Map<VariableReferenceExpression, Integer> layout,
             FunctionManager functionManager,
             TypeManager typeManager,
-            Session session,
-            boolean optimize)
+            Session session)
     {
         Visitor visitor = new Visitor(
                 types,
@@ -157,14 +155,7 @@ public final class SqlToRowExpressionTranslator
                 functionManager,
                 session);
         RowExpression result = visitor.process(expression, null);
-
         requireNonNull(result, "translated expression is null");
-
-        if (optimize) {
-            ExpressionOptimizer optimizer = new ExpressionOptimizer(typeManager, functionManager, session.toConnectorSession());
-            return optimizer.optimize(result);
-        }
-
         return result;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -165,7 +165,7 @@ public final class SqlToRowExpressionTranslator
         requireNonNull(result, "translated expression is null");
 
         if (optimize) {
-            ExpressionOptimizer optimizer = new ExpressionOptimizer(functionManager, session.toConnectorSession());
+            ExpressionOptimizer optimizer = new ExpressionOptimizer(typeManager, functionManager, session.toConnectorSession());
             return optimizer.optimize(result);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
@@ -73,7 +73,6 @@ public class ExpressionOptimizer
         this.session = session;
     }
 
-    // TODO replace ExpressionOptimizer with RowExpressionInterpreter
     public RowExpression optimize(RowExpression expression)
     {
         return expression.accept(new Visitor(), null);

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/optimizer/ExpressionOptimizer.java
@@ -56,6 +56,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.instanceOf;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+@Deprecated
 public class ExpressionOptimizer
 {
     private final FunctionManager functionManager;
@@ -66,7 +67,8 @@ public class ExpressionOptimizer
         this.functionManager = functionManager;
         this.session = session;
     }
-
+    
+    // TODO replace ExpressionOptimizer with RowExpressionInterpreter
     public RowExpression optimize(RowExpression expression)
     {
         return expression.accept(new Visitor(), null);

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestScalarStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestScalarStatsCalculator.java
@@ -39,6 +39,7 @@ import io.airlift.slice.Slices;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
@@ -189,7 +190,7 @@ public class TestScalarStatsCalculator
     public void testCastDoubleToBigint()
     {
         PlanNodeStatsEstimate inputStatistics = PlanNodeStatsEstimate.builder()
-                .addVariableStatistics(new VariableReferenceExpression("a", BIGINT), VariableStatsEstimate.builder()
+                .addVariableStatistics(new VariableReferenceExpression("a", DOUBLE), VariableStatsEstimate.builder()
                         .setNullsFraction(0.3)
                         .setLowValue(1.6)
                         .setHighValue(17.3)
@@ -210,7 +211,7 @@ public class TestScalarStatsCalculator
     public void testCastDoubleToShortRange()
     {
         PlanNodeStatsEstimate inputStatistics = PlanNodeStatsEstimate.builder()
-                .addVariableStatistics(new VariableReferenceExpression("a", BIGINT), VariableStatsEstimate.builder()
+                .addVariableStatistics(new VariableReferenceExpression("a", DOUBLE), VariableStatsEstimate.builder()
                         .setNullsFraction(0.3)
                         .setLowValue(1.6)
                         .setHighValue(3.3)
@@ -231,7 +232,7 @@ public class TestScalarStatsCalculator
     public void testCastDoubleToShortRangeUnknownDistinctValuesCount()
     {
         PlanNodeStatsEstimate inputStatistics = PlanNodeStatsEstimate.builder()
-                .addVariableStatistics(new VariableReferenceExpression("a", BIGINT), VariableStatsEstimate.builder()
+                .addVariableStatistics(new VariableReferenceExpression("a", DOUBLE), VariableStatsEstimate.builder()
                         .setNullsFraction(0.3)
                         .setLowValue(1.6)
                         .setHighValue(3.3)
@@ -251,7 +252,7 @@ public class TestScalarStatsCalculator
     public void testCastBigintToDouble()
     {
         PlanNodeStatsEstimate inputStatistics = PlanNodeStatsEstimate.builder()
-                .addVariableStatistics(new VariableReferenceExpression("a", DOUBLE), VariableStatsEstimate.builder()
+                .addVariableStatistics(new VariableReferenceExpression("a", BIGINT), VariableStatsEstimate.builder()
                         .setNullsFraction(0.3)
                         .setLowValue(2.0)
                         .setHighValue(10.0)
@@ -260,7 +261,7 @@ public class TestScalarStatsCalculator
                         .build())
                 .build();
 
-        assertCalculate(new Cast(new SymbolReference("a"), "double"), inputStatistics, TypeProvider.copyOf(ImmutableMap.of(new Symbol("a"), DOUBLE)))
+        assertCalculate(new Cast(new SymbolReference("a"), "double"), inputStatistics, TypeProvider.copyOf(ImmutableMap.of(new Symbol("a"), BIGINT)))
                 .lowValue(2.0)
                 .highValue(10.0)
                 .distinctValuesCount(4)
@@ -286,7 +287,9 @@ public class TestScalarStatsCalculator
 
     private VariableStatsAssertion assertCalculate(Expression scalarExpression, PlanNodeStatsEstimate inputStatistics)
     {
-        return assertCalculate(scalarExpression, inputStatistics, TypeProvider.copyOf(DEFAULT_SYMBOL_TYPES));
+        Map<Symbol, Type> types = new HashMap<>(DEFAULT_SYMBOL_TYPES);
+        inputStatistics.getVariablesWithKnownStatistics().forEach(variable -> types.put(new Symbol(variable.getName()), variable.getType()));
+        return assertCalculate(scalarExpression, inputStatistics, TypeProvider.copyOf(types));
     }
 
     private VariableStatsAssertion assertCalculate(Expression scalarExpression, PlanNodeStatsEstimate inputStatistics, TypeProvider types)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -958,7 +958,7 @@ public final class FunctionAssertions
 
     private RowExpression toRowExpression(Expression projection, Map<NodeRef<Expression>, Type> expressionTypes, Map<VariableReferenceExpression, Integer> layout)
     {
-        return translate(projection, expressionTypes, layout, metadata.getFunctionManager(), metadata.getTypeManager(), session, false);
+        return translate(projection, expressionTypes, layout, metadata.getFunctionManager(), metadata.getTypeManager(), session);
     }
 
     private static Page getAtMostOnePage(Operator operator, Page sourcePage)

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -1587,7 +1587,7 @@ public class TestExpressionInterpreter
             // It is tricky to check the equivalence of an expression and a row expression.
             // We rely on the optimized translator to fill the gap.
             RowExpression translated = TRANSLATOR.translateAndOptimize((Expression) expressionResult, SYMBOL_TYPES);
-            assertRowExpressionEvaluationEquals(translated, new ExpressionOptimizer(METADATA.getFunctionManager(), SESSION).optimize((RowExpression) rowExpressionResult));
+            assertRowExpressionEvaluationEquals(translated, new ExpressionOptimizer(METADATA.getTypeManager(), METADATA.getFunctionManager(), SESSION).optimize((RowExpression) rowExpressionResult));
         }
         else {
             // We have constants; directly compare

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionOptimizer.java
@@ -66,7 +66,7 @@ public class TestExpressionOptimizer
     {
         TypeManager typeManager = new TypeRegistry();
         functionManager = new FunctionManager(typeManager, new BlockEncodingManager(typeManager), new FeaturesConfig());
-        optimizer = new ExpressionOptimizer(functionManager, SESSION);
+        optimizer = new ExpressionOptimizer(typeManager, functionManager, SESSION);
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -38,6 +38,7 @@ import com.facebook.presto.sql.analyzer.Scope;
 import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
+import com.facebook.presto.sql.relational.optimizer.ExpressionOptimizer;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.type.TypeDeserializer;
@@ -265,7 +266,12 @@ public class TestRowExpressionSerde
 
     private RowExpression translate(Expression expression, boolean optimize)
     {
-        return SqlToRowExpressionTranslator.translate(expression, getExpressionTypes(expression), ImmutableMap.of(), metadata.getFunctionManager(), metadata.getTypeManager(), TEST_SESSION, optimize);
+        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, getExpressionTypes(expression), ImmutableMap.of(), metadata.getFunctionManager(), metadata.getTypeManager(), TEST_SESSION);
+        if (optimize) {
+            ExpressionOptimizer optimizer = new ExpressionOptimizer(metadata.getTypeManager(), metadata.getFunctionManager(), TEST_SESSION.toConnectorSession());
+            return optimizer.optimize(rowExpression);
+        }
+        return rowExpression;
     }
 
     private Map<NodeRef<Expression>, Type> getExpressionTypes(Expression expression)

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestingRowExpressionTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestingRowExpressionTranslator.java
@@ -25,6 +25,7 @@ import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.planner.NoOpSymbolResolver;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
+import com.facebook.presto.sql.relational.optimizer.ExpressionOptimizer;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.google.common.collect.ImmutableMap;
@@ -68,13 +69,14 @@ public class TestingRowExpressionTranslator
                 ImmutableMap.of(),
                 metadata.getFunctionManager(),
                 metadata.getTypeManager(),
-                TEST_SESSION,
-                false);
+                TEST_SESSION);
     }
 
     public RowExpression translateAndOptimize(Expression expression, Map<NodeRef<Expression>, Type> types)
     {
-        return SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionManager(), metadata.getTypeManager(), TEST_SESSION, true);
+        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionManager(), metadata.getTypeManager(), TEST_SESSION);
+        ExpressionOptimizer optimizer = new ExpressionOptimizer(metadata.getTypeManager(), metadata.getFunctionManager(), TEST_SESSION.toConnectorSession());
+        return optimizer.optimize(rowExpression);
     }
 
     Expression simplifyExpression(Expression expression)

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/PageProcessorBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/PageProcessorBenchmark.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
+import com.facebook.presto.sql.relational.optimizer.ExpressionOptimizer;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.testing.TestingSession;
@@ -181,7 +182,9 @@ public class PageProcessorBenchmark
         Expression expression = createExpression(value, METADATA, TypeProvider.copyOf(symbolTypes));
 
         Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, TypeProvider.copyOf(symbolTypes), expression, emptyList(), WarningCollector.NOOP);
-        return SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, METADATA.getFunctionManager(), METADATA.getTypeManager(), TEST_SESSION, true);
+        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, METADATA.getFunctionManager(), METADATA.getTypeManager(), TEST_SESSION);
+        ExpressionOptimizer optimizer = new ExpressionOptimizer(METADATA.getTypeManager(), METADATA.getFunctionManager(), TEST_SESSION.toConnectorSession());
+        return optimizer.optimize(rowExpression);
     }
 
     private static Page createPage(List<? extends Type> types, boolean dictionary)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
@@ -354,6 +354,12 @@ final class RowExpressionVerifier
     @Override
     protected Boolean visitStringLiteral(StringLiteral expected, RowExpression actual)
     {
+        if (actual instanceof CallExpression && functionResolution.isCastFunction(((CallExpression) actual).getFunctionHandle())) {
+            Object actualString = rowExpressionInterpreter(actual, metadata, session.toConnectorSession()).evaluate();
+            if (actualString instanceof Slice) {
+                return expected.getValue().equals(((Slice) actualString).toStringUtf8());
+            }
+        }
         if (actual instanceof ConstantExpression && actual.getType().getJavaType() == Slice.class) {
             String actualString = (String) LiteralInterpreter.evaluate(TEST_SESSION.toConnectorSession(), (ConstantExpression) actual);
             return expected.getValue().equals(actualString);

--- a/presto-main/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
+import com.facebook.presto.sql.relational.optimizer.ExpressionOptimizer;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.google.common.collect.ImmutableList;
@@ -611,7 +612,9 @@ public class BenchmarkDecimalOperators
             Expression expression = createExpression(value, metadata, TypeProvider.copyOf(symbolTypes));
 
             Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, metadata, SQL_PARSER, TypeProvider.copyOf(symbolTypes), expression, emptyList(), WarningCollector.NOOP);
-            return SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, metadata.getFunctionManager(), metadata.getTypeManager(), TEST_SESSION, true);
+            RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, metadata.getFunctionManager(), metadata.getTypeManager(), TEST_SESSION);
+            ExpressionOptimizer optimizer = new ExpressionOptimizer(metadata.getTypeManager(), metadata.getFunctionManager(), TEST_SESSION.toConnectorSession());
+            return optimizer.optimize(rowExpression);
         }
 
         private Object generateRandomValue(Type type)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizer.java
@@ -30,6 +30,7 @@ public interface ExpressionOptimizer
         SERIALIZABLE,
         /**
          * MOST_OPTIMIZED removes all redundancy in a RowExpression but can end up with non-serializable objects (e.g., Regex).
+         * It also removes type only coercion. Only use it after row expression is sent to worker and ready to execute.
          */
         MOST_OPTIMIZED,
         /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizer.java
@@ -25,12 +25,16 @@ public interface ExpressionOptimizer
     enum Level
     {
         /**
-         * SERIALIZABLE guarantees the optimized RowExpression can be serialized and deserialized
+         * SERIALIZABLE guarantees the optimized RowExpression can be serialized and deserialized and no type change in referenced input.
          */
         SERIALIZABLE,
         /**
          * MOST_OPTIMIZED removes all redundancy in a RowExpression but can end up with non-serializable objects (e.g., Regex).
          */
-        MOST_OPTIMIZED
+        MOST_OPTIMIZED,
+        /**
+         * MOST_EVALUATE attempt to evaluate the RowExpression into a constant, even though it can be non-deterministic.
+         */
+        MOST_EVALUATED
     }
 }


### PR DESCRIPTION
This PR attempts to clean up optimization phases of `RowExpression`. One big driven reason is that we want to remove type change optimization (removing cast if the source type is coercible into target type) from SqlToRowExpressionTranslator and move it to optimization phase of RowExpression. With current changes (`Expression` -> `RowExpression`, `Symbol` -> `VariableReferenceExpression`, type changes before execution stage will break dependency checks in optimization rules. 

To make sure `RowExpression` be able to correctly handled in different stages of planning/execution, we can split its life cycle into four steps:
1. **Translated** stage, at this stage. It will be translated from Expression AST and no optimization should be applied.
2. Simplified but still **serializable** stage. This will happen before we fragment the plan and send it to workers. We have to keep a) we do not remove coercion and change so that referenced input variable have different type than original input variable. b) we should not simplify a sub expression into non-serializable constant expression (for example Regex types).
3. **Most optimized** but still executable stage. This will attempt do constant folding as much as possible before we compile this `RowExpression` into byte code. It will not evaluate nondeterministic function nor lambda since lambda will end up be stored as MethodHandle which we cannot reuse later. The end result should never be added back to planNode if it is before Plan fragmentation. 
4. **Most evaluated** stage. This should only be used in places such as generating Values node result, PropertyManager,  ... etc. to attempt to evaluate the expression into constant. If the result is not constant, the result should not be viewed as valid `RowExpression`. As `ExpressionInterpreter`, if the `RowExpression` cannot be evaluated, it can throw Exceptions. 

The `RowExpressionOptimizer` will be updated in respective to handle stage 2-4 based on the optimization `Level` passed in.
We should also deprecate `ExpressionOptimizer` in `com.facebook.presto.sql.relational.optimizer` and use `RowExpressionOptimizer` instead. 

The first two commits are small clean ups. Please let me know if it is necessary to take them out as separate PR. 

This PR should fix #12891