### PR TITLE
Fix SQL Server type mapping and add support for datetimeoffset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -775,7 +775,7 @@
             <dependency>
                 <groupId>com.microsoft.sqlserver</groupId>
                 <artifactId>mssql-jdbc</artifactId>
-                <version>7.0.0.jre8</version>
+                <version>7.2.2.jre8</version>
             </dependency>
 
             <dependency>

--- a/presto-docs/src/main/sphinx/connector/sqlserver.rst
+++ b/presto-docs/src/main/sphinx/connector/sqlserver.rst
@@ -67,8 +67,8 @@ that catalog name instead of ``sqlserver`` in the above examples.
 SQL Server Connector Limitations
 --------------------------------
 
-Presto supports connecting to SQL Server 2016, SQL Server 2014, SQL Server 2012
-and Azure SQL Database.
+Presto supports connecting to SQL Server 2016, SQL Server 2014, SQL Server 2012,
+SQL Server 2008 R2, SQL Server 2008 and Azure SQL Database.
 
 Presto supports the following SQL Server data types.
 The following table shows the mappings between SQL Server and Presto data types.
@@ -76,13 +76,30 @@ The following table shows the mappings between SQL Server and Presto data types.
 ============================= ============================
 SQL Server Type               Presto Type
 ============================= ============================
-``bigint``                    ``bigint``
+``bit``                       ``boolean``
+``tinyint``                   ``tinyint``
 ``smallint``                  ``smallint``
 ``int``                       ``integer``
+``bigint``                    ``bigint``
+``real``                      ``real``
 ``float``                     ``double``
-``char(n)``                   ``char(n)``
-``varchar(n)``                ``varchar(n)``
+``decimal``                   ``decimal``
+``numeric``                   ``decimal``
+``char``                      ``char``
+``varchar``                   ``varchar``
+``nchar``                     ``char``
+``nvarchar``                  ``varchar``
+``binary``                    ``varbinary``
+``varbinary``                 ``varbinary``
 ``date``                      ``date``
+``time``                      ``time``
+``smalldatetime``             ``timestamp``
+``datetime``                  ``timestamp``
+``datetime2``                 ``timestamp``
+``datetimeoffset``            ``timestamp with time zone``
+``smallmoney``                ``decimal(10, 4)``
+``money``                     ``decimal(19, 4)``
+``uniqueidentifier``          ``char(36)``
 ============================= ============================
 
 Complete list of `SQL Server data types

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
@@ -19,6 +19,9 @@ import com.facebook.presto.plugin.jdbc.DriverConnectionFactory;
 import com.facebook.presto.plugin.jdbc.JdbcColumnHandle;
 import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
 import com.facebook.presto.plugin.jdbc.JdbcTableHandle;
+import com.facebook.presto.plugin.jdbc.JdbcTypeHandle;
+import com.facebook.presto.plugin.jdbc.ReadMapping;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.type.CharType;
@@ -27,19 +30,24 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
+import com.microsoft.sqlserver.jdbc.ISQLServerResultSet;
 import com.microsoft.sqlserver.jdbc.SQLServerDriver;
+import microsoft.sql.DateTimeOffset;
 
 import javax.inject.Inject;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static com.facebook.presto.plugin.jdbc.ReadMapping.longReadMapping;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.Chars.isCharType;
+import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -140,6 +148,23 @@ public class SqlServerClient
             return sqlType;
         }
         throw new PrestoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
+    }
+
+    @Override
+    public Optional<ReadMapping> toPrestoType(ConnectorSession session, JdbcTypeHandle typeHandle)
+    {
+        if (typeHandle.getJdbcType() == microsoft.sql.Types.DATETIMEOFFSET) {
+            return Optional.of(dateTimeOffsetReadMapping());
+        }
+        return super.toPrestoType(session, typeHandle);
+    }
+
+    private static ReadMapping dateTimeOffsetReadMapping()
+    {
+        return longReadMapping(TIMESTAMP_WITH_TIME_ZONE, (resultSet, columnIndex) -> {
+            DateTimeOffset dto = resultSet.unwrap(ISQLServerResultSet.class).getDateTimeOffset(columnIndex);
+            return packDateTimeWithZone(dto.getTimestamp().getTime(), dto.getMinutesOffset());
+        });
     }
 
     private static String singleQuote(String... objects)

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
@@ -21,21 +21,59 @@ import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
 import com.facebook.presto.plugin.jdbc.JdbcTableHandle;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.type.CharType;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
 import com.microsoft.sqlserver.jdbc.SQLServerDriver;
 
 import javax.inject.Inject;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Map;
 
 import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.Chars.isCharType;
+import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimeType.TIME;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static java.lang.String.format;
 
 public class SqlServerClient
         extends BaseJdbcClient
 {
     private static final Joiner DOT_JOINER = Joiner.on(".");
+
+    private static final int MAX_CHAR_LENGTH = 8000;
+
+    private static final Map<Type, String> MSSQL_TYPES = ImmutableMap.<Type, String>builder()
+            .put(BOOLEAN, "bit")
+            .put(BIGINT, "bigint")
+            .put(INTEGER, "int")
+            .put(SMALLINT, "smallint")
+            .put(TINYINT, "tinyint")
+            .put(REAL, "float(24)")
+            .put(DOUBLE, "float(53)")
+            .put(VARBINARY, "varbinary(max)")
+            .put(DATE, "date")
+            .put(TIME, "time")
+            .put(TIMESTAMP, "datetime2")
+            .put(TIMESTAMP_WITH_TIME_ZONE, "datetimeoffset")
+            .build();
 
     @Inject
     public SqlServerClient(JdbcConnectorId connectorId, BaseJdbcConfig config)
@@ -71,6 +109,37 @@ public class SqlServerClient
         catch (SQLException e) {
             throw new PrestoException(JDBC_ERROR, e);
         }
+    }
+
+    @Override
+    protected String toSqlType(Type type)
+    {
+        if (isVarcharType(type)) {
+            VarcharType varcharType = (VarcharType) type;
+            if (varcharType.isUnbounded() || varcharType.getLengthSafe() > MAX_CHAR_LENGTH) {
+                return "varchar(max)";
+            }
+            return "varchar(" + varcharType.getLengthSafe() + ")";
+        }
+
+        if (isCharType(type)) {
+            CharType charType = (CharType) type;
+            if (charType.getLength() <= MAX_CHAR_LENGTH) {
+                return "char(" + charType.getLength() + ")";
+            }
+            throw new PrestoException(NOT_SUPPORTED, "Length of char type cannot exceed " + MAX_CHAR_LENGTH);
+        }
+
+        if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            return format("decimal(%s, %s)", decimalType.getPrecision(), decimalType.getScale());
+        }
+
+        String sqlType = MSSQL_TYPES.get(type);
+        if (sqlType != null) {
+            return sqlType;
+        }
+        throw new PrestoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
     }
 
     private static String singleQuote(String... objects)


### PR DESCRIPTION
Refreshed version of #8306 

Corrects type mapping for table creation with SQL Server:
- `bit` instead of `boolean`
- `varchar(max)` for unbounded `varchar`
- `datetime2` instead of `timestamp`
- `datetimeoffset` instead of `timestamp with time zone`

Adds support for reading `datetimeoffset` as a Presto `timestamp with time zone` with the proper offset.