### PR TITLE
Fix accidental removal nested type only cast

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4091,6 +4091,13 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testNestedCast()
+    {
+        assertQuery("select cast(varchar_value as varchar(3)) || ' sfd' from (values ('9898.122')) t(varchar_value)", "VALUES '989 sfd'");
+        assertQuery("select cast(cast(varchar_value as varchar(3)) as varchar(5)) from (values ('9898.122')) t(varchar_value)", "VALUES '989'");
+    }
+
+    @Test
     public void testInvalidCast()
     {
         assertQueryFails(


### PR DESCRIPTION
This is a short term fix for #13116. 
We should rethink how we handle type only cast(which will be tracked on #12891)
