### PR TITLE
Add functions to compute differential entropy

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
@@ -60,6 +60,7 @@ import com.facebook.presto.operator.aggregation.RealSumAggregation;
 import com.facebook.presto.operator.aggregation.SumDataSizeForStats;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
 import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggregationFunction;
+import com.facebook.presto.operator.aggregation.differentialentropy.DifferentialEntropyAggregation;
 import com.facebook.presto.operator.aggregation.histogram.Histogram;
 import com.facebook.presto.operator.aggregation.multimapagg.MultimapAggregationFunction;
 import com.facebook.presto.operator.scalar.ArrayCardinalityFunction;
@@ -440,6 +441,7 @@ public class BuiltInFunctionNamespaceManager
                 .function(REAL_AVERAGE_AGGREGATION)
                 .aggregates(IntervalDayToSecondAverageAggregation.class)
                 .aggregates(IntervalYearToMonthAverageAggregation.class)
+                .aggregates(DifferentialEntropyAggregation.class)
                 .aggregates(EntropyAggregation.class)
                 .aggregates(GeometricMeanAggregations.class)
                 .aggregates(RealGeometricMeanAggregations.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/DifferentialEntropyAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/DifferentialEntropyAggregation.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.google.common.base.Verify.verify;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+
+@AggregationFunction("differential_entropy")
+@Description("Computes differential entropy based on random-variable samples")
+public final class DifferentialEntropyAggregation
+{
+    @VisibleForTesting
+    public static final String FIXED_HISTOGRAM_MLE_METHOD_NAME = "fixed_histogram_mle";
+    @VisibleForTesting
+    public static final String FIXED_HISTOGRAM_JACKNIFE_METHOD_NAME = "fixed_histogram_jacknife";
+
+    private DifferentialEntropyAggregation() {}
+
+    @InputFunction
+    public static void input(
+            @AggregationState DifferentialEntropyState state,
+            @SqlType(StandardTypes.BIGINT) long size,
+            @SqlType(StandardTypes.DOUBLE) double sample,
+            @SqlType(StandardTypes.DOUBLE) double weight,
+            @SqlType(StandardTypes.VARCHAR) Slice method,
+            @SqlType(StandardTypes.DOUBLE) double min,
+            @SqlType(StandardTypes.DOUBLE) double max)
+    {
+        String requestedMethod = method.toStringUtf8().toLowerCase(ENGLISH);
+        DifferentialEntropyStateStrategy strategy = state.getStrategy();
+        if (strategy == null) {
+            switch (requestedMethod) {
+                case FIXED_HISTOGRAM_MLE_METHOD_NAME:
+                    strategy = new FixedHistogramMleStateStrategy(size, min, max);
+                    break;
+                case FIXED_HISTOGRAM_JACKNIFE_METHOD_NAME:
+                    strategy = new FixedHistogramJacknifeStateStrategy(size, min, max);
+                    break;
+                default:
+                    throw new PrestoException(
+                            INVALID_FUNCTION_ARGUMENT,
+                            format("In differential_entropy UDF, invalid method: %s", requestedMethod));
+            }
+            state.setStrategy(strategy);
+        }
+        else {
+            switch (requestedMethod.toLowerCase(ENGLISH)) {
+                case FIXED_HISTOGRAM_MLE_METHOD_NAME:
+                    verify(strategy instanceof FixedHistogramMleStateStrategy,
+                            format("Strategy class is not compatible with entropy method: %s %s", strategy.getClass().getSimpleName(), method));
+                    break;
+                case FIXED_HISTOGRAM_JACKNIFE_METHOD_NAME:
+                    verify(strategy instanceof FixedHistogramJacknifeStateStrategy,
+                            format("Strategy class is not compatible with entropy method: %s %s", strategy.getClass().getSimpleName(), method));
+                    break;
+                default:
+                    verify(false, format("Unknown entropy method %s", method));
+            }
+        }
+        strategy.validateParameters(size, sample, weight, min, max);
+        strategy.add(sample, weight);
+    }
+
+    @InputFunction
+    public static void input(
+            @AggregationState DifferentialEntropyState state,
+            @SqlType(StandardTypes.BIGINT) long size,
+            @SqlType(StandardTypes.DOUBLE) double sample,
+            @SqlType(StandardTypes.DOUBLE) double weight)
+    {
+        DifferentialEntropyStateStrategy strategy = state.getStrategy();
+        if (state.getStrategy() == null) {
+            strategy = new WeightedReservoirSampleStateStrategy(size);
+            state.setStrategy(strategy);
+        }
+        else {
+            verify(strategy instanceof WeightedReservoirSampleStateStrategy,
+                    format("Expected WeightedReservoirSampleStateStrategy, got: %s", strategy.getClass().getSimpleName()));
+        }
+        strategy.validateParameters(size, sample, weight);
+        strategy.add(sample, weight);
+    }
+
+    @InputFunction
+    public static void input(
+            @AggregationState DifferentialEntropyState state,
+            @SqlType(StandardTypes.BIGINT) long size,
+            @SqlType(StandardTypes.DOUBLE) double sample)
+    {
+        DifferentialEntropyStateStrategy strategy = state.getStrategy();
+        if (state.getStrategy() == null) {
+            strategy = new UnweightedReservoirSampleStateStrategy(size);
+            state.setStrategy(strategy);
+        }
+        else {
+            verify(strategy instanceof UnweightedReservoirSampleStateStrategy,
+                    format("Expected UnweightedReservoirSampleStateStrategy, got: %s", strategy.getClass().getSimpleName()));
+        }
+        strategy.validateParameters(size, sample);
+        strategy.add(sample, 1.0);
+    }
+
+    @CombineFunction
+    public static void combine(
+            @AggregationState DifferentialEntropyState state,
+            @AggregationState DifferentialEntropyState otherState)
+    {
+        DifferentialEntropyStateStrategy strategy = state.getStrategy();
+        DifferentialEntropyStateStrategy otherStrategy = otherState.getStrategy();
+        if (strategy == null && otherStrategy != null) {
+            state.setStrategy(otherStrategy);
+            return;
+        }
+        if (otherStrategy == null) {
+            return;
+        }
+
+        verify(strategy.getClass() == otherStrategy.getClass(),
+                format("In combine, %s != %s", strategy.getClass().getSimpleName(), otherStrategy.getClass().getSimpleName()));
+
+        strategy.mergeWith(otherStrategy);
+    }
+
+    @OutputFunction("double")
+    public static void output(@AggregationState DifferentialEntropyState state, BlockBuilder out)
+    {
+        DifferentialEntropyStateStrategy strategy = state.getStrategy();
+        DOUBLE.writeDouble(out, strategy == null ? Double.NaN : strategy.calculateEntropy());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/DifferentialEntropyState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/DifferentialEntropyState.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+
+@AccumulatorStateMetadata(
+        stateSerializerClass = DifferentialEntropyStateSerializer.class,
+        stateFactoryClass = DifferentialEntropyStateFactory.class)
+public interface DifferentialEntropyState
+        extends AccumulatorState
+{
+    void setStrategy(DifferentialEntropyStateStrategy strategy);
+
+    DifferentialEntropyStateStrategy getStrategy();
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/DifferentialEntropyStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/DifferentialEntropyStateFactory.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.operator.aggregation.state.AbstractGroupedAccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+
+import static java.util.Objects.requireNonNull;
+
+public class DifferentialEntropyStateFactory
+        implements AccumulatorStateFactory<DifferentialEntropyState>
+{
+    @Override
+    public DifferentialEntropyState createSingleState()
+    {
+        return new SingleState();
+    }
+
+    @Override
+    public Class<? extends DifferentialEntropyState> getSingleStateClass()
+    {
+        return SingleState.class;
+    }
+
+    @Override
+    public DifferentialEntropyState createGroupedState()
+    {
+        return new GroupedState();
+    }
+
+    @Override
+    public Class<? extends DifferentialEntropyState> getGroupedStateClass()
+    {
+        return GroupedState.class;
+    }
+
+    public static class GroupedState
+            extends AbstractGroupedAccumulatorState
+            implements DifferentialEntropyState
+    {
+        private ObjectBigArray<DifferentialEntropyStateStrategy> strategies = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            strategies.ensureCapacity(size);
+        }
+
+        @Override
+        public void setStrategy(DifferentialEntropyStateStrategy strategy)
+        {
+            DifferentialEntropyStateStrategy previous = requireNonNull(strategy, "strategy is null");
+            if (previous != null) {
+                size -= previous.getEstimatedSize();
+            }
+
+            strategies.set(getGroupId(), strategy);
+            size += strategy.getEstimatedSize();
+        }
+
+        @Override
+        public DifferentialEntropyStateStrategy getStrategy()
+        {
+            return strategies.get(getGroupId());
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + strategies.sizeOf();
+        }
+    }
+
+    public static class SingleState
+            implements DifferentialEntropyState
+    {
+        private DifferentialEntropyStateStrategy strategy;
+
+        @Override
+        public void setStrategy(DifferentialEntropyStateStrategy strategy)
+        {
+            this.strategy = requireNonNull(strategy, "strategy is null");
+        }
+
+        @Override
+        public DifferentialEntropyStateStrategy getStrategy()
+        {
+            return strategy;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            if (strategy == null) {
+                return 0;
+            }
+            return strategy.getEstimatedSize();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/DifferentialEntropyStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/DifferentialEntropyStateSerializer.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.google.common.base.Verify.verify;
+import static java.lang.String.format;
+
+public class DifferentialEntropyStateSerializer
+        implements AccumulatorStateSerializer<DifferentialEntropyState>
+{
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(DifferentialEntropyState state, BlockBuilder output)
+    {
+        DifferentialEntropyStateStrategy strategy = state.getStrategy();
+
+        if (strategy == null) {
+            SliceOutput sliceOut = Slices.allocate(SizeOf.SIZE_OF_INT).getOutput();
+            sliceOut.appendInt(0);
+            VARBINARY.writeSlice(output, sliceOut.getUnderlyingSlice());
+            return;
+        }
+
+        int requiredBytes = SizeOf.SIZE_OF_INT + // Method
+                strategy.getRequiredBytesForSerialization(); // stateStrategy;
+
+        SliceOutput sliceOut = Slices.allocate(requiredBytes).getOutput();
+
+        if (strategy instanceof UnweightedReservoirSampleStateStrategy) {
+            sliceOut.appendInt(1);
+        }
+        else if (strategy instanceof WeightedReservoirSampleStateStrategy) {
+            sliceOut.appendInt(2);
+        }
+        else if (strategy instanceof FixedHistogramMleStateStrategy) {
+            sliceOut.appendInt(3);
+        }
+        else if (strategy instanceof FixedHistogramJacknifeStateStrategy) {
+            sliceOut.appendInt(4);
+        }
+        else {
+            verify(false, format("Strategy cannot be serialized: %s", strategy.getClass().getSimpleName()));
+        }
+
+        strategy.serialize(sliceOut);
+        VARBINARY.writeSlice(output, sliceOut.getUnderlyingSlice());
+    }
+
+    @Override
+    public void deserialize(
+            Block block,
+            int index,
+            DifferentialEntropyState state)
+    {
+        SliceInput input = VARBINARY.getSlice(block, index).getInput();
+        int method = input.readInt();
+        switch (method) {
+            case 0:
+                verify(state.getStrategy() == null, "strategy is not null for null method");
+                return;
+            case 1:
+                state.setStrategy(UnweightedReservoirSampleStateStrategy.deserialize(input));
+                return;
+            case 2:
+                state.setStrategy(WeightedReservoirSampleStateStrategy.deserialize(input));
+                return;
+            case 3:
+                state.setStrategy(FixedHistogramMleStateStrategy.deserialize(input));
+                return;
+            case 4:
+                state.setStrategy(FixedHistogramJacknifeStateStrategy.deserialize(input));
+                return;
+            default:
+                verify(false, format("Unknown method code when deserializing: %s", method));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/DifferentialEntropyStateStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/DifferentialEntropyStateStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import io.airlift.slice.SliceOutput;
+
+import static java.lang.String.format;
+
+/**
+ * Interface for different strategies for calculating entropy: MLE (maximum likelihood
+ * estimator) using NumericHistogram, jacknife estimates using a fixed histogram, compressed
+ * counting and Renyi entropy, and so forth.
+ */
+public interface DifferentialEntropyStateStrategy
+        extends Cloneable
+{
+    void add(double sample, double weight);
+
+    double calculateEntropy();
+
+    long getEstimatedSize();
+
+    int getRequiredBytesForSerialization();
+
+    void serialize(SliceOutput out);
+
+    void mergeWith(DifferentialEntropyStateStrategy other);
+
+    DifferentialEntropyStateStrategy clone();
+
+    default void validateParameters(long bucketCount, double sample, double weight, double min, double max)
+    {
+        throw new UnsupportedOperationException(
+                format("In differential_entropy UDF, unsupported arguments for type: %s", getClass().getSimpleName()));
+    }
+
+    default void validateParameters(long bucketCount, double sample, double weight)
+    {
+        throw new UnsupportedOperationException(
+                format("In differential_entropy UDF, unsupported arguments for type: %s", getClass().getSimpleName()));
+    }
+
+    default void validateParameters(long bucketCount, double sample)
+    {
+        throw new UnsupportedOperationException(
+                format("In differential_entropy UDF, unsupported arguments for type: %s", getClass().getSimpleName()));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/EntropyCalculations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/EntropyCalculations.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import java.util.Arrays;
+
+import static java.lang.Math.toIntExact;
+
+public class EntropyCalculations
+{
+    private EntropyCalculations() {}
+
+    /**
+     * @implNote Based on Alizadeh Noughabi, Hadi & Arghami, N. (2010). "A New Estimator of Entropy".
+     */
+    public static double calculateFromSamples(double[] samples)
+    {
+        if (samples.length == 0) {
+            return Double.NaN;
+        }
+
+        Arrays.sort(samples);
+        int n = samples.length;
+        int m = toIntExact(Math.max(Math.round(Math.sqrt(n)), 2));
+        double entropy = 0;
+        for (int i = 0; i < n; i++) {
+            double sIPlusM = i + m < n ? samples[i + m] : samples[n - 1];
+            double sIMinusM = i - m > 0 ? samples[i - m] : samples[0];
+            double aI = i + m < n && i - m > 0 ? 2 : 1;
+            entropy += Math.log(n / (aI * m) * (sIPlusM - sIMinusM));
+        }
+        return entropy / n / Math.log(2);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/FixedHistogramJacknifeStateStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/FixedHistogramJacknifeStateStrategy.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.operator.aggregation.fixedhistogram.FixedDoubleBreakdownHistogram;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import java.util.Map;
+
+import static com.facebook.presto.operator.aggregation.differentialentropy.FixedHistogramStateStrategyUtils.getXLogX;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.Streams.stream;
+import static java.lang.Math.toIntExact;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.summingDouble;
+
+/**
+ * Calculates sample entropy using jacknife estimates on a fixed histogram.
+ * See http://cs.brown.edu/~pvaliant/unseen_nips.pdf.
+ */
+public class FixedHistogramJacknifeStateStrategy
+        implements DifferentialEntropyStateStrategy
+{
+    private final FixedDoubleBreakdownHistogram histogram;
+
+    public FixedHistogramJacknifeStateStrategy(long bucketCount, double min, double max)
+    {
+        FixedHistogramStateStrategyUtils.validateParameters(
+                bucketCount,
+                min,
+                max);
+
+        histogram = new FixedDoubleBreakdownHistogram(toIntExact(bucketCount), min, max);
+    }
+
+    private FixedHistogramJacknifeStateStrategy(FixedDoubleBreakdownHistogram histogram)
+    {
+        this.histogram = histogram;
+    }
+
+    private FixedHistogramJacknifeStateStrategy(FixedHistogramJacknifeStateStrategy other)
+    {
+        histogram = other.histogram.clone();
+    }
+
+    @Override
+    public void validateParameters(long bucketCount, double sample, double weight, double min, double max)
+    {
+        FixedHistogramStateStrategyUtils.validateParameters(
+                histogram.getBucketCount(),
+                histogram.getMin(),
+                histogram.getMax(),
+                bucketCount,
+                sample,
+                weight,
+                min,
+                max);
+    }
+
+    @Override
+    public void mergeWith(DifferentialEntropyStateStrategy other)
+    {
+        histogram.mergeWith(((FixedHistogramJacknifeStateStrategy) other).histogram);
+    }
+
+    @Override
+    public void add(double value, double weight)
+    {
+        histogram.add(value, weight);
+    }
+
+    @Override
+    public double calculateEntropy()
+    {
+        Map<Double, Double> bucketWeights = stream(histogram.iterator()).collect(
+                groupingBy(
+                        FixedDoubleBreakdownHistogram.Bucket::getLeft,
+                        summingDouble(e -> e.getCount() * e.getWeight())));
+        double sumWeight = bucketWeights.values().stream().mapToDouble(Double::doubleValue).sum();
+        if (sumWeight == 0.0) {
+            return Double.NaN;
+        }
+        long n = stream(histogram.iterator())
+                .mapToLong(FixedDoubleBreakdownHistogram.Bucket::getCount)
+                .sum();
+        double sumWeightLogWeight =
+                bucketWeights.values().stream().mapToDouble(w -> w == 0.0 ? 0.0 : w * Math.log(w)).sum();
+
+        double entropy = n * calculateEntropy(histogram.getWidth(), sumWeight, sumWeightLogWeight);
+        for (FixedDoubleBreakdownHistogram.Bucket bucketWeight : histogram) {
+            double weight = bucketWeights.get(bucketWeight.getLeft());
+            if (weight > 0.0) {
+                entropy -= getHoldOutEntropy(
+                        n,
+                        bucketWeight.getRight() - bucketWeight.getLeft(),
+                        sumWeight,
+                        sumWeightLogWeight,
+                        weight,
+                        bucketWeight.getWeight(),
+                        bucketWeight.getCount());
+            }
+        }
+        return entropy;
+    }
+
+    private static double getHoldOutEntropy(
+            long n,
+            double width,
+            double sumW,
+            double sumWeightLogWeight,
+            double bucketWeight,
+            double entryWeight,
+            long entryMultiplicity)
+    {
+        double holdoutBucketWeight = Math.max(bucketWeight - entryWeight, 0);
+        double holdoutSumWeight =
+                sumW - bucketWeight + holdoutBucketWeight;
+        double holdoutSumWeightLogWeight =
+                sumWeightLogWeight - getXLogX(bucketWeight) + getXLogX(holdoutBucketWeight);
+        double holdoutEntropy = entryMultiplicity * (n - 1) *
+                calculateEntropy(width, holdoutSumWeight, holdoutSumWeightLogWeight) /
+                n;
+        return holdoutEntropy;
+    }
+
+    private static double calculateEntropy(double width, double sumWeight, double sumWeightLogWeight)
+    {
+        verify(sumWeight > 0.0);
+        return Math.max((Math.log(width * sumWeight) - sumWeightLogWeight / sumWeight) / Math.log(2.0), 0.0);
+    }
+
+    @Override
+    public long getEstimatedSize()
+    {
+        return histogram.estimatedInMemorySize();
+    }
+
+    @Override
+    public int getRequiredBytesForSerialization()
+    {
+        return histogram.getRequiredBytesForSerialization();
+    }
+
+    public static FixedHistogramJacknifeStateStrategy deserialize(SliceInput input)
+    {
+        FixedDoubleBreakdownHistogram histogram = FixedDoubleBreakdownHistogram.deserialize(input);
+        return new FixedHistogramJacknifeStateStrategy(histogram);
+    }
+
+    @Override
+    public void serialize(SliceOutput out)
+    {
+        histogram.serialize(out);
+    }
+
+    @Override
+    public DifferentialEntropyStateStrategy clone()
+    {
+        return new FixedHistogramJacknifeStateStrategy(this);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/FixedHistogramMleStateStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/FixedHistogramMleStateStrategy.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.operator.aggregation.fixedhistogram.FixedDoubleHistogram;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import static com.facebook.presto.operator.aggregation.differentialentropy.FixedHistogramStateStrategyUtils.getXLogX;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Calculates sample entropy using MLE (maximum likelihood estimates) on a NumericHistogram.
+ */
+public class FixedHistogramMleStateStrategy
+        implements DifferentialEntropyStateStrategy
+{
+    private final FixedDoubleHistogram histogram;
+
+    public FixedHistogramMleStateStrategy(long bucketCount, double min, double max)
+    {
+        FixedHistogramStateStrategyUtils.validateParameters(
+                bucketCount,
+                min,
+                max);
+
+        histogram = new FixedDoubleHistogram(toIntExact(bucketCount), min, max);
+    }
+
+    private FixedHistogramMleStateStrategy(FixedHistogramMleStateStrategy other)
+    {
+        histogram = other.histogram.clone();
+    }
+
+    private FixedHistogramMleStateStrategy(FixedDoubleHistogram histogram)
+    {
+        this.histogram = requireNonNull(histogram, "histogram is null");
+    }
+
+    @Override
+    public void validateParameters(
+            long bucketCount,
+            double sample,
+            double weight,
+            double min,
+            double max)
+    {
+        FixedHistogramStateStrategyUtils.validateParameters(
+                histogram.getBucketCount(),
+                histogram.getMin(),
+                histogram.getMax(),
+                bucketCount,
+                sample,
+                weight,
+                min,
+                max);
+    }
+
+    @Override
+    public void add(double sample, double weight)
+    {
+        histogram.add(sample, weight);
+    }
+
+    @Override
+    public double calculateEntropy()
+    {
+        double sum = 0;
+        for (FixedDoubleHistogram.Bucket bucket : histogram) {
+            sum += bucket.getWeight();
+        }
+        if (sum == 0.0) {
+            return Double.NaN;
+        }
+
+        double rawEntropy = 0;
+        for (FixedDoubleHistogram.Bucket bucket : histogram) {
+            rawEntropy -= getXLogX(bucket.getWeight() / sum);
+        }
+        return (rawEntropy + Math.log(histogram.getWidth())) / Math.log(2);
+    }
+
+    @Override
+    public long getEstimatedSize()
+    {
+        return histogram.estimatedInMemorySize();
+    }
+
+    @Override
+    public int getRequiredBytesForSerialization()
+    {
+        return histogram.getRequiredBytesForSerialization();
+    }
+
+    @Override
+    public void mergeWith(DifferentialEntropyStateStrategy other)
+    {
+        histogram.mergeWith(((FixedHistogramMleStateStrategy) other).histogram);
+    }
+
+    public static FixedHistogramMleStateStrategy deserialize(SliceInput input)
+    {
+        FixedDoubleHistogram histogram = FixedDoubleHistogram.deserialize(input);
+
+        return new FixedHistogramMleStateStrategy(histogram);
+    }
+
+    @Override
+    public void serialize(SliceOutput out)
+    {
+        histogram.serialize(out);
+    }
+
+    @Override
+    public DifferentialEntropyStateStrategy clone()
+    {
+        return new FixedHistogramMleStateStrategy(this);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/FixedHistogramStateStrategyUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/FixedHistogramStateStrategyUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.spi.PrestoException;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static java.lang.String.format;
+
+/**
+ * Utility class for different strategies for calculating entropy based on fixed histograms.
+ */
+public class FixedHistogramStateStrategyUtils
+{
+    private FixedHistogramStateStrategyUtils() {}
+
+    public static void validateParameters(
+            long bucketCount,
+            double min,
+            double max)
+    {
+        if (bucketCount < 0) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, bucket count must be non-negative: %s", bucketCount));
+        }
+
+        if (min >= max) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT, format(
+                            "In differential_entropy UDF, min must be larger than max: min=%s, max=%s", min, max));
+        }
+    }
+
+    public static void validateParameters(
+            long histogramBucketCount,
+            double histogramMin,
+            double histogramMax,
+            long bucketCount,
+            double sample,
+            double weight,
+            double min,
+            double max)
+    {
+        validateParameters(histogramBucketCount, histogramMin, histogramMax);
+        validateParameters(bucketCount, min, max);
+
+        if (weight < 0.0) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, weight must be non-negative: %s", weight));
+        }
+
+        if (histogramBucketCount != bucketCount) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, inconsistent bucket count: prev=%s, current=%s", histogramBucketCount, bucketCount));
+        }
+        if (histogramMin != min) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, inconsistent min: prev=%s, current=%s", histogramMin, min));
+        }
+        if (histogramMax != max) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, inconsistent max: prev=%s, current=%s", histogramMax, max));
+        }
+        if (sample < min) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, sample must be at least min: sample=%s, min=%s", sample, min));
+        }
+        if (sample > max) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, sample must be at most max: sample=%s, max=%s", sample, max));
+        }
+    }
+
+    public static double getXLogX(double x)
+    {
+        return x <= 0.0 ? 0.0 : x * Math.log(x);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/UnweightedReservoirSampleStateStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/UnweightedReservoirSampleStateStrategy.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.operator.aggregation.reservoirsample.UnweightedDoubleReservoirSample;
+import com.facebook.presto.spi.PrestoException;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import static com.facebook.presto.operator.aggregation.differentialentropy.EntropyCalculations.calculateFromSamples;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+
+public class UnweightedReservoirSampleStateStrategy
+        implements DifferentialEntropyStateStrategy
+{
+    private final UnweightedDoubleReservoirSample reservoir;
+
+    public UnweightedReservoirSampleStateStrategy(long maxSamples)
+    {
+        if (maxSamples <= 0) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, max samples must be positive: %s", maxSamples));
+        }
+        if (maxSamples >= UnweightedDoubleReservoirSample.MAX_SAMPLES_LIMIT) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, max samples  must be capped: max_samples=%s, cap=%s", maxSamples, UnweightedDoubleReservoirSample.MAX_SAMPLES_LIMIT));
+        }
+
+        reservoir = new UnweightedDoubleReservoirSample(toIntExact(maxSamples));
+    }
+
+    private UnweightedReservoirSampleStateStrategy(UnweightedReservoirSampleStateStrategy other)
+    {
+        reservoir = other.reservoir.clone();
+    }
+
+    private UnweightedReservoirSampleStateStrategy(UnweightedDoubleReservoirSample reservoir)
+    {
+        this.reservoir = reservoir;
+    }
+
+    @Override
+    public void validateParameters(long maxSamples, double sample, double weight)
+    {
+        if (weight != 1.0) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, weight must be 1.0: %s", weight));
+        }
+
+        if (maxSamples != reservoir.getMaxSamples()) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, inconsistent maxSamples: %s, %s", maxSamples, reservoir.getMaxSamples()));
+        }
+    }
+
+    @Override
+    public void validateParameters(long maxSamples, double sample)
+    {
+        if (maxSamples != reservoir.getMaxSamples()) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, inconsistent maxSamples: %s, %s", maxSamples, reservoir.getMaxSamples()));
+        }
+    }
+
+    @Override
+    public void mergeWith(DifferentialEntropyStateStrategy other)
+    {
+        reservoir.mergeWith(((UnweightedReservoirSampleStateStrategy) other).reservoir);
+    }
+
+    @Override
+    public void add(double value, double weight)
+    {
+        if (weight != 1.0) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, weight should be 1.0: %s", weight));
+        }
+        reservoir.add(value);
+    }
+
+    @Override
+    public double calculateEntropy()
+    {
+        return calculateFromSamples(reservoir.getSamples());
+    }
+
+    @Override
+    public long getEstimatedSize()
+    {
+        return reservoir.estimatedInMemorySize();
+    }
+
+    @Override
+    public int getRequiredBytesForSerialization()
+    {
+        return reservoir.getRequiredBytesForSerialization();
+    }
+
+    public static UnweightedReservoirSampleStateStrategy deserialize(SliceInput input)
+    {
+        return new UnweightedReservoirSampleStateStrategy(UnweightedDoubleReservoirSample.deserialize(input));
+    }
+
+    @Override
+    public void serialize(SliceOutput out)
+    {
+        reservoir.serialize(out);
+    }
+
+    @Override
+    public DifferentialEntropyStateStrategy clone()
+    {
+        return new UnweightedReservoirSampleStateStrategy(this);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/WeightedReservoirSampleStateStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/differentialentropy/WeightedReservoirSampleStateStrategy.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.operator.aggregation.reservoirsample.WeightedDoubleReservoirSample;
+import com.facebook.presto.spi.PrestoException;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import static com.facebook.presto.operator.aggregation.differentialentropy.EntropyCalculations.calculateFromSamples;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.google.common.base.Verify.verify;
+import static java.lang.String.format;
+
+public class WeightedReservoirSampleStateStrategy
+        implements DifferentialEntropyStateStrategy
+{
+    private final WeightedDoubleReservoirSample reservoir;
+
+    public WeightedReservoirSampleStateStrategy(long maxSamples)
+    {
+        if (maxSamples <= 0) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, max samples must be positive: %s", maxSamples));
+        }
+        if (maxSamples >= WeightedDoubleReservoirSample.MAX_SAMPLES_LIMIT) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, max samples  must be capped: max_samples=%s, cap=%s", maxSamples, WeightedDoubleReservoirSample.MAX_SAMPLES_LIMIT));
+        }
+
+        reservoir = new WeightedDoubleReservoirSample((int) maxSamples);
+    }
+
+    private WeightedReservoirSampleStateStrategy(WeightedReservoirSampleStateStrategy other)
+    {
+        reservoir = other.reservoir.clone();
+    }
+
+    private WeightedReservoirSampleStateStrategy(WeightedDoubleReservoirSample reservoir)
+    {
+        this.reservoir = reservoir;
+    }
+
+    @Override
+    public void validateParameters(
+            long maxSamples,
+            double sample,
+            double weight)
+    {
+        if (weight < 0.0) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("In differential_entropy UDF, weight must be non-negative: %s", weight));
+        }
+
+        if (maxSamples != reservoir.getMaxSamples()) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    format("In differential_entropy UDF, inconsistent maxSamples: %s, %s", maxSamples, reservoir.getMaxSamples()));
+        }
+    }
+
+    @Override
+    public void mergeWith(DifferentialEntropyStateStrategy other)
+    {
+        verify(other instanceof WeightedReservoirSampleStateStrategy,
+                format("class should be an instance of WeightedReservoirSampleStateStrategy: %s", other.getClass().getSimpleName()));
+        reservoir.mergeWith(((WeightedReservoirSampleStateStrategy) other).reservoir);
+    }
+
+    @Override
+    public void add(double value, double weight)
+    {
+        reservoir.add(value, weight);
+    }
+
+    @Override
+    public double calculateEntropy()
+    {
+        return calculateFromSamples(reservoir.getSamples());
+    }
+
+    @Override
+    public long getEstimatedSize()
+    {
+        return reservoir.estimatedInMemorySize();
+    }
+
+    @Override
+    public int getRequiredBytesForSerialization()
+    {
+        return reservoir.getRequiredBytesForSerialization();
+    }
+
+    public static WeightedReservoirSampleStateStrategy deserialize(SliceInput input)
+    {
+        return new WeightedReservoirSampleStateStrategy(WeightedDoubleReservoirSample.deserialize(input));
+    }
+
+    @Override
+    public void serialize(SliceOutput out)
+    {
+        reservoir.serialize(out);
+    }
+
+    @Override
+    public DifferentialEntropyStateStrategy clone()
+    {
+        return new WeightedReservoirSampleStateStrategy(this);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/fixedhistogram/FixedHistogramUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/fixedhistogram/FixedHistogramUtils.java
@@ -19,17 +19,17 @@ class FixedHistogramUtils
 {
     private FixedHistogramUtils() {}
 
-    public static void verifyParameters(int bucketCount, double min, double max)
+    public static void validateParameters(int bucketCount, double min, double max)
     {
-        checkArgument(bucketCount >= 2, "bucketCount %s must be at least 2", bucketCount);
-        checkArgument(min < max, "min %s must be smaller than max %s ", min, max);
+        checkArgument(bucketCount >= 2, "bucketCount must be at least 2: %s", bucketCount);
+        checkArgument(min < max, "min must be smaller than max: %s %s", min, max);
     }
 
     public static int getIndexForValue(int bucketCount, double min, double max, double value)
     {
         checkArgument(
                 value >= min && value < max,
-                "value must be within range [%s, %s]", min, max);
+                "value must be within range: %s [%s, %s]", value, min, max);
         return Math.min(
                 (int) (bucketCount * (value - min) / (max - min)),
                 bucketCount - 1);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/UnweightedDoubleReservoirSample.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/UnweightedDoubleReservoirSample.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.reservoirsample;
+
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class UnweightedDoubleReservoirSample
+        implements Cloneable
+{
+    public static final int MAX_SAMPLES_LIMIT = 1_000_000;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(UnweightedDoubleReservoirSample.class).instanceSize();
+
+    private int seenCount;
+    private double[] samples;
+
+    public UnweightedDoubleReservoirSample(int maxSamples)
+    {
+        checkArgument(
+                maxSamples > 0,
+                format("Maximum number of samples must be positive: %s", maxSamples));
+        checkArgument(
+                maxSamples <= MAX_SAMPLES_LIMIT,
+                format("Maximum number of samples must not exceed maximum: %s %s", maxSamples, MAX_SAMPLES_LIMIT));
+
+        this.samples = new double[maxSamples];
+    }
+
+    private UnweightedDoubleReservoirSample(UnweightedDoubleReservoirSample other)
+    {
+        this.seenCount = other.seenCount;
+        this.samples = Arrays.copyOf(requireNonNull(other.samples, "samples is null"), other.samples.length);
+    }
+
+    private UnweightedDoubleReservoirSample(int seenCount, double[] samples)
+    {
+        this.seenCount = seenCount;
+        this.samples = samples;
+    }
+
+    public int getMaxSamples()
+    {
+        return samples.length;
+    }
+
+    public void add(double sample)
+    {
+        seenCount++;
+        if (seenCount <= samples.length) {
+            samples[seenCount - 1] = sample;
+            return;
+        }
+        int index = ThreadLocalRandom.current().nextInt(0, seenCount);
+        if (index < samples.length) {
+            samples[index] = sample;
+        }
+    }
+
+    public void mergeWith(UnweightedDoubleReservoirSample other)
+    {
+        checkArgument(
+                samples.length == other.samples.length,
+                format("Maximum number of samples %s must be equal to that of other %s", samples.length, other.samples.length));
+        if (other.seenCount < other.samples.length) {
+            for (int i = 0; i < other.seenCount; i++) {
+                add(other.samples[i]);
+            }
+            return;
+        }
+        if (seenCount < samples.length) {
+            UnweightedDoubleReservoirSample target = ((UnweightedDoubleReservoirSample) other.clone());
+            for (int i = 0; i < seenCount; i++) {
+                target.add(samples[i]);
+            }
+            seenCount = target.seenCount;
+            samples = target.samples;
+            return;
+        }
+
+        shuffleArray(samples);
+        shuffleArray(other.samples);
+        int nextIndex = 0;
+        int otherNextIndex = 0;
+        double[] merged = new double[samples.length];
+        for (int i = 0; i < samples.length; i++) {
+            if (ThreadLocalRandom.current().nextLong(0, seenCount + other.seenCount) < seenCount) {
+                merged[i] = samples[nextIndex++];
+            }
+            else {
+                merged[i] = other.samples[otherNextIndex++];
+            }
+        }
+        seenCount += other.seenCount;
+        samples = merged;
+    }
+
+    @Override
+    public UnweightedDoubleReservoirSample clone()
+    {
+        return new UnweightedDoubleReservoirSample(this);
+    }
+
+    public double[] getSamples()
+    {
+        return Arrays.copyOf(samples, Math.min(seenCount, samples.length));
+    }
+
+    private static void shuffleArray(double[] samples)
+    {
+        for (int i = samples.length - 1; i > 0; i--) {
+            int index = ThreadLocalRandom.current().nextInt(0, i + 1);
+            double sample = samples[index];
+            samples[index] = samples[i];
+            samples[i] = sample;
+        }
+    }
+
+    public static UnweightedDoubleReservoirSample deserialize(SliceInput input)
+    {
+        int seenCount = input.readInt();
+        int maxSamples = input.readInt();
+        double[] samples = new double[maxSamples];
+        input.readBytes(Slices.wrappedDoubleArray(samples), Math.min(seenCount, samples.length) * SizeOf.SIZE_OF_DOUBLE);
+        return new UnweightedDoubleReservoirSample(seenCount, samples);
+    }
+
+    public void serialize(SliceOutput output)
+    {
+        output.appendInt(seenCount);
+        output.appendInt(samples.length);
+        for (int i = 0; i < Math.min(seenCount, samples.length); i++) {
+            output.appendDouble(samples[i]);
+        }
+    }
+
+    public int getRequiredBytesForSerialization()
+    {
+        return SizeOf.SIZE_OF_INT + // seenCount
+                SizeOf.SIZE_OF_INT + SizeOf.SIZE_OF_DOUBLE * Math.min(seenCount, samples.length); // samples
+    }
+
+    public long estimatedInMemorySize()
+    {
+        return INSTANCE_SIZE +
+                SizeOf.sizeOf(samples);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/WeightedDoubleReservoirSample.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/reservoirsample/WeightedDoubleReservoirSample.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.reservoirsample;
+
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class WeightedDoubleReservoirSample
+        implements Cloneable
+{
+    public static final int MAX_SAMPLES_LIMIT = 1_000_000;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(WeightedDoubleReservoirSample.class).instanceSize();
+
+    private int count;
+    private double[] samples;
+    private double[] weights;
+
+    public WeightedDoubleReservoirSample(int maxSamples)
+    {
+        checkArgument(maxSamples > 0, format("Maximum number of samples must be positive: %s", maxSamples));
+        checkArgument(
+                maxSamples <= MAX_SAMPLES_LIMIT,
+                format("Maximum number of samples must not exceed limit: %s %s", maxSamples, MAX_SAMPLES_LIMIT));
+
+        this.samples = new double[maxSamples];
+        this.weights = new double[maxSamples];
+    }
+
+    private WeightedDoubleReservoirSample(WeightedDoubleReservoirSample other)
+    {
+        this.count = other.count;
+        this.samples = Arrays.copyOf(other.samples, other.samples.length);
+        this.weights = Arrays.copyOf(other.weights, other.weights.length);
+    }
+
+    private WeightedDoubleReservoirSample(int count, double[] samples, double[] weights)
+    {
+        this.count = count;
+        this.samples = requireNonNull(samples, "samples is null");
+        this.weights = requireNonNull(weights, "weights is null");
+    }
+
+    public long getMaxSamples()
+    {
+        return samples.length;
+    }
+
+    public void add(double sample, double weight)
+    {
+        checkArgument(weight >= 0, format("Weight %s cannot be negative", weight));
+        double adjustedWeight = Math.pow(
+                ThreadLocalRandom.current().nextDouble(),
+                1.0 / weight);
+        addWithAdjustedWeight(sample, adjustedWeight);
+    }
+
+    private void addWithAdjustedWeight(double sample, double adjustedWeight)
+    {
+        if (count < samples.length) {
+            samples[count] = sample;
+            weights[count] = adjustedWeight;
+            count++;
+            bubbleUp();
+            return;
+        }
+
+        if (adjustedWeight <= weights[0]) {
+            return;
+        }
+
+        samples[0] = sample;
+        weights[0] = adjustedWeight;
+        bubbleDown();
+    }
+
+    public void mergeWith(WeightedDoubleReservoirSample other)
+    {
+        for (int i = 0; i < other.count; i++) {
+            addWithAdjustedWeight(other.samples[i], other.weights[i]);
+        }
+    }
+
+    @Override
+    public WeightedDoubleReservoirSample clone()
+    {
+        return new WeightedDoubleReservoirSample(this);
+    }
+
+    public double[] getSamples()
+    {
+        return Arrays.copyOf(samples, count);
+    }
+
+    private void checkArguments()
+    {
+        checkArgument(samples.length > 0, "Number of reservoir samples must be strictly positive");
+        checkArgument(count <= samples.length, "Size must be at most number of samples");
+    }
+
+    private void swap(int i, int j)
+    {
+        double tmpElement = samples[i];
+        double tmpWeight = weights[i];
+        samples[i] = samples[j];
+        weights[i] = weights[j];
+        samples[j] = tmpElement;
+        weights[j] = tmpWeight;
+    }
+
+    private void bubbleDown()
+    {
+        int index = 0;
+        while (leftChild(index) < count) {
+            int smallestChildIndex = leftChild(index);
+
+            if (rightChild(index) < count && weights[leftChild(index)] > weights[rightChild(index)]) {
+                smallestChildIndex = rightChild(index);
+            }
+
+            if (weights[index] > weights[smallestChildIndex]) {
+                swap(index, smallestChildIndex);
+            }
+            else {
+                break;
+            }
+
+            index = smallestChildIndex;
+        }
+    }
+
+    private void bubbleUp()
+    {
+        int index = count - 1;
+        while (index > 0 && weights[index] < weights[parent(index)]) {
+            swap(index, parent(index));
+            index = parent(index);
+        }
+    }
+
+    private static int parent(int pos)
+    {
+        return pos / 2;
+    }
+
+    private static int leftChild(int pos)
+    {
+        return 2 * pos;
+    }
+
+    private static int rightChild(int pos)
+    {
+        return 2 * pos + 1;
+    }
+
+    public static WeightedDoubleReservoirSample deserialize(SliceInput input)
+    {
+        int count = input.readInt();
+        int maxSamples = input.readInt();
+        checkArgument(count <= maxSamples, "count must not be larger than number of samples");
+        double[] samples = new double[maxSamples];
+        input.readBytes(Slices.wrappedDoubleArray(samples), count * SizeOf.SIZE_OF_DOUBLE);
+        double[] weights = new double[maxSamples];
+        input.readBytes(Slices.wrappedDoubleArray(weights), count * SizeOf.SIZE_OF_DOUBLE);
+        return new WeightedDoubleReservoirSample(count, samples, weights);
+    }
+
+    public void serialize(SliceOutput output)
+    {
+        output.appendInt(count);
+        output.appendInt(samples.length);
+        for (int i = 0; i < count; i++) {
+            output.appendDouble(samples[i]);
+        }
+        for (int i = 0; i < count; i++) {
+            output.appendDouble(weights[i]);
+        }
+    }
+
+    public int getRequiredBytesForSerialization()
+    {
+        return SizeOf.SIZE_OF_INT + // count
+                SizeOf.SIZE_OF_INT + 2 * SizeOf.SIZE_OF_DOUBLE * Math.min(count, samples.length); // samples, weights
+    }
+
+    public long estimatedInMemorySize()
+    {
+        return INSTANCE_SIZE +
+                SizeOf.sizeOf(samples) +
+                SizeOf.sizeOf(weights);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/PrecisionRecallStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/PrecisionRecallStateSerializer.java
@@ -67,8 +67,8 @@ public class PrecisionRecallStateSerializer
                 hasHistograms == 0 || hasHistograms == 1,
                 "hasHistogram %s should be boolean-convertible", hasHistograms);
         if (hasHistograms == 1) {
-            state.setTrueWeights(new FixedDoubleHistogram(input));
-            state.setFalseWeights(new FixedDoubleHistogram(input));
+            state.setTrueWeights(FixedDoubleHistogram.deserialize(input));
+            state.setFalseWeights(FixedDoubleHistogram.deserialize(input));
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.Float.floatToRawIntBits;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
@@ -517,6 +518,13 @@ public final class BlockAssertions
     {
         BlockBuilder blockBuilder = BIGINT.createBlockBuilder(null, 1);
         BIGINT.writeLong(blockBuilder, value);
+        return new RunLengthEncodedBlock(blockBuilder.build(), positionCount);
+    }
+
+    public static RunLengthEncodedBlock createRLEBlock(String value, int positionCount)
+    {
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 1);
+        VARCHAR.writeSlice(blockBuilder, wrappedBuffer(value.getBytes()));
         return new RunLengthEncodedBlock(blockBuilder.build(), positionCount);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AggregationTestUtils.java
@@ -166,6 +166,11 @@ public final class AggregationTestUtils
         return maskedPages;
     }
 
+    public static Object aggregation(InternalAggregationFunction function, Block... blocks)
+    {
+        return aggregation(function, new Page(blocks));
+    }
+
     public static Object aggregation(InternalAggregationFunction function, Page... pages)
     {
         // execute with args in positions: arg0, arg1, arg2

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/AbstractTestFixedHistogramAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/AbstractTestFixedHistogramAggregation.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.operator.aggregation.AbstractTestAggregationFunction;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+
+abstract class AbstractTestFixedHistogramAggregation
+        extends AbstractTestAggregationFunction
+{
+    private static final int NUM_BINS = 5;
+    protected final String method;
+
+    protected AbstractTestFixedHistogramAggregation(String method)
+    {
+        this.method = method;
+    }
+
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        int positionCount = 2 * length;
+        BlockBuilder samples = DOUBLE.createBlockBuilder(null, positionCount);
+        BlockBuilder weights = DOUBLE.createBlockBuilder(null, positionCount);
+        for (int weight = 1; weight < 3; weight++) {
+            for (int i = start; i < start + length; i++) {
+                int bin = Math.max(Math.min(i, NUM_BINS - 1), 0);
+                DOUBLE.writeDouble(samples, bin);
+                DOUBLE.writeDouble(weights, weight);
+            }
+        }
+
+        return new Block[] {
+                createRLEBlock(NUM_BINS, positionCount),
+                samples.build(),
+                weights.build(),
+                createRLEBlock(this.method, positionCount),
+                createRLEBlock(0.0, positionCount),
+                createRLEBlock((double) NUM_BINS, positionCount)
+        };
+    }
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "differential_entropy";
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(
+                StandardTypes.INTEGER,
+                StandardTypes.DOUBLE,
+                StandardTypes.DOUBLE,
+                StandardTypes.VARCHAR,
+                StandardTypes.DOUBLE,
+                StandardTypes.DOUBLE);
+    }
+
+    protected static void generateSamplesAndWeights(int start, int length, List<Double> samples, List<Double> weights)
+    {
+        for (int weight = 1; weight < 3; weight++) {
+            for (int i = start; i < start + length; i++) {
+                int bin = Math.max(Math.min(i, NUM_BINS - 1), 0);
+                samples.add(Double.valueOf(bin));
+                weights.add(Double.valueOf(weight));
+            }
+        }
+    }
+
+    protected static double calculateEntropy(List<Double> samples, List<Double> weights)
+    {
+        double totalWeight = weights.stream().mapToDouble(weight -> weight).sum();
+        if (totalWeight == 0.0) {
+            return Double.NaN;
+        }
+
+        Map<Double, Double> bucketWeights = new HashMap<>();
+        for (int i = 0; i < samples.size(); i++) {
+            double sample = samples.get(i);
+            double weight = weights.get(i);
+            bucketWeights.put(sample, bucketWeights.getOrDefault(sample, 0.0) + weight);
+        }
+
+        double entropy = bucketWeights.values().stream()
+                .mapToDouble(weight -> weight == 0.0 ? 0.0 : weight / totalWeight * Math.log(totalWeight / weight))
+                .sum();
+        return entropy / Math.log(2);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/AbstractTestReservoirAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/AbstractTestReservoirAggregation.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.operator.aggregation.AbstractTestAggregationFunction;
+
+import static com.facebook.presto.operator.aggregation.differentialentropy.EntropyCalculations.calculateFromSamples;
+import static org.testng.Assert.assertTrue;
+
+abstract class AbstractTestReservoirAggregation
+        extends AbstractTestAggregationFunction
+{
+    protected static final int MAX_SAMPLES = 500;
+
+    @Override
+    protected String getFunctionName()
+    {
+        return "differential_entropy";
+    }
+
+    @Override
+    public Double getExpectedValue(int start, int length)
+    {
+        assertTrue(length < MAX_SAMPLES);
+        double[] samples = new double[2 * length];
+        for (int i = 0; i < length; i++) {
+            samples[i] = (double) (start + i);
+            samples[i + length] = (double) (start + i);
+        }
+        return calculateFromSamples(samples);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/AbstractTestStateStrategy.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/AbstractTestStateStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import org.testng.annotations.Test;
+
+import java.util.Random;
+import java.util.function.Function;
+
+import static org.testng.Assert.assertEquals;
+
+abstract class AbstractTestStateStrategy
+{
+    protected static final double MIN = 0.0;
+    protected static final double MAX = 10.0;
+
+    private final Function<Integer, DifferentialEntropyStateStrategy> strategySupplier;
+
+    protected AbstractTestStateStrategy(Function<Integer, DifferentialEntropyStateStrategy> strategySupplier)
+    {
+        this.strategySupplier = strategySupplier;
+    }
+
+    @Test
+    public void testUniformDistribution()
+    {
+        DifferentialEntropyStateStrategy strategy = strategySupplier.apply(2000);
+        Random random = new Random(13);
+        for (int i = 0; i < 9_999_999; i++) {
+            strategy.add(10 * random.nextFloat(), 1.0);
+        }
+        double expected = Math.log(10) / Math.log(2);
+        assertEquals(strategy.calculateEntropy(), expected, 0.1);
+    }
+
+    @Test
+    public void testNormalDistribution()
+    {
+        DifferentialEntropyStateStrategy strategy = strategySupplier.apply(200_000);
+        Random random = new Random(13);
+        double sigma = 0.5;
+        for (int i = 0; i < 9_999_999; i++) {
+            strategy.add(5 + sigma * random.nextGaussian(), 1.0);
+        }
+        double expected = 0.5 * Math.log(2 * Math.PI * Math.E * sigma * sigma) / Math.log(2);
+        assertEquals(strategy.calculateEntropy(), expected, 0.02);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestEntropyCalculations.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestEntropyCalculations.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import org.testng.annotations.Test;
+
+import java.util.Random;
+
+import static com.facebook.presto.operator.aggregation.differentialentropy.EntropyCalculations.calculateFromSamples;
+import static org.testng.Assert.assertEquals;
+
+public class TestEntropyCalculations
+{
+    @Test
+    public void testUniformDistribution()
+    {
+        Random random = new Random(13);
+        double[] samples = new double[10000000];
+        for (int i = 0; i < samples.length; i++) {
+            samples[i] = random.nextDouble();
+        }
+        assertEquals(calculateFromSamples(samples), 0, 0.02);
+    }
+
+    @Test
+    public void testNormalDistribution()
+    {
+        Random random = new Random(13);
+        double[] samples = new double[10000000];
+        double sigma = 0.5;
+        for (int i = 0; i < samples.length; i++) {
+            samples[i] = 5 + sigma * random.nextGaussian();
+        }
+        double expected = 0.5 * Math.log(2 * Math.PI * Math.E * sigma * sigma) / Math.log(2);
+        assertEquals(calculateFromSamples(samples), expected, 0.02);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestFixedHistogramJacknifeAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestFixedHistogramJacknifeAggregation.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.spi.PrestoException;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.aggregation;
+
+public class TestFixedHistogramJacknifeAggregation
+        extends AbstractTestFixedHistogramAggregation
+{
+    public TestFixedHistogramJacknifeAggregation()
+    {
+        super(DifferentialEntropyAggregation.FIXED_HISTOGRAM_JACKNIFE_METHOD_NAME);
+    }
+
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, bucket count must be non-negative: -200")
+    public void testIllegalBucketCount()
+    {
+        aggregation(
+                getFunction(),
+                createLongsBlock(-200),
+                createDoublesBlock(0.1),
+                createDoublesBlock(0.2),
+                createStringsBlock(method),
+                createDoublesBlock(0.0),
+                createDoublesBlock(0.2));
+    }
+
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, weight must be non-negative: -0.2")
+    public void testNegativeWeight()
+    {
+        aggregation(
+                getFunction(),
+                createLongsBlock(200),
+                createDoublesBlock(0.1),
+                createDoublesBlock(-0.2),
+                createStringsBlock(method),
+                createDoublesBlock(0.0),
+                createDoublesBlock(0.2));
+    }
+
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, sample must be at least min: sample=-100.0, min=0.0")
+    public void testTooSmallSample()
+    {
+        aggregation(
+                getFunction(),
+                createLongsBlock(200),
+                createDoublesBlock(-100.0),
+                createDoublesBlock(0.2),
+                createStringsBlock(method),
+                createDoublesBlock(0.0),
+                createDoublesBlock(0.2));
+    }
+
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, sample must be at most max: sample=300.0, max=0.2")
+    public void testTooLargeSample()
+    {
+        aggregation(
+                getFunction(),
+                createLongsBlock(200),
+                createDoublesBlock(300.0),
+                createDoublesBlock(0.2),
+                createStringsBlock(method),
+                createDoublesBlock(0.0),
+                createDoublesBlock(0.2));
+    }
+
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, min must be larger than max: min=0.2, max=0.1")
+    public void testIllegalMinMax()
+    {
+        aggregation(
+                getFunction(),
+                createLongsBlock(200),
+                createDoublesBlock(0.1),
+                createDoublesBlock(0.2),
+                createStringsBlock(method),
+                createDoublesBlock(0.2),
+                createDoublesBlock(0.1));
+    }
+
+    @Override
+    public Double getExpectedValue(int start, int length)
+    {
+        List<Double> samples = new ArrayList<>();
+        List<Double> weights = new ArrayList<>();
+        generateSamplesAndWeights(start, length, samples, weights);
+
+        double entropy = samples.size() * calculateEntropy(samples, weights);
+        for (int i = 0; i < samples.size(); ++i) {
+            List<Double> subSamples = new ArrayList<>(samples);
+            subSamples.remove(i);
+            List<Double> subWeights = new ArrayList<>(weights);
+            subWeights.remove(i);
+
+            double holdOutEntropy = (samples.size() - 1) * calculateEntropy(subSamples, subWeights) / samples.size();
+            entropy -= holdOutEntropy;
+        }
+        return entropy;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestFixedHistogramJacknifeStateStrategy.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestFixedHistogramJacknifeStateStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+public class TestFixedHistogramJacknifeStateStrategy
+        extends AbstractTestStateStrategy
+{
+    public TestFixedHistogramJacknifeStateStrategy()
+    {
+        super(size -> new FixedHistogramJacknifeStateStrategy(size, AbstractTestStateStrategy.MIN, AbstractTestStateStrategy.MAX));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestFixedHistogramMleAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestFixedHistogramMleAggregation.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.spi.PrestoException;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.aggregation;
+
+public class TestFixedHistogramMleAggregation
+        extends AbstractTestFixedHistogramAggregation
+{
+    public TestFixedHistogramMleAggregation()
+    {
+        super(DifferentialEntropyAggregation.FIXED_HISTOGRAM_MLE_METHOD_NAME);
+    }
+
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, bucket count must be non-negative: -200")
+    public void testIllegalBucketCount()
+    {
+        aggregation(
+                getFunction(),
+                createLongsBlock(-200),
+                createDoublesBlock(0.1),
+                createDoublesBlock(0.2),
+                createStringsBlock(method),
+                createDoublesBlock(0.0),
+                createDoublesBlock(0.2));
+    }
+
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, weight must be non-negative: -0.2")
+    public void testNegativeWeight()
+    {
+        aggregation(
+                getFunction(),
+                createLongsBlock(200),
+                createDoublesBlock(0.1),
+                createDoublesBlock(-0.2),
+                createStringsBlock(method),
+                createDoublesBlock(0.0),
+                createDoublesBlock(0.2));
+    }
+
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, sample must be at least min: sample=-100.0, min=0.0")
+    public void testTooSmallSample()
+    {
+        aggregation(
+                getFunction(),
+                createLongsBlock(200),
+                createDoublesBlock(-100.0),
+                createDoublesBlock(0.2),
+                createStringsBlock(method),
+                createDoublesBlock(0.0),
+                createDoublesBlock(0.2));
+    }
+
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, sample must be at most max: sample=300.0, max=0.2")
+    public void testTooLargeSample()
+    {
+        aggregation(
+                getFunction(),
+                createLongsBlock(200),
+                createDoublesBlock(300.0),
+                createDoublesBlock(0.2),
+                createStringsBlock(method),
+                createDoublesBlock(0.0),
+                createDoublesBlock(0.2));
+    }
+
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, min must be larger than max: min=0.2, max=0.1")
+    public void testIllegalMinMax()
+    {
+        aggregation(
+                getFunction(),
+                createLongsBlock(200),
+                createDoublesBlock(0.1),
+                createDoublesBlock(0.2),
+                createStringsBlock(method),
+                createDoublesBlock(0.2),
+                createDoublesBlock(0.1));
+    }
+
+    @Override
+    public Double getExpectedValue(int start, int length)
+    {
+        List<Double> samples = new ArrayList<>();
+        List<Double> weights = new ArrayList<>();
+        generateSamplesAndWeights(start, length, samples, weights);
+        return calculateEntropy(samples, weights);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestFixedHistogramMleStateStrategy.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestFixedHistogramMleStateStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+public class TestFixedHistogramMleStateStrategy
+        extends AbstractTestStateStrategy
+{
+    public TestFixedHistogramMleStateStrategy()
+    {
+        super(bucketCount -> new FixedHistogramMleStateStrategy(bucketCount, MIN, MAX));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestIllegalMethodAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestIllegalMethodAggregation.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
+import com.facebook.presto.spi.PrestoException;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.aggregation;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+
+public class TestIllegalMethodAggregation
+{
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, invalid method: no_such_method")
+    public void testIllegalMethod()
+    {
+        FunctionManager functionManager = MetadataManager.createTestMetadataManager().getFunctionManager();
+        InternalAggregationFunction function = functionManager.getAggregateFunctionImplementation(
+                functionManager.lookupFunction(
+                        "differential_entropy",
+                        fromTypes(BIGINT, DOUBLE, DOUBLE, VARCHAR, DOUBLE, DOUBLE)));
+        aggregation(
+                function,
+                createLongsBlock(200),
+                createDoublesBlock(0.1),
+                createDoublesBlock(0.2),
+                createStringsBlock("no_such_method"),
+                createDoublesBlock(0.0),
+                createDoublesBlock(1.0));
+    }
+
+    @Test
+    public void testNullMethod()
+    {
+        FunctionManager functionManager = MetadataManager.createTestMetadataManager().getFunctionManager();
+        InternalAggregationFunction function = functionManager.getAggregateFunctionImplementation(
+                functionManager.lookupFunction(
+                        "differential_entropy",
+                        fromTypes(BIGINT, DOUBLE, DOUBLE, VARCHAR, DOUBLE, DOUBLE)));
+        createStringsBlock((String) null);
+        System.out.println("foo");
+        aggregation(
+                function,
+                createLongsBlock(200),
+                createDoublesBlock(0.1),
+                createDoublesBlock(-0.2),
+                createStringsBlock((String) null),
+                createDoublesBlock(0.0),
+                createDoublesBlock(1.0));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestUnweightedReservoirAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestUnweightedReservoirAggregation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.aggregation;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+
+public class TestUnweightedReservoirAggregation
+        extends AbstractTestReservoirAggregation
+{
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, max samples must be positive: -200")
+    public void testInvalidMaxSamples()
+    {
+        aggregation(
+                getFunction(),
+                createLongsBlock(-200),
+                createDoublesBlock(0.1));
+    }
+
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        int positionCount = 2 * length;
+        BlockBuilder samples = DOUBLE.createBlockBuilder(null, positionCount);
+        for (int weight = 1; weight < 3; weight++) {
+            for (int i = start; i < start + length; i++) {
+                DOUBLE.writeDouble(samples, i);
+            }
+        }
+
+        return new Block[] {
+            createRLEBlock(AbstractTestReservoirAggregation.MAX_SAMPLES, positionCount),
+            samples.build()
+        };
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTEGER, StandardTypes.DOUBLE);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestUnweightedReservoirSampleStateStrategy.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestUnweightedReservoirSampleStateStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+public class TestUnweightedReservoirSampleStateStrategy
+        extends AbstractTestStateStrategy
+{
+    public TestUnweightedReservoirSampleStateStrategy()
+    {
+        super(size -> new UnweightedReservoirSampleStateStrategy(size));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestWeightedReservoirAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestWeightedReservoirAggregation.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.operator.aggregation.AggregationTestUtils.aggregation;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+
+public class TestWeightedReservoirAggregation
+        extends AbstractTestReservoirAggregation
+{
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, max samples must be positive: -200")
+    public void testInvalidMaxSamples()
+    {
+        aggregation(
+                getFunction(),
+                createLongsBlock(-200),
+                createDoublesBlock(0.1),
+                createDoublesBlock(0.2));
+    }
+
+    @Test(
+            expectedExceptions = PrestoException.class,
+            expectedExceptionsMessageRegExp = "In differential_entropy UDF, weight must be non-negative: -0.2")
+    public void testNegativeWeight()
+    {
+        aggregation(
+                getFunction(),
+                createLongsBlock(200),
+                createDoublesBlock(0.1),
+                createDoublesBlock(-0.2));
+    }
+
+    @Override
+    public Block[] getSequenceBlocks(int start, int length)
+    {
+        int positionCount = 2 * length;
+        BlockBuilder samples = DOUBLE.createBlockBuilder(null, positionCount);
+        BlockBuilder weights = DOUBLE.createBlockBuilder(null, positionCount);
+        for (int weight = 1; weight < 3; weight++) {
+            for (int i = start; i < start + length; i++) {
+                DOUBLE.writeDouble(samples, i);
+                DOUBLE.writeDouble(weights, weight);
+            }
+        }
+
+        return new Block[] {
+                createRLEBlock(MAX_SAMPLES, positionCount),
+                samples.build(),
+                weights.build()
+        };
+    }
+
+    @Override
+    protected List<String> getFunctionParameterTypes()
+    {
+        return ImmutableList.of(StandardTypes.INTEGER, StandardTypes.DOUBLE, StandardTypes.DOUBLE);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestWeightedReservoirSampleStateStrategy.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/differentialentropy/TestWeightedReservoirSampleStateStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.differentialentropy;
+
+public class TestWeightedReservoirSampleStateStrategy
+        extends AbstractTestStateStrategy
+{
+    public TestWeightedReservoirSampleStateStrategy()
+    {
+        super(size -> new WeightedReservoirSampleStateStrategy(size));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/fixedhistogram/TestFixedDoubleBreakdownHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/fixedhistogram/TestFixedDoubleBreakdownHistogram.java
@@ -21,7 +21,6 @@ import java.util.stream.IntStream;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 public class TestFixedDoubleBreakdownHistogram
 {
@@ -36,30 +35,20 @@ public class TestFixedDoubleBreakdownHistogram
         assertEquals(histogram.getMax(), 4.0);
     }
 
-    @Test
-    public void testIllegalBucketWeightCount()
+    @Test(
+            expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "bucketCount must be at least 2: -200")
+    public void testIllegalBucketCount()
     {
-        try {
-            new FixedDoubleBreakdownHistogram(-200, 3.0, 4.0);
-            fail("exception expected");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("bucketCount"));
-            assertTrue(e.getMessage().contains("must be at least"));
-        }
+        new FixedDoubleBreakdownHistogram(-200, 3.0, 4.0);
     }
 
-    @Test
+    @Test(
+            expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "min must be smaller than max: 3.0 3.0")
     public void testIllegalMinMax()
     {
-        try {
-            new FixedDoubleBreakdownHistogram(200, 3.0, 3.0);
-            fail("exception expected");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("min"));
-            assertTrue(e.getMessage().contains("must be smaller than"));
-        }
+        new FixedDoubleBreakdownHistogram(200, 3.0, 3.0);
     }
 
     @Test
@@ -72,7 +61,7 @@ public class TestFixedDoubleBreakdownHistogram
         histogram.add(3.8, 200.0);
         histogram.add(3.1, 100.0);
         assertEquals(
-                Streams.stream(histogram.iterator()).mapToDouble(FixedDoubleBreakdownHistogram.BucketWeight::getWeight).sum(),
+                Streams.stream(histogram.iterator()).mapToDouble(FixedDoubleBreakdownHistogram.Bucket::getWeight).sum(),
                 300.0);
     }
 
@@ -94,10 +83,10 @@ public class TestFixedDoubleBreakdownHistogram
                 Streams.stream(histogram.iterator()).count(),
                 3);
         assertEquals(
-                Streams.stream(histogram.iterator()).mapToDouble(FixedDoubleBreakdownHistogram.BucketWeight::getWeight).sum(),
+                Streams.stream(histogram.iterator()).mapToDouble(FixedDoubleBreakdownHistogram.Bucket::getWeight).sum(),
                 0.9);
         assertEquals(
-                Streams.stream(histogram.iterator()).mapToLong(FixedDoubleBreakdownHistogram.BucketWeight::getCount).sum(),
+                Streams.stream(histogram.iterator()).mapToLong(FixedDoubleBreakdownHistogram.Bucket::getCount).sum(),
                 4);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/fixedhistogram/TestFixedDoubleHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/fixedhistogram/TestFixedDoubleHistogram.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.stream.IntStream;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 public class TestFixedDoubleHistogram
 {
@@ -35,30 +33,20 @@ public class TestFixedDoubleHistogram
         assertEquals(histogram.getMax(), 4.0);
     }
 
-    @Test
+    @Test(
+            expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "bucketCount must be at least 2: -200")
     public void testIllegalBucketCount()
     {
-        try {
-            new FixedDoubleHistogram(-200, 3.0, 4.0);
-            fail("exception expected");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("bucketCount"));
-            assertTrue(e.getMessage().contains("must be at least"));
-        }
+        new FixedDoubleHistogram(-200, 3.0, 4.0);
     }
 
-    @Test
+    @Test(
+            expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "min must be smaller than max: 3.0 3.0")
     public void testIllegalMinMax()
     {
-        try {
-            new FixedDoubleHistogram(200, 3.0, 3.0);
-            fail("exception expected");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("min"));
-            assertTrue(e.getMessage().contains("must be smaller than"));
-        }
+        new FixedDoubleHistogram(200, 3.0, 3.0);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/reservoirsample/TestUnweightedDoubleReservoirSample.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/reservoirsample/TestUnweightedDoubleReservoirSample.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.reservoirsample;
+
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestUnweightedDoubleReservoirSample
+{
+    @Test(
+            expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Maximum number of samples must be positive: 0")
+    public void testIllegalMaxSamples()
+    {
+        new UnweightedDoubleReservoirSample(0);
+    }
+
+    @Test
+    public void testGetMaxSamples()
+    {
+        UnweightedDoubleReservoirSample sample = new UnweightedDoubleReservoirSample(200);
+
+        assertEquals(sample.getMaxSamples(), 200);
+    }
+
+    @Test
+    public void testFew()
+    {
+        UnweightedDoubleReservoirSample reservoir = new UnweightedDoubleReservoirSample(200);
+
+        reservoir.add(1.0);
+        reservoir.add(2.0);
+        reservoir.add(3.0);
+
+        assertEquals(Arrays.stream(reservoir.getSamples()).sorted().toArray(), new double[] {1.0, 2.0, 3.0});
+    }
+
+    @Test
+    public void testMany()
+    {
+        UnweightedDoubleReservoirSample reservoir = new UnweightedDoubleReservoirSample(200);
+
+        long streamLength = 1_000_000;
+        for (int i = 0; i < streamLength; ++i) {
+            double value = i * 10 + i % 2;
+            reservoir.add(value);
+        }
+
+        double[] quantized = new double[4];
+        for (double sample : reservoir.getSamples()) {
+            int index = (int) (4.0 * sample / (10.0 * streamLength + 1));
+            ++quantized[index];
+        }
+        for (int i = 0; i < 4; ++i) {
+            assertTrue(quantized[i] > 35, format("Expected quantized[i] > got: i=%s, quantized=%s, got=%s", i, quantized[i], 35));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/reservoirsample/TestWeightedDoubleReservoirSample.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/reservoirsample/TestWeightedDoubleReservoirSample.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.reservoirsample;
+
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static java.lang.String.format;
+
+public class TestWeightedDoubleReservoirSample
+{
+    @Test(
+            expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Maximum number of samples must be positive: 0")
+    public void testIllegalMaxSamples()
+    {
+        new WeightedDoubleReservoirSample(0);
+    }
+
+    @Test
+    public void testGetters()
+    {
+        WeightedDoubleReservoirSample sample = new WeightedDoubleReservoirSample(200);
+
+        assertEquals(sample.getMaxSamples(), 200);
+    }
+
+    @Test
+    public void testFew()
+    {
+        WeightedDoubleReservoirSample reservoir = new WeightedDoubleReservoirSample(200);
+
+        reservoir.add(1.0, 1.0);
+        reservoir.add(2.0, 1.0);
+        reservoir.add(3.0, 0.5);
+
+        assertEquals(Arrays.stream(reservoir.getSamples()).sorted().toArray(), new double[] {1.0, 2.0, 3.0});
+    }
+
+    @Test
+    public void testMany()
+    {
+        WeightedDoubleReservoirSample reservoir = new WeightedDoubleReservoirSample(200);
+
+        long streamLength = 1_000_000;
+        for (int i = 0; i < streamLength; ++i) {
+            double value = i * 10 + i % 2;
+            reservoir.add(value, 1.0);
+        }
+
+        double[] quantized = new double[4];
+        for (double sample : reservoir.getSamples()) {
+            int index = (int) (4.0 * sample / (10.0 * streamLength + 1));
+            ++quantized[index];
+        }
+        for (int i = 0; i < 4; ++i) {
+            assertTrue(quantized[i] > 35, format("Expected quantized[i] > got: i=%s, quantized=%s, got=%s", i, quantized[i], 35));
+        }
+    }
+
+    @Test
+    public void testManyWeighted()
+    {
+        WeightedDoubleReservoirSample reservoir = new WeightedDoubleReservoirSample(200);
+
+        long streamLength = 1_000_000;
+        for (int i = 0; i < streamLength; ++i) {
+            reservoir.add(3, 0.00000001);
+        }
+        for (int i = 0; i < streamLength; ++i) {
+            double value = i * 10 + i % 2;
+            reservoir.add(value, 9999999999.0);
+        }
+
+        double[] quantized = new double[4];
+        for (double sample : reservoir.getSamples()) {
+            int index = (int) (4.0 * sample / (10.0 * streamLength + 1));
+            ++quantized[index];
+        }
+        for (int i = 0; i < 4; ++i) {
+            assertTrue(quantized[i] > 35, format("Expected quantized[i] > got: i=%s, quantized=%s, got=%s", i, quantized[i], 35));
+        }
+    }
+}


### PR DESCRIPTION
Add a set of differential_entropy functions to compute differential entropy using 4 different methods: 
- reservoir sampling, 
- weighted reservoir sampling,
- histogram maximum likelihood, 
- histogram jacknife-corrected estimation.

These implementations have different tradeoffs, and are left to the user. See the documentation (aggregates.rst) for details.

```
RELEASE_NOTES

General Changes
-----------------
* Add :function:`differential_entropy` functions to compute differential entropy
```