### PR TITLE
Fix the Raptor connector to error out on unsupported type

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadataFactory.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadataFactory.java
@@ -15,6 +15,7 @@ package com.facebook.presto.raptor;
 
 import com.facebook.presto.raptor.metadata.ForMetadata;
 import com.facebook.presto.raptor.metadata.ShardManager;
+import com.facebook.presto.spi.type.TypeManager;
 import org.skife.jdbi.v2.IDBI;
 
 import javax.inject.Inject;
@@ -28,20 +29,23 @@ public class RaptorMetadataFactory
     private final String connectorId;
     private final IDBI dbi;
     private final ShardManager shardManager;
+    private final TypeManager typeManager;
 
     @Inject
     public RaptorMetadataFactory(
             RaptorConnectorId connectorId,
             @ForMetadata IDBI dbi,
-            ShardManager shardManager)
+            ShardManager shardManager,
+            TypeManager typeManager)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
         this.dbi = requireNonNull(dbi, "dbi is null");
         this.shardManager = requireNonNull(shardManager, "shardManager is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
     public RaptorMetadata create(LongConsumer beginDeleteForTableId)
     {
-        return new RaptorMetadata(connectorId, dbi, shardManager, beginDeleteForTableId);
+        return new RaptorMetadata(connectorId, dbi, shardManager, typeManager, beginDeleteForTableId);
     }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
@@ -106,7 +106,7 @@ public class TestRaptorConnector
         connector = new RaptorConnector(
                 new LifeCycleManager(ImmutableList.of(), null),
                 new TestingNodeManager(),
-                new RaptorMetadataFactory(connectorId, dbi, shardManager),
+                new RaptorMetadataFactory(connectorId, dbi, shardManager, new TypeRegistry()),
                 new RaptorSplitManager(connectorId, nodeSupplier, shardManager, false),
                 new RaptorPageSourceProvider(storageManager),
                 new RaptorPageSinkProvider(storageManager,

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTest.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTest.java
@@ -79,6 +79,13 @@ public class TestRaptorIntegrationSmokeTest
     }
 
     @Test
+    public void testCreateTableUnsupportedType()
+    {
+        assertQueryFails("CREATE TABLE rowtype_test AS SELECT row(1) AS c", "Type not supported: row\\(integer\\)");
+        assertQueryFails("CREATE TABLE rowtype_test(row_type_field row(s varchar))", "Type not supported: row\\(s varchar\\)");
+    }
+
+    @Test
     public void testMapTable()
     {
         assertUpdate("CREATE TABLE map_test AS SELECT MAP(ARRAY [1, 2, 3], ARRAY ['hi', 'bye', NULL]) AS c", 1);
@@ -836,6 +843,14 @@ public class TestRaptorIntegrationSmokeTest
         assertUpdate("DELETE FROM test_alter_table WHERE c1 = 22", 3);
 
         assertUpdate("DROP TABLE test_alter_table");
+    }
+
+    @Test
+    public void testAlterTableUnsupportedType()
+    {
+        assertUpdate("CREATE TABLE test_alter_table_unsupported_type (c1 bigint, c2 bigint)");
+        assertQueryFails("ALTER TABLE test_alter_table_unsupported_type ADD COLUMN c3 row(bigint)", "Type not supported: row\\(bigint\\)");
+        assertUpdate("DROP TABLE test_alter_table_unsupported_type");
     }
 
     @Test

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorSplitManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorSplitManager.java
@@ -109,7 +109,7 @@ public class TestRaptorSplitManager
         nodeManager.addNode(new InternalNode(nodeName, new URI("http://127.0.0.1/"), NodeVersion.UNKNOWN, false));
 
         RaptorConnectorId connectorId = new RaptorConnectorId("raptor");
-        metadata = new RaptorMetadata(connectorId.toString(), dbi, shardManager);
+        metadata = new RaptorMetadata(connectorId.toString(), dbi, shardManager, new TypeRegistry());
 
         metadata.createTable(SESSION, TEST_TABLE, false);
         tableHandle = metadata.getTableHandle(SESSION, TEST_TABLE.getTable());

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizerUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizerUtil.java
@@ -83,7 +83,7 @@ public class TestShardOrganizerUtil
         createTablesWithRetry(dbi);
         dataDir = Files.createTempDir();
 
-        metadata = new RaptorMetadata("raptor", dbi, createShardManager(dbi));
+        metadata = new RaptorMetadata("raptor", dbi, createShardManager(dbi), new TypeRegistry());
 
         metadataDao = dbi.onDemand(MetadataDao.class);
         shardManager = createShardManager(dbi);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/systemtables/TestShardMetadataRecordCursor.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/systemtables/TestShardMetadataRecordCursor.java
@@ -79,7 +79,7 @@ public class TestShardMetadataRecordCursor
         this.dbi.registerMapper(new TableColumn.Mapper(new TypeRegistry()));
         this.dummyHandle = dbi.open();
         createTablesWithRetry(dbi);
-        this.metadata = new RaptorMetadata("raptor", dbi, createShardManager(dbi));
+        this.metadata = new RaptorMetadata("raptor", dbi, createShardManager(dbi), new TypeRegistry());
 
         // Create table
         ConnectorTableMetadata table = tableMetadataBuilder(DEFAULT_TEST_ORDERS)


### PR DESCRIPTION
Please fill in the release notes towards the bottom of the PR description. See [README](https://github.com/prestodb/presto/blob/master/README.md#release-notes) for details.

```
== RELEASE NOTES ==

Raptor changes
* Error out when creating tables with unsupported types like ROW type.

```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
