### PR TITLE
Math mode in restructured text docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1181,7 +1181,7 @@
                 <plugin>
                     <groupId>io.airlift.maven.plugins</groupId>
                     <artifactId>sphinx-maven-plugin</artifactId>
-                    <version>2.0</version>
+                    <version>2.1</version>
                 </plugin>
 
                 <plugin>

--- a/presto-docs/src/main/sphinx/conf.py
+++ b/presto-docs/src/main/sphinx/conf.py
@@ -60,9 +60,9 @@ def get_version():
 
 # -- General configuration -----------------------------------------------------
 
-needs_sphinx = '1.1'
+needs_sphinx = '1.6.5'
 
-extensions = ['download', 'issue', 'pr']
+extensions = ['download', 'issue', 'pr', 'sphinx.ext.mathjax']
 
 templates_path = ['_templates']
 

--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -314,9 +314,9 @@ Statistical Aggregate Functions
 
     Returns the log-2 entropy of count input-values.
 
-    .. code-block:: none
+    .. math::
 
-        entropy(c) = \sum_i [ c_i / \sum_j [c_j] \log_2(\sum_j [c_j] / c_i) ]
+        \mathrm{entropy}(c) = \sum_i \left[ {c_i \over \sum_j [c_j]} \log_2\left({\sum_j [c_j] \over c_i}\right) \right].
 
     ``c`` must be a ``bigint`` column of non-negative values.
 
@@ -328,9 +328,11 @@ Statistical Aggregate Functions
     Returns the excess kurtosis of all input values. Unbiased estimate using
     the following expression:
 
-    .. code-block:: none
+    .. math::
 
-        kurtosis(x) = n(n+1)/((n-1)(n-2)(n-3))sum[(x_i-mean)^4]/stddev(x)^4-3(n-1)^2/((n-2)(n-3))
+        \mathrm{kurtosis}(x) = {n(n+1) \over (n-1)(n-2)(n-3)} { \sum[(x_i-\mu)^4] \over \sigma^4} -3{ (n-1)^2 \over (n-2)(n-3) },
+
+   where :math:`\mu` is the mean, and :math:`\sigma` is the standard deviation.
 
 .. function:: classification_miss_rate(buckets, y, x, weight) -> array<double>
 


### PR DESCRIPTION
The docs contain some math that is marked as code. reStructuredText [supports math for several years](https://github.com/atavory/presto), so this diff changes two instances to use the `math` tag.

![image](https://user-images.githubusercontent.com/7824605/61710765-352c9000-ad07-11e9-9c9c-291de5946afc.png)
