### PR TITLE
Add point-in-polygon check for spherical geometries

### DIFF
--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -1602,12 +1602,12 @@ public final class GeoFunctions
     {
         OGCGeometry leftGeometry = deserialize(left);
         if (leftGeometry.isEmpty()) {
-            return null;
+            return false;
         }
 
         OGCGeometry rightGeometry = deserialize(right);
         if (rightGeometry.isEmpty()) {
-            return null;
+            return false;
         }
 
         validateSphericalType("ST_Contains", leftGeometry, EnumSet.of(POLYGON));

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -1628,7 +1628,7 @@ public final class GeoFunctions
     private static boolean liesInRange(double point, double rangeStart, double rangeEnd)
     {
         // strictly exclusive
-        return point > rangeStart && point < rangeEnd;
+        return Double.compare(point, rangeStart) > 0 && Double.compare(point, rangeEnd) < 0;
     }
 
     private static boolean haveSameSign(double x, double y)

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -1936,10 +1936,7 @@ public final class GeoFunctions
 
             double tanOfEquatorialBearing = Math.tan(PI / 2.0 - Math.abs(equatorialBearing));
             double sinOfAdjustedLongitude = Math.sin(toRadians(longitude) - longitudeAdjustment);
-            int sign = 1;
-            //if (equatorialBearing % (PI / 2.0) != 0) {
-            //    sign = (Math.tan(equatorialBearing) * sinOfAdjustedLongitude > 0) ? 1 : -1;
-            //}
+            int sign = (equatorialBearing * sinOfAdjustedLongitude >= 0) ? 1 : -1;
             return sign * toDegrees(acos(1.0 / Math.sqrt(1.0 + pow(tanOfEquatorialBearing, 2) * pow(sinOfAdjustedLongitude, 2))));
         }
 

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -1765,9 +1765,6 @@ public final class GeoFunctions
             // check last edge which closes the loop back at the starting point
             Point lastEdgeStart = polygon.getPoint(pathEndIndex - 1);
             Point lastEdgeEnd = polygon.getPoint(pathStartIndex);
-            if (lastEdgeStart.equals(point) || lastEdgeEnd.equals(point)) {
-                return 0;
-            }
 
             if (excludeEdgeStartPoint) {
                 if (haveSameLongitude(lastEdgeStart.getX(), point.getX())) {

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
@@ -256,19 +256,20 @@ public class TestSphericalGeoFunctions
 
         // Test edge cases (pun slightly intended)
         // (see http://geomalgorithms.com/a03-_inclusion.html)
-        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "10 30", true);
-        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 30 ", true);
-        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 10 ", true);
-        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "10 10 ", true);
-        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 10 ", true);
-        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 10 ", true);
-        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "10 17 ", false);
+        // on a vertex
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "10 30", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 30 ", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 10 ", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "10 10 ", false);
+        // on an edge
         assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 19 ", true);
-        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "17 10 ", false);
         assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "18 30.079534371237855", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "10 17 ", true);
+        // inside or outside
         assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "12 20 ", true);
         assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "11 10.5 ", true);
-
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "17 10 ", false);
+        // outside, but directly inline with an edge
         assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "7 10 ", false);
         assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "10 8.2 ", false);
         assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "8 30 ", false);
@@ -278,9 +279,7 @@ public class TestSphericalGeoFunctions
         assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "23.44 10 ", false);
         assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 -7.9", false);
 
-        // test points that line up with corners
-
-        // small, simple 4-sided polygons
+        // other external points
         assertContains("10 10, 10 30, 20 30, 20 10", "50 41", false);
         assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "15 40", false);
         assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "5 20", false);
@@ -289,17 +288,27 @@ public class TestSphericalGeoFunctions
         assertContains("10 -10, 10 -30, 20 -30, 25 -8, 10 -10", "15 -2", false);
         assertContains("-10 10, -10 30, -20 30, -25 8, -10 10", "-15 35", false);
 
+        // points inside and outside a triagle
+        assertContains("-50 70, -15 65, -30 50", "-45 68", true);
+        assertContains("-50 70, -15 65, -30 50", "-50 20", false);
+        assertContains("-50 70, -15 65, -30 50", "-50 70", false);
+        assertContains("-50 70, -15 65, -30 50", "-15 65", false);
+        assertContains("-50 70, -15 65, -30 50", "-30 50", false);
+        assertContains("-50 70, -15 65, -30 50", "-30 41.8", false);
+        assertContains("-50 70, -15 65, -30 50", "-46.2 60.777", false);
+        assertContains("-50 70, -15 65, -30 50", "-50 59.23", false);
+
         // based on flight routes from salt lake city -> buffalo -> ft. lauderdale -> salt lake city
         assertContains(saltBuffFort, wichita, true);
         assertContains(saltBuffFort, grandRapids, true);
-        assertContains(saltBuffFort, fortLauderdale, true);
+        assertContains(saltBuffFort, fortLauderdale, false);
         assertContains(saltBuffFort, newYork, false);
         assertContains(saltBuffFort, santiago, false);
         assertContains(saltBuffFort, oklahomaCity, false);
-        assertContains(saltBuffFort, buffalo, true);
+        assertContains(saltBuffFort, buffalo, false);
 
         // based on flight routes from LA -> melbourne -> sydney -> SF -> LA
-        assertContains(losAngMelSydSanFran, sydney, true);
+        assertContains(losAngMelSydSanFran, sydney, false);
         assertContains(losAngMelSydSanFran, southeastOfSydney, true);
         assertContains(losAngMelSydSanFran, noumea, false);
         assertContains(losAngMelSydSanFran, honolulu, false);

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
@@ -254,6 +254,32 @@ public class TestSphericalGeoFunctions
         // Invalid polygon (contains pole)
         assertInvalidFunction("ST_Contains(to_spherical_geography(ST_GeometryFromText('POLYGON((0 85, 135 85, -70 85, -10 85, 0 85))')), to_spherical_geography(ST_GeometryFromText('POINT (-10 80)')))", "When applied to SphericalGeography inputs, ST_Contains only supports polygons which do not enclose poles.");
 
+        // Test edge cases (pun slightly intended)
+        // (see http://geomalgorithms.com/a03-_inclusion.html)
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "10 30", true);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 30 ", true);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 10 ", true);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "10 10 ", true);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 10 ", true);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 10 ", true);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "10 17 ", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 19 ", true);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "17 10 ", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "18 30.079534371237855", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "12 20 ", true);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "11 10.5 ", true);
+
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "7 10 ", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "10 8.2 ", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "8 30 ", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "10 45 ", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 31 ", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "27 30 ", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "23.44 10 ", false);
+        assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "20 -7.9", false);
+
+        // test points that line up with corners
+
         // small, simple 4-sided polygons
         assertContains("10 10, 10 30, 20 30, 20 10", "50 41", false);
         assertContains("10 10, 10 30, 20 30, 20 10, 10 10", "15 40", false);
@@ -264,12 +290,13 @@ public class TestSphericalGeoFunctions
         assertContains("-10 10, -10 30, -20 30, -25 8, -10 10", "-15 35", false);
 
         // based on flight routes from salt lake city -> buffalo -> ft. lauderdale -> salt lake city
-        assertContains(saltBuffFort, buffalo, true);
         assertContains(saltBuffFort, wichita, true);
+        assertContains(saltBuffFort, grandRapids, true);
+        assertContains(saltBuffFort, fortLauderdale, true);
         assertContains(saltBuffFort, newYork, false);
         assertContains(saltBuffFort, santiago, false);
         assertContains(saltBuffFort, oklahomaCity, false);
-        assertContains(saltBuffFort, grandRapids, true);
+        assertContains(saltBuffFort, buffalo, true);
 
         // based on flight routes from LA -> melbourne -> sydney -> SF -> LA
         assertContains(losAngMelSydSanFran, sydney, true);

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
@@ -223,6 +223,7 @@ public class TestSphericalGeoFunctions
         String sanFrancisco = "-122.3790 37.6213";
         String santiago = "-70.6693 -33.4489";
         String sydney = "151.1753 -33.9399";
+        String southeastOfSydney = "151.3 -34.0";
         String wichita = "-97.3301 37.6872";
 
         String[] saltBuffFortArr = {saltLakeCity, buffalo, fortLauderdale, saltLakeCity};
@@ -272,7 +273,9 @@ public class TestSphericalGeoFunctions
 
         // based on flight routes from LA -> melbourne -> sydney -> SF -> LA
         assertContains(losAngMelSydSanFran, sydney, true);
+        assertContains(losAngMelSydSanFran, southeastOfSydney, true);
         assertContains(losAngMelSydSanFran, noumea, false);
+        assertContains(losAngMelSydSanFran, honolulu, false);
         assertContains(losAngMelSydSanFran, grandRapids, false);
 
         // polygon that looks like "I", starting from lower left corner
@@ -282,6 +285,7 @@ public class TestSphericalGeoFunctions
 
         // polygon with a hole, starting from lower left corner
         assertContains("-10 -80, -30 -80, -30 -50, -10 -50), (-12 -72, -20 -72, -20 -12", "-18 -70", false);
+        assertContains("-10 -80, -30 -80, -30 -50, -10 -50), (-12 -72, -20 -72, -20 -12", "-25 -55", true);
     }
 
     private String buildPolygon(String[] polygonPoints)


### PR DESCRIPTION
Currently users are able to query whether a set of points lies within a set of polygons  for non-spherical geometries. This change is an initial implementation of a check for a single point inside a single valid polygon. 

What it does support:
1. Polygons with holes
2. Polygons that are very large (i.e. greater than a quarter of the earth's area)

What it doesn't support:
1. Polygons that encompass either pole, even if the pole is inside a hole
2. Checking multiple polygons
3. Invalid polygons (i.e. only 2 sides)
4. Checking multiple points inside a polygon

I'm a n00b, so feedback is particularly appreciated!

The math comes from https://trs-new.jpl.nasa.gov/bitstream/handle/2014/40409/JPL%20Pub%2007-3%20%20w%20Errata.pdf