### PR TITLE
Fix NPE in spatial joins with GeometryCollections

### DIFF
--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
@@ -96,6 +96,26 @@ public final class GeometryUtils
         }
     }
 
+    public static org.locationtech.jts.geom.Envelope getJtsEnvelope(OGCGeometry ogcGeometry, double radius)
+    {
+        Envelope esriEnvelope = getEnvelope(ogcGeometry);
+
+        if (esriEnvelope.isEmpty()) {
+            return new org.locationtech.jts.geom.Envelope();
+        }
+
+        return new org.locationtech.jts.geom.Envelope(
+                esriEnvelope.getXMin() - radius,
+                esriEnvelope.getXMax() + radius,
+                esriEnvelope.getYMin() - radius,
+                esriEnvelope.getYMax() + radius);
+    }
+
+    public static org.locationtech.jts.geom.Envelope getJtsEnvelope(OGCGeometry ogcGeometry)
+    {
+        return getJtsEnvelope(ogcGeometry, 0.0);
+    }
+
     public static boolean disjoint(Envelope envelope, OGCGeometry ogcGeometry)
     {
         GeometryCursor cursor = ogcGeometry.getEsriGeometryCursor();

--- a/presto-geospatial-toolkit/src/test/java/com/facebook/presto/geospatial/TestGeometryUtils.java
+++ b/presto-geospatial-toolkit/src/test/java/com/facebook/presto/geospatial/TestGeometryUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.geospatial;
+
+import com.esri.core.geometry.ogc.OGCGeometry;
+import org.locationtech.jts.geom.Envelope;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestGeometryUtils
+{
+    @Test
+    public void testGetJtsEnvelopeEmpty()
+    {
+        assertJtsEnvelope(
+                "MULTIPOLYGON EMPTY",
+                new Envelope());
+    }
+
+    @Test
+    public void testGetJtsEnvelopePoint()
+    {
+        assertJtsEnvelope(
+                "POINT (-23.4 12.2)",
+                new Envelope(-23.4, -23.4, 12.2, 12.2));
+    }
+
+    @Test
+    public void testGetJtsEnvelopeLineString()
+    {
+        assertJtsEnvelope(
+                "LINESTRING (-75.9375 23.6359, -75.9375 23.6364)",
+                new Envelope(-75.9375, -75.9375, 23.6359, 23.6364));
+    }
+
+    @Test
+    public void testGetJtsEnvelopeGeometryCollection()
+    {
+        assertJtsEnvelope(
+                "GEOMETRYCOLLECTION (" +
+                        "  LINESTRING (-75.9375 23.6359, -75.9375 23.6364)," +
+                        "  MULTIPOLYGON (((-75.9375 23.45520, -75.9371 23.4554, -75.9375 23.46023325, -75.9375 23.45520)))" +
+                        ")",
+                new Envelope(-75.9375, -75.9371, 23.4552, 23.6364));
+    }
+
+    private void assertJtsEnvelope(String wkt, Envelope expected)
+    {
+        Envelope calculated = GeometryUtils.getJtsEnvelope(OGCGeometry.fromText(wkt));
+        assertEquals(calculated, expected);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndexSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndexSupplier.java
@@ -151,19 +151,6 @@ public class PagesSpatialIndexSupplier
         return new Envelope(envelope.getXMin() - radius, envelope.getXMax() + radius, envelope.getYMin() - radius, envelope.getYMax() + radius);
     }
 
-    private long computeMemorySizeInBytes(AbstractNode root)
-    {
-        if (root.getLevel() == 0) {
-            return ABSTRACT_NODE_INSTANCE_SIZE + ENVELOPE_INSTANCE_SIZE + root.getChildBoundables().stream().mapToLong(child -> computeMemorySizeInBytes((ItemBoundable) child)).sum();
-        }
-        return ABSTRACT_NODE_INSTANCE_SIZE + ENVELOPE_INSTANCE_SIZE + root.getChildBoundables().stream().mapToLong(child -> computeMemorySizeInBytes((AbstractNode) child)).sum();
-    }
-
-    private long computeMemorySizeInBytes(ItemBoundable item)
-    {
-        return ENVELOPE_INSTANCE_SIZE + ((GeometryWithPosition) item.getItem()).getEstimatedMemorySizeInBytes();
-    }
-
     private static void accelerateGeometry(OGCGeometry ogcGeometry, Operator relateOperator)
     {
         // Recurse into GeometryCollections
@@ -175,6 +162,19 @@ public class PagesSpatialIndexSupplier
             }
             relateOperator.accelerateGeometry(esriGeometry, null, Geometry.GeometryAccelerationDegree.enumMild);
         }
+    }
+
+    private long computeMemorySizeInBytes(AbstractNode root)
+    {
+        if (root.getLevel() == 0) {
+            return ABSTRACT_NODE_INSTANCE_SIZE + ENVELOPE_INSTANCE_SIZE + root.getChildBoundables().stream().mapToLong(child -> computeMemorySizeInBytes((ItemBoundable) child)).sum();
+        }
+        return ABSTRACT_NODE_INSTANCE_SIZE + ENVELOPE_INSTANCE_SIZE + root.getChildBoundables().stream().mapToLong(child -> computeMemorySizeInBytes((AbstractNode) child)).sum();
+    }
+
+    private long computeMemorySizeInBytes(ItemBoundable item)
+    {
+        return ENVELOPE_INSTANCE_SIZE + ((GeometryWithPosition) item.getItem()).getEstimatedMemorySizeInBytes();
     }
 
     // doesn't include memory used by channels and addresses which are shared with PagesIndex

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndexSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndexSupplier.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static com.facebook.presto.geospatial.GeometryUtils.getJtsEnvelope;
 import static com.facebook.presto.geospatial.serde.GeometrySerde.deserialize;
 import static com.facebook.presto.operator.PagesSpatialIndex.EMPTY_INDEX;
 import static com.facebook.presto.operator.SyntheticAddress.decodePosition;
@@ -136,19 +137,11 @@ public class PagesSpatialIndexSupplier
                 partition = toIntExact(INTEGER.getLong(partitionBlock, blockPosition));
             }
 
-            rtree.insert(getEnvelope(ogcGeometry, radius), new GeometryWithPosition(ogcGeometry, partition, position));
+            rtree.insert(getJtsEnvelope(ogcGeometry, radius), new GeometryWithPosition(ogcGeometry, partition, position));
         }
 
         rtree.build();
         return rtree;
-    }
-
-    private static Envelope getEnvelope(OGCGeometry ogcGeometry, double radius)
-    {
-        com.esri.core.geometry.Envelope envelope = new com.esri.core.geometry.Envelope();
-        ogcGeometry.getEsriGeometry().queryEnvelope(envelope);
-
-        return new Envelope(envelope.getXMin() - radius, envelope.getXMax() + radius, envelope.getYMin() - radius, envelope.getYMax() + radius);
     }
 
     private static void accelerateGeometry(OGCGeometry ogcGeometry, Operator relateOperator)


### PR DESCRIPTION
The code which gets a (JTS) Envelope from a GeometryCollection
raised an NPE: getting an Esri Envelope from an OgcGeometry that
wraps a GeometryCollection returns null.  We correct for this
in the GeometryUtils.getEnvelope; this commit delegates getting
the Esri envelope to that function, and converts it to a JTS
Envelope in GeometryUtils.  It also adds some tests, including the
breaking GeometryCollection (a reduced test case that caused the
bug in production).