### PR TITLE
Support resubmitting certain verification failures

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
@@ -57,7 +57,7 @@ public abstract class AbstractVerification
 {
     private static final Logger log = Logger.get(AbstractVerification.class);
 
-    private final JdbcPrestoAction prestoAction;
+    private final PrestoAction prestoAction;
     private final SourceQuery sourceQuery;
     private final QueryRewriter queryRewriter;
     private final List<FailureResolver> failureResolvers;
@@ -69,7 +69,7 @@ public abstract class AbstractVerification
     private final VerificationContext verificationContext = new VerificationContext();
 
     public AbstractVerification(
-            JdbcPrestoAction prestoAction,
+            PrestoAction prestoAction,
             SourceQuery sourceQuery,
             QueryRewriter queryRewriter,
             List<FailureResolver> failureResolvers,
@@ -153,7 +153,7 @@ public abstract class AbstractVerification
         }
     }
 
-    protected JdbcPrestoAction getPrestoAction()
+    protected PrestoAction getPrestoAction()
     {
         return prestoAction;
     }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
@@ -57,7 +57,7 @@ public abstract class AbstractVerification
 {
     private static final Logger log = Logger.get(AbstractVerification.class);
 
-    private final PrestoAction prestoAction;
+    private final JdbcPrestoAction prestoAction;
     private final SourceQuery sourceQuery;
     private final QueryRewriter queryRewriter;
     private final List<FailureResolver> failureResolvers;
@@ -69,7 +69,7 @@ public abstract class AbstractVerification
     private final VerificationContext verificationContext = new VerificationContext();
 
     public AbstractVerification(
-            PrestoAction prestoAction,
+            JdbcPrestoAction prestoAction,
             SourceQuery sourceQuery,
             QueryRewriter queryRewriter,
             List<FailureResolver> failureResolvers,
@@ -153,7 +153,7 @@ public abstract class AbstractVerification
         }
     }
 
-    protected PrestoAction getPrestoAction()
+    protected JdbcPrestoAction getPrestoAction()
     {
         return prestoAction;
     }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerifyCommand.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerifyCommand.java
@@ -54,7 +54,6 @@ public abstract class AbstractVerifyCommand
         Injector injector = null;
         try {
             injector = app.strictConfig().initialize();
-            injector.getInstance(VerificationManager.class).start();
         }
         catch (Exception e) {
             throwIfUnchecked(e);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.verifier.framework;
 
-import com.facebook.presto.jdbc.QueryStats;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.ShowColumns;
@@ -38,7 +37,6 @@ import static com.facebook.presto.verifier.framework.QueryOrigin.TargetCluster.C
 import static com.facebook.presto.verifier.framework.QueryOrigin.TargetCluster.TEST;
 import static com.facebook.presto.verifier.framework.QueryOrigin.forChecksum;
 import static com.facebook.presto.verifier.framework.QueryOrigin.forDescribe;
-import static com.facebook.presto.verifier.framework.QueryOrigin.forMain;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Objects.requireNonNull;
 
@@ -62,8 +60,6 @@ public class DataVerification
     @Override
     public VerificationResult verify(QueryBundle control, QueryBundle test)
     {
-        setQueryStats(setupAndRun(control, CONTROL), CONTROL);
-        setQueryStats(setupAndRun(test, TEST), TEST);
         List<Column> controlColumns = getColumns(control.getTableName(), CONTROL);
         List<Column> testColumns = getColumns(test.getTableName(), TEST);
         ChecksumQueryAndResult controlChecksum = computeChecksum(control, controlColumns, CONTROL);
@@ -113,12 +109,6 @@ public class DataVerification
                 teardownSafely(thirdRun, CONTROL);
             }
         }
-    }
-
-    private QueryStats setupAndRun(QueryBundle control, TargetCluster cluster)
-    {
-        setup(control, cluster);
-        return getPrestoAction().execute(control.getQuery(), getConfiguration(cluster), forMain(cluster), getVerificationContext());
     }
 
     private MatchResult match(

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -46,7 +46,7 @@ public class DataVerification
     private final ChecksumValidator checksumValidator;
 
     public DataVerification(
-            PrestoAction prestoAction,
+            JdbcPrestoAction prestoAction,
             SourceQuery sourceQuery,
             QueryRewriter queryRewriter,
             List<FailureResolver> failureResolvers,

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -46,6 +46,7 @@ public class DataVerification
     private final ChecksumValidator checksumValidator;
 
     public DataVerification(
+            VerificationResubmitter verificationResubmitter,
             PrestoAction prestoAction,
             SourceQuery sourceQuery,
             QueryRewriter queryRewriter,
@@ -53,7 +54,7 @@ public class DataVerification
             VerifierConfig config,
             ChecksumValidator checksumValidator)
     {
-        super(prestoAction, sourceQuery, queryRewriter, failureResolvers, config);
+        super(verificationResubmitter, prestoAction, sourceQuery, queryRewriter, failureResolvers, config);
         this.checksumValidator = requireNonNull(checksumValidator, "checksumValidator is null");
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -46,7 +46,7 @@ public class DataVerification
     private final ChecksumValidator checksumValidator;
 
     public DataVerification(
-            JdbcPrestoAction prestoAction,
+            PrestoAction prestoAction,
             SourceQuery sourceQuery,
             QueryRewriter queryRewriter,
             List<FailureResolver> failureResolvers,

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/JdbcPrestoAction.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/JdbcPrestoAction.java
@@ -32,7 +32,6 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -48,22 +47,8 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class JdbcPrestoAction
+        implements PrestoAction
 {
-    @FunctionalInterface
-    interface ResultSetConverter<R>
-    {
-        R apply(ResultSet resultSet)
-                throws SQLException;
-
-        ResultSetConverter<List<Object>> DEFAULT = resultSet -> {
-            ImmutableList.Builder<Object> row = ImmutableList.builder();
-            for (int i = 0; i < resultSet.getMetaData().getColumnCount(); i++) {
-                row.add(resultSet.getObject(i));
-            }
-            return row.build();
-        };
-    }
-
     private static final String QUERY_MAX_EXECUTION_TIME = "query_max_execution_time";
 
     private final SqlExceptionClassifier exceptionClassifier;
@@ -97,6 +82,7 @@ public class JdbcPrestoAction
         this.prestoRetry = new RetryDriver(prestoRetryConfig, queryException -> queryException.getType() == PRESTO && queryException.isRetryable());
     }
 
+    @Override
     public QueryStats execute(
             Statement statement,
             QueryConfiguration configuration,
@@ -106,6 +92,7 @@ public class JdbcPrestoAction
         return execute(statement, configuration, queryOrigin, context, Optional.empty()).getQueryStats();
     }
 
+    @Override
     public <R> QueryResult<R> execute(
             Statement statement,
             QueryConfiguration configuration,
@@ -189,7 +176,7 @@ public class JdbcPrestoAction
         }
     }
 
-    public PrestoConnection getConnection(
+    private PrestoConnection getConnection(
             QueryConfiguration configuration,
             QueryOrigin queryOrigin)
             throws SQLException

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/JdbcPrestoAction.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/JdbcPrestoAction.java
@@ -47,7 +47,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-public class PrestoAction
+public class JdbcPrestoAction
 {
     @FunctionalInterface
     interface ResultSetConverter<R>
@@ -78,7 +78,7 @@ public class PrestoAction
     private final RetryDriver prestoRetry;
 
     @Inject
-    public PrestoAction(
+    public JdbcPrestoAction(
             SqlExceptionClassifier exceptionClassifier,
             VerifierConfig config,
             @ForClusterConnection RetryConfig networkRetryConfig,

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/PrestoAction.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/PrestoAction.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.sql.tree.Statement;
+import com.google.common.collect.ImmutableList;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public interface PrestoAction
+{
+    @FunctionalInterface
+    interface ResultSetConverter<R>
+    {
+        R apply(ResultSet resultSet)
+                throws SQLException;
+
+        ResultSetConverter<List<Object>> DEFAULT = resultSet -> {
+            ImmutableList.Builder<Object> row = ImmutableList.builder();
+            for (int i = 0; i < resultSet.getMetaData().getColumnCount(); i++) {
+                row.add(resultSet.getObject(i));
+            }
+            return row.build();
+        };
+    }
+
+    QueryStats execute(
+            Statement statement,
+            QueryConfiguration configuration,
+            QueryOrigin queryOrigin,
+            VerificationContext context);
+
+    <R> QueryResult<R> execute(
+            Statement statement,
+            QueryConfiguration configuration,
+            QueryOrigin queryOrigin,
+            VerificationContext context,
+            ResultSetConverter<R> converter);
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryRewriter.java
@@ -26,7 +26,7 @@ import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.Statement;
-import com.facebook.presto.verifier.framework.PrestoAction.ResultSetConverter;
+import com.facebook.presto.verifier.framework.JdbcPrestoAction.ResultSetConverter;
 import com.facebook.presto.verifier.framework.QueryOrigin.TargetCluster;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -60,12 +60,12 @@ import static java.util.UUID.randomUUID;
 public class QueryRewriter
 {
     private final SqlParser sqlParser;
-    private final PrestoAction prestoAction;
+    private final JdbcPrestoAction prestoAction;
     private final List<Property> tablePropertyOverrides;
     private final Map<TargetCluster, QualifiedName> prefixes;
 
     @Inject
-    public QueryRewriter(SqlParser sqlParser, PrestoAction prestoAction, List<Property> tablePropertyOverrides, VerifierConfig config)
+    public QueryRewriter(SqlParser sqlParser, JdbcPrestoAction prestoAction, List<Property> tablePropertyOverrides, VerifierConfig config)
     {
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.prestoAction = requireNonNull(prestoAction, "prestoAction is null");

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryRewriter.java
@@ -26,7 +26,7 @@ import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.Statement;
-import com.facebook.presto.verifier.framework.JdbcPrestoAction.ResultSetConverter;
+import com.facebook.presto.verifier.framework.PrestoAction.ResultSetConverter;
 import com.facebook.presto.verifier.framework.QueryOrigin.TargetCluster;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -60,12 +60,12 @@ import static java.util.UUID.randomUUID;
 public class QueryRewriter
 {
     private final SqlParser sqlParser;
-    private final JdbcPrestoAction prestoAction;
+    private final PrestoAction prestoAction;
     private final List<Property> tablePropertyOverrides;
     private final Map<TargetCluster, QualifiedName> prefixes;
 
     @Inject
-    public QueryRewriter(SqlParser sqlParser, JdbcPrestoAction prestoAction, List<Property> tablePropertyOverrides, VerifierConfig config)
+    public QueryRewriter(SqlParser sqlParser, PrestoAction prestoAction, List<Property> tablePropertyOverrides, VerifierConfig config)
     {
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.prestoAction = requireNonNull(prestoAction, "prestoAction is null");

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
@@ -51,12 +51,12 @@ public class VerificationFactory
         this.config = requireNonNull(config, "config is null");
     }
 
-    public Verification get(SourceQuery sourceQuery)
+    public Verification get(VerificationResubmitter verificationResubmitter, SourceQuery sourceQuery)
     {
         QueryType queryType = QueryType.of(sqlParser.createStatement(sourceQuery.getControlQuery(), PARSING_OPTIONS));
         switch (queryType.getCategory()) {
             case DATA_PRODUCING:
-                return new DataVerification(prestoAction, sourceQuery, queryRewriter, failureResolvers, config, checksumValidator);
+                return new DataVerification(verificationResubmitter, prestoAction, sourceQuery, queryRewriter, failureResolvers, config, checksumValidator);
             default:
                 throw new IllegalStateException(format("Unsupported query type: %s", queryType));
         }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
 public class VerificationFactory
 {
     private final SqlParser sqlParser;
-    private final PrestoAction prestoAction;
+    private final JdbcPrestoAction prestoAction;
     private final QueryRewriter queryRewriter;
     private final ChecksumValidator checksumValidator;
     private final List<FailureResolver> failureResolvers;
@@ -37,7 +37,7 @@ public class VerificationFactory
     @Inject
     public VerificationFactory(
             SqlParser sqlParser,
-            PrestoAction prestoAction,
+            JdbcPrestoAction prestoAction,
             QueryRewriter queryRewriter,
             ChecksumValidator checksumValidator,
             List<FailureResolver> failureResolvers,

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
 public class VerificationFactory
 {
     private final SqlParser sqlParser;
-    private final JdbcPrestoAction prestoAction;
+    private final PrestoAction prestoAction;
     private final QueryRewriter queryRewriter;
     private final ChecksumValidator checksumValidator;
     private final List<FailureResolver> failureResolvers;
@@ -37,7 +37,7 @@ public class VerificationFactory
     @Inject
     public VerificationFactory(
             SqlParser sqlParser,
-            JdbcPrestoAction prestoAction,
+            PrestoAction prestoAction,
             QueryRewriter queryRewriter,
             ChecksumValidator checksumValidator,
             List<FailureResolver> failureResolvers,

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationManager.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationManager.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.event.client.EventClient;
 import io.airlift.log.Logger;
 
+import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
@@ -129,6 +130,7 @@ public class VerificationManager
         this.verificationResubmissionLimit = config.getVerificationResubmissionLimit();
     }
 
+    @PostConstruct
     public void start()
     {
         initializeDrivers(additionalJdbcDriverPath, controlJdbcDriverClass, testJdbcDriverClass);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationRef.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationRef.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import static java.lang.System.identityHashCode;
+import static java.util.Objects.requireNonNull;
+
+public class VerificationRef
+{
+    private final Verification verification;
+
+    public VerificationRef(Verification verification)
+    {
+        this.verification = requireNonNull(verification, "verification is null");
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        VerificationRef other = (VerificationRef) o;
+        return verification == other.verification;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return identityHashCode(verification);
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationResubmitter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationResubmitter.java
@@ -13,13 +13,7 @@
  */
 package com.facebook.presto.verifier.framework;
 
-import com.facebook.presto.verifier.event.VerifierQueryEvent;
-
-import java.util.Optional;
-
-public interface Verification
+public interface VerificationResubmitter
 {
-    SourceQuery getSourceQuery();
-
-    Optional<VerifierQueryEvent> run();
+    boolean resubmit(Verification verification, QueryException e);
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
@@ -74,6 +74,7 @@ public class VerifierConfig
     private double absoluteErrorMargin = 1e-12;
     private boolean runTearDownOnResultMismatch;
     private boolean failureResolverEnabled = true;
+    private int verificationResubmissionLimit = 2;
 
     @NotNull
     public Optional<String> getAdditionalJdbcDriverPath()
@@ -532,6 +533,20 @@ public class VerifierConfig
     public VerifierConfig setFailureResolverEnabled(boolean failureResolverEnabled)
     {
         this.failureResolverEnabled = failureResolverEnabled;
+        return this;
+    }
+
+    @Min(0)
+    public int getVerificationResubmissionLimit()
+    {
+        return verificationResubmissionLimit;
+    }
+
+    @ConfigDescription("Maximum number of time a transiently failed verification can be resubmitted")
+    @Config("verification-resubmission.limit")
+    public VerifierConfig setVerificationResubmissionLimit(int verificationResubmissionLimit)
+    {
+        this.verificationResubmissionLimit = verificationResubmissionLimit;
         return this;
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
@@ -76,7 +76,7 @@ public class VerifierModule
         binder.bind(SqlParserOptions.class).toInstance(sqlParserOptions);
         binder.bind(SqlParser.class).in(SINGLETON);
         binder.bind(QueryRewriter.class).in(SINGLETON);
-        binder.bind(PrestoAction.class).in(SINGLETON);
+        binder.bind(JdbcPrestoAction.class).in(SINGLETON);
         binder.bind(VerificationManager.class).in(SINGLETON);
         binder.bind(VerificationFactory.class).in(SINGLETON);
         binder.bind(ChecksumValidator.class).in(SINGLETON);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
@@ -76,7 +76,7 @@ public class VerifierModule
         binder.bind(SqlParserOptions.class).toInstance(sqlParserOptions);
         binder.bind(SqlParser.class).in(SINGLETON);
         binder.bind(QueryRewriter.class).in(SINGLETON);
-        binder.bind(JdbcPrestoAction.class).in(SINGLETON);
+        binder.bind(PrestoAction.class).to(JdbcPrestoAction.class).in(SINGLETON);
         binder.bind(VerificationManager.class).in(SINGLETON);
         binder.bind(VerificationFactory.class).in(SINGLETON);
         binder.bind(ChecksumValidator.class).in(SINGLETON);

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -98,7 +98,7 @@ public class TestDataVerification
     {
         QueryConfiguration configuration = new QueryConfiguration(CATALOG, SCHEMA, "test-user", Optional.empty(), ImmutableMap.of());
         SourceQuery sourceQuery = new SourceQuery(SUITE, NAME, controlQuery, testQuery, configuration, configuration);
-        return new DataVerification(prestoAction, sourceQuery, queryRewriter, ImmutableList.of(), verifierConfig, checksumValidator);
+        return new DataVerification((verification, e) -> false, prestoAction, sourceQuery, queryRewriter, ImmutableList.of(), verifierConfig, checksumValidator);
     }
 
     @Test

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -57,7 +57,7 @@ public class TestDataVerification
     private static StandaloneQueryRunner queryRunner;
 
     private VerifierConfig verifierConfig;
-    private PrestoAction prestoAction;
+    private JdbcPrestoAction prestoAction;
     private QueryRewriter queryRewriter;
     private ChecksumValidator checksumValidator;
 
@@ -78,7 +78,7 @@ public class TestDataVerification
                 .setTestJdbcUrl(jdbcUrl)
                 .setTestId(TEST_ID)
                 .setFailureResolverEnabled(false);
-        prestoAction = new PrestoAction(
+        prestoAction = new JdbcPrestoAction(
                 new PrestoExceptionClassifier(ImmutableSet.of(), ImmutableSet.of()),
                 verifierConfig,
                 retryConfig,

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -57,7 +57,7 @@ public class TestDataVerification
     private static StandaloneQueryRunner queryRunner;
 
     private VerifierConfig verifierConfig;
-    private JdbcPrestoAction prestoAction;
+    private PrestoAction prestoAction;
     private QueryRewriter queryRewriter;
     private ChecksumValidator checksumValidator;
 

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestJdbcPrestoAction.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestJdbcPrestoAction.java
@@ -48,13 +48,13 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-public class TestPrestoAction
+public class TestJdbcPrestoAction
 {
     private static final QueryOrigin QUERY_ORIGIN = forMain(CONTROL);
     private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
     private static StandaloneQueryRunner queryRunner;
 
-    private PrestoAction prestoAction;
+    private JdbcPrestoAction prestoAction;
 
     @BeforeClass
     public void setupQueryRunner()
@@ -67,7 +67,7 @@ public class TestPrestoAction
     public void setup()
     {
         String jdbcUrl = getJdbcUrl(queryRunner);
-        prestoAction = new PrestoAction(
+        prestoAction = new JdbcPrestoAction(
                 new PrestoExceptionClassifier(ImmutableSet.of(), ImmutableSet.of()),
                 new VerifierConfig()
                         .setControlJdbcUrl(jdbcUrl)

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestJdbcPrestoAction.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestJdbcPrestoAction.java
@@ -54,7 +54,7 @@ public class TestJdbcPrestoAction
     private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
     private static StandaloneQueryRunner queryRunner;
 
-    private JdbcPrestoAction prestoAction;
+    private PrestoAction prestoAction;
 
     @BeforeClass
     public void setupQueryRunner()

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryRewriter.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryRewriter.java
@@ -200,7 +200,7 @@ public class TestQueryRewriter
                 .setTestTablePrefix(prefix);
         return new QueryRewriter(
                 sqlParser,
-                new PrestoAction(
+                new JdbcPrestoAction(
                         new PrestoExceptionClassifier(ImmutableSet.of(), ImmutableSet.of()),
                         config,
                         new RetryConfig(),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.spi.ErrorCodeSupplier;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.verifier.checksum.ChecksumValidator;
+import com.facebook.presto.verifier.checksum.FloatingPointColumnValidator;
+import com.facebook.presto.verifier.checksum.OrderableArrayColumnValidator;
+import com.facebook.presto.verifier.checksum.SimpleColumnValidator;
+import com.facebook.presto.verifier.resolver.ExceededGlobalMemoryLimitFailureResolver;
+import com.facebook.presto.verifier.resolver.ExceededTimeLimitFailureResolver;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_DROPPED_DURING_QUERY;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.sql.parser.IdentifierSymbol.AT_SIGN;
+import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+public class TestVerificationManager
+{
+    private static class MockPrestoAction
+            implements PrestoAction
+    {
+        private final ErrorCodeSupplier errorCode;
+
+        public MockPrestoAction(ErrorCodeSupplier errorCode)
+        {
+            this.errorCode = requireNonNull(errorCode, "errorCode is null");
+        }
+
+        @Override
+        public QueryStats execute(
+                Statement statement,
+                QueryConfiguration configuration,
+                QueryOrigin queryOrigin,
+                VerificationContext context)
+        {
+            throw QueryException.forPresto(new RuntimeException(), Optional.of(errorCode), false, Optional.empty(), queryOrigin);
+        }
+
+        @Override
+        public <R> QueryResult<R> execute(
+                Statement statement,
+                QueryConfiguration configuration,
+                QueryOrigin queryOrigin,
+                VerificationContext context,
+                ResultSetConverter<R> converter)
+        {
+            throw QueryException.forPresto(new RuntimeException(), Optional.of(errorCode), false, Optional.empty(), queryOrigin);
+        }
+    }
+
+    private static final String SUITE = "test-suite";
+    private static final String NAME = "test-query";
+    private static final SqlParser SQL_PARSER = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(AT_SIGN, COLON));
+    private static final QueryConfiguration QUERY_CONFIGURATION = new QueryConfiguration("test", "di", "user", Optional.empty(), ImmutableMap.of());
+    private static final SourceQuery SOURCE_QUERY = new SourceQuery(
+            SUITE,
+            NAME,
+            "SELECT 1",
+            "SELECT 2",
+            QUERY_CONFIGURATION,
+            QUERY_CONFIGURATION);
+    private static final VerifierConfig VERIFIER_CONFIG = new VerifierConfig().setTestId("test");
+
+    @Test
+    public void testFailureRequeued()
+    {
+        VerificationManager manager = getVerificationManager(ImmutableList.of(SOURCE_QUERY), new MockPrestoAction(HIVE_PARTITION_DROPPED_DURING_QUERY), VERIFIER_CONFIG);
+        manager.start();
+        assertEquals(manager.getQueriesSubmitted().get(), 3);
+    }
+
+    @Test
+    public void testFailureNotRequeued()
+    {
+        VerificationManager manager = getVerificationManager(ImmutableList.of(SOURCE_QUERY), new MockPrestoAction(GENERIC_INTERNAL_ERROR), VERIFIER_CONFIG);
+        manager.start();
+        assertEquals(manager.getQueriesSubmitted().get(), 1);
+    }
+
+    @Test
+    public void testFailureRequeueDisabled()
+    {
+        VerificationManager manager = getVerificationManager(
+                ImmutableList.of(SOURCE_QUERY),
+                new MockPrestoAction(HIVE_PARTITION_DROPPED_DURING_QUERY),
+                new VerifierConfig().setTestId("test").setVerificationResubmissionLimit(0));
+        manager.start();
+        assertEquals(manager.getQueriesSubmitted().get(), 1);
+    }
+
+    private static VerificationManager getVerificationManager(List<SourceQuery> sourceQueries, PrestoAction prestoAction, VerifierConfig config)
+    {
+        return new VerificationManager(
+                () -> sourceQueries,
+                new VerificationFactory(
+                        SQL_PARSER,
+                        prestoAction,
+                        new QueryRewriter(SQL_PARSER, prestoAction, ImmutableList.of(), config),
+                        new ChecksumValidator(new SimpleColumnValidator(), new FloatingPointColumnValidator(config), new OrderableArrayColumnValidator()),
+                        ImmutableList.of(new ExceededGlobalMemoryLimitFailureResolver(), new ExceededTimeLimitFailureResolver()),
+                        config),
+                SQL_PARSER,
+                ImmutableSet.of(),
+                ImmutableList.of(),
+                config);
+    }
+}

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
@@ -63,7 +63,8 @@ public class TestVerifierConfig
                 .setRelativeErrorMargin(1e-4)
                 .setAbsoluteErrorMargin(1e-12)
                 .setRunTearDownOnResultMismatch(false)
-                .setFailureResolverEnabled(true));
+                .setFailureResolverEnabled(true)
+                .setVerificationResubmissionLimit(2));
     }
 
     @Test
@@ -103,6 +104,7 @@ public class TestVerifierConfig
                 .put("absolute-error-margin", "1e-14")
                 .put("run-teardown-on-result-mismatch", "true")
                 .put("failure-resolver.enabled", "false")
+                .put("verification-resubmission.limit", "1")
                 .build();
         VerifierConfig expected = new VerifierConfig()
                 .setAdditionalJdbcDriverPath("/path/to/file")
@@ -137,7 +139,8 @@ public class TestVerifierConfig
                 .setRelativeErrorMargin(2e-5)
                 .setAbsoluteErrorMargin(1e-14)
                 .setRunTearDownOnResultMismatch(true)
-                .setFailureResolverEnabled(false);
+                .setFailureResolverEnabled(false)
+                .setVerificationResubmissionLimit(1);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Verification failed with one of the following Presto error will be re-queued. Maximum number of re-queue can be configured through `verification-resubmission.limit`
- HIVE_PARTITION_DROPPED_DURING_QUERY
- HIVE_TABLE_DROPPED_DURING_QUERY