### PR TITLE
Enable setQueryMaxTotalMemory for TestingTaskContext

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
@@ -88,7 +88,7 @@ public final class TestingTaskContext
         private QueryId queryId = new QueryId("test_query");
         private TaskStateMachine taskStateMachine;
         private DataSize queryMaxMemory = new DataSize(256, MEGABYTE);
-        private final DataSize queryMaxTotalMemory = new DataSize(512, MEGABYTE);
+        private DataSize queryMaxTotalMemory = new DataSize(512, MEGABYTE);
         private DataSize memoryPoolSize = new DataSize(1, GIGABYTE);
         private DataSize maxSpillSize = new DataSize(1, GIGABYTE);
         private DataSize queryMaxSpillSize = new DataSize(1, GIGABYTE);
@@ -110,6 +110,12 @@ public final class TestingTaskContext
         public Builder setQueryMaxMemory(DataSize queryMaxMemory)
         {
             this.queryMaxMemory = queryMaxMemory;
+            return this;
+        }
+
+        public Builder setQueryMaxTotalMemory(DataSize queryMaxTotalMemory)
+        {
+            this.queryMaxTotalMemory = queryMaxTotalMemory;
             return this;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
@@ -195,6 +195,7 @@ public class BenchmarkPartitionedOutputOperator
         {
             return TestingTaskContext.builder(EXECUTOR, SCHEDULER, TEST_SESSION)
                     .setMemoryPoolSize(MAX_MEMORY)
+                    .setQueryMaxTotalMemory(MAX_MEMORY)
                     .build()
                     .addPipelineContext(0, true, true, false)
                     .addDriverContext();


### PR DESCRIPTION
Adding setQueryMaxTotalMemory to avoid "Query exceeded per-node total memory limit of 512MB" error when running the new BenchmarkPartitionedOutputOperator