### PR TITLE
WIP - PartitionedOutputOperator optimizations

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestAriaPartitionedOutputDistributedQuries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestAriaPartitionedOutputDistributedQuries.java
@@ -1,0 +1,459 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZED_PARTITIONED_OUTPUT;
+import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.airlift.tpch.TpchTable.getTables;
+import static io.airlift.units.Duration.nanosSince;
+import static org.testng.Assert.assertEquals;
+
+public class TestAriaPartitionedOutputDistributedQuries
+        extends AbstractTestQueryFramework
+{
+    private static final Logger log = Logger.get(TestAriaPartitionedOutputDistributedQuries.class);
+
+    protected TestAriaPartitionedOutputDistributedQuries()
+    {
+        super(() -> createQueryRunner());
+    }
+
+    private static QueryRunner createQueryRunner()
+            throws Exception
+    {
+        QueryRunner queryRunner = HiveQueryRunner.createQueryRunner(ImmutableList.of());
+
+        Session noAria = Session.builder(queryRunner.getDefaultSession())
+                .setSystemProperty(OPTIMIZED_PARTITIONED_OUTPUT, "false")
+                .build();
+
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, noAria, getTables());
+
+        createTable(queryRunner, noAria, "lineitem_nulls", "CREATE TABLE lineitem_nulls AS\n" +
+                "SELECT *,\n" +
+                "   IF(have_complex_nulls, null, map(array[1, 2, 3], array[orderkey, partkey, suppkey])) as order_part_supp_map,\n" +
+                "   IF(have_complex_nulls, null, array[orderkey, partkey, suppkey]) as order_part_supp_array\n" +
+                "FROM (\n" +
+                "   SELECT \n" +
+                "       orderkey,\n" +
+                "       linenumber,\n" +
+                "       have_simple_nulls and mod(orderkey + linenumber, 5) = 0 AS have_complex_nulls,\n" +
+                "       IF(have_simple_nulls and mod(orderkey + linenumber, 11) = 0, null, partkey) as partkey,\n" +
+                "       IF(have_simple_nulls and mod(orderkey + linenumber, 13) = 0, null, suppkey) as suppkey,\n" +
+                "       IF(have_simple_nulls and mod (orderkey + linenumber, 17) = 0, null, quantity) as quantity,\n" +
+                "       IF(have_simple_nulls and mod (orderkey + linenumber, 19) = 0, null, extendedprice) as extendedprice,\n" +
+                "       IF(have_simple_nulls and mod (orderkey + linenumber, 23) = 0, null, shipmode) as shipmode,\n" +
+                "       IF(have_simple_nulls and mod (orderkey + linenumber, 7) = 0, null, comment) as comment,\n" +
+                "       IF(have_simple_nulls and mod(orderkey + linenumber, 31) = 0, null, returnflag = 'R') as is_returned,\n" +
+                "       IF(have_simple_nulls and mod(orderkey + linenumber, 37) = 0, null, CAST(quantity + 1 as real)) as float_quantity\n" +
+                "   FROM (SELECT mod(orderkey, 198000) > 99000 as have_simple_nulls, * from tpch.tiny.lineitem))\n");
+
+        createTable(queryRunner, noAria, "lineitem_map_array", "CREATE TABLE lineitem_map_array AS\n" +
+                "SELECT\n" +
+                "    *,\n" +
+                "    map(ARRAY[1, 2, 3], ARRAY[l_orderkey, l_partkey, l_suppkey]) AS l_map,\n" +
+                "    ARRAY[l_orderkey,\n" +
+                "    l_partkey,\n" +
+                "    l_suppkey] AS l_array\n" +
+                "FROM (\n" +
+                "    SELECT\n" +
+                "        orderkey AS l_orderkey,\n" +
+                "        partkey AS l_partkey,\n" +
+                "        suppkey AS l_suppkey,\n" +
+                "        linenumber AS l_linenumber,\n" +
+                "        quantity AS l_quantity,\n" +
+                "        extendedprice AS l_extendedprice,\n" +
+                "        shipmode AS l_shipmode,\n" +
+                "        COMMENT AS l_comment,\n" +
+                "        returnflag = 'R' AS is_returned,\n" +
+                "        CAST(quantity + 1 AS REAL) AS l_floatQuantity\n" +
+                "    FROM lineitem\n" +
+                ")\n");
+
+        createTable(queryRunner, noAria, "lineitem_array_of_array", "CREATE TABLE lineitem_array_of_array AS\n" +
+                "SELECT\n" +
+                "    l_partkey,\n" +
+                "    l_suppkey,\n" +
+                "    ARRAY_AGG(l_array) l_array_of_array\n" +
+                "FROM (\n" +
+                "    SELECT\n" +
+                "        l_partkey,\n" +
+                "        l_suppkey,\n" +
+                "        l_array\n" +
+                "    FROM lineitem_map_array\n" +
+                "    )\n" +
+                "GROUP BY \n" +
+                "    l_partkey,\n" +
+                "    l_suppkey");
+
+        createTable(queryRunner, noAria, "lineitem_string_structs_with_nulls", "CREATE TABLE lineitem_string_structs_with_nulls AS\n" +
+                "SELECT\n" +
+                "    orderkey,\n" +
+                "    partkey,\n" +
+                "    suppkey,\n" +
+                "    linenumber,\n" +
+                "    CAST(\n" +
+                "        IF(mod(partkey, 5) = 0, NULL,\n" +
+                "            ROW(\n" +
+                "                comment,\n" +
+                "                IF (mod(partkey, 13) = 0, NULL,\n" +
+                "                    CONCAT(CAST(partkey AS VARCHAR), comment)\n" +
+                "                )\n" +
+                "            )\n" +
+                "        ) AS ROW(\n" +
+                "            comment VARCHAR,\n" +
+                "            partkey_comment VARCHAR\n" +
+                "        )\n" +
+                "    ) AS partkey_struct\n" +
+//                "    CAST(\n" +
+//                "        IF(mod(suppkey, 7) = 0, NULL,\n" +
+//                "            ROW(\n" +
+//                "                IF (mod(suppkey, 17) = 0, NULL,\n" +
+//                "                    CONCAT(CAST(suppkey AS VARCHAR), comment)\n" +
+//                "                ),\n" +
+//                "                CONCAT(CAST(quantity AS VARCHAR), comment)\n" +
+//                "            )\n" +
+//                "        ) AS ROW(\n" +
+//                "            suppkey_comment VARCHAR,\n" +
+//                "            quantity_comment varchar\n" +
+//                "        )\n" +
+//                "    ) AS suppkey_quantity_struct\n" +
+                "FROM tpch.tiny.lineitem\n" +
+                "WHERE orderkey < 100000");
+
+        createTable(queryRunner, noAria, "lineitem_struct", "CREATE TABLE lineitem_struct AS\n" +
+                "SELECT\n" +
+                "    l.orderkey AS l_orderkey,\n" +
+                "    linenumber AS l_linenumber,\n" +
+                "    CAST(\n" +
+                "        ROW (\n" +
+                "            l.partkey,\n" +
+                "            l.suppkey,\n" +
+                "            extendedprice,\n" +
+                "            discount,\n" +
+                "            quantity,\n" +
+                "            shipdate,\n" +
+                "            receiptdate,\n" +
+                "            commitdate,\n" +
+                "            l.comment\n" +
+                "        ) AS ROW(\n" +
+                "            l_partkey BIGINT,\n" +
+                "            l_suppkey BIGINT,\n" +
+                "            l_extendedprice DOUBLE,\n" +
+                "            l_discount DOUBLE,\n" +
+                "            l_quantity DOUBLE,\n" +
+                "            l_shipdate DATE,\n" +
+                "            l_receiptdate DATE,\n" +
+                "            l_commitdate DATE,\n" +
+                "            l_comment VARCHAR(44)\n" +
+                "        )\n" +
+                "    ) AS l_shipment,\n" +
+                "    CASE\n" +
+                "        WHEN S.nationkey = C.nationkey THEN NULL\n" +
+                "        ELSE CAST(\n" +
+                "            ROW(\n" +
+                "                S.NATIONKEY,\n" +
+                "                C.NATIONKEY,\n" +
+                "                CASE\n" +
+                "                    WHEN (S.NATIONKEY IN (6, 7, 19) AND C.NATIONKEY IN (6, 7, 19)) THEN 1\n" +
+                "                    ELSE 0\n" +
+                "                END,\n" +
+                "                CASE\n" +
+                "                    WHEN s.nationkey = 24 AND c.nationkey = 10 THEN 1\n" +
+                "                    ELSE 0\n" +
+                "                END,\n" +
+                "                CASE\n" +
+                "                    WHEN p.comment LIKE '%fur%' OR p.comment LIKE '%care%' THEN ROW(\n" +
+                "                        o.orderdate,\n" +
+                "                        l.shipdate,\n" +
+                "                        l.partkey + l.suppkey,\n" +
+                "                        CONCAT(p.comment, l.comment)\n" +
+                "                    )\n" +
+                "                    ELSE NULL\n" +
+                "                END\n" +
+                "            ) AS ROW (\n" +
+                "                s_nation BIGINT,\n" +
+                "                c_nation BIGINT,\n" +
+                "                is_inside_eu int,\n" +
+                "                is_restricted int,\n" +
+                "                license ROW (applydate DATE, grantdate DATE, filing_no BIGINT, COMMENT VARCHAR)\n" +
+                "            )\n" +
+                "        )\n" +
+                "    END AS l_export\n" +
+                "FROM lineitem l,\n" +
+                "    orders o,\n" +
+                "    customer c,\n" +
+                "    supplier s,\n" +
+                "    part p\n" +
+                "WHERE\n" +
+                "    l.orderkey = o.orderkey\n" +
+                "    AND l.partkey = p.partkey\n" +
+                "    AND l.suppkey = s.suppkey\n" +
+                "    AND c.custkey = o.custkey");
+
+        return queryRunner;
+    }
+
+    private static void createTable(QueryRunner queryRunner, Session session, String tableName, String sql)
+    {
+        log.info("Creating %s table", tableName);
+        long start = System.nanoTime();
+        long rows = (Long) queryRunner.execute(session, sql).getMaterializedRows().get(0).getField(0);
+        log.info("Created %s rows for %s in %s", rows, tableName, nanosSince(start).convertToMostSuccinctTimeUnit());
+    }
+
+    private Session ariaSession()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(OPTIMIZED_PARTITIONED_OUTPUT, "true")
+                .build();
+    }
+
+    private Session noAriaSession()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+            .setSystemProperty(OPTIMIZED_PARTITIONED_OUTPUT, "false")
+            .build();
+    }
+
+    @Test
+    public void testInteger()
+    {
+        assertQuery(ariaSession(), "SELECT\n" +
+                "    l.linenumber\n" +
+                "FROM lineitem l, partsupp p\n" +
+                "WHERE\n" +
+                "    l.partkey = p.partkey\n" +
+                "    AND l.suppkey = p.suppkey\n" +
+                "    AND p.availqty < 1000");
+    }
+
+    @Test
+    public void testBigInt()
+    {
+        assertQuery(ariaSession(), "SELECT\n" +
+                "    l.partkey\n" +
+                "FROM lineitem l, partsupp p\n" +
+                "WHERE\n" +
+                "    l.partkey = p.partkey\n" +
+                "    AND l.suppkey = p.suppkey\n" +
+                "    AND p.availqty < 1000");
+    }
+
+    @Test
+    public void testIpAddress()
+    {
+        String sql = "WITH lineitem_ipaddress AS \n" +
+                "(\n" +
+                "SELECT\n" +
+                "    partkey,\n" +
+                "    CAST(\n" +
+                "        CONCAT(\n" +
+                "            CONCAT(\n" +
+                "                CONCAT(\n" +
+                "                    CONCAT(\n" +
+                "                        CONCAT(\n" +
+                "                            CONCAT(CAST((orderkey % 255) AS VARCHAR), '.'),\n" +
+                "                            CAST((partkey % 255) AS VARCHAR)\n" +
+                "                        ),\n" +
+                "                        '.'\n" +
+                "                    ),\n" +
+                "                    CAST(suppkey AS VARCHAR)\n" +
+                "                ),\n" +
+                "                '.'\n" +
+                "            ),\n" +
+                "            CAST(linenumber AS VARCHAR)\n" +
+                "        ) AS IPADDRESS\n" +
+                "    ) AS ip\n" +
+                "FROM lineitem\n" +
+                "    )\n" +
+                "SELECT\n" +
+                "    CHECKSUM(l.ip) \n" +
+                "FROM lineitem_ipaddress l,\n" +
+                "    partsupp p\n" +
+                "WHERE\n" +
+                "    l.partkey = p.partkey";
+
+        Object expected = computeActual(noAriaSession(), sql).getOnlyValue();
+        Object result = computeActual(ariaSession(), sql).getOnlyValue();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testBigIntWithNulls()
+    {
+        assertQuery(ariaSession(), "SELECT\n" +
+                "    l.partkey\n" +
+                "FROM lineitem_nulls l, partsupp p\n" +
+                "WHERE\n" +
+                "    l.partkey = p.partkey\n" +
+                "    AND l.suppkey = p.suppkey\n" +
+                "    AND p.availqty < 1000");
+    }
+
+    @Test
+    public void testVarchar()
+    {
+        assertQuery(ariaSession(), "SELECT\n" +
+                "    l.comment\n" +
+                "FROM lineitem l, partsupp p\n" +
+                "WHERE\n" +
+                "    l.partkey = p.partkey\n" +
+                "    AND l.suppkey = p.suppkey\n" +
+                "    AND p.availqty < 1000");
+    }
+
+    @Test
+    public void testDictionaryOfVarcharWithNulls()
+    {
+        assertQuery(ariaSession(), "SELECT\n" +
+                "    l.shipmode\n" +
+                "FROM lineitem l,\n" +
+                "    partsupp p\n" +
+                "WHERE\n" +
+                "    l.partkey = p.partkey\n" +
+                "    AND l.suppkey = p.suppkey\n" +
+                "    AND p.availqty < 1000");
+    }
+
+    @Test
+    public void testArrayOfBigInt()
+    {
+        String sql = "SELECT\n" +
+                "    checksum(l.l_array)\n" +
+                "FROM lineitem_map_array l,\n" +
+                "    partsupp p\n" +
+                "WHERE\n" +
+                "    l.l_partkey = p.partkey\n" +
+                "    AND l.l_suppkey = p.suppkey\n" +
+                "    AND p.availqty < 1000";
+
+        Object expected = computeActual(noAriaSession(), sql).getOnlyValue();
+        Object result = computeActual(ariaSession(), sql).getOnlyValue();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testArrayOfArray()
+    {
+        String sql = "SELECT\n" +
+                "    checksum(l.l_shipment)\n" +
+                "FROM lineitem_struct l,\n" +
+                "    orders o\n" +
+                "WHERE\n" +
+                "    l.l_orderkey = o.orderkey";
+
+        Object expected = computeActual(noAriaSession(), sql).getOnlyValue();
+        Object result = computeActual(ariaSession(), sql).getOnlyValue();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testMap()
+    {
+        String sql = "SELECT\n" +
+                "    checksum(l.l_map)\n" +
+                "FROM lineitem_map_array l,\n" +
+                "    orders o\n" +
+                "WHERE\n" +
+                "    l.l_orderkey = o.orderkey";
+
+        Object expected = computeActual(noAriaSession(), sql).getOnlyValue();
+        Object result = computeActual(ariaSession(), sql).getOnlyValue();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testStruct()
+    {
+        String sql = "SELECT\n" +
+                "    checksum(l.l_shipment)\n" +
+                "FROM lineitem_struct l,\n" +
+                "    orders o\n" +
+                "WHERE\n" +
+                "    l.l_orderkey = o.orderkey";
+
+        Object expected = computeActual(noAriaSession(), sql).getOnlyValue();
+        Object result = computeActual(ariaSession(), sql).getOnlyValue();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testStructWithNullsType()
+    {
+        String sql = "SELECT\n" +
+                "    checksum(partkey_struct)\n" +
+//                "    checksum(suppkey_quantity_struct)\n" +
+                "FROM lineitem_string_structs_with_nulls l,\n" +
+                "    orders o\n" +
+                "WHERE\n" +
+                "    l.orderkey = o.orderkey";
+
+        Object expected = computeActual(noAriaSession(), sql).getOnlyValue();
+        Object result = computeActual(ariaSession(), sql).getOnlyValue();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testMapWithoutHashTables()
+    {
+        String sql = "SELECT\n" +
+                "    checksum(l.l_map)\n" +
+                "FROM lineitem_map_array l,\n" +
+                "    orders o\n" +
+                "WHERE\n" +
+                "    l.l_orderkey = o.orderkey";
+
+        Object expected = computeActual(noAriaSession(), sql).getOnlyValue();
+        Object result = computeActual(ariaSession(), sql).getOnlyValue();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testMapWithHashTables()
+    {
+        String sql = "SELECT\n" +
+                "    checksum(l.l_map)\n" +
+                "FROM lineitem_map_array l,\n" +
+                "    orders o\n" +
+                "WHERE\n" +
+                "    l.l_orderkey = o.orderkey\n" +
+                "    AND l.l_map[1] IS NOT NULL";
+
+        Object expected = computeActual(noAriaSession(), sql).getOnlyValue();
+        Object result = computeActual(ariaSession(), sql).getOnlyValue();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testQueenOfTheNight()
+    {
+        assertQuery(ariaSession(), "SELECT\n" +
+                "    COUNT(*),\n" +
+                "    SUM(l.extendedprice * (1 - l.discount) - l.quantity * p.supplycost)\n" +
+                "FROM lineitem l, partsupp p\n" +
+                "WHERE\n" +
+                "    l.partkey = p.partkey\n" +
+                "    AND l.suppkey = p.suppkey\n" +
+                "    AND p.availqty < 1000");
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -129,6 +129,7 @@ public final class SystemSessionProperties
     public static final String DEFAULT_FILTER_FACTOR_ENABLED = "default_filter_factor_enabled";
     public static final String PUSH_LIMIT_THROUGH_OUTER_JOIN = "push_limit_through_outer_join";
     public static final String MAX_CONCURRENT_MATERIALIZATIONS = "max_concurrent_materializations";
+    public static final String OPTIMIZED_PARTITIONED_OUTPUT = "optmized_partitioned_output";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -620,6 +621,11 @@ public final class SystemSessionProperties
                         MAX_CONCURRENT_MATERIALIZATIONS,
                         "Maximum number of materializing plan sections that can run concurrently",
                         featuresConfig.getMaxConcurrentMaterializations(),
+                        false),
+                booleanProperty(
+                        OPTIMIZED_PARTITIONED_OUTPUT,
+                        "push limits to the outer side of an outer join",
+                        featuresConfig.isOptimizedPartitionedOutput(),
                         false));
     }
 
@@ -1051,5 +1057,10 @@ public final class SystemSessionProperties
     public static int getMaxConcurrentMaterializations(Session session)
     {
         return session.getSystemProperty(MAX_CONCURRENT_MATERIALIZATIONS, Integer.class);
+    }
+
+    public static boolean isOptimizedPartitionedOutputEnabled(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZED_PARTITIONED_OUTPUT, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/TestingPartitionedOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/TestingPartitionedOutputBuffer.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.buffer;
+
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.StateMachine;
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import io.airlift.units.DataSize;
+
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+public class TestingPartitionedOutputBuffer
+        extends PartitionedOutputBuffer
+{
+    public TestingPartitionedOutputBuffer(
+            String taskInstanceId,
+            StateMachine<BufferState> state,
+            OutputBuffers outputBuffers,
+            DataSize maxBufferSize,
+            Supplier<LocalMemoryContext> systemMemoryContextSupplier,
+            Executor notificationExecutor)
+    {
+        super(taskInstanceId, state, outputBuffers, maxBufferSize, systemMemoryContextSupplier, notificationExecutor);
+    }
+
+    @Override
+    public void enqueue(Lifespan lifespan, int partitionNumber, List<SerializedPage> pages)
+    {
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ArrayBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ArrayBlockEncodingBuffers.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.ColumnarArray;
+import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import io.airlift.slice.ByteArrays;
+import io.airlift.slice.SliceOutput;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.ByteArrayUtils.writeLengthPrefixedString;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+
+public class ArrayBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    public static final String NAME = "ARRAY";
+
+    private byte[] offsetsBuffer;
+    private int offsetsBufferIndex;
+    private int[] offsets;          // This array holds the condensed offsets for each position
+    private int[] entrySizes;
+    private int[] positionOffsets;  // This array holds the offsets into nested block for each top level row
+
+    private ColumnarArray columnarArray;
+    private BlockEncodingBuffers rawBlockBuffer;
+
+    ArrayBlockEncodingBuffers(PartitionedOutputOperator.DecodedObjectNode columnarArrayBlockNode, int initialBufferSize)
+    {
+        this.initialBufferSize = initialBufferSize;
+        rawBlockBuffer = createBlockEncodingBuffers(columnarArrayBlockNode.getChild(0), initialBufferSize);
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        // TODO: These local buffers will be requested from the buffer pools in the future.
+        if (offsetsBuffer == null) {
+            offsetsBuffer = new byte[initialBufferSize * ARRAY_INT_INDEX_SCALE];
+        }
+        offsetsBufferIndex = 0;
+
+        rawBlockBuffer.prepareBuffers();
+    }
+
+    @Override
+    protected void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        nullsBufferIndex = 0;
+        remainingNullsCount = 0;
+        nullsBufferContainsNull = false;
+        offsetsBufferIndex = 0;
+
+        rawBlockBuffer.resetBuffers();
+    }
+
+    @Override
+    protected void setupDecodedBlockAndMapPositions(PartitionedOutputOperator.DecodedObjectNode decodedObjectNode)
+    {
+        mapPositions(decodedObjectNode);
+
+        populateNestedPositions();
+
+        rawBlockBuffer.setupDecodedBlockAndMapPositions(decodedObjectNode.getChild(0));
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] rowSizes)
+    {
+        // Top level positionCount should be greater than 0
+        verify(positionCount > 0);
+
+        int averageElementSize = Integer.BYTES + Byte.BYTES;
+
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += averageElementSize;
+        }
+
+        ensurePositionOffsetsSize();
+        System.arraycopy(offsets, 0, positionOffsets, 0, positionCount);
+
+        rawBlockBuffer.accumulateRowSizes(positionOffsets, positionCount, rowSizes);
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        // The nested level positionCount could be 0.
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int averageElementSize = Integer.BYTES + Byte.BYTES;
+
+        int lastOffset = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int currentOffset = positionOffsets[i];
+
+            int entryCount = currentOffset - lastOffset;
+            rowSizes[i] += averageElementSize * entryCount;
+
+            positionOffsets[i] = currentOffset == 0 ? 0 : this.offsets[currentOffset - 1];
+
+            lastOffset = currentOffset;
+        }
+
+        // this.offsetsBuffer and Next level positions should have already be written
+        rawBlockBuffer.accumulateRowSizes(positionOffsets, positionCount, rowSizes);
+    }
+
+    @Override
+    protected void setNextBatch(int positionsOffset, int batchSize)
+    {
+        this.positionsOffset = positionsOffset;
+        this.batchSize = batchSize;
+
+        // The nested level positionCount could be 0.
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int nestedLevelPositionBegin = positionsOffset == 0 ? 0 : offsets[positionsOffset - 1];
+        int nestedLevelPositionEnd = offsets[positionsOffset + batchSize - 1];
+
+        rawBlockBuffer.setNextBatch(nestedLevelPositionBegin, nestedLevelPositionEnd - nestedLevelPositionBegin);
+    }
+
+    @Override
+    protected void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+        verify(positionsOffset + batchSize - 1 < positions.length && positions[positionsOffset] >= 0 &&
+                positions[positionsOffset + batchSize - 1] < columnarArray.getPositionCount());
+
+        appendNulls();
+        appendOffsets();
+        rawBlockBuffer.copyValues();
+
+        bufferedPositionCount += batchSize;
+    }
+
+    @Override
+    protected void writeTo(SliceOutput sliceOutput)
+    {
+        // TODO: getSizeInBytes() was calculated in flush and doesnt need to recalculated
+        verify(getSizeInBytes() <= sliceOutput.writableBytes());
+        writeLengthPrefixedString(sliceOutput, NAME);
+
+        rawBlockBuffer.writeTo(sliceOutput);
+
+        sliceOutput.writeInt(bufferedPositionCount); //positionCount
+
+        sliceOutput.writeInt(0);  // the base position
+        sliceOutput.appendBytes(offsetsBuffer, 0, offsetsBufferIndex);
+
+        writeNullsTo(sliceOutput);
+    }
+
+    @Override
+    protected int getSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +        // encoding name
+                rawBlockBuffer.getSizeInBytes() +   // nested block
+                SIZE_OF_INT +                       // positionCount
+                SIZE_OF_INT +                       // offset 0. The offsetsBuffer doesn't contain the offset 0 so we need to add it here.
+                offsetsBufferIndex +                // offsets buffer.
+                SIZE_OF_BYTE +                      // nulls uses 1 byte for mayHaveNull
+                nullsBufferIndex +                  // nulls buffer
+                (remainingNullsCount > 0 ? SIZE_OF_BYTE : 0); // the remaining nulls not serialized yet
+    }
+
+    private void mapPositions(PartitionedOutputOperator.DecodedObjectNode decodedObjectNode)
+    {
+        // Remap positions
+        Object decodedObject = decodedObjectNode.getDecodedBlock();
+
+        if (decodedObject instanceof DictionaryBlock) {
+            DictionaryBlock dictionaryBlock = (DictionaryBlock) decodedObject;
+            mapPositionsForDictionary(dictionaryBlock);
+            decodedObjectNode = decodedObjectNode.getChild(0);
+            isPositionsMapped = true;
+        }
+        else if (decodedObject instanceof RunLengthEncodedBlock) {
+            mapPositionsForRle();
+            decodedObjectNode = decodedObjectNode.getChild(0);
+            isPositionsMapped = true;
+        }
+        else {
+            isPositionsMapped = false;
+        }
+
+        columnarArray = (ColumnarArray) decodedObjectNode.getDecodedBlock();
+        decodedBlock = columnarArray.getNullCheckBlock();
+    }
+
+    private void populateNestedPositions()
+    {
+        if (positionCount == 0) {
+            return;
+        }
+
+        verify(positionsOffset == 0);
+        verify(columnarArray != null);
+
+        ensureOffsetsSize();
+
+        // Nested level positions always start from 0.
+        rawBlockBuffer.positionsOffset = 0;
+        rawBlockBuffer.positionCount = 0;
+        rawBlockBuffer.isPositionsMapped = false;
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        int lastOffset = 0;
+        int columnarArrayBaseOffset = columnarArray.getOffset(0);
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            int beginOffsetInBlock = columnarArray.getOffset(position);
+            int endOffsetInBlock = columnarArray.getOffset(position + 1);
+            int currentRowSize = endOffsetInBlock - beginOffsetInBlock;
+            int currentOffset = lastOffset + currentRowSize;
+
+            offsets[i] = currentOffset;
+
+            if (currentRowSize > 0) {
+                // beginOffsetInBlock is the absolute position in the nested block. We need to substract the base offset from it to get the logical position.
+                rawBlockBuffer.appendPositionRange(beginOffsetInBlock - columnarArrayBaseOffset, currentRowSize);
+            }
+
+            lastOffset = currentOffset;
+        }
+    }
+
+    private void appendOffsets()
+    {
+        ensureOffsetsBufferSize();
+
+        int baseOffset = getLastOffsetInBuffer();
+
+        if (positionsOffset > 0) {
+            baseOffset -= offsets[positionsOffset - 1];
+        }
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int currentOffset = offsets[i];
+            ByteArrayUtils.writeInt(offsetsBuffer, offsetsBufferIndex, currentOffset + baseOffset);
+            offsetsBufferIndex += ARRAY_INT_INDEX_SCALE;
+        }
+
+        verify(offsetsBufferIndex == (bufferedPositionCount + batchSize) * ARRAY_INT_INDEX_SCALE);
+    }
+
+    private int getLastOffsetInBuffer()
+    {
+        int offset = 0;
+        if (offsetsBufferIndex > 0) {
+            // There're already some values in the buffer
+            offset = ByteArrays.getInt(offsetsBuffer, offsetsBufferIndex - ARRAY_INT_INDEX_SCALE);
+        }
+        return offset;
+    }
+
+    private void ensureOffsetsSize()
+    {
+        if (offsets == null || offsets.length < positionCount) {
+            offsets = new int[positionCount * 2];
+        }
+    }
+
+    private void ensurePositionOffsetsSize()
+    {
+        if (positionOffsets == null || positionOffsets.length < positionCount) {
+            positionOffsets = new int[positionCount * 2];
+        }
+    }
+    private void ensureOffsetsBufferSize()
+    {
+        int requiredSize = offsetsBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE;
+        if (requiredSize > offsetsBuffer.length) {
+            offsetsBuffer = Arrays.copyOf(offsetsBuffer, max(requiredSize, offsetsBuffer.length * 2));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
@@ -1,0 +1,398 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.ByteArrayBlock;
+import com.facebook.presto.spi.block.ColumnarArray;
+import com.facebook.presto.spi.block.ColumnarMap;
+import com.facebook.presto.spi.block.ColumnarRow;
+import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.Int128ArrayBlock;
+import com.facebook.presto.spi.block.IntArrayBlock;
+import com.facebook.presto.spi.block.LongArrayBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.block.ShortArrayBlock;
+import com.facebook.presto.spi.block.VariableWidthBlock;
+import io.airlift.slice.SliceOutput;
+
+import java.util.Arrays;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static java.lang.Math.max;
+
+public abstract class BlockEncodingBuffers
+{
+    private static final int BITS_IN_BYTE = 8;
+    private static final int INITIAL_POSITION_COUNT = 1024;
+
+    protected int[] positions;
+    protected int[] mappedPositions;
+    protected int positionCount;
+    protected boolean isPositionsMapped;
+
+    protected int positionsOffset;  // each batch we copy the values of rows from positions[positionsOffset] to positions[positionsOffset + batchSize]
+    protected int batchSize;
+    protected int bufferedPositionCount;
+
+    protected int initialBufferSize;
+
+    private byte[] nullsBuffer;
+    protected int nullsBufferIndex;  //The next byte address if new values to be added.
+    protected boolean[] remainingNullsFromLastBatch = new boolean[BITS_IN_BYTE];
+    protected int remainingNullsCount;
+    protected boolean nullsBufferContainsNull;
+
+    protected Block decodedBlock;
+
+    public static BlockEncodingBuffers createBlockEncodingBuffers(PartitionedOutputOperator.DecodedObjectNode decodedObjectNode, int initialBufferSize)
+    {
+        Object decodedBlock = decodedObjectNode.getDecodedBlock();
+
+        // Skip the Dictionary/Rle block node. The mapping info is not needed when creating buffers.
+        if (decodedBlock instanceof DictionaryBlock) {
+            DictionaryBlock dictionaryBlock = (DictionaryBlock) decodedBlock;
+            decodedBlock = dictionaryBlock.getDictionary();
+        }
+        else if (decodedBlock instanceof RunLengthEncodedBlock) {
+            decodedBlock = ((RunLengthEncodedBlock) decodedBlock).getValue();
+        }
+
+        if (decodedBlock instanceof LongArrayBlock) {
+            return new LongArrayBlockEncodingBuffers(initialBufferSize);
+        }
+        else if (decodedBlock instanceof VariableWidthBlock) {
+            return new VariableWidthBlockEncodingBuffers(initialBufferSize);
+        }
+        else if (decodedBlock instanceof IntArrayBlock) {
+            return new IntArrayBlockEncodingBuffers(initialBufferSize);
+        }
+        else if (decodedBlock instanceof ByteArrayBlock) {
+            return new ByteArrayBlockEncodingBuffers(initialBufferSize);
+        }
+        else if (decodedBlock instanceof ShortArrayBlock) {
+            return new ShortArrayBlockEncodingBuffers(initialBufferSize);
+        }
+        else if (decodedBlock instanceof ColumnarArray) {
+            return new ArrayBlockEncodingBuffers(decodedObjectNode, initialBufferSize);
+        }
+        else if (decodedBlock instanceof ColumnarMap) {
+            return new MapBlockEncodingBuffers(decodedObjectNode, initialBufferSize);
+        }
+        else if (decodedBlock instanceof ColumnarRow) {
+            return new RowBlockEncodingBuffers(decodedObjectNode, initialBufferSize);
+        }
+        else if (decodedBlock instanceof Int128ArrayBlock) {
+            return new Int128ArrayBlockEncodingBuffers(initialBufferSize);
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported encoding: " + ((Block) decodedBlock).getEncodingName());
+        }
+    }
+
+    protected abstract void prepareBuffers();
+
+    protected abstract void resetBuffers();
+
+    protected abstract void copyValues();
+
+    protected abstract void writeTo(SliceOutput sliceOutput);
+
+    protected abstract int getSizeInBytes();
+
+    protected abstract void accumulateRowSizes(int[] rowSizes);
+
+    protected abstract void accumulateRowSizes(int[] offsetsBuffer, int positionCount, int[] rowSizes);
+
+    protected void setupDecodedBlocksAndPositions(PartitionedOutputOperator.DecodedObjectNode decodedObjectNode, int[] positions, int positionCount)
+    {
+        checkArgument(decodedObjectNode != null);
+
+        this.positions = positions;
+        this.positionCount = positionCount;
+        this.positionsOffset = 0;
+
+        setupDecodedBlockAndMapPositions(decodedObjectNode);
+    }
+
+    protected void setupDecodedBlockAndMapPositions(PartitionedOutputOperator.DecodedObjectNode decodedObjectNode)
+    {
+        Object decodedObject = decodedObjectNode.getDecodedBlock();
+
+        if (decodedObject instanceof DictionaryBlock) {
+            DictionaryBlock dictionaryBlock = (DictionaryBlock) decodedObject;
+            mapPositionsForDictionary(dictionaryBlock);
+
+            decodedBlock = dictionaryBlock.getDictionary();
+            isPositionsMapped = true;
+        }
+        else if (decodedObject instanceof RunLengthEncodedBlock) {
+            RunLengthEncodedBlock rleBlock = (RunLengthEncodedBlock) decodedObject;
+            mapPositionsForRle();
+
+            decodedBlock = rleBlock.getValue();
+            isPositionsMapped = true;
+        }
+        else {
+            decodedBlock = (Block) decodedObject;
+            isPositionsMapped = false;
+        }
+    }
+
+    protected void setPositions(int[] positions)
+    {
+        this.positions = positions;
+    }
+
+    protected void mapPositionsForDictionary(DictionaryBlock dictionaryBlock)
+    {
+        ensureMappedPositionsCapacity();
+        for (int i = 0; i < positionCount; i++) {
+            mappedPositions[i] = dictionaryBlock.getId(positions[i]);
+        }
+    }
+
+    protected void mapPositionsForRle()
+    {
+        ensureMappedPositionsCapacity();
+        Arrays.fill(mappedPositions, 0, positionCount, 0);
+    }
+
+    protected void setNextBatch(int positionsOffset, int batchSize)
+    {
+        this.positionsOffset = positionsOffset;
+        this.batchSize = batchSize;
+    }
+
+    protected void appendPositionRange(int offset, int addedLength)
+    {
+        ensurePositionsCapacity(positionCount + addedLength);
+        for (int i = 0; i < addedLength; i++) {
+            positions[positionCount++] = offset + i;
+        }
+    }
+
+    protected void appendNulls()
+    {
+        if (decodedBlock.mayHaveNull()) {
+            // We write to the buffer if there're potential nulls. Note that even though the decodedBlock may contains null, the rows that go to this partition may not.
+            // But we still write them to nullsBuffer anyways because of performance considerations.
+            ensureNullsValueBufferSize();
+            int bufferedNullsCount = nullsBufferIndex * BITS_IN_BYTE + remainingNullsCount;
+
+            if (bufferedPositionCount > bufferedNullsCount) {
+                // THere were no nulls for the rows in (bufferedNullsCount, bufferedPositionCount]. Backfill them as all 0's
+                int falsesToWrite = bufferedPositionCount - bufferedNullsCount;
+                encodeFalseValuesAsBits(falsesToWrite);
+                verify(nullsBufferIndex * BITS_IN_BYTE + remainingNullsCount == bufferedPositionCount);
+            }
+
+            // Append this batch
+            encodeNullsAsBits(decodedBlock);
+
+            verify(nullsBufferIndex * BITS_IN_BYTE + remainingNullsCount == bufferedPositionCount + batchSize);
+        }
+        else {
+            if (containsNull()) {
+                // There were nulls in previously buffered rows, but for this batch there can't be any nulls. Any how we need to append 0's for this batch.
+                verify(nullsBufferIndex * BITS_IN_BYTE + remainingNullsCount == bufferedPositionCount);
+
+                ensureNullsValueBufferSize();
+                encodeFalseValuesAsBits(batchSize);
+
+                verify(nullsBufferIndex * BITS_IN_BYTE + remainingNullsCount == bufferedPositionCount + batchSize);
+            }
+        }
+    }
+
+    protected void writeNullsTo(SliceOutput sliceOutput)
+    {
+        if (remainingNullsCount > 0) {
+            encodeRemainingNullsAsBits();
+            remainingNullsCount = 0;
+        }
+
+        if (nullsBufferContainsNull) {
+            if (!((nullsBufferIndex - 1) * BITS_IN_BYTE < bufferedPositionCount && nullsBufferIndex * BITS_IN_BYTE >= bufferedPositionCount)) {
+            }
+            verify((nullsBufferIndex - 1) * BITS_IN_BYTE < bufferedPositionCount && nullsBufferIndex * BITS_IN_BYTE >= bufferedPositionCount);
+
+            sliceOutput.writeBoolean(true);
+            sliceOutput.appendBytes(nullsBuffer, 0, nullsBufferIndex);
+        }
+        else {
+            sliceOutput.writeBoolean(false);
+        }
+    }
+
+    private boolean containsNull()
+    {
+        return nullsBufferContainsNull || remainingNullsContainsNulls();
+    }
+
+    private boolean remainingNullsContainsNulls()
+    {
+        boolean result = false;
+        for (int i = 0; i < remainingNullsCount; i++) {
+            result |= remainingNullsFromLastBatch[i];
+        }
+        return result;
+    }
+
+    private void encodeNullsAsBits(Block block)
+    {
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        if (remainingNullsCount + batchSize < BITS_IN_BYTE) {
+            // just put all of this batch to remainingNullsFromLastBatch
+            for (int offset = positionsOffset; offset < positionsOffset + batchSize; offset++) {
+                int position = positions[offset];
+                remainingNullsFromLastBatch[remainingNullsCount++] = block.isNull(position);
+            }
+            return;
+        }
+
+        // Process the remaining nulls from last batch
+        int offset = positionsOffset;
+
+        if (remainingNullsCount > 0) {
+            byte value = 0;
+            int mask = 0b1000_0000;
+            for (int i = 0; i < remainingNullsCount; i++) {
+                value |= remainingNullsFromLastBatch[i] ? mask : 0;
+                mask >>>= 1;
+            }
+
+            // Process the next a few nulls to make up one byte
+            int positionCountForFirstByte = BITS_IN_BYTE - remainingNullsCount;
+            int endPositionOffset = positionsOffset + positionCountForFirstByte;
+            while (offset < endPositionOffset) {
+                int position = positions[offset];
+                value |= block.isNull(position) ? mask : 0;
+                mask >>>= 1;
+                offset++;
+            }
+            nullsBufferContainsNull |= (value != 0);
+            ByteArrayUtils.writeByte(nullsBuffer, nullsBufferIndex++, value);
+        }
+
+        // Process the next BITS_IN_BYTE * n positions. We now have processed (offset - positionsOffset) positions
+        int remainingPositions = batchSize - (offset - positionsOffset);
+        int positionsToEncode = remainingPositions & ~0b111;
+        int endPositionOffset = offset + positionsToEncode;
+        while (offset < endPositionOffset) {
+            byte value = 0;
+            value |= block.isNull(positions[offset]) ? 0b1000_0000 : 0;
+            value |= block.isNull(positions[offset + 1]) ? 0b0100_0000 : 0;
+            value |= block.isNull(positions[offset + 2]) ? 0b0010_0000 : 0;
+            value |= block.isNull(positions[offset + 3]) ? 0b0001_0000 : 0;
+            value |= block.isNull(positions[offset + 4]) ? 0b0000_1000 : 0;
+            value |= block.isNull(positions[offset + 5]) ? 0b0000_0100 : 0;
+            value |= block.isNull(positions[offset + 6]) ? 0b0000_0010 : 0;
+            value |= block.isNull(positions[offset + 7]) ? 0b0000_0001 : 0;
+
+            nullsBufferContainsNull |= (value != 0);
+            ByteArrayUtils.writeByte(nullsBuffer, nullsBufferIndex, value);
+            nullsBufferIndex++;
+            offset += BITS_IN_BYTE;
+        }
+
+        remainingPositions &= 0b111;
+        verify(remainingPositions < BITS_IN_BYTE);
+        remainingNullsCount = 0;
+        while (remainingNullsCount < remainingPositions) {
+            int position = positions[offset++];
+            remainingNullsFromLastBatch[remainingNullsCount++] = block.isNull(position);
+        }
+    }
+
+    private void encodeFalseValuesAsBits(int count)
+    {
+        if (remainingNullsCount + count < BITS_IN_BYTE) {
+            // just put all of this batch to remainingNullsFromLastBatch
+            for (int i = 0; i < count; i++) {
+                remainingNullsFromLastBatch[remainingNullsCount++] = false;
+            }
+            return;
+        }
+
+        // Have to do this before calling encodeRemainingNullsAsBits() because it resets remainingNullsCount
+        int remainingPositions = count;
+
+        // Process the remaining nulls from last batch
+        if (remainingNullsCount > 0) {
+            encodeRemainingNullsAsBits();
+            remainingPositions -= (BITS_IN_BYTE - remainingNullsCount);
+            remainingNullsCount = 0;
+        }
+
+        int bytesCount = remainingPositions >>> 3;
+
+        ByteArrayUtils.fill(nullsBuffer, nullsBufferIndex, bytesCount, (byte) 0);
+        nullsBufferIndex += bytesCount;
+
+        remainingPositions &= 0b111;
+        remainingNullsCount = 0;
+        while (remainingNullsCount < remainingPositions) {
+            remainingNullsFromLastBatch[remainingNullsCount++] = false;
+        }
+    }
+
+    private void encodeRemainingNullsAsBits()
+    {
+        byte value = 0;
+        int mask = 0b1000_0000;
+        for (int i = 0; i < remainingNullsCount; i++) {
+            value |= remainingNullsFromLastBatch[i] ? mask : 0;
+            mask >>>= 1;
+        }
+
+        nullsBufferContainsNull |= (value != 0);
+        ByteArrayUtils.writeByte(nullsBuffer, nullsBufferIndex, value);
+        nullsBufferIndex++;
+    }
+
+    private void ensurePositionsCapacity(int length)
+    {
+        if (positions == null) {
+            positions = new int[INITIAL_POSITION_COUNT];
+        }
+        else if (this.positions.length < length) {
+            positions = Arrays.copyOf(positions, max(positions.length * 2, length));
+        }
+    }
+
+    private void ensureMappedPositionsCapacity()
+    {
+        if (this.mappedPositions == null || this.mappedPositions.length < positionCount) {
+            mappedPositions = new int[positionCount * 2];
+        }
+    }
+
+    private void ensureNullsValueBufferSize()
+    {
+        // This may overestimate the size by 1 byte to allow faster computation
+        int requiredBytes = (bufferedPositionCount + batchSize) / BITS_IN_BYTE + 1;
+
+        if (nullsBuffer == null) {
+            int newSize = max(requiredBytes, initialBufferSize / BITS_IN_BYTE);
+            nullsBuffer = new byte[newSize];
+        }
+        else if (nullsBuffer.length < requiredBytes) {
+            int newSize = max(requiredBytes, nullsBuffer.length * 2);
+            nullsBuffer = Arrays.copyOf(nullsBuffer, newSize);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ByteArrayBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ByteArrayBlockEncodingBuffers.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import io.airlift.slice.SliceOutput;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.ByteArrayUtils.writeLengthPrefixedString;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_BYTE_INDEX_SCALE;
+
+public class ByteArrayBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    public static final String NAME = "BYTE_ARRAY";
+
+    private byte[] valuesBuffer;
+    private int valuesBufferIndex;
+
+    ByteArrayBlockEncodingBuffers(int initialBufferSize)
+    {
+        this.initialBufferSize = initialBufferSize;
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        if (valuesBuffer == null) {
+            valuesBuffer = new byte[initialBufferSize];
+        }
+        valuesBufferIndex = 0;
+    }
+
+    @Override
+    protected void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+
+        nullsBufferIndex = 0;
+        remainingNullsCount = 0;
+        nullsBufferContainsNull = false;
+
+        valuesBufferIndex = 0;
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] rowSizes)
+    {
+        int averageElementSize = Byte.BYTES * 2;
+
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += averageElementSize;
+        }
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        int averageElementSize = Byte.BYTES * 2;
+
+        int lastOffset = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int currentOffset = positionOffsets[i];
+            int entryCount = currentOffset - lastOffset;
+            rowSizes[i] += entryCount * averageElementSize;
+            lastOffset = currentOffset;
+        }
+    }
+
+    @Override
+    protected void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        verify(decodedBlock != null);
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+        verify(positionsOffset + batchSize - 1 < positions.length && positions[positionsOffset] >= 0 &&
+                positions[positionsOffset + batchSize - 1] < decodedBlock.getPositionCount());
+
+        appendValuesToBuffer();
+        appendNulls();
+        bufferedPositionCount += batchSize;
+    }
+
+    @Override
+    protected void writeTo(SliceOutput sliceOutput)
+    {
+        // TODO: getSizeInBytes() was calculated in flush and doesnt need to recalculated
+        verify(getSizeInBytes() <= sliceOutput.writableBytes());
+
+        writeLengthPrefixedString(sliceOutput, NAME);
+
+        sliceOutput.writeInt(bufferedPositionCount);
+
+        writeNullsTo(sliceOutput);
+
+        sliceOutput.appendBytes(valuesBuffer, 0, valuesBufferIndex);
+    }
+
+    @Override
+    protected int getSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +    // NAME
+                SIZE_OF_INT +                   // positionCount
+                SIZE_OF_BYTE +                  // nulls uses 1 byte for mayHaveNull
+                nullsBufferIndex +              // nulls buffer
+                (remainingNullsCount > 0 ? SIZE_OF_BYTE : 0) +  // the remaining nulls not serialized yet
+                valuesBufferIndex;              // values buffer
+    }
+
+    private void appendValuesToBuffer()
+    {
+        ensureValueBufferSize();
+
+        if (decodedBlock.mayHaveNull()) {
+            appendBytesWithNullsToBuffer();
+        }
+        else {
+            appendBytesToBuffer();
+        }
+    }
+
+    private void appendBytesToBuffer()
+    {
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            byte value = decodedBlock.getByte(positions[i]);
+            ByteArrayUtils.writeByte(valuesBuffer, valuesBufferIndex, value);
+            valuesBufferIndex += ARRAY_BYTE_INDEX_SCALE;
+        }
+    }
+
+    private void appendBytesWithNullsToBuffer()
+    {
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int position = positions[i];
+            byte value = decodedBlock.getByte(position);
+            ByteArrayUtils.writeByte(valuesBuffer, valuesBufferIndex, value);
+
+            if (!decodedBlock.isNull(position)) {
+                valuesBufferIndex += ARRAY_BYTE_INDEX_SCALE;
+            }
+        }
+    }
+
+    private void ensureValueBufferSize()
+    {
+        verify(valuesBuffer != null);
+
+        int requiredSize = valuesBufferIndex + batchSize;
+        if (requiredSize > valuesBuffer.length) {
+            valuesBuffer = Arrays.copyOf(valuesBuffer, max(valuesBuffer.length * 2, requiredSize));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ByteArrayUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ByteArrayUtils.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+
+public class ByteArrayUtils
+{
+    static Unsafe unsafe;
+
+    static {
+        try {
+            Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            unsafe = (Unsafe) field.get(null);
+            if (unsafe == null) {
+                throw new RuntimeException("Unsafe access not available");
+            }
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ByteArrayUtils() {}
+
+    public static int writeInts(byte[] target, int targetIndex, int[] values, int offset, int length)
+    {
+        try {
+            checkArgument(targetIndex + length * ARRAY_INT_INDEX_SCALE <= target.length || targetIndex >= 0);
+            checkArgument(offset + length <= values.length);
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        for (int i = offset; i < offset + length; i++) {
+            unsafe.putInt(target, (long) targetIndex + ARRAY_BYTE_BASE_OFFSET, values[i]);
+            targetIndex += ARRAY_INT_INDEX_SCALE;
+        }
+        return targetIndex;
+    }
+
+    public static int writeLongs(byte[] target, int targetIndex, long[] values, int[] positions, int positionsOffset, int length, int offsetBase)
+    {
+        if (target.length < targetIndex + length * ARRAY_LONG_INDEX_SCALE || targetIndex < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        for (int i = positionsOffset; i < positionsOffset + length; i++) {
+            // Note that positions is logical row number. It may not start from 0 in the values array.
+            unsafe.putLong(target, (long) targetIndex + ARRAY_BYTE_BASE_OFFSET, values[positions[i] + offsetBase]);
+            targetIndex += ARRAY_LONG_INDEX_SCALE;
+        }
+        return targetIndex;
+    }
+
+    public static int writeLongsWithNulls(byte[] target, int targetIndex, long[] values, boolean[] nulls, int[] positions, int positionsOffset, int length, int offsetBase)
+    {
+        if (target.length < targetIndex + length * ARRAY_LONG_INDEX_SCALE || targetIndex < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        for (int i = positionsOffset; i < positionsOffset + length; i++) {
+            // Note that positions is logical row number. It may not start from 0 in the values array.
+            int position = positions[i] + offsetBase;
+            unsafe.putLong(target, (long) targetIndex + ARRAY_BYTE_BASE_OFFSET, values[position]);
+            if (!nulls[position]) {
+                targetIndex += ARRAY_LONG_INDEX_SCALE;
+            }
+        }
+        return targetIndex;
+    }
+
+    public static int writeLongs(byte[] target, int targetIndex, long[] values, int[] ids, int[] positions, int positionsOffset, int length, int offsetBase)
+    {
+        if (target.length < targetIndex + length * ARRAY_LONG_INDEX_SCALE || targetIndex < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        for (int i = positionsOffset; i < positionsOffset + length; i++) {
+            // Note that positions is logical row number. It may not start from 0 in the values array.
+            unsafe.putLong(target, (long) targetIndex + ARRAY_BYTE_BASE_OFFSET, values[ids[positions[i] + offsetBase]]);
+            targetIndex += ARRAY_LONG_INDEX_SCALE;
+        }
+        return targetIndex;
+    }
+
+    public static int writeLongsWithNulls(byte[] target, int targetIndex, long[] values, int[] ids, boolean[] nulls, int[] positions, int positionsOffset, int length, int offsetBase)
+    {
+        if (target.length < targetIndex + length * ARRAY_LONG_INDEX_SCALE || targetIndex < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        for (int i = positionsOffset; i < positionsOffset + length; i++) {
+            // Note that positions is logical row number. It may not start from 0 in the values array.
+            int position = positions[i] + offsetBase;
+            unsafe.putLong(target, (long) targetIndex + ARRAY_BYTE_BASE_OFFSET, values[ids[position]]);
+            if (!nulls[position]) {
+                targetIndex += ARRAY_LONG_INDEX_SCALE;
+            }
+        }
+        return targetIndex;
+    }
+
+    // Sequential copy
+    public static int writeLongs(byte[] target, int targetIndex, long[] values, int positionsOffset, int batchSize, int offsetBase)
+    {
+        if (target.length < targetIndex + batchSize * ARRAY_LONG_INDEX_SCALE || targetIndex < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        for (int position = positionsOffset; position < positionsOffset + batchSize; position++) {
+            // Note that positions is logical row number. It may not start from 0 in the values array.
+            unsafe.putLong(target, (long) targetIndex + ARRAY_BYTE_BASE_OFFSET, values[position + offsetBase]);
+            targetIndex += ARRAY_LONG_INDEX_SCALE;
+        }
+        return targetIndex;
+    }
+
+    // Sequential copy
+    public static int writeLongsWithNulls(byte[] target, int targetIndex, long[] values, boolean[] nulls, int positionsOffset, int batchSize, int offsetBase)
+    {
+        if (target.length < targetIndex - ARRAY_BYTE_BASE_OFFSET + batchSize * ARRAY_LONG_INDEX_SCALE || targetIndex < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            // Note that positions is logical row number. It may not start from 0 in the values array.
+            int position = i + offsetBase;
+            unsafe.putLong(target, (long) targetIndex, values[position]);
+            if (!nulls[position]) {
+                targetIndex += ARRAY_LONG_INDEX_SCALE;
+            }
+        }
+        return targetIndex;
+    }
+
+    public static void writeByte(byte[] target, int targetIndex, byte value)
+    {
+        unsafe.putByte(target, (long) targetIndex + ARRAY_BYTE_BASE_OFFSET, value);
+    }
+
+    public static void writeShort(byte[] target, int targetIndex, short value)
+    {
+        unsafe.putShort(target, (long) targetIndex + ARRAY_BYTE_BASE_OFFSET, value);
+    }
+
+    public static void writeInt(byte[] target, int targetIndex, int value)
+    {
+        unsafe.putInt(target, (long) targetIndex + ARRAY_BYTE_BASE_OFFSET, value);
+    }
+
+    public static void writeLong(byte[] target, int targetIndex, long value)
+    {
+        unsafe.putLong(target, (long) targetIndex + ARRAY_BYTE_BASE_OFFSET, value);
+    }
+
+    public static int writeSlice(byte[] target, int targetIndex, Slice slice)
+    {
+        unsafe.copyMemory(slice.getBase(), slice.getAddress(), target, (long) targetIndex + ARRAY_BYTE_BASE_OFFSET, slice.length());
+        return targetIndex + slice.length();
+    }
+
+    public static int fill(byte[] target, int targetIndex, int length, byte value)
+    {
+        unsafe.setMemory(target, targetIndex + ARRAY_BYTE_BASE_OFFSET, length, value);
+        return targetIndex + length;
+    }
+
+    public static int copyBytes(byte[] target, int targetIndex, byte[] source, int sourceIndex, int length)
+    {
+        // The performance of one copy and two copies (one big chunk at  bytes boundary + else) from Slice are about the same.
+        unsafe.copyMemory(source, (long) sourceIndex + ARRAY_BYTE_BASE_OFFSET, target, (long) targetIndex + ARRAY_BYTE_BASE_OFFSET, length);
+        return targetIndex + length;
+    }
+
+    static void writeLengthPrefixedString(SliceOutput output, String value)
+    {
+        byte[] bytes = value.getBytes(UTF_8);
+        output.writeInt(bytes.length);
+        output.writeBytes(bytes);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/Int128ArrayBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Int128ArrayBlockEncodingBuffers.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import io.airlift.slice.SliceOutput;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.ByteArrayUtils.writeLengthPrefixedString;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+
+public class Int128ArrayBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    public static final String NAME = "INT128_ARRAY";
+
+    private byte[] valuesBuffer;
+    private int valuesBufferIndex;
+
+    Int128ArrayBlockEncodingBuffers(int initialElementCount)
+    {
+        this.initialBufferSize = initialBufferSize;
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        if (valuesBuffer == null) {
+            valuesBuffer = new byte[initialBufferSize * ARRAY_LONG_INDEX_SCALE * 2];
+        }
+        valuesBufferIndex = 0;
+    }
+
+    @Override
+    protected void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        valuesBufferIndex = 0;
+        nullsBufferIndex = 0;
+        remainingNullsCount = 0;
+        nullsBufferContainsNull = false;
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] rowSizes)
+    {
+        int averageElementSize = Long.BYTES * 2 + Byte.BYTES;
+
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += averageElementSize;
+        }
+    }
+
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        int averageElementSize = Long.BYTES * 2 + Byte.BYTES;
+
+        // it starts from 0 because top level offsets were normalized
+        int lastOffset = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int currentOffset = positionOffsets[i];
+            int entryCount = currentOffset - lastOffset;
+            rowSizes[i] += entryCount * averageElementSize;
+
+            lastOffset = currentOffset;
+        }
+    }
+
+    @Override
+    protected void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        verify(decodedBlock != null);
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+        verify(positionsOffset + batchSize - 1 < positions.length && positions[positionsOffset] >= 0 &&
+                positions[positionsOffset + batchSize - 1] < decodedBlock.getPositionCount());
+
+        appendValuesToBuffer();
+        appendNulls();
+        bufferedPositionCount += batchSize;
+    }
+
+    @Override
+    protected void writeTo(SliceOutput sliceOutput)
+    {
+        // TODO: getSizeInBytes() was calculated in flush and doesnt need to recalculated
+        verify(getSizeInBytes() <= sliceOutput.writableBytes());
+
+        writeLengthPrefixedString(sliceOutput, NAME);
+        sliceOutput.writeInt(bufferedPositionCount);
+        writeNullsTo(sliceOutput);
+        sliceOutput.appendBytes(valuesBuffer, 0, valuesBufferIndex);
+    }
+
+    @Override
+    protected int getSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +    // NAME
+                SIZE_OF_INT +                   // positionCount
+                SIZE_OF_BYTE +                  // nulls uses 1 byte for mayHaveNull
+                nullsBufferIndex +              // nulls buffer
+                (remainingNullsCount > 0 ? SIZE_OF_BYTE : 0) +  // the remaining nulls not serialized yet
+                valuesBufferIndex;              // values buffer
+    }
+
+    private void appendValuesToBuffer()
+    {
+        verify(decodedBlock != null);
+
+        ensureValueBufferSize();
+
+        if (decodedBlock.mayHaveNull()) {
+            appendIpAddresesWithNullsToBuffer();
+        }
+        else {
+            appendIpAddresesToBuffer();
+        }
+    }
+
+    private void appendIpAddresesToBuffer()
+    {
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int position = positions[i];
+
+            long value = decodedBlock.getLong(position, 0);
+            ByteArrayUtils.writeLong(valuesBuffer, valuesBufferIndex, value);
+            valuesBufferIndex += ARRAY_LONG_INDEX_SCALE;
+
+            value = decodedBlock.getLong(position, 8);
+            ByteArrayUtils.writeLong(valuesBuffer, valuesBufferIndex, value);
+            valuesBufferIndex += ARRAY_LONG_INDEX_SCALE;
+        }
+    }
+
+    private void appendIpAddresesWithNullsToBuffer()
+    {
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int position = positions[i];
+
+            long value = decodedBlock.getLong(position, 0);
+            ByteArrayUtils.writeLong(valuesBuffer, valuesBufferIndex, value);
+            valuesBufferIndex += ARRAY_LONG_INDEX_SCALE;
+
+            value = decodedBlock.getLong(position, 8);
+            ByteArrayUtils.writeLong(valuesBuffer, valuesBufferIndex, value);
+            valuesBufferIndex += ARRAY_LONG_INDEX_SCALE;
+
+            if (decodedBlock.isNull(position)) {
+                valuesBufferIndex -= ARRAY_LONG_INDEX_SCALE * 2;
+            }
+        }
+    }
+
+    private void ensureValueBufferSize()
+    {
+        verify(valuesBuffer != null);
+
+        int requiredSize = valuesBufferIndex + batchSize * ARRAY_LONG_INDEX_SCALE * 2;
+        if (requiredSize > valuesBuffer.length) {
+            valuesBuffer = Arrays.copyOf(valuesBuffer, max(valuesBuffer.length * 2, requiredSize));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/IntArrayBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/IntArrayBlockEncodingBuffers.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import io.airlift.slice.SliceOutput;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.ByteArrayUtils.writeLengthPrefixedString;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+
+public class IntArrayBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    public static final String NAME = "INT_ARRAY";
+
+    private byte[] valuesBuffer;
+    private int valuesBufferIndex;
+
+    IntArrayBlockEncodingBuffers(int initialBufferSize)
+    {
+        this.initialBufferSize = initialBufferSize;
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        if (valuesBuffer == null) {
+            valuesBuffer = new byte[initialBufferSize * ARRAY_INT_INDEX_SCALE];
+        }
+        valuesBufferIndex = 0;
+    }
+
+    @Override
+    protected void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        valuesBufferIndex = 0;
+        nullsBufferIndex = 0;
+        remainingNullsCount = 0;
+        nullsBufferContainsNull = false;
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] rowSizes)
+    {
+        int averageElementSize = Long.BYTES + Byte.BYTES;
+
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += averageElementSize;
+        }
+    }
+
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        int averageElementSize = Integer.BYTES + Byte.BYTES;
+
+        // it starts from 0 because top level offsets were normalized
+        int lastOffset = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int currentOffset = positionOffsets[i];
+            int entryCount = currentOffset - lastOffset;
+            rowSizes[i] += entryCount * averageElementSize;
+
+            lastOffset = currentOffset;
+        }
+    }
+
+    @Override
+    protected void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        verify(decodedBlock != null);
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+        verify(positionsOffset + batchSize - 1 < positions.length &&
+                    positions[positionsOffset] >= 0 &&
+                    positions[positionsOffset + batchSize - 1] < decodedBlock.getPositionCount());
+
+        appendValuesToBuffer();
+        appendNulls();
+        bufferedPositionCount += batchSize;
+    }
+
+    @Override
+    protected void writeTo(SliceOutput sliceOutput)
+    {
+        // TODO: getSizeInBytes() was calculated in flush and doesnt need to recalculated
+        verify(getSizeInBytes() <= sliceOutput.writableBytes());
+
+        writeLengthPrefixedString(sliceOutput, NAME);
+        sliceOutput.writeInt(bufferedPositionCount);
+        writeNullsTo(sliceOutput);
+        sliceOutput.appendBytes(valuesBuffer, 0, valuesBufferIndex);
+    }
+
+    @Override
+    protected int getSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +    // NAME
+                SIZE_OF_INT +                   // positionCount
+                SIZE_OF_BYTE +                  // nulls uses 1 byte for mayHaveNull
+                nullsBufferIndex +              // nulls buffer
+                (remainingNullsCount > 0 ? SIZE_OF_BYTE : 0) +  // the remaining nulls not serialized yet
+                valuesBufferIndex;              // values buffer
+    }
+
+    private void appendValuesToBuffer()
+    {
+        verify(decodedBlock != null);
+
+        ensureValueBufferSize();
+
+        if (decodedBlock.mayHaveNull()) {
+            appendIntegersWithNullsToBuffer();
+        }
+        else {
+            appendIntegersToBuffer();
+        }
+    }
+
+    private void appendIntegersToBuffer()
+    {
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int value = decodedBlock.getInt(positions[i]);
+            ByteArrayUtils.writeLong(valuesBuffer, valuesBufferIndex, value);
+            valuesBufferIndex += ARRAY_INT_INDEX_SCALE;
+        }
+    }
+
+    private void appendIntegersWithNullsToBuffer()
+    {
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int position = positions[i];
+            int value = decodedBlock.getInt(position);
+            ByteArrayUtils.writeLong(valuesBuffer, valuesBufferIndex, value);
+
+            if (!decodedBlock.isNull(position)) {
+                valuesBufferIndex += ARRAY_INT_INDEX_SCALE;
+            }
+        }
+    }
+
+    private void ensureValueBufferSize()
+    {
+        verify(valuesBuffer != null);
+
+        int requiredSize = valuesBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE;
+        if (requiredSize > valuesBuffer.length) {
+            valuesBuffer = Arrays.copyOf(valuesBuffer, max(valuesBuffer.length * 2, requiredSize));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/LongArrayBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LongArrayBlockEncodingBuffers.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import io.airlift.slice.SliceOutput;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.ByteArrayUtils.writeLengthPrefixedString;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+
+public class LongArrayBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    public static final String NAME = "LONG_ARRAY";
+
+    private byte[] valuesBuffer;
+    private int valuesBufferIndex;
+
+    LongArrayBlockEncodingBuffers(int initialBufferSize)
+    {
+        this.initialBufferSize = initialBufferSize;
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        if (valuesBuffer == null) {
+            valuesBuffer = new byte[initialBufferSize * ARRAY_LONG_INDEX_SCALE];
+        }
+        valuesBufferIndex = 0;
+    }
+
+    @Override
+    protected void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        valuesBufferIndex = 0;
+        nullsBufferIndex = 0;
+        remainingNullsCount = 0;
+        nullsBufferContainsNull = false;
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] rowSizes)
+    {
+        int averageElementSize = Long.BYTES + Byte.BYTES;
+
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += averageElementSize;
+        }
+    }
+
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        int averageElementSize = Long.BYTES + Byte.BYTES;
+
+        // it starts from 0 because top level offsets were normalized
+        int lastOffset = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int currentOffset = positionOffsets[i];
+            int entryCount = currentOffset - lastOffset;
+            rowSizes[i] += entryCount * averageElementSize;
+
+            lastOffset = currentOffset;
+        }
+    }
+
+    @Override
+    protected void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        verify(decodedBlock != null);
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+        verify(positionsOffset + batchSize - 1 < positions.length && positions[positionsOffset] >= 0 &&
+                positions[positionsOffset + batchSize - 1] < decodedBlock.getPositionCount());
+
+        appendValuesToBuffer();
+        appendNulls();
+        bufferedPositionCount += batchSize;
+    }
+
+    @Override
+    protected void writeTo(SliceOutput sliceOutput)
+    {
+        // TODO: getSizeInBytes() was calculated in flush and doesnt need to recalculated
+        verify(getSizeInBytes() <= sliceOutput.writableBytes());
+
+        writeLengthPrefixedString(sliceOutput, NAME);
+        sliceOutput.writeInt(bufferedPositionCount);
+        writeNullsTo(sliceOutput);
+        sliceOutput.appendBytes(valuesBuffer, 0, valuesBufferIndex);
+    }
+
+    @Override
+    protected int getSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +    // NAME
+                SIZE_OF_INT +                   // positionCount
+                SIZE_OF_BYTE +                  // nulls uses 1 byte for mayHaveNull
+                nullsBufferIndex +              // nulls buffer
+                (remainingNullsCount > 0 ? SIZE_OF_BYTE : 0) +  // the remaining nulls not serialized yet
+                valuesBufferIndex;              // values buffer
+    }
+
+    private void appendValuesToBuffer()
+    {
+        verify(decodedBlock != null);
+
+        ensureValueBufferSize();
+
+        if (decodedBlock.mayHaveNull()) {
+            appendLongsWithNullsToBuffer();
+        }
+        else {
+            appendLongsToBuffer();
+        }
+    }
+
+    private void appendLongsToBuffer()
+    {
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            long value = decodedBlock.getLong(positions[i]);
+            ByteArrayUtils.writeLong(valuesBuffer, valuesBufferIndex, value);
+            valuesBufferIndex += ARRAY_LONG_INDEX_SCALE;
+        }
+    }
+
+    private void appendLongsWithNullsToBuffer()
+    {
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int position = positions[i];
+            long value = decodedBlock.getLong(position);
+            ByteArrayUtils.writeLong(valuesBuffer, valuesBufferIndex, value);
+
+            if (!decodedBlock.isNull(position)) {
+                valuesBufferIndex += ARRAY_LONG_INDEX_SCALE;
+            }
+        }
+    }
+
+    private void ensureValueBufferSize()
+    {
+        verify(valuesBuffer != null);
+
+        int requiredSize = valuesBufferIndex + batchSize * ARRAY_LONG_INDEX_SCALE;
+        if (requiredSize > valuesBuffer.length) {
+            valuesBuffer = Arrays.copyOf(valuesBuffer, max(valuesBuffer.length * 2, requiredSize));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/MapBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MapBlockEncodingBuffers.java
@@ -1,0 +1,415 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.ColumnarMap;
+import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.TypeSerde;
+import io.airlift.slice.ByteArrays;
+import io.airlift.slice.SliceOutput;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.facebook.presto.operator.ByteArrayUtils.writeLengthPrefixedString;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+
+public class MapBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    public static final String NAME = "MAP";
+
+    private static final int HASH_MULTIPLIER = 2;
+
+    private byte[] hashTablesBuffer;
+    private int hashTableBufferIndex;
+    private boolean noHashTables;
+
+    private byte[] offsetsBuffer;
+    private int offsetsBufferIndex;
+
+    private int[] offsets;          // This array holds the condensed offsets for each position
+    private int[] positionOffsets;  // This array holds the offsets into the above offsets array to mark the top level row boundaries for the nested block
+
+    private ColumnarMap columnarMap;
+    private BlockEncodingBuffers rawKeyBlockBuffer;
+    private BlockEncodingBuffers rawValueBlockBuffer;
+
+    MapBlockEncodingBuffers(PartitionedOutputOperator.DecodedObjectNode columnarMapBlockNode, int initialBufferSize)
+    {
+        verify(columnarMapBlockNode.getChildren().size() == 2);
+
+        this.initialBufferSize = initialBufferSize;
+
+        rawKeyBlockBuffer = createBlockEncodingBuffers(columnarMapBlockNode.getChild(0), initialBufferSize);
+        rawValueBlockBuffer = createBlockEncodingBuffers(columnarMapBlockNode.getChild(1), initialBufferSize);
+
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        if (hashTablesBuffer == null) {
+            hashTablesBuffer = new byte[initialBufferSize * ARRAY_INT_INDEX_SCALE * HASH_MULTIPLIER];
+        }
+        hashTableBufferIndex = 0;
+
+        if (offsetsBuffer == null) {
+            offsetsBuffer = new byte[initialBufferSize * ARRAY_INT_INDEX_SCALE];
+        }
+        offsetsBufferIndex = 0;
+
+        rawKeyBlockBuffer.prepareBuffers();
+        rawValueBlockBuffer.prepareBuffers();
+    }
+
+    @Override
+    protected void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        nullsBufferIndex = 0;
+        remainingNullsCount = 0;
+        nullsBufferContainsNull = false;
+        offsetsBufferIndex = 0;
+        hashTableBufferIndex = 0;
+        noHashTables = false;
+
+        rawKeyBlockBuffer.resetBuffers();
+        rawValueBlockBuffer.resetBuffers();
+    }
+
+    @Override
+    protected void setupDecodedBlockAndMapPositions(PartitionedOutputOperator.DecodedObjectNode columnarMapBlockNode)
+    {
+        verify(columnarMapBlockNode.getChildren().size() == 2);
+
+        mapPositions(columnarMapBlockNode);
+
+        populateNestedPositions();
+
+        rawKeyBlockBuffer.setupDecodedBlockAndMapPositions(columnarMapBlockNode.getChild(0));
+        rawValueBlockBuffer.setupDecodedBlockAndMapPositions(columnarMapBlockNode.getChild(1));
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] rowSizes)
+    {
+        // Top level positionCount should be greater than 0
+        verify(positionCount > 0);
+
+        int averageElementSize = Integer.BYTES + Byte.BYTES;
+
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += averageElementSize;
+        }
+
+        ensurePositionOffsetsSize();
+        System.arraycopy(offsets, 0, positionOffsets, 0, positionCount);
+
+        rawKeyBlockBuffer.accumulateRowSizes(positionOffsets, positionCount, rowSizes);
+        rawValueBlockBuffer.accumulateRowSizes(positionOffsets, positionCount, rowSizes);
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        // The nested level positionCount could be 0.
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int averageElementSize = Integer.BYTES + Byte.BYTES;
+
+        int lastOffset = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int currentOffset = positionOffsets[i];
+
+            int entryCount = currentOffset - lastOffset;
+            rowSizes[i] += averageElementSize * entryCount;
+
+            positionOffsets[i] = currentOffset == 0 ? 0 : this.offsets[currentOffset - 1];
+
+            lastOffset = currentOffset;
+        }
+
+        // this.offsetsBuffer and Next level positions should have already be written
+        rawKeyBlockBuffer.accumulateRowSizes(positionOffsets, positionCount, rowSizes);
+        rawValueBlockBuffer.accumulateRowSizes(positionOffsets, positionCount, rowSizes);
+    }
+
+    @Override
+    protected void setNextBatch(int positionsOffset, int batchSize)
+    {
+        this.positionsOffset = positionsOffset;
+        this.batchSize = batchSize;
+
+        // The nested level positionCount could be 0.
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int nestedLevelPositionBegin = positionsOffset == 0 ? 0 : offsets[positionsOffset - 1];
+        int nestedLevelPositionEnd = offsets[positionsOffset + batchSize - 1];
+
+        rawKeyBlockBuffer.setNextBatch(nestedLevelPositionBegin, nestedLevelPositionEnd - nestedLevelPositionBegin);
+        rawValueBlockBuffer.setNextBatch(nestedLevelPositionBegin, nestedLevelPositionEnd - nestedLevelPositionBegin);
+    }
+
+    @Override
+    protected void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+        verify(positionsOffset + batchSize - 1 < positions.length && positions[positionsOffset] >= 0 &&
+                positions[positionsOffset + batchSize - 1] < columnarMap.getPositionCount());
+
+        appendNulls();
+        appendOffsets();
+        appendHashTables();
+
+        rawKeyBlockBuffer.copyValues();
+        rawValueBlockBuffer.copyValues();
+
+        bufferedPositionCount += batchSize;
+    }
+
+    @Override
+    protected void writeTo(SliceOutput sliceOutput)
+    {
+        // TODO: getSizeInBytes() was calculated in flush and doesnt need to recalculated
+        verify(getSizeInBytes() <= sliceOutput.writableBytes());
+        writeLengthPrefixedString(sliceOutput, NAME);
+        TypeSerde.writeType(sliceOutput, columnarMap.getKeyType());
+        rawKeyBlockBuffer.writeTo(sliceOutput);
+        rawValueBlockBuffer.writeTo(sliceOutput);
+
+        // Hashtables
+        int hashTableSize = getLastOffsetInBuffer() * HASH_MULTIPLIER;
+        verify(hashTableBufferIndex == 0 || hashTableSize * ARRAY_INT_INDEX_SCALE == hashTableBufferIndex);
+
+        if (hashTableBufferIndex == 0) {
+            sliceOutput.appendInt(-1);
+        }
+        else {
+            sliceOutput.appendInt(hashTableSize);
+            sliceOutput.appendBytes(hashTablesBuffer, 0, hashTableBufferIndex);
+        }
+
+        sliceOutput.writeInt(bufferedPositionCount); //positionCount
+        sliceOutput.appendInt(0);
+        sliceOutput.appendBytes(offsetsBuffer, 0, offsetsBufferIndex);
+
+        writeNullsTo(sliceOutput);
+    }
+
+    @Override
+    protected int getSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +            // length prefixed encoding name
+                columnarMap.getKeyType().getTypeSignature().toString().length() + SIZE_OF_INT + // length prefixed type string
+                rawKeyBlockBuffer.getSizeInBytes() +    // nested key block
+                rawValueBlockBuffer.getSizeInBytes() +  // nested value block
+                SIZE_OF_INT +                           // hash tables size
+                hashTableBufferIndex +                  // hash tables
+                SIZE_OF_INT +                           // positionCount
+                offsetsBufferIndex + SIZE_OF_INT +      // offsets buffer.
+                SIZE_OF_BYTE +                          // nulls uses 1 byte for mayHaveNull
+                nullsBufferIndex +                      // nulls buffer
+                (remainingNullsCount > 0 ? SIZE_OF_BYTE : 0); // the remaining nulls not serialized yet
+    }
+
+    private void mapPositions(PartitionedOutputOperator.DecodedObjectNode decodedObjectNode)
+    {
+        // Remap positions
+        Object decodedObject = decodedObjectNode.getDecodedBlock();
+
+        if (decodedObject instanceof DictionaryBlock) {
+            DictionaryBlock dictionaryBlock = (DictionaryBlock) decodedObject;
+            mapPositionsForDictionary(dictionaryBlock);
+
+            decodedObjectNode = decodedObjectNode.getChild(0);
+
+            isPositionsMapped = true;
+        }
+        else if (decodedObject instanceof RunLengthEncodedBlock) {
+            //RunLengthEncodedBlock rleBlock = (RunLengthEncodedBlock) decodedObject;
+            mapPositionsForRle();
+
+            decodedObjectNode = decodedObjectNode.getChild(0);
+
+            isPositionsMapped = true;
+        }
+        else {
+            isPositionsMapped = false;
+        }
+
+        columnarMap = (ColumnarMap) decodedObjectNode.getDecodedBlock();
+        decodedBlock = columnarMap.getNullCheckBlock();
+    }
+
+    private void populateNestedPositions()
+    {
+        if (positionCount == 0) {
+            return;
+        }
+
+        verify(positionsOffset == 0);
+        verify(columnarMap != null);
+
+        ensureOffsetsSize();
+
+        // Nested level positions always start from 0.
+        rawKeyBlockBuffer.positionsOffset = 0;
+        rawKeyBlockBuffer.positionCount = 0;
+        rawKeyBlockBuffer.isPositionsMapped = false;
+
+        rawValueBlockBuffer.positionsOffset = 0;
+        rawValueBlockBuffer.positionCount = 0;
+        rawValueBlockBuffer.isPositionsMapped = false;
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        int lastOffset = 0;
+        int columnarArrayBaseOffset = columnarMap.getOffset(0);
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            int beginOffsetInBlock = columnarMap.getOffset(position);
+            int endOffsetInBlock = columnarMap.getOffset(position + 1);
+            int currentRowSize = endOffsetInBlock - beginOffsetInBlock;
+            int currentOffset = lastOffset + currentRowSize;
+
+            offsets[i] = currentOffset;
+
+            beginOffsetInBlock -= columnarArrayBaseOffset;
+            if (currentRowSize > 0) {
+                rawKeyBlockBuffer.appendPositionRange(beginOffsetInBlock, currentRowSize);
+                rawValueBlockBuffer.appendPositionRange(beginOffsetInBlock, currentRowSize);
+            }
+
+            lastOffset = currentOffset;
+        }
+    }
+
+    private void appendOffsets()
+    {
+        ensureOffsetsBufferSize();
+
+        int baseOffset = getLastOffsetInBuffer();
+
+        if (positionsOffset > 0) {
+            baseOffset -= offsets[positionsOffset - 1];
+        }
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int currentOffset = offsets[i];
+            ByteArrayUtils.writeInt(offsetsBuffer, offsetsBufferIndex, currentOffset + baseOffset);
+            offsetsBufferIndex += ARRAY_INT_INDEX_SCALE;
+        }
+
+        verify(offsetsBufferIndex == (bufferedPositionCount + batchSize) * ARRAY_INT_INDEX_SCALE);
+    }
+
+    private void appendHashTables()
+    {
+        // MergingPageOutput may build hash tables for some of the smallers blocks. But if there're some blocks
+        // without hash tables, it means hash tables are not needed so far. In this case we don't send the hash tables.
+        if (noHashTables) {
+            return;
+        }
+
+        Optional<int[]> hashTables = columnarMap.getHashTables();
+        if (!hashTables.isPresent()) {
+            noHashTables = true;
+            hashTableBufferIndex = 0;
+            return;
+        }
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        int[] hashTable = hashTables.get();
+
+        int beginHashTableBufferIndex = hashTableBufferIndex;
+
+        int beginOffset = positionsOffset == 0 ? 0 : offsets[positionsOffset - 1];
+        int endOffset = offsets[positionsOffset + batchSize - 1];
+        int hashTablesSize = (endOffset - beginOffset) * HASH_MULTIPLIER;
+
+        ensureHashTablesBufferSize(hashTableBufferIndex + hashTablesSize * ARRAY_INT_INDEX_SCALE);
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int position = positions[i];
+
+            int beginOffsetInBlock = columnarMap.getOffset(position);
+            int endOffsetInBlock = columnarMap.getOffset(position + 1);
+
+            hashTableBufferIndex = ByteArrayUtils.writeInts(
+                    hashTablesBuffer,
+                    hashTableBufferIndex,
+                    hashTable,
+                    beginOffsetInBlock * HASH_MULTIPLIER,
+                    (endOffsetInBlock - beginOffsetInBlock) * HASH_MULTIPLIER);
+        }
+
+        verify(hashTablesSize * ARRAY_INT_INDEX_SCALE == hashTableBufferIndex - beginHashTableBufferIndex);
+        verify(getLastOffsetInBuffer() * ARRAY_INT_INDEX_SCALE * HASH_MULTIPLIER == hashTableBufferIndex);
+    }
+
+    private int getLastOffsetInBuffer()
+    {
+        int offset = 0;
+        if (offsetsBufferIndex > 0) {
+            // There're already some values in the buffer
+            offset = ByteArrays.getInt(offsetsBuffer, offsetsBufferIndex - ARRAY_INT_INDEX_SCALE);
+        }
+        return offset;
+    }
+
+    private void ensureOffsetsSize()
+    {
+        if (offsets == null || offsets.length < positionCount) {
+            offsets = new int[positionCount * 2];
+        }
+    }
+
+    private void ensurePositionOffsetsSize()
+    {
+        if (positionOffsets == null || positionOffsets.length < positionCount) {
+            positionOffsets = new int[positionCount * 2];
+        }
+    }
+
+    private void ensureOffsetsBufferSize()
+    {
+        int requiredSize = offsetsBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE;
+        if (requiredSize > offsetsBuffer.length) {
+            offsetsBuffer = Arrays.copyOf(offsetsBuffer, max(requiredSize, offsetsBuffer.length * 2));
+        }
+    }
+
+    private void ensureHashTablesBufferSize(int requiredSize)
+    {
+        if (requiredSize > hashTablesBuffer.length) {
+            hashTablesBuffer = Arrays.copyOf(hashTablesBuffer, max(requiredSize, hashTablesBuffer.length * 2));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/RowBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/RowBlockEncodingBuffers.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.ColumnarRow;
+import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import io.airlift.slice.ByteArrays;
+import io.airlift.slice.SliceOutput;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.ByteArrayUtils.writeLengthPrefixedString;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+
+public class RowBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    public static final String NAME = "ROW";
+
+    private byte[] offsetsBuffer;
+    private int offsetsBufferIndex;
+    private int[] offsets;          // This array holds the condensed offsets for each position
+    private int[][] positionOffsets;  // This array holds the offsets into nested block for each top level row
+
+    private ColumnarRow columnarRow;
+    private BlockEncodingBuffers[] rawFieldBlockBuffers;
+
+    RowBlockEncodingBuffers(PartitionedOutputOperator.DecodedObjectNode columnarRowBlockNode, int initialBufferSize)
+    {
+        this.initialBufferSize = initialBufferSize;
+
+        ArrayList<PartitionedOutputOperator.DecodedObjectNode> childrenNodes = columnarRowBlockNode.getChildren();
+        rawFieldBlockBuffers = new BlockEncodingBuffers[childrenNodes.size()];
+        for (int i = 0; i < childrenNodes.size(); i++) {
+            rawFieldBlockBuffers[i] = createBlockEncodingBuffers(columnarRowBlockNode.getChild(i), initialBufferSize);
+        }
+
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        // TODO: These local buffers will be requested from the buffer pools in the future.
+        if (offsetsBuffer == null) {
+            offsetsBuffer = new byte[initialBufferSize * ARRAY_INT_INDEX_SCALE];
+        }
+        offsetsBufferIndex = 0;
+
+        for (int i = 0; i < rawFieldBlockBuffers.length; i++) {
+            rawFieldBlockBuffers[i].prepareBuffers();
+        }
+    }
+
+    @Override
+    protected void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        nullsBufferIndex = 0;
+        remainingNullsCount = 0;
+        nullsBufferContainsNull = false;
+        offsetsBufferIndex = 0;
+
+        for (int i = 0; i < rawFieldBlockBuffers.length; i++) {
+            rawFieldBlockBuffers[i].resetBuffers();
+        }
+    }
+
+    @Override
+    protected void setupDecodedBlockAndMapPositions(PartitionedOutputOperator.DecodedObjectNode decodedObjectNode)
+    {
+        mapPositions(decodedObjectNode);
+
+        populateNestedPositions();
+
+        for (int i = 0; i < rawFieldBlockBuffers.length; i++) {
+            rawFieldBlockBuffers[i].setupDecodedBlockAndMapPositions(decodedObjectNode.getChild(i));
+        }
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] rowSizes)
+    {
+        // Top level positionCount should be greater than 0
+        verify(positionCount > 0);
+
+        int averageElementSize = Integer.BYTES + Byte.BYTES;
+
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += averageElementSize;
+        }
+
+        ensurePositionOffsetsSize(positionCount);
+
+        for (int i = 0; i < rawFieldBlockBuffers.length; i++) {
+            // Nested level BlockEncodingBuffers will modify the positionOffsets array in place,
+            // so we need to make a copy for each rawFieldBlockBuffers.
+            int[] currentPositionOffsets = positionOffsets[i];
+            System.arraycopy(offsets, 0, currentPositionOffsets, 0, positionCount);
+            rawFieldBlockBuffers[i].accumulateRowSizes(currentPositionOffsets, positionCount, rowSizes);
+        }
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        // The nested level positionCount could be 0.
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int averageElementSize = Integer.BYTES + Byte.BYTES;
+
+        int lastOffset = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int currentOffset = positionOffsets[i];
+
+            int entryCount = currentOffset - lastOffset;
+            rowSizes[i] += averageElementSize * entryCount;
+
+            positionOffsets[i] = currentOffset == 0 ? 0 : this.offsets[currentOffset - 1];
+
+            lastOffset = currentOffset;
+        }
+
+        ensurePositionOffsetsSize(positionCount);
+        for (int i = 0; i < rawFieldBlockBuffers.length; i++) {
+            // Nested level BlockEncodingBuffers will modify the positionOffsets array in place,
+            // so we need to make a copy for each rawFieldBlockBuffers.
+            int[] destinationPositionOffsets = this.positionOffsets[i];
+            System.arraycopy(positionOffsets, 0, destinationPositionOffsets, 0, positionCount);
+            rawFieldBlockBuffers[i].accumulateRowSizes(destinationPositionOffsets, positionCount, rowSizes);
+        }
+    }
+
+    @Override
+    protected void setNextBatch(int positionsOffset, int batchSize)
+    {
+        this.positionsOffset = positionsOffset;
+        this.batchSize = batchSize;
+
+        // The nested level positionCount could be 0.
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int nestedLevelPositionBegin = positionsOffset == 0 ? 0 : offsets[positionsOffset - 1];
+        int nestedLevelPositionEnd = offsets[positionsOffset + batchSize - 1];
+
+        for (int i = 0; i < rawFieldBlockBuffers.length; i++) {
+            rawFieldBlockBuffers[i].setNextBatch(nestedLevelPositionBegin, nestedLevelPositionEnd - nestedLevelPositionBegin);
+        }
+    }
+
+    @Override
+    protected void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+        verify(positionsOffset + batchSize - 1 < positions.length && positions[positionsOffset] >= 0 &&
+                positions[positionsOffset + batchSize - 1] < columnarRow.getPositionCount());
+
+        appendNulls();
+        appendOffsets();
+
+        for (int i = 0; i < rawFieldBlockBuffers.length; i++) {
+            rawFieldBlockBuffers[i].copyValues();
+        }
+
+        bufferedPositionCount += batchSize;
+    }
+
+    @Override
+    protected void writeTo(SliceOutput sliceOutput)
+    {
+        // TODO: getSizeInBytes() was calculated in flush and doesnt need to recalculated
+        verify(getSizeInBytes() <= sliceOutput.writableBytes());
+
+        writeLengthPrefixedString(sliceOutput, NAME);
+        sliceOutput.writeInt(rawFieldBlockBuffers.length);
+        for (int i = 0; i < rawFieldBlockBuffers.length; i++) {
+            rawFieldBlockBuffers[i].writeTo(sliceOutput);
+        }
+
+        sliceOutput.writeInt(bufferedPositionCount); //positionCount
+        sliceOutput.writeInt(0);  // the base position
+        sliceOutput.appendBytes(offsetsBuffer, 0, offsetsBufferIndex);
+
+        writeNullsTo(sliceOutput);
+    }
+
+    @Override
+    protected int getSizeInBytes()
+    {
+        int rawFieldBlockBuffersSize = 0;
+        for (int i = 0; i < rawFieldBlockBuffers.length; i++) {
+            rawFieldBlockBuffersSize += rawFieldBlockBuffers[i].getSizeInBytes();
+        }
+
+        return NAME.length() + SIZE_OF_INT +        // encoding name
+                SIZE_OF_INT +                       // field count
+                rawFieldBlockBuffersSize +          // field blocks
+                SIZE_OF_INT +                       // positionCount
+                SIZE_OF_INT +                       // offset 0. The offsetsBuffer doesn't contain the offset 0 so we need to add it here.
+                offsetsBufferIndex +                // offsets buffer.
+                SIZE_OF_BYTE +                      // nulls uses 1 byte for mayHaveNull
+                nullsBufferIndex +                  // nulls buffer
+                (remainingNullsCount > 0 ? SIZE_OF_BYTE : 0); // the remaining nulls not serialized yet
+    }
+
+    private void mapPositions(PartitionedOutputOperator.DecodedObjectNode decodedObjectNode)
+    {
+        // Remap positions
+        Object decodedObject = decodedObjectNode.getDecodedBlock();
+
+        if (decodedObject instanceof DictionaryBlock) {
+            DictionaryBlock dictionaryBlock = (DictionaryBlock) decodedObject;
+            mapPositionsForDictionary(dictionaryBlock);
+
+            decodedObjectNode = decodedObjectNode.getChild(0);
+
+            isPositionsMapped = true;
+        }
+        else if (decodedObject instanceof RunLengthEncodedBlock) {
+            //RunLengthEncodedBlock rleBlock = (RunLengthEncodedBlock) decodedObject;
+            mapPositionsForRle();
+
+            decodedObjectNode = decodedObjectNode.getChild(0);
+
+            isPositionsMapped = true;
+        }
+        else {
+            isPositionsMapped = false;
+        }
+
+        columnarRow = (ColumnarRow) decodedObjectNode.getDecodedBlock();
+        decodedBlock = columnarRow.getNullCheckBlock();
+    }
+
+    private void populateNestedPositions()
+    {
+        if (positionCount == 0) {
+            return;
+        }
+
+        verify(positionsOffset == 0);
+        verify(columnarRow != null);
+
+        ensureOffsetsSize();
+
+        // Nested level positions always start from 0.
+        for (int i = 0; i < rawFieldBlockBuffers.length; i++) {
+            rawFieldBlockBuffers[i].positionsOffset = 0;
+            rawFieldBlockBuffers[i].positionCount = 0;
+            rawFieldBlockBuffers[i].isPositionsMapped = false;
+        }
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        int lastOffset = 0;
+        int columnarArrayBaseOffset = columnarRow.getOffset(0);
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            int beginOffsetInBlock = columnarRow.getOffset(position);
+            int endOffsetInBlock = columnarRow.getOffset(position + 1);  // if the row is null, endOffsetInBlock == beginOffsetInBlock
+            int currentRowSize = endOffsetInBlock - beginOffsetInBlock;
+            int currentOffset = lastOffset + currentRowSize;
+
+            offsets[i] = currentOffset;
+
+            if (currentRowSize > 0) {
+                for (int j = 0; j < rawFieldBlockBuffers.length; j++) {
+                    rawFieldBlockBuffers[j].appendPositionRange(beginOffsetInBlock - columnarArrayBaseOffset, currentRowSize);
+                }
+            }
+
+            lastOffset = currentOffset;
+        }
+    }
+
+    private void appendOffsets()
+    {
+        ensureOffsetsBufferSize();
+
+        int baseOffset = getLastOffsetInBuffer();
+
+        if (positionsOffset > 0) {
+            baseOffset -= offsets[positionsOffset - 1];
+        }
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int currentOffset = offsets[i];
+            ByteArrayUtils.writeInt(offsetsBuffer, offsetsBufferIndex, currentOffset + baseOffset);
+            offsetsBufferIndex += ARRAY_INT_INDEX_SCALE;
+        }
+
+        verify(offsetsBufferIndex == (bufferedPositionCount + batchSize) * ARRAY_INT_INDEX_SCALE);
+    }
+
+    private int getLastOffsetInBuffer()
+    {
+        int offset = 0;
+        if (offsetsBufferIndex > 0) {
+            // There're already some values in the buffer
+            offset = ByteArrays.getInt(offsetsBuffer, offsetsBufferIndex - ARRAY_INT_INDEX_SCALE);
+        }
+        return offset;
+    }
+
+    private void ensureOffsetsSize()
+    {
+        if (offsets == null || offsets.length < positionCount) {
+            offsets = new int[positionCount * 2];
+        }
+    }
+
+    private void ensurePositionOffsetsSize(int positionCount)
+    {
+        if (positionOffsets == null || positionOffsets[0].length < positionCount) {
+            positionOffsets = new int[rawFieldBlockBuffers.length][positionCount * 2];
+        }
+    }
+    private void ensureOffsetsBufferSize()
+    {
+        int requiredSize = offsetsBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE;
+        if (requiredSize > offsetsBuffer.length) {
+            offsetsBuffer = Arrays.copyOf(offsetsBuffer, max(requiredSize, offsetsBuffer.length * 2));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ShortArrayBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ShortArrayBlockEncodingBuffers.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import io.airlift.slice.SliceOutput;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.ByteArrayUtils.writeLengthPrefixedString;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_SHORT_INDEX_SCALE;
+
+public class ShortArrayBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    public static final String NAME = "SHORT_ARRAY";
+
+    private byte[] valuesBuffer;
+    private int valuesBufferIndex;
+
+    ShortArrayBlockEncodingBuffers(int initialBufferSize)
+    {
+        this.initialBufferSize = initialBufferSize;
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        if (valuesBuffer == null) {
+            valuesBuffer = new byte[initialBufferSize * ARRAY_SHORT_INDEX_SCALE];
+        }
+        valuesBufferIndex = 0;
+    }
+
+    @Override
+    protected void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        valuesBufferIndex = 0;
+        nullsBufferIndex = 0;
+        remainingNullsCount = 0;
+        nullsBufferContainsNull = false;
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] rowSizes)
+    {
+        int averageElementSize = Short.BYTES + Byte.BYTES;
+
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += averageElementSize;
+        }
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        int averageElementSize = Short.BYTES + Byte.BYTES;
+
+        // it starts from 0 because top level offsets were normalized
+        int lastOffset = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int currentOffset = positionOffsets[i];
+            int entryCount = currentOffset - lastOffset;
+            rowSizes[i] += entryCount * averageElementSize;
+
+            lastOffset = currentOffset;
+        }
+    }
+
+    @Override
+    protected void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        verify(decodedBlock != null);
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+        verify(positionsOffset + batchSize - 1 < positions.length && positions[positionsOffset] >= 0 &&
+                positions[positionsOffset + batchSize - 1] < decodedBlock.getPositionCount());
+
+        appendValuesToBuffer();
+        appendNulls();
+        bufferedPositionCount += batchSize;
+    }
+
+    @Override
+    protected void writeTo(SliceOutput sliceOutput)
+    {
+        // TODO: getSizeInBytes() was calculated in flush and doesnt need to recalculated
+        verify(getSizeInBytes() <= sliceOutput.writableBytes());
+
+        writeLengthPrefixedString(sliceOutput, NAME);
+        sliceOutput.writeInt(bufferedPositionCount);
+        writeNullsTo(sliceOutput);
+        sliceOutput.appendBytes(valuesBuffer, 0, valuesBufferIndex);
+    }
+
+    @Override
+    protected int getSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +    // NAME
+                SIZE_OF_INT +                   // positionCount
+                SIZE_OF_BYTE +                  // nulls uses 1 byte for mayHaveNull
+                nullsBufferIndex +              // nulls buffer
+                (remainingNullsCount > 0 ? SIZE_OF_BYTE : 0) +  // the remaining nulls not serialized yet
+                valuesBufferIndex;              // values buffer
+    }
+
+    private void appendValuesToBuffer()
+    {
+        verify(decodedBlock != null);
+
+        ensureValueBufferSize();
+
+      // System.out.println("appendValuesToBuffer before positionsOffset " + positionsOffset + " batchSize " + batchSize + " valuesBufferIndex " + valuesBufferIndex + " decodedBlock.mayHaveNull() " + decodedBlock.mayHaveNull());
+        if (decodedBlock.mayHaveNull()) {
+            appendShortsWithNullsToBuffer();
+        }
+        else {
+            appendShortsToBuffer();
+        }
+      // System.out.println("appendValuesToBuffer after positionsOffset " + positionsOffset + " batchSize " + batchSize + " valuesBufferIndex " + valuesBufferIndex);
+    }
+
+    private void appendShortsToBuffer()
+    {
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            short value = decodedBlock.getShort(positions[i]);
+            ByteArrayUtils.writeShort(valuesBuffer, valuesBufferIndex, value);
+            valuesBufferIndex += ARRAY_SHORT_INDEX_SCALE;
+        }
+    }
+
+    private void appendShortsWithNullsToBuffer()
+    {
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int position = positions[i];
+
+            short value = decodedBlock.getShort(position);
+            ByteArrayUtils.writeLong(valuesBuffer, valuesBufferIndex, value);
+
+            if (!decodedBlock.isNull(position)) {
+                valuesBufferIndex += ARRAY_SHORT_INDEX_SCALE;
+            }
+        }
+    }
+
+    private void ensureValueBufferSize()
+    {
+        verify(valuesBuffer != null);
+
+        int requiredSize = valuesBufferIndex + batchSize * ARRAY_SHORT_INDEX_SCALE;
+        if (requiredSize > valuesBuffer.length) {
+            valuesBuffer = Arrays.copyOf(valuesBuffer, max(valuesBuffer.length * 2, requiredSize));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/TestingSliceOutput.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TestingSliceOutput.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+
+import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+
+public class TestingSliceOutput
+{
+    static Unsafe unsafe;
+
+    static {
+        try {
+            Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            unsafe = (Unsafe) field.get(null);
+            if (unsafe == null) {
+                throw new RuntimeException("Unsafe access not available");
+            }
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private byte[] buffer;
+    public int size;
+
+    TestingSliceOutput(int predefinedSize)
+    {
+        buffer = new byte[predefinedSize];
+    }
+
+    public void writeLong(long value)
+    {
+        unsafe.putLong(buffer, (long) size + ARRAY_BYTE_BASE_OFFSET, value);
+        size += ARRAY_LONG_INDEX_SCALE;
+    }
+
+    public void writeLong(long value, int address)
+    {
+        unsafe.putLong(buffer, (long) address + ARRAY_BYTE_BASE_OFFSET, value);
+    }
+
+    public void writeLong(long value, boolean condition)
+    {
+        unsafe.putLong(buffer, (long) size + ARRAY_BYTE_BASE_OFFSET, value);
+        if (condition) {
+            size += ARRAY_LONG_INDEX_SCALE;
+        }
+    }
+
+    public void writeLongArray(long[] values, boolean[] nulls, int offset, int length)
+    {
+        for (int i = offset; i < offset + length; i++) {
+            unsafe.putLong(buffer, (long) size + ARRAY_BYTE_BASE_OFFSET, values[i]);
+
+            if (!nulls[i]) {
+                size += ARRAY_LONG_INDEX_SCALE;
+            }
+        }
+    }
+
+    public int size()
+    {
+        return size;
+    }
+
+    public int capacity()
+    {
+        return buffer.length;
+    }
+
+    public void reset()
+    {
+        size = 0;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/VariableWidthBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/VariableWidthBlockEncodingBuffers.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.AbstractVariableWidthBlock;
+import io.airlift.slice.ByteArrays;
+import io.airlift.slice.SliceOutput;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.ByteArrayUtils.writeLengthPrefixedString;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+
+public class VariableWidthBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    public static final String NAME = "VARIABLE_WIDTH";
+
+    private byte[] sliceBuffer;
+    private int sliceBufferIndex;
+
+    private byte[] offsetsBuffer;
+    private int offsetsBufferIndex;
+
+    VariableWidthBlockEncodingBuffers(int initialBufferSize)
+    {
+        this.initialBufferSize = initialBufferSize;
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        if (sliceBuffer == null) {
+            sliceBuffer = new byte[initialBufferSize * ARRAY_LONG_INDEX_SCALE * 2];
+        }
+        sliceBufferIndex = 0;
+
+        if (offsetsBuffer == null) {
+            offsetsBuffer = new byte[initialBufferSize * ARRAY_INT_INDEX_SCALE];
+        }
+        offsetsBufferIndex = 0;
+    }
+
+    @Override
+    protected void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        nullsBufferIndex = 0;
+        remainingNullsCount = 0;
+        nullsBufferContainsNull = false;
+        sliceBufferIndex = 0;
+        offsetsBufferIndex = 0;
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] rowSizes)
+    {
+        int averageElementSize = Integer.BYTES + Byte.BYTES;
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            rowSizes[i] += decodedBlock.getSliceLength(position);
+            rowSizes[i] += averageElementSize;
+        }
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        // The nested level positionCount could be 0.
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int averageElementSize = Integer.BYTES + Byte.BYTES;
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        int largestPosition = positionOffsets[positionCount - 1];
+        verify(positions.length >= largestPosition);
+        verify(decodedBlock.getPositionCount() >= largestPosition);
+
+        int lastOffset = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int currentOffset = positionOffsets[i];
+            int entryCount = currentOffset - lastOffset;
+
+            int entrySize = 0;
+            for (int j = 0; j < entryCount; j++) {
+                int position = positions[lastOffset + j];
+                entrySize += decodedBlock.getSliceLength(position);
+            }
+
+            rowSizes[i] += (averageElementSize + entrySize);
+
+            lastOffset = currentOffset;
+        }
+    }
+
+    @Override
+    protected void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        verify(positionsOffset + batchSize - 1 < positions.length && positions[positionsOffset] >= 0 &&
+                positions[positionsOffset + batchSize - 1] < decodedBlock.getPositionCount());
+
+        appendOffsetsAndSlices();
+        appendNulls();
+        bufferedPositionCount += batchSize;
+    }
+
+    @Override
+    protected void writeTo(SliceOutput sliceOutput)
+    {
+        // TODO: getSizeInBytes() was calculated in flush and doesnt need to recalculated
+        verify(getSizeInBytes() <= sliceOutput.writableBytes());
+
+        writeLengthPrefixedString(sliceOutput, NAME);
+        sliceOutput.writeInt(bufferedPositionCount);
+
+        // offsets
+        // note that VariableWidthBlock doesn't write the initial offset 0
+        sliceOutput.appendBytes(offsetsBuffer, 0, offsetsBufferIndex);
+        // nulls
+        writeNullsTo(sliceOutput);
+        sliceOutput.writeInt(sliceBufferIndex);  // totalLength
+        sliceOutput.appendBytes(sliceBuffer, 0, sliceBufferIndex);
+    }
+
+    @Override
+    protected int getSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +    // NAME
+                SIZE_OF_INT +                   // positionCount
+                offsetsBufferIndex +            // offsets buffer.
+                SIZE_OF_BYTE +                  // nulls uses 1 byte for mayHaveNull
+                nullsBufferIndex +              // nulls buffer
+                (remainingNullsCount > 0 ? SIZE_OF_BYTE : 0) +  // the remaining nulls not serialized yet
+                SIZE_OF_INT +                   // sliceBuffer size.
+                sliceBufferIndex;               // sliceBuffer
+    }
+
+    // This implementation requires variableWidthBlock.getPositionOffset() to be public but it's much faster than the below one
+    private void appendOffsetsAndSlices()
+    {
+        verify(offsetsBufferIndex == bufferedPositionCount * ARRAY_INT_INDEX_SCALE);
+
+        int lastOffset = 0;
+        if (offsetsBufferIndex > 0) {
+            // There're already some values in the buffer
+            lastOffset = ByteArrays.getInt(offsetsBuffer, offsetsBufferIndex - ARRAY_INT_INDEX_SCALE);
+        }
+
+        ensureOffsetsBufferSize();
+
+        AbstractVariableWidthBlock variableWidthBlock = (AbstractVariableWidthBlock) decodedBlock;
+        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+
+        // Get the whole slice then access specific rows to allow faster copy
+        int sliceLength = variableWidthBlock.getPositionOffset(variableWidthBlock.getPositionCount()) - variableWidthBlock.getPositionOffset(0);
+        byte[] sliceBase = (byte[]) variableWidthBlock.getSlice(0, 0, sliceLength).getBase();
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int position = positions[i];
+            int beginOffsetInBlock = variableWidthBlock.getPositionOffset(position);
+            int endOffsetInBlock = variableWidthBlock.getPositionOffset(position + 1);
+            int currentRowSize = endOffsetInBlock - beginOffsetInBlock;
+            int currentOffset = lastOffset + currentRowSize;
+
+            ByteArrayUtils.writeInt(offsetsBuffer, offsetsBufferIndex, currentOffset);
+            offsetsBufferIndex += ARRAY_INT_INDEX_SCALE;
+
+            ensureSliceBufferSize(currentRowSize);
+
+            sliceBufferIndex = ByteArrayUtils.copyBytes(sliceBuffer, sliceBufferIndex, sliceBase, beginOffsetInBlock, currentRowSize);
+
+            lastOffset = currentOffset;
+        }
+
+        verify(offsetsBufferIndex == (bufferedPositionCount + batchSize) * ARRAY_INT_INDEX_SCALE);
+        verify(getLastOffsetInBuffer() == sliceBufferIndex);
+    }
+
+    // This implementation doesn't need to expose variableWidthBlock.getPositionOffset() but it's too slow, because it's calling getSlice()
+    // for every row and has too much overhead in constructing the Slice object
+//    private void appendOffsetsAndSlices()
+//    {
+//        verify(offsetsBufferIndex == bufferedPositionCount * ARRAY_INT_INDEX_SCALE);
+//        // format("offsetsBufferIndex %d should equal to bufferedPositionCount %d * ARRAY_INT_INDEX_SCALE %d.", offsetsBufferIndex, bufferedPositionCount, ARRAY_INT_INDEX_SCALE));
+//
+//        int lastOffset = 0;
+//        if (offsetsBufferIndex > 0) {
+//            // There're already some values in the buffer
+//            //// System.out.println(offsetsBufferIndex);
+//            try {
+//                lastOffset = ByteArrays.getInt(offsetsBuffer, offsetsBufferIndex - ARRAY_INT_INDEX_SCALE);
+//            }
+//            catch (Exception e) {
+//                e.printStackTrace();
+//            }
+//        }
+//
+//        ensureOffsetsBufferSize();
+//        int[] positions = isPositionsMapped ? mappedPositions : this.positions;
+//
+//        AbstractVariableWidthBlock variableWidthBlock = (AbstractVariableWidthBlock) decodedBlock;
+//        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+//            int position = positions[i];
+//            int currentRowSize = variableWidthBlock.getSliceLength(position);
+//            int currentOffset = lastOffset + currentRowSize;
+//
+//            ByteArrayUtils.writeInt(offsetsBuffer, offsetsBufferIndex, currentOffset);
+//            offsetsBufferIndex += ARRAY_INT_INDEX_SCALE;
+//
+//            //// // System.out.println("positionsOffset " + positionsOffset + " batchSize " + batchSize + " i " + i +
+//            //      " position " + position + " sliceBufferIndex " + sliceBufferIndex + " slice.length " + currentRowSize);
+//
+//            ensureSliceBufferSize(currentRowSize);
+//            sliceBufferIndex = ByteArrayUtils.writeSlice(sliceBuffer, sliceBufferIndex, variableWidthBlock.getSlice(position, 0, currentRowSize));
+//
+//            lastOffset = currentOffset;
+//        }
+//    }
+
+    private int getLastOffsetInBuffer()
+    {
+        int offset = 0;
+        if (offsetsBufferIndex > 0) {
+            // There're already some values in the buffer
+            offset = ByteArrays.getInt(offsetsBuffer, offsetsBufferIndex - ARRAY_INT_INDEX_SCALE);
+        }
+        return offset;
+    }
+
+    private void ensureSliceBufferSize(int currentRowSize)
+    {
+        int requiredSize = sliceBufferIndex + currentRowSize;
+        if (requiredSize > sliceBuffer.length) {
+            sliceBuffer = Arrays.copyOf(sliceBuffer, max(sliceBuffer.length * 2, requiredSize));
+        }
+    }
+
+    private void ensureOffsetsBufferSize()
+    {
+        int requiredSize = offsetsBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE;
+        if (requiredSize > offsetsBuffer.length) {
+            offsetsBuffer = Arrays.copyOf(offsetsBuffer, max(requiredSize, offsetsBuffer.length * 2));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -133,6 +133,7 @@ public class FeaturesConfig
 
     private boolean jsonSerdeCodeGenerationEnabled;
     private int maxConcurrentMaterializations = 10;
+    private boolean useOptimizedPartitionedOutput;
 
     public enum JoinReorderingStrategy
     {
@@ -1028,5 +1029,10 @@ public class FeaturesConfig
     public int getMaxConcurrentMaterializations()
     {
         return maxConcurrentMaterializations;
+    }
+
+    public boolean isOptimizedPartitionedOutput()
+    {
+        return useOptimizedPartitionedOutput;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
@@ -13,23 +13,36 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.client.ClientCapabilities;
 import com.facebook.presto.execution.StateMachine;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.buffer.PagesSerdeFactory;
 import com.facebook.presto.execution.buffer.PartitionedOutputBuffer;
+import com.facebook.presto.execution.buffer.TestingPartitionedOutputBuffer;
 import com.facebook.presto.memory.context.SimpleLocalMemoryContext;
 import com.facebook.presto.operator.PartitionedOutputOperator.PartitionedOutputFactory;
 import com.facebook.presto.operator.exchange.LocalPartitionGenerator;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.LongArrayBlockBuilder;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic;
 import com.facebook.presto.testing.TestingTaskContext;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -37,7 +50,9 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
@@ -46,36 +61,52 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
+import java.lang.invoke.MethodHandle;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZED_PARTITIONED_OUTPUT;
 import static com.facebook.presto.execution.buffer.BufferState.OPEN;
 import static com.facebook.presto.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
 import static com.facebook.presto.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
 import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.spi.block.MethodHandleUtil.compose;
+import static com.facebook.presto.spi.block.MethodHandleUtil.nativeValueGetter;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static java.util.Arrays.stream;
+import static java.util.Collections.nCopies;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @State(Scope.Thread)
 @OutputTimeUnit(MILLISECONDS)
-@Fork(2)
-@Warmup(iterations = 20, time = 500, timeUnit = MILLISECONDS)
-@Measurement(iterations = 20, time = 500, timeUnit = MILLISECONDS)
+@Fork(3)
+@Warmup(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = MILLISECONDS)
 @BenchmarkMode(Mode.AverageTime)
 public class BenchmarkPartitionedOutputOperator
 {
@@ -83,8 +114,8 @@ public class BenchmarkPartitionedOutputOperator
     public void addPage(BenchmarkData data)
     {
         PartitionedOutputOperator operator = data.createPartitionedOutputOperator();
-        for (int i = 0; i < data.getPageCount(); i++) {
-            operator.addInput(data.getDataPage());
+        for (int i = 0; i < data.pageCount; i++) {
+            operator.addInput(data.dataPage);
         }
         operator.finish();
     }
@@ -92,30 +123,415 @@ public class BenchmarkPartitionedOutputOperator
     @State(Scope.Thread)
     public static class BenchmarkData
     {
-        private static final int PAGE_COUNT = 5000;
         private static final int PARTITION_COUNT = 512;
-        private static final int ENTRIES_PER_PAGE = 256;
+        private static final int ROW_SIZE = 4;
+        private static final int ARRAY_SIZE = 10;
+        private static final int MAP_SIZE = 10;
+        private static final int STRING_SIZE = 4;
+        private static final int DICTIONARY_SIZE = 20;
         private static final DataSize MAX_MEMORY = new DataSize(1, GIGABYTE);
-        private static final RowType rowType = RowType.anonymous(ImmutableList.of(VARCHAR, VARCHAR, VARCHAR, VARCHAR));
-        private static final List<Type> TYPES = ImmutableList.of(BIGINT, rowType, rowType, rowType);
         private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-EXECUTOR-%s"));
         private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%s"));
 
-        private final Page dataPage = createPage();
+        //@Param({"false", "true"})
+        private String useOptimized = "true";
 
-        private int getPageCount()
+        @Param({"1", "2"})
+        private int channelCount = 2;
+
+       // @Param({"4096", "8192"})
+        private int positionCount = 8192;
+
+        //@Param({"BIGINT", "BOOLEAN", "DECIMAL", "DOUBLE","VARCHAR","ROW(VARCHAR)", "ARRAY(BIGINT)", "ARRAY(VARCHAR)", "ARRAY(ARRAY(VARCHAR))", "MAP(BIGINT, VARCHAR)", "DICTIONARY", "RLE"})
+        private String type = "ARRAY(ARRAY(VARCHAR))";
+
+        //@Param({"true", "false"})
+        private boolean hasNull = true;
+
+        private int pageCount;
+        private Page dataPage;
+        private List<Type> types;
+
+        @Setup
+        public void setup()
         {
-            return PAGE_COUNT;
+            createPages(type);
         }
 
-        public Page getDataPage()
+        private void createPages(String inputType)
         {
-            return dataPage;
+            switch (inputType) {
+                case "BIGINT":
+                    createPagesWithBuilders(this::createBigintChannel, BIGINT);
+                    pageCount = 5000;
+                    break;
+                case "BOOLEAN":
+                    createPagesWithBuilders(this::createBooleanChannel, BOOLEAN);
+                    pageCount = 5000;
+                    break;
+                case "DECIMAL":
+                    createPagesWithBuilders(this::createLongDecimalChannel, createDecimalType());
+                    pageCount = 5000;
+                    break;
+                case "DOUBLE":
+                    createPagesWithBuilders(this::createDoubleChannel, DOUBLE);
+                    pageCount = 5000;
+                    break;
+                case "VARCHAR":
+                    createPagesWithBuilders(this::createVarcharChannel, VARCHAR);
+                    pageCount = 5000;
+                    break;
+                case "ROW(VARCHAR)":
+                    createPagesWithBuilders(this::createRowChannel, RowType.anonymous(nCopies(ROW_SIZE, VARCHAR)));
+                    pageCount = 1000;
+                    break;
+                case "ARRAY(BIGINT)":
+                    createPagesWithBuilders(this::createArrayOfBigintChannel, new ArrayType(BIGINT));
+                    pageCount = 1000;
+                    break;
+                case "ARRAY(VARCHAR)":
+                    createPagesWithBuilders(this::createArrayOfVarcharChannel, new ArrayType(VARCHAR));
+                    pageCount = 1000;
+                    break;
+                case "ARRAY(ARRAY(VARCHAR))":
+                    createPagesWithBuilders(this::createArrayOfArrayOfVarcharChannel, new ArrayType(new ArrayType(VARCHAR)));
+                    pageCount = 100;
+                    break;
+                case "ARRAY(ARRAY(BIGINT))":
+                    createPagesWithBuilders(this::createArrayOfArrayOfBigintChannel, new ArrayType(new ArrayType(BIGINT)));
+                    pageCount = 1000;
+                    break;
+                case "MAP(BIGINT, VARCHAR)":
+                    createPagesWithBuilders(this::createMapChannel, createMapType());
+                    pageCount = 1000;
+                    break;
+                case "DICTIONARY":
+                    createDictionaryPages();
+                    pageCount = 3000;
+                    break;
+                case "RLE":
+                    createRLEPages();
+                    pageCount = 3000;
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unsupported dataType");
+            }
+        }
+
+        private void createPagesWithBuilders(BiConsumer<BlockBuilder, Type> createChannelConsumer, Type type)
+        {
+            createTypes(type);
+
+            PageBuilder pageBuilder = new PageBuilder(types);
+            BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
+            createBigintChannel(blockBuilder, BIGINT);
+
+            for (int channelIndex = 1; channelIndex <= channelCount; channelIndex++) {
+                blockBuilder = pageBuilder.getBlockBuilder(channelIndex);
+                createChannelConsumer.accept(blockBuilder, type);
+            }
+            pageBuilder.declarePositions(positionCount);
+
+            dataPage = pageBuilder.build();
+        }
+
+        private void createDictionaryPages()
+        {
+            createTypes(VARBINARY);
+
+            Block[] blocks = new Block[channelCount + 1];
+            blocks[0] = createBigintChannel();
+            for (int channelIndex = 1; channelIndex < channelCount + 1; channelIndex++) {
+                blocks[channelIndex] = createDictionaryChannel();
+            }
+            dataPage = new Page(blocks);
+        }
+
+        private void createRLEPages()
+        {
+            createTypes(VARBINARY);
+
+            Block[] blocks = new Block[channelCount + 1];
+            blocks[0] = createBigintChannel();
+            for (int channelIndex = 1; channelIndex < channelCount + 1; channelIndex++) {
+                blocks[channelIndex] = createRLEChannel();
+            }
+            dataPage = new Page(blocks);
+        }
+
+        private void createTypes(Type type)
+        {
+            types = new ArrayList<>(channelCount + 1);
+            types.add(0, BIGINT);
+            for (int i = 1; i <= channelCount; i++) {
+                types.add(i, type);
+            }
+        }
+
+        private Type createMapType()
+        {
+            Type keyType = BIGINT;
+            Type valueType = VARCHAR;
+            MethodHandle keyNativeEquals = TYPE_MANAGER.resolveOperator(OperatorType.EQUAL, ImmutableList.of(keyType, keyType));
+            MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
+            MethodHandle keyBlockEquals = compose(keyNativeEquals, nativeValueGetter(keyType), nativeValueGetter(keyType));
+            MethodHandle keyNativeHashCode = TYPE_MANAGER.resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(keyType));
+            MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
+            Type mapType = new MapType(
+                    keyType,
+                    valueType,
+                    keyBlockNativeEquals,
+                    keyBlockEquals,
+                    keyNativeHashCode,
+                    keyBlockHashCode);
+            return mapType;
+        }
+
+        private Block createBigintChannel()
+        {
+            LongArrayBlockBuilder builder = new LongArrayBlockBuilder(null, positionCount);
+            for (int position = 0; position < positionCount; position++) {
+                if (hasNull && position % 10 == 0) {
+                    builder.appendNull();
+                }
+                else {
+                    BIGINT.writeLong(builder, ThreadLocalRandom.current().nextLong());
+                }
+            }
+            return builder.build();
+        }
+
+        private void createBigintChannel(BlockBuilder blockBuilder, Type type)
+        {
+            for (int position = 0; position < positionCount; position++) {
+                if (hasNull && position % 10 == 0) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    type.writeLong(blockBuilder, position);
+                }
+            }
+        }
+
+        private void createBooleanChannel(BlockBuilder blockBuilder, Type type)
+        {
+            for (int position = 0; position < positionCount; position++) {
+                if (hasNull && position % 10 == 0) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    type.writeBoolean(blockBuilder, ThreadLocalRandom.current().nextBoolean());
+                }
+            }
+        }
+
+        private void createDoubleChannel(BlockBuilder blockBuilder, Type type)
+        {
+            for (int position = 0; position < positionCount; position++) {
+                if (hasNull && position % 10 == 0) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    type.writeDouble(blockBuilder, position);
+                }
+            }
+        }
+
+        private void createLongDecimalChannel(BlockBuilder blockBuilder, Type decimalType)
+        {
+            for (int position = 0; position < positionCount; position++) {
+                if (hasNull && position % 10 == 0) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    Slice decimal = UnscaledDecimal128Arithmetic.unscaledDecimal();
+                    decimal.setDouble(0, ThreadLocalRandom.current().nextDouble());
+
+                    decimalType.writeSlice(blockBuilder, decimal);
+                }
+            }
+        }
+
+        private void createVarcharChannel(BlockBuilder blockBuilder, Type type)
+        {
+            for (int position = 0; position < positionCount; position++) {
+                if (hasNull && position % 10 == 0) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    type.writeSlice(blockBuilder, Slices.utf8Slice(getRandomString(ThreadLocalRandom.current().nextInt(STRING_SIZE))));
+                }
+            }
+        }
+
+        private void createRowChannel(BlockBuilder blockBuilder, Type type)
+        {
+            List<Type> subTypes = ((RowType) type).getTypeParameters();
+            for (int position = 0; position < positionCount; position++) {
+                if (hasNull && position % 10 == 0) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    BlockBuilder singleRowBlockWriter = blockBuilder.beginBlockEntry();
+                    for (Type subType : subTypes) {
+                        subType.writeSlice(singleRowBlockWriter, utf8Slice(getRandomString(STRING_SIZE)));
+                    }
+                    blockBuilder.closeEntry();
+                }
+            }
+        }
+
+        private void createArrayOfBigintChannel(BlockBuilder blockBuilder, Type type)
+        {
+            ArrayType arrayType = (ArrayType) type;
+            for (int position = 0; position < positionCount; position++) {
+                if (hasNull && position % 10 == 0) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+                    for (int i = 0; i < ARRAY_SIZE; i++) {
+                        arrayType.getElementType().writeLong(entryBuilder, ThreadLocalRandom.current().nextLong());
+                    }
+                    blockBuilder.closeEntry();
+                }
+            }
+        }
+
+        private void createArrayOfVarcharChannel(BlockBuilder blockBuilder, Type type)
+        {
+            ArrayType arrayType = (ArrayType) type;
+            for (int position = 0; position < positionCount; position++) {
+                if (hasNull && position % 10 == 0) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+                    for (int i = 0; i < ARRAY_SIZE; i++) {
+                        if (hasNull && i % 10 == 0) {
+                            entryBuilder.appendNull();
+                        }
+                        else {
+                            arrayType.getElementType().writeSlice(entryBuilder, Slices.wrappedBuffer(getRandomString(STRING_SIZE).getBytes()));
+                        }
+                    }
+                    blockBuilder.closeEntry();
+                }
+            }
+        }
+
+        private void createArrayOfArrayOfVarcharChannel(BlockBuilder blockBuilder, Type type)
+        {
+            ArrayType arrayType = (ArrayType) type;
+            for (int position = 0; position < positionCount; position++) {
+                if (hasNull && position % 10 == 0) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    BlockBuilder entryBuilder1 = blockBuilder.beginBlockEntry();
+                    for (int i = 0; i < ARRAY_SIZE; i++) {
+                        if (hasNull && i % 10 == 0) {
+                            entryBuilder1.appendNull();
+                        }
+                        else {
+                            BlockBuilder entryBuilder2 = entryBuilder1.beginBlockEntry();
+                            for (int j = 0; j < ARRAY_SIZE; j++) {
+                                if (hasNull && j % 10 == 0) {
+                                    entryBuilder2.appendNull();
+                                }
+                                else {
+                                    ((ArrayType) arrayType.getElementType()).getElementType().writeSlice(entryBuilder2, Slices.wrappedBuffer(getRandomString(8).getBytes()));
+                                }
+                            }
+                            entryBuilder1.closeEntry();
+                        }
+                    }
+                    blockBuilder.closeEntry();
+                }
+            }
+        }
+
+        private void createArrayOfArrayOfBigintChannel(BlockBuilder blockBuilder, Type type)
+        {
+            ArrayType arrayType = (ArrayType) type;
+            for (int position = 0; position < positionCount; position++) {
+                if (hasNull && position % 10 == 0) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    BlockBuilder entryBuilder1 = blockBuilder.beginBlockEntry();
+                    for (int i = 0; i < ARRAY_SIZE; i++) {
+                        if (hasNull && i % 10 == 0) {
+                            entryBuilder1.appendNull();
+                        }
+                        else {
+                            BlockBuilder entryBuilder2 = entryBuilder1.beginBlockEntry();
+                            for (int j = 0; j < ARRAY_SIZE; j++) {
+                                if (hasNull && j % 10 == 0) {
+                                    entryBuilder2.appendNull();
+                                }
+                                else {
+                                    ((ArrayType) arrayType.getElementType()).getElementType().writeLong(entryBuilder2, ThreadLocalRandom.current().nextLong());
+                                }
+                            }
+                            entryBuilder1.closeEntry();
+                        }
+                    }
+                    blockBuilder.closeEntry();
+                }
+            }
+        }
+
+        private void createMapChannel(BlockBuilder blockBuilder, Type type)
+        {
+            MapType mapType = (MapType) type;
+            for (int position = 0; position < positionCount; position++) {
+                if (hasNull && position % 10 == 0) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+                    for (int i = 0; i < MAP_SIZE; i++) {
+                        mapType.getKeyType().writeLong(entryBuilder, position + i);
+                        mapType.getValueType().writeSlice(entryBuilder, Slices.utf8Slice(getRandomString(ThreadLocalRandom.current().nextInt(STRING_SIZE))));
+                    }
+                    blockBuilder.closeEntry();
+                }
+            }
+        }
+
+        private Block createDictionaryChannel()
+        {
+            BlockBuilder dictionaryBuilder = VARBINARY.createBlockBuilder(null, 100);
+            for (int position = 0; position < DICTIONARY_SIZE; position++) {
+                VARBINARY.writeSlice(dictionaryBuilder, utf8Slice("testString" + position));
+            }
+            Block dictionary = dictionaryBuilder.build();
+
+            int[] ids = new int[positionCount];
+            for (int i = 0; i < ids.length; i++) {
+                ids[i] = ThreadLocalRandom.current().nextInt(DICTIONARY_SIZE);
+            }
+            return new DictionaryBlock(dictionary, ids);
+        }
+
+        private Block createRLEChannel()
+        {
+            return RunLengthEncodedBlock.create(VARCHAR, utf8Slice(getRandomString(100)), positionCount);
+        }
+
+        private static String getRandomString(int size)
+        {
+            byte[] array = new byte[size];
+            ThreadLocalRandom.current().nextBytes(array);
+            return new String(array, Charset.forName("UTF-8"));
         }
 
         private PartitionedOutputOperator createPartitionedOutputOperator()
         {
-            PartitionFunction partitionFunction = new LocalPartitionGenerator(new InterpretedHashGenerator(ImmutableList.of(BIGINT), new int[] {0}), PARTITION_COUNT);
+            PartitionFunction partitionFunction = new LocalPartitionGenerator(new PrecomputedHashGenerator(0), PARTITION_COUNT);
+
+            //PartitionFunction partitionFunction = new LocalPartitionGenerator(new InterpretedHashGenerator(ImmutableList.of(BIGINT), new int[] {0}), PARTITION_COUNT);
             PagesSerdeFactory serdeFactory = new PagesSerdeFactory(new BlockEncodingManager(new TypeRegistry()), false);
             OutputBuffers buffers = createInitialEmptyOutputBuffers(PARTITIONED);
             for (int partition = 0; partition < PARTITION_COUNT; partition++) {
@@ -134,75 +550,31 @@ public class BenchmarkPartitionedOutputOperator
                     buffer,
                     new DataSize(1, GIGABYTE));
             return (PartitionedOutputOperator) operatorFactory
-                    .createOutputOperator(0, new PlanNodeId("plan-node-0"), TYPES, Function.identity(), serdeFactory)
+                    .createOutputOperator(0, new PlanNodeId("plan-node-0"), types, Function.identity(), serdeFactory)
                     .createOperator(createDriverContext());
-        }
-
-        private Page createPage()
-        {
-            List<Object>[] testRows = generateTestRows(ImmutableList.of(VARCHAR, VARCHAR, VARCHAR, VARCHAR), ENTRIES_PER_PAGE);
-            PageBuilder pageBuilder = new PageBuilder(TYPES);
-            BlockBuilder bigintBlockBuilder = pageBuilder.getBlockBuilder(0);
-            BlockBuilder rowBlockBuilder = pageBuilder.getBlockBuilder(1);
-            BlockBuilder rowBlockBuilder2 = pageBuilder.getBlockBuilder(2);
-            BlockBuilder rowBlockBuilder3 = pageBuilder.getBlockBuilder(3);
-            for (int i = 0; i < ENTRIES_PER_PAGE; i++) {
-                BIGINT.writeLong(bigintBlockBuilder, i);
-                writeRow(testRows[i], rowBlockBuilder);
-                writeRow(testRows[i], rowBlockBuilder2);
-                writeRow(testRows[i], rowBlockBuilder3);
-            }
-            pageBuilder.declarePositions(ENTRIES_PER_PAGE);
-            return pageBuilder.build();
-        }
-
-        private void writeRow(List<Object> testRow, BlockBuilder rowBlockBuilder)
-        {
-            BlockBuilder singleRowBlockWriter = rowBlockBuilder.beginBlockEntry();
-            for (Object fieldValue : testRow) {
-                if (fieldValue instanceof String) {
-                    VARCHAR.writeSlice(singleRowBlockWriter, utf8Slice((String) fieldValue));
-                }
-                else {
-                    throw new UnsupportedOperationException();
-                }
-            }
-            rowBlockBuilder.closeEntry();
-        }
-
-        // copied & modifed from TestRowBlock
-        private List<Object>[] generateTestRows(List<Type> fieldTypes, int numRows)
-        {
-            List<Object>[] testRows = new List[numRows];
-            for (int i = 0; i < numRows; i++) {
-                List<Object> testRow = new ArrayList<>(fieldTypes.size());
-                for (int j = 0; j < fieldTypes.size(); j++) {
-                    if (fieldTypes.get(j) == VARCHAR) {
-                        byte[] data = new byte[ThreadLocalRandom.current().nextInt(128)];
-                        ThreadLocalRandom.current().nextBytes(data);
-                        testRow.add(new String(data));
-                    }
-                    else {
-                        throw new UnsupportedOperationException();
-                    }
-                }
-                testRows[i] = testRow;
-            }
-            return testRows;
         }
 
         private DriverContext createDriverContext()
         {
-            return TestingTaskContext.builder(EXECUTOR, SCHEDULER, TEST_SESSION)
+            Session testSession = testSessionBuilder()
+                    .setCatalog("tpch")
+                    .setSchema(TINY_SCHEMA_NAME)
+                    .setClientCapabilities(stream(ClientCapabilities.values())
+                            .map(ClientCapabilities::toString)
+                            .collect(toImmutableSet()))
+                    .setSystemProperty(OPTIMIZED_PARTITIONED_OUTPUT, useOptimized)
+                    .build();
+
+            return TestingTaskContext.builder(EXECUTOR, SCHEDULER, testSession)
                     .setMemoryPoolSize(MAX_MEMORY)
                     .build()
                     .addPipelineContext(0, true, true, false)
                     .addDriverContext();
         }
 
-        private PartitionedOutputBuffer createPartitionedBuffer(OutputBuffers buffers, DataSize dataSize)
+        private TestingPartitionedOutputBuffer createPartitionedBuffer(OutputBuffers buffers, DataSize dataSize)
         {
-            return new PartitionedOutputBuffer(
+            return new TestingPartitionedOutputBuffer(
                     "task-instance-id",
                     new StateMachine<>("bufferState", SCHEDULER, OPEN, TERMINAL_BUFFER_STATES),
                     buffers,
@@ -217,10 +589,11 @@ public class BenchmarkPartitionedOutputOperator
     {
         // assure the benchmarks are valid before running
         BenchmarkData data = new BenchmarkData();
+        data.setup();
         new BenchmarkPartitionedOutputOperator().addPage(data);
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .jvmArgs("-Xmx10g")
+                .jvmArgs("-Xmx80g")
                 .include(".*" + BenchmarkPartitionedOutputOperator.class.getSimpleName() + ".*")
                 .build();
         new Runner(options).run();

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperatorAppendToBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperatorAppendToBuffers.java
@@ -1,0 +1,1372 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import io.airlift.slice.BasicSliceOutput;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.LinuxPerfAsmProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.BiFunction;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+
+@State(Scope.Thread)
+@OutputTimeUnit(MILLISECONDS)
+@Fork(3)
+@Warmup(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkPartitionedOutputOperatorAppendToBuffers
+{
+    private static final int RUNS = 1000;
+
+    @Benchmark
+    public void copyLongValuesToByteArrayBufferChannelFirst(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                    long[] longValues = data.longValues[pageIndex][channelIndex];
+                    boolean[] nulls = data.nulls[pageIndex][channelIndex];
+                    for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                        if (data.mayHaveNull) {
+                            longValueBufferIndexes[partition][channelIndex] = ByteArrayUtils.writeLongsWithNulls(
+                                    data.longValuesBuffers[partition][channelIndex], longValueBufferIndexes[partition][channelIndex], longValues,
+                                    nulls,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0);
+                        }
+                        else {
+                            longValueBufferIndexes[partition][channelIndex] = ByteArrayUtils.writeLongs(
+                                    data.longValuesBuffers[partition][channelIndex], longValueBufferIndexes[partition][channelIndex], longValues,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyLongValuesToByteArrayBuffer(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                    for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                        long[] longValues = data.longValues[pageIndex][channelIndex];
+                        boolean[] nulls = data.nulls[pageIndex][channelIndex];
+                        if (data.mayHaveNull) {
+                            longValueBufferIndexes[partition][channelIndex] = ByteArrayUtils.writeLongsWithNulls(
+                                    data.longValuesBuffers[partition][channelIndex], longValueBufferIndexes[partition][channelIndex], longValues,
+                                    nulls,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0);
+                        }
+                        else {
+                            longValueBufferIndexes[partition][channelIndex] = ByteArrayUtils.writeLongs(
+                                    data.longValuesBuffers[partition][channelIndex], longValueBufferIndexes[partition][channelIndex], longValues,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyLongPagesToByteArrayBufferChannelFirst(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                Page page = data.bigintDataPages[pageIndex];
+                for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                    Block bigintBlock = page.getBlock(channelIndex);
+                    for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                        int[] positions = data.positions[partition];
+                        int positionCount = data.positionCounts[partition];
+
+                        if (data.mayHaveNull) {
+                            longValueBufferIndexes[partition][channelIndex] = putBigintWithNullsBlockToByteArrayBuffer(
+                                    bigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                        else {
+                            longValueBufferIndexes[partition][channelIndex] = putBigintBlockToByteArrayBuffer(
+                                    bigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyLongPagesToByteArrayBuffer(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                Page page = data.bigintDataPages[pageIndex];
+                for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                    int[] positions = data.positions[partition];
+                    int positionCount = data.positionCounts[partition];
+
+                    for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                        Block bigintBlock = page.getBlock(channelIndex);
+
+                        if (data.mayHaveNull) {
+                            longValueBufferIndexes[partition][channelIndex] = putBigintWithNullsBlockToByteArrayBuffer(
+                                    bigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                        else {
+                            longValueBufferIndexes[partition][channelIndex] = putBigintBlockToByteArrayBuffer(
+                                    bigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyDictionaryLongValuesToByteArrayBuffer(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                    int positionCounts = data.positionCounts[partition];
+                    int[] positions = data.positions[partition];
+
+                    for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                        long[] longValuesForDicitionary = data.longValuesForDicitionary[pageIndex][channelIndex];
+                        int[] ids  = data.ids[pageIndex][channelIndex];
+                        boolean[] nulls = data.nulls[pageIndex][channelIndex];
+                        if (data.mayHaveNull) {
+                            longValueBufferIndexes[partition][channelIndex] = ByteArrayUtils.writeLongsWithNulls(
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex],
+                                    longValuesForDicitionary,
+                                    ids,
+                                    nulls,
+                                    positions,
+                                    0,
+                                    positionCounts,
+                                    0);
+                        }
+                        else {
+                            longValueBufferIndexes[partition][channelIndex] = ByteArrayUtils.writeLongs(
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex],
+                                    longValuesForDicitionary,
+                                    ids,
+                                    positions,
+                                    0,
+                                    positionCounts,
+                                    0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyDictionaryBigintPagesToByteArrayBuffer(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                Page page = data.dictionaryDataPages[pageIndex];
+                for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                    int[] positions = data.positions[partition];
+                    int positionCount = data.positionCounts[partition];
+
+                    for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                        Block dictionaryBigintBlock = page.getBlock(channelIndex);
+
+                        if (data.mayHaveNull) {
+                            longValueBufferIndexes[partition][channelIndex] = putBigintWithNullsBlockToByteArrayBuffer(
+                                    dictionaryBigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                        else {
+                            longValueBufferIndexes[partition][channelIndex] = putBigintBlockToByteArrayBuffer(
+                                    dictionaryBigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyUncheckedDictionaryBigintPagesToByteArrayBuffer(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                Page page = data.dictionaryDataPages[pageIndex];
+                for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                    int[] positions = data.positions[partition];
+                    int positionCount = data.positionCounts[partition];
+
+                    for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                        Block dictionaryBigintBlock = page.getBlock(channelIndex);
+
+                        if (data.mayHaveNull) {
+                            longValueBufferIndexes[partition][channelIndex] = putUncheckedBigintWithNullsBlockToByteArrayBuffer(
+                                    dictionaryBigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                        else {
+                            longValueBufferIndexes[partition][channelIndex] = putUncheckedBigintBlockToByteArrayBuffer(
+                                    dictionaryBigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyCompositeLongValuesToByteArrayBuffer(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                    for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                        long[] longValues = data.longValues[pageIndex][channelIndex];
+                        long[] longValuesForDicitionary = data.longValuesForDicitionary[pageIndex][channelIndex];
+                        int[] ids  = data.ids[pageIndex][channelIndex];
+                        boolean[] nulls = data.nulls[pageIndex][channelIndex];
+                        if (data.mayHaveNull) {
+                            longValueBufferIndexes[partition][channelIndex] = ByteArrayUtils.writeLongsWithNulls(
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex],
+                                    longValues,
+                                    ids,
+                                    nulls,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0);
+                            longValueBufferIndexes[partition][channelIndex] = ByteArrayUtils.writeLongsWithNulls(
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex],
+                                    longValuesForDicitionary,
+                                    ids,
+                                    nulls,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0);
+                        }
+                        else {
+                            longValueBufferIndexes[partition][channelIndex] = ByteArrayUtils.writeLongs(
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex],
+                                    longValues,
+                                    ids,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0);
+                            longValueBufferIndexes[partition][channelIndex] = ByteArrayUtils.writeLongs(
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex],
+                                    longValuesForDicitionary,
+                                    ids,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyCompositePagesToByteArrayBuffer(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                Page page = data.compositeDataPages[pageIndex];
+                for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                    int[] positions = data.positions[partition];
+                    int positionCount = data.positionCounts[partition];
+
+                    for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                        Block bigintBlock = page.getBlock(channelIndex * 2);
+                        Block dictionaryBigintBlock = page.getBlock(channelIndex * 2 + 1);
+
+                        if (data.mayHaveNull) {
+                            longValueBufferIndexes[partition][channelIndex] = putBigintWithNullsBlockToByteArrayBuffer(
+                                    bigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                            longValueBufferIndexes[partition][channelIndex] = putBigintWithNullsBlockToByteArrayBuffer(
+                                    dictionaryBigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                        else {
+                            longValueBufferIndexes[partition][channelIndex] = putBigintBlockToByteArrayBuffer(
+                                    bigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                            longValueBufferIndexes[partition][channelIndex] = putBigintBlockToByteArrayBuffer(
+                                    dictionaryBigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyCompositeUncheckedPagesToByteArrayBuffer(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                Page page = data .compositeDataPages[pageIndex];
+                for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                    int[] positions = data.positions[partition];
+                    int positionCount = data.positionCounts[partition];
+
+                    for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                        Block bigintBlock = page.getBlock(channelIndex * 2);
+                        Block dictionaryBigintBlock = page.getBlock(channelIndex * 2 + 1);
+
+                        if (data.mayHaveNull) {
+                            longValueBufferIndexes[partition][channelIndex] = putUncheckedBigintWithNullsBlockToByteArrayBuffer(
+                                    bigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                            longValueBufferIndexes[partition][channelIndex] = putUncheckedBigintWithNullsBlockToByteArrayBuffer(
+                                    dictionaryBigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                        else {
+                            longValueBufferIndexes[partition][channelIndex] = putUncheckedBigintBlockToByteArrayBuffer(
+                                    bigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                            longValueBufferIndexes[partition][channelIndex] = putUncheckedBigintBlockToByteArrayBuffer(
+                                    dictionaryBigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyLongValuesToDynamicSliceOutput(BenchmarkData data)
+    {
+        copyLongValuesToSliceOutput(data, data::getDynamicSliceOutput);
+    }
+
+    @Benchmark
+    public void copyLongValuesToBasicSliceOutput(BenchmarkData data)
+    {
+        copyLongValuesToSliceOutput(data, data::getBasicSliceOutput);
+    }
+
+    private void copyLongValuesToSliceOutput(BenchmarkData data, BiFunction<Integer, Integer, SliceOutput> getSliceOutput)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            data.resetSliceOutput();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                    long[] longValues = data.longValues[pageIndex][channelIndex];
+                    boolean[] nulls = data.nulls[pageIndex][channelIndex];
+                    for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                        SliceOutput sliceOutput = getSliceOutput.apply(partition, channelIndex);
+                        if (data.mayHaveNull) {
+                            putLongValuesWithNullsToSliceOutput(
+                                    longValues,
+                                    nulls,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0,
+                                    sliceOutput);
+                        }
+                        else {
+                            putLongValuesToSliceOutput(
+                                    longValues,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0,
+                                    sliceOutput);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyLongValuesToTestingSliceOutputEncapsulated(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            data.resetTestingSliceOutput();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                    long[] longValues = data.longValues[pageIndex][channelIndex];
+                    boolean[] nulls = data.nulls[pageIndex][channelIndex];
+                    for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                        TestingSliceOutput sliceOutput = data.testingSliceOutput[partition][channelIndex];
+                        if (data.mayHaveNull) {
+                            putLongValuesWithNullsToTestingSliceOutputEncapsulated(
+                                    longValues,
+                                    nulls,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0,
+                                    sliceOutput);
+                        }
+                        else {
+                            putLongValuesToTestingSliceOutput(
+                                    longValues,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0,
+                                    sliceOutput);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyLongValuesToTestingSliceOutputWriteLongArray(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            data.resetTestingSliceOutput();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                    long[] longValues = data.longValues[pageIndex][channelIndex];
+                    boolean[] nulls = data.nulls[pageIndex][channelIndex];
+                    for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                        TestingSliceOutput sliceOutput = data.testingSliceOutput[partition][channelIndex];
+                        if (data.mayHaveNull) {
+                            putLongValuesWithNullsToTestingSliceOutputWriteLongArray(
+                                    longValues,
+                                    nulls,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0,
+                                    sliceOutput);
+                        }
+                        else {
+                            putLongValuesToTestingSliceOutput(
+                                    longValues,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0,
+                                    sliceOutput);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyLongValuesToTestingSliceOutputNoEncapsulation(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            data.resetTestingSliceOutput();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                    long[] longValues = data.longValues[pageIndex][channelIndex];
+                    boolean[] nulls = data.nulls[pageIndex][channelIndex];
+                    for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                        TestingSliceOutput sliceOutput = data.testingSliceOutput[partition][channelIndex];
+                        if (data.mayHaveNull) {
+                            putLongValuesWithNullsToTestingSliceOutputNoEncapsulation(
+                                    longValues,
+                                    nulls,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0,
+                                    sliceOutput);
+                        }
+                        else {
+                            putLongValuesToTestingSliceOutput(
+                                    longValues,
+                                    data.positions[partition],
+                                    0,
+                                    data.positionCounts[partition],
+                                    0,
+                                    sliceOutput);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyLongPagesToDynamicSliceOutput(BenchmarkData data)
+    {
+        copyLongPagesToSliceOutput(data, data::getDynamicSliceOutput);
+    }
+
+    @Benchmark
+    public void copyLongPagesToBasicSliceOutput(BenchmarkData data)
+    {
+        copyLongPagesToSliceOutput(data, data::getBasicSliceOutput);
+    }
+
+    private void copyLongPagesToSliceOutput(BenchmarkData data, BiFunction<Integer, Integer, SliceOutput> getSliceOutput)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            data.resetSliceOutput();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                Page page = data.bigintDataPages[pageIndex];
+                for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                    Block bigintBlock = page.getBlock(channelIndex);
+                    for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                        int[] positions = data.positions[partition];
+                        int positionCount = data.positionCounts[partition];
+                        SliceOutput sliceOutput = getSliceOutput.apply(partition, channelIndex);
+
+                        if (data.mayHaveNull) {
+                            putBigintWithNullsBlockToSliceOutput(bigintBlock, positions, positionCount, sliceOutput);
+                        }
+                        else {
+                            putBigintBlockToSliceOutput(bigintBlock, positions, positionCount, sliceOutput);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void copyLongPagesUncheckedToByteArrayBuffer(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                Page page = data.bigintDataPages[pageIndex];
+                for (int partition = 0; partition < data.PARTITION_COUNT; partition++) {
+                    int[] positions = data.positions[partition];
+                    int positionCount = data.positionCounts[partition];
+
+                    for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                        Block bigintBlock = page.getBlock(channelIndex);
+
+                        if (data.mayHaveNull) {
+                            longValueBufferIndexes[partition][channelIndex] = putUncheckedBigintWithNullsBlockToByteArrayBuffer(
+                                    bigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                        else {
+                            longValueBufferIndexes[partition][channelIndex] = putUncheckedBigintBlockToByteArrayBuffer(
+                                    bigintBlock,
+                                    positions,
+                                    positionCount,
+                                    data.longValuesBuffers[partition][channelIndex],
+                                    longValueBufferIndexes[partition][channelIndex]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void sequentialCopyLongValuesToByteArrayBuffer(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                    long[] longValues = data.longValues[pageIndex][channelIndex];
+                    boolean[] nulls = data.nulls[pageIndex][channelIndex];
+                    if (data.mayHaveNull) {
+                        ByteArrayUtils.writeLongsWithNulls(
+                                data.longValuesBuffers[0][channelIndex],
+                                longValueBufferIndexes[0][channelIndex],
+                                longValues,
+                                nulls,
+                                0,
+                                longValues.length,
+                                0);
+                    }
+                    else {
+                        ByteArrayUtils.writeLongs(
+                                data.longValuesBuffers[0][channelIndex],
+                                longValueBufferIndexes[0][channelIndex],
+                                longValues,
+                                0,
+                                longValues.length,
+                                0);
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void sequentialCopyLongPagesToByteArrayBuffer(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                Page page = data.bigintDataPages[pageIndex];
+                for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                    Block bigintBlock = page.getBlock(channelIndex);
+
+                    if (data.mayHaveNull) {
+                        putAllBigintWithNullsBlockDataToByteArrayBuffer(
+                                bigintBlock,
+                                data.longValuesBuffers[0][channelIndex],
+                                longValueBufferIndexes[0][channelIndex]);
+                    }
+                    else {
+                        putAllBigintBlockDataToByteArrayBuffer(
+                                bigintBlock,
+                                data.longValuesBuffers[0][channelIndex],
+                                longValueBufferIndexes[0][channelIndex]);
+                    }
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void sequentialCopyUncheckedLongPagesToByteArrayBuffer(BenchmarkData data)
+    {
+        for (int i = 0; i < RUNS; i++) {
+            int[][] longValueBufferIndexes = data.getLongValueBufferIndexes();
+
+            int pageCount = data.PAGE_COUNT;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                Page page = data.bigintDataPages[pageIndex];
+                for (int channelIndex = 0; channelIndex < data.channelCount; channelIndex++) {
+                    Block bigintBlock = page.getBlock(channelIndex);
+
+                    if (data.mayHaveNull) {
+                        putAllUncheckedBigintWithNullsBlockDataToByteArrayBuffer(
+                                bigintBlock,
+                                data.longValuesBuffers[0][channelIndex],
+                                longValueBufferIndexes[0][channelIndex]);
+                    }
+                    else {
+                        putAllUncheckedBigintBlockDataToByteArrayBuffer(
+                                bigintBlock,
+                                data.longValuesBuffers[0][channelIndex],
+                                longValueBufferIndexes[0][channelIndex]);
+                    }
+                }
+            }
+        }
+    }
+
+    private static int putBigintWithNullsBlockToByteArrayBuffer(Block block, int[] positions, int positionCount, byte[] longValueBuffer, int longBufferIndex)
+    {
+        for (int j = 0; j < positionCount; j++) {
+            int position = positions[j];
+            long longValue = block.getLong(positions[j]);
+            ByteArrayUtils.writeLong(longValueBuffer, longBufferIndex, longValue);
+            if (!block.isNull(position)) {
+                longBufferIndex += ARRAY_LONG_INDEX_SCALE;
+            }
+        }
+
+        return longBufferIndex;
+    }
+
+    private static int putBigintBlockToByteArrayBuffer(Block block, int[] positions, int positionCount, byte[] longValueBuffer, int longBufferIndex)
+    {
+        for (int j = 0; j < positionCount; j++) {
+            long longValue = block.getLong(positions[j]);
+            ByteArrayUtils.writeLong(longValueBuffer, longBufferIndex, longValue);
+            longBufferIndex += ARRAY_LONG_INDEX_SCALE;
+        }
+
+        return longBufferIndex;
+    }
+
+    private static int putUncheckedBigintWithNullsBlockToByteArrayBuffer(Block block, int[] positions, int positionCount, byte[] longValueBuffer, int longBufferIndex)
+    {
+        int offsetBase = block.getOffsetBase();
+        for (int j = 0; j < positionCount; j++) {
+            int position = positions[j];
+            //long longValue = block.getLongUnchecked(positions[j]);
+            long longValue = block.getLongUnchecked(positions[j] + offsetBase);
+            ByteArrayUtils.writeLong(longValueBuffer, longBufferIndex, longValue);
+            if (!block.isNullUnchecked(position + offsetBase)) {
+            //if (!block.isNullUnchecked(position)) {
+                longBufferIndex += ARRAY_LONG_INDEX_SCALE;
+            }
+        }
+
+        return longBufferIndex;
+    }
+
+    private static int putUncheckedBigintBlockToByteArrayBuffer(Block block, int[] positions, int positionCount, byte[] longValueBuffer, int longBufferIndex)
+    {
+        int offsetBase = block.getOffsetBase();
+        for (int j = 0; j < positionCount; j++) {
+            long longValue = block.getLongUnchecked(positions[j] + offsetBase);
+            ByteArrayUtils.writeLong(longValueBuffer, longBufferIndex, longValue);
+            longBufferIndex += ARRAY_LONG_INDEX_SCALE;
+        }
+
+        return longBufferIndex;
+    }
+
+    private static int putLongValuesWithNullsToSliceOutput(long[] values, boolean[] nulls, int[] positions, int positionsOffset, int batchSize, int offsetBase, SliceOutput sliceOutput)
+    {
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int position = positions[i] + offsetBase;
+            long value = values[positions[i] + offsetBase];
+            if (!nulls[position]) {
+                sliceOutput.writeLong(value);
+            }
+        }
+        return sliceOutput.size();
+    }
+
+    private static int putLongValuesToSliceOutput(long[] values, int[] positions, int positionsOffset, int batchSize, int offsetBase, SliceOutput sliceOutput)
+    {
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            sliceOutput.writeLong(values[positions[i] + offsetBase]);
+        }
+        return sliceOutput.size();
+    }
+
+    private static int putBigintWithNullsBlockToSliceOutput(Block block, int[] positions, int positionCount, SliceOutput sliceOutput)
+    {
+        for (int j = 0; j < positionCount; j++) {
+            int position = positions[j];
+            long value = block.getLong(position);
+            sliceOutput.writeLong(value);
+            if (!block.isNull(position)) {
+                sliceOutput.writeLong(value);
+            }
+        }
+
+        return sliceOutput.size();
+    }
+
+    private static int putBigintBlockToSliceOutput(Block block, int[] positions, int positionCount, SliceOutput sliceOutput)
+    {
+        for (int j = 0; j < positionCount; j++) {
+            sliceOutput.writeLong(block.getLong(positions[j]));
+        }
+
+        return sliceOutput.size();
+    }
+
+    private static int putLongValuesToTestingSliceOutput(long[] values, int[] positions, int positionsOffset, int batchSize, int offsetBase, TestingSliceOutput sliceOutput)
+    {
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            sliceOutput.writeLong(values[positions[i] + offsetBase]);
+        }
+        return sliceOutput.size();
+    }
+
+    private static int putLongValuesWithNullsToTestingSliceOutputNoEncapsulation(long[] values, boolean[] nulls, int[] positions, int positionsOffset, int batchSize, int offsetBase, TestingSliceOutput sliceOutput)
+    {
+        if (sliceOutput.capacity() < batchSize * 8) {
+            throw new IllegalArgumentException(format("batchSize %d is too large to fit in buffer %d", batchSize, sliceOutput.capacity()));
+        }
+
+        int address = 0;
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int position = positions[i];
+            long value = values[positions[i] + offsetBase];
+            sliceOutput.writeLong(values[position], address);
+            if (!nulls[position]) {
+                address += ARRAY_LONG_INDEX_SCALE;
+            }
+        }
+        return sliceOutput.size();
+    }
+
+    private static void putLongValuesWithNullsToTestingSliceOutputEncapsulated(long[] values, boolean[] nulls, int[] positions, int positionsOffset, int batchSize, int offsetBase, TestingSliceOutput sliceOutput)
+    {
+        if (sliceOutput.capacity() < batchSize * 8) {
+            throw new IllegalArgumentException(format("batchSize %d is too large to fit in buffer %d", batchSize, sliceOutput.capacity()));
+        }
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int position = positions[i];
+            long value = values[position + offsetBase];
+            boolean isNull = nulls[position + offsetBase];
+            sliceOutput.writeLong(value, isNull);
+        }
+    }
+
+    private static void putLongValuesWithNullsToTestingSliceOutputWriteLongArray(long[] values, boolean[] nulls, int[] positions, int positionsOffset, int batchSize, int offsetBase, TestingSliceOutput sliceOutput)
+    {
+        if (sliceOutput.capacity() < batchSize * 8) {
+            throw new IllegalArgumentException(format("batchSize %d is too large to fit in buffer %d", batchSize, sliceOutput.capacity()));
+        }
+
+        // Use values and nulls as temp array to store compacted data
+        for (int i = 0; i < batchSize; i++) {
+            int position = positions[i + positionsOffset] + offsetBase;
+            values[i] = values[position];
+            nulls[i] = nulls[position];
+        }
+
+        sliceOutput.writeLongArray(values, nulls, 0, batchSize);
+    }
+
+    private static int putAllBigintBlockDataToByteArrayBuffer(Block block, byte[] longValueBuffer, int longBufferIndex)
+    {
+        int positionCount = block.getPositionCount();
+        for (int position = 0; position < positionCount; position++) {
+            long longValue = block.getLong(position);
+            ByteArrayUtils.writeLong(longValueBuffer, longBufferIndex, longValue);
+            longBufferIndex += ARRAY_LONG_INDEX_SCALE;
+        }
+
+        return longBufferIndex;
+    }
+
+    private static int putAllBigintWithNullsBlockDataToByteArrayBuffer(Block block, byte[] longValueBuffer, int longBufferIndex)
+    {
+        int positionCount = block.getPositionCount();
+        for (int position = 0; position < positionCount; position++) {
+            long longValue = block.getLong(position);
+            ByteArrayUtils.writeLong(longValueBuffer, longBufferIndex, longValue);
+            if (!block.isNull(position)) {
+                longBufferIndex += ARRAY_LONG_INDEX_SCALE;
+            }
+        }
+
+        return longBufferIndex;
+    }
+
+    private static int putAllUncheckedBigintBlockDataToByteArrayBuffer(Block block, byte[] longValueBuffer, int longBufferIndex)
+    {
+        int positionCount = block.getPositionCount();
+        for (int position = 0; position < positionCount; position++) {
+            long longValue = block.getLongUnchecked(position);
+            ByteArrayUtils.writeLong(longValueBuffer, longBufferIndex, longValue);
+            longBufferIndex += ARRAY_LONG_INDEX_SCALE;
+        }
+
+        return longBufferIndex;
+    }
+
+    private static int putAllUncheckedBigintWithNullsBlockDataToByteArrayBuffer(Block block, byte[] longValueBuffer, int longBufferIndex)
+    {
+        int positionCount = block.getPositionCount();
+        for (int position = 0; position < positionCount; position++) {
+            long longValue = block.getLongUnchecked(position);
+            ByteArrayUtils.writeLong(longValueBuffer, longBufferIndex, longValue);
+            if (!block.isNull(position)) {
+                longBufferIndex += ARRAY_LONG_INDEX_SCALE;
+            }
+        }
+
+        return longBufferIndex;
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        // Ideally we'd like multiple pages that takes up reasonable amount of memory which is larger than CPU cache size
+        private static final int PAGE_COUNT = 4;
+        private static final int PARTITION_COUNT = 333;
+        private static final int POSITIONS_PER_PAGE = 10000;
+        private static final int DICTIONARY_SIZE = 1024;
+
+        private final int[][] positions = new int[PARTITION_COUNT][POSITIONS_PER_PAGE];
+        private final int[] positionCounts = new int[PARTITION_COUNT];
+
+        private long[][][] longValues;
+        private long[][][] longValuesForDicitionary;
+        private int[][][] ids;
+        private boolean[][][] nulls;
+        private Page[] bigintDataPages;
+        private Page[] dictionaryDataPages;
+        private Page[] compositeDataPages;
+
+        private byte[][][] longValuesBuffers;
+        private int[][] longValueBufferIndexes;
+
+        private SliceOutput[][] basicSliceOutput;
+        private SliceOutput[][] dynamicSliceOutput;
+        private TestingSliceOutput[][] testingSliceOutput;
+
+        @Param({"1", "2"})
+        private int channelCount = 1;
+
+        @Param({"true", "false"})
+        private boolean mayHaveNull =true;
+
+        @Setup
+        public void setup()
+        {
+            createBigintValues();
+            createBigintValuesForDictionary();
+            createIds();
+            createNulls();
+
+            createBigintPages();
+            createDictionaryPages();
+            createCompositePages();
+
+            createBigintByteArrayBuffers();
+            createBigintByteArrayBufferIndex();
+
+            createBasicSliceOutput();
+            createDynamicSliceOutput();
+            createTestingSliceOutput();
+
+            populatePositions();
+        }
+
+        public int[][] getLongValueBufferIndexes()
+        {
+            for (int j = 0; j < PARTITION_COUNT; j++) {
+                Arrays.fill(longValueBufferIndexes[j], 0);
+            }
+            return longValueBufferIndexes;
+        }
+
+        public SliceOutput getBasicSliceOutput(Integer partition, Integer channelIndex)
+        {
+            return basicSliceOutput[partition][channelIndex];
+        }
+
+        public SliceOutput getDynamicSliceOutput(int partition, int channelIndex)
+        {
+            return dynamicSliceOutput[partition][channelIndex];
+        }
+
+        public void resetSliceOutput()
+        {
+            for (int pageIndex = 0; pageIndex < PARTITION_COUNT; pageIndex++) {
+                for (int channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+                    basicSliceOutput[pageIndex][channelIndex].reset();
+                    dynamicSliceOutput[pageIndex][channelIndex].reset();
+                }
+            }
+        }
+
+        public void resetTestingSliceOutput()
+        {
+            for (int pageIndex = 0; pageIndex < PARTITION_COUNT; pageIndex++) {
+                for (int channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+                    testingSliceOutput[pageIndex][channelIndex].reset();
+                }
+            }
+        }
+
+        private void createBigintPages()
+        {
+            bigintDataPages = new Page[PAGE_COUNT];
+
+            for (int pageIndex = 0; pageIndex < PAGE_COUNT; pageIndex++) {
+                Block[] blocks = new Block[channelCount];
+                for (int channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+                    if (mayHaveNull) {
+                        blocks[channelIndex] = createBigintWithNullsChannel();
+                    }
+                    else {
+                        blocks[channelIndex] = createBigintChannel();
+                    }
+                }
+                bigintDataPages[pageIndex] = new Page(blocks);
+            }
+        }
+
+        private void createDictionaryPages()
+        {
+            dictionaryDataPages = new Page[PAGE_COUNT];
+
+            for (int pageIndex = 0; pageIndex < PAGE_COUNT; pageIndex++) {
+                Block[] blocks = new Block[channelCount];
+                for (int channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+                    if (mayHaveNull) {
+                        blocks[channelIndex] = createDictionaryBigintWithNullsChannel();
+                    }
+                    else {
+                        blocks[channelIndex] = createDictionaryBigintChannel();
+                    }
+                }
+                dictionaryDataPages[pageIndex] = new Page(blocks);
+            }
+        }
+
+        private void createCompositePages()
+        {
+            compositeDataPages = new Page[PAGE_COUNT];
+
+            for (int pageIndex = 0; pageIndex < PAGE_COUNT; pageIndex++) {
+                Block[] blocks = new Block[channelCount * 2];
+                for (int channelIndex = 0; channelIndex < channelCount * 2; channelIndex += 2) {
+                    if (mayHaveNull) {
+                        blocks[channelIndex] = createBigintWithNullsChannel();
+                        blocks[channelIndex + 1] = createDictionaryBigintWithNullsChannel();
+                    }
+                    else {
+                        blocks[channelIndex] = createBigintChannel();
+                        blocks[channelIndex + 1] = createDictionaryBigintChannel();
+                    }
+                }
+                compositeDataPages[pageIndex] = new Page(blocks);
+            }
+        }
+
+        private Block createBigintChannel()
+        {
+            BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, POSITIONS_PER_PAGE);
+            for (int position = 0; position < POSITIONS_PER_PAGE; position++) {
+                BIGINT.writeLong(blockBuilder, position);
+            }
+            return blockBuilder.build();
+        }
+
+        private Block createBigintWithNullsChannel()
+        {
+            BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, POSITIONS_PER_PAGE);
+            for (int position = 0; position < POSITIONS_PER_PAGE; position++) {
+                if (ThreadLocalRandom.current().nextBoolean()) {
+                    BIGINT.writeLong(blockBuilder, position);
+                }
+                else {
+                    blockBuilder.appendNull();
+                }
+            }
+            return blockBuilder.build();
+        }
+
+        private Block createDictionaryBigintWithNullsChannel()
+        {
+            BlockBuilder dictionaryBuilder = BIGINT.createBlockBuilder(null, POSITIONS_PER_PAGE);
+            for (int position = 0; position < 1024; position++) {
+                if (ThreadLocalRandom.current().nextBoolean()) {
+                    BIGINT.writeLong(dictionaryBuilder, position);
+                }
+                else {
+                    dictionaryBuilder.appendNull();
+                }
+            }
+            Block dictionary = dictionaryBuilder.build();
+
+            int[] ids = new int[POSITIONS_PER_PAGE];
+            for (int i = 0; i < ids.length; i++) {
+                ids[i] = ThreadLocalRandom.current().nextInt(1024);
+            }
+            return new DictionaryBlock(dictionary, ids);
+        }
+
+        private Block createDictionaryBigintChannel()
+        {
+            BlockBuilder dictionaryBuilder = BIGINT.createBlockBuilder(null, POSITIONS_PER_PAGE);
+            for (int position = 0; position < 1024; position++) {
+                BIGINT.writeLong(dictionaryBuilder, position);
+            }
+            Block dictionary = dictionaryBuilder.build();
+
+            int[] ids = new int[POSITIONS_PER_PAGE];
+            for (int i = 0; i < ids.length; i++) {
+                ids[i] = ThreadLocalRandom.current().nextInt(DICTIONARY_SIZE);
+            }
+            return new DictionaryBlock(dictionary, ids);
+        }
+
+        private Block createRLEChannel()
+        {
+            return RunLengthEncodedBlock.create(BIGINT, 0, POSITIONS_PER_PAGE);
+        }
+        
+        private void createBigintValues()
+        {
+            longValues = new long[PAGE_COUNT][channelCount][POSITIONS_PER_PAGE];
+            for (int pageIndex = 0; pageIndex < PAGE_COUNT; pageIndex++) {
+                for (int channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+                    for (int position = 0; position < POSITIONS_PER_PAGE; position++) {
+                        longValues[pageIndex][channelIndex][position] = (long) position;
+                    }
+                }
+            }
+        }
+
+        private void createBigintValuesForDictionary()
+        {
+            longValuesForDicitionary = new long[PAGE_COUNT][channelCount][DICTIONARY_SIZE];
+            for (int pageIndex = 0; pageIndex < PAGE_COUNT; pageIndex++) {
+                for (int channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+                    for (int position = 0; position < DICTIONARY_SIZE; position++) {
+                        longValuesForDicitionary[pageIndex][channelIndex][position] = (long) position;
+                    }
+                }
+            }
+        }
+
+        private void createIds()
+        {
+            ids = new int[PAGE_COUNT][channelCount][POSITIONS_PER_PAGE];
+            for (int pageIndex = 0; pageIndex < PAGE_COUNT; pageIndex++) {
+                for (int channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+                    for (int position = 0; position < POSITIONS_PER_PAGE; position++) {
+                        ids[pageIndex][channelIndex][position] = ThreadLocalRandom.current().nextInt(DICTIONARY_SIZE);
+                    }
+                }
+            }
+        }
+
+        private void createNulls()
+        {
+            nulls = new boolean[PAGE_COUNT][channelCount][POSITIONS_PER_PAGE];
+            for (int pageIndex = 0; pageIndex < PAGE_COUNT; pageIndex++) {
+                for (int channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+                    for (int position = 0; position < POSITIONS_PER_PAGE; position++) {
+                        nulls[pageIndex][channelIndex][position] = ThreadLocalRandom.current().nextBoolean();
+                    }
+                }
+            }
+        }
+
+        private void createBigintByteArrayBuffers()
+        {
+            longValuesBuffers = new byte[PARTITION_COUNT][channelCount][PAGE_COUNT * POSITIONS_PER_PAGE * ARRAY_LONG_INDEX_SCALE];
+        }
+
+        private void createBigintByteArrayBufferIndex()
+        {
+            longValueBufferIndexes = new int[PARTITION_COUNT][channelCount];
+        }
+
+        private void createBasicSliceOutput()
+        {
+            basicSliceOutput = new BasicSliceOutput[PARTITION_COUNT][channelCount];
+            for (int partitionIndex = 0; partitionIndex < PARTITION_COUNT; partitionIndex++) {
+                for (int channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+                    Slice slice = Slices.wrappedBuffer(new byte[PAGE_COUNT * POSITIONS_PER_PAGE * ARRAY_LONG_INDEX_SCALE]);
+                    basicSliceOutput[partitionIndex][channelIndex] = slice.getOutput();
+                }
+            }
+        }
+
+        private void createDynamicSliceOutput()
+        {
+            dynamicSliceOutput = new DynamicSliceOutput[PARTITION_COUNT][channelCount];
+            for (int partitionIndex = 0; partitionIndex < PARTITION_COUNT; partitionIndex++) {
+                for (int channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+                    dynamicSliceOutput[partitionIndex][channelIndex] = new DynamicSliceOutput(1024 * ARRAY_LONG_INDEX_SCALE);
+                }
+            }
+        }
+
+        private void createTestingSliceOutput()
+        {
+            testingSliceOutput = new TestingSliceOutput[PARTITION_COUNT][channelCount];
+            for (int partitionIndex = 0; partitionIndex < PARTITION_COUNT; partitionIndex++) {
+                for (int channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+                    testingSliceOutput[partitionIndex][channelIndex] = new TestingSliceOutput(10 * PAGE_COUNT * POSITIONS_PER_PAGE * ARRAY_LONG_INDEX_SCALE);
+                }
+            }
+        }
+
+        private void populatePositions()
+        {
+            for (int i = 0; i < POSITIONS_PER_PAGE; i++) {
+                int partition = ThreadLocalRandom.current().nextInt(PARTITION_COUNT);
+                int indexForPartition = positionCounts[partition];
+                positions[partition][indexForPartition] = i;
+                positionCounts[partition]++;
+            }
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+//        new BenchmarkPartitionedOutputOperatorAppendToBuffers().copyUncheckedDictionaryBigintPagesToByteArrayBuffer(data);
+//        new BenchmarkPartitionedOutputOperatorAppendToBuffers().copyLongValuesToByteArrayBuffer(data);
+//        new BenchmarkPartitionedOutputOperatorAppendToBuffers().copyLongValuesToByteArrayBuffer(data);
+//        new BenchmarkPartitionedOutputOperatorAppendToBuffers().copyLongValuesToByteArrayBuffer2(data);
+//        new BenchmarkPartitionedOutputOperatorAppendToBuffers().copyLongPagesToByteArrayBuffer(data);
+//        new BenchmarkPartitionedOutputOperatorAppendToBuffers().copyLongPagesToByteArrayBuffer2(data);
+//        new BenchmarkPartitionedOutputOperatorAppendToBuffers().addCompositeValuesToByteArrayBuffer(data);
+//        new BenchmarkPartitionedOutputOperatorAppendToBuffers().copyLongValuesToDynamicSliceOutput(data);
+       // new BenchmarkPartitionedOutputOperatorAppendToBuffers().copyLongPagesToDynamicSliceOutput(data);
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .jvmArgs("-Xmx40g") //,
+//                        "-XX:+UnlockDiagnosticVMOptions",
+//                        "-XX:+PrintAssembly",
+//                        "-XX:PrintAssemblyOptions=intel",
+//                        "-XX:CompileCommand=print,*BenchmarkPartitionedOutputOperatorAppendToBuffers.copyCompositePagesToByteArrayBuffer")
+
+                .include(".*" + BenchmarkPartitionedOutputOperatorAppendToBuffers.class.getSimpleName() + ".*")
+                .addProfiler(LinuxPerfAsmProfiler.class, "events=cpu-clock")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -116,7 +116,8 @@ public class TestFeaturesConfig
                 .setLegacyUnnestArrayRows(false)
                 .setJsonSerdeCodeGenerationEnabled(false)
                 .setPushLimitThroughOuterJoin(true)
-                .setMaxConcurrentMaterializations(10));
+                .setMaxConcurrentMaterializations(10)
+                .setPushLimitThroughOuterJoin(true));
     }
 
     @Test
@@ -192,6 +193,7 @@ public class TestFeaturesConfig
                 .put("experimental.json-serde-codegen-enabled", "true")
                 .put("optimizer.push-limit-through-outer-join", "false")
                 .put("max-concurrent-materializations", "5")
+                .put("experimental.use-optimized-partitioned-output", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -263,7 +265,8 @@ public class TestFeaturesConfig
                 .setDefaultFilterFactorEnabled(true)
                 .setJsonSerdeCodeGenerationEnabled(true)
                 .setPushLimitThroughOuterJoin(false)
-                .setMaxConcurrentMaterializations(5);
+                .setMaxConcurrentMaterializations(5)
+                .setPushLimitThroughOuterJoin(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
@@ -25,7 +25,7 @@ public abstract class AbstractVariableWidthBlock
 {
     protected abstract Slice getRawSlice(int position);
 
-    protected abstract int getPositionOffset(int position);
+    public abstract int getPositionOffset(int position);
 
     protected abstract boolean isEntryNull(int position);
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarArray.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarArray.java
@@ -136,7 +136,7 @@ public class ColumnarArray
         return getOffset(position + 1) - getOffset(position);
     }
 
-    private int getOffset(int position)
+    public int getOffset(int position)
     {
         return offsets[position + offsetsOffset];
     }
@@ -144,5 +144,10 @@ public class ColumnarArray
     public Block getElementsBlock()
     {
         return elementsBlock;
+    }
+
+    public Block getNullCheckBlock()
+    {
+        return nullCheckBlock;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarRow.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarRow.java
@@ -134,4 +134,14 @@ public final class ColumnarRow
     {
         return fields[index];
     }
+
+    public int getOffset(int position)
+    {
+        return ((AbstractRowBlock) nullCheckBlock).getFieldBlockOffset(position);
+    }
+
+    public Block getNullCheckBlock()
+    {
+        return nullCheckBlock;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
@@ -83,7 +83,7 @@ public class VariableWidthBlock
     }
 
     @Override
-    protected final int getPositionOffset(int position)
+    public final int getPositionOffset(int position)
     {
         return offsets[position + arrayOffset];
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -78,7 +78,7 @@ public class VariableWidthBlockBuilder
     }
 
     @Override
-    protected int getPositionOffset(int position)
+    public int getPositionOffset(int position)
     {
         checkValidPosition(position, positions);
         return getOffset(position);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/LongDecimalType.java
@@ -29,7 +29,7 @@ import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.UNSCALED
 import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.compare;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 
-final class LongDecimalType
+public final class LongDecimalType
         extends DecimalType
 {
     LongDecimalType(int precision, int scale)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ShortDecimalType.java
@@ -26,7 +26,7 @@ import java.math.BigInteger;
 import static com.facebook.presto.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 
-final class ShortDecimalType
+public final class ShortDecimalType
         extends DecimalType
 {
     ShortDecimalType(int precision, int scale)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -168,6 +168,23 @@ public class H2QueryRunner
                 "  comment VARCHAR(23) NOT NULL\n" +
                 ")");
         insertRows(tpchMetadata, PART);
+
+        handle.execute("CREATE TABLE lineitem_nulls AS\n" +
+                "SELECT *\n" +
+                "FROM (\n" +
+                "   SELECT \n" +
+                "       orderkey,\n" +
+                "       linenumber,\n" +
+                "       have_simple_nulls and mod(orderkey + linenumber, 5) = 0 AS have_complex_nulls,\n" +
+                "       CASEWHEN(have_simple_nulls and mod(orderkey + linenumber, 11) = 0, null, partkey) as partkey,\n" +
+                "       CASEWHEN(have_simple_nulls and mod(orderkey + linenumber, 13) = 0, null, suppkey) as suppkey,\n" +
+                "       CASEWHEN(have_simple_nulls and mod (orderkey + linenumber, 17) = 0, null, quantity) as quantity,\n" +
+                "       CASEWHEN(have_simple_nulls and mod (orderkey + linenumber, 19) = 0, null, extendedprice) as extendedprice,\n" +
+                "       CASEWHEN(have_simple_nulls and mod (orderkey + linenumber, 23) = 0, null, shipmode) as shipmode,\n" +
+                "       CASEWHEN(have_simple_nulls and mod (orderkey + linenumber, 7) = 0, null, comment) as comment,\n" +
+                "       CASEWHEN(have_simple_nulls and mod(orderkey + linenumber, 31) = 0, null, returnflag = 'R') as is_returned,\n" +
+                "       CASEWHEN(have_simple_nulls and mod(orderkey + linenumber, 37) = 0, null, CAST(quantity + 1 as real)) as float_quantity\n" +
+                "   FROM (SELECT mod(orderkey, 198000) > 99000 as have_simple_nulls, * FROM lineitem))\n");
     }
 
     private void insertRows(TpchMetadata tpchMetadata, TpchTable tpchTable)


### PR DESCRIPTION
This is the WIP PR for https://github.com/prestodb/presto/issues/13015

The new PartitionedOutputOperator skips the block building step, and
directly append the data into buffers, then wrap the buffers into
SerializedPage.

JMH benchmark only 1000-5000 pages with 8296 rows with 1-2 channels
shows improvement up to 3x.

Has Nulls?	| 	FALSE|	FALSE|	FALSE |	FALSE|	TRUE	|TRUE	|TRUE|	TRUE
-----------------------|---------|------------|--------|---------|-----------|--------|----------|-------
#channels	| 	1|	2|	1 |	2|	1	|2	|1|	2
 New implementation? |	FALSE |	 TRUE 	| FALSE |	 TRUE |	 FALSE 	| TRUE |	 FALSE 	| TRUE
 ARRAY(BIGINT) 	 |	3,850 |	 1,171 	| 7,015 |	 2,070 	| 2,734 |	 1,345 |	 6,709 |	 2,328
 ARRAY(VARCHAR) |	7,789 |	 3,577 	| 13,821  |7,113 	| 5,399 |	 4,189 |	 13,549 | 8,167
 BIGINT 	 |	4,017 |	 1,300 |	 6,019 	| 1,903 |	 3,904 	| 1,548 	| 5,793 |	 2,945
 BOOLEAN 	 |	3,897 	| 1,295 	| 5,200 	| 1,636 	| 3,993 	| 1,686 	| 5,353 	| 2,506
 DECIMAL 	 |	4,850 	| 1,648 	| 7,461 	| 2,116 	| 4,792 	| 2,266 	| 6,935 	| 3,086
 DICTIONARY 	 |	4,357 	| 1,674 	 |7,661 	| 2,645 	| 4,012 	 |1,844 	| 7,170 	| 2,882
 DOUBLE 	 |	4,163 	| 1,288 	 |5,867 	 |1,613 	 |4,076 	 |1,921 	| 5,619 	| 2,490
 VARCHAR 	 |	5,981 	| 2,999 	 |10,248  | 4,514 	| 5,752 	| 3,333 	 |9,744 	| 5,284
 MAP(BIGINT, VARCHAR) |	8,600 	| 4,565 	| 17,535 | 11,512 	| 7,760 	 |4,336 	| 15,890 |10,041

Initial verifier run on random 150~ queries show 34% improvement in PartitionedOutputOperator
and 27% overall.
