### PR TITLE
Fix a typo in the description of a session property

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -311,7 +311,7 @@ public final class HiveSessionProperties
                         false),
                 booleanProperty(
                         OPTIMIZE_MISMATCHED_BUCKET_COUNT,
-                        "Experimenal: Enable optimization to avoid shuffle when bucket count is compatible but not the same",
+                        "Experimental: Enable optimization to avoid shuffle when bucket count is compatible but not the same",
                         hiveClientConfig.isOptimizeMismatchedBucketCount(),
                         false),
                 booleanProperty(


### PR DESCRIPTION
I saw a typo in the description of a session property that I was using. Creating a PR to fix it :D.