### PR TITLE
Add t-digest support for approx_percentile

### DIFF
--- a/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkApproximateDoublePercentileAggregation.java
+++ b/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkApproximateDoublePercentileAggregation.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.plugin.memory.MemoryConnectorFactory;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableMap;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.IOException;
+
+import static com.facebook.presto.tdigest.StatisticalDigestImplementation.QDIGEST;
+import static com.facebook.presto.tdigest.StatisticalDigestImplementation.TDIGEST;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(AverageTime)
+@Fork(2)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class BenchmarkApproximateDoublePercentileAggregation
+{
+    @State(Scope.Thread)
+    public static class Context
+    {
+        private static final FeaturesConfig TDIGEST_FEATURES_CONFIG = new FeaturesConfig()
+                .setStatisticalDigestImplementation(TDIGEST);
+
+        private static final FeaturesConfig QDIGEST_FEATURES_CONFIG = new FeaturesConfig()
+                .setStatisticalDigestImplementation(QDIGEST);
+
+        @Param({"tiny", "sf1", "sf4"})
+        String scalingFactor;
+
+        private LocalQueryRunner[] queryRunner = new LocalQueryRunner[2];
+
+        private LocalQueryRunner getQuantileDigestQueryRunner()
+        {
+            return queryRunner[0];
+        }
+
+        private LocalQueryRunner getTDigestQueryRunner()
+        {
+            return queryRunner[1];
+        }
+
+        @Setup
+        public void setUp()
+                throws IOException
+        {
+            queryRunner[0] = new LocalQueryRunner(testSessionBuilder()
+                    .setCatalog("memory")
+                    .setSchema("default")
+                    .build(), QDIGEST_FEATURES_CONFIG);
+            queryRunner[1] = new LocalQueryRunner(testSessionBuilder()
+                    .setCatalog("memory")
+                    .setSchema("default")
+                    .build(), TDIGEST_FEATURES_CONFIG);
+
+            for (LocalQueryRunner localQueryRunner : queryRunner) {
+                localQueryRunner.createCatalog("tpch", new TpchConnectorFactory(), ImmutableMap.of());
+                localQueryRunner.createCatalog("memory", new MemoryConnectorFactory(), ImmutableMap.of());
+                localQueryRunner.execute(format("CREATE TABLE memory.default.testingtable AS SELECT totalprice from tpch.%s.orders", scalingFactor));
+            }
+        }
+
+        @TearDown
+        public void tearDown()
+        {
+            for (LocalQueryRunner localQueryRunner : queryRunner) {
+                localQueryRunner.close();
+                localQueryRunner = null;
+            }
+        }
+    }
+
+    @Benchmark
+    public MaterializedResult benchmarkQuantileDigestDoublePercentileAggregation(Context context)
+    {
+        return context.getQuantileDigestQueryRunner()
+                .execute("SELECT approx_percentile(totalprice, 0.5) FROM memory.default.testingtable");
+    }
+
+    @Benchmark
+    public MaterializedResult benchmarkTDigestDoublePercentileAggregation(Context context)
+    {
+        return context.getTDigestQueryRunner()
+                .execute("SELECT approx_percentile(totalprice, 0.5) FROM memory.default.testingtable");
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        Options options = new OptionsBuilder()
+                .include(".*" + BenchmarkApproximateDoublePercentileAggregation.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options)
+                .run();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespace.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespace.java
@@ -22,6 +22,8 @@ import com.facebook.presto.operator.aggregation.ApproximateLongPercentileArrayAg
 import com.facebook.presto.operator.aggregation.ApproximateRealPercentileAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateRealPercentileArrayAggregations;
 import com.facebook.presto.operator.aggregation.ApproximateSetAggregation;
+import com.facebook.presto.operator.aggregation.ApproximateTDigestDoublePercentileAggregations;
+import com.facebook.presto.operator.aggregation.ApproximateTDigestDoublePercentileArrayAggregations;
 import com.facebook.presto.operator.aggregation.AverageAggregations;
 import com.facebook.presto.operator.aggregation.BitwiseAndAggregation;
 import com.facebook.presto.operator.aggregation.BitwiseOrAggregation;
@@ -439,8 +441,6 @@ class StaticFunctionNamespace
                 .aggregates(CentralMomentsAggregation.class)
                 .aggregates(ApproximateLongPercentileAggregations.class)
                 .aggregates(ApproximateLongPercentileArrayAggregations.class)
-                .aggregates(ApproximateDoublePercentileAggregations.class)
-                .aggregates(ApproximateDoublePercentileArrayAggregations.class)
                 .aggregates(ApproximateRealPercentileAggregations.class)
                 .aggregates(ApproximateRealPercentileArrayAggregations.class)
                 .aggregates(CountIfAggregation.class)
@@ -665,6 +665,17 @@ class StaticFunctionNamespace
             case RE2J:
                 builder.scalars(Re2JRegexpFunctions.class);
                 builder.scalar(Re2JRegexpReplaceLambdaFunction.class);
+                break;
+        }
+
+        switch (featuresConfig.getStatisticalDigestImplementation()) {
+            case TDIGEST:
+                builder.aggregates(ApproximateTDigestDoublePercentileAggregations.class);
+                builder.aggregates(ApproximateTDigestDoublePercentileArrayAggregations.class);
+                break;
+            case QDIGEST:
+                builder.aggregates(ApproximateDoublePercentileAggregations.class);
+                builder.aggregates(ApproximateDoublePercentileArrayAggregations.class);
                 break;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateTDigestDoublePercentileAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateTDigestDoublePercentileAggregations.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.TDigestAndPercentileState;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.LongArrayBlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.tdigest.TDigest;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.operator.aggregation.ApproximateTDigestDoublePercentileArrayAggregations.initializeDigest;
+import static com.facebook.presto.operator.aggregation.ApproximateTDigestDoublePercentileArrayAggregations.initializePercentilesArray;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.util.Failures.checkCondition;
+
+@AggregationFunction("approx_percentile")
+public final class ApproximateTDigestDoublePercentileAggregations
+{
+    private static final double STANDARD_COMPRESSION_FACTOR = 100;
+
+    private ApproximateTDigestDoublePercentileAggregations() {}
+
+    @InputFunction
+    public static void input(@AggregationState TDigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double percentile)
+    {
+        initializePercentilesArray(state, createPercentileBlock(percentile));
+        initializeDigest(state, STANDARD_COMPRESSION_FACTOR);
+
+        TDigest digest = state.getDigest();
+        state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
+        digest.add(value);
+        state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+
+        state.setPercentiles(ImmutableList.of(percentile));
+    }
+
+    private static Block createPercentileBlock(double percentile)
+    {
+        LongArrayBlockBuilder blockBuilder = new LongArrayBlockBuilder(null, 1);
+        DOUBLE.writeDouble(blockBuilder, percentile);
+        return blockBuilder.build();
+    }
+
+    @InputFunction
+    public static void weightedInput(@AggregationState TDigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile)
+    {
+        checkCondition(weight > 0, INVALID_FUNCTION_ARGUMENT, "Percentile weight must be positive");
+
+        initializePercentilesArray(state, createPercentileBlock(percentile));
+        initializeDigest(state, STANDARD_COMPRESSION_FACTOR);
+
+        TDigest digest = state.getDigest();
+        state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
+        digest.add(value, weight);
+        state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+
+        state.setPercentiles(ImmutableList.of(percentile));
+    }
+
+    @InputFunction
+    public static void weightedInput(@AggregationState TDigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile, @SqlType(StandardTypes.DOUBLE) double compression)
+    {
+        checkCondition(weight > 0, INVALID_FUNCTION_ARGUMENT, "Percentile weight must be positive");
+
+        initializePercentilesArray(state, createPercentileBlock(percentile));
+        initializeDigest(state, compression);
+
+        TDigest digest = state.getDigest();
+        state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
+        digest.add(value, weight);
+        state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+
+        state.setPercentiles(ImmutableList.of(percentile));
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState TDigestAndPercentileState state, TDigestAndPercentileState otherState)
+    {
+        TDigest input = otherState.getDigest();
+        TDigest previous = state.getDigest();
+
+        if (previous == null) {
+            state.setDigest(input);
+            state.addMemoryUsage(input.estimatedInMemorySizeInBytes());
+        }
+        else {
+            state.addMemoryUsage(-previous.estimatedInMemorySizeInBytes());
+            previous.merge(input);
+            state.addMemoryUsage(previous.estimatedInMemorySizeInBytes());
+        }
+
+        state.setPercentiles(otherState.getPercentiles());
+    }
+
+    @OutputFunction(StandardTypes.DOUBLE)
+    public static void output(@AggregationState TDigestAndPercentileState state, BlockBuilder out)
+    {
+        TDigest digest = state.getDigest();
+        List<Double> percentiles = state.getPercentiles();
+
+        if (percentiles == null || digest == null) {
+            out.appendNull();
+            return;
+        }
+
+        checkCondition(0 <= percentiles.get(0) && percentiles.get(0) <= 1, INVALID_FUNCTION_ARGUMENT, "Percentile must be between 0 and 1");
+        DOUBLE.writeDouble(out, digest.getQuantile(percentiles.get(0)));
+
+        out.closeEntry();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateTDigestDoublePercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateTDigestDoublePercentileArrayAggregations.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.operator.aggregation.state.TDigestAndPercentileState;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.tdigest.TDigest;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.tdigest.TDigest.createTDigest;
+import static com.facebook.presto.util.Failures.checkCondition;
+
+@AggregationFunction("approx_percentile")
+public final class ApproximateTDigestDoublePercentileArrayAggregations
+{
+    private ApproximateTDigestDoublePercentileArrayAggregations() {}
+
+    private static final double STANDARD_COMPRESSION_FACTOR = 100.0;
+
+    @InputFunction
+    public static void input(@AggregationState TDigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType("array(double)") Block percentilesArrayBlock)
+    {
+        initializePercentilesArray(state, percentilesArrayBlock);
+        initializeDigest(state, STANDARD_COMPRESSION_FACTOR);
+
+        TDigest digest = state.getDigest();
+        state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
+        digest.add(value);
+        state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+    }
+
+    @InputFunction
+    public static void weightedInput(@AggregationState TDigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType("array(double)") Block percentilesArrayBlock)
+    {
+        initializePercentilesArray(state, percentilesArrayBlock);
+        initializeDigest(state, STANDARD_COMPRESSION_FACTOR);
+
+        TDigest digest = state.getDigest();
+        state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
+        digest.add(value, weight);
+        state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState TDigestAndPercentileState state, TDigestAndPercentileState otherState)
+    {
+        TDigest otherDigest = otherState.getDigest();
+        TDigest digest = state.getDigest();
+
+        if (digest == null) {
+            state.setDigest(otherDigest);
+            state.addMemoryUsage(otherDigest.estimatedInMemorySizeInBytes());
+        }
+        else {
+            state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
+            digest.merge(otherDigest);
+            state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+        }
+
+        state.setPercentiles(otherState.getPercentiles());
+    }
+
+    @OutputFunction("array(double)")
+    public static void output(@AggregationState TDigestAndPercentileState state, BlockBuilder out)
+    {
+        TDigest digest = state.getDigest();
+        List<Double> percentiles = state.getPercentiles();
+
+        if (percentiles == null || digest == null) {
+            out.appendNull();
+            return;
+        }
+
+        BlockBuilder blockBuilder = out.beginBlockEntry();
+
+        for (Double percentile : percentiles) {
+            DOUBLE.writeDouble(blockBuilder, digest.getQuantile(percentile));
+        }
+
+        out.closeEntry();
+    }
+
+    static void initializePercentilesArray(@AggregationState TDigestAndPercentileState state, Block percentilesArrayBlock)
+    {
+        if (state.getPercentiles() == null) {
+            ImmutableList.Builder<Double> percentilesListBuilder = ImmutableList.builder();
+
+            for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
+                checkCondition(!percentilesArrayBlock.isNull(i), INVALID_FUNCTION_ARGUMENT, "Percentile cannot be null");
+                double percentile = DOUBLE.getDouble(percentilesArrayBlock, i);
+                checkCondition(0 <= percentile && percentile <= 1, INVALID_FUNCTION_ARGUMENT, "Percentile must be between 0 and 1");
+                percentilesListBuilder.add(percentile);
+            }
+
+            state.setPercentiles(percentilesListBuilder.build());
+        }
+    }
+
+    static void initializeDigest(@AggregationState TDigestAndPercentileState state, double compression)
+    {
+        TDigest digest = state.getDigest();
+        if (digest == null) {
+            digest = createTDigest(compression);
+            state.setDigest(digest);
+            state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/TDigestAndPercentileState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/TDigestAndPercentileState.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+import com.facebook.presto.tdigest.TDigest;
+
+import java.util.List;
+
+@AccumulatorStateMetadata(stateSerializerClass = TDigestAndPercentileStateSerializer.class, stateFactoryClass = TDigestAndPercentileStateFactory.class)
+public interface TDigestAndPercentileState
+        extends AccumulatorState
+{
+    TDigest getDigest();
+
+    void setDigest(TDigest digest);
+
+    void setPercentiles(List<Double> percentiles);
+
+    List<Double> getPercentiles();
+
+    void addMemoryUsage(long value);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/TDigestAndPercentileStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/TDigestAndPercentileStateFactory.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import com.facebook.presto.tdigest.TDigest;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.airlift.slice.SizeOf.sizeOfDoubleArray;
+import static java.util.Objects.requireNonNull;
+
+public class TDigestAndPercentileStateFactory
+        implements AccumulatorStateFactory<TDigestAndPercentileState>
+{
+    @Override
+    public TDigestAndPercentileState createSingleState()
+    {
+        return new SingleTDigestAndPercentileState();
+    }
+
+    @Override
+    public Class<? extends TDigestAndPercentileState> getSingleStateClass()
+    {
+        return SingleTDigestAndPercentileState.class;
+    }
+
+    @Override
+    public TDigestAndPercentileState createGroupedState()
+    {
+        return new GroupedTDigestAndPercentileState();
+    }
+
+    @Override
+    public Class<? extends TDigestAndPercentileState> getGroupedStateClass()
+    {
+        return GroupedTDigestAndPercentileState.class;
+    }
+
+    public static class GroupedTDigestAndPercentileState
+            extends AbstractGroupedAccumulatorState
+            implements TDigestAndPercentileState
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedTDigestAndPercentileState.class).instanceSize();
+        private final ObjectBigArray<TDigest> digests = new ObjectBigArray<>();
+        private List<Double> percentilesList;
+        private long size;
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            digests.ensureCapacity(size);
+        }
+
+        @Override
+        public TDigest getDigest()
+        {
+            return digests.get(getGroupId());
+        }
+
+        @Override
+        public void setDigest(TDigest digest)
+        {
+            if (digest == null) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "TDigest is null");
+            }
+            if (digests.get(getGroupId()) != null && digests.get(getGroupId()).getCompressionFactor() != digest.getCompressionFactor()) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "TDigest compression factor must be constant");
+            }
+            digests.set(getGroupId(), digest);
+        }
+
+        @Override
+        public List<Double> getPercentiles()
+        {
+            return percentilesList;
+        }
+
+        @Override
+        public void setPercentiles(List<Double> percentiles)
+        {
+            if (percentiles == null) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Percentiles is null");
+            }
+            if (percentilesList != null && !percentilesList.equals(percentiles)) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Percentiles must be constant");
+            }
+            percentilesList = percentiles;
+        }
+
+        @Override
+        public void addMemoryUsage(long value)
+        {
+            size += value;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            long estimatedSize = INSTANCE_SIZE + size + digests.sizeOf();
+            if (percentilesList != null) {
+                estimatedSize += sizeOfDoubleArray(percentilesList.size());
+            }
+            return estimatedSize;
+        }
+    }
+
+    public static class SingleTDigestAndPercentileState
+            implements TDigestAndPercentileState
+    {
+        public static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleTDigestAndPercentileState.class).instanceSize();
+        private TDigest digest;
+        private List<Double> percentiles;
+
+        @Override
+        public TDigest getDigest()
+        {
+            return digest;
+        }
+
+        @Override
+        public void setDigest(TDigest digest)
+        {
+            this.digest = requireNonNull(digest, "digest is null");
+        }
+
+        @Override
+        public List<Double> getPercentiles()
+        {
+            return percentiles;
+        }
+
+        @Override
+        public void setPercentiles(List<Double> percentiles)
+        {
+            if (percentiles == null) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Percentiles is null");
+            }
+            if (this.percentiles != null && !this.percentiles.equals(percentiles)) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Percentiles must be constant");
+            }
+            this.percentiles = percentiles;
+        }
+
+        @Override
+        public void addMemoryUsage(long value)
+        {
+            // noop
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            long estimatedSize = INSTANCE_SIZE;
+            if (digest != null) {
+                estimatedSize += digest.estimatedInMemorySizeInBytes();
+            }
+            if (percentiles != null) {
+                estimatedSize += sizeOfDoubleArray(percentiles.size());
+            }
+            return estimatedSize;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/TDigestAndPercentileStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/TDigestAndPercentileStateSerializer.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.tdigest.TDigest.createTDigest;
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+
+public class TDigestAndPercentileStateSerializer
+        implements AccumulatorStateSerializer<TDigestAndPercentileState>
+{
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(TDigestAndPercentileState state, BlockBuilder out)
+    {
+        if (state.getDigest() == null) {
+            out.appendNull();
+        }
+        else {
+            Slice digest = state.getDigest().serialize();
+
+            SliceOutput output = Slices.allocate(
+                    SIZE_OF_INT + // number of percentiles
+                            state.getPercentiles().size() * SIZE_OF_DOUBLE + // percentiles
+                            SIZE_OF_INT + // digest length
+                            digest.length()) // digest
+                    .getOutput();
+
+            // write percentiles
+            List<Double> percentiles = state.getPercentiles();
+            output.appendInt(percentiles.size());
+            for (double percentile : percentiles) {
+                output.appendDouble(percentile);
+            }
+
+            output.appendInt(digest.length());
+            output.appendBytes(digest);
+
+            VARBINARY.writeSlice(out, output.slice());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, TDigestAndPercentileState state)
+    {
+        SliceInput input = VARBINARY.getSlice(block, index).getInput();
+
+        // read number of percentiles
+        int numPercentiles = input.readInt();
+
+        ImmutableList.Builder<Double> percentilesListBuilder = ImmutableList.builder();
+        for (int i = 0; i < numPercentiles; i++) {
+            percentilesListBuilder.add(input.readDouble());
+        }
+        state.setPercentiles(percentilesListBuilder.build());
+
+        // read digest
+        int length = input.readInt();
+        state.setDigest(createTDigest(input.readSlice(length)));
+        state.addMemoryUsage(state.getDigest().estimatedInMemorySizeInBytes());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.analyzer;
 import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggGroupImplementation;
 import com.facebook.presto.operator.aggregation.histogram.HistogramGroupImplementation;
 import com.facebook.presto.operator.aggregation.multimapagg.MultimapAggGroupImplementation;
+import com.facebook.presto.tdigest.StatisticalDigestImplementation;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -102,6 +103,7 @@ public class FeaturesConfig
     private int re2JDfaStatesLimit = Integer.MAX_VALUE;
     private int re2JDfaRetries = 5;
     private RegexLibrary regexLibrary = JONI;
+    private StatisticalDigestImplementation statisticalDigestImplementation = StatisticalDigestImplementation.QDIGEST;
     private HistogramGroupImplementation histogramGroupImplementation = HistogramGroupImplementation.NEW;
     private ArrayAggGroupImplementation arrayAggGroupImplementation = ArrayAggGroupImplementation.NEW;
     private MultimapAggGroupImplementation multimapAggGroupImplementation = MultimapAggGroupImplementation.NEW;
@@ -633,10 +635,22 @@ public class FeaturesConfig
         return regexLibrary;
     }
 
+    public StatisticalDigestImplementation getStatisticalDigestImplementation()
+    {
+        return statisticalDigestImplementation;
+    }
+
     @Config("regex-library")
     public FeaturesConfig setRegexLibrary(RegexLibrary regexLibrary)
     {
         this.regexLibrary = regexLibrary;
+        return this;
+    }
+
+    @Config("statistical-digest-implementation")
+    public FeaturesConfig setStatisticalDigestImplementation(StatisticalDigestImplementation digest)
+    {
+        this.statisticalDigestImplementation = digest;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/tdigest/StatisticalDigestImplementation.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/StatisticalDigestImplementation.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tdigest;
+
+public enum StatisticalDigestImplementation
+{
+    TDIGEST, QDIGEST
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStatisticalDigestApproximatePercentileAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestStatisticalDigestApproximatePercentileAggregation.java
@@ -1,0 +1,333 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.block.BlockAssertions;
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.math3.distribution.AbstractRealDistribution;
+import org.apache.commons.math3.distribution.ChiSquaredDistribution;
+import org.apache.commons.math3.distribution.NormalDistribution;
+import org.apache.commons.math3.distribution.UniformRealDistribution;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static com.facebook.presto.block.BlockAssertions.createDoubleSequenceBlock;
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongRepeatBlock;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static java.lang.Integer.min;
+import static org.testng.Assert.assertTrue;
+
+public abstract class TestStatisticalDigestApproximatePercentileAggregation
+        extends AbstractTestFunctions
+{
+    private static final List<Double> quantiles = ImmutableList.of(0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.95, 0.99, 0.995, 0.999, 0.9995, 0.9999);
+    private static final double STANDARD_ERROR = 0.01;
+    private static final double STANDARD_COMPRESSION_FACTOR = 100;
+    private final double parameter;
+
+    protected TestStatisticalDigestApproximatePercentileAggregation(FeaturesConfig featuresConfig)
+    {
+        super(featuresConfig);
+
+        switch (config.getStatisticalDigestImplementation()) {
+            case TDIGEST:
+                parameter = STANDARD_COMPRESSION_FACTOR;
+                break;
+            case QDIGEST:
+                parameter = STANDARD_ERROR;
+                break;
+            default:
+                throw new IllegalArgumentException("Expected a statistical digest");
+        }
+    }
+
+    @DataProvider(name = "distributions")
+    public static Object[][] getDistributions()
+    {
+        return new Object[][] {
+                new Object[] {new NormalDistribution(200_000, 7500)},
+                new Object[] {new UniformRealDistribution(-5000, 5000)},
+                new Object[] {new ChiSquaredDistribution(4)}};
+    }
+
+    /*
+    Tests aggregations for normal and uniform distributions with 1_000_000 elements
+    Disabled because it takes around 15-30s per distribution to run
+     */
+    @Test(dataProvider = "distributions", enabled = false)
+    public void testDoublePartialStep(AbstractRealDistribution distribution)
+    {
+        final double[] inputs = getDistributionValues(distribution, 1_000_000);
+        final Double[] objectInputs = new Double[inputs.length];
+        for (int i = 0; i < inputs.length; i++) {
+            objectInputs[i] = Double.valueOf(inputs[i]);
+        }
+
+        for (double quantile : quantiles) {
+            testAggregationDouble(
+                    createDoublesBlock(objectInputs),
+                    createLongRepeatBlock(1, 1_000_000),
+                    createRLEBlock(quantile, 1_000_000),
+                    STANDARD_ERROR,
+                    quantile,
+                    parameter,
+                    inputs);
+        }
+    }
+
+    @Test
+    public void testDoublePartialStep()
+    {
+        // regular approx_percentile
+        testAggregationDouble(
+                createDoublesBlock(null, null),
+                BlockAssertions.createRLEBlock(1, 2),
+                createRLEBlock(0.5, 2),
+                STANDARD_ERROR,
+                0.5,
+                parameter);
+
+        testAggregationDouble(
+                createDoublesBlock(null, 1.0),
+                BlockAssertions.createRLEBlock(1, 2),
+                createRLEBlock(0.2, 2),
+                STANDARD_ERROR,
+                0.2,
+                parameter,
+                1.0);
+
+        testAggregationDouble(
+                createDoublesBlock(null, 1.0, 2.0, 3.0),
+                BlockAssertions.createRLEBlock(1, 4),
+                createRLEBlock(0.1, 4),
+                STANDARD_ERROR,
+                0.1,
+                parameter,
+                1.0, 2.0, 3.0);
+
+        testAggregationDouble(
+                createDoublesBlock(1.0, 2.0, 3.0),
+                BlockAssertions.createRLEBlock(1, 3),
+                createRLEBlock(0.7, 3),
+                STANDARD_ERROR,
+                0.7,
+                parameter,
+                1.0, 2.0, 3.0);
+
+        testAggregationDouble(
+                createDoublesBlock(1.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 3.0, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
+                BlockAssertions.createRLEBlock(1, 21),
+                createRLEBlock(0.9, 21),
+                STANDARD_ERROR,
+                0.9,
+                parameter,
+                1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0, 4.0, 5.0, 6.0, 7.0);
+
+        // array of approx_percentile
+        testArrayAggregationDouble(
+                createDoublesBlock(null, null),
+                BlockAssertions.createRLEBlock(1, 2),
+                createRLEBlock(quantiles, 2),
+                STANDARD_ERROR,
+                quantiles);
+
+        testArrayAggregationDouble(
+                createDoublesBlock(null, 1.0),
+                BlockAssertions.createRLEBlock(1, 2),
+                createRLEBlock(quantiles, 2),
+                STANDARD_ERROR,
+                quantiles,
+                1.0);
+
+        testArrayAggregationDouble(
+                createDoublesBlock(null, 1.0, 2.0, 3.0),
+                BlockAssertions.createRLEBlock(1, 4),
+                createRLEBlock(quantiles, 4),
+                STANDARD_ERROR,
+                quantiles,
+                1.0, 2.0, 3.0);
+
+        testArrayAggregationDouble(
+                createDoublesBlock(1.0, 2.0, 3.0),
+                BlockAssertions.createRLEBlock(1, 3),
+                createRLEBlock(quantiles, 3),
+                STANDARD_ERROR,
+                quantiles,
+                1.0, 2.0, 3.0);
+
+        testArrayAggregationDouble(
+                createDoublesBlock(1.0, null, 2.0, null, 2.0, null, 2.0, null, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0, 7.0),
+                BlockAssertions.createRLEBlock(1, 18),
+                createRLEBlock(quantiles, 18),
+                STANDARD_ERROR,
+                quantiles,
+                1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 5.0, 6.0, 7.0, 7.0);
+
+        testArrayAggregationDouble(
+                createDoubleSequenceBlock(0, 10000),
+                createLongRepeatBlock(1, 10000),
+                createRLEBlock(quantiles, 10000),
+                STANDARD_ERROR,
+                quantiles,
+                LongStream.range(0, 10000).asDoubleStream().toArray());
+    }
+
+    private static double[] getDistributionValues(AbstractRealDistribution distribution, int size)
+    {
+        double[] values = new double[size];
+        for (int i = 0; i < size; i++) {
+            values[i] = distribution.sample();
+        }
+        return values;
+    }
+
+    private void testAggregationDouble(Block doublesBlock, Block weightsBlock, Block percentiles, double error, double quantile, double parameter, double... inputs)
+    {
+        // Test without weights and accuracy
+        testAggregationDoubles(
+                getInternalAggregationFunction(2),
+                new Page(doublesBlock, percentiles),
+                error,
+                ImmutableList.of(quantile),
+                inputs);
+        // Test with weights and without accuracy
+        testAggregationDoubles(
+                getInternalAggregationFunction(3),
+                new Page(doublesBlock, weightsBlock, percentiles),
+                error,
+                ImmutableList.of(quantile),
+                inputs);
+        // Test with weights and accuracy
+        testAggregationDoubles(
+                getInternalAggregationFunction(4),
+                new Page(doublesBlock, weightsBlock, percentiles, BlockAssertions.createRLEBlock(parameter, doublesBlock.getPositionCount())),
+                error,
+                ImmutableList.of(quantile),
+                inputs);
+    }
+
+    private void testArrayAggregationDouble(Block doublesBlock, Block weightsBlock, Block percentiles, double error, List<Double> quantiles, double... inputs)
+    {
+        // Test without weights and without accuracy/compression
+        testAggregationDoubles(
+                getArrayInternalAggregationFunction(2),
+                new Page(doublesBlock, percentiles),
+                error,
+                quantiles,
+                inputs);
+        // Test with weights and without accuracy/compression
+        testAggregationDoubles(
+                getArrayInternalAggregationFunction(3),
+                new Page(doublesBlock, weightsBlock, percentiles),
+                error,
+                quantiles,
+                inputs);
+    }
+
+    abstract InternalAggregationFunction getInternalAggregationFunction(int arity);
+
+    abstract InternalAggregationFunction getArrayInternalAggregationFunction(int arity);
+
+    private void testAggregationDoubles(InternalAggregationFunction function, Page page, double error, List<Double> quantiles, double... inputs)
+    {
+        // test scalars
+        List<Double> rows = Arrays.stream(inputs).sorted().boxed().collect(Collectors.toList());
+        Object aggregation = AggregationTestUtils.aggregation(function, page);
+
+        final List<Double> returned;
+        if (aggregation == null) {
+            returned = new ArrayList<>();
+        }
+        else {
+            if (aggregation instanceof Double) {
+                returned = ImmutableList.of((Double) aggregation);
+            }
+            else if (aggregation instanceof List) {
+                returned = (List<Double>) aggregation;
+            }
+            else {
+                throw new IllegalArgumentException("Aggregation object is invalid");
+            }
+        }
+        assertPercentilesWithinError(returned, error, quantiles, rows);
+    }
+
+    private void assertPercentilesWithinError(List<Double> result, double error, List<Double> quantiles, List<? extends Number> rows)
+    {
+        if (rows.isEmpty()) {
+            // Nothing to assert except that the digest is empty
+            return;
+        }
+
+        // Test each quantile individually (value_at_quantile)
+        for (int i = 0; i < result.size(); i++) {
+            assertPercentileWithinError(result.get(i), error, quantiles.get(i), rows);
+        }
+    }
+
+    private void assertPercentileWithinError(Double result, double error, double percentile, List<? extends Number> rows)
+    {
+        double lowerBound = Math.max(0, percentile - error);
+        double upperBound = Math.min(1, percentile + error);
+
+        double min = rows.get((int) (rows.size() * lowerBound)).doubleValue();
+        double max = rows.get(min(rows.size() - 1, (int) (rows.size() * upperBound))).doubleValue();
+        // Check that the chosen quantile is within the upper and lower bound of the error
+        assertTrue(result >= min);
+        assertTrue(result <= max);
+    }
+
+    protected static InternalAggregationFunction getAggregation(FunctionManager functionManager, Type... arguments)
+    {
+        return functionManager.getAggregateFunctionImplementation(functionManager.lookupFunction("approx_percentile", fromTypes(arguments)));
+    }
+
+    protected static RunLengthEncodedBlock createRLEBlock(double percentile, int positionCount)
+    {
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, 1);
+        DOUBLE.writeDouble(blockBuilder, percentile);
+        return new RunLengthEncodedBlock(blockBuilder.build(), positionCount);
+    }
+
+    protected static RunLengthEncodedBlock createRLEBlock(Iterable<Double> percentiles, int positionCount)
+    {
+        BlockBuilder rleBlockBuilder = new ArrayType(DOUBLE).createBlockBuilder(null, 1);
+        BlockBuilder arrayBlockBuilder = rleBlockBuilder.beginBlockEntry();
+
+        for (double percentile : percentiles) {
+            DOUBLE.writeDouble(arrayBlockBuilder, percentile);
+        }
+
+        rleBlockBuilder.closeEntry();
+
+        return new RunLengthEncodedBlock(rleBlockBuilder.build(), positionCount);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTDigestApproximatePercentileAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTDigestApproximatePercentileAggregation.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.tdigest.StatisticalDigestImplementation.TDIGEST;
+
+public class TestTDigestApproximatePercentileAggregation
+        extends TestStatisticalDigestApproximatePercentileAggregation
+{
+    private static final FunctionManager functionManager = MetadataManager.createTestMetadataManager(new FeaturesConfig().setStatisticalDigestImplementation(TDIGEST)).getFunctionManager();
+
+    private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_AGGREGATION = getAggregation(functionManager, DOUBLE, DOUBLE);
+    private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION = getAggregation(functionManager, DOUBLE, BIGINT, DOUBLE);
+    private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_PARAMETER = getAggregation(functionManager, DOUBLE, BIGINT, DOUBLE, DOUBLE);
+
+    private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = getAggregation(functionManager, DOUBLE, new ArrayType(DOUBLE));
+    private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = getAggregation(functionManager, DOUBLE, BIGINT, new ArrayType(DOUBLE));
+
+    private TestTDigestApproximatePercentileAggregation()
+    {
+        super(new FeaturesConfig().setStatisticalDigestImplementation(TDIGEST));
+    }
+
+    @Override
+    protected InternalAggregationFunction getInternalAggregationFunction(int arity)
+    {
+        switch (arity) {
+            case 2:
+                return DOUBLE_APPROXIMATE_PERCENTILE_AGGREGATION;
+            case 3:
+                return DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION;
+            case 4:
+                return DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_PARAMETER;
+            default:
+                throw new IllegalArgumentException("Unsupported number of arguments");
+        }
+    }
+
+    @Override
+    protected InternalAggregationFunction getArrayInternalAggregationFunction(int arity)
+    {
+        switch (arity) {
+            case 2:
+                return DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION;
+            case 3:
+                return DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION;
+            default:
+                throw new IllegalArgumentException("Unsupported number of arguments");
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -54,7 +54,7 @@ import static org.testng.Assert.fail;
 public abstract class AbstractTestFunctions
 {
     protected final Session session;
-    private final FeaturesConfig config;
+    protected final FeaturesConfig config;
     protected FunctionAssertions functionAssertions;
 
     protected AbstractTestFunctions()

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.analyzer;
 import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggGroupImplementation;
 import com.facebook.presto.operator.aggregation.histogram.HistogramGroupImplementation;
 import com.facebook.presto.operator.aggregation.multimapagg.MultimapAggGroupImplementation;
+import com.facebook.presto.tdigest.StatisticalDigestImplementation;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.configuration.ConfigurationFactory;
 import io.airlift.configuration.testing.ConfigAssertions;
@@ -34,6 +35,7 @@ import static com.facebook.presto.sql.analyzer.FeaturesConfig.SPILLER_SPILL_PATH
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.SPILL_ENABLED;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.RE2J;
+import static com.facebook.presto.tdigest.StatisticalDigestImplementation.QDIGEST;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
@@ -111,6 +113,7 @@ public class TestFeaturesConfig
                 .setHistogramGroupImplementation(HistogramGroupImplementation.NEW)
                 .setArrayAggGroupImplementation(ArrayAggGroupImplementation.NEW)
                 .setMultimapAggGroupImplementation(MultimapAggGroupImplementation.NEW)
+                .setStatisticalDigestImplementation(QDIGEST)
                 .setDistributedSortEnabled(true)
                 .setMaxGroupingSets(2048)
                 .setLegacyUnnestArrayRows(false)
@@ -184,6 +187,7 @@ public class TestFeaturesConfig
                 .put("histogram.implementation", "LEGACY")
                 .put("arrayagg.implementation", "LEGACY")
                 .put("multimapagg.implementation", "LEGACY")
+                .put("statistical-digest-implementation", "TDIGEST")
                 .put("optimizer.use-mark-distinct", "false")
                 .put("optimizer.prefer-partial-aggregation", "false")
                 .put("optimizer.optimize-top-n-row-number", "false")
@@ -259,6 +263,7 @@ public class TestFeaturesConfig
                 .setHistogramGroupImplementation(HistogramGroupImplementation.LEGACY)
                 .setArrayAggGroupImplementation(ArrayAggGroupImplementation.LEGACY)
                 .setMultimapAggGroupImplementation(MultimapAggGroupImplementation.LEGACY)
+                .setStatisticalDigestImplementation(StatisticalDigestImplementation.TDIGEST)
                 .setDistributedSortEnabled(false)
                 .setMaxGroupingSets(2047)
                 .setLegacyUnnestArrayRows(true)


### PR DESCRIPTION
Use t-digest as the underlying data structure when querying from a distribution of doubles using `approx_percentile` function.