### PR TITLE
WIP - RepartitionedOutputOperator optimizations

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithOptimizedRepartitioning.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithOptimizedRepartitioning.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.AbstractTestDistributedQueries;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.tree.ExplainType.Type.LOGICAL;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.airlift.tpch.TpchTable.getTables;
+import static org.testng.Assert.assertEquals;
+
+public class TestHiveDistributedQueriesWithOptimizedRepartitioning
+        extends AbstractTestDistributedQueries
+{
+    public TestHiveDistributedQueriesWithOptimizedRepartitioning()
+    {
+        super(() -> HiveQueryRunner.createQueryRunner(
+                getTables(),
+                ImmutableMap.of("experimental.optimized-repartitioning", "true",
+                        "driver.max-page-partitioning-buffer-size", "200B"),
+                Optional.empty()));
+    }
+
+    @Override
+    protected boolean supportsNotNullColumns()
+    {
+        return false;
+    }
+
+    @Override
+    public void testDelete()
+    {
+        // Hive connector currently does not support row-by-row delete
+    }
+
+    @Test
+    public void testExplainOfCreateTableAs()
+    {
+        String query = "CREATE TABLE copy_orders AS SELECT * FROM orders";
+        MaterializedResult result = computeActual("EXPLAIN " + query);
+        assertEquals(getOnlyElement(result.getOnlyColumnAsSet()), getExplainPlan(query, LOGICAL));
+    }
+
+    // Hive specific tests should normally go in TestHiveIntegrationSmokeTest
+}

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -130,6 +130,7 @@ public final class SystemSessionProperties
     public static final String PUSH_LIMIT_THROUGH_OUTER_JOIN = "push_limit_through_outer_join";
     public static final String MAX_CONCURRENT_MATERIALIZATIONS = "max_concurrent_materializations";
     public static final String PUSHDOWN_SUBFIELDS_ENABLED = "pushdown_subfields_enabled";
+    public static final String OPTIMIZED_REPARTITIONING_ENABLED = "optmized_repartitioning";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -626,6 +627,11 @@ public final class SystemSessionProperties
                         PUSHDOWN_SUBFIELDS_ENABLED,
                         "Experimental: enable subfield pruning",
                         featuresConfig.isPushdownSubfieldsEnabled(),
+                        false),
+                booleanProperty(
+                        OPTIMIZED_REPARTITIONING_ENABLED,
+                        "Experimental: Use optimized repartitioning",
+                        featuresConfig.isOptimizedRepartitioningEnabled(),
                         false));
     }
 
@@ -1062,5 +1068,10 @@ public final class SystemSessionProperties
     public static boolean isPushdownSubfieldsEnabled(Session session)
     {
         return session.getSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, Boolean.class);
+    }
+
+    public static boolean isOptimizedRepartitioningEnabled(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZED_REPARTITIONING_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/TestingPartitionedOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/TestingPartitionedOutputBuffer.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.buffer;
+
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.StateMachine;
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import io.airlift.units.DataSize;
+
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+public class TestingPartitionedOutputBuffer
+        extends PartitionedOutputBuffer
+{
+    public TestingPartitionedOutputBuffer(
+            String taskInstanceId,
+            StateMachine<BufferState> state,
+            OutputBuffers outputBuffers,
+            DataSize maxBufferSize,
+            Supplier<LocalMemoryContext> systemMemoryContextSupplier,
+            Executor notificationExecutor)
+    {
+        super(taskInstanceId, state, outputBuffers, maxBufferSize, systemMemoryContextSupplier, notificationExecutor);
+    }
+
+    @Override
+    public void enqueue(Lifespan lifespan, int partitionNumber, List<SerializedPage> pages)
+    {
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ArrayBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ArrayBlockEncodingBuffers.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.ColumnarArray;
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.UncheckedByteArrays.setInt;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+
+public class ArrayBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    @VisibleForTesting
+    public static final int POSITION_SIZE = SIZE_OF_INT + SIZE_OF_BYTE;
+
+    private static final String NAME = "ARRAY";
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ArrayBlockEncodingBuffers.class).instanceSize();
+
+    // The buffer for the offsets for all incoming blocks so far
+    private byte[] offsetsBuffer;
+
+    // The address that the next offset value will be written to.
+    private int offsetsBufferIndex;
+
+    // This array holds the condensed offsets for each position for the incoming block.
+    private int[] offsets;
+
+    // The last offset in the offsets buffer
+    private int lastOffset;
+
+    // This array holds the offsets into its nested raw block for each top level row.
+    private int[] offsetsOffsets;
+
+    // The current incoming ArrayBlock is converted into ColumnarArray
+    private ColumnarArray columnarArray;
+
+    private final BlockEncodingBuffers elementsBuffers;
+
+    public ArrayBlockEncodingBuffers(DecodedBlockNode decodedBlockNode, int initialPositionCount)
+    {
+        super(initialPositionCount);
+        elementsBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0), initialPositionCount);
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        offsetsBuffer = new byte[initialPositionCount * ARRAY_INT_INDEX_SCALE];
+        offsetsBufferIndex = 0;
+
+        elementsBuffers.prepareBuffers();
+    }
+
+    @Override
+    public void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        offsetsBufferIndex = 0;
+        lastOffset = 0;
+        resetNullsBuffer();
+
+        elementsBuffers.resetBuffers();
+    }
+
+    @Override
+    protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode)
+    {
+        requireNonNull(decodedBlockNode, "decodedBlockNode is null");
+
+        decodedBlockNode = mapPositions(decodedBlockNode);
+        columnarArray = (ColumnarArray) decodedBlockNode.getDecodedBlock();
+        decodedBlock = columnarArray.getNullCheckBlock();
+
+        populateNestedPositions();
+
+        elementsBuffers.setupDecodedBlockAndMapPositions(decodedBlockNode.getChildren().get(0));
+    }
+
+    @Override
+    public void accumulateRowSizes(int[] rowSizes)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += POSITION_SIZE;
+        }
+
+        ensureOffsetsOffsetsCapacity();
+        System.arraycopy(offsets, 0, offsetsOffsets, 0, positionCount + 1);
+
+        elementsBuffers.accumulateRowSizes(offsetsOffsets, positionCount, rowSizes);
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] offsetsOffsets, int positionCount, int[] rowSizes)
+    {
+        // The nested level positionCount could be 0.
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int lastOffset = offsetsOffsets[0];
+        for (int i = 0; i < positionCount; i++) {
+            int offset = offsetsOffsets[i + 1];
+            rowSizes[i] += POSITION_SIZE * (offset - lastOffset);
+            lastOffset = offset;
+            offsetsOffsets[i + 1] = offsets[offset];
+        }
+
+        // this.offsetsBuffer and Next level positions should have already be written
+        elementsBuffers.accumulateRowSizes(offsetsOffsets, positionCount, rowSizes);
+    }
+
+    @Override
+    public void setNextBatch(int positionsOffset, int batchSize)
+    {
+        this.positionsOffset = positionsOffset;
+        this.batchSize = batchSize;
+
+        // The nested level positionCount could be 0.
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int offset = offsets[positionsOffset];
+
+        elementsBuffers.setNextBatch(offset, offsets[positionsOffset + batchSize] - offset);
+    }
+
+    @Override
+    public void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        appendNulls();
+        appendOffsets();
+        elementsBuffers.copyValues();
+
+        bufferedPositionCount += batchSize;
+    }
+
+    @Override
+    public void serializeTo(SliceOutput output)
+    {
+        writeLengthPrefixedString(output, NAME);
+
+        elementsBuffers.serializeTo(output);
+
+        output.writeInt(bufferedPositionCount);
+
+        output.writeInt(0);  // the base position
+        output.appendBytes(offsetsBuffer, 0, offsetsBufferIndex);
+
+        serializeNullsTo(output);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return getPositionsSizeInBytes() +      // positions and mappedPositions
+                offsetsBufferIndex +
+                positionCount * SIZE_OF_INT * 2 +   // offsets and offsetsOffsets
+                getNullsBufferSizeInBytes() +
+                columnarArray.getSizeInBytes();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE +
+                getPostionsRetainedSizeInBytes() +
+                sizeOf(offsetsBuffer) +
+                sizeOf(offsets) +
+                sizeOf(offsetsOffsets) +
+                getNullsBufferRetainedSizeInBytes() +
+                columnarArray.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public long getSerializedSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +            // encoding name
+                elementsBuffers.getSerializedSizeInBytes() +   // nested block
+                SIZE_OF_INT +                           // positionCount
+                SIZE_OF_INT +                           // offset 0. The offsetsBuffer doesn't contain the offset 0 so we need to add it here.
+                offsetsBufferIndex +                    // offsets buffer.
+                getNullsBufferSerializedSizeInBytes();  // nulls
+    }
+
+    private void populateNestedPositions()
+    {
+        // Nested level positions always start from 0.
+        elementsBuffers.positionsOffset = 0;
+        elementsBuffers.positionCount = 0;
+        elementsBuffers.isPositionsMapped = false;
+
+        if (positionCount == 0) {
+            return;
+        }
+
+        ensureOffsetsCapacity();
+
+        int[] positions = getPositions();
+
+        int columnarArrayBaseOffset = columnarArray.getOffset(0);
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            int beginOffset = columnarArray.getOffset(position);
+            int endOffset = columnarArray.getOffset(position + 1);
+            int currentRowSize = endOffset - beginOffset;
+
+            offsets[i + 1] = offsets[i] + currentRowSize;
+
+            if (currentRowSize > 0) {
+                // beginOffsetInBlock is the absolute position in the nested block. We need to subtract the base offset from it to get the logical position.
+                elementsBuffers.appendPositionRange(beginOffset - columnarArrayBaseOffset, currentRowSize);
+            }
+        }
+    }
+
+    private void appendOffsets()
+    {
+        ensureOffsetsBufferCapacity();
+
+        int baseOffset = lastOffset - offsets[positionsOffset];
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            offsetsBufferIndex = setInt(offsetsBuffer, offsetsBufferIndex, offsets[i + 1] + baseOffset);
+        }
+        lastOffset = offsets[positionsOffset + batchSize] + baseOffset;
+    }
+
+    private void ensureOffsetsCapacity()
+    {
+        if (offsets == null || offsets.length < positionCount + 1) {
+            offsets = new int[positionCount * 2];
+        }
+    }
+
+    private void ensureOffsetsOffsetsCapacity()
+    {
+        if (offsetsOffsets == null || offsetsOffsets.length < positionCount + 1) {
+            offsetsOffsets = new int[positionCount * 2];
+        }
+    }
+
+    private void ensureOffsetsBufferCapacity()
+    {
+        int capacity = offsetsBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE;
+        if (offsetsBuffer.length < capacity) {
+            offsetsBuffer = Arrays.copyOf(offsetsBuffer, max(capacity, offsetsBuffer.length * 2));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
@@ -108,6 +108,10 @@ public abstract class BlockEncodingBuffers
             return new LongArrayBlockEncodingBuffers(initialPositionCount);
         }
 
+        if (decodedBlock instanceof Int128ArrayBlock) {
+            return new Int128ArrayBlockEncodingBuffers(initialPositionCount);
+        }
+
         throw new IllegalArgumentException("Unsupported encoding: " + decodedBlock.getClass().getSimpleName());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
@@ -112,6 +112,10 @@ public abstract class BlockEncodingBuffers
             return new IntArrayBlockEncodingBuffers(initialPositionCount);
         }
 
+        if (decodedBlock instanceof ByteArrayBlock) {
+            return new ByteArrayBlockEncodingBuffers(initialPositionCount);
+        }
+
         if (decodedBlock instanceof ShortArrayBlock) {
             return new ShortArrayBlockEncodingBuffers(initialPositionCount);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
@@ -112,6 +112,10 @@ public abstract class BlockEncodingBuffers
             return new IntArrayBlockEncodingBuffers(initialPositionCount);
         }
 
+        if (decodedBlock instanceof ShortArrayBlock) {
+            return new ShortArrayBlockEncodingBuffers(initialPositionCount);
+        }
+
         if (decodedBlock instanceof Int128ArrayBlock) {
             return new Int128ArrayBlockEncodingBuffers(initialPositionCount);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
@@ -1,0 +1,442 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.ByteArrayBlock;
+import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.Int128ArrayBlock;
+import com.facebook.presto.spi.block.IntArrayBlock;
+import com.facebook.presto.spi.block.LongArrayBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.block.ShortArrayBlock;
+import io.airlift.slice.SliceOutput;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.UncheckedByteArrays.fill;
+import static com.facebook.presto.operator.UncheckedByteArrays.setByte;
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public abstract class BlockEncodingBuffers
+{
+    private static final int BITS_IN_BYTE = 8;
+    private static final int INITIAL_POSITION_COUNT = 1024;
+
+    // The initial buffer size in terms of number of elements
+    protected final int initialPositionCount;
+
+    // The block after peeling off the Dictionary or RLE wrappings.
+    protected Block decodedBlock;
+
+    // The number of positions (rows) to be copied from the incoming block.
+    protected int positionCount;
+
+    // The number of positions (rows) to be copied from the incoming block within current batch.
+    protected int batchSize;
+
+    // The offset into positions/mappedPositions array that the current batch starts copying.
+    // I.e. in each batch we copy the values of rows from positions[positionsOffset] to positions[positionsOffset + batchSize]
+    protected int positionsOffset;
+
+    // The number of positions (rows) buffered so far
+    protected int bufferedPositionCount;
+
+    // Whether the positions array was mapped to mappedPositions
+    protected boolean isPositionsMapped;
+
+    // The positions (row numbers) of the incoming Block to be copied to this buffer.
+    // All top level BlockEncodingBuffers for the same partition share the same positions array.
+    private int[] positions;
+
+    // The mapped positions of the incoming Dictionary or RLE Block
+    @Nullable
+    private int[] mappedPositions;
+
+    @Nullable
+    private byte[] nullsBuffer;
+
+    // The address offset in the nullsBuffer if new values are to be added.
+    private int nullsBufferIndex;
+
+    // For each batch we put the nulls values up to a multiple of 8 into nullsBuffer. The rest is kept in remainingNullsFromLastBatch.
+    private final boolean[] remainingNullsFromLastBatch = new boolean[BITS_IN_BYTE];
+
+    // Number of null values not put into nullsBuffer from last batch
+    private int remainingNullsCount;
+
+    // Whether nullsBuffer contains nulls. It is possible that the nullsBuffer contains all non-nulls.
+    private boolean nullsBufferContainsNull;
+
+    public static BlockEncodingBuffers createBlockEncodingBuffers(DecodedBlockNode decodedBlockNode, int initialPositionCount)
+    {
+        requireNonNull(decodedBlockNode, "decodedBlockNode is null");
+
+        Object decodedBlock = decodedBlockNode.getDecodedBlock();
+
+        // Skip the Dictionary/Rle block node. The mapping info is not needed when creating buffers.
+        if (decodedBlock instanceof DictionaryBlock) {
+            decodedBlockNode = decodedBlockNode.getChildren().get(0);
+            decodedBlock = decodedBlockNode.getDecodedBlock();
+        }
+
+        if (decodedBlock instanceof RunLengthEncodedBlock) {
+            decodedBlockNode = decodedBlockNode.getChildren().get(0);
+            decodedBlock = decodedBlockNode.getDecodedBlock();
+        }
+
+        if (decodedBlock instanceof LongArrayBlock) {
+            return new LongArrayBlockEncodingBuffers(initialPositionCount);
+        }
+
+        throw new IllegalArgumentException("Unsupported encoding: " + decodedBlock.getClass().getSimpleName());
+    }
+
+    public BlockEncodingBuffers(int initialPositionCount)
+    {
+        this.initialPositionCount = initialPositionCount;
+    }
+
+    protected static void writeLengthPrefixedString(SliceOutput output, String value)
+    {
+        byte[] bytes = value.getBytes(UTF_8);
+        output.writeInt(bytes.length);
+        output.writeBytes(bytes);
+    }
+
+    protected abstract void prepareBuffers();
+
+    public abstract void resetBuffers();
+
+    protected void resetNullsBuffer()
+    {
+        nullsBufferIndex = 0;
+        remainingNullsCount = 0;
+        nullsBufferContainsNull = false;
+    }
+
+    public void setNextBatch(int positionsOffset, int batchSize)
+    {
+        this.positionsOffset = positionsOffset;
+        this.batchSize = batchSize;
+    }
+
+    public abstract void copyValues();
+
+    public abstract void serializeTo(SliceOutput sliceOutput);
+
+    public abstract long getSizeInBytes();
+
+    public abstract long getRetainedSizeInBytes();
+
+    public abstract long getSerializedSizeInBytes();
+
+    public abstract void accumulateRowSizes(int[] rowSizes);
+
+    protected abstract void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes);
+
+    public void setupDecodedBlocksAndPositions(DecodedBlockNode decodedBlockNode, int[] positions, int positionCount)
+    {
+        requireNonNull(decodedBlockNode, "decodedBlockNode is null");
+        requireNonNull(positions, "positions is null");
+
+        this.positions = positions;
+        this.positionCount = positionCount;
+        this.positionsOffset = 0;
+
+        setupDecodedBlockAndMapPositions(decodedBlockNode);
+    }
+
+    protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode)
+    {
+        requireNonNull(decodedBlockNode, "decodedBlockNode is null");
+        decodedBlock = (Block) mapPositions(decodedBlockNode).getDecodedBlock();
+    }
+
+    protected DecodedBlockNode mapPositions(DecodedBlockNode decodedBlockNode)
+    {
+        Object decodedObject = decodedBlockNode.getDecodedBlock();
+
+        if (decodedObject instanceof DictionaryBlock) {
+            mapPositionsForDictionary((DictionaryBlock) decodedObject);
+            isPositionsMapped = true;
+            return decodedBlockNode.getChildren().get(0);
+        }
+
+        if (decodedObject instanceof RunLengthEncodedBlock) {
+            mapPositionsForRle();
+            isPositionsMapped = true;
+            return decodedBlockNode.getChildren().get(0);
+        }
+
+        isPositionsMapped = false;
+        return decodedBlockNode;
+    }
+
+    protected void mapPositionsForDictionary(DictionaryBlock dictionaryBlock)
+    {
+        requireNonNull(dictionaryBlock, "decodedBlockNode is null");
+
+        ensureMappedPositionsCapacity(positionCount);
+        for (int i = 0; i < positionCount; i++) {
+            mappedPositions[i] = dictionaryBlock.getId(positions[i]);
+        }
+    }
+
+    protected void mapPositionsForRle()
+    {
+        ensureMappedPositionsCapacity(positionCount);
+        Arrays.fill(mappedPositions, 0, positionCount, 0);
+    }
+
+    protected void appendPositionRange(int offset, int addedLength)
+    {
+        ensurePositionsCapacity(positionCount + addedLength);
+        for (int i = 0; i < addedLength; i++) {
+            positions[positionCount++] = offset + i;
+        }
+    }
+
+    protected int[] getPositions()
+    {
+        if (isPositionsMapped) {
+            verify(mappedPositions != null);
+            return mappedPositions;
+        }
+
+        return positions;
+    }
+
+    protected void appendNulls()
+    {
+        if (decodedBlock.mayHaveNull()) {
+            // Write to nullsBuffer if there is a possibility to have nulls. It is possible that the
+            // decodedBlock contains nulls, but rows that go into this partition don't. Write to nullsBuffer anyway.
+            ensureNullsValueBufferCapacity();
+            int bufferedNullsCount = nullsBufferIndex * BITS_IN_BYTE + remainingNullsCount;
+
+            if (bufferedPositionCount > bufferedNullsCount) {
+                // There are no nulls in positions (bufferedNullsCount, bufferedPositionCount]
+                encodeNonNullsAsBits(bufferedPositionCount - bufferedNullsCount);
+            }
+
+            // Append this batch
+            encodeNullsAsBits(decodedBlock);
+        }
+        else if (containsNull()) {
+            // There were nulls in previously buffered rows, but for this batch there can't be any nulls.
+            // Any how we need to append 0's for this batch.
+            ensureNullsValueBufferCapacity();
+            encodeNonNullsAsBits(batchSize);
+        }
+    }
+
+    protected void serializeNullsTo(SliceOutput output)
+    {
+        encodeRemainingNullsAsBits();
+
+        if (nullsBufferContainsNull) {
+            output.writeBoolean(true);
+            output.appendBytes(nullsBuffer, 0, nullsBufferIndex);
+        }
+        else {
+            output.writeBoolean(false);
+        }
+    }
+
+    private boolean containsNull()
+    {
+        if (nullsBufferContainsNull) {
+            return true;
+        }
+        for (int i = 0; i < remainingNullsCount; i++) {
+            if (remainingNullsFromLastBatch[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void encodeNullsAsBits(Block block)
+    {
+        int[] positions = getPositions();
+
+        if (remainingNullsCount + batchSize < BITS_IN_BYTE) {
+            // just put all of this batch to remainingNullsFromLastBatch
+            for (int offset = positionsOffset; offset < positionsOffset + batchSize; offset++) {
+                remainingNullsFromLastBatch[remainingNullsCount++] = block.isNull(positions[offset]);
+            }
+            return;
+        }
+
+        // Process the remaining nulls from last batch
+        int offset = positionsOffset;
+
+        if (remainingNullsCount > 0) {
+            byte value = 0;
+
+            for (int i = 0; i < remainingNullsCount; i++) {
+                value |= remainingNullsFromLastBatch[i] ? 0b1000_0000 >>> i : 0;
+            }
+
+            // process a few more nulls to make up one byte
+            for (int i = remainingNullsCount; i < BITS_IN_BYTE; i++) {
+                value |= block.isNull(positions[offset++]) ? 0b1000_0000 >>> i : 0;
+            }
+
+            nullsBufferContainsNull |= (value != 0);
+            nullsBufferIndex = setByte(nullsBuffer, nullsBufferIndex, value);
+
+            remainingNullsCount = 0;
+        }
+
+        // Process the next BITS_IN_BYTE * n positions. We now have processed (offset - positionsOffset) positions
+        int remainingPositions = batchSize - (offset - positionsOffset);
+        int positionsToEncode = remainingPositions & ~0b111;
+        for (int i = 0; i < positionsToEncode; i += BITS_IN_BYTE) {
+            byte value = 0;
+            value |= block.isNull(positions[offset]) ? 0b1000_0000 : 0;
+            value |= block.isNull(positions[offset + 1]) ? 0b0100_0000 : 0;
+            value |= block.isNull(positions[offset + 2]) ? 0b0010_0000 : 0;
+            value |= block.isNull(positions[offset + 3]) ? 0b0001_0000 : 0;
+            value |= block.isNull(positions[offset + 4]) ? 0b0000_1000 : 0;
+            value |= block.isNull(positions[offset + 5]) ? 0b0000_0100 : 0;
+            value |= block.isNull(positions[offset + 6]) ? 0b0000_0010 : 0;
+            value |= block.isNull(positions[offset + 7]) ? 0b0000_0001 : 0;
+
+            nullsBufferContainsNull |= (value != 0);
+            nullsBufferIndex = setByte(nullsBuffer, nullsBufferIndex, value);
+            offset += BITS_IN_BYTE;
+        }
+
+        // Process the remaining positions
+        remainingPositions &= 0b111;
+        while (remainingNullsCount < remainingPositions) {
+            remainingNullsFromLastBatch[remainingNullsCount++] = block.isNull(positions[offset++]);
+        }
+    }
+
+    private void encodeNonNullsAsBits(int count)
+    {
+        if (remainingNullsCount + count < BITS_IN_BYTE) {
+            // just put all of this batch to remainingNullsFromLastBatch
+            for (int i = 0; i < count; i++) {
+                remainingNullsFromLastBatch[remainingNullsCount++] = false;
+            }
+            return;
+        }
+
+        int remainingPositions = count - encodeRemainingNullsAsBits();
+        int bytesCount = remainingPositions >>> 3;
+
+        nullsBufferIndex = fill(nullsBuffer, nullsBufferIndex, bytesCount, (byte) 0);
+
+        remainingPositions &= 0b111;
+        while (remainingNullsCount < remainingPositions) {
+            remainingNullsFromLastBatch[remainingNullsCount++] = false;
+        }
+    }
+
+    private int encodeRemainingNullsAsBits()
+    {
+        if (remainingNullsCount == 0) {
+            return 0;
+        }
+
+        byte value = 0;
+        for (int i = 0; i < remainingNullsCount; i++) {
+            value |= remainingNullsFromLastBatch[i] ? 0b1000_0000 >>> i : 0;
+        }
+
+        nullsBufferContainsNull |= (value != 0);
+        nullsBufferIndex = setByte(nullsBuffer, nullsBufferIndex, value);
+
+        int padding = BITS_IN_BYTE - remainingNullsCount;
+        remainingNullsCount = 0;
+        return padding;
+    }
+
+    protected long getNullsBufferSizeInBytes()
+    {
+        return nullsBufferIndex +                               // nulls buffer
+                remainingNullsCount;   // the remaining nulls not serialized yet
+    }
+
+    protected long getNullsBufferRetainedSizeInBytes()
+    {
+        return sizeOf(nullsBuffer) +                    // nulls buffer
+                sizeOf(remainingNullsFromLastBatch);    // the remaining nulls not serialized yet
+    }
+
+    protected long getNullsBufferSerializedSizeInBytes()
+    {
+        long size = SIZE_OF_BYTE;       // nulls uses 1 byte for mayHaveNull
+        if (containsNull()) {
+            size += nullsBufferIndex +  // nulls buffer
+                    (remainingNullsCount > 0 ? SIZE_OF_BYTE : 0);   // The remaining nulls not serialized yet. We have to add it here because at the time of calling this function, the remaining nulls was not put into the nullsBuffer yet.
+        }
+        return size;
+    }
+
+    protected long getPositionsSizeInBytes()
+    {
+        if (mappedPositions != null) {
+            return 2 * SIZE_OF_INT * positionCount;
+        }
+        return SIZE_OF_INT * positionCount;
+    }
+
+    protected long getPostionsRetainedSizeInBytes()
+    {
+        return sizeOf(positions) + sizeOf(mappedPositions);
+    }
+
+    private void ensureMappedPositionsCapacity(int capacity)
+    {
+        if (mappedPositions == null || this.mappedPositions.length < capacity) {
+            mappedPositions = new int[max(INITIAL_POSITION_COUNT, capacity)];
+        }
+    }
+
+    private void ensurePositionsCapacity(int capacity)
+    {
+        // This is for the nested level buffers and the positions array could be null at the beginning
+        if (positions == null) {
+            positions = new int[max(INITIAL_POSITION_COUNT, capacity)];
+        }
+        else if (this.positions.length < capacity) {
+            positions = Arrays.copyOf(positions, max(positions.length * 2, capacity));
+        }
+    }
+
+    private void ensureNullsValueBufferCapacity()
+    {
+        int capacity = (bufferedPositionCount + batchSize) / BITS_IN_BYTE + 1;
+
+        if (nullsBuffer == null) {
+            nullsBuffer = new byte[max(initialPositionCount / BITS_IN_BYTE, capacity)];
+        }
+        else if (nullsBuffer.length < capacity) {
+            nullsBuffer = Arrays.copyOf(nullsBuffer, max(nullsBuffer.length * 2, capacity));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
@@ -15,6 +15,9 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.ByteArrayBlock;
+import com.facebook.presto.spi.block.ColumnarArray;
+import com.facebook.presto.spi.block.ColumnarMap;
+import com.facebook.presto.spi.block.ColumnarRow;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.block.Int128ArrayBlock;
 import com.facebook.presto.spi.block.IntArrayBlock;
@@ -119,6 +122,10 @@ public abstract class BlockEncodingBuffers
 
         if (decodedBlock instanceof ShortArrayBlock) {
             return new ShortArrayBlockEncodingBuffers(initialPositionCount);
+        }
+
+        if (decodedBlock instanceof ColumnarArray) {
+            return new ArrayBlockEncodingBuffers(decodedBlockNode, initialPositionCount);
         }
 
         if (decodedBlock instanceof Int128ArrayBlock) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.block.IntArrayBlock;
 import com.facebook.presto.spi.block.LongArrayBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.block.ShortArrayBlock;
+import com.facebook.presto.spi.block.VariableWidthBlock;
 import io.airlift.slice.SliceOutput;
 
 import javax.annotation.Nullable;
@@ -122,6 +123,10 @@ public abstract class BlockEncodingBuffers
 
         if (decodedBlock instanceof Int128ArrayBlock) {
             return new Int128ArrayBlockEncodingBuffers(initialPositionCount);
+        }
+
+        if (decodedBlock instanceof VariableWidthBlock) {
+            return new VariableWidthBlockEncodingBuffers(initialPositionCount);
         }
 
         throw new IllegalArgumentException("Unsupported encoding: " + decodedBlock.getClass().getSimpleName());

--- a/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
@@ -108,6 +108,10 @@ public abstract class BlockEncodingBuffers
             return new LongArrayBlockEncodingBuffers(initialPositionCount);
         }
 
+        if (decodedBlock instanceof IntArrayBlock) {
+            return new IntArrayBlockEncodingBuffers(initialPositionCount);
+        }
+
         if (decodedBlock instanceof Int128ArrayBlock) {
             return new Int128ArrayBlockEncodingBuffers(initialPositionCount);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
@@ -140,6 +140,9 @@ public abstract class BlockEncodingBuffers
             return new MapBlockEncodingBuffers(decodedBlockNode, initialPositionCount);
         }
 
+        if (decodedBlock instanceof ColumnarRow) {
+            return new RowBlockEncodingBuffers(decodedBlockNode, initialPositionCount);
+        }
         throw new IllegalArgumentException("Unsupported encoding: " + decodedBlock.getClass().getSimpleName());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BlockEncodingBuffers.java
@@ -136,6 +136,10 @@ public abstract class BlockEncodingBuffers
             return new VariableWidthBlockEncodingBuffers(initialPositionCount);
         }
 
+        if (decodedBlock instanceof ColumnarMap) {
+            return new MapBlockEncodingBuffers(decodedBlockNode, initialPositionCount);
+        }
+
         throw new IllegalArgumentException("Unsupported encoding: " + decodedBlock.getClass().getSimpleName());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/ByteArrayBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ByteArrayBlockEncodingBuffers.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.UncheckedByteArrays.setByte;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+
+public class ByteArrayBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    @VisibleForTesting
+    public static final int POSITION_SIZE = Byte.BYTES + Byte.BYTES;
+
+    private static final String NAME = "BYTE_ARRAY";
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ByteArrayBlockEncodingBuffers.class).instanceSize();
+
+    private byte[] valuesBuffer;
+    private int valuesBufferIndex;
+
+    public ByteArrayBlockEncodingBuffers(int initialPositionCount)
+    {
+        super(initialPositionCount);
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        valuesBuffer = new byte[initialPositionCount];
+        valuesBufferIndex = 0;
+    }
+
+    @Override
+    public void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        valuesBufferIndex = 0;
+        resetNullsBuffer();
+    }
+
+    @Override
+    public void accumulateRowSizes(int[] rowSizes)
+    {
+        throw new UnsupportedOperationException("accumulateRowSizes is not supported for fixed width types");
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += (positionOffsets[i + 1] - positionOffsets[i]) * POSITION_SIZE;
+        }
+    }
+
+    @Override
+    public void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        appendValuesToBuffer();
+        appendNulls();
+        bufferedPositionCount += batchSize;
+    }
+
+    public void serializeTo(SliceOutput sliceOutput)
+    {
+        writeLengthPrefixedString(sliceOutput, NAME);
+
+        sliceOutput.writeInt(bufferedPositionCount);
+
+        serializeNullsTo(sliceOutput);
+
+        sliceOutput.appendBytes(valuesBuffer, 0, valuesBufferIndex);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return getPositionsSizeInBytes() + // positions and mappedPositions
+                valuesBufferIndex +
+                getNullsBufferSizeInBytes();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE +
+                getPostionsRetainedSizeInBytes() +
+                sizeOf(valuesBuffer) +
+                getNullsBufferRetainedSizeInBytes();
+    }
+
+    @Override
+    public long getSerializedSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +    // NAME
+                SIZE_OF_INT +                   // positionCount
+                valuesBufferIndex +             // values buffer
+                getNullsBufferSerializedSizeInBytes();    // nulls buffer
+    }
+
+    private void appendValuesToBuffer()
+    {
+        ensureValueBufferCapacity();
+
+        int[] positions = getPositions();
+        if (decodedBlock.mayHaveNull()) {
+            for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+                int position = positions[i];
+                byte value = decodedBlock.getByte(position);
+                int newIndex = setByte(valuesBuffer, valuesBufferIndex, value);
+
+                if (!decodedBlock.isNull(position)) {
+                    valuesBufferIndex = newIndex;
+                }
+            }
+        }
+        else {
+            for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+                byte value = decodedBlock.getByte(positions[i]);
+                valuesBufferIndex = setByte(valuesBuffer, valuesBufferIndex, value);
+            }
+        }
+    }
+
+    private void ensureValueBufferCapacity()
+    {
+        int capacity = valuesBufferIndex + batchSize;
+        if (valuesBuffer.length < capacity) {
+            valuesBuffer = Arrays.copyOf(valuesBuffer, max(valuesBuffer.length * 2, capacity));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/DecodedBlockNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DecodedBlockNode.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.Block;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+class DecodedBlockNode
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(DecodedBlockNode.class).instanceSize();
+
+    private final Object decodedBlock;
+    private final List<DecodedBlockNode> children;
+
+    public DecodedBlockNode(Object decodedBlock, List<DecodedBlockNode> children)
+    {
+        this.decodedBlock = requireNonNull(decodedBlock, "decodedBlock is null");
+        this.children = requireNonNull(children, "children is null");
+    }
+
+    public Object getDecodedBlock()
+    {
+        return decodedBlock;
+    }
+
+    public List<DecodedBlockNode> getChildren()
+    {
+        return children;
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        int size = INSTANCE_SIZE;
+        if (decodedBlock instanceof Block) {
+            size += ((Block) decodedBlock).getRetainedSizeInBytes();
+        }
+
+        // TODO: count for Columnar objects
+
+        for (DecodedBlockNode child : children) {
+            size += child.getRetainedSizeInBytes();
+        }
+        return size;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/Int128ArrayBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Int128ArrayBlockEncodingBuffers.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.UncheckedByteArrays.setLong;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+
+public class Int128ArrayBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    @VisibleForTesting
+    public static final int POSITION_SIZE = Long.BYTES * 2 + Byte.BYTES;
+
+    private static final String NAME = "INT128_ARRAY";
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Int128ArrayBlockEncodingBuffers.class).instanceSize();
+
+    private byte[] valuesBuffer;
+    private int valuesBufferIndex;
+
+    public Int128ArrayBlockEncodingBuffers(int initialPositionCount)
+    {
+        super(initialPositionCount);
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        valuesBuffer = new byte[initialPositionCount * ARRAY_LONG_INDEX_SCALE * 2];
+        valuesBufferIndex = 0;
+    }
+
+    @Override
+    public void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        valuesBufferIndex = 0;
+        resetNullsBuffer();
+    }
+
+    @Override
+    public void accumulateRowSizes(int[] rowSizes)
+    {
+        throw new UnsupportedOperationException("accumulateRowSizes is not supported for fixed width types");
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += (positionOffsets[i + 1] - positionOffsets[i]) * POSITION_SIZE;
+        }
+    }
+
+    @Override
+    public void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        appendValuesToBuffer();
+        appendNulls();
+        bufferedPositionCount += batchSize;
+    }
+
+    public void serializeTo(SliceOutput sliceOutput)
+    {
+        writeLengthPrefixedString(sliceOutput, NAME);
+        sliceOutput.writeInt(bufferedPositionCount);
+        serializeNullsTo(sliceOutput);
+        sliceOutput.appendBytes(valuesBuffer, 0, valuesBufferIndex);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return getPositionsSizeInBytes() + // positions and mappedPositions
+                valuesBufferIndex +
+                getNullsBufferSizeInBytes();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE +
+                getPostionsRetainedSizeInBytes() +
+                sizeOf(valuesBuffer) +
+                getNullsBufferRetainedSizeInBytes();
+    }
+
+    @Override
+    public long getSerializedSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +    // NAME
+                SIZE_OF_INT +                   // positionCount
+                valuesBufferIndex +             // values buffer
+                getNullsBufferSerializedSizeInBytes();    // nulls buffer
+    }
+
+    private void appendValuesToBuffer()
+    {
+        ensureValueBufferCapacity();
+
+        int[] positions = getPositions();
+
+        if (decodedBlock.mayHaveNull()) {
+            for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+                int position = positions[i];
+
+                long value = decodedBlock.getLong(position, 0);
+                valuesBufferIndex = setLong(valuesBuffer, valuesBufferIndex, value);
+
+                value = decodedBlock.getLong(position, 8);
+                valuesBufferIndex = setLong(valuesBuffer, valuesBufferIndex, value);
+
+                if (decodedBlock.isNull(position)) {
+                    valuesBufferIndex -= ARRAY_LONG_INDEX_SCALE * 2;
+                }
+            }
+        }
+        else {
+            for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+                int position = positions[i];
+
+                long value = decodedBlock.getLong(position, 0);
+                valuesBufferIndex = setLong(valuesBuffer, valuesBufferIndex, value);
+
+                value = decodedBlock.getLong(position, 8);
+                valuesBufferIndex = setLong(valuesBuffer, valuesBufferIndex, value);
+            }
+        }
+    }
+
+    private void ensureValueBufferCapacity()
+    {
+        int capacity = valuesBufferIndex + batchSize * ARRAY_LONG_INDEX_SCALE * 2;
+        if (valuesBuffer.length < capacity) {
+            valuesBuffer = Arrays.copyOf(valuesBuffer, max(valuesBuffer.length * 2, capacity));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/IntArrayBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/IntArrayBlockEncodingBuffers.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.UncheckedByteArrays.setInt;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+
+public class IntArrayBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    @VisibleForTesting
+    public static final int POSITION_SIZE = Integer.BYTES + Byte.BYTES;
+
+    private static final String NAME = "INT_ARRAY";
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(IntArrayBlockEncodingBuffers.class).instanceSize();
+
+    private byte[] valuesBuffer;
+    private int valuesBufferIndex;
+
+    public IntArrayBlockEncodingBuffers(int initialPositionCount)
+    {
+        super(initialPositionCount);
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        valuesBuffer = new byte[initialPositionCount * ARRAY_INT_INDEX_SCALE];
+        valuesBufferIndex = 0;
+    }
+
+    @Override
+    public void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        valuesBufferIndex = 0;
+        resetNullsBuffer();
+    }
+
+    @Override
+    public void accumulateRowSizes(int[] rowSizes)
+    {
+        throw new UnsupportedOperationException("accumulateRowSizes is not supported for fixed width types");
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += (positionOffsets[i + 1] - positionOffsets[i]) * POSITION_SIZE;
+        }
+    }
+
+    @Override
+    public void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        appendValuesToBuffer();
+        appendNulls();
+        bufferedPositionCount += batchSize;
+    }
+
+    public void serializeTo(SliceOutput sliceOutput)
+    {
+        writeLengthPrefixedString(sliceOutput, NAME);
+        sliceOutput.writeInt(bufferedPositionCount);
+        serializeNullsTo(sliceOutput);
+        sliceOutput.appendBytes(valuesBuffer, 0, valuesBufferIndex);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return getPositionsSizeInBytes() + // positions and mappedPositions
+                valuesBufferIndex +
+                getNullsBufferSizeInBytes();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE +
+                getPostionsRetainedSizeInBytes() +
+                sizeOf(valuesBuffer) +
+                getNullsBufferRetainedSizeInBytes();
+    }
+
+    @Override
+    public long getSerializedSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +    // NAME
+                SIZE_OF_INT +                   // positionCount
+                getNullsBufferSerializedSizeInBytes() +  // nulls buffer
+                valuesBufferIndex;              // values buffer
+    }
+
+    private void appendValuesToBuffer()
+    {
+        ensureValueBufferCapacity();
+
+        int[] positions = getPositions();
+
+        if (decodedBlock.mayHaveNull()) {
+            for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+                int position = positions[i];
+                int value = decodedBlock.getInt(position);
+                int newIndex = setInt(valuesBuffer, valuesBufferIndex, value);
+
+                if (!decodedBlock.isNull(position)) {
+                    valuesBufferIndex = newIndex;
+                }
+            }
+        }
+        else {
+            for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+                int value = decodedBlock.getInt(positions[i]);
+                valuesBufferIndex = setInt(valuesBuffer, valuesBufferIndex, value);
+            }
+        }
+    }
+
+    private void ensureValueBufferCapacity()
+    {
+        int capacity = valuesBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE;
+        if (valuesBuffer.length < capacity) {
+            valuesBuffer = Arrays.copyOf(valuesBuffer, max(valuesBuffer.length * 2, capacity));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/LongArrayBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LongArrayBlockEncodingBuffers.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.UncheckedByteArrays.setLong;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+
+public class LongArrayBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    @VisibleForTesting
+    public static final int POSITION_SIZE = Long.BYTES + Byte.BYTES;
+
+    private static final String NAME = "LONG_ARRAY";
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongArrayBlockEncodingBuffers.class).instanceSize();
+
+    private byte[] valuesBuffer;
+    private int valuesBufferIndex;
+
+    public LongArrayBlockEncodingBuffers(int initialPositionCount)
+    {
+        super(initialPositionCount);
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        valuesBuffer = new byte[initialPositionCount * ARRAY_LONG_INDEX_SCALE];
+        valuesBufferIndex = 0;
+    }
+
+    @Override
+    public void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        valuesBufferIndex = 0;
+        resetNullsBuffer();
+    }
+
+    @Override
+    public void accumulateRowSizes(int[] rowSizes)
+    {
+        throw new UnsupportedOperationException("accumulateRowSizes is not supported for fixed width types");
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += (positionOffsets[i + 1] - positionOffsets[i]) * POSITION_SIZE;
+        }
+    }
+
+    @Override
+    public void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        appendValuesToBuffer();
+        appendNulls();
+        bufferedPositionCount += batchSize;
+    }
+
+    @Override
+    public void serializeTo(SliceOutput output)
+    {
+        writeLengthPrefixedString(output, NAME);
+        output.writeInt(bufferedPositionCount);
+        serializeNullsTo(output);
+        output.appendBytes(valuesBuffer, 0, valuesBufferIndex);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return getPositionsSizeInBytes() + // positions and mappedPositions
+                valuesBufferIndex +
+                getNullsBufferSizeInBytes();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE +
+                getPostionsRetainedSizeInBytes() +
+                sizeOf(valuesBuffer) +
+                getNullsBufferRetainedSizeInBytes();
+    }
+
+    @Override
+    public long getSerializedSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +    // NAME
+                SIZE_OF_INT +                   // positionCount
+                getNullsBufferSerializedSizeInBytes() +   // nulls buffer
+                valuesBufferIndex;              // values buffer
+    }
+
+    private void appendValuesToBuffer()
+    {
+        ensureValuesBufferCapacity();
+
+        int[] positions = getPositions();
+        if (decodedBlock.mayHaveNull()) {
+            for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+                int position = positions[i];
+                int newIndex = setLong(valuesBuffer, valuesBufferIndex, decodedBlock.getLong(position));
+
+                // Make sure the if block contains only one instruction so that it compiles to a conditional move (cmov)
+                if (!decodedBlock.isNull(position)) {
+                    valuesBufferIndex = newIndex;
+                }
+            }
+        }
+        else {
+            for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+                valuesBufferIndex = setLong(valuesBuffer, valuesBufferIndex, decodedBlock.getLong(positions[i]));
+            }
+        }
+    }
+
+    private void ensureValuesBufferCapacity()
+    {
+        int capacity = valuesBufferIndex + batchSize * ARRAY_LONG_INDEX_SCALE;
+
+        if (valuesBuffer.length < capacity) {
+            valuesBuffer = Arrays.copyOf(valuesBuffer, max(valuesBuffer.length * 2, capacity));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/MapBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MapBlockEncodingBuffers.java
@@ -1,0 +1,386 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.ColumnarMap;
+import com.facebook.presto.spi.type.TypeSerde;
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.facebook.presto.operator.UncheckedByteArrays.setInt;
+import static com.facebook.presto.operator.UncheckedByteArrays.setInts;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+
+public class MapBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    @VisibleForTesting
+    public static final int POSITION_SIZE = SIZE_OF_INT + SIZE_OF_BYTE;
+
+    private static final String NAME = "MAP";
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapBlockEncodingBuffers.class).instanceSize();
+
+    private static final int HASH_MULTIPLIER = 2;
+
+    // The buffer for the hashtables for all incoming blocks so far
+    private byte[] hashTablesBuffer;
+
+    // The address that the next hashtable entry will be written to.
+    private int hashTableBufferIndex;
+
+    // If any of the incoming blocks do not contain the hashtable, noHashTables is set to true.
+    private boolean noHashTables;
+
+    // The buffer for the offsets for all incoming blocks so far
+    private byte[] offsetsBuffer;
+
+    // The address that the next offset value will be written to.
+    private int offsetsBufferIndex;
+
+    // This array holds the condensed offsets for each position for the incoming block.
+    private int[] offsets;
+
+    // The last offset in the offsets buffer
+    private int lastOffset;
+
+    // This array holds the offsets into its nested raw block for each top level row.
+    private int[] keyOffsetsOffsets;
+    private int[] valueOffsetsOffsets;
+
+    // The current incoming MapBlock is converted into ColumnarMap
+    private ColumnarMap columnarMap;
+
+    private final BlockEncodingBuffers keyBuffers;
+    private final BlockEncodingBuffers valueBuffers;
+
+    public MapBlockEncodingBuffers(DecodedBlockNode decodedBlockNode, int initialPositionCount)
+    {
+        super(initialPositionCount);
+
+        keyBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0), initialPositionCount);
+        valueBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(1), initialPositionCount);
+
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        hashTablesBuffer = new byte[initialPositionCount * ARRAY_INT_INDEX_SCALE * HASH_MULTIPLIER];
+        hashTableBufferIndex = 0;
+
+        offsetsBuffer = new byte[initialPositionCount * ARRAY_INT_INDEX_SCALE];
+        offsetsBufferIndex = 0;
+
+        keyBuffers.prepareBuffers();
+        valueBuffers.prepareBuffers();
+    }
+
+    @Override
+    public void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        offsetsBufferIndex = 0;
+        lastOffset = 0;
+        hashTableBufferIndex = 0;
+        noHashTables = false;
+        resetNullsBuffer();
+
+        keyBuffers.resetBuffers();
+        valueBuffers.resetBuffers();
+    }
+
+    @Override
+    protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode)
+    {
+        requireNonNull(decodedBlockNode, "decodedBlockNode is null");
+
+        decodedBlockNode = mapPositions(decodedBlockNode);
+        columnarMap = (ColumnarMap) decodedBlockNode.getDecodedBlock();
+        decodedBlock = columnarMap.getNullCheckBlock();
+
+        populateNestedPositions();
+
+        keyBuffers.setupDecodedBlockAndMapPositions(decodedBlockNode.getChildren().get(0));
+        valueBuffers.setupDecodedBlockAndMapPositions(decodedBlockNode.getChildren().get(1));
+    }
+
+    @Override
+    public void accumulateRowSizes(int[] rowSizes)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += POSITION_SIZE;
+        }
+
+        ensureOffsetsOffsetsCapacity(positionCount);
+        System.arraycopy(offsets, 0, keyOffsetsOffsets, 0, positionCount + 1);
+        System.arraycopy(offsets, 0, valueOffsetsOffsets, 0, positionCount + 1);
+
+        keyBuffers.accumulateRowSizes(keyOffsetsOffsets, positionCount, rowSizes);
+        valueBuffers.accumulateRowSizes(valueOffsetsOffsets, positionCount, rowSizes);
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] offsetsOffsets, int positionCount, int[] rowSizes)
+    {
+        // The nested level positionCount could be 0.
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int lastOffset = offsetsOffsets[0];
+        for (int i = 0; i < positionCount; i++) {
+            int offset = offsetsOffsets[i + 1];
+            rowSizes[i] += POSITION_SIZE * (offset - lastOffset);
+            lastOffset = offset;
+            offsetsOffsets[i + 1] = offsets[offset];
+        }
+
+        // offsetsOffsets might be modified by the next level. Save it for the valueBuffers first.
+        ensureOffsetsOffsetsCapacity(positionCount);
+        System.arraycopy(offsetsOffsets, 0, valueOffsetsOffsets, 0, positionCount + 1);
+
+        keyBuffers.accumulateRowSizes(offsetsOffsets, positionCount, rowSizes);
+        valueBuffers.accumulateRowSizes(offsetsOffsets, positionCount, rowSizes);
+    }
+
+    @Override
+    public void setNextBatch(int positionsOffset, int batchSize)
+    {
+        this.positionsOffset = positionsOffset;
+        this.batchSize = batchSize;
+
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int beginOffset = offsets[positionsOffset];
+        int endOffset = offsets[positionsOffset + batchSize];
+
+        keyBuffers.setNextBatch(beginOffset, endOffset - beginOffset);
+        valueBuffers.setNextBatch(beginOffset, endOffset - beginOffset);
+    }
+
+    @Override
+    public void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        appendNulls();
+        appendOffsets();
+        appendHashTables();
+
+        keyBuffers.copyValues();
+        valueBuffers.copyValues();
+
+        bufferedPositionCount += batchSize;
+    }
+
+    public void serializeTo(SliceOutput sliceOutput)
+    {
+        writeLengthPrefixedString(sliceOutput, NAME);
+
+        TypeSerde.writeType(sliceOutput, columnarMap.getKeyType());
+
+        keyBuffers.serializeTo(sliceOutput);
+        valueBuffers.serializeTo(sliceOutput);
+
+        // Hashtables
+        int hashTableSize = lastOffset * HASH_MULTIPLIER;
+
+        if (hashTableBufferIndex == 0) {
+            sliceOutput.appendInt(-1);
+        }
+        else {
+            sliceOutput.appendInt(hashTableSize);
+            sliceOutput.appendBytes(hashTablesBuffer, 0, hashTableBufferIndex);
+        }
+
+        sliceOutput.writeInt(bufferedPositionCount); //positionCount
+        sliceOutput.appendInt(0);
+        sliceOutput.appendBytes(offsetsBuffer, 0, offsetsBufferIndex);
+
+        serializeNullsTo(sliceOutput);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return getPositionsSizeInBytes() +          // positions and mappedPositions
+                offsetsBufferIndex +
+                SIZE_OF_INT * positionCount +       // offsets array
+                SIZE_OF_INT * positionCount * 2 +   // keyOffsetsOffsets and valueOffsetsOffsets
+                getNullsBufferSizeInBytes() +
+                keyBuffers.getSizeInBytes() +
+                valueBuffers.getSizeInBytes() +
+                hashTableBufferIndex +
+                columnarMap.getSizeInBytes();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE +
+                getPostionsRetainedSizeInBytes() +
+                sizeOf(offsets) +
+                sizeOf(offsetsBuffer) +
+                sizeOf(keyOffsetsOffsets) +
+                sizeOf(valueOffsetsOffsets) +
+                getNullsBufferRetainedSizeInBytes() +
+                keyBuffers.getRetainedSizeInBytes() +
+                valueBuffers.getRetainedSizeInBytes() +
+                sizeOf(hashTablesBuffer) +
+                columnarMap.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public long getSerializedSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +            // length prefixed encoding name
+                columnarMap.getKeyType().getTypeSignature().toString().length() + SIZE_OF_INT + // length prefixed type string
+                keyBuffers.getSerializedSizeInBytes() +    // nested key block
+                valueBuffers.getSerializedSizeInBytes() +  // nested value block
+                SIZE_OF_INT +                           // hash tables size
+                hashTableBufferIndex +                  // hash tables
+                SIZE_OF_INT +                           // positionCount
+                offsetsBufferIndex + SIZE_OF_INT +      // offsets buffer.
+                getNullsBufferSerializedSizeInBytes();  // nulls
+    }
+
+    private void populateNestedPositions()
+    {
+        // Nested level positions always start from 0.
+        keyBuffers.positionsOffset = 0;
+        keyBuffers.positionCount = 0;
+        keyBuffers.isPositionsMapped = false;
+
+        valueBuffers.positionsOffset = 0;
+        valueBuffers.positionCount = 0;
+        valueBuffers.isPositionsMapped = false;
+
+        if (positionCount == 0) {
+            return;
+        }
+
+        ensureOffsetsCapacity();
+
+        int[] positions = getPositions();
+
+        int columnarArrayBaseOffset = columnarMap.getOffset(0);
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            int beginOffset = columnarMap.getOffset(position);
+            int endOffset = columnarMap.getOffset(position + 1);
+            int currentRowSize = endOffset - beginOffset;
+
+            offsets[i + 1] = offsets[i] + currentRowSize;
+
+            beginOffset -= columnarArrayBaseOffset;
+            if (currentRowSize > 0) {
+                keyBuffers.appendPositionRange(beginOffset, currentRowSize);
+                valueBuffers.appendPositionRange(beginOffset, currentRowSize);
+            }
+        }
+    }
+
+    private void appendOffsets()
+    {
+        ensureOffsetsBufferCapacity();
+
+        int baseOffset = lastOffset - offsets[positionsOffset];
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            offsetsBufferIndex = setInt(offsetsBuffer, offsetsBufferIndex, offsets[i + 1] + baseOffset);
+        }
+        lastOffset = offsets[positionsOffset + batchSize] + baseOffset;
+    }
+
+    private void appendHashTables()
+    {
+        // MergingPageOutput may build hash tables for some of the smallers blocks. But if there're some blocks
+        // without hash tables, it means hash tables are not needed so far. In this case we don't send the hash tables.
+        if (noHashTables) {
+            return;
+        }
+
+        Optional<int[]> hashTables = columnarMap.getHashTables();
+        if (!hashTables.isPresent()) {
+            noHashTables = true;
+            hashTableBufferIndex = 0;
+            return;
+        }
+
+        int hashTablesSize = (offsets[positionsOffset + batchSize] - offsets[positionsOffset]) * HASH_MULTIPLIER;
+        ensureHashTablesBufferSize(hashTableBufferIndex + hashTablesSize * ARRAY_INT_INDEX_SCALE);
+
+        int[] positions = getPositions();
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int position = positions[i];
+
+            int beginOffset = columnarMap.getOffset(position);
+            int endOffset = columnarMap.getOffset(position + 1);
+
+            hashTableBufferIndex = setInts(
+                    hashTablesBuffer,
+                    hashTableBufferIndex,
+                    hashTables.get(),
+                    beginOffset * HASH_MULTIPLIER,
+                    (endOffset - beginOffset) * HASH_MULTIPLIER);
+        }
+    }
+
+    private void ensureOffsetsCapacity()
+    {
+        if (offsets == null || offsets.length < positionCount + 1) {
+            offsets = new int[positionCount * 2];
+        }
+    }
+
+    private void ensureOffsetsOffsetsCapacity(int positionCount)
+    {
+        if (keyOffsetsOffsets == null || keyOffsetsOffsets.length < positionCount + 1) {
+            keyOffsetsOffsets = new int[positionCount * 2];
+        }
+
+        if (valueOffsetsOffsets == null || valueOffsetsOffsets.length < positionCount + 1) {
+            valueOffsetsOffsets = new int[positionCount * 2];
+        }
+    }
+
+    private void ensureOffsetsBufferCapacity()
+    {
+        int capacity = offsetsBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE;
+        if (offsetsBuffer.length < capacity) {
+            offsetsBuffer = Arrays.copyOf(offsetsBuffer, max(capacity, offsetsBuffer.length * 2));
+        }
+    }
+
+    private void ensureHashTablesBufferSize(int capacity)
+    {
+        if (hashTablesBuffer.length < capacity) {
+            hashTablesBuffer = Arrays.copyOf(hashTablesBuffer, max(capacity, hashTablesBuffer.length * 2));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorInfo.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator;
 
-import com.facebook.presto.operator.PartitionedOutputOperator.PartitionedOutputInfo;
 import com.facebook.presto.operator.TableWriterOperator.TableWriterInfo;
 import com.facebook.presto.operator.exchange.LocalExchangeBufferInfo;
 import com.fasterxml.jackson.annotation.JsonSubTypes;

--- a/presto-main/src/main/java/com/facebook/presto/operator/OptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OptimizedPartitionedOutputOperator.java
@@ -1,0 +1,793 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.buffer.OutputBuffer;
+import com.facebook.presto.execution.buffer.PagesSerde;
+import com.facebook.presto.execution.buffer.PagesSerdeFactory;
+import com.facebook.presto.execution.buffer.SerializedPage;
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.ArrayBlock;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockFlattener;
+import com.facebook.presto.spi.block.BlockLease;
+import com.facebook.presto.spi.block.ColumnarArray;
+import com.facebook.presto.spi.block.ColumnarMap;
+import com.facebook.presto.spi.block.ColumnarRow;
+import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.MapBlock;
+import com.facebook.presto.spi.block.RowBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceOutput;
+import io.airlift.units.DataSize;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+import static com.facebook.presto.operator.BlockEncodingBuffers.createBlockEncodingBuffers;
+import static com.facebook.presto.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
+import static com.facebook.presto.spi.type.Decimals.MAX_PRECISION;
+import static com.facebook.presto.spi.type.Decimals.MAX_SHORT_PRECISION;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimeType.TIME;
+import static com.facebook.presto.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+import static com.facebook.presto.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+import static com.facebook.presto.type.IpAddressType.IPADDRESS;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class OptimizedPartitionedOutputOperator
+        implements Operator
+{
+    public static class OptimizedPartitionedOutputFactory
+            implements OutputFactory
+    {
+        private final PartitionFunction partitionFunction;
+        private final List<Integer> partitionChannels;
+        private final List<Optional<ConstantExpression>> partitionConstants;
+        private final OutputBuffer outputBuffer;
+        private final boolean replicatesAnyRow;
+        private final OptionalInt nullChannel;
+        private final DataSize maxMemory;
+
+        public OptimizedPartitionedOutputFactory(
+                PartitionFunction partitionFunction,
+                List<Integer> partitionChannels,
+                List<Optional<ConstantExpression>> partitionConstants,
+                boolean replicatesAnyRow,
+                OptionalInt nullChannel,
+                OutputBuffer outputBuffer,
+                DataSize maxMemory)
+        {
+            this.partitionFunction = requireNonNull(partitionFunction, "partitionFunction is null");
+            this.partitionChannels = requireNonNull(partitionChannels, "partitionChannels is null");
+            this.partitionConstants = requireNonNull(partitionConstants, "partitionConstants is null");
+            this.replicatesAnyRow = replicatesAnyRow;
+            this.nullChannel = requireNonNull(nullChannel, "nullChannel is null");
+            this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
+            this.maxMemory = requireNonNull(maxMemory, "maxMemory is null");
+        }
+
+        @Override
+        public OperatorFactory createOutputOperator(
+                int operatorId,
+                PlanNodeId planNodeId,
+                List<Type> types,
+                Function<Page, Page> pagePreprocessor,
+                PagesSerdeFactory serdeFactory)
+        {
+            return new OptimizedPartitionedOutputOperatorFactory(
+                    operatorId,
+                    planNodeId,
+                    types,
+                    pagePreprocessor,
+                    partitionFunction,
+                    partitionChannels,
+                    partitionConstants,
+                    replicatesAnyRow,
+                    nullChannel,
+                    outputBuffer,
+                    serdeFactory,
+                    maxMemory);
+        }
+    }
+
+    public static class OptimizedPartitionedOutputOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+        private final List<Type> sourceTypes;
+        private final Function<Page, Page> pagePreprocessor;
+        private final PartitionFunction partitionFunction;
+        private final List<Integer> partitionChannels;
+        private final List<Optional<ConstantExpression>> partitionConstants;
+        private final boolean replicatesAnyRow;
+        private final OptionalInt nullChannel;
+        private final OutputBuffer outputBuffer;
+        private final PagesSerdeFactory serdeFactory;
+        private final DataSize maxMemory;
+
+        public OptimizedPartitionedOutputOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                List<Type> sourceTypes,
+                Function<Page, Page> pagePreprocessor,
+                PartitionFunction partitionFunction,
+                List<Integer> partitionChannels,
+                List<Optional<ConstantExpression>> partitionConstants,
+                boolean replicatesAnyRow,
+                OptionalInt nullChannel,
+                OutputBuffer outputBuffer,
+                PagesSerdeFactory serdeFactory,
+                DataSize maxMemory)
+        {
+            this.operatorId = operatorId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.sourceTypes = requireNonNull(sourceTypes, "sourceTypes is null");
+            this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
+            this.partitionFunction = requireNonNull(partitionFunction, "partitionFunction is null");
+            this.partitionChannels = requireNonNull(partitionChannels, "partitionChannels is null");
+            this.partitionConstants = requireNonNull(partitionConstants, "partitionConstants is null");
+            this.replicatesAnyRow = replicatesAnyRow;
+            this.nullChannel = requireNonNull(nullChannel, "nullChannel is null");
+            this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
+            this.serdeFactory = requireNonNull(serdeFactory, "serdeFactory is null");
+            this.maxMemory = requireNonNull(maxMemory, "maxMemory is null");
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, PartitionedOutputOperator.class.getSimpleName());
+            return new OptimizedPartitionedOutputOperator(
+                    operatorContext,
+                    sourceTypes,
+                    pagePreprocessor,
+                    partitionFunction,
+                    partitionChannels,
+                    partitionConstants,
+                    replicatesAnyRow,
+                    nullChannel,
+                    outputBuffer,
+                    serdeFactory,
+                    maxMemory);
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            return new OptimizedPartitionedOutputOperatorFactory(
+                    operatorId,
+                    planNodeId,
+                    sourceTypes,
+                    pagePreprocessor,
+                    partitionFunction,
+                    partitionChannels,
+                    partitionConstants,
+                    replicatesAnyRow,
+                    nullChannel,
+                    outputBuffer,
+                    serdeFactory,
+                    maxMemory);
+        }
+    }
+
+    private final OperatorContext operatorContext;
+    private final Function<Page, Page> pagePreprocessor;
+    private final PagePartitioner partitionFunction;
+    private final LocalMemoryContext systemMemoryContext;
+    private final long partitionsInitialRetainedSize;
+    private boolean finished;
+
+    public OptimizedPartitionedOutputOperator(
+            OperatorContext operatorContext,
+            List<Type> sourceTypes,
+            Function<Page, Page> pagePreprocessor,
+            PartitionFunction partitionFunction,
+            List<Integer> partitionChannels,
+            List<Optional<ConstantExpression>> partitionConstants,
+            boolean replicatesAnyRow,
+            OptionalInt nullChannel,
+            OutputBuffer outputBuffer,
+            PagesSerdeFactory serdeFactory,
+            DataSize maxMemory)
+    {
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
+        this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
+        this.partitionFunction = new PagePartitioner(
+                partitionFunction,
+                partitionChannels,
+                partitionConstants,
+                replicatesAnyRow,
+                nullChannel,
+                outputBuffer,
+                serdeFactory,
+                sourceTypes,
+                maxMemory,
+                operatorContext.getDriverContext().getLifespan());
+
+        operatorContext.setInfoSupplier(this::getInfo);
+        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(PartitionedOutputOperator.class.getSimpleName());
+        this.partitionsInitialRetainedSize = this.partitionFunction.getRetainedSizeInBytes();
+        this.systemMemoryContext.setBytes(partitionsInitialRetainedSize);
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    public PartitionedOutputInfo getInfo()
+    {
+        return partitionFunction.getInfo();
+    }
+
+    @Override
+    public void finish()
+    {
+        finished = true;
+        partitionFunction.flush();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finished && isBlocked().isDone();
+    }
+
+    @Override
+    public ListenableFuture<?> isBlocked()
+    {
+        ListenableFuture<?> blocked = partitionFunction.isFull();
+        return blocked.isDone() ? NOT_BLOCKED : blocked;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return !finished && isBlocked().isDone();
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        requireNonNull(page, "page is null");
+
+        if (page.getPositionCount() == 0) {
+            return;
+        }
+
+        page = pagePreprocessor.apply(page);
+        partitionFunction.partitionPage(page);
+
+        // TODO: PartitionedOutputOperator reports incorrect output data size #11770
+        operatorContext.recordOutput(page.getSizeInBytes(), page.getPositionCount());
+
+        // We use getSizeInBytes() here instead of getRetainedSizeInBytes() for an approximation of
+        // the amount of memory used by the pageBuilders, because calculating the retained
+        // size can be expensive especially for complex types.
+        long partitionsSizeInBytes = partitionFunction.getSizeInBytes();
+
+        // We also add partitionsInitialRetainedSize as an approximation of the object overhead of the partitions.
+        systemMemoryContext.setBytes(partitionsSizeInBytes + partitionsInitialRetainedSize);
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        return null;
+    }
+
+    private static class PartitionData
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(PartitionData.class).instanceSize();
+        private static final int INITIAL_POSITION_COUNT = 64 * 1024;
+        private static final int DEFAULT_ELEMENT_SIZE_IN_BYTES = 8;
+
+        private final int partition;
+        private final AtomicLong rowsAdded;
+        private final AtomicLong pagesAdded;
+        private final PagesSerde serde;
+        private final Lifespan lifespan;
+        private final int capacity;
+        private final int channelCount;
+
+        private int[] positions = new int[INITIAL_POSITION_COUNT];   // the default positions array for top level BlockEncodingBuffers
+        private int[] rowSizes = new int[INITIAL_POSITION_COUNT];
+        private int positionCount;  // number of positions to be copied for this partition
+        private BlockEncodingBuffers[] blockEncodingBuffers;
+
+        private int bufferedRowCount;
+        private boolean bufferFull;
+
+        PartitionData(int partition, int channelCount, int capacity, AtomicLong pagesAdded, AtomicLong rowsAdded, PagesSerde serde, Lifespan lifespan)
+        {
+            this.partition = partition;
+            this.channelCount = channelCount;
+            this.capacity = capacity;
+            this.pagesAdded = requireNonNull(pagesAdded, "pagesAdded is null");
+            this.rowsAdded = requireNonNull(rowsAdded, "rowsAdded is null");
+            this.serde = requireNonNull(serde, "serde is null");
+            this.lifespan = requireNonNull(lifespan, "lifespan is null");
+        }
+
+        public void resetPositionCount()
+        {
+            positionCount = 0;
+        }
+
+        public void appendPosition(int position)
+        {
+            positions[positionCount++] = position;
+        }
+
+        public void appendRows(DecodedBlockNode[] decodedBlocks, int fixedWidthRowSize, List<Integer> variableWidthChannels, OutputBuffer outputBuffer)
+        {
+            checkArgument(decodedBlocks.length == channelCount, "Unexpected number of blocks");
+
+            if (positionCount == 0) {
+                return;
+            }
+
+            if (channelCount == 0) {
+                bufferedRowCount += positionCount;
+                return;
+            }
+
+            initializeBlockEncodingBuffers(decodedBlocks);
+
+            for (int i = 0; i < channelCount; i++) {
+                blockEncodingBuffers[i].setupDecodedBlocksAndPositions(decodedBlocks[i], positions, positionCount);
+            }
+
+            calculateRowSizes(fixedWidthRowSize, variableWidthChannels);
+
+            int offset = 0;
+            do {
+                int batchSize = calculateNextBatchSize(fixedWidthRowSize, variableWidthChannels, offset);
+
+                for (int i = 0; i < channelCount; i++) {
+                    blockEncodingBuffers[i].setNextBatch(offset, batchSize);
+                    blockEncodingBuffers[i].copyValues();
+                }
+
+                bufferedRowCount += batchSize;
+                offset += batchSize;
+
+                if (bufferFull) {
+                    flush(outputBuffer);
+
+                    bufferFull = false;
+                }
+            }
+            while (offset < positionCount);
+        }
+
+        public long getSizeInBytes()
+        {
+            long buffersSizeInBytes = 0;
+            if (blockEncodingBuffers != null) {
+                for (int i = 0; i < channelCount; i++) {
+                    buffersSizeInBytes += blockEncodingBuffers[i].getSizeInBytes();
+                }
+            }
+
+            // Add up sizes for positions and rowSizes arrays
+            return SIZE_OF_INT * 2 * positionCount + buffersSizeInBytes;
+        }
+
+        public long getRetainedSizeInBytes()
+        {
+            long buffersSizeInBytes = 0;
+            if (blockEncodingBuffers != null) {
+                for (int i = 0; i < channelCount; i++) {
+                    buffersSizeInBytes += blockEncodingBuffers[i].getRetainedSizeInBytes();
+                }
+            }
+
+            return INSTANCE_SIZE + sizeOf(positions) + sizeOf(rowSizes) + buffersSizeInBytes;
+        }
+
+        private void initializeBlockEncodingBuffers(DecodedBlockNode[] decodedBlocks)
+        {
+            // Create buffers has to be done after seeing the first page.
+            if (blockEncodingBuffers == null) {
+                int initialElementCount = min(capacity / channelCount / DEFAULT_ELEMENT_SIZE_IN_BYTES, INITIAL_POSITION_COUNT);
+
+                blockEncodingBuffers = new BlockEncodingBuffers[channelCount];
+                for (int i = 0; i < channelCount; i++) {
+                    blockEncodingBuffers[i] = createBlockEncodingBuffers(decodedBlocks[i], initialElementCount);
+                }
+            }
+        }
+
+        private void calculateRowSizes(int fixedWidthRowSize, List<Integer> variableWidthChannels)
+        {
+            if (variableWidthChannels.isEmpty()) {
+                return;
+            }
+
+            ensureRowSizesCapacityAndInitialize();
+
+            for (int i : variableWidthChannels) {
+                blockEncodingBuffers[i].accumulateRowSizes(rowSizes);
+            }
+
+            for (int i = 0; i < positionCount; i++) {
+                rowSizes[i] += fixedWidthRowSize;
+            }
+        }
+
+        private int calculateNextBatchSize(int fixedWidthRowSize, List<Integer> variableWidthChannels, int startPosition)
+        {
+            int bytesRemaining = capacity - toIntExact(getSerializedBuffersSizeInBytes());
+
+            if (variableWidthChannels.isEmpty()) {
+                int positionsFit = max(bytesRemaining / fixedWidthRowSize, 1);
+                bufferFull = (positionsFit <= positionCount - startPosition);
+                return min(positionsFit, positionCount - startPosition);
+            }
+
+            verify(rowSizes != null);
+            for (int i = startPosition; i < positionCount; i++) {
+                bytesRemaining -= rowSizes[i];
+
+                if (bytesRemaining <= 0) {
+                    bufferFull = true;
+                    return max(i - startPosition, 1);
+                }
+            }
+
+            return positionCount - startPosition;
+        }
+
+        private void flush(OutputBuffer outputBuffer)
+        {
+            if (bufferedRowCount == 0) {
+                return;
+            }
+
+            SliceOutput output = new DynamicSliceOutput(toIntExact(getSerializedBuffersSizeInBytes()));
+            output.writeInt(channelCount);
+
+            for (int i = 0; i < channelCount; i++) {
+                blockEncodingBuffers[i].serializeTo(output);
+            }
+
+            SerializedPage serializedPage = serde.serialize(output.slice(), bufferedRowCount);
+            outputBuffer.enqueue(lifespan, partition, ImmutableList.of(serializedPage));
+            pagesAdded.incrementAndGet();
+            rowsAdded.addAndGet(bufferedRowCount);
+
+            if (blockEncodingBuffers != null) {
+                for (int i = 0; i < blockEncodingBuffers.length; i++) {
+                    blockEncodingBuffers[i].resetBuffers();
+                }
+            }
+
+            bufferedRowCount = 0;
+        }
+
+        private void ensurePositionsCapacity(int positionCount)
+        {
+            if (positions.length < positionCount) {
+                positions = new int[positionCount];
+            }
+        }
+
+        private void ensureRowSizesCapacityAndInitialize()
+        {
+            if (rowSizes.length <= positionCount) {
+                rowSizes = new int[max(2 * rowSizes.length, positionCount)];
+            }
+            else {
+                Arrays.fill(rowSizes, 0, positionCount, 0);
+            }
+        }
+
+        private long getSerializedBuffersSizeInBytes()
+        {
+            int size = 0;
+
+            for (int i = 0; i < channelCount; i++) {
+                size += blockEncodingBuffers[i].getSerializedSizeInBytes();
+            }
+
+            return SIZE_OF_INT + size;  // channelCount takes one int
+        }
+    }
+
+    private static class PagePartitioner
+    {
+        // flattener borrows one array for each nested Dictionary/Rle level. We assume the maximum nested level is 100.
+        private static final int MAX_FLATTENER_OUTSTANDING_ARRAYS = 100;
+
+        private final OutputBuffer outputBuffer;
+        private final PartitionFunction partitionFunction;
+        private final List<Integer> partitionChannels;
+        private final List<Optional<Block>> partitionConstants;
+        private final PagesSerde serde;
+        private final boolean replicatesAnyRow;
+        private final OptionalInt nullChannel; // when present, send the position to every partition if this channel is null.
+        private final AtomicLong rowsAdded = new AtomicLong();
+        private final AtomicLong pagesAdded = new AtomicLong();
+        private boolean hasAnyRowBeenReplicated;
+
+        private final PartitionData[] partitionData;
+        private final List<Integer> variableWidthChannels = new ArrayList<>();
+        private final int fixedWidthRowSize;
+        private final BlockFlattener flattener;
+        private final DecodedBlockNode[] decodedBlocks;
+        private final List<Type> sourceTypes;
+
+        private static final Map<Type, Integer> FIXED_WIDTH_TYPE_SERIALIZED_BYTES = ImmutableMap.<Type, Integer>builder()
+                .put(BIGINT, 9)
+                .put(INTEGER, 5)
+                .put(BOOLEAN, 2)
+                .put(DATE, 5)
+                .put(DOUBLE, 9)
+                .put(INTERVAL_DAY_TIME, 9)
+                .put(INTERVAL_YEAR_MONTH, 5)
+                .put(IPADDRESS, 17)
+                .put(createDecimalType(MAX_PRECISION), 17)
+                .put(createDecimalType(MAX_SHORT_PRECISION), 9)
+                .put(SMALLINT, 3)
+                .put(TIME, 9)
+                .put(TIME_WITH_TIME_ZONE, 9)
+                .put(TIMESTAMP, 9)
+                .put(TIMESTAMP_WITH_TIME_ZONE, 9)
+                .put(TINYINT, 2)
+                .put(UNKNOWN, 2)
+                .build();
+
+        public PagePartitioner(
+                PartitionFunction partitionFunction,
+                List<Integer> partitionChannels,
+                List<Optional<ConstantExpression>> partitionConstants,
+                boolean replicatesAnyRow,
+                OptionalInt nullChannel,
+                OutputBuffer outputBuffer,
+                PagesSerdeFactory serdeFactory,
+                List<Type> sourceTypes,
+                DataSize maxMemory,
+                Lifespan lifespan)
+        {
+            this.partitionFunction = requireNonNull(partitionFunction, "partitionFunction is null");
+            this.partitionChannels = requireNonNull(partitionChannels, "partitionChannels is null");
+            this.partitionConstants = requireNonNull(partitionConstants, "partitionConstants is null").stream()
+                    .map(constant -> constant.map(ConstantExpression::getValueBlock))
+                    .collect(toImmutableList());
+            this.replicatesAnyRow = replicatesAnyRow;
+            this.nullChannel = requireNonNull(nullChannel, "nullChannel is null");
+            this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
+            this.serde = requireNonNull(serdeFactory, "serdeFactory is null").createPagesSerde();
+
+            int partitionCount = partitionFunction.getPartitionCount();
+
+            int pageSize = max(1, min(DEFAULT_MAX_PAGE_SIZE_IN_BYTES, toIntExact(maxMemory.toBytes()) / partitionCount));
+
+            partitionData = new PartitionData[partitionCount];
+            for (int i = 0; i < partitionCount; i++) {
+                partitionData[i] = new PartitionData(i, sourceTypes.size(), pageSize, pagesAdded, rowsAdded, serde, lifespan);
+            }
+
+            this.sourceTypes = sourceTypes;
+            flattener = new BlockFlattener(new SimpleArrayAllocator(MAX_FLATTENER_OUTSTANDING_ARRAYS));
+
+            decodedBlocks = new DecodedBlockNode[sourceTypes.size()];
+
+            int fixedWidthRowSize = 0;
+            for (int i = 0; i < sourceTypes.size(); i++) {
+                int bytesPerPosition = getFixedWidthTypeSize(i);
+                fixedWidthRowSize += bytesPerPosition;
+
+                if (bytesPerPosition == 0) {
+                    variableWidthChannels.add(i);
+                }
+            }
+            this.fixedWidthRowSize = fixedWidthRowSize;
+        }
+
+        public ListenableFuture<?> isFull()
+        {
+            return outputBuffer.isFull();
+        }
+
+        public long getSizeInBytes()
+        {
+            long sizeInBytes = 0;
+            for (int i = 0; i < partitionData.length; i++) {
+                sizeInBytes += partitionData[i].getSizeInBytes();
+            }
+
+            return sizeInBytes;
+        }
+
+        public long getRetainedSizeInBytes()
+        {
+            long retainedSizeInBytes = 0;
+            for (int i = 0; i < partitionData.length; i++) {
+                retainedSizeInBytes += partitionData[i].getRetainedSizeInBytes();
+            }
+
+            for (int i = 0; i < decodedBlocks.length; i++) {
+                retainedSizeInBytes += decodedBlocks[i] == null ? 0 : decodedBlocks[i].getRetainedSizeInBytes();
+            }
+
+            return retainedSizeInBytes;
+        }
+
+        public PartitionedOutputInfo getInfo()
+        {
+            return new PartitionedOutputInfo(rowsAdded.get(), pagesAdded.get(), outputBuffer.getPeakMemoryUsage());
+        }
+
+        public void partitionPage(Page page)
+        {
+            populatePositionsForEachPartition(page);
+
+            for (int i = 0; i < decodedBlocks.length; i++) {
+                decodedBlocks[i] = decodeBlock(flattener, page.getBlock(i));
+            }
+
+            for (int i = 0; i < partitionData.length; i++) {
+                partitionData[i].appendRows(decodedBlocks, fixedWidthRowSize, variableWidthChannels, outputBuffer);
+            }
+        }
+
+        public void flush()
+        {
+            for (int i = 0; i < partitionData.length; i++) {
+                partitionData[i].flush(outputBuffer);
+            }
+        }
+
+        private void populatePositionsForEachPartition(Page page)
+        {
+            int positionCount = page.getPositionCount();
+
+            for (int i = 0; i < partitionData.length; i++) {
+                partitionData[i].ensurePositionsCapacity(positionCount);
+                partitionData[i].resetPositionCount();
+            }
+
+            Block nullBlock = nullChannel.isPresent() ? page.getBlock(nullChannel.getAsInt()) : null;
+            Page partitionFunctionArgs = getPartitionFunctionArguments(page);
+
+            for (int position = 0; position < positionCount; position++) {
+                boolean shouldReplicate = (replicatesAnyRow && !hasAnyRowBeenReplicated) ||
+                        nullChannel.isPresent() && nullBlock.isNull(position);
+
+                if (shouldReplicate) {
+                    for (int i = 0; i < partitionData.length; i++) {
+                        partitionData[i].appendPosition(position);
+                    }
+                    hasAnyRowBeenReplicated = true;
+                }
+                else {
+                    int partition = partitionFunction.getPartition(partitionFunctionArgs, position);
+                    partitionData[partition].appendPosition(position);
+                }
+            }
+        }
+
+        private Page getPartitionFunctionArguments(Page page)
+        {
+            Block[] blocks = new Block[partitionChannels.size()];
+            for (int i = 0; i < blocks.length; i++) {
+                Optional<Block> partitionConstant = partitionConstants.get(i);
+                if (partitionConstant.isPresent()) {
+                    blocks[i] = new RunLengthEncodedBlock(partitionConstant.get(), page.getPositionCount());
+                }
+                else {
+                    blocks[i] = page.getBlock(partitionChannels.get(i));
+                }
+            }
+            return new Page(page.getPositionCount(), blocks);
+        }
+
+        private int getFixedWidthTypeSize(int channel)
+        {
+            Type type = sourceTypes.get(channel);
+            int bytesPerPosition = FIXED_WIDTH_TYPE_SERIALIZED_BYTES.getOrDefault(type, 0);
+            if (type instanceof DecimalType) {
+                if (((DecimalType) type).isShort()) {
+                    return 9;
+                }
+                return 17;
+            }
+            return bytesPerPosition;
+        }
+    }
+
+    @VisibleForTesting
+    static DecodedBlockNode decodeBlock(BlockFlattener flattener, Block block)
+    {
+        try (BlockLease lease = flattener.flatten(block)) {
+            Block decodedBlock = lease.get();
+
+            if (decodedBlock instanceof ArrayBlock) {
+                ColumnarArray columnarArray = ColumnarArray.toColumnarArray(decodedBlock);
+                return new DecodedBlockNode(columnarArray, ImmutableList.of(decodeBlock(flattener, columnarArray.getElementsBlock())));
+            }
+
+            if (decodedBlock instanceof MapBlock) {
+                ColumnarMap columnarMap = ColumnarMap.toColumnarMap(decodedBlock);
+                return new DecodedBlockNode(columnarMap, ImmutableList.of(decodeBlock(flattener, columnarMap.getKeysBlock()), decodeBlock(flattener, columnarMap.getValuesBlock())));
+            }
+
+            if (decodedBlock instanceof RowBlock) {
+                ColumnarRow columnarRow = ColumnarRow.toColumnarRow(decodedBlock);
+                ImmutableList.Builder<DecodedBlockNode> children = ImmutableList.builder();
+                for (int i = 0; i < columnarRow.getFieldCount(); i++) {
+                    children.add(decodeBlock(flattener, columnarRow.getField(i)));
+                }
+                return new DecodedBlockNode(columnarRow, children.build());
+            }
+
+            if (decodedBlock instanceof DictionaryBlock) {
+                return new DecodedBlockNode(decodedBlock, ImmutableList.of(decodeBlock(flattener, ((DictionaryBlock) decodedBlock).getDictionary())));
+            }
+
+            if (decodedBlock instanceof RunLengthEncodedBlock) {
+                return new DecodedBlockNode(decodedBlock, ImmutableList.of(decodeBlock(flattener, ((RunLengthEncodedBlock) decodedBlock).getValue())));
+            }
+
+            return new DecodedBlockNode(decodedBlock, ImmutableList.of());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputInfo.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.util.Mergeable;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class PartitionedOutputInfo
+        implements Mergeable<PartitionedOutputInfo>, OperatorInfo
+{
+    private final long rowsAdded;
+    private final long pagesAdded;
+    private final long outputBufferPeakMemoryUsage;
+
+    @JsonCreator
+    public PartitionedOutputInfo(
+            @JsonProperty("rowsAdded") long rowsAdded,
+            @JsonProperty("pagesAdded") long pagesAdded,
+            @JsonProperty("outputBufferPeakMemoryUsage") long outputBufferPeakMemoryUsage)
+    {
+        this.rowsAdded = rowsAdded;
+        this.pagesAdded = pagesAdded;
+        this.outputBufferPeakMemoryUsage = outputBufferPeakMemoryUsage;
+    }
+
+    @JsonProperty
+    public long getRowsAdded()
+    {
+        return rowsAdded;
+    }
+
+    @JsonProperty
+    public long getPagesAdded()
+    {
+        return pagesAdded;
+    }
+
+    @JsonProperty
+    public long getOutputBufferPeakMemoryUsage()
+    {
+        return outputBufferPeakMemoryUsage;
+    }
+
+    @Override
+    public PartitionedOutputInfo mergeWith(PartitionedOutputInfo other)
+    {
+        return new PartitionedOutputInfo(
+                rowsAdded + other.rowsAdded,
+                pagesAdded + other.pagesAdded,
+                Math.max(outputBufferPeakMemoryUsage, other.outputBufferPeakMemoryUsage));
+    }
+
+    @Override
+    public boolean isFinal()
+    {
+        return true;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("rowsAdded", rowsAdded)
+                .add("pagesAdded", pagesAdded)
+                .add("outputBufferPeakMemoryUsage", outputBufferPeakMemoryUsage)
+                .toString();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
@@ -26,9 +26,6 @@ import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.util.Mergeable;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 
@@ -40,7 +37,6 @@ import java.util.function.Function;
 
 import static com.facebook.presto.execution.buffer.PageSplitterUtil.splitPage;
 import static com.facebook.presto.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
-import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -442,68 +438,6 @@ public class PartitionedOutputOperator
                     rowsAdded.addAndGet(pagePartition.getPositionCount());
                 }
             }
-        }
-    }
-
-    public static class PartitionedOutputInfo
-            implements Mergeable<PartitionedOutputInfo>, OperatorInfo
-    {
-        private final long rowsAdded;
-        private final long pagesAdded;
-        private final long outputBufferPeakMemoryUsage;
-
-        @JsonCreator
-        public PartitionedOutputInfo(
-                @JsonProperty("rowsAdded") long rowsAdded,
-                @JsonProperty("pagesAdded") long pagesAdded,
-                @JsonProperty("outputBufferPeakMemoryUsage") long outputBufferPeakMemoryUsage)
-        {
-            this.rowsAdded = rowsAdded;
-            this.pagesAdded = pagesAdded;
-            this.outputBufferPeakMemoryUsage = outputBufferPeakMemoryUsage;
-        }
-
-        @JsonProperty
-        public long getRowsAdded()
-        {
-            return rowsAdded;
-        }
-
-        @JsonProperty
-        public long getPagesAdded()
-        {
-            return pagesAdded;
-        }
-
-        @JsonProperty
-        public long getOutputBufferPeakMemoryUsage()
-        {
-            return outputBufferPeakMemoryUsage;
-        }
-
-        @Override
-        public PartitionedOutputInfo mergeWith(PartitionedOutputInfo other)
-        {
-            return new PartitionedOutputInfo(
-                    rowsAdded + other.rowsAdded,
-                    pagesAdded + other.pagesAdded,
-                    Math.max(outputBufferPeakMemoryUsage, other.outputBufferPeakMemoryUsage));
-        }
-
-        @Override
-        public boolean isFinal()
-        {
-            return true;
-        }
-
-        @Override
-        public String toString()
-        {
-            return toStringHelper(this)
-                    .add("rowsAdded", rowsAdded)
-                    .add("pagesAdded", pagesAdded)
-                    .add("outputBufferPeakMemoryUsage", outputBufferPeakMemoryUsage)
-                    .toString();
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/RowBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/RowBlockEncodingBuffers.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.ColumnarRow;
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.facebook.presto.operator.UncheckedByteArrays.setInt;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+
+public class RowBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    @VisibleForTesting
+    public static final int POSITION_SIZE = SIZE_OF_INT + SIZE_OF_BYTE;
+
+    private static final String NAME = "ROW";
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(RowBlockEncodingBuffers.class).instanceSize();
+
+    // The buffer for the offsets for all incoming blocks so far
+    private byte[] offsetsBuffer;
+
+    // The address next offset value will be written to.
+    private int offsetsBufferIndex;
+
+    // This array holds the condensed offsets for each position for the incoming block.
+    private int[] offsets;
+
+    // The last offset in the offsets buffer
+    private int lastOffset;
+
+    // This array holds the offsets into its nested raw block for each top level row.
+    private int[][] offsetsOffsets;
+
+    // The current incoming RowBlock is converted into ColumnarRow
+    private ColumnarRow columnarRow;
+
+    private final BlockEncodingBuffers[] fieldBuffers;
+
+    public RowBlockEncodingBuffers(DecodedBlockNode decodedBlockNode, int initialPositionCount)
+    {
+        super(initialPositionCount);
+
+        List<DecodedBlockNode> childrenNodes = decodedBlockNode.getChildren();
+        fieldBuffers = new BlockEncodingBuffers[childrenNodes.size()];
+        for (int i = 0; i < childrenNodes.size(); i++) {
+            fieldBuffers[i] = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(i), initialPositionCount);
+        }
+
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        offsetsBuffer = new byte[initialPositionCount * ARRAY_INT_INDEX_SCALE];
+        offsetsBufferIndex = 0;
+
+        for (int i = 0; i < fieldBuffers.length; i++) {
+            fieldBuffers[i].prepareBuffers();
+        }
+    }
+
+    @Override
+    public void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        offsetsBufferIndex = 0;
+        lastOffset = 0;
+        resetNullsBuffer();
+
+        for (int i = 0; i < fieldBuffers.length; i++) {
+            fieldBuffers[i].resetBuffers();
+        }
+    }
+
+    @Override
+    protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode)
+    {
+        requireNonNull(decodedBlockNode, "decodedBlockNode is null");
+
+        decodedBlockNode = mapPositions(decodedBlockNode);
+        columnarRow = (ColumnarRow) decodedBlockNode.getDecodedBlock();
+        decodedBlock = columnarRow.getNullCheckBlock();
+
+        populateNestedPositions();
+
+        for (int i = 0; i < fieldBuffers.length; i++) {
+            fieldBuffers[i].setupDecodedBlockAndMapPositions(decodedBlockNode.getChildren().get(i));
+        }
+    }
+
+    @Override
+    public void accumulateRowSizes(int[] rowSizes)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += POSITION_SIZE;
+        }
+
+        ensureOffsetsOffsetsCapacity(positionCount);
+
+        for (int i = 0; i < fieldBuffers.length; i++) {
+            // Nested level BlockEncodingBuffers will modify the offsetsOffsets array in place,
+            // so we need to make a copy for each fieldBuffers.
+            System.arraycopy(offsets, 0, offsetsOffsets[i], 0, positionCount + 1);
+            fieldBuffers[i].accumulateRowSizes(offsetsOffsets[i], positionCount, rowSizes);
+        }
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] offsetsOffsets, int positionCount, int[] rowSizes)
+    {
+        // The nested level positionCount could be 0.
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int lastOffset = offsetsOffsets[0];
+        for (int i = 0; i < positionCount; i++) {
+            int offset = offsetsOffsets[i + 1];
+            rowSizes[i] += POSITION_SIZE * (offset - lastOffset);
+            lastOffset = offset;
+            offsetsOffsets[i + 1] = this.offsets[offset];
+        }
+
+        ensureOffsetsOffsetsCapacity(positionCount);
+        for (int i = 0; i < fieldBuffers.length; i++) {
+            // Nested level BlockEncodingBuffers will modify the offsetsOffsets array in place,
+            // so we need to make a copy for each fieldBuffers.
+            System.arraycopy(offsetsOffsets, 0, this.offsetsOffsets[i], 0, positionCount + 1);
+            fieldBuffers[i].accumulateRowSizes(this.offsetsOffsets[i], positionCount, rowSizes);
+        }
+    }
+
+    @Override
+    public void setNextBatch(int positionsOffset, int batchSize)
+    {
+        this.positionsOffset = positionsOffset;
+        this.batchSize = batchSize;
+
+        // The nested level positionCount could be 0.
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int offset = offsets[positionsOffset];
+
+        for (int i = 0; i < fieldBuffers.length; i++) {
+            fieldBuffers[i].setNextBatch(offset, offsets[positionsOffset + batchSize] - offset);
+        }
+    }
+
+    @Override
+    public void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        appendNulls();
+        appendOffsets();
+
+        for (int i = 0; i < fieldBuffers.length; i++) {
+            fieldBuffers[i].copyValues();
+        }
+
+        bufferedPositionCount += batchSize;
+    }
+
+    public void serializeTo(SliceOutput sliceOutput)
+    {
+        writeLengthPrefixedString(sliceOutput, NAME);
+
+        sliceOutput.writeInt(fieldBuffers.length);
+        for (int i = 0; i < fieldBuffers.length; i++) {
+            fieldBuffers[i].serializeTo(sliceOutput);
+        }
+
+        sliceOutput.writeInt(bufferedPositionCount); //positionCount
+        sliceOutput.writeInt(0);  // the base position
+        sliceOutput.appendBytes(offsetsBuffer, 0, offsetsBufferIndex);
+
+        serializeNullsTo(sliceOutput);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        int fieldsSize = 0;
+        for (int i = 0; i < fieldBuffers.length; i++) {
+            fieldsSize += fieldBuffers[i].getSizeInBytes();
+        }
+
+        return getPositionsSizeInBytes() +                          // positions and mappedPositions
+                offsetsBufferIndex +
+                positionCount * SIZE_OF_INT +                       // offsets
+                positionCount * fieldBuffers.length * SIZE_OF_INT + // offsetsOffsets
+                getNullsBufferSizeInBytes() +
+                fieldsSize +
+                columnarRow.getSizeInBytes();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        int fieldsRetainedSize = 0;
+        for (int i = 0; i < fieldBuffers.length; i++) {
+            fieldsRetainedSize += fieldBuffers[i].getRetainedSizeInBytes();
+        }
+
+        return INSTANCE_SIZE +
+                getPostionsRetainedSizeInBytes() +
+                sizeOf(offsetsBuffer) +
+                sizeOf(offsets) +
+                sizeOf(offsetsOffsets) +
+                getNullsBufferRetainedSizeInBytes() +
+                fieldsRetainedSize +
+                columnarRow.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public long getSerializedSizeInBytes()
+    {
+        int fieldsSerializedSize = 0;
+        for (int i = 0; i < fieldBuffers.length; i++) {
+            fieldsSerializedSize += fieldBuffers[i].getSerializedSizeInBytes();
+        }
+
+        return NAME.length() + SIZE_OF_INT +            // encoding name
+                SIZE_OF_INT +                           // field count
+                fieldsSerializedSize +                  // field blocks
+                SIZE_OF_INT +                           // positionCount
+                SIZE_OF_INT +                           // offset 0. The offsetsBuffer doesn't contain the offset 0 so we need to add it here.
+                offsetsBufferIndex +                    // offsets buffer.
+                getNullsBufferSerializedSizeInBytes();  // nulls
+    }
+
+    private void populateNestedPositions()
+    {
+        // Nested level positions always start from 0.
+        for (int i = 0; i < fieldBuffers.length; i++) {
+            fieldBuffers[i].positionsOffset = 0;
+            fieldBuffers[i].positionCount = 0;
+            fieldBuffers[i].isPositionsMapped = false;
+        }
+
+        if (positionCount == 0) {
+            return;
+        }
+
+        ensureOffsetsCapacity();
+
+        int[] positions = getPositions();
+
+        int columnarArrayBaseOffset = columnarRow.getOffset(0);
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            int beginOffset = columnarRow.getOffset(position);
+            int endOffset = columnarRow.getOffset(position + 1);  // if the row is null, endOffsetInBlock == beginOffsetInBlock
+            int currentRowSize = endOffset - beginOffset;
+            offsets[i + 1] = offsets[i] + currentRowSize;
+
+            if (currentRowSize > 0) {
+                for (int j = 0; j < fieldBuffers.length; j++) {
+                    fieldBuffers[j].appendPositionRange(beginOffset - columnarArrayBaseOffset, currentRowSize);
+                }
+            }
+        }
+    }
+
+    private void appendOffsets()
+    {
+        ensureOffsetsBufferCapacity();
+
+        int baseOffset = lastOffset - offsets[positionsOffset];
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            offsetsBufferIndex = setInt(offsetsBuffer, offsetsBufferIndex, offsets[i + 1] + baseOffset);
+        }
+        lastOffset = offsets[positionsOffset + batchSize] + baseOffset;
+    }
+
+    private void ensureOffsetsCapacity()
+    {
+        if (offsets == null || offsets.length < positionCount + 1) {
+            offsets = new int[positionCount * 2];
+        }
+    }
+
+    private void ensureOffsetsOffsetsCapacity(int positionCount)
+    {
+        if (offsetsOffsets == null || offsetsOffsets[0].length < positionCount + 1) {
+            offsetsOffsets = new int[fieldBuffers.length][positionCount * 2];
+        }
+    }
+
+    private void ensureOffsetsBufferCapacity()
+    {
+        int capacity = offsetsBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE;
+        if (offsetsBuffer.length < capacity) {
+            offsetsBuffer = Arrays.copyOf(offsetsBuffer, max(capacity, offsetsBuffer.length * 2));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ShortArrayBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ShortArrayBlockEncodingBuffers.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.UncheckedByteArrays.setShort;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_SHORT_INDEX_SCALE;
+
+public class ShortArrayBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    @VisibleForTesting
+    public static final int POSITION_SIZE = Short.BYTES + Byte.BYTES;
+
+    private static final String NAME = "SHORT_ARRAY";
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ShortArrayBlockEncodingBuffers.class).instanceSize();
+
+    private byte[] valuesBuffer;
+    private int valuesBufferIndex;
+
+    public ShortArrayBlockEncodingBuffers(int initialPositionCount)
+    {
+        super(initialPositionCount);
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        valuesBuffer = new byte[initialPositionCount * ARRAY_SHORT_INDEX_SCALE];
+        valuesBufferIndex = 0;
+    }
+
+    @Override
+    public void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        valuesBufferIndex = 0;
+        resetNullsBuffer();
+    }
+
+    @Override
+    public void accumulateRowSizes(int[] rowSizes)
+    {
+        throw new UnsupportedOperationException("accumulateRowSizes is not supported for fixed width types");
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] positionOffsets, int positionCount, int[] rowSizes)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += (positionOffsets[i + 1] - positionOffsets[i]) * POSITION_SIZE;
+        }
+    }
+
+    @Override
+    public void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        appendValuesToBuffer();
+        appendNulls();
+        bufferedPositionCount += batchSize;
+    }
+
+    public void serializeTo(SliceOutput sliceOutput)
+    {
+        writeLengthPrefixedString(sliceOutput, NAME);
+        sliceOutput.writeInt(bufferedPositionCount);
+        serializeNullsTo(sliceOutput);
+        sliceOutput.appendBytes(valuesBuffer, 0, valuesBufferIndex);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return getPositionsSizeInBytes() + // positions and mappedPositions
+                valuesBufferIndex +
+                getNullsBufferSizeInBytes();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE +
+                getPostionsRetainedSizeInBytes() +
+                sizeOf(valuesBuffer) +
+                getNullsBufferRetainedSizeInBytes();
+    }
+
+    @Override
+    public long getSerializedSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +    // NAME
+                SIZE_OF_INT +                   // positionCount
+                getNullsBufferSerializedSizeInBytes() +   // nulls
+                valuesBufferIndex;              // values buffer
+    }
+
+    private void appendValuesToBuffer()
+    {
+        ensureValueBufferCapacity();
+
+        int[] positions = getPositions();
+        if (decodedBlock.mayHaveNull()) {
+            for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+                int position = positions[i];
+
+                short value = decodedBlock.getShort(position);
+                int newIndex = setShort(valuesBuffer, valuesBufferIndex, value);
+
+                if (!decodedBlock.isNull(position)) {
+                    valuesBufferIndex = newIndex;
+                }
+            }
+        }
+        else {
+            for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+                short value = decodedBlock.getShort(positions[i]);
+                valuesBufferIndex = setShort(valuesBuffer, valuesBufferIndex, value);
+            }
+        }
+    }
+
+    private void ensureValueBufferCapacity()
+    {
+        int capacity = valuesBufferIndex + batchSize * ARRAY_SHORT_INDEX_SCALE;
+        if (valuesBuffer.length < capacity) {
+            valuesBuffer = Arrays.copyOf(valuesBuffer, max(valuesBuffer.length * 2, capacity));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/UncheckedByteArrays.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/UncheckedByteArrays.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+
+import static java.util.Objects.requireNonNull;
+import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+import static sun.misc.Unsafe.ARRAY_BYTE_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_SHORT_INDEX_SCALE;
+
+public class UncheckedByteArrays
+{
+    private static final Unsafe unsafe;
+
+    static {
+        try {
+            Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            unsafe = (Unsafe) field.get(null);
+            if (unsafe == null) {
+                throw new RuntimeException("Unsafe access not available");
+            }
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private UncheckedByteArrays()
+    {}
+
+    public static byte getByte(byte[] bytes, int index)
+    {
+        return unsafe.getByte(bytes, (long) index + ARRAY_BYTE_BASE_OFFSET);
+    }
+
+    public static int setByte(byte[] bytes, int index, byte value)
+    {
+        unsafe.putByte(bytes, (long) index + ARRAY_BYTE_BASE_OFFSET, value);
+        return index + ARRAY_BYTE_INDEX_SCALE;
+    }
+
+    public static short getShort(byte[] bytes, int index)
+    {
+        return unsafe.getShort(bytes, (long) index + ARRAY_BYTE_BASE_OFFSET);
+    }
+
+    public static int setShort(byte[] bytes, int index, short value)
+    {
+        unsafe.putShort(bytes, (long) index + ARRAY_BYTE_BASE_OFFSET, value);
+        return index + ARRAY_SHORT_INDEX_SCALE;
+    }
+
+    public static int getInt(byte[] bytes, int index)
+    {
+        return unsafe.getInt(bytes, (long) index + ARRAY_BYTE_BASE_OFFSET);
+    }
+
+    public static int setInt(byte[] bytes, int index, int value)
+    {
+        unsafe.putInt(bytes, (long) index + ARRAY_BYTE_BASE_OFFSET, value);
+        return index + ARRAY_INT_INDEX_SCALE;
+    }
+
+    public static long getLong(byte[] bytes, int index)
+    {
+        return unsafe.getLong(bytes, (long) index + ARRAY_BYTE_BASE_OFFSET);
+    }
+
+    public static int setLong(byte[] bytes, int index, long value)
+    {
+        unsafe.putLong(bytes, (long) index + ARRAY_BYTE_BASE_OFFSET, value);
+        return index + ARRAY_LONG_INDEX_SCALE;
+    }
+
+    public static int fill(byte[] bytes, int index, int length, byte value)
+    {
+        unsafe.setMemory(bytes, index + ARRAY_BYTE_BASE_OFFSET, length, value);
+        return index + length;
+    }
+
+    public static int setBytes(byte[] bytes, int index, byte[] values, int offset, int length)
+    {
+        requireNonNull(bytes, "bytes is null");
+        requireNonNull(values, "values is null");
+
+        checkPositionIndex(index, length, bytes.length);
+        checkPositionIndex(offset, length, values.length);
+
+        // The performance of one copy and two copies (one big chunk at 8 bytes boundary + rest) are about the same.
+        unsafe.copyMemory(values, (long) offset + ARRAY_BYTE_BASE_OFFSET, bytes, (long) index + ARRAY_BYTE_BASE_OFFSET, length);
+        return index + length;
+    }
+
+    public static int setInts(byte[] bytes, int index, int[] values, int offset, int length)
+    {
+        requireNonNull(bytes, "bytes is null");
+        requireNonNull(values, "values is null");
+
+        checkPositionIndex(index, length * ARRAY_INT_INDEX_SCALE, bytes.length);
+        checkPositionIndex(offset, length, values.length);
+
+        for (int i = offset; i < offset + length; i++) {
+            unsafe.putInt(bytes, (long) index + ARRAY_BYTE_BASE_OFFSET, values[i]);
+            index += ARRAY_INT_INDEX_SCALE;
+        }
+        return index;
+    }
+
+    public static void checkPositionIndex(int start, int length, int size)
+    {
+        if (start < 0 || length < 0 || start + length > size) {
+            throw new IndexOutOfBoundsException();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/VariableWidthBlockEncodingBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/VariableWidthBlockEncodingBuffers.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.AbstractVariableWidthBlock;
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
+import static com.facebook.presto.operator.UncheckedByteArrays.setBytes;
+import static com.facebook.presto.operator.UncheckedByteArrays.setInt;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+
+public class VariableWidthBlockEncodingBuffers
+        extends BlockEncodingBuffers
+{
+    @VisibleForTesting
+    public static final int POSITION_SIZE = Integer.BYTES + Byte.BYTES;
+
+    private static final String NAME = "VARIABLE_WIDTH";
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(VariableWidthBlockEncodingBuffers.class).instanceSize();
+
+    // The buffer for the slice for all incoming blocks so far
+    private byte[] sliceBuffer;
+
+    // The address that the next slice will be written to.
+    private int sliceBufferIndex;
+
+    // The buffer for the offsets for all incoming blocks so far
+    private byte[] offsetsBuffer;
+
+    // The address that the next offset value will be written to.
+    private int offsetsBufferIndex;
+
+    // The last offset in the offsets buffer
+    private int lastOffset;
+
+    public VariableWidthBlockEncodingBuffers(int initialPositionCount)
+    {
+        super(initialPositionCount);
+        prepareBuffers();
+    }
+
+    @Override
+    protected void prepareBuffers()
+    {
+        sliceBuffer = new byte[initialPositionCount * ARRAY_LONG_INDEX_SCALE * 2];
+        sliceBufferIndex = 0;
+
+        offsetsBuffer = new byte[initialPositionCount * ARRAY_INT_INDEX_SCALE];
+        offsetsBufferIndex = 0;
+    }
+
+    @Override
+    public void resetBuffers()
+    {
+        bufferedPositionCount = 0;
+        sliceBufferIndex = 0;
+        offsetsBufferIndex = 0;
+        lastOffset = 0;
+        resetNullsBuffer();
+    }
+
+    @Override
+    public void accumulateRowSizes(int[] rowSizes)
+    {
+        int[] positions = getPositions();
+        for (int i = 0; i < positionCount; i++) {
+            rowSizes[i] += decodedBlock.getSliceLength(positions[i]);
+            rowSizes[i] += POSITION_SIZE;
+        }
+    }
+
+    @Override
+    protected void accumulateRowSizes(int[] offsetsOffsets, int positionCount, int[] rowSizes)
+    {
+        // The nested level positionCount could be 0.
+        if (this.positionCount == 0) {
+            return;
+        }
+
+        int[] positions = getPositions();
+
+        for (int i = 0; i < positionCount; i++) {
+            int length = 0;
+
+            int positionOffset = offsetsOffsets[i];
+            int entryCount = offsetsOffsets[i + 1] - positionOffset;
+            for (int j = 0; j < entryCount; j++) {
+                length += decodedBlock.getSliceLength(positions[positionOffset++]);
+                length += POSITION_SIZE;
+            }
+
+            rowSizes[i] += length;
+        }
+    }
+
+    @Override
+    public void copyValues()
+    {
+        if (batchSize == 0) {
+            return;
+        }
+
+        appendOffsetsAndSlices();
+        appendNulls();
+        bufferedPositionCount += batchSize;
+    }
+
+    public void serializeTo(SliceOutput sliceOutput)
+    {
+        writeLengthPrefixedString(sliceOutput, NAME);
+
+        sliceOutput.writeInt(bufferedPositionCount);
+
+        // offsets
+        // note that VariableWidthBlock doesn't write the initial offset 0
+        sliceOutput.appendBytes(offsetsBuffer, 0, offsetsBufferIndex);
+
+        // nulls
+        serializeNullsTo(sliceOutput);
+        sliceOutput.writeInt(sliceBufferIndex);  // totalLength
+        sliceOutput.appendBytes(sliceBuffer, 0, sliceBufferIndex);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return getPositionsSizeInBytes() + // positions and mappedPositions
+                offsetsBufferIndex +
+                getNullsBufferSizeInBytes() +
+                sliceBufferIndex;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE +
+                getPostionsRetainedSizeInBytes() +
+                sizeOf(offsetsBuffer) +
+                getNullsBufferRetainedSizeInBytes() +
+                sizeOf(sliceBuffer);
+    }
+
+    @Override
+    public long getSerializedSizeInBytes()
+    {
+        return NAME.length() + SIZE_OF_INT +    // NAME
+                SIZE_OF_INT +                   // positionCount
+                offsetsBufferIndex +            // offsets buffer.
+                SIZE_OF_INT +                   // sliceBuffer size.
+                sliceBufferIndex +               // sliceBuffer
+                getNullsBufferSerializedSizeInBytes();  // nulls
+    }
+
+    // This implementation requires variableWidthBlock.getPositionOffset() to be public but it's much faster than the below one
+    private void appendOffsetsAndSlices()
+    {
+        ensureOffsetsBufferCapacity();
+
+        AbstractVariableWidthBlock variableWidthBlock = (AbstractVariableWidthBlock) decodedBlock;
+        int[] positions = getPositions();
+
+        // Get the whole slice then access specific rows to allow faster copy
+        int sliceLength = variableWidthBlock.getPositionOffset(variableWidthBlock.getPositionCount()) - variableWidthBlock.getPositionOffset(0);
+
+        byte[] sliceBase = (byte[]) variableWidthBlock.getSlice(0, 0, sliceLength).getBase();
+
+        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+            int position = positions[i];
+            int beginOffset = variableWidthBlock.getPositionOffset(position);
+            int endOffset = variableWidthBlock.getPositionOffset(position + 1);
+            int currentRowSize = endOffset - beginOffset;
+
+            lastOffset += currentRowSize;
+
+            offsetsBufferIndex = setInt(offsetsBuffer, offsetsBufferIndex, lastOffset);
+
+            ensureSliceBufferCapacity(currentRowSize);
+
+            if (currentRowSize > 0) {
+                sliceBufferIndex = setBytes(sliceBuffer, sliceBufferIndex, sliceBase, beginOffset, currentRowSize);
+            }
+        }
+    }
+
+    // This implementation doesn't need to expose variableWidthBlock.getPositionOffset() but it's too slow, because it's calling getSlice()
+    // for every row and has too much overhead in constructing the Slice object
+//    private void appendOffsetsAndSlices()
+//    {
+//        verify(offsetsBufferIndex == bufferedPositionCount * ARRAY_INT_INDEX_SCALE);
+//        // format("offsetsBufferIndex %d should equal to bufferedPositionCount %d * ARRAY_INT_INDEX_SCALE %d.", offsetsBufferIndex, bufferedPositionCount, ARRAY_INT_INDEX_SCALE));
+//
+//        int lastOffset = 0;
+//        if (offsetsBufferIndex > 0) {
+//            // There're already some values in the buffer
+//            //// System.out.println(offsetsBufferIndex);
+//            try {
+//                lastOffset = ByteArrays.getInt(offsetsBuffer, offsetsBufferIndex - ARRAY_INT_INDEX_SCALE);
+//            }
+//            catch (Exception e) {
+//                e.printStackTrace();
+//            }
+//        }
+//
+//        ensureOffsetsBufferCapacity();
+//        int[] positions = getPositions();
+//
+//        AbstractVariableWidthBlock variableWidthBlock = (AbstractVariableWidthBlock) decodedBlock;
+//        for (int i = positionsOffset; i < positionsOffset + batchSize; i++) {
+//            int position = positions[i];
+//            int currentRowSize = variableWidthBlock.getSliceLength(position);
+//            int currentOffset = lastOffset + currentRowSize;
+//
+//            ByteArrayUtils.setInt(offsetsBuffer, offsetsBufferIndex, currentOffset);
+//            offsetsBufferIndex += ARRAY_INT_INDEX_SCALE;
+//
+//            //// // System.out.println("positionsOffset " + positionsOffset + " batchSize " + batchSize + " i " + i +
+//            //      " position " + position + " sliceBufferIndex " + sliceBufferIndex + " slice.length " + currentRowSize);
+//
+//            ensureSliceBufferCapacity(currentRowSize);
+//            sliceBufferIndex = ByteArrayUtils.writeSlice(sliceBuffer, sliceBufferIndex, variableWidthBlock.getSlice(position, 0, currentRowSize));
+//
+//            lastOffset = currentOffset;
+//        }
+//    }
+
+    private void ensureSliceBufferCapacity(int currentRowSize)
+    {
+        int capacity = sliceBufferIndex + currentRowSize;
+        if (capacity > sliceBuffer.length) {
+            sliceBuffer = Arrays.copyOf(sliceBuffer, max(sliceBuffer.length * 2, capacity));
+        }
+    }
+
+    private void ensureOffsetsBufferCapacity()
+    {
+        int capacity = offsetsBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE;
+        if (offsetsBuffer.length < capacity) {
+            offsetsBuffer = Arrays.copyOf(offsetsBuffer, max(capacity, offsetsBuffer.length * 2));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -133,6 +133,7 @@ public class FeaturesConfig
 
     private boolean jsonSerdeCodeGenerationEnabled;
     private int maxConcurrentMaterializations = 10;
+    private boolean optimizedRepartitioningEnabled;
 
     private boolean pushdownSubfieldsEnabled;
 
@@ -1043,5 +1044,18 @@ public class FeaturesConfig
     public boolean isPushdownSubfieldsEnabled()
     {
         return pushdownSubfieldsEnabled;
+    }
+
+    public boolean isOptimizedRepartitioningEnabled()
+    {
+        return optimizedRepartitioningEnabled;
+    }
+
+    @Config("experimental.optimized-repartitioning")
+    @ConfigDescription("Experimental: Use optimized repartitioning")
+    public FeaturesConfig setOptimizedRepartitioningEnabled(boolean optimizedRepartitioningEnabled)
+    {
+        this.optimizedRepartitioningEnabled = optimizedRepartitioningEnabled;
+        return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkReadBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkReadBlock.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.Block;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import static com.facebook.presto.operator.UncheckedByteArrays.setLong;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+
+@State(Scope.Thread)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(3)
+@Warmup(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkReadBlock
+{
+    @Benchmark
+    public int sequentialCopyLongValues(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            index = setLong(data.bytes, index, data.longValues[i]);
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int sequentialCopyLongArrayBlock(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            index = setLong(data.bytes, index, data.blockNoNulls.getLong(i));
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int sequentialCopyUncheckedLongArrayBlock(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            index = setLong(data.bytes, index, data.blockNoNulls.getLongUnchecked(i));
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int randomCopyLongValues(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            index = setLong(data.bytes, index, data.longValues[data.positions[i]]);
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int randomCopyLongArrayBlock(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            index = setLong(data.bytes, index, data.blockNoNulls.getLong(data.positions[i]));
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int randomCopyUncheckedLongArrayBlock(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            index = setLong(data.bytes, index, data.blockNoNulls.getLongUnchecked(data.positions[i]));
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int sequentialCopyLongValuesWithNulls(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            int newIndex = setLong(data.bytes, index, data.longValues[i]);
+            if (!data.nulls[i]) {
+                index = newIndex;
+            }
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int sequentialCopyLongArrayBlockWithNulls(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            int newIndex = setLong(data.bytes, index, data.blockWithNulls.getLong(i));
+            if (!data.blockWithNulls.isNull(i)) {
+                index = newIndex;
+            }
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int sequentialCopyUncheckedLongArrayBlockWithNulls(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            int newIndex = setLong(data.bytes, index, data.blockWithNulls.getLongUnchecked(i));
+            if (!data.blockWithNulls.isNullUnchecked(i)) {
+                index = newIndex;
+            }
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int randomCopyLongValuesWithNulls(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            int newIndex = setLong(data.bytes, index, data.longValues[data.positions[i]]);
+            if (!data.nulls[data.positions[i]]) {
+                index = newIndex;
+            }
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int randomCopyLongArrayBlockWithNulls(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            int newIndex = setLong(data.bytes, index, data.blockNoNulls.getLong(data.positions[i]));
+            if (!data.blockWithNulls.isNull(data.positions[i])) {
+                index = newIndex;
+            }
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int randomCopyUncheckedLongArrayBlockWithNulls(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            int newIndex = setLong(data.bytes, index, data.blockNoNulls.getLongUnchecked(data.positions[i]));
+            if (!data.blockWithNulls.isNullUnchecked(data.positions[i])) {
+                index = newIndex;
+            }
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int randomCopyLongValuesWithDictionary(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            index = setLong(data.bytes, index, data.longValues[data.ids[data.positions[i]]]);
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int randomCopyDictionaryBlock(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            index = setLong(data.bytes, index, data.dictionaryBlockNoNulls.getLong(data.positions[i]));
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int randomCopyUncheckedDictionaryBlock(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            index = setLong(data.bytes, index, data.dictionaryBlockNoNulls.getLongUnchecked(data.positions[i]));
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int randomCopyLongValuesWithDictionaryWithNulls(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            int newIndex = setLong(data.bytes, index, data.longValues[data.positions[i]]);
+            if (!data.nulls[data.ids[data.positions[i]]]) {
+                index = newIndex;
+            }
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int randomCopyDictionaryBlockWithNulls(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            int newIndex = setLong(data.bytes, index, data.dictionaryBlockWithNulls.getLong(data.positions[i]));
+            if (!data.dictionaryBlockWithNulls.isNull(data.positions[i])) {
+                index = newIndex;
+            }
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int randomCopyUncheckedDictionaryBlockWithNulls(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            int newIndex = setLong(data.bytes, index, data.dictionaryBlockWithNulls.getLongUnchecked(data.positions[i]));
+            if (!data.dictionaryBlockWithNulls.isNullUnchecked(data.positions[i])) {
+                index = newIndex;
+            }
+        }
+        return index;
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private static final int POSITIONS_PER_PAGE = 10000;
+
+        private final Random random = new Random(0);
+        private final TestingBlockBuilders blockBuilders = new TestingBlockBuilders();
+
+        private final long[] longValues = LongStream.range(0, POSITIONS_PER_PAGE).map(i -> random.nextLong()).toArray();
+        private final boolean[] nulls = new boolean[POSITIONS_PER_PAGE];
+        private final int[] ids = IntStream.range(0, POSITIONS_PER_PAGE).map(i -> random.nextInt(POSITIONS_PER_PAGE / 10)).toArray();
+        private final int[] positions = IntStream.range(0, POSITIONS_PER_PAGE).toArray();
+
+        private final Block blockNoNulls = blockBuilders.buildBigintBlock(POSITIONS_PER_PAGE, false);
+        private final Block blockWithNulls = blockBuilders.buildBigintBlock(POSITIONS_PER_PAGE, true);
+        private final Block dictionaryBlockNoNulls = blockBuilders.buildDictionaryBlock(blockNoNulls, POSITIONS_PER_PAGE);
+        private final Block dictionaryBlockWithNulls = blockBuilders.buildDictionaryBlock(blockWithNulls, POSITIONS_PER_PAGE);
+
+        private byte[] bytes;
+
+        @Setup
+        public void setup()
+        {
+            for (int i = 0; i < POSITIONS_PER_PAGE; i++) {
+                if (i % 7 == 0) {
+                    nulls[i] = true;
+                }
+            }
+
+            bytes = new byte[POSITIONS_PER_PAGE * ARRAY_LONG_INDEX_SCALE];
+        }
+    }
+
+    public void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkReadBlock.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkUncheckedByteArrays.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkUncheckedByteArrays.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.google.common.primitives.Booleans;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.operator.UncheckedByteArrays.setBytes;
+import static com.facebook.presto.operator.UncheckedByteArrays.setLong;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+
+@State(Scope.Thread)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(3)
+@Warmup(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkUncheckedByteArrays
+{
+    @Benchmark
+    public int sequentialCopyToByteArray(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            index = setLong(data.bytes, index, data.longValues[i]);
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int sequentialCopyToBasicSliceOutput(BenchmarkData data)
+    {
+        return sequentialCopyToSliceOutput(data.basicSliceOutput, data.longValues);
+    }
+
+    @Benchmark
+    public int sequentialCopyToDynamicSliceOutput(BenchmarkData data)
+    {
+        return sequentialCopyToSliceOutput(data.dynamicSliceOutput, data.longValues);
+    }
+
+    @Benchmark
+    public int sequentialCopyToTestingSliceOutput(BenchmarkData data)
+    {
+        TestingSliceOutput sliceOutput = data.testingSliceOutput;
+        sliceOutput.reset();
+        for (int i = 0; i < data.longValues.length; i++) {
+            sliceOutput.writeLong(data.longValues[i]);
+        }
+        return sliceOutput.size();
+    }
+
+    @Benchmark
+    public int sequentialCopyWithNullsToByteArray(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            int newIndex = setLong(data.bytes, index, data.longValues[i]);
+            // Only update the index when it's not null. This will be compiled to conditional move instruction instead of compare and jumps.
+            if (data.nulls[i]) {
+                index = newIndex;
+            }
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int sequentialCopyWithNullsToByteArrayNaive(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            // This will be compiled to compare and jumps.
+            if (!data.nulls[i]) {
+                index = setLong(data.bytes, index, data.longValues[i]);
+            }
+        }
+        return index;
+    }
+
+    @Benchmark
+    public int sequentialCopyWithNullsToBasicSliceOutput(BenchmarkData data)
+    {
+        return sequentialCopyWithNullsToSliceOutput(data.basicSliceOutput, data.longValues, data.nulls);
+    }
+
+    @Benchmark
+    public int sequentialCopyWithNullsToDynamicSliceOutput(BenchmarkData data)
+    {
+        return sequentialCopyWithNullsToSliceOutput(data.dynamicSliceOutput, data.longValues, data.nulls);
+    }
+
+    @Benchmark
+    public int sequentialCopyWithNullsToTestingSliceOutputNaive(BenchmarkData data)
+    {
+        TestingSliceOutput sliceOutput = data.testingSliceOutput;
+        sliceOutput.reset();
+        for (int i = 0; i < data.longValues.length; i++) {
+            if (data.nulls[i]) {
+                sliceOutput.writeLong(data.longValues[i]);
+            }
+        }
+        return sliceOutput.size();
+    }
+
+    @Benchmark
+    public int sequentialCopyWithNullsToTestingSliceOutput(BenchmarkData data)
+    {
+        TestingSliceOutput sliceOutput = data.testingSliceOutput;
+        sliceOutput.reset();
+        for (int i = 0; i < data.longValues.length; i++) {
+            sliceOutput.writeLong(data.longValues[i], data.nulls[i]);
+        }
+        return sliceOutput.size();
+    }
+
+    @Benchmark
+    public int randomCopyToByteArray(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            index = setLong(data.bytes, data.positions[i] * ARRAY_LONG_INDEX_SCALE, data.longValues[i]);
+        }
+        return index;
+    }
+
+    // We can't apply the trick on null check when copying to random locations in the byte array
+    @Benchmark
+    public int randomCopyWithNullsToByteArray(BenchmarkData data)
+    {
+        int index = 0;
+        for (int i = 0; i < data.longValues.length; i++) {
+            if (data.nulls[i]) {
+                index = setLong(data.bytes, data.positions[i] * ARRAY_LONG_INDEX_SCALE, data.longValues[i]);
+            }
+        }
+        return index;
+    }
+
+    @Benchmark
+    public void copyBytesToByteArray(BenchmarkData data)
+    {
+        setBytes(data.bytes, 0, data.byteValues, 0, data.bytes.length);
+    }
+
+    @Benchmark
+    public void copyBytesToBasicSliceOutput(BenchmarkData data)
+    {
+        data.basicSliceOutput.reset();
+        data.basicSliceOutput.writeBytes(data.slice, 0, data.slice.length());
+    }
+
+    @Benchmark
+    public void copyBytesToDynamicSliceOutput(BenchmarkData data)
+    {
+        data.dynamicSliceOutput.reset();
+        data.dynamicSliceOutput.writeBytes(data.slice, 0, data.slice.length());
+    }
+
+    private int sequentialCopyToSliceOutput(SliceOutput sliceOutput, long[] values)
+    {
+        sliceOutput.reset();
+        for (int i = 0; i < values.length; i++) {
+            sliceOutput.writeLong(values[i]);
+        }
+        return sliceOutput.size();
+    }
+
+    private int sequentialCopyWithNullsToSliceOutput(SliceOutput sliceOutput, long[] values, boolean[] nulls)
+    {
+        sliceOutput.reset();
+        for (int i = 0; i < values.length; i++) {
+            if (!nulls[i]) {
+                sliceOutput.writeLong(values[i]);
+            }
+        }
+        return sliceOutput.size();
+    }
+
+    private static class TestingSliceOutput
+    {
+        private Unsafe unsafe;
+
+        {
+            try {
+                Field field = Unsafe.class.getDeclaredField("theUnsafe");
+                field.setAccessible(true);
+                unsafe = (Unsafe) field.get(null);
+                if (unsafe == null) {
+                    throw new RuntimeException("Unsafe access not available");
+                }
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private byte[] buffer;
+        public int size;
+
+        TestingSliceOutput(int initialSize)
+        {
+            buffer = new byte[initialSize];
+        }
+
+        public void writeLong(long value)
+        {
+            unsafe.putLong(buffer, (long) size + ARRAY_BYTE_BASE_OFFSET, value);
+            size += ARRAY_LONG_INDEX_SCALE;
+        }
+
+        public void writeLong(long value, int address)
+        {
+            unsafe.putLong(buffer, (long) address + ARRAY_BYTE_BASE_OFFSET, value);
+        }
+
+        public void writeLong(long value, boolean isNull)
+        {
+            unsafe.putLong(buffer, (long) size + ARRAY_BYTE_BASE_OFFSET, value);
+            if (!isNull) {
+                size += ARRAY_LONG_INDEX_SCALE;
+            }
+        }
+
+        public int size()
+        {
+            return size;
+        }
+
+        public void reset()
+        {
+            size = 0;
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private static final int POSITIONS_PER_PAGE = 10000;
+
+        private final Random random = new Random(0);
+
+        private final long[] longValues = LongStream.range(0, POSITIONS_PER_PAGE).map(i -> random.nextLong()).toArray();
+        private final boolean[] nulls = Booleans.toArray(Stream.generate(() -> random.nextBoolean()).limit(POSITIONS_PER_PAGE).collect(Collectors.toCollection(ArrayList::new)));
+        private final int[] positions = IntStream.range(0, POSITIONS_PER_PAGE).toArray();
+
+        private final byte[] byteValues = new byte[POSITIONS_PER_PAGE * ARRAY_LONG_INDEX_SCALE];
+        private final Slice slice = Slices.wrappedBuffer(byteValues);
+
+        private byte[] bytes;
+        private SliceOutput basicSliceOutput;
+        private SliceOutput dynamicSliceOutput;
+        private TestingSliceOutput testingSliceOutput;
+
+        @Setup
+        public void setup()
+        {
+            random.nextBytes(byteValues);
+
+            bytes = new byte[POSITIONS_PER_PAGE * ARRAY_LONG_INDEX_SCALE];
+
+            dynamicSliceOutput = new DynamicSliceOutput(POSITIONS_PER_PAGE * ARRAY_LONG_INDEX_SCALE);
+
+            Slice slice = Slices.wrappedBuffer(new byte[POSITIONS_PER_PAGE * ARRAY_LONG_INDEX_SCALE]);
+            basicSliceOutput = slice.getOutput();
+
+            testingSliceOutput = new TestingSliceOutput(POSITIONS_PER_PAGE * ARRAY_LONG_INDEX_SCALE);
+        }
+    }
+
+    public void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkUncheckedByteArrays.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
@@ -27,14 +27,6 @@ import java.util.Random;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.block.BlockAssertions.assertBlockEquals;
-<<<<<<< HEAD
-=======
-import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
-import static com.facebook.presto.block.BlockAssertions.createIntsBlock;
-import static com.facebook.presto.block.BlockAssertions.createLongDecimalsBlock;
-import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
-import static com.facebook.presto.block.BlockAssertions.createTypedLongsBlock;
->>>>>>> 1cb7d86bd5... Optimize repartitioning for BOOLEAN type
 import static com.facebook.presto.block.BlockSerdeUtil.readBlock;
 import static com.facebook.presto.operator.BlockEncodingBuffers.createBlockEncodingBuffers;
 import static com.facebook.presto.operator.OptimizedPartitionedOutputOperator.decodeBlock;
@@ -44,6 +36,7 @@ import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -84,6 +77,14 @@ public class TestBlockEncodingBuffers
     public void testBoolean()
     {
         testBlock(BOOLEAN, TESTING_BLOCK_BUILDERS.buildBooleanBlock(POSITIONS_PER_BLOCK, true));
+    }
+
+    @Test
+    public void testVarchar()
+    {
+        testBlock(VARCHAR, TESTING_BLOCK_BUILDERS.buildVarcharBlock(POSITIONS_PER_BLOCK, true, 10));
+        testBlock(VARCHAR, TESTING_BLOCK_BUILDERS.buildVarcharBlock(POSITIONS_PER_BLOCK, true, 0));
+        testBlock(VARCHAR, TESTING_BLOCK_BUILDERS.buildRleBlock(TESTING_BLOCK_BUILDERS.buildVarcharBlock(POSITIONS_PER_BLOCK, true, 0), POSITIONS_PER_BLOCK));
     }
 
     private void testBlock(Type type, Block block)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
@@ -34,6 +34,7 @@ import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -62,6 +63,12 @@ public class TestBlockEncodingBuffers
     public void testInteger()
     {
         testBlock(INTEGER, TESTING_BLOCK_BUILDERS.buildIntegerBlock(POSITIONS_PER_BLOCK, true));
+    }
+
+    @Test
+    public void testSmallint()
+    {
+        testBlock(SMALLINT, TESTING_BLOCK_BUILDERS.buildSmallintBlock(POSITIONS_PER_BLOCK, true));
     }
 
     private void testBlock(Type type, Block block)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
@@ -33,6 +33,7 @@ import static com.facebook.presto.operator.OptimizedPartitionedOutputOperator.de
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.spi.type.Decimals.MAX_SHORT_PRECISION;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -55,6 +56,12 @@ public class TestBlockEncodingBuffers
     public void testLongDecimal()
     {
         testBlock(createDecimalType(MAX_SHORT_PRECISION + 1), TESTING_BLOCK_BUILDERS.buildLongDecimalBlock(POSITIONS_PER_BLOCK, true));
+    }
+
+    @Test
+    public void testInteger()
+    {
+        testBlock(INTEGER, TESTING_BLOCK_BUILDERS.buildIntegerBlock(POSITIONS_PER_BLOCK, true));
     }
 
     private void testBlock(Type type, Block block)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
@@ -31,6 +31,8 @@ import static com.facebook.presto.block.BlockSerdeUtil.readBlock;
 import static com.facebook.presto.operator.BlockEncodingBuffers.createBlockEncodingBuffers;
 import static com.facebook.presto.operator.OptimizedPartitionedOutputOperator.decodeBlock;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
+import static com.facebook.presto.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -47,6 +49,12 @@ public class TestBlockEncodingBuffers
     public void testBigint()
     {
         testBlock(BIGINT, TESTING_BLOCK_BUILDERS.buildBigintBlock(POSITIONS_PER_BLOCK, true));
+    }
+
+    @Test
+    public void testLongDecimal()
+    {
+        testBlock(createDecimalType(MAX_SHORT_PRECISION + 1), TESTING_BLOCK_BUILDERS.buildLongDecimalBlock(POSITIONS_PER_BLOCK, true));
     }
 
     private void testBlock(Type type, Block block)
@@ -75,6 +83,7 @@ public class TestBlockEncodingBuffers
         assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block.getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3), POSITIONS_PER_BLOCK, Optional.of("D")));
         assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block.getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3), POSITIONS_PER_BLOCK, Optional.of("R")));
         assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block.getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3), POSITIONS_PER_BLOCK, Optional.of("DDRR")));
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block.getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3), POSITIONS_PER_BLOCK, Optional.of("RRDD")));
     }
 
     private static void assertSerialized(Type type, Block block)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
@@ -27,10 +27,19 @@ import java.util.Random;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.block.BlockAssertions.assertBlockEquals;
+<<<<<<< HEAD
+=======
+import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
+import static com.facebook.presto.block.BlockAssertions.createIntsBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongDecimalsBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createTypedLongsBlock;
+>>>>>>> 1cb7d86bd5... Optimize repartitioning for BOOLEAN type
 import static com.facebook.presto.block.BlockSerdeUtil.readBlock;
 import static com.facebook.presto.operator.BlockEncodingBuffers.createBlockEncodingBuffers;
 import static com.facebook.presto.operator.OptimizedPartitionedOutputOperator.decodeBlock;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -69,6 +78,12 @@ public class TestBlockEncodingBuffers
     public void testSmallint()
     {
         testBlock(SMALLINT, TESTING_BLOCK_BUILDERS.buildSmallintBlock(POSITIONS_PER_BLOCK, true));
+    }
+
+    @Test
+    public void testBoolean()
+    {
+        testBlock(BOOLEAN, TESTING_BLOCK_BUILDERS.buildBooleanBlock(POSITIONS_PER_BLOCK, true));
     }
 
     private void testBlock(Type type, Block block)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockFlattener;
+import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceOutput;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.block.BlockAssertions.assertBlockEquals;
+import static com.facebook.presto.block.BlockSerdeUtil.readBlock;
+import static com.facebook.presto.operator.BlockEncodingBuffers.createBlockEncodingBuffers;
+import static com.facebook.presto.operator.OptimizedPartitionedOutputOperator.decodeBlock;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+public class TestBlockEncodingBuffers
+{
+    private static final int POSITIONS_PER_BLOCK = 1000;
+    private static final TestingBlockBuilders TESTING_BLOCK_BUILDERS = new TestingBlockBuilders();
+
+    private Random random = new Random(0);
+
+    @Test
+    public void testBigint()
+    {
+        testBlock(BIGINT, TESTING_BLOCK_BUILDERS.buildBigintBlock(POSITIONS_PER_BLOCK, true));
+    }
+
+    private void testBlock(Type type, Block block)
+    {
+        requireNonNull(type);
+
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildNullBlock(type, POSITIONS_PER_BLOCK));
+        assertSerialized(type, block);
+
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block, POSITIONS_PER_BLOCK, Optional.of("D")));
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block, POSITIONS_PER_BLOCK, Optional.of("R")));
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block, POSITIONS_PER_BLOCK, Optional.of("DDRR")));
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block, POSITIONS_PER_BLOCK, Optional.of("RRDD")));
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block, POSITIONS_PER_BLOCK, Optional.of("DRDR")));
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block, POSITIONS_PER_BLOCK, Optional.of("RDRD")));
+
+        assertSerialized(type, block.getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3));
+
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block, POSITIONS_PER_BLOCK, Optional.of("D")).getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3));
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block, POSITIONS_PER_BLOCK, Optional.of("R")).getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3));
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block, POSITIONS_PER_BLOCK, Optional.of("DDRR")).getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3));
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block, POSITIONS_PER_BLOCK, Optional.of("RRDD")).getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3));
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block, POSITIONS_PER_BLOCK, Optional.of("DRDR")).getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3));
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block, POSITIONS_PER_BLOCK, Optional.of("RDRD")).getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3));
+
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block.getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3), POSITIONS_PER_BLOCK, Optional.of("D")));
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block.getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3), POSITIONS_PER_BLOCK, Optional.of("R")));
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block.getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3), POSITIONS_PER_BLOCK, Optional.of("DDRR")));
+    }
+
+    private static void assertSerialized(Type type, Block block)
+    {
+        assertSerialized(type, block, null);
+    }
+
+    private static void assertSerialized(Type type, Block block, int[] expectedRowSizes)
+    {
+        // The number 5 was chosen to be greater than the maximum Dictionary/RLE nested level
+        BlockFlattener flattener = new BlockFlattener(new SimpleArrayAllocator(5));
+        DecodedBlockNode decodedBlock = decodeBlock(flattener, block);
+
+        BlockEncodingBuffers buffers = createBlockEncodingBuffers(decodedBlock, 100);
+
+        int[] positions = IntStream.range(0, block.getPositionCount() / 2).toArray();
+        copyPositions(decodedBlock, buffers, positions, expectedRowSizes);
+
+        positions = IntStream.range(block.getPositionCount() / 2, block.getPositionCount()).toArray();
+        copyPositions(decodedBlock, buffers, positions, expectedRowSizes);
+
+        assertBlockEquals(type, serialize(buffers), block);
+
+        buffers.resetBuffers();
+
+        positions = IntStream.range(0, block.getPositionCount()).filter(n -> n % 2 == 0).toArray();
+        Block expectedBlock = block.copyPositions(positions, 0, positions.length);
+        copyPositions(decodedBlock, buffers, positions, expectedRowSizes);
+
+        assertBlockEquals(type, serialize(buffers), expectedBlock);
+    }
+
+    private static void copyPositions(DecodedBlockNode decodedBlock, BlockEncodingBuffers buffers, int[] positions, int[] expectedRowSizes)
+    {
+        buffers.setupDecodedBlocksAndPositions(decodedBlock, positions, positions.length);
+
+        if (expectedRowSizes != null) {
+            int[] actualSizes = new int[positions.length];
+            buffers.accumulateRowSizes(actualSizes);
+
+            int[] expectedSizes = Arrays.stream(positions).map(i -> expectedRowSizes[i]).toArray();
+            assertEquals(actualSizes, expectedSizes);
+        }
+
+        buffers.setNextBatch(0, positions.length);
+        buffers.copyValues();
+    }
+
+    private static Block serialize(BlockEncodingBuffers buffers)
+    {
+        SliceOutput output = new DynamicSliceOutput(toIntExact(buffers.getSerializedSizeInBytes()));
+        buffers.serializeTo(output);
+
+        BlockEncodingManager blockEncodingSerde = new BlockEncodingManager(TYPE_MANAGER);
+        return readBlock(blockEncodingSerde, output.slice().getInput());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
@@ -16,6 +16,9 @@ package com.facebook.presto.operator;
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockFlattener;
+import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.SliceOutput;
@@ -30,6 +33,7 @@ import static com.facebook.presto.block.BlockAssertions.assertBlockEquals;
 import static com.facebook.presto.block.BlockSerdeUtil.readBlock;
 import static com.facebook.presto.operator.BlockEncodingBuffers.createBlockEncodingBuffers;
 import static com.facebook.presto.operator.OptimizedPartitionedOutputOperator.decodeBlock;
+import static com.facebook.presto.spi.block.ArrayBlock.fromElementBlock;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
@@ -38,7 +42,9 @@ import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
 
@@ -87,6 +93,31 @@ public class TestBlockEncodingBuffers
         testBlock(VARCHAR, TESTING_BLOCK_BUILDERS.buildRleBlock(TESTING_BLOCK_BUILDERS.buildVarcharBlock(POSITIONS_PER_BLOCK, true, 0), POSITIONS_PER_BLOCK));
     }
 
+    @Test
+    public void testArray()
+    {
+        testNestedBlock(new ArrayType(BIGINT));
+        testNestedBlock(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)));
+        testNestedBlock(new ArrayType(INTEGER));
+        testNestedBlock(new ArrayType(SMALLINT));
+        testNestedBlock(new ArrayType(BOOLEAN));
+        testNestedBlock(new ArrayType(VARCHAR));
+
+        testNestedBlock(new ArrayType(new ArrayType(BIGINT)));
+        testNestedBlock(new ArrayType(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1))));
+        testNestedBlock(new ArrayType(new ArrayType(INTEGER)));
+        testNestedBlock(new ArrayType(new ArrayType(SMALLINT)));
+        testNestedBlock(new ArrayType(new ArrayType(BOOLEAN)));
+        testNestedBlock(new ArrayType(new ArrayType(VARCHAR)));
+
+        testNestedBlock(new ArrayType(new ArrayType(new ArrayType(BIGINT))));
+        testNestedBlock(new ArrayType(new ArrayType(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testNestedBlock(new ArrayType(new ArrayType(new ArrayType(INTEGER))));
+        testNestedBlock(new ArrayType(new ArrayType(new ArrayType(SMALLINT))));
+        testNestedBlock(new ArrayType(new ArrayType(new ArrayType(BOOLEAN))));
+        testNestedBlock(new ArrayType(new ArrayType(new ArrayType(VARCHAR))));
+    }
+
     private void testBlock(Type type, Block block)
     {
         requireNonNull(type);
@@ -114,6 +145,248 @@ public class TestBlockEncodingBuffers
         assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block.getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3), POSITIONS_PER_BLOCK, Optional.of("R")));
         assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block.getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3), POSITIONS_PER_BLOCK, Optional.of("DDRR")));
         assertSerialized(type, TESTING_BLOCK_BUILDERS.buildDictRleBlock(block.getRegion(POSITIONS_PER_BLOCK / 2, POSITIONS_PER_BLOCK / 3), POSITIONS_PER_BLOCK, Optional.of("RRDD")));
+    }
+
+    private void testNestedBlock(Type type)
+    {
+        requireNonNull(type);
+
+        assertSerialized(type, TESTING_BLOCK_BUILDERS.buildNullBlock(type, POSITIONS_PER_BLOCK));
+
+        BlockStatus blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, false, Optional.empty());
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, false, Optional.of("D"));
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, false, Optional.of("R"));
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, false, Optional.of("DDR"));
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, false, Optional.of("DDRR"));
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, false, Optional.of("RRDD"));
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, false, Optional.of("DRDR"));
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, false, Optional.of("RDRD"));
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, true, Optional.empty());
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, true, Optional.of("D"));
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, true, Optional.of("R"));
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, true, Optional.of("DDRR"));
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, true, Optional.of("RRDD"));
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, true, Optional.of("DRDR"));
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+
+        blockStatus = buildBlockStatusWithType(type, POSITIONS_PER_BLOCK, true, Optional.of("RDRD"));
+        assertSerialized(type, blockStatus.block, blockStatus.expectedRowSizes);
+    }
+
+    private BlockStatus buildBlockStatusWithType(Type type, int positionCount, boolean isView, Optional<String> wrappings)
+    {
+        return buildBlockStatusWithType(type, positionCount, isView, true, wrappings);
+    }
+
+    private BlockStatus buildBlockStatusWithType(Type type, int positionCount, boolean isView, boolean allowNulls, Optional<String> wrappings)
+    {
+        BlockStatus blockStatus = null;
+
+        if (isView) {
+            positionCount *= 2;
+        }
+
+        if (type == BIGINT) {
+            blockStatus = buildBigintBlockStatus(positionCount, allowNulls);
+        }
+        else if (type instanceof DecimalType && !((DecimalType) type).isShort()) {
+            blockStatus = buildLongDecimalBlockStatus(positionCount, allowNulls);
+        }
+        else if (type == INTEGER) {
+            blockStatus = buildIntegerBlockStatus(positionCount, allowNulls);
+        }
+        else if (type == SMALLINT) {
+            blockStatus = buildSmallintBlockStatus(positionCount, allowNulls);
+        }
+        else if (type == BOOLEAN) {
+            blockStatus = buildBooleanBlockStatus(positionCount, allowNulls);
+        }
+        else if (type == VARCHAR) {
+            blockStatus = buildVarcharBlockStatus(positionCount, allowNulls, 10);
+        }
+        else {
+            // Nested types
+            // Build isNull and offsets of size positionCount
+            boolean[] isNull = new boolean[positionCount];
+            int[] offsets = new int[positionCount + 1];
+            for (int position = 0; position < positionCount; position++) {
+                if (allowNulls && position % 7 == 0) {
+                    isNull[position] = true;
+                    offsets[position + 1] = offsets[position];
+                }
+                else {
+                    offsets[position + 1] = offsets[position] + random.nextInt(10) + 1;
+                }
+            }
+
+            // Build the nested block of size offsets[positionCount].
+            if (type instanceof ArrayType) {
+                blockStatus = buildArrayBlockStatus((ArrayType) type, positionCount, isView, isNull, offsets, allowNulls, wrappings);
+            }
+            else {
+                throw new UnsupportedOperationException(format("type %s is not supported.", type));
+            }
+        }
+
+        if (isView) {
+            positionCount /= 2;
+            int offset = positionCount / 2;
+            Block blockView = blockStatus.block.getRegion(offset, positionCount);
+            int[] expectedRowSizesView = Arrays.stream(blockStatus.expectedRowSizes, offset, offset + positionCount).toArray();
+            blockStatus = new BlockStatus(blockView, expectedRowSizesView);
+        }
+
+        blockStatus = buildDictRleBlockStatus(blockStatus, positionCount, wrappings);
+
+        return blockStatus;
+    }
+
+    private BlockStatus buildBigintBlockStatus(int positionCount, boolean allowNulls)
+    {
+        Block block = TESTING_BLOCK_BUILDERS.buildBigintBlock(positionCount, allowNulls);
+        int[] expectedRowSizes = IntStream.generate(() -> LongArrayBlockEncodingBuffers.POSITION_SIZE).limit(positionCount).toArray();
+
+        return new BlockStatus(block, expectedRowSizes);
+    }
+
+    private BlockStatus buildLongDecimalBlockStatus(int positionCount, boolean allowNulls)
+    {
+        Block block = TESTING_BLOCK_BUILDERS.buildLongDecimalBlock(positionCount, allowNulls);
+        int[] expectedRowSizes = IntStream.generate(() -> Int128ArrayBlockEncodingBuffers.POSITION_SIZE).limit(positionCount).toArray();
+
+        return new BlockStatus(block, expectedRowSizes);
+    }
+
+    private BlockStatus buildIntegerBlockStatus(int positionCount, boolean allowNulls)
+    {
+        Block block = TESTING_BLOCK_BUILDERS.buildIntegerBlock(positionCount, allowNulls);
+        int[] expectedRowSizes = IntStream.generate(() -> IntArrayBlockEncodingBuffers.POSITION_SIZE).limit(positionCount).toArray();
+
+        return new BlockStatus(block, expectedRowSizes);
+    }
+
+    private BlockStatus buildSmallintBlockStatus(int positionCount, boolean allowNulls)
+    {
+        Block block = TESTING_BLOCK_BUILDERS.buildSmallintBlock(positionCount, allowNulls);
+        int[] expectedRowSizes = IntStream.generate(() -> ShortArrayBlockEncodingBuffers.POSITION_SIZE).limit(positionCount).toArray();
+
+        return new BlockStatus(block, expectedRowSizes);
+    }
+
+    private BlockStatus buildBooleanBlockStatus(int positionCount, boolean allowNulls)
+    {
+        Block block = TESTING_BLOCK_BUILDERS.buildBooleanBlock(positionCount, allowNulls);
+        int[] expectedRowSizes = IntStream.generate(() -> ByteArrayBlockEncodingBuffers.POSITION_SIZE).limit(positionCount).toArray();
+
+        return new BlockStatus(block, expectedRowSizes);
+    }
+
+    private BlockStatus buildVarcharBlockStatus(int positionCount, boolean allowNulls, int maxStringLength)
+    {
+        Block block = TESTING_BLOCK_BUILDERS.buildVarcharBlock(positionCount, allowNulls, maxStringLength);
+
+        int[] expectedRowSizes = IntStream
+                .range(0, positionCount)
+                .map(i -> block.getSliceLength(i) + VariableWidthBlockEncodingBuffers.POSITION_SIZE)
+                .toArray();
+
+        return new BlockStatus(block, expectedRowSizes);
+    }
+
+    private BlockStatus buildDictRleBlockStatus(BlockStatus blockStatus, int positionCount, Optional<String> wrappings)
+    {
+        checkArgument(blockStatus.block.getPositionCount() == positionCount);
+
+        if (!wrappings.isPresent()) {
+            return blockStatus;
+        }
+
+        for (int i = wrappings.get().length() - 1; i >= 0; i--) {
+            if (wrappings.get().charAt(i) == 'D') {
+                blockStatus = buildDictionaryBlockStatus(blockStatus, positionCount);
+            }
+            else if (wrappings.get().charAt(i) == 'R') {
+                blockStatus = buildRleBlockStatus(blockStatus, positionCount);
+            }
+            else {
+                throw new IllegalArgumentException(format("wrappings %s is incorrect", wrappings));
+            }
+        }
+        return blockStatus;
+    }
+
+    private BlockStatus buildDictionaryBlockStatus(BlockStatus dictionary, int positionCount)
+    {
+        DictionaryBlock dictionaryBlock = TESTING_BLOCK_BUILDERS.buildDictionaryBlock(dictionary.block, positionCount);
+        int[] mappedExpectedRowSizes = IntStream.range(0, positionCount).map(i -> dictionary.expectedRowSizes[dictionaryBlock.getId(i)]).toArray();
+        return new BlockStatus(dictionaryBlock, mappedExpectedRowSizes);
+    }
+
+    private BlockStatus buildRleBlockStatus(BlockStatus blockStatus, int positionCount)
+    {
+        int[] expectedRowSizes = new int[positionCount];
+        // When we contructed the Rle block, we chose the row at the middle.
+        Arrays.setAll(expectedRowSizes, i -> blockStatus.expectedRowSizes[blockStatus.block.getPositionCount() / 2]);
+        return new BlockStatus(
+                TESTING_BLOCK_BUILDERS.buildRleBlock(blockStatus.block, positionCount),
+                expectedRowSizes);
+    }
+
+    private BlockStatus buildArrayBlockStatus(
+            ArrayType arrayType,
+            int positionCount,
+            boolean isView,
+            boolean[] isNull,
+            int[] offsets,
+            boolean allowNulls,
+            Optional<String> wrappings)
+    {
+        requireNonNull(isNull);
+        requireNonNull(offsets);
+
+        BlockStatus blockStatus;
+
+        BlockStatus valuesBlockStatus = buildBlockStatusWithType(
+                arrayType.getElementType(),
+                offsets[positionCount],
+                isView,
+                allowNulls,
+                wrappings);
+
+        int[] expectedRowSizes = IntStream.range(0, positionCount)
+                .map(i -> ArrayBlockEncodingBuffers.POSITION_SIZE + Arrays.stream(valuesBlockStatus.expectedRowSizes, offsets[i], offsets[i + 1]).sum())
+                .toArray();
+
+        blockStatus = new BlockStatus(
+                fromElementBlock(positionCount, Optional.of(isNull), offsets, valuesBlockStatus.block),
+                expectedRowSizes);
+        return blockStatus;
     }
 
     private static void assertSerialized(Type type, Block block)
@@ -169,5 +442,17 @@ public class TestBlockEncodingBuffers
 
         BlockEncodingManager blockEncodingSerde = new BlockEncodingManager(TYPE_MANAGER);
         return readBlock(blockEncodingSerde, output.slice().getInput());
+    }
+
+    private static class BlockStatus
+    {
+        private final Block block;
+        private final int[] expectedRowSizes;
+
+        BlockStatus(Block block, int[] expectedRowSizes)
+        {
+            this.block = requireNonNull(block, "block is null");
+            this.expectedRowSizes = requireNonNull(expectedRowSizes, "expectedRowSizes is null");
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestBlockEncodingBuffers.java
@@ -17,13 +17,17 @@ import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockFlattener;
 import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.SliceOutput;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandle;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Random;
@@ -34,6 +38,9 @@ import static com.facebook.presto.block.BlockSerdeUtil.readBlock;
 import static com.facebook.presto.operator.BlockEncodingBuffers.createBlockEncodingBuffers;
 import static com.facebook.presto.operator.OptimizedPartitionedOutputOperator.decodeBlock;
 import static com.facebook.presto.spi.block.ArrayBlock.fromElementBlock;
+import static com.facebook.presto.spi.block.MapBlock.fromKeyValueBlock;
+import static com.facebook.presto.spi.block.MethodHandleUtil.compose;
+import static com.facebook.presto.spi.block.MethodHandleUtil.nativeValueGetter;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
@@ -116,6 +123,31 @@ public class TestBlockEncodingBuffers
         testNestedBlock(new ArrayType(new ArrayType(new ArrayType(SMALLINT))));
         testNestedBlock(new ArrayType(new ArrayType(new ArrayType(BOOLEAN))));
         testNestedBlock(new ArrayType(new ArrayType(new ArrayType(VARCHAR))));
+    }
+
+    @Test
+    public void testMap()
+    {
+        testNestedBlock(createMapType(BIGINT, BIGINT));
+        testNestedBlock(createMapType(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1)));
+        testNestedBlock(createMapType(INTEGER, INTEGER));
+        testNestedBlock(createMapType(SMALLINT, SMALLINT));
+        testNestedBlock(createMapType(BOOLEAN, BOOLEAN));
+        testNestedBlock(createMapType(VARCHAR, VARCHAR));
+
+        testNestedBlock(createMapType(BIGINT, createMapType(BIGINT, BIGINT)));
+        testNestedBlock(createMapType(createDecimalType(MAX_SHORT_PRECISION + 1), createMapType(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1))));
+        testNestedBlock(createMapType(INTEGER, createMapType(INTEGER, INTEGER)));
+        testNestedBlock(createMapType(SMALLINT, createMapType(SMALLINT, SMALLINT)));
+        testNestedBlock(createMapType(BOOLEAN, createMapType(BOOLEAN, BOOLEAN)));
+        testNestedBlock(createMapType(VARCHAR, createMapType(VARCHAR, VARCHAR)));
+
+        testNestedBlock(createMapType(BIGINT, new ArrayType(BIGINT)));
+        testNestedBlock(createMapType(createDecimalType(MAX_SHORT_PRECISION + 1), new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1))));
+        testNestedBlock(createMapType(INTEGER, new ArrayType(INTEGER)));
+        testNestedBlock(createMapType(SMALLINT, new ArrayType(SMALLINT)));
+        testNestedBlock(createMapType(BOOLEAN, new ArrayType(BOOLEAN)));
+        testNestedBlock(createMapType(VARCHAR, new ArrayType(VARCHAR)));
     }
 
     private void testBlock(Type type, Block block)
@@ -248,6 +280,9 @@ public class TestBlockEncodingBuffers
             // Build the nested block of size offsets[positionCount].
             if (type instanceof ArrayType) {
                 blockStatus = buildArrayBlockStatus((ArrayType) type, positionCount, isView, isNull, offsets, allowNulls, wrappings);
+            }
+            else if (type instanceof MapType) {
+                blockStatus = buildMapBlockStatus((MapType) type, positionCount, isView, isNull, offsets, allowNulls, wrappings);
             }
             else {
                 throw new UnsupportedOperationException(format("type %s is not supported.", type));
@@ -389,6 +424,60 @@ public class TestBlockEncodingBuffers
         return blockStatus;
     }
 
+    private BlockStatus buildMapBlockStatus(
+            MapType mapType,
+            int positionCount,
+            boolean isView,
+            boolean[] isNull,
+            int[] offsets,
+            boolean allowNulls,
+            Optional<String> wrappings)
+    {
+        requireNonNull(isNull);
+
+        BlockStatus blockStatus;
+
+        BlockStatus keyBlockStatus = buildBlockStatusWithType(
+                mapType.getKeyType(),
+                offsets[positionCount],
+                isView,
+                false,
+                wrappings);
+        BlockStatus valueBlockStatus = buildBlockStatusWithType(
+                mapType.getValueType(),
+                offsets[positionCount],
+                isView,
+                allowNulls,
+                wrappings);
+
+        int[] expectedKeySizes = keyBlockStatus.expectedRowSizes;
+        int[] expectedValueSizes = valueBlockStatus.expectedRowSizes;
+        // Use expectedKeySizes for the total size for both key and values
+        Arrays.setAll(expectedKeySizes, i -> expectedKeySizes[i] + expectedValueSizes[i]);
+        int[] expectedRowSizes = IntStream.range(0, positionCount)
+                .map(i -> MapBlockEncodingBuffers.POSITION_SIZE + Arrays.stream(expectedKeySizes, offsets[i], offsets[i + 1]).sum())
+                .toArray();
+
+        Type keyType = mapType.getKeyType();
+        MethodHandle keyNativeEquals = TYPE_MANAGER.resolveOperator(OperatorType.EQUAL, ImmutableList.of(keyType, keyType));
+        MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
+        MethodHandle keyNativeHashCode = TYPE_MANAGER.resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(keyType));
+        MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
+
+        blockStatus = new BlockStatus(
+                fromKeyValueBlock(
+                        Optional.of(isNull),
+                        offsets,
+                        keyBlockStatus.block,
+                        valueBlockStatus.block,
+                        mapType,
+                        keyBlockNativeEquals,
+                        keyNativeHashCode,
+                        keyBlockHashCode),
+                expectedRowSizes);
+        return blockStatus;
+    }
+
     private static void assertSerialized(Type type, Block block)
     {
         assertSerialized(type, block, null);
@@ -442,6 +531,22 @@ public class TestBlockEncodingBuffers
 
         BlockEncodingManager blockEncodingSerde = new BlockEncodingManager(TYPE_MANAGER);
         return readBlock(blockEncodingSerde, output.slice().getInput());
+    }
+
+    private MapType createMapType(Type keyType, Type valueType)
+    {
+        MethodHandle keyNativeEquals = TYPE_MANAGER.resolveOperator(OperatorType.EQUAL, ImmutableList.of(keyType, keyType));
+        MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
+        MethodHandle keyBlockEquals = compose(keyNativeEquals, nativeValueGetter(keyType), nativeValueGetter(keyType));
+        MethodHandle keyNativeHashCode = TYPE_MANAGER.resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(keyType));
+        MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
+        return new MapType(
+                keyType,
+                valueType,
+                keyBlockNativeEquals,
+                keyBlockEquals,
+                keyNativeHashCode,
+                keyBlockHashCode);
     }
 
     private static class BlockStatus

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator;
 
-import com.facebook.presto.operator.PartitionedOutputOperator.PartitionedOutputInfo;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.DataSize;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOptimizedPartitionedOutputOperator.java
@@ -1,0 +1,794 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.client.ClientCapabilities;
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.StateMachine;
+import com.facebook.presto.execution.buffer.BufferState;
+import com.facebook.presto.execution.buffer.OutputBuffers;
+import com.facebook.presto.execution.buffer.PagesSerde;
+import com.facebook.presto.execution.buffer.PagesSerdeFactory;
+import com.facebook.presto.execution.buffer.PartitionedOutputBuffer;
+import com.facebook.presto.execution.buffer.SerializedPage;
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.memory.context.SimpleLocalMemoryContext;
+import com.facebook.presto.operator.OptimizedPartitionedOutputOperator.OptimizedPartitionedOutputFactory;
+import com.facebook.presto.operator.exchange.LocalPartitionGenerator;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.testing.TestingTaskContext;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Random;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.execution.buffer.BufferState.OPEN;
+import static com.facebook.presto.execution.buffer.BufferState.TERMINAL_BUFFER_STATES;
+import static com.facebook.presto.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
+import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.operator.PageAssertions.assertPageEquals;
+import static com.facebook.presto.operator.TestingBlockBuilders.createMapType;
+import static com.facebook.presto.operator.TestingPageBuilders.buildPage;
+import static com.facebook.presto.operator.TestingPageBuilders.buildTypes;
+import static com.facebook.presto.operator.TestingPageBuilders.mergePages;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
+import static com.facebook.presto.spi.type.Decimals.MAX_SHORT_PRECISION;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RowType.withDefaultFieldNames;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.Arrays.stream;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertEquals;
+
+public class TestOptimizedPartitionedOutputOperator
+{
+    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-EXECUTOR-%s"));
+    private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%s"));
+    private static final DataSize MAX_MEMORY = new DataSize(1, GIGABYTE);
+    private static final PagesSerde PAGES_SERDE = new PagesSerdeFactory(new BlockEncodingManager(TYPE_MANAGER), false).createPagesSerde(); //testingPagesSerde();
+    private static final int PARTITION_COUNT = 16;
+    private static final int PAGE_COUNT = 50;
+    private static final int POSITION_COUNT = 100;
+
+    private final Random random = new Random(0);
+
+    @Test
+    public void testPartitionedSinglePagePrimitiveTypes()
+    {
+        testPartitionedSinglePage(ImmutableList.of(BIGINT));
+        testPartitionedSinglePage(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1)));
+        testPartitionedSinglePage(ImmutableList.of(SMALLINT));
+        testPartitionedSinglePage(ImmutableList.of(INTEGER));
+        testPartitionedSinglePage(ImmutableList.of(BOOLEAN));
+        testPartitionedSinglePage(ImmutableList.of(VARCHAR));
+
+        testPartitionedSinglePage(ImmutableList.of(BIGINT, BIGINT));
+        testPartitionedSinglePage(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION - 1)));
+        testPartitionedSinglePage(ImmutableList.of(SMALLINT, SMALLINT));
+        testPartitionedSinglePage(ImmutableList.of(INTEGER, INTEGER));
+        testPartitionedSinglePage(ImmutableList.of(BOOLEAN, BOOLEAN));
+        testPartitionedSinglePage(ImmutableList.of(VARCHAR, VARCHAR));
+    }
+
+    @Test
+    public void testPartitionedSinglePageForArray()
+    {
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(BIGINT), new ArrayType(BIGINT)));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), new ArrayType((createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(SMALLINT), new ArrayType(SMALLINT)));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(INTEGER), new ArrayType(INTEGER)));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(BOOLEAN), new ArrayType(BOOLEAN)));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(VARCHAR), new ArrayType(VARCHAR)));
+
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(BIGINT))));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(SMALLINT))));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(INTEGER))));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(BOOLEAN))));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(VARCHAR))));
+
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(BIGINT)))));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(SMALLINT)))));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(INTEGER)))));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(BOOLEAN)))));
+        testPartitionedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(VARCHAR)))));
+    }
+
+    @Test
+    public void testPartitionedSinglePageForMap()
+    {
+        testPartitionedSinglePage(ImmutableList.of(createMapType(BIGINT, BIGINT)));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1))));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(SMALLINT, SMALLINT)));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(INTEGER, INTEGER)));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(BOOLEAN, BOOLEAN)));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(VARCHAR, VARCHAR)));
+
+        testPartitionedSinglePage(ImmutableList.of(createMapType(BIGINT, createMapType(BIGINT, BIGINT))));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(createDecimalType(MAX_SHORT_PRECISION + 1), createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(SMALLINT, createMapType(SMALLINT, SMALLINT))));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(INTEGER, createMapType(INTEGER, INTEGER))));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(BOOLEAN, createMapType(BOOLEAN, BOOLEAN))));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(VARCHAR, createMapType(VARCHAR, VARCHAR))));
+
+        testPartitionedSinglePage(ImmutableList.of(createMapType(createMapType(BIGINT, BIGINT), new ArrayType(createMapType(BIGINT, BIGINT)))));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1)), new ArrayType(createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(createMapType(SMALLINT, SMALLINT), new ArrayType(createMapType(SMALLINT, SMALLINT)))));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(createMapType(INTEGER, INTEGER), new ArrayType(createMapType(INTEGER, INTEGER)))));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(createMapType(INTEGER, INTEGER), new ArrayType(createMapType(INTEGER, INTEGER)))));
+        testPartitionedSinglePage(ImmutableList.of(createMapType(createMapType(INTEGER, INTEGER), new ArrayType(createMapType(INTEGER, INTEGER)))));
+    }
+
+    @Test
+    public void testPartitionedSinglePageForRow()
+    {
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT, BIGINT))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(INTEGER, INTEGER, INTEGER))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(SMALLINT, SMALLINT, SMALLINT))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BOOLEAN, BOOLEAN, BOOLEAN))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(VARCHAR, VARCHAR, VARCHAR))));
+
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BIGINT, withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT))))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT))))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(INTEGER, withDefaultFieldNames(ImmutableList.of(INTEGER, INTEGER))))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(SMALLINT, withDefaultFieldNames(ImmutableList.of(SMALLINT, SMALLINT))))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BOOLEAN, withDefaultFieldNames(ImmutableList.of(BOOLEAN, BOOLEAN, BOOLEAN))))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(VARCHAR, withDefaultFieldNames(ImmutableList.of(VARCHAR, VARCHAR, VARCHAR))))));
+
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BIGINT), new ArrayType(BIGINT)))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(INTEGER), new ArrayType(INTEGER)))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(SMALLINT), new ArrayType(SMALLINT)))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BOOLEAN), new ArrayType(BOOLEAN)))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(VARCHAR), new ArrayType(VARCHAR)))));
+
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BIGINT), createMapType(BIGINT, BIGINT)))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(INTEGER), createMapType(INTEGER, INTEGER)))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(SMALLINT), createMapType(SMALLINT, SMALLINT)))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BOOLEAN), createMapType(BOOLEAN, BOOLEAN)))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(VARCHAR), createMapType(VARCHAR, VARCHAR)))));
+
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BIGINT), createMapType(BIGINT, withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT)))))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), createMapType(BIGINT, withDefaultFieldNames(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1))))))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(INTEGER), createMapType(INTEGER, withDefaultFieldNames(ImmutableList.of(INTEGER, INTEGER)))))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(SMALLINT), createMapType(SMALLINT, withDefaultFieldNames(ImmutableList.of(SMALLINT, SMALLINT)))))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BOOLEAN), createMapType(BOOLEAN, withDefaultFieldNames(ImmutableList.of(BOOLEAN, BOOLEAN)))))));
+        testPartitionedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(VARCHAR), createMapType(VARCHAR, withDefaultFieldNames(ImmutableList.of(VARCHAR, VARCHAR)))))));
+    }
+
+    @Test
+    public void testPartitionedMultiplePagesPrimitiveTypes()
+    {
+        testPartitionedMultiplePages(ImmutableList.of(BIGINT));
+        testPartitionedMultiplePages(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1)));
+        testPartitionedMultiplePages(ImmutableList.of(SMALLINT));
+        testPartitionedMultiplePages(ImmutableList.of(INTEGER));
+        testPartitionedMultiplePages(ImmutableList.of(BOOLEAN));
+        testPartitionedMultiplePages(ImmutableList.of(VARCHAR));
+
+        testPartitionedMultiplePages(ImmutableList.of(BIGINT, BIGINT));
+        testPartitionedMultiplePages(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION - 1)));
+        testPartitionedMultiplePages(ImmutableList.of(SMALLINT, SMALLINT));
+        testPartitionedMultiplePages(ImmutableList.of(INTEGER, INTEGER));
+        testPartitionedMultiplePages(ImmutableList.of(BOOLEAN, BOOLEAN));
+        testPartitionedMultiplePages(ImmutableList.of(VARCHAR, VARCHAR));
+    }
+
+    @Test
+    public void testPartitionedMultiplePagesForArray()
+    {
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(BIGINT), new ArrayType(BIGINT)));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), new ArrayType((createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(SMALLINT), new ArrayType(SMALLINT)));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(INTEGER), new ArrayType(INTEGER)));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(BOOLEAN), new ArrayType(BOOLEAN)));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(VARCHAR), new ArrayType(VARCHAR)));
+
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(BIGINT))));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(SMALLINT))));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(INTEGER))));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(BOOLEAN))));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(VARCHAR))));
+
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(BIGINT)))));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(SMALLINT)))));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(INTEGER)))));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(BOOLEAN)))));
+        testPartitionedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(VARCHAR)))));
+    }
+
+    @Test
+    public void testPartitionedMultiplePagesForMap()
+    {
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(BIGINT, BIGINT)));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1))));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(SMALLINT, SMALLINT)));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(INTEGER, INTEGER)));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(BOOLEAN, BOOLEAN)));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(VARCHAR, VARCHAR)));
+
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(BIGINT, createMapType(BIGINT, BIGINT))));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(createDecimalType(MAX_SHORT_PRECISION + 1), createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(SMALLINT, createMapType(SMALLINT, SMALLINT))));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(INTEGER, createMapType(INTEGER, INTEGER))));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(BOOLEAN, createMapType(BOOLEAN, BOOLEAN))));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(VARCHAR, createMapType(VARCHAR, VARCHAR))));
+
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(createMapType(BIGINT, BIGINT), new ArrayType(createMapType(BIGINT, BIGINT)))));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1)), new ArrayType(createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(createMapType(SMALLINT, SMALLINT), new ArrayType(createMapType(SMALLINT, SMALLINT)))));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(createMapType(INTEGER, INTEGER), new ArrayType(createMapType(INTEGER, INTEGER)))));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(createMapType(INTEGER, INTEGER), new ArrayType(createMapType(INTEGER, INTEGER)))));
+        testPartitionedMultiplePages(ImmutableList.of(createMapType(createMapType(INTEGER, INTEGER), new ArrayType(createMapType(INTEGER, INTEGER)))));
+    }
+
+    @Test
+    public void testPartitionedMultiplePagesForRow()
+    {
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT, BIGINT))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(INTEGER, INTEGER, INTEGER))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(SMALLINT, SMALLINT, SMALLINT))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BOOLEAN, BOOLEAN, BOOLEAN))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(VARCHAR, VARCHAR, VARCHAR))));
+
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BIGINT, withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT))))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT))))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(INTEGER, withDefaultFieldNames(ImmutableList.of(INTEGER, INTEGER))))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(SMALLINT, withDefaultFieldNames(ImmutableList.of(SMALLINT, SMALLINT))))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BOOLEAN, withDefaultFieldNames(ImmutableList.of(BOOLEAN, BOOLEAN, BOOLEAN))))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(VARCHAR, withDefaultFieldNames(ImmutableList.of(VARCHAR, VARCHAR, VARCHAR))))));
+
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BIGINT), new ArrayType(BIGINT)))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(INTEGER), new ArrayType(INTEGER)))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(SMALLINT), new ArrayType(SMALLINT)))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BOOLEAN), new ArrayType(BOOLEAN)))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(VARCHAR), new ArrayType(VARCHAR)))));
+
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BIGINT), createMapType(BIGINT, BIGINT)))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(INTEGER), createMapType(INTEGER, INTEGER)))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(SMALLINT), createMapType(SMALLINT, SMALLINT)))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BOOLEAN), createMapType(BOOLEAN, BOOLEAN)))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(VARCHAR), createMapType(VARCHAR, VARCHAR)))));
+
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BIGINT), createMapType(BIGINT, withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT)))))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), createMapType(BIGINT, withDefaultFieldNames(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1))))))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(INTEGER), createMapType(INTEGER, withDefaultFieldNames(ImmutableList.of(INTEGER, INTEGER)))))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(SMALLINT), createMapType(SMALLINT, withDefaultFieldNames(ImmutableList.of(SMALLINT, SMALLINT)))))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BOOLEAN), createMapType(BOOLEAN, withDefaultFieldNames(ImmutableList.of(BOOLEAN, BOOLEAN)))))));
+        testPartitionedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(VARCHAR), createMapType(VARCHAR, withDefaultFieldNames(ImmutableList.of(VARCHAR, VARCHAR)))))));
+    }
+
+    @Test
+    public void testReplicatedSinglePagePrimitiveTypes()
+    {
+        testReplicatedSinglePage(ImmutableList.of(BIGINT));
+        testReplicatedSinglePage(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1)));
+        testReplicatedSinglePage(ImmutableList.of(SMALLINT));
+        testReplicatedSinglePage(ImmutableList.of(INTEGER));
+        testReplicatedSinglePage(ImmutableList.of(BOOLEAN));
+        testReplicatedSinglePage(ImmutableList.of(VARCHAR));
+
+        testReplicatedSinglePage(ImmutableList.of(BIGINT, BIGINT));
+        testReplicatedSinglePage(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION - 1)));
+        testReplicatedSinglePage(ImmutableList.of(SMALLINT, SMALLINT));
+        testReplicatedSinglePage(ImmutableList.of(INTEGER, INTEGER));
+        testReplicatedSinglePage(ImmutableList.of(BOOLEAN, BOOLEAN));
+        testReplicatedSinglePage(ImmutableList.of(VARCHAR, VARCHAR));
+    }
+
+    @Test
+    public void testReplicatedSinglePageForArray()
+    {
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(BIGINT), new ArrayType(BIGINT)));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), new ArrayType((createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(SMALLINT), new ArrayType(SMALLINT)));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(INTEGER), new ArrayType(INTEGER)));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(BOOLEAN), new ArrayType(BOOLEAN)));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(VARCHAR), new ArrayType(VARCHAR)));
+
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(BIGINT))));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(SMALLINT))));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(INTEGER))));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(BOOLEAN))));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(VARCHAR))));
+
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(BIGINT)))));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(SMALLINT)))));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(INTEGER)))));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(BOOLEAN)))));
+        testReplicatedSinglePage(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(VARCHAR)))));
+    }
+
+    @Test
+    public void testReplicatedSinglePageForMap()
+    {
+        testReplicatedSinglePage(ImmutableList.of(createMapType(BIGINT, BIGINT)));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1))));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(SMALLINT, SMALLINT)));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(INTEGER, INTEGER)));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(BOOLEAN, BOOLEAN)));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(VARCHAR, VARCHAR)));
+
+        testReplicatedSinglePage(ImmutableList.of(createMapType(BIGINT, createMapType(BIGINT, BIGINT))));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(createDecimalType(MAX_SHORT_PRECISION + 1), createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(SMALLINT, createMapType(SMALLINT, SMALLINT))));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(INTEGER, createMapType(INTEGER, INTEGER))));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(BOOLEAN, createMapType(BOOLEAN, BOOLEAN))));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(VARCHAR, createMapType(VARCHAR, VARCHAR))));
+
+        testReplicatedSinglePage(ImmutableList.of(createMapType(createMapType(BIGINT, BIGINT), new ArrayType(createMapType(BIGINT, BIGINT)))));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1)), new ArrayType(createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(createMapType(SMALLINT, SMALLINT), new ArrayType(createMapType(SMALLINT, SMALLINT)))));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(createMapType(INTEGER, INTEGER), new ArrayType(createMapType(INTEGER, INTEGER)))));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(createMapType(INTEGER, INTEGER), new ArrayType(createMapType(INTEGER, INTEGER)))));
+        testReplicatedSinglePage(ImmutableList.of(createMapType(createMapType(INTEGER, INTEGER), new ArrayType(createMapType(INTEGER, INTEGER)))));
+    }
+
+    @Test
+    public void testReplicatedSinglePageForRow()
+    {
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT, BIGINT))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(INTEGER, INTEGER, INTEGER))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(SMALLINT, SMALLINT, SMALLINT))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BOOLEAN, BOOLEAN, BOOLEAN))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(VARCHAR, VARCHAR, VARCHAR))));
+
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BIGINT, withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT))))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT))))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(INTEGER, withDefaultFieldNames(ImmutableList.of(INTEGER, INTEGER))))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(SMALLINT, withDefaultFieldNames(ImmutableList.of(SMALLINT, SMALLINT))))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BOOLEAN, withDefaultFieldNames(ImmutableList.of(BOOLEAN, BOOLEAN, BOOLEAN))))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(VARCHAR, withDefaultFieldNames(ImmutableList.of(VARCHAR, VARCHAR, VARCHAR))))));
+
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BIGINT), new ArrayType(BIGINT)))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(INTEGER), new ArrayType(INTEGER)))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(SMALLINT), new ArrayType(SMALLINT)))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BOOLEAN), new ArrayType(BOOLEAN)))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(VARCHAR), new ArrayType(VARCHAR)))));
+
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BIGINT), createMapType(BIGINT, BIGINT)))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(INTEGER), createMapType(INTEGER, INTEGER)))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(SMALLINT), createMapType(SMALLINT, SMALLINT)))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BOOLEAN), createMapType(BOOLEAN, BOOLEAN)))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(VARCHAR), createMapType(VARCHAR, VARCHAR)))));
+
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BIGINT), createMapType(BIGINT, withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT)))))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), createMapType(BIGINT, withDefaultFieldNames(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1))))))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(INTEGER), createMapType(INTEGER, withDefaultFieldNames(ImmutableList.of(INTEGER, INTEGER)))))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(SMALLINT), createMapType(SMALLINT, withDefaultFieldNames(ImmutableList.of(SMALLINT, SMALLINT)))))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BOOLEAN), createMapType(BOOLEAN, withDefaultFieldNames(ImmutableList.of(BOOLEAN, BOOLEAN)))))));
+        testReplicatedSinglePage(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(VARCHAR), createMapType(VARCHAR, withDefaultFieldNames(ImmutableList.of(VARCHAR, VARCHAR)))))));
+    }
+
+    @Test
+    public void testReplicatedMultiplePagesPrimitiveTypes()
+    {
+        testReplicatedMultiplePages(ImmutableList.of(BIGINT));
+        testReplicatedMultiplePages(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1)));
+        testReplicatedMultiplePages(ImmutableList.of(SMALLINT));
+        testReplicatedMultiplePages(ImmutableList.of(INTEGER));
+        testReplicatedMultiplePages(ImmutableList.of(BOOLEAN));
+        testReplicatedMultiplePages(ImmutableList.of(VARCHAR));
+
+        testReplicatedMultiplePages(ImmutableList.of(BIGINT, BIGINT));
+        testReplicatedMultiplePages(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION - 1)));
+        testReplicatedMultiplePages(ImmutableList.of(SMALLINT, SMALLINT));
+        testReplicatedMultiplePages(ImmutableList.of(INTEGER, INTEGER));
+        testReplicatedMultiplePages(ImmutableList.of(BOOLEAN, BOOLEAN));
+        testReplicatedMultiplePages(ImmutableList.of(VARCHAR, VARCHAR));
+    }
+
+    @Test
+    public void testReplicatedMultiplePagesForArray()
+    {
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(BIGINT), new ArrayType(BIGINT)));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), new ArrayType((createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(SMALLINT), new ArrayType(SMALLINT)));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(INTEGER), new ArrayType(INTEGER)));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(BOOLEAN), new ArrayType(BOOLEAN)));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(VARCHAR), new ArrayType(VARCHAR)));
+
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(BIGINT))));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(SMALLINT))));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(INTEGER))));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(BOOLEAN))));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(VARCHAR))));
+
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(BIGINT)))));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(SMALLINT)))));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(INTEGER)))));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(BOOLEAN)))));
+        testReplicatedMultiplePages(ImmutableList.of(new ArrayType(new ArrayType(new ArrayType(VARCHAR)))));
+    }
+
+    @Test
+    public void testReplicatedMultiplePagesForMap()
+    {
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(BIGINT, BIGINT)));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1))));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(SMALLINT, SMALLINT)));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(INTEGER, INTEGER)));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(BOOLEAN, BOOLEAN)));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(VARCHAR, VARCHAR)));
+
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(BIGINT, createMapType(BIGINT, BIGINT))));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(createDecimalType(MAX_SHORT_PRECISION + 1), createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(SMALLINT, createMapType(SMALLINT, SMALLINT))));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(INTEGER, createMapType(INTEGER, INTEGER))));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(BOOLEAN, createMapType(BOOLEAN, BOOLEAN))));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(VARCHAR, createMapType(VARCHAR, VARCHAR))));
+
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(createMapType(BIGINT, BIGINT), new ArrayType(createMapType(BIGINT, BIGINT)))));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1)), new ArrayType(createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(createMapType(SMALLINT, SMALLINT), new ArrayType(createMapType(SMALLINT, SMALLINT)))));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(createMapType(INTEGER, INTEGER), new ArrayType(createMapType(INTEGER, INTEGER)))));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(createMapType(INTEGER, INTEGER), new ArrayType(createMapType(INTEGER, INTEGER)))));
+        testReplicatedMultiplePages(ImmutableList.of(createMapType(createMapType(INTEGER, INTEGER), new ArrayType(createMapType(INTEGER, INTEGER)))));
+    }
+
+    @Test
+    public void testReplicatedMultiplePagesForRow()
+    {
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT, BIGINT))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1)))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(INTEGER, INTEGER, INTEGER))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(SMALLINT, SMALLINT, SMALLINT))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BOOLEAN, BOOLEAN, BOOLEAN))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(VARCHAR, VARCHAR, VARCHAR))));
+
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BIGINT, withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT))))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT))))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(INTEGER, withDefaultFieldNames(ImmutableList.of(INTEGER, INTEGER))))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(SMALLINT, withDefaultFieldNames(ImmutableList.of(SMALLINT, SMALLINT))))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(BOOLEAN, withDefaultFieldNames(ImmutableList.of(BOOLEAN, BOOLEAN, BOOLEAN))))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(VARCHAR, withDefaultFieldNames(ImmutableList.of(VARCHAR, VARCHAR, VARCHAR))))));
+
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BIGINT), new ArrayType(BIGINT)))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(INTEGER), new ArrayType(INTEGER)))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(SMALLINT), new ArrayType(SMALLINT)))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BOOLEAN), new ArrayType(BOOLEAN)))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(VARCHAR), new ArrayType(VARCHAR)))));
+
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BIGINT), createMapType(BIGINT, BIGINT)))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), createMapType(BIGINT, createDecimalType(MAX_SHORT_PRECISION + 1))))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(INTEGER), createMapType(INTEGER, INTEGER)))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(SMALLINT), createMapType(SMALLINT, SMALLINT)))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BOOLEAN), createMapType(BOOLEAN, BOOLEAN)))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(VARCHAR), createMapType(VARCHAR, VARCHAR)))));
+
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BIGINT), createMapType(BIGINT, withDefaultFieldNames(ImmutableList.of(BIGINT, BIGINT)))))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(createDecimalType(MAX_SHORT_PRECISION + 1)), createMapType(BIGINT, withDefaultFieldNames(ImmutableList.of(createDecimalType(MAX_SHORT_PRECISION + 1), createDecimalType(MAX_SHORT_PRECISION + 1))))))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(INTEGER), createMapType(INTEGER, withDefaultFieldNames(ImmutableList.of(INTEGER, INTEGER)))))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(SMALLINT), createMapType(SMALLINT, withDefaultFieldNames(ImmutableList.of(SMALLINT, SMALLINT)))))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(BOOLEAN), createMapType(BOOLEAN, withDefaultFieldNames(ImmutableList.of(BOOLEAN, BOOLEAN)))))));
+        testReplicatedMultiplePages(ImmutableList.of(withDefaultFieldNames(ImmutableList.of(new ArrayType(VARCHAR), createMapType(VARCHAR, withDefaultFieldNames(ImmutableList.of(VARCHAR, VARCHAR)))))));
+    }
+
+    @Test
+    public void testEmptyPage()
+    {
+        List<Type> types = buildTypes(ImmutableList.of(BIGINT), true, false);
+        Page page = buildPage(ImmutableList.of(BIGINT), 0, true, false, false, Optional.empty());
+
+        testPartitioned(types, ImmutableList.of(page), new DataSize(128, MEGABYTE));
+    }
+
+    @Test
+    public void testPageWithNoBlocks()
+    {
+        List<Type> types = buildTypes(ImmutableList.of(), false, false);
+        Page page = buildPage(ImmutableList.of(), 1, false, false, false, Optional.empty());
+
+        testPartitionedForZeroBlocks(types, ImmutableList.of(page), new DataSize(128, MEGABYTE));
+    }
+
+    private void testPartitionedSinglePage(List<Type> targetTypes)
+    {
+        List<Type> types = buildTypes(targetTypes, true, false);
+
+        // Test plain blocks: no block views, no Dicrtionary/RLE blocks
+        Page page = buildPage(targetTypes, POSITION_COUNT, true, false, false, Optional.empty());
+
+        // First test for the cases where the buffer can hold the whole page, then force flushing for every a few rows.
+        testPartitioned(types, ImmutableList.of(page), new DataSize(128, MEGABYTE));
+        testPartitioned(types, ImmutableList.of(page), new DataSize(1, KILOBYTE));
+
+        // Test block views and Dicrtionary/RLE blocks
+        page = buildPage(targetTypes, POSITION_COUNT, true, false, true, Optional.of("DDRR"));
+        testPartitioned(types, ImmutableList.of(page), new DataSize(128, MEGABYTE));
+        testPartitioned(types, ImmutableList.of(page), new DataSize(1, KILOBYTE));
+
+        page = buildPage(targetTypes, POSITION_COUNT, true, false, true, Optional.of("RDRD"));
+        testPartitioned(types, ImmutableList.of(page), new DataSize(128, MEGABYTE));
+        testPartitioned(types, ImmutableList.of(page), new DataSize(1, KILOBYTE));
+    }
+
+    private void testPartitionedMultiplePages(List<Type> targetTypes)
+    {
+        List<Type> types = buildTypes(targetTypes, true, false);
+        List<Page> pages = new ArrayList<>();
+        for (int i = 0; i < PAGE_COUNT; i++) {
+            pages.add(buildPage(targetTypes, POSITION_COUNT + random.nextInt(POSITION_COUNT), true, false, false, Optional.empty()));
+            pages.add(buildPage(targetTypes, POSITION_COUNT + random.nextInt(POSITION_COUNT), true, false, true, Optional.of("DDRR")));
+            pages.add(buildPage(targetTypes, POSITION_COUNT + random.nextInt(POSITION_COUNT), true, false, true, Optional.of("RRDD")));
+        }
+
+        testPartitioned(types, pages, new DataSize(128, MEGABYTE));
+        testPartitioned(types, pages, new DataSize(1, KILOBYTE));
+
+        pages.clear();
+        for (int i = 0; i < PAGE_COUNT / 3; i++) {
+            pages.add(buildPage(targetTypes, POSITION_COUNT + random.nextInt(POSITION_COUNT), true, false, false, Optional.empty()));
+            pages.add(buildPage(targetTypes, POSITION_COUNT + random.nextInt(POSITION_COUNT), true, false, true, Optional.of("DDRR")));
+            pages.add(buildPage(targetTypes, POSITION_COUNT + random.nextInt(POSITION_COUNT), true, false, true, Optional.of("RRDD")));
+        }
+
+        testPartitioned(types, pages, new DataSize(128, MEGABYTE));
+        testPartitioned(types, pages, new DataSize(1, KILOBYTE));
+    }
+
+    private void testReplicatedSinglePage(List<Type> targetTypes)
+    {
+        // Add a block that only contain null as the last block to force replicating all rows.
+        List<Type> types = buildTypes(targetTypes, true, true);
+        Page page = buildPage(targetTypes, POSITION_COUNT, true, true, false, Optional.empty());
+        testReplicated(types, ImmutableList.of(page), new DataSize(128, MEGABYTE));
+        testReplicated(types, ImmutableList.of(page), new DataSize(1, KILOBYTE));
+    }
+
+    private void testReplicatedMultiplePages(List<Type> targetTypes)
+    {
+        List<Type> types = buildTypes(targetTypes, true, true);
+        List<Page> pages = new ArrayList<>();
+        for (int i = 0; i < PAGE_COUNT; i++) {
+            pages.add(buildPage(targetTypes, POSITION_COUNT + random.nextInt(POSITION_COUNT), true, true, false, Optional.empty()));
+        }
+
+        testReplicated(types, pages, new DataSize(128, MEGABYTE));
+        testReplicated(types, pages, new DataSize(1, KILOBYTE));
+    }
+
+    private void testPartitionedForZeroBlocks(List<Type> types, List<Page> pages, DataSize maxMemory)
+    {
+        testPartitioned(types, pages, maxMemory, ImmutableList.of(), new InterpretedHashGenerator(ImmutableList.of(), new int[0]));
+    }
+
+    private void testPartitioned(List<Type> types, List<Page> pages, DataSize maxMemory)
+    {
+        testPartitioned(types, pages, maxMemory, ImmutableList.of(0), new PrecomputedHashGenerator(0));
+    }
+
+    private void testPartitioned(List<Type> types, List<Page> pages, DataSize maxMemory, List<Integer> partitionChannel, HashGenerator hashGenerator)
+    {
+        TestingPartitionedOutputBuffer outputBuffer = createPartitionedOutputBuffer();
+        PartitionFunction partitionFunction = new LocalPartitionGenerator(hashGenerator, PARTITION_COUNT);
+        OptimizedPartitionedOutputOperator operator = createOptimizedPartitionedOutputOperator(
+                types,
+                partitionChannel,
+                partitionFunction,
+                outputBuffer,
+                OptionalInt.empty(),
+                maxMemory);
+
+        Map<Integer, List<Page>> expectedPageList = new HashMap<>();
+
+        for (Page page : pages) {
+            Map<Integer, List<Integer>> positionsByPartition = new HashMap<>();
+            for (int i = 0; i < page.getPositionCount(); i++) {
+                int partitionNumber = partitionFunction.getPartition(page, i);
+                positionsByPartition.computeIfAbsent(partitionNumber, k -> new ArrayList<>()).add(i);
+            }
+
+            for (Map.Entry<Integer, List<Integer>> entry : positionsByPartition.entrySet()) {
+                if (!entry.getValue().isEmpty()) {
+                    expectedPageList.computeIfAbsent(entry.getKey(), k -> new ArrayList<>()).add(copyPositions(page, entry.getValue()));
+                }
+            }
+
+            operator.addInput(page);
+        }
+        operator.finish();
+
+        Map<Integer, Page> expectedPages = Maps.transformValues(expectedPageList, outputPages -> mergePages(types, outputPages));
+        Map<Integer, Page> actualPages = Maps.transformValues(outputBuffer.getPages(), outputPages -> mergePages(types, outputPages));
+
+        assertEquals(actualPages.size(), expectedPages.size());
+
+        assertEquals(actualPages.keySet(), expectedPages.keySet());
+
+        for (Map.Entry<Integer, Page> entry : expectedPages.entrySet()) {
+            int key = entry.getKey();
+            assertPageEquals(types, actualPages.get(key), entry.getValue());
+        }
+    }
+
+    private void testReplicated(List<Type> types, List<Page> pages, DataSize maxMemory)
+    {
+        TestingPartitionedOutputBuffer outputBuffer = createPartitionedOutputBuffer();
+        PartitionFunction partitionFunction = new LocalPartitionGenerator(new PrecomputedHashGenerator(0), PARTITION_COUNT);
+        OptimizedPartitionedOutputOperator operator = createOptimizedPartitionedOutputOperator(
+                types,
+                ImmutableList.of(0),
+                partitionFunction,
+                outputBuffer,
+                OptionalInt.of(types.size() - 1), maxMemory);
+
+        for (Page page : pages) {
+            operator.addInput(page);
+        }
+        operator.finish();
+
+        Map<Integer, List<Page>> acutualPageLists = outputBuffer.getPages();
+
+        assertEquals(acutualPageLists.size(), PARTITION_COUNT);
+
+        Page expectedPage = mergePages(types, pages);
+
+        acutualPageLists.values().forEach(pageList -> assertPageEquals(types, mergePages(types, pageList), expectedPage));
+    }
+
+    private Page copyPositions(Page page, List<Integer> positions)
+    {
+        Block[] blocks = new Block[page.getChannelCount()];
+        for (int i = 0; i < blocks.length; i++) {
+            blocks[i] = page.getBlock(i).copyPositions(positions.stream().mapToInt(j -> j).toArray(), 0, positions.size());
+        }
+        return new Page(positions.size(), blocks);
+    }
+
+    private static class TestingPartitionedOutputBuffer
+            extends PartitionedOutputBuffer
+    {
+        private final Map<Integer, List<Page>> pages = new HashMap<>();
+
+        public TestingPartitionedOutputBuffer(
+                String taskInstanceId,
+                StateMachine<BufferState> state,
+                OutputBuffers outputBuffers,
+                DataSize maxBufferSize,
+                Supplier<LocalMemoryContext> systemMemoryContextSupplier,
+                Executor notificationExecutor)
+        {
+            super(taskInstanceId, state, outputBuffers, maxBufferSize, systemMemoryContextSupplier, notificationExecutor);
+        }
+
+        @Override
+        public void enqueue(Lifespan lifespan, int partitionNumber, List<SerializedPage> pages)
+        {
+            this.pages.computeIfAbsent(partitionNumber, k -> new ArrayList<>());
+            pages.stream().map(PAGES_SERDE::deserialize).forEach(this.pages.get(partitionNumber)::add);
+        }
+
+        public Map<Integer, List<Page>> getPages()
+        {
+            return pages;
+        }
+    }
+
+    private TestingPartitionedOutputBuffer createPartitionedOutputBuffer()
+    {
+        OutputBuffers buffers = createInitialEmptyOutputBuffers(PARTITIONED);
+        for (int partition = 0; partition < PARTITION_COUNT; partition++) {
+            buffers = buffers.withBuffer(new OutputBuffers.OutputBufferId(partition), partition);
+        }
+        TestingPartitionedOutputBuffer buffer = createPartitionedBuffer(
+                buffers.withNoMoreBufferIds(),
+                new DataSize(Long.MAX_VALUE, BYTE)); // don't let output buffer block
+        buffer.registerLifespanCompletionCallback(ignore -> {});
+
+        return buffer;
+    }
+
+    private OptimizedPartitionedOutputOperator createOptimizedPartitionedOutputOperator(
+            List<Type> types,
+            List<Integer> partitionChannel,
+            PartitionFunction partitionFunction,
+            PartitionedOutputBuffer buffer,
+            OptionalInt nullChannel,
+            DataSize maxMemory)
+    {
+        //new FunctionManager(TYPE_MANAGER, new BlockEncodingManager(TYPE_MANAGER), new FeaturesConfig());
+        PagesSerdeFactory serdeFactory = new PagesSerdeFactory(new BlockEncodingManager(TYPE_MANAGER), false);
+
+        OptimizedPartitionedOutputFactory operatorFactory = new OptimizedPartitionedOutputFactory(
+                partitionFunction,
+                partitionChannel,
+                ImmutableList.of(Optional.empty()),
+                false,
+                nullChannel,
+                buffer,
+                maxMemory);
+
+        return (OptimizedPartitionedOutputOperator) operatorFactory
+                .createOutputOperator(0, new PlanNodeId("plan-node-0"), types, Function.identity(), serdeFactory)
+                .createOperator(createDriverContext());
+    }
+
+    private DriverContext createDriverContext()
+    {
+        Session testSession = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema(TINY_SCHEMA_NAME)
+                .setClientCapabilities(stream(ClientCapabilities.values())
+                        .map(ClientCapabilities::toString)
+                        .collect(toImmutableSet()))
+                .build();
+
+        return TestingTaskContext.builder(EXECUTOR, SCHEDULER, testSession)
+                .setMemoryPoolSize(MAX_MEMORY)
+                .build()
+                .addPipelineContext(0, true, true, false)
+                .addDriverContext();
+    }
+
+    private TestingPartitionedOutputBuffer createPartitionedBuffer(OutputBuffers buffers, DataSize dataSize)
+    {
+        return new TestingPartitionedOutputBuffer(
+                "task-instance-id",
+                new StateMachine<>("bufferState", SCHEDULER, OPEN, TERMINAL_BUFFER_STATES),
+                buffers,
+                dataSize,
+                () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
+                SCHEDULER);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestUncheckedByteArrays.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestUncheckedByteArrays.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.google.common.primitives.Bytes;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import static com.facebook.presto.operator.UncheckedByteArrays.fill;
+import static com.facebook.presto.operator.UncheckedByteArrays.getByte;
+import static com.facebook.presto.operator.UncheckedByteArrays.getInt;
+import static com.facebook.presto.operator.UncheckedByteArrays.getLong;
+import static com.facebook.presto.operator.UncheckedByteArrays.getShort;
+import static com.facebook.presto.operator.UncheckedByteArrays.setByte;
+import static com.facebook.presto.operator.UncheckedByteArrays.setBytes;
+import static com.facebook.presto.operator.UncheckedByteArrays.setInt;
+import static com.facebook.presto.operator.UncheckedByteArrays.setInts;
+import static com.facebook.presto.operator.UncheckedByteArrays.setLong;
+import static com.facebook.presto.operator.UncheckedByteArrays.setShort;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static sun.misc.Unsafe.ARRAY_BYTE_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_SHORT_INDEX_SCALE;
+
+public class TestUncheckedByteArrays
+{
+    private static final int POSITIONS_PER_PAGE = 10000;
+    private static final Random RANDOM = new Random(0);
+
+    private TestUncheckedByteArrays()
+    {}
+
+    @Test
+    public static void testSetByte()
+    {
+        final byte[] destination = new byte[POSITIONS_PER_PAGE];
+
+        byte[] sourceBytes = new byte[POSITIONS_PER_PAGE];
+        RANDOM.nextBytes(sourceBytes);
+        List<Byte> source = Bytes.asList(sourceBytes);
+        testSequential(
+                source,
+                ARRAY_BYTE_INDEX_SCALE,
+                destination,
+                (bytes, index, value) -> setByte((byte[]) bytes, (int) index, (byte) value),
+                (bytes, index) -> getByte((byte[]) bytes, (int) index));
+
+        source = new ArrayList<Byte>(Collections.nCopies(POSITIONS_PER_PAGE, (byte) 0));
+        testRandom(
+                source,
+                ARRAY_BYTE_INDEX_SCALE,
+                destination,
+                (bytes, index, value) -> setByte((byte[]) bytes, (int) index, (byte) value),
+                (bytes, index) -> getByte((byte[]) bytes, (int) index));
+    }
+
+    @Test
+    public static void testSetShort()
+    {
+        final byte[] destination = new byte[POSITIONS_PER_PAGE * ARRAY_SHORT_INDEX_SCALE];
+
+        List<Short> source = IntStream.range(0, POSITIONS_PER_PAGE).mapToObj(i -> (short) RANDOM.nextInt(256)).collect(Collectors.toList());
+        testSequential(
+                source,
+                ARRAY_SHORT_INDEX_SCALE,
+                destination,
+                (bytes, index, value) -> setShort((byte[]) bytes, (int) index, (short) value),
+                (bytes, index) -> getShort((byte[]) bytes, (int) index));
+
+        source = new ArrayList<Short>(Collections.nCopies(POSITIONS_PER_PAGE, (short) 0));
+        testRandom(
+                source,
+                ARRAY_SHORT_INDEX_SCALE,
+                destination,
+                (bytes, index, value) -> setShort((byte[]) bytes, (int) index, (short) value),
+                (bytes, index) -> getShort((byte[]) bytes, (int) index));
+    }
+
+    @Test
+    public static void testSetInt()
+    {
+        final byte[] destination = new byte[POSITIONS_PER_PAGE * ARRAY_INT_INDEX_SCALE];
+
+        List<Integer> source = IntStream.range(0, POSITIONS_PER_PAGE).boxed().collect(Collectors.toList());
+        testSequential(
+                source,
+                ARRAY_INT_INDEX_SCALE,
+                destination,
+                (bytes, index, value) -> setInt((byte[]) bytes, (int) index, (int) value),
+                (bytes, index) -> getInt((byte[]) bytes, (int) index));
+
+        source = new ArrayList<Integer>(Collections.nCopies(POSITIONS_PER_PAGE, 0));
+        testRandom(
+                source,
+                ARRAY_INT_INDEX_SCALE,
+                destination,
+                (bytes, index, value) -> setInt((byte[]) bytes, (int) index, (int) value),
+                (bytes, index) -> getInt((byte[]) bytes, (int) index));
+    }
+
+    @Test
+    public static void testSetLong()
+    {
+        final byte[] destination = new byte[POSITIONS_PER_PAGE * ARRAY_LONG_INDEX_SCALE];
+
+        List<Long> source = LongStream.range(0, POSITIONS_PER_PAGE).boxed().collect(Collectors.toList());
+        testSequential(
+                source,
+                ARRAY_LONG_INDEX_SCALE,
+                destination,
+                (bytes, index, value) -> setLong((byte[]) bytes, (int) index, (long) value),
+                (bytes, index) -> getLong((byte[]) bytes, (int) index));
+
+        source = new ArrayList<Long>(Collections.nCopies(POSITIONS_PER_PAGE, 0L));
+        testRandom(
+                source,
+                ARRAY_LONG_INDEX_SCALE,
+                destination,
+                (bytes, index, value) -> setLong((byte[]) bytes, (int) index, (long) value),
+                (bytes, index) -> getLong((byte[]) bytes, (int) index));
+    }
+
+    @Test
+    public static void testFill()
+    {
+        final byte[] destination = new byte[POSITIONS_PER_PAGE];
+        int filledBytes = fill(destination, 0, POSITIONS_PER_PAGE, (byte) 5);
+
+        assertEquals(filledBytes, POSITIONS_PER_PAGE);
+
+        ArrayList<Byte> expected = new ArrayList<Byte>(Collections.nCopies(POSITIONS_PER_PAGE, (byte) 5));
+        assertCopied(expected, destination, ARRAY_BYTE_INDEX_SCALE, (bytes, index) -> getByte((byte[]) bytes, (int) index));
+    }
+
+    @Test
+    public static void testSetBytes()
+    {
+        final byte[] destination = new byte[POSITIONS_PER_PAGE];
+
+        byte[] source = new byte[POSITIONS_PER_PAGE];
+        RANDOM.nextBytes(source);
+
+        int setBytes = setBytes(destination, 0, source, 0, POSITIONS_PER_PAGE);
+
+        assertEquals(setBytes, POSITIONS_PER_PAGE);
+
+        assertCopied(Bytes.asList(source), destination, ARRAY_BYTE_INDEX_SCALE, (bytes, index) -> getByte((byte[]) bytes, (int) index));
+    }
+
+    @Test
+    public static void testSetInts()
+    {
+        final byte[] destination = new byte[POSITIONS_PER_PAGE * ARRAY_INT_INDEX_SCALE];
+
+        int copiedBytes = setInts(destination, 0, IntStream.range(0, POSITIONS_PER_PAGE).toArray(), 0, POSITIONS_PER_PAGE);
+
+        assertEquals(copiedBytes, POSITIONS_PER_PAGE * ARRAY_INT_INDEX_SCALE);
+
+        List<Integer> expected = IntStream.range(0, POSITIONS_PER_PAGE).boxed().collect(Collectors.toList());
+        assertCopied(expected, destination, ARRAY_INT_INDEX_SCALE, (bytes, index) -> getInt((byte[]) bytes, (int) index));
+    }
+
+    private static <T> void testSequential(List<T> source, int elementSize, byte[] destination, TriFunction writeFunction, BiFunction readFunction)
+    {
+        int index = 0;
+        for (int i = 0; i < source.size(); i++) {
+            index = writeFunction.apply(destination, index, (T) source.get(i));
+        }
+        assertEquals(index, POSITIONS_PER_PAGE * elementSize);
+        assertCopied(source, destination, elementSize, readFunction);
+    }
+
+    // source should contain identical elements.
+    private static <T> void testRandom(List<T> source, int elementSize, byte[] destination, TriFunction writeFunction, BiFunction readFunction)
+    {
+        Arrays.fill(destination, (byte) 0);
+
+        int index = 0;
+        for (int i = 0; i < source.size(); i++) {
+            int newIndex = writeFunction.apply(destination, index, (T) source.get(i));
+            if (i % 2 == 0) {
+                index = newIndex;
+            }
+        }
+
+        assertEquals(index, POSITIONS_PER_PAGE / 2 * elementSize);
+        assertCopied(source.subList(0, POSITIONS_PER_PAGE / 2), Arrays.copyOf(destination, POSITIONS_PER_PAGE / 2), elementSize, readFunction);
+        assertCopied(source.subList(POSITIONS_PER_PAGE / 2 + 1, POSITIONS_PER_PAGE), Arrays.copyOf(destination, POSITIONS_PER_PAGE / 2), elementSize, readFunction);
+    }
+
+    private static <T> boolean assertCopied(List<T> expected, byte[] actual, int elementSize, BiFunction readFunction)
+    {
+        for (int index = 0; index < actual.length; index++) {
+            if ((readFunction.apply(actual, index) != expected.get(index))) {
+                return false;
+            }
+            index += elementSize;
+        }
+        return true;
+    }
+
+    @FunctionalInterface
+    private interface TriFunction<T, U, S>
+    {
+        Integer apply(T t, U u, S s);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestingBlockBuilders.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestingBlockBuilders.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.RowType;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
+import static com.facebook.presto.block.BlockAssertions.createIntsBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongDecimalsBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
+import static com.facebook.presto.block.BlockAssertions.createTypedLongsBlock;
+import static com.facebook.presto.spi.block.ArrayBlock.fromElementBlock;
+import static com.facebook.presto.spi.block.MapBlock.fromKeyValueBlock;
+import static com.facebook.presto.spi.block.MethodHandleUtil.compose;
+import static com.facebook.presto.spi.block.MethodHandleUtil.nativeValueGetter;
+import static com.facebook.presto.spi.block.RowBlock.fromFieldBlocks;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+
+public class TestingBlockBuilders
+{
+    private static final int ENTRY_SIZE = 4;
+    private static final int MAX_STRING_SIZE = 10;
+
+    private final Random random = new Random(0);
+
+    Block buildNullBlock(Type type, int positionCount)
+    {
+        return new RunLengthEncodedBlock(type.createBlockBuilder(null, 1).appendNull().build(), positionCount);
+    }
+
+    Block buildBigintBlock(int positionCount, boolean allowNulls)
+    {
+        return createLongsBlock(
+                IntStream.range(0, positionCount)
+                        .mapToObj(i -> allowNulls && i % 7 == 0 ? null : random.nextLong())
+                        .collect(Collectors.toList()));
+    }
+
+    Block buildLongDecimalBlock(int positionCount, boolean allowNulls)
+    {
+        return createLongDecimalsBlock(
+                IntStream.range(0, positionCount)
+                        .mapToObj(i -> allowNulls && i % 7 == 0 ? null : Double.toString(random.nextDouble() * random.nextInt()))
+                        .collect(Collectors.toList()));
+    }
+
+    Block buildIntegerBlock(int positionCount, boolean allowNulls)
+    {
+        return createIntsBlock(
+                IntStream.range(0, positionCount)
+                        .mapToObj(i -> allowNulls && i % 7 == 0 ? null : random.nextInt())
+                        .collect(Collectors.toList()));
+    }
+
+    Block buildSmallintBlock(int positionCount, boolean allowNulls)
+    {
+        return createTypedLongsBlock(
+                SMALLINT,
+                IntStream.range(0, positionCount)
+                        .mapToObj(i -> allowNulls && i % 7 == 0 ? null : random.nextLong() % Short.MIN_VALUE)
+                        .collect(Collectors.toList()));
+    }
+
+    Block buildBooleanBlock(int positionCount, boolean allowNulls)
+    {
+        return createBooleansBlock(
+                IntStream.range(0, positionCount)
+                        .mapToObj(i -> allowNulls && i % 7 == 0 ? null : random.nextBoolean())
+                        .collect(Collectors.toList()));
+    }
+
+    Block buildVarcharBlock(int positionCount, boolean allowNulls, int maxStringLength)
+    {
+        return createStringsBlock(
+                IntStream.range(0, positionCount)
+                        .mapToObj(i -> allowNulls && i % 7 == 0 ? null : getRandomString(maxStringLength))
+                        .collect(Collectors.toList()));
+    }
+
+    DictionaryBlock buildDictionaryBlock(Block dictionary, int positionCount)
+    {
+        int[] ids = IntStream.range(0, positionCount).map(i -> random.nextInt(dictionary.getPositionCount() / 10)).toArray();
+        return new DictionaryBlock(dictionary, ids);
+    }
+
+    RunLengthEncodedBlock buildRleBlock(Block block, int positionCount)
+    {
+        checkArgument(block.getPositionCount() > 0);
+        return new RunLengthEncodedBlock(block.getRegion(block.getPositionCount() / 2, 1), positionCount);
+    }
+
+    Block buildDictRleBlock(Block block, int positionCount, Optional<String> wrappings)
+    {
+        if (!wrappings.isPresent()) {
+            return null;
+        }
+
+        for (int i = wrappings.get().length() - 1; i >= 0; i--) {
+            if (wrappings.get().charAt(i) == 'D') {
+                block = buildDictionaryBlock(block, positionCount);
+            }
+            else if (wrappings.get().charAt(i) == 'R') {
+                block = buildRleBlock(block, positionCount);
+            }
+            else {
+                throw new IllegalArgumentException(format("wrappings %s is incorrect", wrappings));
+            }
+        }
+        return block;
+    }
+
+    Block buildBlockWithType(Type type, int positionCount, boolean allowNulls, boolean isView, Optional<String> wrappings)
+    {
+        Block block = null;
+
+        if (isView) {
+            positionCount *= 2;
+        }
+
+        if (type == BIGINT || type instanceof DecimalType && ((DecimalType) type).isShort()) {
+            block = buildBigintBlock(positionCount, allowNulls);
+        }
+        else if (type instanceof DecimalType && !((DecimalType) type).isShort()) {
+            block = buildLongDecimalBlock(positionCount, allowNulls);
+        }
+        else if (type == INTEGER) {
+            block = buildIntegerBlock(positionCount, allowNulls);
+        }
+        else if (type == SMALLINT) {
+            block = buildSmallintBlock(positionCount, allowNulls);
+        }
+        else if (type == BOOLEAN) {
+            block = buildBooleanBlock(positionCount, allowNulls);
+        }
+        else if (type == VARCHAR) {
+            block = buildVarcharBlock(positionCount, allowNulls, MAX_STRING_SIZE);
+        }
+        else {
+            // Nested types
+            // Build isNull and offsets of size positionCount
+            boolean[] isNull = new boolean[positionCount];
+            int[] offsets = new int[positionCount + 1];
+            for (int position = 0; position < positionCount; position++) {
+                if (allowNulls && position % 7 == 0) {
+                    isNull[position] = true;
+                    offsets[position + 1] = offsets[position];
+                }
+                else {
+                    offsets[position + 1] = offsets[position] + (type instanceof RowType ? 1 : random.nextInt(ENTRY_SIZE) + 1);
+                }
+            }
+
+            // Build the nested block of size offsets[positionCount].
+            if (type instanceof ArrayType) {
+                Block valuesBlock = buildBlockWithType(
+                        ((ArrayType) type).getElementType(),
+                        offsets[positionCount],
+                        allowNulls, isView,
+                        wrappings);
+
+                block = fromElementBlock(positionCount, Optional.of(isNull), offsets, valuesBlock);
+            }
+            else if (type instanceof MapType) {
+                Block keyBlock = buildBlockWithType(
+                        ((MapType) type).getKeyType(),
+                        offsets[positionCount],
+                        false, isView,
+                        wrappings);
+                Block valueBlock = buildBlockWithType(
+                        ((MapType) type).getValueType(),
+                        offsets[positionCount],
+                        allowNulls, isView,
+                        wrappings);
+
+                Type keyType = ((MapType) type).getKeyType();
+                MethodHandle keyNativeEquals = TYPE_MANAGER.resolveOperator(OperatorType.EQUAL, ImmutableList.of(keyType, keyType));
+                MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
+                MethodHandle keyNativeHashCode = TYPE_MANAGER.resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(keyType));
+                MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
+
+                block = fromKeyValueBlock(
+                        Optional.of(isNull),
+                        offsets,
+                        keyBlock,
+                        valueBlock,
+                        ((MapType) type),
+                        keyBlockNativeEquals,
+                        keyNativeHashCode,
+                        keyBlockHashCode);
+            }
+            else if (type instanceof RowType) {
+                List<Type> fieldTypes = ((RowType) type).getTypeParameters();
+                Block[] fieldBlocks = new Block[fieldTypes.size()];
+
+                for (int i = 0; i < fieldBlocks.length; i++) {
+                    Block fieldBlock = buildBlockWithType(
+                            fieldTypes.get(i),
+                            positionCount,
+                            allowNulls, isView,
+                            wrappings);
+                    fieldBlocks[i] = fieldBlock;
+                }
+
+                block = fromFieldBlocks(positionCount, Optional.of(isNull), fieldBlocks);
+            }
+            else {
+                throw new UnsupportedOperationException(format("type %s is not supported.", type));
+            }
+        }
+
+        if (isView) {
+            positionCount /= 2;
+            int offset = positionCount / 2;
+            block = block.getRegion(offset, positionCount);
+        }
+
+        if (wrappings.isPresent()) {
+            block = buildDictRleBlock(block, positionCount, wrappings);
+        }
+
+        return block;
+    }
+
+    static MapType createMapType(Type keyType, Type valueType)
+    {
+        MethodHandle keyNativeEquals = TYPE_MANAGER.resolveOperator(OperatorType.EQUAL, ImmutableList.of(keyType, keyType));
+        MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
+        MethodHandle keyBlockEquals = compose(keyNativeEquals, nativeValueGetter(keyType), nativeValueGetter(keyType));
+        MethodHandle keyNativeHashCode = TYPE_MANAGER.resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(keyType));
+        MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
+        return new MapType(
+                keyType,
+                valueType,
+                keyBlockNativeEquals,
+                keyBlockEquals,
+                keyNativeHashCode,
+                keyBlockHashCode);
+    }
+
+    private String getRandomString(int maxStringLength)
+    {
+        byte[] array = new byte[maxStringLength];
+        random.nextBytes(array);
+        return new String(array, Charset.forName("UTF-8"));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestingPageBuilders.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestingPageBuilders.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+
+public class TestingPageBuilders
+{
+    private TestingPageBuilders()
+    {}
+
+    static Page buildPage(List<Type> types, int positionCount, boolean allowNulls)
+    {
+        return buildPage(types, positionCount, true, false, allowNulls, false, Optional.empty());
+    }
+
+    static Page buildDictionaryPage(List<Type> types, int positionCount, boolean allowNulls)
+    {
+        return buildPage(types, positionCount, true, false, allowNulls, false, Optional.of("D"));
+    }
+
+    static Page buildRlePage(List<Type> types, int positionCount, boolean allowNulls)
+    {
+        return buildPage(types, positionCount, true, false, allowNulls, false, Optional.of("R"));
+    }
+
+    static Page buildPage(List<Type> types, int positionCount, boolean addPreComputedHashBlockAtBegin, boolean addNullBlockAtEnd, boolean useBlockView, Optional<String> wrappings)
+    {
+        return buildPage(types, positionCount, addPreComputedHashBlockAtBegin, addNullBlockAtEnd, true, useBlockView, wrappings);
+    }
+
+    static Page buildPage(List<Type> types, int positionCount, boolean addPreComputedHashBlockAtBegin, boolean addNullBlockAtEnd, boolean allowNulls, boolean useBlockView, Optional<String> wrappings)
+    {
+        TestingBlockBuilders blockBuilders = new TestingBlockBuilders();
+
+        int channelCount = types.size();
+        int preComputedChannelCount = (addPreComputedHashBlockAtBegin ? 1 : 0);
+        int nullChannelCount = (addNullBlockAtEnd ? 1 : 0);
+
+        Block[] blocks = new Block[channelCount + preComputedChannelCount + nullChannelCount];
+
+        if (addPreComputedHashBlockAtBegin) {
+            blocks[0] = blockBuilders.buildBigintBlock(positionCount, false);
+        }
+
+        for (int i = 0; i < channelCount; i++) {
+            blocks[i + preComputedChannelCount] = blockBuilders.buildBlockWithType(types.get(i), positionCount, allowNulls, useBlockView, wrappings);
+        }
+
+        if (addNullBlockAtEnd) {
+            blocks[channelCount + preComputedChannelCount] = blockBuilders.buildNullBlock(BIGINT, positionCount);
+        }
+
+        return new Page(positionCount, blocks);
+    }
+
+    static Page mergePages(List<Type> types, List<Page> pages)
+    {
+        PageBuilder pageBuilder = new PageBuilder(types);
+        int rowCount = 0;
+        for (Page page : pages) {
+            for (int i = 0; i < types.size(); i++) {
+                BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(i);
+                Block block = page.getBlock(i);
+                for (int j = 0; j < page.getPositionCount(); j++) {
+                    if (block.isNull(j)) {
+                        blockBuilder.appendNull();
+                    }
+                    else {
+                        page.getBlock(i).writePositionTo(j, blockBuilder);
+                    }
+                }
+            }
+            rowCount += page.getPositionCount();
+        }
+        pageBuilder.declarePositions(rowCount);
+        return pageBuilder.build();
+    }
+
+    static List<Type> buildTypes(List<Type> types, boolean addPreComputedHashBlockAtBegin, boolean addNullBlockAtEnd)
+    {
+        ArrayList<Type> updatedTypes = new ArrayList<>(types);
+
+        if (addPreComputedHashBlockAtBegin) {
+            updatedTypes.add(0, BIGINT);
+        }
+
+        if (addNullBlockAtEnd) {
+            updatedTypes.add(BIGINT);
+        }
+
+        return updatedTypes;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -117,7 +117,8 @@ public class TestFeaturesConfig
                 .setJsonSerdeCodeGenerationEnabled(false)
                 .setPushLimitThroughOuterJoin(true)
                 .setMaxConcurrentMaterializations(10)
-                .setPushdownSubfieldsEnabled(false));
+                .setPushdownSubfieldsEnabled(false)
+                .setOptimizedRepartitioningEnabled(false));
     }
 
     @Test
@@ -194,6 +195,7 @@ public class TestFeaturesConfig
                 .put("optimizer.push-limit-through-outer-join", "false")
                 .put("max-concurrent-materializations", "5")
                 .put("experimental.pushdown-subfields-enabled", "true")
+                .put("experimental.optimized-repartitioning", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -266,7 +268,8 @@ public class TestFeaturesConfig
                 .setJsonSerdeCodeGenerationEnabled(true)
                 .setPushLimitThroughOuterJoin(false)
                 .setMaxConcurrentMaterializations(5)
-                .setPushdownSubfieldsEnabled(true);
+                .setPushdownSubfieldsEnabled(true)
+                .setOptimizedRepartitioningEnabled(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/AbstractVariableWidthBlock.java
@@ -25,7 +25,8 @@ public abstract class AbstractVariableWidthBlock
 {
     protected abstract Slice getRawSlice(int position);
 
-    protected abstract int getPositionOffset(int position);
+    // TODO: expose offset in ColumnarSlice
+    public abstract int getPositionOffset(int position);
 
     protected abstract boolean isEntryNull(int position);
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarArray.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarArray.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.spi.block;
 
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
 public class ColumnarArray
@@ -136,7 +138,7 @@ public class ColumnarArray
         return getOffset(position + 1) - getOffset(position);
     }
 
-    private int getOffset(int position)
+    public int getOffset(int position)
     {
         return offsets[position + offsetsOffset];
     }
@@ -144,5 +146,20 @@ public class ColumnarArray
     public Block getElementsBlock()
     {
         return elementsBlock;
+    }
+
+    public Block getNullCheckBlock()
+    {
+        return nullCheckBlock;
+    }
+
+    public long getSizeInBytes()
+    {
+        return nullCheckBlock.getSizeInBytes() + elementsBlock.getSizeInBytes() + SIZE_OF_INT * getPositionCount();
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return nullCheckBlock.getRetainedSizeInBytes() + elementsBlock.getRetainedSizeInBytes() + sizeOf(offsets);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarMap.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarMap.java
@@ -13,6 +13,13 @@
  */
 package com.facebook.presto.spi.block;
 
+import com.facebook.presto.spi.type.Type;
+
+import java.util.Optional;
+
+import static com.facebook.presto.spi.block.AbstractMapBlock.HASH_MULTIPLIER;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
 public class ColumnarMap
@@ -22,6 +29,8 @@ public class ColumnarMap
     private final int[] offsets;
     private final Block keysBlock;
     private final Block valuesBlock;
+    private final Type keyType;
+    private final int[] hashTables;
 
     public static ColumnarMap toColumnarMap(Block block)
     {
@@ -48,8 +57,9 @@ public class ColumnarMap
         int totalEntryCount = mapBlock.getOffset(block.getPositionCount()) - firstEntryPosition;
         Block keysBlock = mapBlock.getRawKeyBlock().getRegion(firstEntryPosition, totalEntryCount);
         Block valuesBlock = mapBlock.getRawValueBlock().getRegion(firstEntryPosition, totalEntryCount);
+        Optional<int[]> hashTables = mapBlock.getHashTables().get();
 
-        return new ColumnarMap(block, offsetBase, offsets, keysBlock, valuesBlock);
+        return new ColumnarMap(block, offsetBase, offsets, keysBlock, valuesBlock, mapBlock.keyType, hashTables);
     }
 
     private static ColumnarMap toColumnarMap(DictionaryBlock dictionaryBlock)
@@ -83,7 +93,9 @@ public class ColumnarMap
                 0,
                 offsets,
                 new DictionaryBlock(dictionaryIds.length, columnarMap.getKeysBlock(), dictionaryIds),
-                new DictionaryBlock(dictionaryIds.length, columnarMap.getValuesBlock(), dictionaryIds));
+                new DictionaryBlock(dictionaryIds.length, columnarMap.getValuesBlock(), dictionaryIds),
+                columnarMap.keyType,
+                columnarMap.getHashTables());
     }
 
     private static ColumnarMap toColumnarMap(RunLengthEncodedBlock rleBlock)
@@ -112,16 +124,20 @@ public class ColumnarMap
                 0,
                 offsets,
                 new DictionaryBlock(dictionaryIds.length, columnarMap.getKeysBlock(), dictionaryIds),
-                new DictionaryBlock(dictionaryIds.length, columnarMap.getValuesBlock(), dictionaryIds));
+                new DictionaryBlock(dictionaryIds.length, columnarMap.getValuesBlock(), dictionaryIds),
+                columnarMap.keyType,
+                columnarMap.getHashTables());
     }
 
-    private ColumnarMap(Block nullCheckBlock, int offsetsOffset, int[] offsets, Block keysBlock, Block valuesBlock)
+    private ColumnarMap(Block nullCheckBlock, int offsetsOffset, int[] offsets, Block keysBlock, Block valuesBlock, Type keyType, Optional<int[]> hashTables)
     {
         this.nullCheckBlock = nullCheckBlock;
         this.offsetsOffset = offsetsOffset;
         this.offsets = offsets;
         this.keysBlock = keysBlock;
         this.valuesBlock = valuesBlock;
+        this.keyType = keyType;
+        this.hashTables = hashTables.orElse(null);
     }
 
     public int getPositionCount()
@@ -139,7 +155,7 @@ public class ColumnarMap
         return (offsets[position + 1 + offsetsOffset] - offsets[position + offsetsOffset]);
     }
 
-    private int getOffset(int position)
+    public int getOffset(int position)
     {
         return offsets[position + offsetsOffset];
     }
@@ -152,5 +168,30 @@ public class ColumnarMap
     public Block getValuesBlock()
     {
         return valuesBlock;
+    }
+
+    public Block getNullCheckBlock()
+    {
+        return nullCheckBlock;
+    }
+
+    public Type getKeyType()
+    {
+        return keyType;
+    }
+
+    public Optional<int[]> getHashTables()
+    {
+        return Optional.ofNullable(hashTables);
+    }
+
+    public long getSizeInBytes()
+    {
+        return nullCheckBlock.getSizeInBytes() + keysBlock.getSizeInBytes() + valuesBlock.getSizeInBytes() + SIZE_OF_INT * getPositionCount() + SIZE_OF_INT * getPositionCount() * HASH_MULTIPLIER;
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return nullCheckBlock.getRetainedSizeInBytes() + keysBlock.getRetainedSizeInBytes() + valuesBlock.getRetainedSizeInBytes() + sizeOf(offsets) + sizeOf(hashTables);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarRow.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarRow.java
@@ -134,4 +134,32 @@ public final class ColumnarRow
     {
         return fields[index];
     }
+
+    public int getOffset(int position)
+    {
+        return ((AbstractRowBlock) nullCheckBlock).getFieldBlockOffset(position);
+    }
+
+    public Block getNullCheckBlock()
+    {
+        return nullCheckBlock;
+    }
+
+    public long getSizeInBytes()
+    {
+        int fieldsSize = 0;
+        for (int i = 0; i < fields.length; i++) {
+            fieldsSize += fields[i].getSizeInBytes();
+        }
+        return nullCheckBlock.getSizeInBytes() + fieldsSize;
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        int fieldsRetainedSize = 0;
+        for (int i = 0; i < fields.length; i++) {
+            fieldsRetainedSize += fields[i].getSizeInBytes();
+        }
+        return nullCheckBlock.getRetainedSizeInBytes() + fieldsRetainedSize;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlock.java
@@ -83,7 +83,7 @@ public class VariableWidthBlock
     }
 
     @Override
-    protected final int getPositionOffset(int position)
+    public final int getPositionOffset(int position)
     {
         return offsets[position + arrayOffset];
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/VariableWidthBlockBuilder.java
@@ -78,7 +78,7 @@ public class VariableWidthBlockBuilder
     }
 
     @Override
-    protected int getPositionOffset(int position)
+    public int getPositionOffset(int position)
     {
         checkValidPosition(position, positions);
         return getOffset(position);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestOptimizedPartitionedOutputOperatorQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestOptimizedPartitionedOutputOperatorQueries.java
@@ -1,0 +1,330 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public abstract class AbstractTestOptimizedPartitionedOutputOperatorQueries
+        extends AbstractTestQueryFramework
+{
+    protected AbstractTestOptimizedPartitionedOutputOperatorQueries(QueryRunnerSupplier supplier)
+    {
+        super(supplier);
+    }
+
+    @Test
+    public void testBoolean()
+    {
+        assertQuery("WITH lineitem_ex AS (\n" +
+                        "    SELECT\n" +
+                        "        partkey,\n" +
+                        "        suppkey,\n" +
+                        "        IF (mod(orderkey + linenumber, 11) = 0, FALSE, TRUE) AS flag\n" +
+                        "    FROM lineitem\n" +
+                        ")\n" +
+                        "SELECT\n" +
+                        "    CHECKSUM(l.flag)\n" +
+                        "FROM lineitem_ex l,\n" +
+                        "    partsupp p\n" +
+                        "WHERE\n" +
+                        "    l.partkey = p.partkey\n" +
+                        "    AND l.suppkey = p.suppkey\n" +
+                        "    AND p.availqty < 1000",
+                new byte[] {126, 85, 59, 72, -71, -42, 49, 21});
+    }
+
+    @Test
+    public void testSmallInt()
+    {
+        assertQuery("WITH lineitem_ex AS (\n" +
+                        "    SELECT\n" +
+                        "        partkey,\n" +
+                        "        suppkey,\n" +
+                        "        CAST(linenumber AS SMALLINT) AS l_linenumber\n" +
+                        "    FROM lineitem\n" +
+                        ")\n" +
+                        "SELECT\n" +
+                        "    CHECKSUM(l.l_linenumber)\n" +
+                        "FROM lineitem_ex l,\n" +
+                        "    partsupp p\n" +
+                        "WHERE\n" +
+                        "    l.partkey = p.partkey\n" +
+                        "    AND l.suppkey = p.suppkey\n" +
+                        "    AND p.availqty < 1000",
+                new byte[] {-87, -84, -37, 75, -52, 22, 87, -29});
+    }
+
+    @Test
+    public void testInteger()
+    {
+        assertQuery("SELECT\n" +
+                        "    CHECKSUM(l.linenumber)\n" +
+                        "    FROM lineitem l, partsupp p\n" +
+                        "WHERE\n" +
+                        "    l.partkey = p.partkey\n" +
+                        "    AND l.suppkey = p.suppkey\n" +
+                        "    AND p.availqty < 1000",
+                new byte[] {-87, -84, -37, 75, -52, 22, 87, -29});
+    }
+
+    @Test
+    public void testBigInt()
+    {
+        assertQuery("SELECT\n" +
+                        "    CHECKSUM(l.partkey)\n" +
+                        "    FROM lineitem l, partsupp p\n" +
+                        "WHERE\n" +
+                        "    l.partkey = p.partkey\n" +
+                        "    AND l.suppkey = p.suppkey\n" +
+                        "    AND p.availqty < 1000",
+                new byte[] {122, -36, -24, 126, -7, 61, -78, 5});
+    }
+
+    @Test
+    public void testIpAddress()
+    {
+        assertQuery("WITH lineitem_ex AS \n" +
+                        "(\n" +
+                        "SELECT\n" +
+                        "    partkey,\n" +
+                        "    CAST(\n" +
+                        "        CONCAT(\n" +
+                        "            CONCAT(\n" +
+                        "                CONCAT(\n" +
+                        "                    CONCAT(\n" +
+                        "                        CONCAT(\n" +
+                        "                            CONCAT(CAST((orderkey % 255) AS VARCHAR), '.'),\n" +
+                        "                            CAST((partkey % 255) AS VARCHAR)\n" +
+                        "                        ),\n" +
+                        "                        '.'\n" +
+                        "                    ),\n" +
+                        "                    CAST(suppkey AS VARCHAR)\n" +
+                        "                ),\n" +
+                        "                '.'\n" +
+                        "            ),\n" +
+                        "            CAST(linenumber AS VARCHAR)\n" +
+                        "        ) AS ipaddress\n" +
+                        "    ) AS ip\n" +
+                        "    FROM lineitem\n" +
+                        "    )\n" +
+                        "SELECT\n" +
+                        "    CHECKSUM(l.ip) \n" +
+                        "FROM lineitem_ex l,\n" +
+                        "    partsupp p\n" +
+                        "WHERE\n" +
+                        "    l.partkey = p.partkey",
+                new byte[] {92, -57, -31, -119, -122, 9, 118, -31});
+    }
+
+    @Test
+    public void testBigintWithNulls()
+    {
+        assertQuery("WITH lineitem_ex AS (\n" +
+                        "    SELECT\n" +
+                        "        IF (mod(orderkey + linenumber, 11) = 0, NULL, partkey) AS l_partkey\n" +
+                        "    FROM lineitem\n" +
+                        ")\n" +
+                        "SELECT\n" +
+                        "    CHECKSUM(l.l_partkey)\n" +
+                        "FROM lineitem_ex l,\n" +
+                        "    partsupp p\n" +
+                        "WHERE\n" +
+                        "    l.l_partkey = p.partkey",
+                new byte[] {-4, -54, 21, 27, 121, 66, 3, 35});
+    }
+
+    @Test
+    public void testVarchar()
+    {
+        assertQuery("SELECT\n" +
+                        "    CHECKSUM(l.comment)\n" +
+                        "    FROM lineitem l, partsupp p\n" +
+                        "WHERE\n" +
+                        "    l.partkey = p.partkey\n" +
+                        "    AND l.suppkey = p.suppkey\n" +
+                        "    AND p.availqty < 1000",
+                new byte[] {14, -4, 62, 87, 52, 53, -101, -100});
+    }
+
+    @Test
+    public void testDictionaryOfVarcharWithNulls()
+    {
+        assertQuery("SELECT\n" +
+                        "    CHECKSUM(l.shipmode)\n" +
+                        "    FROM lineitem l, partsupp p\n" +
+                        "WHERE\n" +
+                        "    l.partkey = p.partkey\n" +
+                        "    AND l.suppkey = p.suppkey\n" +
+                        "    AND p.availqty < 1000",
+                new byte[] {127, 108, -69, -115, -43, 44, -54, 88});
+    }
+
+    @Test
+    public void testArrayOfBigInt()
+    {
+        assertQuery("WITH lineitem_ex AS (\n" +
+                        "    SELECT\n" +
+                        "        partkey,\n" +
+                        "        suppkey,\n" +
+                        "        ARRAY[orderkey, partkey, suppkey] AS l_array\n" +
+                        "    FROM lineitem\n" +
+                        ")\n" +
+                        "SELECT\n" +
+                        "    CHECKSUM(l.l_array)\n" +
+                        "FROM lineitem_ex l,\n" +
+                        "    partsupp p\n" +
+                        "WHERE\n" +
+                        "    l.partkey = p.partkey\n" +
+                        "    AND l.suppkey = p.suppkey\n" +
+                        "    AND p.availqty < 1000",
+                new byte[] {10, -59, 46, 87, 22, -93, 58, -16});
+    }
+
+    @Test
+    public void testArrayOfArray()
+    {
+        assertQuery("WITH lineitem_ex AS (\n" +
+                        "    SELECT\n" +
+                        "        partkey,\n" +
+                        "        suppkey,\n" +
+                        "        ARRAY[ARRAY[orderkey, partkey], ARRAY[suppkey]] AS l_array\n" +
+                        "    FROM lineitem\n" +
+                        ")\n" +
+                        "SELECT\n" +
+                        "    CHECKSUM(l.l_array)\n" +
+                        "FROM lineitem_ex l,\n" +
+                        "    partsupp p\n" +
+                        "WHERE\n" +
+                        "    l.partkey = p.partkey\n" +
+                        "    AND l.suppkey = p.suppkey\n" +
+                        "    AND p.availqty < 1000",
+                new byte[] {10, -59, 46, 87, 22, -93, 58, -16});
+    }
+
+    @Test
+    public void testStruct()
+    {
+        assertQuery("WITH lineitem_ex AS (\n" +
+                        "    SELECT\n" +
+                        "        orderkey,\n" +
+                        "        CAST(\n" +
+                        "            ROW (\n" +
+                        "                partkey,\n" +
+                        "                suppkey,\n" +
+                        "                extendedprice,\n" +
+                        "                discount,\n" +
+                        "                quantity,\n" +
+                        "                shipdate,\n" +
+                        "                receiptdate,\n" +
+                        "                commitdate,\n" +
+                        "                comment\n" +
+                        "            ) AS ROW(\n" +
+                        "                l_partkey BIGINT,\n" +
+                        "                l_suppkey BIGINT,\n" +
+                        "                l_extendedprice DOUBLE,\n" +
+                        "                l_discount DOUBLE,\n" +
+                        "                l_quantity DOUBLE,\n" +
+                        "                l_shipdate DATE,\n" +
+                        "                l_receiptdate DATE,\n" +
+                        "                l_commitdate DATE,\n" +
+                        "                l_comment VARCHAR(44)\n" +
+                        "            )\n" +
+                        "        ) AS l_shipment\n" +
+                        "    FROM lineitem\n" +
+                        ")\n" +
+                        "SELECT\n" +
+                        "    CHECKSUM(l.l_shipment)\n" +
+                        "FROM lineitem_ex l,\n" +
+                        "    orders o\n" +
+                        "WHERE\n" +
+                        "    l.orderkey = o.orderkey",
+                new byte[] {-56, 110, 18, -107, -123, 121, 87, 79});
+    }
+
+    @Test
+    public void testStructWithNulls()
+    {
+        assertQuery("WITH lineitem_ex AS (\n" +
+                        "    SELECT\n" +
+                        "        orderkey,\n" +
+                        "        CAST(\n" +
+                        "            IF (\n" +
+                        "                mod(partkey, 5) = 0,\n" +
+                        "                NULL,\n" +
+                        "                ROW(\n" +
+                        "                    COMMENT,\n" +
+                        "                    IF (\n" +
+                        "                        mod(partkey, 13) = 0,\n" +
+                        "                        NULL,\n" +
+                        "                        CONCAT(CAST(partkey AS VARCHAR), COMMENT)\n" +
+                        "                    )\n" +
+                        "                )\n" +
+                        "            ) AS ROW(s1 VARCHAR, s2 VARCHAR)\n" +
+                        "        ) AS l_partkey_struct\n" +
+                        "    FROM lineitem\n" +
+                        ")\n" +
+                        "SELECT\n" +
+                        "    CHECKSUM(l.l_partkey_struct)\n" +
+                        "FROM lineitem_ex l,\n" +
+                        "    orders o\n" +
+                        "WHERE\n" +
+                        "    l.orderkey = o.orderkey",
+                new byte[] {67, 108, 83, 92, 16, -5, 66, 65});
+    }
+
+    @Test
+    public void testMaps()
+    {
+        assertQuery("WITH lineitem_ex AS (\n" +
+                        "    SELECT\n" +
+                        "        partkey,\n" +
+                        "        suppkey,\n" +
+                        "        MAP(ARRAY[1, 2, 3], ARRAY[orderkey, partkey, suppkey]) AS l_map\n" +
+                        "    FROM lineitem\n" +
+                        ")\n" +
+                        "SELECT\n" +
+                        "    CHECKSUM(l.l_map)\n" +
+                        "FROM lineitem_ex l,\n" +
+                        "    partsupp p\n" +
+                        "WHERE\n" +
+                        "    l.partkey = p.partkey\n" +
+                        "    AND l.suppkey = p.suppkey\n" +
+                        "    AND p.availqty < 1000",
+                new byte[] {-28, 76, -12, -42, 116, -118, -9, 46});
+
+        assertQuery("WITH lineitem_ex AS (\n" +
+                        "    SELECT\n" +
+                        "        partkey,\n" +
+                        "        suppkey,\n" +
+                        "        MAP(ARRAY[1, 2, 3], ARRAY[orderkey, partkey, suppkey]) AS l_map\n" +
+                        "    FROM lineitem\n" +
+                        ")\n" +
+                        "SELECT\n" +
+                        "    CHECKSUM(l.l_map[1])\n" +
+                        "FROM lineitem_ex l,\n" +
+                        "    partsupp p\n" +
+                        "WHERE\n" +
+                        "    l.partkey = p.partkey\n" +
+                        "    AND l.suppkey = p.suppkey\n" +
+                        "    AND p.availqty < 1000\n",
+                new byte[] {121, 123, -114, -120, -18, 98, -124, 105});
+    }
+
+    private void assertQuery(String query, byte[] checksum)
+    {
+        assertEquals(computeActual(query).getOnlyValue(), checksum);
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestOptimizedPartitionedOutputOperatorQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestOptimizedPartitionedOutputOperatorQueries.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder;
+
+public class TestOptimizedPartitionedOutputOperatorQueries
+        extends AbstractTestOptimizedPartitionedOutputOperatorQueries
+{
+    public TestOptimizedPartitionedOutputOperatorQueries()
+    {
+        super(() -> TpchQueryRunnerBuilder.builder()
+                .setSingleExtraProperty("experimental.optimized-repartitioning", "true")
+                .build());
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestOptimizedPartitionedOutputOperatorQueriesWithSmallPages.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestOptimizedPartitionedOutputOperatorQueriesWithSmallPages.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder;
+import com.google.common.collect.ImmutableMap;
+
+public class TestOptimizedPartitionedOutputOperatorQueriesWithSmallPages
+        extends AbstractTestOptimizedPartitionedOutputOperatorQueries
+{
+    protected TestOptimizedPartitionedOutputOperatorQueriesWithSmallPages()
+    {
+        super(() -> TpchQueryRunnerBuilder.builder()
+                .setExtraProperties(ImmutableMap.of("experimental.optimized-repartitioning", "true",
+                        "driver.max-page-partitioning-buffer-size", "200B"))
+                .build());
+    }
+}


### PR DESCRIPTION
This is the WIP PR for https://github.com/prestodb/presto/issues/13015

The new PartitionedOutputOperator skips the block building step, and
directly appends the data into the buffers, then wraps the buffers into
SerializedPage.

A verifier run on random 150 queries shows 34% improvement in PartitionedOutputOperator
and 22% overall.

JMH benchmark only 1000-5000 pages with 8296 rows with 1-2 channels
shows improvement up to 3x.

Update:
07/13/2019
1) Added TestOptimizedPartitionedOutputOperatorQueriesWithSmallPages that uses small SerializedPage to force flushing
2) Added test cases for bucketed tables
3) Fixed one bug that the array out of bound when copying hashtables
4)  Addressed comments

07/11/2019
1) Made "Extract PartitionedOutputInfo as a standalone class" a separate commit
2) Comments addressed and some code clean up

TODO:

1)   Fix the problem that concurrent query run using shadow tool on verifiers tend to fail with communication error. Individual manually submitted queries doesn't have the problem though.
2) Fix all bugs from 14 failed queries (out of 600 queries) on verifiers. Unfixed ones include:
    a) Copying values array of bigint produces out of bound error.
    b) ArrayIndexOutOfBoundsException in MapBlockEncodingBuffers.populateNestedPositions
    c) PositionCount verify failure in VariableWidthBlockEncodingBuffers.accumulateRowSizes 
3) Add unit and round trip tests for all general cases and make sure they cover the bugs found.