### PR TITLE
Make BlockFlattener tests single threaded

### DIFF
--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestBlockFlattenner.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestBlockFlattenner.java
@@ -35,6 +35,7 @@ import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
+@Test(singleThreaded = true)
 public class TestBlockFlattenner
 {
     private ArrayAllocator allocator;


### PR DESCRIPTION
@rschlussel @mayankgarg1990 @mbasmanova 

The allocator in this test is intentionally reused across all tests to help catch problems related to requesting/releasing arrays.  Therefore I'd prefer to keep it that way and just ensure access is single threaded.