### PR TITLE
Add TimestampSelectiveStreamReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ApacheHiveTimestampDecoder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ApacheHiveTimestampDecoder.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+final class ApacheHiveTimestampDecoder
+{
+    private ApacheHiveTimestampDecoder() {}
+
+    // This comes from the Apache Hive ORC code
+    public static long decodeTimestamp(long seconds, long serializedNanos, long baseTimestampInSeconds)
+    {
+        long millis = (seconds + baseTimestampInSeconds) * 1000;
+        long nanos = parseNanos(serializedNanos);
+        if (nanos > 999999999 || nanos < 0) {
+            throw new IllegalArgumentException("nanos field of an encoded timestamp in ORC must be between 0 and 999999999 inclusive, got " + nanos);
+        }
+
+        // the rounding error exists because java always rounds up when dividing integers
+        // -42001/1000 = -42; and -42001 % 1000 = -1 (+ 1000)
+        // to get the correct value we need
+        // (-42 - 1)*1000 + 999 = -42001
+        // (42)*1000 + 1 = 42001
+        if (millis < 0 && nanos != 0) {
+            millis -= 1000;
+        }
+        // Truncate nanos to millis and add to mills
+        return millis + (nanos / 1_000_000);
+    }
+
+    // This comes from the Apache Hive ORC code
+    private static int parseNanos(long serialized)
+    {
+        int zeros = ((int) serialized) & 0b111;
+        int result = (int) (serialized >>> 3);
+        if (zeros != 0) {
+            for (int i = 0; i <= zeros; ++i) {
+                result *= 10;
+            }
+        }
+        return result;
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
@@ -66,8 +66,11 @@ public final class SelectiveStreamReaders
             case STRING:
             case VARCHAR:
             case CHAR:
-            case TIMESTAMP:
                 throw new IllegalArgumentException("Unsupported type: " + streamDescriptor.getStreamType());
+            case TIMESTAMP: {
+                checkArgument(requiredSubfields.isEmpty(), "Timestamp stream reader doesn't support subfields");
+                return new TimestampSelectiveStreamReader(streamDescriptor, getOptionalOnlyFilter(type, filters), hiveStorageTimeZone, outputType.isPresent(), systemMemoryContext.newLocalMemoryContext(SelectiveStreamReaders.class.getSimpleName()));
+            }
             case LIST:
                 return new ListSelectiveStreamReader(streamDescriptor, filters, requiredSubfields, null, 0, outputType, hiveStorageTimeZone, systemMemoryContext);
             case STRUCT:

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampBatchStreamReader.java
@@ -36,6 +36,7 @@ import java.util.List;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.SECONDARY;
+import static com.facebook.presto.orc.reader.ApacheHiveTimestampDecoder.decodeTimestamp;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verify;
@@ -200,40 +201,6 @@ public class TimestampBatchStreamReader
         return toStringHelper(this)
                 .addValue(streamDescriptor)
                 .toString();
-    }
-
-    // This comes from the Apache Hive ORC code
-    public static long decodeTimestamp(long seconds, long serializedNanos, long baseTimestampInSeconds)
-    {
-        long millis = (seconds + baseTimestampInSeconds) * MILLIS_PER_SECOND;
-        long nanos = parseNanos(serializedNanos);
-        if (nanos > 999999999 || nanos < 0) {
-            throw new IllegalArgumentException("nanos field of an encoded timestamp in ORC must be between 0 and 999999999 inclusive, got " + nanos);
-        }
-
-        // the rounding error exists because java always rounds up when dividing integers
-        // -42001/1000 = -42; and -42001 % 1000 = -1 (+ 1000)
-        // to get the correct value we need
-        // (-42 - 1)*1000 + 999 = -42001
-        // (42)*1000 + 1 = 42001
-        if (millis < 0 && nanos != 0) {
-            millis -= 1000;
-        }
-        // Truncate nanos to millis and add to mills
-        return millis + (nanos / 1_000_000);
-    }
-
-    // This comes from the Apache Hive ORC code
-    private static int parseNanos(long serialized)
-    {
-        int zeros = ((int) serialized) & 0b111;
-        int result = (int) (serialized >>> 3);
-        if (zeros != 0) {
-            for (int i = 0; i <= zeros; ++i) {
-                result *= 10;
-            }
-        }
-        return result;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
@@ -1,0 +1,424 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.orc.TupleDomainFilter;
+import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.stream.BooleanInputStream;
+import com.facebook.presto.orc.stream.InputStreamSource;
+import com.facebook.presto.orc.stream.InputStreamSources;
+import com.facebook.presto.orc.stream.LongInputStream;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockLease;
+import com.facebook.presto.spi.block.ClosingBlockLease;
+import com.facebook.presto.spi.block.LongArrayBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.openjdk.jol.info.ClassLayout;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.SECONDARY;
+import static com.facebook.presto.orc.reader.ApacheHiveTimestampDecoder.decodeTimestamp;
+import static com.facebook.presto.orc.reader.Arrays.ensureCapacity;
+import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.util.Objects.requireNonNull;
+
+public class TimestampSelectiveStreamReader
+        implements SelectiveStreamReader
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(TimestampSelectiveStreamReader.class).instanceSize();
+    private static final Block NULL_BLOCK = TIMESTAMP.createBlockBuilder(null, 1).appendNull().build();
+
+    private final StreamDescriptor streamDescriptor;
+    private final TupleDomainFilter filter;
+    private final boolean nullsAllowed;
+    private final boolean outputRequired;
+    private final LocalMemoryContext systemMemoryContext;
+    private final long baseTimestampInSeconds;
+    private final boolean nonDeterministicFilter;
+
+    private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
+    private InputStreamSource<LongInputStream> secondsStreamSource = missingStreamSource(LongInputStream.class);
+    private InputStreamSource<LongInputStream> nanosStreamSource = missingStreamSource(LongInputStream.class);
+
+    @Nullable
+    private BooleanInputStream presentStream;
+    private LongInputStream secondsStream;
+    private LongInputStream nanosStream;
+    private boolean rowGroupOpen;
+
+    private int readOffset;
+    @Nullable
+    private long[] values;
+    @Nullable
+    private boolean[] nulls;
+    @Nullable
+    private int[] outputPositions;
+    private int outputPositionCount;
+    private boolean allNulls;
+    private boolean valuesInUse;
+
+    public TimestampSelectiveStreamReader(
+            StreamDescriptor streamDescriptor,
+            Optional<TupleDomainFilter> filter,
+            DateTimeZone hiveStorageTimeZone,
+            boolean outputRequired,
+            LocalMemoryContext systemMemoryContext)
+    {
+        this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
+        this.filter = filter.orElse(null);
+        this.outputRequired = outputRequired;
+        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
+        this.nonDeterministicFilter = this.filter != null && !this.filter.isDeterministic();
+        this.nullsAllowed = this.filter == null || nonDeterministicFilter || this.filter.testNull();
+        this.baseTimestampInSeconds = new DateTime(2015, 1, 1, 0, 0, requireNonNull(hiveStorageTimeZone, "hiveStorageTimeZone is null")).getMillis() / 1000;
+    }
+
+    @Override
+    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    {
+        presentStreamSource = missingStreamSource(BooleanInputStream.class);
+        secondsStreamSource = missingStreamSource(LongInputStream.class);
+        nanosStreamSource = missingStreamSource(LongInputStream.class);
+        readOffset = 0;
+        presentStream = null;
+        secondsStream = null;
+        nanosStream = null;
+        rowGroupOpen = false;
+    }
+
+    @Override
+    public void startRowGroup(InputStreamSources dataStreamSources)
+    {
+        presentStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, PRESENT, BooleanInputStream.class);
+        secondsStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, DATA, LongInputStream.class);
+        nanosStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, SECONDARY, LongInputStream.class);
+        readOffset = 0;
+        presentStream = null;
+        secondsStream = null;
+        nanosStream = null;
+        rowGroupOpen = false;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(values) + sizeOf(nulls) + sizeOf(outputPositions);
+    }
+
+    private void openRowGroup()
+            throws IOException
+    {
+        presentStream = presentStreamSource.openStream();
+        secondsStream = secondsStreamSource.openStream();
+        nanosStream = nanosStreamSource.openStream();
+        rowGroupOpen = true;
+    }
+
+    @Override
+    public int read(int offset, int[] positions, int positionCount)
+            throws IOException
+    {
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
+        if (!rowGroupOpen) {
+            openRowGroup();
+        }
+
+        allNulls = false;
+
+        if (outputRequired) {
+            ensureValuesCapacity(positionCount, nullsAllowed && presentStream != null);
+        }
+
+        if (filter != null) {
+            outputPositions = ensureCapacity(outputPositions, positionCount);
+        }
+        else {
+            outputPositions = positions;
+        }
+
+        // account memory used by values, nulls and outputPositions
+        systemMemoryContext.setBytes(getRetainedSizeInBytes());
+
+        if (readOffset < offset) {
+            skip(offset - readOffset);
+        }
+
+        int streamPosition = 0;
+        if (secondsStream == null && nanosStream == null && presentStream != null) {
+            streamPosition = readAllNulls(positions, positionCount);
+        }
+        else if (filter == null) {
+            streamPosition = readNoFilter(positions, positionCount);
+        }
+        else {
+            streamPosition = readWithFilter(positions, positionCount);
+        }
+
+        readOffset = offset + streamPosition;
+        return outputPositionCount;
+    }
+
+    private int readWithFilter(int[] positions, int positionCount)
+            throws IOException
+    {
+        int streamPosition = 0;
+        outputPositionCount = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            if (position > streamPosition) {
+                skip(position - streamPosition);
+                streamPosition = position;
+            }
+
+            if (presentStream != null && !presentStream.nextBit()) {
+                if ((nonDeterministicFilter && filter.testNull()) || nullsAllowed) {
+                    if (outputRequired) {
+                        nulls[outputPositionCount] = true;
+                    }
+                    outputPositions[outputPositionCount] = position;
+                    outputPositionCount++;
+                }
+            }
+            else {
+                long value = decodeTimestamp(secondsStream.next(), nanosStream.next(), baseTimestampInSeconds);
+                if (filter.testLong(value)) {
+                    if (outputRequired) {
+                        values[outputPositionCount] = value;
+                        if (nullsAllowed && presentStream != null) {
+                            nulls[outputPositionCount] = false;
+                        }
+                    }
+                    outputPositions[outputPositionCount] = position;
+                    outputPositionCount++;
+                }
+            }
+            streamPosition++;
+        }
+        return streamPosition;
+    }
+
+    private int readAllNulls(int[] positions, int positionCount)
+            throws IOException
+    {
+        presentStream.skip(positions[positionCount - 1]);
+
+        if (nonDeterministicFilter) {
+            outputPositionCount = 0;
+            for (int i = 0; i < positionCount; i++) {
+                if (filter.testNull()) {
+                    outputPositionCount++;
+                }
+            }
+        }
+        else if (nullsAllowed) {
+            outputPositionCount = positionCount;
+            allNulls = true;
+        }
+        else {
+            outputPositionCount = 0;
+        }
+
+        return positions[positionCount - 1] + 1;
+    }
+
+    private int readNoFilter(int[] positions, int positionCount)
+            throws IOException
+    {
+        // filter == null implies outputRequired == true
+        int streamPosition = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            if (position > streamPosition) {
+                skip(position - streamPosition);
+                streamPosition = position;
+            }
+
+            if (presentStream != null && !presentStream.nextBit()) {
+                nulls[i] = true;
+            }
+            else {
+                values[i] = decodeTimestamp(secondsStream.next(), nanosStream.next(), baseTimestampInSeconds);
+                if (presentStream != null) {
+                    nulls[i] = false;
+                }
+            }
+            streamPosition++;
+        }
+        outputPositionCount = positionCount;
+        return streamPosition;
+    }
+
+    private void skip(int items)
+            throws IOException
+    {
+        if (secondsStream == null && nanosStream == null) {
+            presentStream.skip(items);
+        }
+        else if (presentStream != null) {
+            int dataToSkip = presentStream.countBitsSet(items);
+            secondsStream.skip(dataToSkip);
+            nanosStream.skip(dataToSkip);
+        }
+        else {
+            secondsStream.skip(items);
+            nanosStream.skip(items);
+        }
+    }
+
+    private void ensureValuesCapacity(int capacity, boolean recordNulls)
+    {
+        values = ensureCapacity(values, capacity);
+
+        if (recordNulls) {
+            nulls = ensureCapacity(nulls, capacity);
+        }
+    }
+
+    @Override
+    public int[] getReadPositions()
+    {
+        return outputPositions;
+    }
+
+    @Override
+    public Block getBlock(int[] positions, int positionCount)
+    {
+        checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
+        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(positionCount <= outputPositionCount, "Not enough values");
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
+        if (allNulls) {
+            return new RunLengthEncodedBlock(NULL_BLOCK, outputPositionCount);
+        }
+
+        boolean includeNulls = nullsAllowed && presentStream != null;
+        if (positionCount == outputPositionCount) {
+            Block block = new LongArrayBlock(positionCount, Optional.ofNullable(includeNulls ? nulls : null), values);
+            nulls = null;
+            values = null;
+            return block;
+        }
+
+        long[] valuesCopy = new long[positionCount];
+        boolean[] nullsCopy = null;
+        if (includeNulls) {
+            nullsCopy = new boolean[positionCount];
+        }
+
+        int positionIndex = 0;
+        int nextPosition = positions[positionIndex];
+        for (int i = 0; i < outputPositionCount; i++) {
+            if (outputPositions[i] < nextPosition) {
+                continue;
+            }
+
+            assert outputPositions[i] == nextPosition;
+
+            valuesCopy[positionIndex] = this.values[i];
+            if (nullsCopy != null) {
+                nullsCopy[positionIndex] = this.nulls[i];
+            }
+
+            positionIndex++;
+            if (positionIndex >= positionCount) {
+                break;
+            }
+
+            nextPosition = positions[positionIndex];
+        }
+
+        return new LongArrayBlock(positionCount, Optional.ofNullable(nullsCopy), valuesCopy);
+    }
+
+    @Override
+    public BlockLease getBlockView(int[] positions, int positionCount)
+    {
+        checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
+        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(positionCount <= outputPositionCount, "Not enough values");
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
+        if (allNulls) {
+            return newLease(new RunLengthEncodedBlock(NULL_BLOCK, outputPositionCount));
+        }
+
+        boolean includeNulls = nullsAllowed && presentStream != null;
+        if (positionCount != outputPositionCount) {
+            compactValues(positions, positionCount, includeNulls);
+        }
+
+        return newLease(new LongArrayBlock(positionCount, Optional.ofNullable(includeNulls ? nulls : null), values));
+    }
+
+    private BlockLease newLease(Block block)
+    {
+        valuesInUse = true;
+        return ClosingBlockLease.newLease(block, () -> valuesInUse = false);
+    }
+
+    private void compactValues(int[] positions, int positionCount, boolean compactNulls)
+    {
+        int positionIndex = 0;
+        int nextPosition = positions[positionIndex];
+        for (int i = 0; i < outputPositionCount; i++) {
+            if (outputPositions[i] < nextPosition) {
+                continue;
+            }
+
+            assert outputPositions[i] == nextPosition;
+
+            values[positionIndex] = values[i];
+            if (compactNulls) {
+                nulls[positionIndex] = nulls[i];
+            }
+            outputPositions[positionIndex] = nextPosition;
+
+            positionIndex++;
+            if (positionIndex >= positionCount) {
+                break;
+            }
+            nextPosition = positions[positionIndex];
+        }
+
+        outputPositionCount = positionCount;
+    }
+
+    @Override
+    public void close()
+    {
+        systemMemoryContext.close();
+    }
+
+    @Override
+    public void throwAnyError(int[] positions, int positionCount)
+    {
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -19,6 +19,8 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.Subfield;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.SqlDate;
+import com.facebook.presto.spi.type.SqlTimestamp;
+import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.type.TypeRegistry;
@@ -63,6 +65,7 @@ import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -188,7 +191,8 @@ public class BenchmarkSelectiveStreamReaders
                 "bigint",
                 "smallint",
                 "tinyint",
-                "date"
+                "date",
+                "timestamp"
         })
         private String typeSignature;
 
@@ -217,7 +221,8 @@ public class BenchmarkSelectiveStreamReaders
                 "bigint",
                 "smallint",
                 "tinyint",
-                "date"
+                "date",
+                "timestamp"
         })
         private String typeSignature;
 
@@ -247,7 +252,7 @@ public class BenchmarkSelectiveStreamReaders
                 return Optional.of(BooleanValue.of(true, true));
             }
 
-            if (type == TINYINT || type == BIGINT || type == INTEGER || type == SMALLINT || type == DATE) {
+            if (type == TINYINT || type == BIGINT || type == INTEGER || type == SMALLINT || type == DATE || type == TIMESTAMP) {
                 return Optional.of(BigintRange.of(0, Long.MAX_VALUE, true));
             }
 
@@ -287,6 +292,10 @@ public class BenchmarkSelectiveStreamReaders
 
             if (getType() == DATE) {
                 return new SqlDate(random.nextInt());
+            }
+
+            if (getType() == TIMESTAMP) {
+                return new SqlTimestamp(random.nextLong(), TimeZoneKey.UTC_KEY);
             }
 
             throw new UnsupportedOperationException("Unsupported type: " + getType());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -727,6 +727,12 @@ public class OrcTester
                         return false;
                     }
                 }
+                else if (type == TIMESTAMP) {
+                    if (!filter.testLong(((SqlTimestamp) value).getMillisUtc())) {
+                        return false;
+                    }
+                }
+
                 else {
                     fail("Unsupported type: " + type);
                 }


### PR DESCRIPTION
```
Benchmark                                       (typeSignature)  (withNulls)  Mode  Cnt  Score    Error  Units
BenchmarkSelectiveStreamReaders.read                  timestamp         true  avgt   60  0.115 ±  0.001   s/op
BenchmarkSelectiveStreamReaders.read                  timestamp        false  avgt   60  0.177 ±  0.002   s/op
BenchmarkSelectiveStreamReaders.readAllNull           timestamp          N/A  avgt   60  0.003 ±  0.001   s/op
BenchmarkSelectiveStreamReaders.readWithFilter        timestamp         true  avgt   60  0.114 ±  0.001   s/op
BenchmarkSelectiveStreamReaders.readWithFilter        timestamp        false  avgt   60  0.198 ±  0.004   s/op

Benchmark                                          Mode  Cnt  Score   Error  Units
BenchmarkBatchStreamReaders.readTimestampNoNull    avgt   60  0.188 ± 0.005   s/op
BenchmarkBatchStreamReaders.readTimestampWithNull  avgt   60  0.166 ± 0.003   s/op
```

```
== NO RELEASE NOTE ==
```