### PR TITLE
Disable PushdownSubfields rule

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -46,6 +46,7 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
@@ -83,7 +84,7 @@ public class TestHiveLogicalPlanner
 {
     public TestHiveLogicalPlanner()
     {
-        super(() -> createQueryRunner(LINE_ITEM));
+        super(() -> createQueryRunner(ImmutableList.of(LINE_ITEM), ImmutableMap.of("experimental.pushdown-subfields-enabled", "true"), Optional.empty()));
     }
 
     @Test

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -129,6 +129,7 @@ public final class SystemSessionProperties
     public static final String DEFAULT_FILTER_FACTOR_ENABLED = "default_filter_factor_enabled";
     public static final String PUSH_LIMIT_THROUGH_OUTER_JOIN = "push_limit_through_outer_join";
     public static final String MAX_CONCURRENT_MATERIALIZATIONS = "max_concurrent_materializations";
+    public static final String PUSHDOWN_SUBFIELDS_ENABLED = "pushdown_subfields_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -620,6 +621,11 @@ public final class SystemSessionProperties
                         MAX_CONCURRENT_MATERIALIZATIONS,
                         "Maximum number of materializing plan sections that can run concurrently",
                         featuresConfig.getMaxConcurrentMaterializations(),
+                        false),
+                booleanProperty(
+                        PUSHDOWN_SUBFIELDS_ENABLED,
+                        "Experimental: enable subfield pruning",
+                        featuresConfig.isPushdownSubfieldsEnabled(),
                         false));
     }
 
@@ -1051,5 +1057,10 @@ public final class SystemSessionProperties
     public static int getMaxConcurrentMaterializations(Session session)
     {
         return session.getSystemProperty(MAX_CONCURRENT_MATERIALIZATIONS, Integer.class);
+    }
+
+    public static boolean isPushdownSubfieldsEnabled(Session session)
+    {
+        return session.getSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -134,6 +134,8 @@ public class FeaturesConfig
     private boolean jsonSerdeCodeGenerationEnabled;
     private int maxConcurrentMaterializations = 10;
 
+    private boolean pushdownSubfieldsEnabled;
+
     public enum JoinReorderingStrategy
     {
         NONE,
@@ -1028,5 +1030,18 @@ public class FeaturesConfig
     public int getMaxConcurrentMaterializations()
     {
         return maxConcurrentMaterializations;
+    }
+
+    @Config("experimental.pushdown-subfields-enabled")
+    @ConfigDescription("Experimental: enable subfield pruning")
+    public FeaturesConfig setPushdownSubfieldsEnabled(boolean pushdownSubfieldsEnabled)
+    {
+        this.pushdownSubfieldsEnabled = pushdownSubfieldsEnabled;
+        return this;
+    }
+
+    public boolean isPushdownSubfieldsEnabled()
+    {
+        return pushdownSubfieldsEnabled;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -76,6 +76,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.SystemSessionProperties.isPushdownSubfieldsEnabled;
 import static com.facebook.presto.spi.Subfield.allSubscripts;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToExpression;
@@ -99,6 +100,10 @@ public class PushdownSubfields
         requireNonNull(plan, "plan is null");
         requireNonNull(session, "session is null");
         requireNonNull(types, "types is null");
+
+        if (!isPushdownSubfieldsEnabled(session)) {
+            return plan;
+        }
 
         return SimplePlanRewriter.rewriteWith(new Rewriter(session, metadata, types), plan, new Rewriter.Context());
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -116,7 +116,8 @@ public class TestFeaturesConfig
                 .setLegacyUnnestArrayRows(false)
                 .setJsonSerdeCodeGenerationEnabled(false)
                 .setPushLimitThroughOuterJoin(true)
-                .setMaxConcurrentMaterializations(10));
+                .setMaxConcurrentMaterializations(10)
+                .setPushdownSubfieldsEnabled(false));
     }
 
     @Test
@@ -192,6 +193,7 @@ public class TestFeaturesConfig
                 .put("experimental.json-serde-codegen-enabled", "true")
                 .put("optimizer.push-limit-through-outer-join", "false")
                 .put("max-concurrent-materializations", "5")
+                .put("experimental.pushdown-subfields-enabled", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -263,7 +265,8 @@ public class TestFeaturesConfig
                 .setDefaultFilterFactorEnabled(true)
                 .setJsonSerdeCodeGenerationEnabled(true)
                 .setPushLimitThroughOuterJoin(false)
-                .setMaxConcurrentMaterializations(5);
+                .setMaxConcurrentMaterializations(5)
+                .setPushdownSubfieldsEnabled(true);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
Turns out PushdownSubfields doesn't interoperate with CBO yet. PushdownSubfields
changes ColumnHandles, but TableScanStatsRule uses them to look up statistics in
a map keyed by unmodified ColumnHandles.

Introduced pushdown_subfields_enabled session property with default value 'false'
to control whether PushdownSubfields rule runs or not.