### PR TITLE
Add SelectiveStreamReader for LIST type

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -17,25 +17,35 @@ import com.facebook.presto.Session;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
 import static com.facebook.presto.hive.HiveSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static io.airlift.tpch.TpchTable.getTables;
+import static java.lang.String.format;
 
 public class TestHivePushdownFilterQueries
         extends AbstractTestQueryFramework
 {
-    private static final String WITH_LINEITEM_EX = "WITH lineitem_ex AS (" +
-            "SELECT linenumber, orderkey, " +
+    private static final Pattern ARRAY_SUBSCRIPT_PATTERN = Pattern.compile("([a-z_+]+)((\\[[0-9]+\\])+)");
+
+    private static final String WITH_LINEITEM_EX = "WITH lineitem_ex AS (\n" +
+            "SELECT linenumber, orderkey, partkey, suppkey, \n" +
+            "   CASE WHEN linenumber % 5 = 0 THEN null ELSE shipmode = 'AIR' END AS ship_by_air, \n" +
+            "   CASE WHEN linenumber % 7 = 0 THEN null ELSE returnflag = 'R' END AS is_returned, \n" +
             "   CASE WHEN linenumber % 4 = 0 THEN NULL ELSE CAST(day(shipdate) AS TINYINT) END AS ship_day, " +
             "   CASE WHEN linenumber % 6 = 0 THEN NULL ELSE CAST(month(shipdate) AS TINYINT) END AS ship_month, " +
-            "   CASE WHEN linenumber % 7 = 0 THEN null ELSE shipmode = 'AIR' END AS ship_by_air, " +
-            "   CASE WHEN linenumber % 5 = 0 THEN null ELSE returnflag = 'R' END AS is_returned " +
-            "FROM lineitem)";
+            "   CASE WHEN orderkey % 11 = 0 THEN null ELSE (orderkey, partkey, suppkey) END AS keys, \n" +
+            "   CASE WHEN orderkey % 13 = 0 THEN null ELSE ((orderkey, partkey), (suppkey,), CASE WHEN orderkey % 17 = 0 THEN null ELSE (orderkey, partkey) END) END AS nested_keys, \n" +
+            "   CASE WHEN orderkey % 17 = 0 THEN null ELSE (shipmode = 'AIR', returnflag = 'R') END as flags\n" +
+            "FROM lineitem)\n";
 
     protected TestHivePushdownFilterQueries()
     {
@@ -52,13 +62,15 @@ public class TestHivePushdownFilterQueries
                 Optional.empty());
 
         queryRunner.execute(noPushdownFilter(queryRunner.getDefaultSession()),
-                "CREATE TABLE lineitem_ex (linenumber, orderkey, ship_by_air, is_returned, ship_day, ship_month) AS " +
-                        "SELECT linenumber, " +
-                        "   orderkey, " +
-                        "   IF (linenumber % 7 = 0, null, shipmode = 'AIR') AS ship_by_air, " +
-                        "   IF (linenumber % 5 = 0, null, returnflag = 'R') AS is_returned, " +
+                "CREATE TABLE lineitem_ex (linenumber, orderkey, partkey, suppkey, ship_by_air, is_returned, ship_day, ship_month, keys, nested_keys, flags) AS " +
+                        "SELECT linenumber, orderkey, partkey, suppkey, " +
+                        "   IF (linenumber % 5 = 0, null, shipmode = 'AIR') AS ship_by_air, " +
+                        "   IF (linenumber % 7 = 0, null, returnflag = 'R') AS is_returned, " +
                         "   IF (linenumber % 4 = 0, null, CAST(day(shipdate) AS TINYINT)) AS ship_day, " +
-                        "   IF (linenumber % 6 = 0, null, CAST(month(shipdate) AS TINYINT)) AS ship_month " +
+                        "   IF (linenumber % 6 = 0, null, CAST(month(shipdate) AS TINYINT)) AS ship_month, " +
+                        "   IF (orderkey % 11 = 0, null, ARRAY[orderkey, partkey, suppkey]), " +
+                        "   IF (orderkey % 13 = 0, null, ARRAY[ARRAY[orderkey, partkey], ARRAY[suppkey], IF (orderkey % 17 = 0, null, ARRAY[orderkey, partkey])]), " +
+                        "   IF (orderkey % 17 = 0, null, ARRAY[shipmode = 'AIR', returnflag = 'R']) " +
                         "FROM lineitem");
 
         return queryRunner;
@@ -133,6 +145,78 @@ public class TestHivePushdownFilterQueries
     }
 
     @Test
+    public void testArrays()
+    {
+        // read all positions
+        assertQueryUsingH2Cte("SELECT * FROM lineitem_ex");
+
+        // top-level IS [NOT] NULL filters
+        assertFilterProject("keys IS NULL", "orderkey, flags");
+        assertFilterProject("nested_keys IS NULL", "keys, flags");
+
+        assertFilterProject("flags IS NOT NULL", "keys, orderkey");
+        assertFilterProject("nested_keys IS NOT NULL", "keys, flags");
+
+        // mid-level IS [NOR] NULL filters
+        assertFilterProject("nested_keys[3] IS NULL", "keys, flags");
+        assertFilterProject("nested_keys[3] IS NOT NULL", "keys, flags");
+
+        // read selected positions
+        assertQueryUsingH2Cte("SELECT * FROM lineitem_ex WHERE orderkey = 1");
+
+        // read all positions; extract selected positions
+        assertQueryUsingH2Cte("SELECT * FROM lineitem_ex WHERE orderkey % 3 = 1");
+
+        // filter
+        assertFilterProject("keys[2] = 1", "orderkey, flags");
+        assertFilterProject("nested_keys[1][2] = 1", "orderkey, flags");
+
+        // filter function
+        assertFilterProject("keys[2] % 3 = 1", "orderkey, flags");
+        assertFilterProject("nested_keys[1][2] % 3 = 1", "orderkey, flags");
+
+        // less selective filter
+        assertFilterProject("keys[1] < 1000", "orderkey, flags");
+        assertFilterProject("nested_keys[1][1] < 1000", "orderkey, flags");
+
+        // filter plus filter function
+        assertFilterProject("keys[1] < 1000 AND keys[2] % 3 = 1", "orderkey, flags");
+        assertFilterProject("nested_keys[1][1] < 1000 AND nested_keys[1][2] % 3 = 1", "orderkey, flags");
+
+        // filter function on multiple columns
+        assertFilterProject("keys[1] % 3 = 1 AND (orderkey + keys[2]) % 5 = 1", "orderkey, flags");
+        assertFilterProject("nested_keys[1][1] % 3 = 1 AND (orderkey + nested_keys[1][2]) % 5 = 1", "orderkey, flags");
+
+        // filter on multiple columns, plus filter function
+        assertFilterProject("keys[1] < 1000 AND flags[2] = true AND keys[2] % 2 = if(flags[1], 0, 1)", "orderkey, flags");
+        assertFilterProject("nested_keys[1][1] < 1000 AND flags[2] = true AND nested_keys[1][2] % 2 = if(flags[1], 0, 1)", "orderkey, flags");
+
+        // filters at different levels
+        assertFilterProject("nested_keys IS NOT NULL AND nested_keys[1][1] > 0", "keys");
+        assertFilterProject("nested_keys[3] IS NULL AND nested_keys[2][1] > 10", "keys, flags");
+        assertFilterProject("nested_keys[3] IS NOT NULL AND nested_keys[1][2] > 10", "keys, flags");
+        assertFilterProject("nested_keys IS NOT NULL AND nested_keys[3] IS NOT NULL AND nested_keys[1][1] > 0", "keys");
+        assertFilterProject("nested_keys IS NOT NULL AND nested_keys[3] IS NULL AND nested_keys[1][1] > 0", "keys");
+
+        assertFilterProjectFails("keys[5] > 0", "orderkey", "Array subscript out of bounds");
+        assertFilterProjectFails("nested_keys[5][1] > 0", "orderkey", "Array subscript out of bounds");
+        assertFilterProjectFails("nested_keys[1][5] > 0", "orderkey", "Array subscript out of bounds");
+        assertFilterProjectFails("nested_keys[2][5] > 0", "orderkey", "Array subscript out of bounds");
+    }
+
+    private void assertFilterProject(String filter, String projections)
+    {
+        assertQueryUsingH2Cte(format("SELECT * FROM lineitem_ex WHERE %s", filter));
+        assertQueryUsingH2Cte(format("SELECT %s FROM lineitem_ex WHERE %s", projections, filter));
+    }
+
+    private void assertFilterProjectFails(String filter, String projections, String expectedMessageRegExp)
+    {
+        assertQueryFails(format("SELECT * FROM lineitem_ex WHERE %s", filter), expectedMessageRegExp);
+        assertQueryFails(format("SELECT %s FROM lineitem_ex WHERE %s", projections, filter), expectedMessageRegExp);
+    }
+
+    @Test
     public void testFilterFunctions()
     {
         // filter function on orderkey; orderkey is projected out
@@ -154,10 +238,33 @@ public class TestHivePushdownFilterQueries
         assertQueryFails("SELECT custkey, orderdate FROM orders WHERE array[1, 2, 3][orderkey % 5 + custkey % 7 + 1] > 0", "Array subscript out of bounds");
 
         // filter function with "recoverable" error
-        assertQuery("SELECT custkey, orderdate FROM orders WHERE array[1, 2, 3][orderkey % 5 + custkey %7 + 1] > 0 AND orderkey % 5 = 1 AND custkey % 7 = 0", "SELECT custkey, orderdate FROM orders WHERE orderkey % 5 = 1 AND custkey % 7 = 0");
+        assertQuery("SELECT custkey, orderdate FROM orders WHERE array[1, 2, 3][orderkey % 5 + custkey % 7 + 1] > 0 AND orderkey % 5 = 1 AND custkey % 7 = 0", "SELECT custkey, orderdate FROM orders WHERE orderkey % 5 = 1 AND custkey % 7 = 0");
 
-        // filter function on numeric and boolean columnss
-        assertQuery("SELECT linenumber FROM lineitem_ex WHERE if(is_returned, linenumber, orderkey) % 5 = 0", WITH_LINEITEM_EX + "SELECT linenumber FROM lineitem_ex WHERE CASE WHEN is_returned THEN linenumber ELSE orderkey END % 5 = 0");
+        // filter function on numeric and boolean columns
+        assertFilterProject("if(is_returned, linenumber, orderkey) % 5 = 0", "linenumber");
+
+        // filter functions on array columns
+        assertFilterProject("keys[1] % 5 = 0", "orderkey");
+        assertFilterProject("nested_keys[1][1] % 5 = 0", "orderkey");
+
+        assertFilterProject("keys[1] % 5 = 0 AND keys[2] > 100", "orderkey");
+        assertFilterProject("keys[1] % 5 = 0 AND nested_keys[1][2] > 100", "orderkey");
+
+        assertFilterProject("keys[1] % 5 = 0 AND keys[2] % 7 = 0", "orderkey");
+        assertFilterProject("keys[1] % 5 = 0 AND nested_keys[1][2] % 7 = 0", "orderkey");
+
+        assertFilterProject("(cast(keys[1] as integer) + keys[3]) % 5 = 0", "orderkey");
+        assertFilterProject("(cast(keys[1] as integer) + nested_keys[1][2]) % 5 = 0", "orderkey");
+
+        // subscript out of bounds
+        assertQueryFails("SELECT orderkey FROM lineitem_ex WHERE keys[5] % 7 = 0", "Array subscript out of bounds");
+        assertQueryFails("SELECT orderkey FROM lineitem_ex WHERE nested_keys[1][5] % 7 = 0", "Array subscript out of bounds");
+
+        assertQueryFails("SELECT * FROM lineitem_ex WHERE nested_keys[1][5] > 0", "Array subscript out of bounds");
+        assertQueryFails("SELECT orderkey FROM lineitem_ex WHERE nested_keys[1][5] > 0", "Array subscript out of bounds");
+        assertQueryFails("SELECT * FROM lineitem_ex WHERE nested_keys[1][5] > 0 AND orderkey % 5 = 0", "Array subscript out of bounds");
+
+        assertFilterProject("nested_keys[1][5] > 0 AND orderkey % 5 > 10", "keys");
     }
 
     @Test
@@ -201,7 +308,32 @@ public class TestHivePushdownFilterQueries
 
     private void assertQueryUsingH2Cte(String query)
     {
-        assertQuery(query, WITH_LINEITEM_EX + query);
+        assertQuery(query, WITH_LINEITEM_EX + toH2(query));
+    }
+
+    private static String toH2(String query)
+    {
+        return replaceArraySubscripts(query).replaceAll(" if\\(", " casewhen(");
+    }
+
+    private static String replaceArraySubscripts(String query)
+    {
+        Matcher matcher = ARRAY_SUBSCRIPT_PATTERN.matcher(query);
+
+        StringBuilder builder = new StringBuilder();
+        int offset = 0;
+        while (matcher.find()) {
+            String expression = matcher.group(1);
+            List<String> indices = Splitter.onPattern("[^0-9]").omitEmptyStrings().splitToList(matcher.group(2));
+            for (int i = 0; i < indices.size(); i++) {
+                expression = format("array_get(%s, %s)", expression, indices.get(i));
+            }
+
+            builder.append(query, offset, matcher.start()).append(expression);
+            offset = matcher.end();
+        }
+        builder.append(query.substring(offset));
+        return builder.toString();
     }
 
     private static Session noPushdownFilter(Session session)

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -182,6 +182,12 @@
             <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -265,7 +265,7 @@ public class OrcReader
     public OrcSelectiveRecordReader createSelectiveRecordReader(
             Map<Integer, Type> includedColumns,
             List<Integer> outputColumns,
-            Map<Integer, TupleDomainFilter> filters,
+            Map<Integer, Map<Subfield, TupleDomainFilter>> filters,
             List<FilterFunction> filterFunctions,
             Map<Integer, Integer> filterFunctionInputs,
             Map<Integer, List<Subfield>> requiredSubfields,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -28,6 +28,7 @@ import com.facebook.presto.spi.block.BlockLease;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 import io.airlift.slice.Slice;
@@ -76,7 +77,7 @@ public class OrcSelectiveRecordReader
     public OrcSelectiveRecordReader(
             Map<Integer, Type> includedColumns,                 // key: hiveColumnIndex
             List<Integer> outputColumns,                        // elements are hive column indices
-            Map<Integer, TupleDomainFilter> filters,            // key: hiveColumnIndex
+            Map<Integer, Map<Subfield, TupleDomainFilter>> filters, // key: hiveColumnIndex
             List<FilterFunction> filterFunctions,
             Map<Integer, Integer> filterFunctionInputMapping,   // channel-to-hiveColumnIndex mapping for all filter function inputs
             Map<Integer, List<Subfield>> requiredSubfields,     // key: hiveColumnIndex
@@ -199,7 +200,7 @@ public class OrcSelectiveRecordReader
             DateTimeZone hiveStorageTimeZone,
             Map<Integer, Type> includedColumns,
             List<Integer> outputColumns,
-            Map<Integer, TupleDomainFilter> filters,
+            Map<Integer, Map<Subfield, TupleDomainFilter>> filters,
             List<FilterFunction> filterFunctions,
             Map<Integer, Integer> filterFunctionInputMapping,
             Map<Integer, List<Subfield>> requiredSubfields,
@@ -224,7 +225,7 @@ public class OrcSelectiveRecordReader
                 boolean outputRequired = outputColumns.contains(columnId) || filterFunctionInputColumns.contains(columnId);
                 streamReaders[columnId] = createStreamReader(
                         streamDescriptor,
-                        Optional.ofNullable(filters.get(columnId)),
+                        Optional.ofNullable(filters.get(columnId)).orElse(ImmutableMap.of()),
                         outputRequired ? Optional.of(includedColumns.get(columnId)) : Optional.empty(),
                         Optional.ofNullable(requiredSubfields.get(columnId)).orElse(ImmutableList.of()),
                         hiveStorageTimeZone,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -279,6 +279,12 @@ public class OrcSelectiveRecordReader
             return new Page(0);
         }
 
+        for (SelectiveStreamReader reader : getStreamReaders()) {
+            if (reader != null) {
+                reader.throwAnyError(positionsToRead, positionCount);
+            }
+        }
+
         Block[] blocks = new Block[outputColumns.size()];
         for (int i = 0; i < outputColumns.size(); i++) {
             int columnIndex = outputColumns.get(i);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
@@ -58,36 +58,43 @@ public interface TupleDomainFilter
             this.nullAllowed = nullAllowed;
         }
 
+        @Override
         public boolean testNull()
         {
             return nullAllowed;
         }
 
+        @Override
         public boolean testLong(long value)
         {
             throw new UnsupportedOperationException();
         }
 
+        @Override
         public boolean testDouble(double value)
         {
             throw new UnsupportedOperationException();
         }
 
+        @Override
         public boolean testFloat(float value)
         {
             throw new UnsupportedOperationException();
         }
 
+        @Override
         public boolean testDecimal(long low, long high)
         {
             throw new UnsupportedOperationException();
         }
 
+        @Override
         public boolean testBoolean(boolean value)
         {
             throw new UnsupportedOperationException();
         }
 
+        @Override
         public boolean testBytes(byte[] buffer, int offset, int length)
         {
             throw new UnsupportedOperationException();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
@@ -56,6 +56,21 @@ public interface TupleDomainFilter
 
     boolean testBytes(byte[] buffer, int offset, int length);
 
+    /**
+     * When a filter applied to a nested column fails, the whole top-level position should
+     * fail. To enable this functionality, the filter keeps track of the boundaries of
+     * top-level positions and allows the caller to find out where the current top-level
+     * position started and how far it continues.
+     * @return number of positions from the start of the current top-level position up to
+     * the current position (excluding current position)
+     */
+    int getPrecedingPositionsToFail();
+
+    /**
+     * @return number of positions remaining until the end of the current top-level position
+     */
+    int getSucceedingPositionsToFail();
+
     abstract class AbstractTupleDomainFilter
             implements TupleDomainFilter
     {
@@ -113,6 +128,18 @@ public interface TupleDomainFilter
         public boolean testBytes(byte[] buffer, int offset, int length)
         {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getPrecedingPositionsToFail()
+        {
+            return 0;
+        }
+
+        @Override
+        public int getSucceedingPositionsToFail()
+        {
+            return 0;
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractLongSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractLongSelectiveStreamReader.java
@@ -79,6 +79,11 @@ abstract class AbstractLongSelectiveStreamReader
         return outputPositions;
     }
 
+    @Override
+    public void throwAnyError(int[] positions, int positionCount)
+    {
+    }
+
     protected BlockLease buildOutputBlockView(int[] positions, int positionCount, boolean includeNulls)
     {
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractLongSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractLongSelectiveStreamReader.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 
 import java.util.Optional;
 
+import static com.facebook.presto.orc.reader.Arrays.ensureCapacity;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -280,21 +281,10 @@ abstract class AbstractLongSelectiveStreamReader
 
     protected void ensureValuesCapacity(int capacity, boolean recordNulls)
     {
-        if (values == null || values.length < capacity) {
-            values = new long[capacity];
-        }
+        values = ensureCapacity(values, capacity);
 
         if (recordNulls) {
-            if (nulls == null || nulls.length < capacity) {
-                nulls = new boolean[capacity];
-            }
-        }
-    }
-
-    protected void ensureOutputPositionsCapacity(int capacity)
-    {
-        if (outputPositions == null || outputPositions.length < capacity) {
-            outputPositions = new int[capacity];
+            nulls = ensureCapacity(nulls, capacity);
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/Arrays.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/Arrays.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+public class Arrays
+{
+    private Arrays() {}
+
+    public static int[] ensureCapacity(int[] buffer, int capacity)
+    {
+        if (buffer == null || buffer.length < capacity) {
+            return new int[capacity];
+        }
+
+        return buffer;
+    }
+
+    public static long[] ensureCapacity(long[] buffer, int capacity)
+    {
+        if (buffer == null || buffer.length < capacity) {
+            return new long[capacity];
+        }
+
+        return buffer;
+    }
+
+    public static boolean[] ensureCapacity(boolean[] buffer, int capacity)
+    {
+        if (buffer == null || buffer.length < capacity) {
+            return new boolean[capacity];
+        }
+
+        return buffer;
+    }
+
+    public static byte[] ensureCapacity(byte[] buffer, int capacity)
+    {
+        if (buffer == null || buffer.length < capacity) {
+            return new byte[capacity];
+        }
+
+        return buffer;
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
@@ -219,7 +219,22 @@ public class BooleanSelectiveStreamReader
                         outputPositionCount++;
                     }
                 }
+
+                outputPositionCount -= filter.getPrecedingPositionsToFail();
+
                 streamPosition++;
+
+                int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
+                if (succeedingPositionsToFail > 0) {
+                    int positionsToSkip = 0;
+                    for (int j = 0; j < succeedingPositionsToFail; j++) {
+                        i++;
+                        int nextPosition = positions[i];
+                        positionsToSkip += 1 + nextPosition - streamPosition;
+                        streamPosition = nextPosition + 1;
+                    }
+                    skip(positionsToSkip);
+                }
             }
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -162,7 +163,7 @@ public class BooleanSelectiveStreamReader
         }
 
         if (filter != null) {
-            ensureOutputPositionsCapacity(positionCount);
+            outputPositions = ensureCapacity(outputPositions, positionCount);
         }
         else {
             outputPositions = positions;
@@ -310,21 +311,10 @@ public class BooleanSelectiveStreamReader
 
     private void ensureValuesCapacity(int capacity, boolean recordNulls)
     {
-        if (values == null || values.length < capacity) {
-            values = new byte[capacity];
-        }
+        values = ensureCapacity(values, capacity);
 
         if (recordNulls) {
-            if (nulls == null || nulls.length < capacity) {
-                nulls = new boolean[capacity];
-            }
-        }
-    }
-
-    private void ensureOutputPositionsCapacity(int capacity)
-    {
-        if (outputPositions == null || outputPositions.length < capacity) {
-            outputPositions = new int[capacity];
+            nulls = ensureCapacity(nulls, capacity);
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
@@ -405,6 +405,11 @@ public class BooleanSelectiveStreamReader
         return newLease(new ByteArrayBlock(positionCount, Optional.ofNullable(includeNulls ? nulls : null), values));
     }
 
+    @Override
+    public void throwAnyError(int[] positions, int positionCount)
+    {
+    }
+
     private BlockLease newLease(Block block)
     {
         valuesInUse = true;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -141,7 +142,7 @@ public class ByteSelectiveStreamReader
         }
 
         if (filter != null) {
-            ensureOutputPositionsCapacity(positionCount);
+            outputPositions = ensureCapacity(outputPositions, positionCount);
         }
         else {
             outputPositions = positions;
@@ -268,21 +269,10 @@ public class ByteSelectiveStreamReader
 
     private void ensureValuesCapacity(int capacity, boolean recordNulls)
     {
-        if (values == null || values.length < capacity) {
-            values = new byte[capacity];
-        }
+        values = ensureCapacity(values, capacity);
 
         if (recordNulls) {
-            if (nulls == null || nulls.length < capacity) {
-                nulls = new boolean[capacity];
-            }
-        }
-    }
-
-    private void ensureOutputPositionsCapacity(int capacity)
-    {
-        if (outputPositions == null || outputPositions.length < capacity) {
-            outputPositions = new int[capacity];
+            nulls = ensureCapacity(nulls, capacity);
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
@@ -363,6 +363,11 @@ public class ByteSelectiveStreamReader
         return newLease(new ByteArrayBlock(positionCount, Optional.ofNullable(includeNulls ? nulls : null), values));
     }
 
+    @Override
+    public void throwAnyError(int[] positions, int positionCount)
+    {
+    }
+
     private BlockLease newLease(Block block)
     {
         valuesInUse = true;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/HierarchicalFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/HierarchicalFilter.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.orc.TupleDomainFilter;
+import com.facebook.presto.orc.TupleDomainFilter.NullsFilter;
+import com.facebook.presto.orc.TupleDomainFilter.PositionalFilter;
+import com.facebook.presto.spi.Subfield;
+
+import java.util.Map;
+
+public interface HierarchicalFilter
+{
+    HierarchicalFilter getChild();
+
+    // Positional IS [NOT] NULL filters to apply at the next level
+    NullsFilter getNullsFilter();
+
+    // Positional range filters to apply at the very bottom level
+    PositionalFilter getPositionalFilter();
+
+    // Top-level offsets
+    int[] getTopLevelOffsets();
+
+    // Number of valid entries in the top-level offsets array
+    int getTopLevelOffsetCount();
+
+    // Filters per-position; positions with no filters are populated with nulls
+    long[] getElementFilters();
+
+    // Flags indicating top-level positions with at least one subfield with failed filter
+    boolean[] getTopLevelFailed();
+
+    // Flags indicating top-level positions missing elements to apply subfield filters to
+    boolean[] getTopLevelIndexOutOfBounds();
+
+    long getRetainedSizeInBytes();
+
+    static HierarchicalFilter createHierarchicalFilter(StreamDescriptor streamDescriptor, Map<Subfield, TupleDomainFilter> subfieldFilters, int level, HierarchicalFilter parent)
+    {
+        switch (streamDescriptor.getStreamType()) {
+            case LIST:
+                return new ListFilter(streamDescriptor, subfieldFilters, level, parent);
+            case MAP:
+            case STRUCT:
+                throw new UnsupportedOperationException();
+            default:
+                return null;
+        }
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListFilter.java
@@ -1,0 +1,436 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.orc.TupleDomainFilter;
+import com.facebook.presto.orc.TupleDomainFilter.NullsFilter;
+import com.facebook.presto.orc.TupleDomainFilter.PositionalFilter;
+import com.facebook.presto.spi.Subfield;
+import org.openjdk.jol.info.ClassLayout;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import static com.facebook.presto.orc.TupleDomainFilter.IS_NOT_NULL;
+import static com.facebook.presto.orc.TupleDomainFilter.IS_NULL;
+import static com.facebook.presto.orc.reader.HierarchicalFilter.createHierarchicalFilter;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Long.numberOfTrailingZeros;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class ListFilter
+        implements HierarchicalFilter
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ListFilter.class).instanceSize();
+
+    @Nullable
+    private final HierarchicalFilter parent;
+    @Nullable
+    private final HierarchicalFilter child;
+
+    // Array of filters in a fixed order
+    private final TupleDomainFilter[] tupleDomainFilters;
+
+    // Set only at the deepest level
+    @Nullable
+    private final PositionalFilter positionalFilter;
+
+    // filter per position; populated only at the deepest level
+    // used to setup positionalFilter
+    private TupleDomainFilter[] elementTupleDomainFilters;
+
+    // filters per subscript: subscriptFilters[subscript - 1] = {"> 3", "= 10"}
+    // individual subscripts may have multiple filters
+    // for example, consider this filter: a[1][2] > 3 and a[1][4] = 10 and a[3][2] < 100
+    //  - at level 0, subscript 1 has 2 filters (> 3, = 10) and subscript 3 has one filter (< 100)
+    //  - at level 2, subscript 2 has 2 filters (> 3, < 100), subscript 4 has one filter (= 10)
+    // each value represents multiple filters - the long value has bits corresponding to filter
+    // indices in tupleDomainFilters array set
+    private final long[] subscriptFilters;
+
+    // filters per position; positions with no filters are populated with nulls
+    private long[] elementFilters;
+
+    // offsets into elementFilters array identifying ranges corresponding to individual top-level values
+    private int[] topLevelOffsets;
+
+    // number of valid entries in topLevelOffsets array, e.g. number of top-level positions
+    private int topLevelOffsetCount;
+
+    // IS [NOT] NULL filters that apply to this level
+    private final long nullFilters;
+
+    // IS [NOT] NULL positional filters
+    private final NullsFilter nullsFilter;
+
+    // positions with nulls allowed, e.g. positions with no filter or with IS NULL filter; used to setup nullsFilter
+    private boolean[] nullsAllowed;
+
+    // positions with non-nulls allowed, e.g. positions with no filter or with IS NOT NULL filter; used to setup nullsFilter
+    private boolean[] nonNullsAllowed;
+
+    // top-level positions with "Array index out of bounds" errors
+    private boolean[] indexOutOfBounds;
+
+    public ListFilter(StreamDescriptor streamDescriptor, Map<Subfield, TupleDomainFilter> subfieldFilters)
+    {
+        this(streamDescriptor, subfieldFilters, 0, null);
+    }
+
+    public ListFilter(StreamDescriptor streamDescriptor, Map<Subfield, TupleDomainFilter> subfieldFilters, int level, HierarchicalFilter parent)
+    {
+        requireNonNull(streamDescriptor, "streamDescriptor is null");
+        requireNonNull(subfieldFilters, "subfieldFilters is null");
+        checkArgument(!subfieldFilters.isEmpty(), "subfieldFilters is empty");
+        checkArgument(subfieldFilters.size() <= 64, "Number of filters cannot exceed 64");
+        checkArgument((level == 0 && parent == null) || (level > 0 && parent != null), "parent must be null for top-level filter and non-null otherwise");
+
+        this.parent = parent;
+        tupleDomainFilters = subfieldFilters.values().toArray(new TupleDomainFilter[0]);
+        subscriptFilters = extractFilters(subfieldFilters, level, subfield -> subfield.getPath().size() > level);
+        nullFilters = combineFilters(extractFilters(subfieldFilters, level, subfield -> subfield.getPath().size() == level + 1));
+        if (nullFilters > 0) {
+            nullsFilter = new NullsFilter();
+        }
+        else {
+            nullsFilter = null;
+        }
+
+        StreamDescriptor elementStreamDescriptor = streamDescriptor.getNestedStreams().get(0);
+        child = createHierarchicalFilter(elementStreamDescriptor, subfieldFilters, level + 1, this);
+        if (child == null) {
+            positionalFilter = new PositionalFilter();
+        }
+        else {
+            positionalFilter = null;
+        }
+    }
+
+    public HierarchicalFilter getParent()
+    {
+        return parent;
+    }
+
+    @Override
+    public HierarchicalFilter getChild()
+    {
+        return child;
+    }
+
+    @Override
+    public NullsFilter getNullsFilter()
+    {
+        return nullsFilter;
+    }
+
+    @Override
+    public int[] getTopLevelOffsets()
+    {
+        return topLevelOffsets;
+    }
+
+    @Override
+    public int getTopLevelOffsetCount()
+    {
+        return topLevelOffsetCount;
+    }
+
+    @Override
+    public long[] getElementFilters()
+    {
+        return elementFilters;
+    }
+
+    @Override
+    public PositionalFilter getPositionalFilter()
+    {
+        return positionalFilter;
+    }
+
+    public void populateElementFilters(int positionCount, boolean[] nulls, int[] lengths, int lengthSum)
+    {
+        elementFilters = ensureCapacity(elementFilters, lengthSum);
+
+        if (parent == null) {
+            topLevelOffsetCount = positionCount + 1;
+        }
+        else {
+            topLevelOffsetCount = parent.getTopLevelOffsetCount();
+        }
+        topLevelOffsets = ensureCapacity(topLevelOffsets, topLevelOffsetCount);
+        indexOutOfBounds = ensureCapacity(indexOutOfBounds, topLevelOffsetCount);
+        Arrays.fill(indexOutOfBounds, 0, topLevelOffsetCount, false);
+
+        int elementPosition = 0;
+        if (parent == null) {   // top-level filter
+            for (int i = 0; i < positionCount; i++) {
+                topLevelOffsets[i] = elementPosition;
+
+                for (int j = 0; j < lengths[i]; j++) {
+                    if (j < subscriptFilters.length) {
+                        elementFilters[elementPosition] = subscriptFilters[j];
+                    }
+                    else {
+                        elementFilters[elementPosition] = 0;
+                    }
+                    elementPosition++;
+                }
+
+                if (nulls == null || !nulls[i]) {
+                    for (int j = lengths[i]; j < subscriptFilters.length; j++) {
+                        if (subscriptFilters[j] > 0) {
+                            // this entry doesn't have enough elements for all filters,
+                            // hence, raise "Array index out of bound" error
+                            indexOutOfBounds[i] = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            int[] parentTopLevelOffsets = updateParentTopLevelOffsets();
+            long[] parentElementFilters = parent.getElementFilters();
+
+            int offsetIndex = 0;
+            int nextOffset = parentTopLevelOffsets[offsetIndex + 1];
+            for (int i = 0; i < positionCount; i++) {
+                while (i == nextOffset) {   // there might be duplicate offsets (if some offsets failed)
+                    offsetIndex++;
+                    topLevelOffsets[offsetIndex] = elementPosition;
+                    nextOffset = parentTopLevelOffsets[offsetIndex + 1];
+                }
+
+                long parentElementFilter = parentElementFilters[i];
+                for (int j = 0; j < lengths[i]; j++) {
+                    if (subscriptFilters != null && j < subscriptFilters.length) {
+                        elementFilters[elementPosition] = parentElementFilter & subscriptFilters[j];
+                    }
+                    else {
+                        elementFilters[elementPosition] = 0;
+                    }
+                    elementPosition++;
+                }
+
+                if (subscriptFilters != null && (nulls == null || !nulls[i])) {
+                    for (int j = lengths[i]; j < subscriptFilters.length; j++) {
+                        if ((parentElementFilter & subscriptFilters[j]) > 0) {
+                            // this entry doesn't have enough elements for all filters,
+                            // hence, raise "Array index out of bound" error
+                            indexOutOfBounds[offsetIndex] = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            while (offsetIndex < topLevelOffsetCount - 1) {
+                offsetIndex++;
+                topLevelOffsets[offsetIndex] = elementPosition;
+            }
+        }
+        topLevelOffsets[topLevelOffsetCount - 1] = elementPosition;
+
+        if (positionalFilter != null) {
+            setupPositionalFilter();
+        }
+        else if (nullsFilter != null) {
+            setupNullsFilter();
+        }
+    }
+
+    // update parentTopLevelOffsets to take into account failed positions
+    private int[] updateParentTopLevelOffsets()
+    {
+        int[] parentTopLevelOffsets = parent.getTopLevelOffsets();
+
+        NullsFilter nullsFilter = parent.getNullsFilter();
+        if (nullsFilter != null) {
+            boolean[] failed = nullsFilter.getFailed();
+            int skipped = 0;
+            for (int i = 0; i < topLevelOffsetCount - 1; i++) {
+                parentTopLevelOffsets[i] -= skipped;
+                if (failed[i]) {
+                    skipped += parentTopLevelOffsets[i + 1] - parentTopLevelOffsets[i] - skipped;
+                }
+            }
+            parentTopLevelOffsets[topLevelOffsetCount - 1] -= skipped;
+        }
+
+        return parentTopLevelOffsets;
+    }
+
+    private void setupPositionalFilter()
+    {
+        int count = topLevelOffsets[topLevelOffsetCount - 1];
+        if (elementTupleDomainFilters == null || elementTupleDomainFilters.length < count) {
+            elementTupleDomainFilters = new TupleDomainFilter[count];
+        }
+        for (int i = 0; i < count; i++) {
+            long filter = elementFilters[i];
+            if (filter > 0) {
+                elementTupleDomainFilters[i] = tupleDomainFilters[numberOfTrailingZeros(filter)];
+            }
+            else {
+                elementTupleDomainFilters[i] = null;
+            }
+        }
+        positionalFilter.setFilters(elementTupleDomainFilters, topLevelOffsets);
+    }
+
+    private void setupNullsFilter()
+    {
+        int count = topLevelOffsets[topLevelOffsetCount - 1];
+        nullsAllowed = ensureCapacity(nullsAllowed, count);
+        nonNullsAllowed = ensureCapacity(nonNullsAllowed, count);
+
+        for (int i = 0; i < count; i++) {
+            long filter = elementFilters[i] & nullFilters;
+            if (filter > 0) {
+                TupleDomainFilter tupleDomainFilter = tupleDomainFilters[numberOfTrailingZeros(filter)];
+                nullsAllowed[i] = tupleDomainFilter == IS_NULL;
+                nonNullsAllowed[i] = tupleDomainFilter == IS_NOT_NULL;
+            }
+            else {
+                nullsAllowed[i] = true;
+                nonNullsAllowed[i] = true;
+            }
+        }
+        nullsFilter.setup(nullsAllowed, nonNullsAllowed, topLevelOffsets);
+    }
+
+    @Override
+    public boolean[] getTopLevelFailed()
+    {
+        if (child == null) {
+            return positionalFilter.getFailed();
+        }
+
+        boolean[] failed = child.getTopLevelFailed();
+        if (nullsFilter != null) {
+            for (int i = 0; i < failed.length; i++) {
+                failed[i] |= nullsFilter.getFailed()[i];
+            }
+        }
+
+        return failed;
+    }
+
+    @Override
+    public boolean[] getTopLevelIndexOutOfBounds()
+    {
+        if (child == null) {
+            return indexOutOfBounds;
+        }
+
+        boolean[] indexOutOfBounds = child.getTopLevelIndexOutOfBounds();
+        for (int i = 0; i < indexOutOfBounds.length; i++) {
+            indexOutOfBounds[i] |= this.indexOutOfBounds[i];
+        }
+
+        return indexOutOfBounds;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(elementFilters) + sizeOf(tupleDomainFilters) + sizeOf(subscriptFilters) +
+                sizeOf(elementTupleDomainFilters) + sizeOf(topLevelOffsets) +
+                sizeOf(nonNullsAllowed) + sizeOf(nullsAllowed) + sizeOf(indexOutOfBounds) +
+                (child != null ? child.getRetainedSizeInBytes() : 0);
+    }
+
+    private static long[] extractFilters(Map<Subfield, TupleDomainFilter> filters, int level, Predicate<Subfield> predicate)
+    {
+        int maxSubscript = -1;
+        int[] subscripts = new int[filters.size()];
+        int index = 0;
+        for (Subfield subfield : filters.keySet()) {
+            if (predicate.test(subfield)) {
+                subscripts[index] = toSubscript(subfield, level);
+                maxSubscript = Math.max(maxSubscript, subscripts[index]);
+            }
+            else {
+                subscripts[index] = -1;
+            }
+            index++;
+        }
+
+        if (maxSubscript == -1) {
+            return null;
+        }
+
+        long[] filterCodes = new long[maxSubscript + 1];
+        for (int i = 0; i < subscripts.length; i++) {
+            if (subscripts[i] != -1) {
+                filterCodes[subscripts[i]] |= 1 << i;
+            }
+        }
+
+        return filterCodes;
+    }
+
+    private static int toSubscript(Subfield subfield, int level)
+    {
+        checkArgument(subfield.getPath().size() > level);
+        checkArgument(subfield.getPath().get(level) instanceof Subfield.LongSubscript);
+
+        return toIntExact(((Subfield.LongSubscript) subfield.getPath().get(level)).getIndex()) - 1;
+    }
+
+    private static long combineFilters(long[] filters)
+    {
+        if (filters == null) {
+            return 0;
+        }
+
+        int combined = 0;
+        for (long filter : filters) {
+            combined |= filter;
+        }
+        return combined;
+    }
+
+    private static int[] ensureCapacity(int[] buffer, int capacity)
+    {
+        if (buffer == null || buffer.length < capacity) {
+            return new int[capacity];
+        }
+
+        return buffer;
+    }
+
+    private static long[] ensureCapacity(long[] buffer, int capacity)
+    {
+        if (buffer == null || buffer.length < capacity) {
+            return new long[capacity];
+        }
+
+        return buffer;
+    }
+
+    private static boolean[] ensureCapacity(boolean[] buffer, int capacity)
+    {
+        if (buffer == null || buffer.length < capacity) {
+            return new boolean[capacity];
+        }
+
+        return buffer;
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
@@ -1,0 +1,688 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.memory.context.AggregatedMemoryContext;
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.orc.TupleDomainFilter;
+import com.facebook.presto.orc.TupleDomainFilter.NullsFilter;
+import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.stream.BooleanInputStream;
+import com.facebook.presto.orc.stream.InputStreamSource;
+import com.facebook.presto.orc.stream.InputStreamSources;
+import com.facebook.presto.orc.stream.LongInputStream;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.Subfield;
+import com.facebook.presto.spi.block.ArrayBlock;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockLease;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import org.joda.time.DateTimeZone;
+import org.openjdk.jol.info.ClassLayout;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.orc.TupleDomainFilter.IS_NOT_NULL;
+import static com.facebook.presto.orc.TupleDomainFilter.IS_NULL;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.Arrays.ensureCapacity;
+import static com.facebook.presto.orc.reader.SelectiveStreamReaders.createNestedStreamReader;
+import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.block.ClosingBlockLease.newLease;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class ListSelectiveStreamReader
+        implements SelectiveStreamReader
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ListSelectiveStreamReader.class).instanceSize();
+
+    private final StreamDescriptor streamDescriptor;
+    private final int level;
+    private final ListFilter listFilter;
+    private final NullsFilter nullsFilter;
+    private final boolean nullsAllowed;
+    private final boolean nonNullsAllowed;
+    private final boolean outputRequired;
+    @Nullable
+    private final Type outputType;
+    // elementStreamReader is null if output is not required and filter is a simple IS [NOT] NULL
+    @Nullable
+    private final SelectiveStreamReader elementStreamReader;
+    private final LocalMemoryContext systemMemoryContext;
+
+    private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
+    @Nullable
+    private BooleanInputStream presentStream;
+
+    private InputStreamSource<LongInputStream> lengthStreamSource = missingStreamSource(LongInputStream.class);
+    @Nullable
+    private LongInputStream lengthStream;
+
+    private boolean rowGroupOpen;
+    private int readOffset;
+    @Nullable
+    private int[] offsets;
+    @Nullable
+    private boolean[] nulls;
+    @Nullable
+    private int[] outputPositions;
+    private int outputPositionCount;
+    private boolean[] indexOutOfBounds;
+    private boolean allNulls;
+
+    private int elementReadOffset;          // offset within elementStream relative to row group start
+    private int[] elementOffsets;           // offsets within elementStream relative to elementReadOffset
+    private int[] elementLengths;           // aligned with elementOffsets
+    private int[] elementPositions;         // positions in elementStream corresponding to positions passed to read(); relative to elementReadOffset
+    private int elementOutputPositionCount;
+    private int[] elementOutputPositions;
+
+    private boolean valuesInUse;
+
+    public ListSelectiveStreamReader(
+            StreamDescriptor streamDescriptor,
+            Map<Subfield, TupleDomainFilter> filters,
+            List<Subfield> subfields,
+            ListFilter listFilter,
+            int subfieldLevel,  // 0 - top level
+            Optional<Type> outputType,
+            DateTimeZone hiveStorageTimeZone,
+            AggregatedMemoryContext systemMemoryContext)
+    {
+        requireNonNull(filters, "filters is null");
+        requireNonNull(subfields, "subfields is null");
+        requireNonNull(systemMemoryContext, "systemMemoryContext is null");
+
+        checkArgument(subfields.isEmpty(), "Subfield pruning is not supported yet");
+
+        if (listFilter != null) {
+            checkArgument(subfieldLevel > 0, "SubfieldFilter is not expected at the top level");
+            checkArgument(filters.isEmpty(), "Range filters are not expected at mid level");
+        }
+
+        this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
+        this.outputRequired = requireNonNull(outputType, "outputType is null").isPresent();
+        this.outputType = outputType.orElse(null);
+        this.level = subfieldLevel;
+
+        if (listFilter != null) {
+            nullsAllowed = true;
+            nonNullsAllowed = true;
+            this.listFilter = listFilter;
+            nullsFilter = listFilter.getParent().getNullsFilter();
+        }
+        else if (!filters.isEmpty()) {
+            Optional<TupleDomainFilter> topLevelFilter = getTopLevelFilter(filters);
+            if (topLevelFilter.isPresent()) {
+                nullsAllowed = topLevelFilter.get() == IS_NULL;
+                nonNullsAllowed = !nullsAllowed;
+            }
+            else {
+                nullsAllowed = filters.values().stream().allMatch(TupleDomainFilter::testNull);
+                nonNullsAllowed = true;
+            }
+
+            if (filters.keySet().stream().anyMatch(path -> !path.getPath().isEmpty())) {
+                this.listFilter = new ListFilter(streamDescriptor, filters);
+            }
+            else {
+                this.listFilter = null;
+            }
+
+            nullsFilter = null;
+        }
+        else {
+            nullsAllowed = true;
+            nonNullsAllowed = true;
+            this.listFilter = null;
+            nullsFilter = null;
+        }
+
+        StreamDescriptor elementStreamDescriptor = streamDescriptor.getNestedStreams().get(0);
+        Optional<Type> elementOutputType = outputType.map(type -> type.getTypeParameters().get(0));
+
+        this.elementStreamReader = createNestedStreamReader(elementStreamDescriptor, level + 1, Optional.ofNullable(this.listFilter), elementOutputType, hiveStorageTimeZone, systemMemoryContext);
+        this.systemMemoryContext = systemMemoryContext.newLocalMemoryContext(ListSelectiveStreamReader.class.getSimpleName());
+    }
+
+    private static Optional<TupleDomainFilter> getTopLevelFilter(Map<Subfield, TupleDomainFilter> filters)
+    {
+        Map<Subfield, TupleDomainFilter> topLevelFilters = Maps.filterEntries(filters, entry -> entry.getKey().getPath().isEmpty());
+        if (topLevelFilters.isEmpty()) {
+            return Optional.empty();
+        }
+
+        checkArgument(topLevelFilters.size() == 1, "ARRAY column may have at most one top-level range filter");
+        TupleDomainFilter filter = Iterables.getOnlyElement(topLevelFilters.values());
+        checkArgument(filter == IS_NULL || filter == IS_NOT_NULL, "Top-level range filter on ARRAY column must be IS NULL or IS NOT NULL");
+        return Optional.of(filter);
+    }
+
+    @Override
+    public int read(int offset, int[] positions, int positionCount)
+            throws IOException
+    {
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
+        if (!rowGroupOpen) {
+            openRowGroup();
+        }
+
+        allNulls = false;
+
+        if (outputRequired) {
+            offsets = ensureCapacity(offsets, positionCount + 1);
+        }
+
+        if (nullsAllowed && presentStream != null && (outputRequired || listFilter != null)) {
+            nulls = ensureCapacity(nulls, positionCount);
+        }
+
+        if (!(nullsAllowed && nonNullsAllowed) || nullsFilter != null || listFilter != null) {
+            outputPositions = ensureCapacity(outputPositions, positionCount);
+        }
+        else {
+            outputPositions = positions;
+        }
+
+        systemMemoryContext.setBytes(getRetainedSizeInBytes());
+
+        if (readOffset < offset) {
+            elementReadOffset += skip(offset - readOffset);
+        }
+
+        int streamPosition;
+        if (lengthStream == null && presentStream != null) {
+            streamPosition = readAllNulls(positions, positionCount);
+        }
+        else {
+            streamPosition = readNotAllNulls(positions, positionCount);
+        }
+
+        readOffset = offset + streamPosition;
+        return outputPositionCount;
+    }
+
+    private void openRowGroup()
+            throws IOException
+    {
+        presentStream = presentStreamSource.openStream();
+        lengthStream = lengthStreamSource.openStream();
+
+        rowGroupOpen = true;
+    }
+
+    private int skip(int items)
+            throws IOException
+    {
+        if (lengthStream == null) {
+            presentStream.skip(items);
+            return 0;
+        }
+
+        if (presentStream != null) {
+            int lengthsToSkip = presentStream.countBitsSet(items);
+            return toIntExact(lengthStream.sum(lengthsToSkip));
+        }
+
+        return toIntExact(lengthStream.sum(items));
+    }
+
+    private int readAllNulls(int[] positions, int positionCount)
+            throws IOException
+    {
+        presentStream.skip(positions[positionCount - 1]);
+
+        if (nullsAllowed) {
+            if (nullsFilter != null) {
+                for (int i = 0; i < positionCount; i++) {
+                    if (nullsFilter.testNull()) {
+                        outputPositionCount++;
+                    }
+                }
+            }
+            else {
+                outputPositionCount = positionCount;
+                allNulls = true;
+            }
+        }
+        else {
+            outputPositionCount = 0;
+        }
+
+        return positions[positionCount - 1] + 1;
+    }
+
+    private int readNotAllNulls(int[] positions, int positionCount)
+            throws IOException
+    {
+        // populate elementOffsets, elementLengths, and nulls
+        elementOffsets = ensureCapacity(elementOffsets, positionCount + 1);
+        elementLengths = ensureCapacity(elementLengths, positionCount);
+
+        systemMemoryContext.setBytes(getRetainedSizeInBytes());
+
+        int streamPosition = 0;
+        int skippedElements = 0;
+        int elementPositionCount = 0;
+
+        outputPositionCount = 0;
+
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            if (position > streamPosition) {
+                skippedElements += skip(position - streamPosition);
+                streamPosition = position;
+            }
+
+            if (presentStream != null && !presentStream.nextBit()) {
+                if (nullsAllowed && (nullsFilter == null || nullsFilter.testNull())) {
+                    if (outputRequired || listFilter != null) {
+                        nulls[outputPositionCount] = true;
+                    }
+
+                    elementOffsets[outputPositionCount] = elementPositionCount + skippedElements;
+                    elementLengths[outputPositionCount] = 0;
+
+                    outputPositions[outputPositionCount] = position;
+                    outputPositionCount++;
+                }
+            }
+            else {
+                int length = toIntExact(lengthStream.next());
+
+                if (nonNullsAllowed && (nullsFilter == null || nullsFilter.testNonNull())) {
+                    elementOffsets[outputPositionCount] = elementPositionCount + skippedElements;
+                    elementLengths[outputPositionCount] = length;
+
+                    elementPositionCount += length;
+
+                    if ((outputRequired || listFilter != null) && nullsAllowed && presentStream != null) {
+                        nulls[outputPositionCount] = false;
+                    }
+
+                    outputPositions[outputPositionCount] = position;
+                    outputPositionCount++;
+                }
+                else {
+                    skippedElements += length;
+                }
+            }
+
+            streamPosition++;
+
+            if (nullsFilter != null) {
+                int precedingPositionsToFail = nullsFilter.getPrecedingPositionsToFail();
+
+                for (int j = 0; j < precedingPositionsToFail; j++) {
+                    int length = elementLengths[outputPositionCount - 1 - j];
+                    skippedElements += length;
+                    elementPositionCount -= length;
+                }
+                outputPositionCount -= precedingPositionsToFail;
+
+                int succeedingPositionsToFail = nullsFilter.getSucceedingPositionsToFail();
+                if (succeedingPositionsToFail > 0) {
+                    int positionsToSkip = 0;
+                    for (int j = 0; j < succeedingPositionsToFail; j++) {
+                        i++;
+                        int nextPosition = positions[i];
+                        positionsToSkip += 1 + nextPosition - streamPosition;
+                        streamPosition = nextPosition + 1;
+                    }
+                    skippedElements += skip(positionsToSkip);
+                }
+            }
+        }
+        elementOffsets[outputPositionCount] = elementPositionCount + skippedElements;
+
+        populateElementPositions(elementPositionCount);
+
+        if (listFilter != null) {
+            listFilter.populateElementFilters(outputPositionCount, nulls, elementLengths, elementPositionCount);
+        }
+
+        if (elementStreamReader != null) {
+            elementStreamReader.read(elementReadOffset, elementPositions, elementPositionCount);
+        }
+        elementReadOffset += elementPositionCount + skippedElements;
+
+        if (listFilter == null || level > 0) {
+            populateOutputPositionsNoFilter(elementPositionCount);
+        }
+        else {
+            populateOutputPositionsWithFilter(elementPositionCount);
+        }
+
+        return streamPosition;
+    }
+
+    private void populateElementPositions(int elementPositionCount)
+    {
+        elementPositions = ensureCapacity(elementPositions, elementPositionCount);
+
+        int index = 0;
+        for (int i = 0; i < outputPositionCount; i++) {
+            for (int j = 0; j < elementLengths[i]; j++) {
+                elementPositions[index] = elementOffsets[i] + j;
+                index++;
+            }
+        }
+    }
+
+    private void populateOutputPositionsNoFilter(int elementPositionCount)
+    {
+        if (outputRequired) {
+            elementOutputPositionCount = elementPositionCount;
+            elementOutputPositions = ensureCapacity(elementOutputPositions, elementPositionCount);
+            System.arraycopy(elementPositions, 0, elementOutputPositions, 0, elementPositionCount);
+
+            int offset = 0;
+            for (int i = 0; i < outputPositionCount; i++) {
+                offsets[i] = offset;
+                offset += elementLengths[i];
+            }
+            offsets[outputPositionCount] = offset;
+        }
+    }
+
+    private void populateOutputPositionsWithFilter(int elementPositionCount)
+    {
+        elementOutputPositionCount = 0;
+        elementOutputPositions = ensureCapacity(elementOutputPositions, elementPositionCount);
+
+        indexOutOfBounds = listFilter.getTopLevelIndexOutOfBounds();
+
+        int outputPosition = 0;
+        int elementOffset = 0;
+        boolean[] positionsFailed = listFilter.getTopLevelFailed();
+        for (int i = 0; i < outputPositionCount; i++) {
+            if (!positionsFailed[i]) {
+                indexOutOfBounds[outputPosition] = indexOutOfBounds[i];
+                outputPositions[outputPosition] = outputPositions[i];
+                if (outputRequired) {
+                    if (nullsAllowed && presentStream != null) {
+                        nulls[outputPosition] = nulls[i];
+                    }
+                    offsets[outputPosition] = elementOutputPositionCount;
+                    for (int j = 0; j < elementLengths[i]; j++) {
+                        elementOutputPositions[elementOutputPositionCount] = elementPositions[elementOffset + j];
+                        elementOutputPositionCount++;
+                    }
+                }
+                outputPosition++;
+            }
+            elementOffset += elementLengths[i];
+        }
+        if (outputRequired) {
+            this.offsets[outputPosition] = elementOutputPositionCount;
+        }
+
+        outputPositionCount = outputPosition;
+    }
+
+    @Override
+    public int[] getReadPositions()
+    {
+        return outputPositions;
+    }
+
+    @Override
+    public Block getBlock(int[] positions, int positionCount)
+    {
+        checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
+        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(positionCount <= outputPositionCount, "Not enough values: " + outputPositionCount + ", " + positionCount);
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
+        if (allNulls) {
+            return new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), outputPositionCount);
+        }
+
+        boolean mayHaveNulls = nullsAllowed && presentStream != null;
+
+        if (positionCount == outputPositionCount) {
+            if (elementOutputPositionCount == 0) {
+                return new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), outputPositionCount);
+            }
+
+            Block block = ArrayBlock.fromElementBlock(positionCount, Optional.ofNullable(mayHaveNulls ? nulls : null), offsets, elementStreamReader.getBlock(elementOutputPositions, elementOutputPositionCount));
+            nulls = null;
+            offsets = null;
+            return block;
+        }
+
+        int[] offsetsCopy = new int[positionCount + 1];
+        boolean[] nullsCopy = null;
+        if (mayHaveNulls) {
+            nullsCopy = new boolean[positionCount];
+        }
+
+        elementOutputPositionCount = 0;
+
+        int positionIndex = 0;
+        int nextPosition = positions[positionIndex];
+        int skippedElements = 0;
+        for (int i = 0; i < outputPositionCount; i++) {
+            if (outputPositions[i] < nextPosition) {
+                skippedElements += offsets[i + 1] - offsets[i];
+                continue;
+            }
+
+            assert outputPositions[i] == nextPosition;
+
+            offsetsCopy[positionIndex] = this.offsets[i] - skippedElements;
+            if (nullsCopy != null) {
+                nullsCopy[positionIndex] = this.nulls[i];
+            }
+            for (int j = 0; j < offsets[i + 1] - offsets[i]; j++) {
+                elementOutputPositions[elementOutputPositionCount] = elementOutputPositions[elementOutputPositionCount + skippedElements];
+                elementOutputPositionCount++;
+            }
+
+            positionIndex++;
+            if (positionIndex >= positionCount) {
+                offsetsCopy[positionCount] = this.offsets[i + 1] - skippedElements;
+                break;
+            }
+
+            nextPosition = positions[positionIndex];
+        }
+
+        return ArrayBlock.fromElementBlock(positionCount, Optional.ofNullable(nullsCopy), offsetsCopy, elementStreamReader.getBlock(elementOutputPositions, elementOutputPositionCount));
+    }
+
+    @Override
+    public BlockLease getBlockView(int[] positions, int positionCount)
+    {
+        checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
+        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(positionCount <= outputPositionCount, "Not enough values");
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
+        if (allNulls) {
+            return newLease(new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), outputPositionCount));
+        }
+
+        boolean includeNulls = nullsAllowed && presentStream != null;
+        if (positionCount != outputPositionCount) {
+            compactValues(positions, positionCount, includeNulls);
+        }
+
+        if (elementOutputPositionCount == 0) {
+            return newLease(new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), positionCount));
+        }
+
+        valuesInUse = true;
+        BlockLease elementBlockLease = elementStreamReader.getBlockView(elementOutputPositions, elementOutputPositionCount);
+        Block block = ArrayBlock.fromElementBlock(positionCount, Optional.ofNullable(includeNulls ? nulls : null), offsets, elementBlockLease.get());
+        return newLease(block, () -> closeBlockLease(elementBlockLease));
+    }
+
+    @Override
+    public void throwAnyError(int[] positions, int positionCount)
+    {
+        if (indexOutOfBounds == null) {
+            return;
+        }
+
+        int positionIndex = 0;
+        int nextPosition = positions[positionIndex];
+        for (int i = 0; i < outputPositionCount; i++) {
+            if (outputPositions[i] < nextPosition) {
+                continue;
+            }
+
+            assert outputPositions[i] == nextPosition;
+
+            if (indexOutOfBounds[i]) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Array subscript out of bounds");
+            }
+
+            positionIndex++;
+            if (positionIndex >= positionCount) {
+                break;
+            }
+
+            nextPosition = positions[positionIndex];
+        }
+    }
+
+    private void closeBlockLease(BlockLease elementBlockLease)
+    {
+        elementBlockLease.close();
+        valuesInUse = false;
+    }
+
+    private void compactValues(int[] positions, int positionCount, boolean compactNulls)
+    {
+        int positionIndex = 0;
+        int nextPosition = positions[positionIndex];
+        int skippedElements = 0;
+        elementOutputPositionCount = 0;
+        for (int i = 0; i < outputPositionCount; i++) {
+            if (outputPositions[i] < nextPosition) {
+                skippedElements += offsets[i + 1] - offsets[i];
+                continue;
+            }
+
+            assert outputPositions[i] == nextPosition;
+
+            for (int j = 0; j < offsets[i + 1] - offsets[i]; j++) {
+                elementOutputPositions[elementOutputPositionCount] = elementOutputPositions[elementOutputPositionCount + skippedElements];
+                elementOutputPositionCount++;
+            }
+
+            offsets[positionIndex] = offsets[i] - skippedElements;
+            if (compactNulls) {
+                nulls[positionIndex] = nulls[i];
+            }
+            outputPositions[positionIndex] = nextPosition;
+            if (indexOutOfBounds != null) {
+                indexOutOfBounds[positionIndex] = indexOutOfBounds[i];
+            }
+
+            positionIndex++;
+            if (positionIndex >= positionCount) {
+                offsets[positionCount] = offsets[i + 1] - skippedElements;
+                break;
+            }
+            nextPosition = positions[positionIndex];
+        }
+
+        outputPositionCount = positionCount;
+    }
+
+    @Override
+    public void close()
+    {
+        if (elementStreamReader != null) {
+            elementStreamReader.close();
+        }
+    }
+
+    @Override
+    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+            throws IOException
+    {
+        presentStreamSource = missingStreamSource(BooleanInputStream.class);
+        lengthStreamSource = missingStreamSource(LongInputStream.class);
+
+        readOffset = 0;
+        elementReadOffset = 0;
+
+        presentStream = null;
+        lengthStream = null;
+
+        rowGroupOpen = false;
+
+        if (elementStreamReader != null) {
+            elementStreamReader.startStripe(dictionaryStreamSources, encoding);
+        }
+    }
+
+    @Override
+    public void startRowGroup(InputStreamSources dataStreamSources)
+            throws IOException
+    {
+        presentStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, PRESENT, BooleanInputStream.class);
+        lengthStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, LENGTH, LongInputStream.class);
+
+        readOffset = 0;
+        elementReadOffset = 0;
+
+        presentStream = null;
+        lengthStream = null;
+
+        rowGroupOpen = false;
+
+        if (elementStreamReader != null) {
+            elementStreamReader.startRowGroup(dataStreamSources);
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(streamDescriptor)
+                .toString();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(offsets) + sizeOf(nulls) + sizeOf(outputPositions) + sizeOf(indexOutOfBounds) +
+                sizeOf(elementOffsets) + sizeOf(elementLengths) + sizeOf(elementPositions) +
+                sizeOf(elementOutputPositions) +
+                (listFilter != null ? listFilter.getRetainedSizeInBytes() : 0) +
+                (elementStreamReader != null ? elementStreamReader.getRetainedSizeInBytes() : 0);
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
@@ -155,7 +155,24 @@ public class LongDictionarySelectiveStreamReader
                     outputPositionCount++;
                 }
             }
+
             streamPosition++;
+
+            if (filter != null) {
+                outputPositionCount -= filter.getPrecedingPositionsToFail();
+
+                int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
+                if (succeedingPositionsToFail > 0) {
+                    int positionsToSkip = 0;
+                    for (int j = 0; j < succeedingPositionsToFail; j++) {
+                        i++;
+                        int nextPosition = positions[i];
+                        positionsToSkip += 1 + nextPosition - streamPosition;
+                        streamPosition = nextPosition + 1;
+                    }
+                    skip(positionsToSkip);
+                }
+            }
         }
 
         readOffset = offset + streamPosition;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
@@ -37,6 +37,7 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.IN_DICTIONARY;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -103,7 +104,7 @@ public class LongDictionarySelectiveStreamReader
         prepareNextRead(positionCount, presentStream != null && nullsAllowed);
 
         if (filter != null) {
-            ensureOutputPositionsCapacity(positionCount);
+            outputPositions = ensureCapacity(outputPositions, positionCount);
         }
         else {
             outputPositions = positions;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
@@ -148,7 +148,24 @@ public class LongDirectSelectiveStreamReader
                         outputPositionCount++;
                     }
                 }
+
                 streamPosition++;
+
+                if (filter != null) {
+                    outputPositionCount -= filter.getPrecedingPositionsToFail();
+
+                    int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
+                    if (succeedingPositionsToFail > 0) {
+                        int positionsToSkip = 0;
+                        for (int j = 0; j < succeedingPositionsToFail; j++) {
+                            i++;
+                            int nextPosition = positions[i];
+                            positionsToSkip += 1 + nextPosition - streamPosition;
+                            streamPosition = nextPosition + 1;
+                        }
+                        skip(positionsToSkip);
+                    }
+                }
             }
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.facebook.presto.spi.block.ClosingBlockLease.newLease;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -96,7 +97,7 @@ public class LongDirectSelectiveStreamReader
         allNulls = false;
 
         if (filter != null) {
-            ensureOutputPositionsCapacity(positionCount);
+            outputPositions = ensureCapacity(outputPositions, positionCount);
         }
         else {
             outputPositions = positions;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongSelectiveStreamReader.java
@@ -133,4 +133,10 @@ public class LongSelectiveStreamReader
     {
         return currentReader.getBlockView(positions, positionCount);
     }
+
+    @Override
+    public void throwAnyError(int[] positions, int positionCount)
+    {
+        currentReader.throwAnyError(positions, positionCount);
+    }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReader.java
@@ -64,5 +64,12 @@ public interface SelectiveStreamReader
      */
     BlockLease getBlockView(int[] positions, int positionCount);
 
+    /**
+     * Throws any error that occurred while reading specified positions.
+     *
+     * Used by list and map readers to raise "subscript out of bounds" error.
+     */
+    void throwAnyError(int[] positions, int positionCount);
+
     void close();
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc;
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
 import com.facebook.presto.orc.TupleDomainFilter.BooleanValue;
 import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.Subfield;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.SqlDate;
 import com.facebook.presto.spi.type.Type;
@@ -161,7 +162,7 @@ public class BenchmarkSelectiveStreamReaders
             return orcReader.createSelectiveRecordReader(
                     ImmutableMap.of(0, type),
                     ImmutableList.of(0),
-                    filter.map(f -> ImmutableMap.of(0, f)).orElse(ImmutableMap.of()),
+                    filter.isPresent() ? ImmutableMap.of(0, ImmutableMap.of(new Subfield("c"), filter.get())) : ImmutableMap.of(),
                     ImmutableList.of(),
                     ImmutableMap.of(),
                     ImmutableMap.of(),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -289,6 +289,7 @@ public class OrcTester
     public static OrcTester quickSelectiveOrcTester()
     {
         OrcTester orcTester = new OrcTester();
+        orcTester.listTestsEnabled = true;
         orcTester.nullTestsEnabled = true;
         orcTester.skipBatchTestsEnabled = true;
         orcTester.formats = ImmutableSet.of(ORC_12, ORC_11, DWRF);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -19,6 +19,7 @@ import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.Subfield;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.CharType;
@@ -45,6 +46,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
@@ -886,7 +888,7 @@ public class OrcTester
         return orcReader.createSelectiveRecordReader(
                 columnTypes,
                 IntStream.range(0, types.size()).boxed().collect(toList()),
-                filters,
+                Maps.transformValues(filters, v -> ImmutableMap.of(new Subfield("c"), v)),
                 ImmutableList.of(),
                 ImmutableMap.of(),
                 ImmutableMap.of(),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
+import com.facebook.presto.orc.TupleDomainFilter.PositionalFilter;
+import com.facebook.presto.orc.reader.ListFilter;
+import com.facebook.presto.spi.Subfield;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Random;
+
+import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.INT;
+import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.LIST;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+
+public class TestListFilter
+{
+    private static final int ROW_COUNT = 1_000;
+    private final Random random = new Random(0);
+
+    @Test
+    public void testArray()
+    {
+        Integer[][] data = new Integer[ROW_COUNT][];
+        int count = 0;
+        for (int i = 0; i < data.length; i++) {
+            data[i] = new Integer[3 + random.nextInt(10)];
+            for (int j = 0; j < data[i].length; j++) {
+                if (count++ % 11 == 0) {
+                    data[i][j] = null;
+                }
+                else {
+                    data[i][j] = random.nextInt(100);
+                }
+            }
+        }
+
+        assertPositionalFilter(ImmutableMap.of(
+                1, BigintRange.of(0, 50, false)), data);
+
+        assertPositionalFilter(ImmutableMap.of(
+                1, BigintRange.of(0, 50, false),
+                2, BigintRange.of(25, 50, false)), data);
+
+        assertPositionalFilter(ImmutableMap.of(
+                2, BigintRange.of(25, 50, false)), data);
+    }
+
+    private void assertPositionalFilter(Map<Integer, TupleDomainFilter> filters, Integer[][] data)
+    {
+        ListFilter listFilter = buildListFilter(filters, data);
+
+        TestFilter1 testFilter = (i, value) -> Optional.ofNullable(filters.get(i + 1))
+                .map(filter -> value == null ? filter.testNull() : filter.testLong(value))
+                .orElse(true);
+
+        PositionalFilter positionalFilter = listFilter.getPositionalFilter();
+
+        for (int i = 0; i < data.length; i++) {
+            for (int j = 0; j < data[i].length; j++) {
+                Integer value = data[i][j];
+                boolean expectedToPass = testFilter.test(j, value);
+                assertEquals(value == null ? positionalFilter.testNull() : positionalFilter.testLong(value), expectedToPass);
+                if (!expectedToPass) {
+                    assertEquals(positionalFilter.getPrecedingPositionsToFail(), j);
+                    assertEquals(positionalFilter.getSucceedingPositionsToFail(), data[i].length - j - 1);
+                    break;
+                }
+            }
+        }
+    }
+
+    private static ListFilter buildListFilter(Map<Integer, TupleDomainFilter> filters, Integer[][] data)
+    {
+        Map<Subfield, TupleDomainFilter> subfieldFilters = filters.entrySet().stream()
+                .collect(toImmutableMap(entry -> toSubfield(entry.getKey()), Map.Entry::getValue));
+
+        ListFilter filter = new ListFilter(makeStreamDescriptor(1), subfieldFilters);
+
+        int[] lengths = Arrays.stream(data).mapToInt(v -> v.length).toArray();
+        filter.populateElementFilters(data.length, null, lengths, Arrays.stream(lengths).sum());
+
+        return filter;
+    }
+
+    private static Subfield toSubfield(Integer index)
+    {
+        return new Subfield(format("c[%s]", index));
+    }
+
+    @Test
+    public void testNestedArray()
+    {
+        Integer[][][] data = new Integer[ROW_COUNT][][];
+        int count = 0;
+        for (int i = 0; i < data.length; i++) {
+            data[i] = new Integer[3 + random.nextInt(10)][];
+            for (int j = 0; j < data[i].length; j++) {
+                data[i][j] = new Integer[3 + random.nextInt(10)];
+                for (int k = 0; k < data[i][j].length; k++) {
+                    if (count++ % 11 == 0) {
+                        data[i][j][k] = null;
+                    }
+                    else {
+                        data[i][j][k] = random.nextInt(100);
+                    }
+                }
+            }
+        }
+
+        assertPositionalFilter(ImmutableMap.of(
+                RowAndColumn.of(1, 1), BigintRange.of(0, 50, false)), data);
+
+        assertPositionalFilter(ImmutableMap.of(
+                RowAndColumn.of(1, 2), BigintRange.of(0, 50, false),
+                RowAndColumn.of(3, 2), BigintRange.of(25, 50, false)), data);
+
+        assertPositionalFilter(ImmutableMap.of(
+                RowAndColumn.of(2, 1), BigintRange.of(0, 50, false),
+                RowAndColumn.of(2, 2), BigintRange.of(10, 40, false),
+                RowAndColumn.of(3, 3), BigintRange.of(20, 30, false)), data);
+    }
+
+    private void assertPositionalFilter(Map<RowAndColumn, TupleDomainFilter> filters, Integer[][][] data)
+    {
+        ListFilter listFilter = buildListFilter(filters, data);
+
+        TestFilter2 testFilter = (i, j, value) -> Optional.ofNullable(filters.get(RowAndColumn.of(i + 1, j + 1)))
+                .map(filter -> value == null ? filter.testNull() : filter.testLong(value))
+                .orElse(true);
+
+        PositionalFilter positionalFilter = listFilter.getChild().getPositionalFilter();
+
+        for (int i = 0; i < data.length; i++) {
+            boolean expectedToPass = true;
+            int passCount = 0;
+            int failCount = 0;
+            for (int j = 0; j < data[i].length; j++) {
+                if (!expectedToPass) {
+                    failCount += data[i][j].length;
+                    continue;
+                }
+                for (int k = 0; k < data[i][j].length; k++) {
+                    Integer value = data[i][j][k];
+                    expectedToPass = testFilter.test(j, k, value);
+                    assertEquals(value == null ? positionalFilter.testNull() : positionalFilter.testLong(value), expectedToPass);
+                    if (!expectedToPass) {
+                        assertEquals(positionalFilter.getPrecedingPositionsToFail(), passCount);
+                        failCount = data[i][j].length - k - 1;
+                        break;
+                    }
+                    passCount++;
+                }
+            }
+            assertEquals(positionalFilter.getSucceedingPositionsToFail(), failCount);
+        }
+    }
+
+    private static ListFilter buildListFilter(Map<RowAndColumn, TupleDomainFilter> filters, Integer[][][] data)
+    {
+        Map<Subfield, TupleDomainFilter> subfieldFilters = filters.entrySet().stream()
+                .collect(toImmutableMap(entry -> toSubfield(entry.getKey()), Map.Entry::getValue));
+
+        ListFilter filter = new ListFilter(makeStreamDescriptor(2), subfieldFilters);
+
+        int[] lengths = Arrays.stream(data).mapToInt(v -> v.length).toArray();
+        filter.populateElementFilters(data.length, null, lengths, Arrays.stream(lengths).sum());
+
+        int[] nestedLenghts = Arrays.stream(data).flatMap(Arrays::stream).mapToInt(v -> v.length).toArray();
+        ((ListFilter) filter.getChild()).populateElementFilters(Arrays.stream(lengths).sum(), null, nestedLenghts, Arrays.stream(nestedLenghts).sum());
+
+        return filter;
+    }
+
+    private static StreamDescriptor makeStreamDescriptor(int levels)
+    {
+        DummyOrcDataSource orcDataSource = new DummyOrcDataSource();
+
+        StreamDescriptor streamDescriptor = new StreamDescriptor("a", 0, "a", INT, orcDataSource, ImmutableList.of());
+        for (int i = 0; i < levels; i++) {
+            streamDescriptor = new StreamDescriptor("a", 0, "a", LIST, orcDataSource, ImmutableList.of(streamDescriptor));
+        }
+
+        return streamDescriptor;
+    }
+
+    private static Subfield toSubfield(RowAndColumn indices)
+    {
+        return new Subfield(format("c[%s][%s]", indices.getRow(), indices.getColumn()));
+    }
+
+    private interface TestFilter1
+    {
+        boolean test(int i, Integer value);
+    }
+
+    private interface TestFilter2
+    {
+        boolean test(int i, int j, Integer value);
+    }
+
+    private static class DummyOrcDataSource
+            implements OrcDataSource
+    {
+        @Override
+        public OrcDataSourceId getId()
+        {
+            return null;
+        }
+
+        @Override
+        public long getReadBytes()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getReadTimeNanos()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getSize()
+        {
+            return 0;
+        }
+
+        @Override
+        public void readFully(long position, byte[] buffer)
+        {
+        }
+
+        @Override
+        public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
+        {
+        }
+
+        @Override
+        public <K> Map<K, OrcDataSourceInput> readFully(Map<K, DiskRange> diskRanges)
+        {
+            return null;
+        }
+    }
+
+    private static final class RowAndColumn
+    {
+        private final int row;
+        private final int column;
+
+        private RowAndColumn(int row, int column)
+        {
+            this.row = row;
+            this.column = column;
+        }
+
+        public static RowAndColumn of(int row, int column)
+        {
+            return new RowAndColumn(row, column);
+        }
+
+        public int getRow()
+        {
+            return row;
+        }
+
+        public int getColumn()
+        {
+            return column;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            RowAndColumn that = (RowAndColumn) o;
+            return row == that.row &&
+                    column == that.column;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(row, column);
+        }
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestPositionalFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestPositionalFilter.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
+import com.facebook.presto.orc.TupleDomainFilter.PositionalFilter;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+
+public class TestPositionalFilter
+{
+    @Test
+    public void test()
+    {
+        PositionalFilter filter = new PositionalFilter();
+
+        // a[1] = 1 and a[3] = 3
+
+        TupleDomainFilter[] filters = new TupleDomainFilter[] {
+                equals(1), null, equals(3), null,
+                equals(1), null, equals(3), null,
+                equals(1), null, equals(3), null, null,
+                equals(1), null, equals(3), null, null, null,
+                equals(1), null, equals(3), null, null, null, null
+        };
+
+        long[] values = new long[] {
+            1, 2, 3, 4,         // pass
+            0, 2, 3, 4,         // fail
+            1, 2, 0, 4, 5,      // fail
+            1, 0, 3, 0, 5, 6,   // pass
+            1, 1, 2, 2, 3, 3, 4 // fail
+        };
+
+        boolean[] expectedResults = new boolean[] {
+            true, true, true, true,
+            false,
+            true, true, false,
+            true, true, true, true, true, true,
+            true, true, false,
+        };
+
+        int[] offsets = new int[] {0, 4, 8, 13, 19, 26};
+
+        filter.setFilters(filters, offsets);
+
+        int valuesIndex = 0;
+        for (int i = 0; i < expectedResults.length; i++) {
+            assertEquals(expectedResults[i], filter.testLong(values[valuesIndex++]));
+            if (expectedResults[i] == false) {
+                valuesIndex += filter.getSucceedingPositionsToFail();
+            }
+        }
+        assertEquals(new boolean[] {false, true, true, false, true, false}, filter.getFailed());
+    }
+
+    private TupleDomainFilter equals(int value)
+    {
+        return BigintRange.of(value, value, false);
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -51,9 +51,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -363,7 +365,16 @@ public class H2QueryRunner
                             row.add(null);
                         }
                         else {
-                            row.add(newArrayList((Object[]) array.getArray()));
+                            Object[] elements = (Object[]) array.getArray();
+                            Type elementType = ((ArrayType) type).getElementType();
+                            if (elementType instanceof ArrayType) {
+                                row.add(Arrays.stream(elements)
+                                        .map(v -> v == null ? null : newArrayList((Object[]) v))
+                                        .collect(Collectors.toList()));
+                            }
+                            else {
+                                row.add(newArrayList(elements));
+                            }
                         }
                     }
                     else {


### PR DESCRIPTION
Introduce SelectiveStreamReader for LIST type with support for top level filters (`c IS NULL` and `c IS NOT NULL`) and range filters on elements multiple levels deep (`c[1] = 5`, `c[1][2] > 10`). 

The values of LIST type are encoded using 3 streams: 
- is-null (present) stream has an entry for each row which specified whether the value in the row is null or not
- lengths stream has an entry for each non-null row which specified the size of the array value; length of zero indicates an empty array
- data stream represents a flat list of array elements

<img width="811" alt="Screen Shot 2019-07-25 at 10 16 26 AM" src="https://user-images.githubusercontent.com/27965151/61881866-5b982a00-aec5-11e9-8a5c-85b6dd693d37.png">

`ListSelectiveStreamReader` reads the is-null and lengths streams and generates an array of positions in the data stream to read. It then creates a `PositionalFilter` that applies range filters to the *right* positions in the data stream.

<img width="809" alt="Screen Shot 2019-07-25 at 10 16 37 AM" src="https://user-images.githubusercontent.com/27965151/61881869-5dfa8400-aec5-11e9-9354-02849d8d22c3.png">

List types can be composed to create nested lists:

<img width="932" alt="Screen Shot 2019-07-25 at 10 41 15 AM" src="https://user-images.githubusercontent.com/27965151/61883722-fba38280-aec8-11e9-95d2-b7201ec2dfb0.png">

In such cases, multiple `ListSelectiveStreamReader`s work together. Each reader is responsible for one level in the hierarchy. Reader at a higher level provides `NullsFilter` to the reader and the next level to allow for applying IS [NOT] NULL filters at mid levels, e.g. `a[1] is null AND a[2][3] > 10`.

Depends on #13072 

Part of #12585