### PR TITLE
Compact tupple domain before sending

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainOrcPredicate.java
@@ -28,7 +28,6 @@ import com.facebook.presto.spi.type.VarbinaryType;
 import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import org.apache.hive.common.util.BloomFilter;
 
@@ -68,29 +67,9 @@ public class TupleDomainOrcPredicate<C>
     public TupleDomainOrcPredicate(TupleDomain<C> effectivePredicate, List<ColumnReference<C>> columnReferences, boolean orcBloomFiltersEnabled, Optional<Integer> domainCompactionThreshold)
     {
         requireNonNull(effectivePredicate, "effectivePredicate is null");
-        this.effectivePredicate = domainCompactionThreshold.map(threshold -> toCompactTupleDomain(effectivePredicate, threshold)).orElse(effectivePredicate);
+        this.effectivePredicate = domainCompactionThreshold.map(effectivePredicate::compact).orElse(effectivePredicate);
         this.columnReferences = ImmutableList.copyOf(requireNonNull(columnReferences, "columnReferences is null"));
         this.orcBloomFiltersEnabled = orcBloomFiltersEnabled;
-    }
-
-    private static <C> TupleDomain<C> toCompactTupleDomain(TupleDomain<C> effectivePredicate, int threshold)
-    {
-        ImmutableMap.Builder<C, Domain> builder = ImmutableMap.builder();
-        effectivePredicate.getDomains().ifPresent(domains -> {
-            for (Map.Entry<C, Domain> entry : domains.entrySet()) {
-                C hiveColumnHandle = entry.getKey();
-                Domain domain = entry.getValue();
-
-                ValueSet values = domain.getValues();
-                ValueSet compactValueSet = values.getValuesProcessor().<Optional<ValueSet>>transform(
-                        ranges -> ranges.getRangeCount() > threshold ? Optional.of(ValueSet.ofRanges(ranges.getSpan())) : Optional.empty(),
-                        discreteValues -> discreteValues.getValues().size() > threshold ? Optional.of(ValueSet.all(values.getType())) : Optional.empty(),
-                        allOrNone -> Optional.empty())
-                        .orElse(values);
-                builder.put(hiveColumnHandle, Domain.create(compactValueSet, domain.isNullAllowed()));
-            }
-        });
-        return TupleDomain.withColumnDomains(builder.build());
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/TupleDomain.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/TupleDomain.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
+import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
@@ -67,7 +68,7 @@ public final class TupleDomain<T>
             if (containsNoneDomain(map)) {
                 return Optional.empty();
             }
-            return Optional.of(Collections.unmodifiableMap(normalizeAndCopy(map)));
+            return Optional.of(unmodifiableMap(normalizeAndCopy(map)));
         });
     }
 


### PR DESCRIPTION
TupleDomain compaction reduces a long list of well specified values to a
range if the number of values threshold is crossed.

The compaction has been moved as part of the 76ea27e commit.

effectivePredicate is carried to a worker with a HiveSplit. HiveSplit
must be serialized into JSON on the coordinator. Without a compaction
the serialization of large tupple domains (100+ values) results in
excessive CPU usage on coordinator.