### PR TITLE
Fix variable expression serde

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolAllocator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SymbolAllocator.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -39,6 +40,8 @@ import static java.util.Objects.requireNonNull;
 public class SymbolAllocator
         implements VariableAllocator
 {
+    private static final Pattern DISALLOWED_CHAR_PATTERN = Pattern.compile("[^a-zA-Z0-9_\\-$]+");
+
     private final Map<Symbol, Type> symbols;
     private int nextId;
 
@@ -115,6 +118,8 @@ public class SymbolAllocator
         if (suffix != null) {
             unique = unique + "$" + suffix;
         }
+        // remove special characters for other special serde
+        unique = DISALLOWED_CHAR_PATTERN.matcher(unique).replaceAll("_");
 
         String attempt = unique;
         while (symbols.containsKey(new Symbol(attempt))) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -572,6 +572,9 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT b FROM UNNEST(ARRAY[1, 2, 3], ARRAY[4, 5]) t(a, b)", "SELECT * FROM VALUES 4, 5, NULL");
         assertQuery("SELECT count(*) FROM UNNEST(ARRAY[1, 2, 3], ARRAY[4, 5])", "SELECT 3");
         assertQuery("SELECT a FROM UNNEST(ARRAY['kittens', 'puppies']) t(a)", "SELECT * FROM VALUES ('kittens'), ('puppies')");
+        assertQuery(
+                "WITH unioned AS ( SELECT 1 UNION ALL SELECT 2 ) SELECT * FROM unioned CROSS JOIN UNNEST(ARRAY[3]) steps (step)",
+                "SELECT * FROM (VALUES (1, 3), (2, 3))");
         assertQuery("" +
                         "SELECT c " +
                         "FROM UNNEST(ARRAY[1, 2, 3], ARRAY[4, 5]) t(a, b) " +


### PR DESCRIPTION
Variables were serialized as "name(type)". This conflicts with some
special literal naming convention like "$literal$array(integer)", which
is a legit name. Fix this by using angle brackets "name<type>".