### PR TITLE
Remove ValuesNode verification in ApplyConnectorOptimization

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
@@ -166,7 +166,6 @@ public class ApplyConnectorOptimization
                 builder.add(((TableScanNode) node).getTable().getConnectorId());
             }
             else {
-                verify(node instanceof ValuesNode, "Unexpected node type: " + node.getClass().getSimpleName());
                 builder.add(EMPTY_CONNECTOR_ID);
             }
             return;


### PR DESCRIPTION
IndexSourceNode could also hit this code path and the planning would
fail. This verification does not seem useful so we'd rather remove
it instead of enhancing it.