### PR TITLE
Update Drift version to 1.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dep.aws-sdk.version>1.11.445</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
-        <dep.drift.version>1.19</dep.drift.version>
+        <dep.drift.version>1.20</dep.drift.version>
         <dep.joda.version>2.10</dep.joda.version>
         <dep.tempto.version>1.50</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>


### PR DESCRIPTION
In this version the default request timeout reduces from 1m to 10s.
The total request duration (including retries) remains the same 1m.

```
== NO RELEASE NOTE ==
```
