### PR TITLE
Completely remove joda-to-java-time-bridge.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -617,12 +617,6 @@
             </dependency>
 
             <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>joda-to-java-time-bridge</artifactId>
-                <version>3</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.facebook.drift</groupId>
                 <artifactId>drift-api</artifactId>
                 <version>${dep.drift.version}</version>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -246,12 +246,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
         </dependency>

--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -69,12 +69,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -78,12 +78,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -173,12 +173,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
         </dependency>

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -68,12 +68,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>

--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -55,12 +55,6 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
 

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -187,11 +187,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.teradata</groupId>
             <artifactId>re2j-td</artifactId>
         </dependency>

--- a/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
@@ -14,10 +14,8 @@
 package com.facebook.presto.util;
 
 import com.facebook.presto.spi.type.TimeZoneKey;
-import io.airlift.jodabridge.JdkBasedZoneInfoProvider;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.time.ZoneId;
@@ -32,26 +30,12 @@ import static org.testng.Assert.assertEquals;
 
 public class TestTimeZoneUtils
 {
-    @BeforeClass
-    protected void validateJodaZoneInfoProvider()
-    {
-        try {
-            JdkBasedZoneInfoProvider.registerAsJodaZoneInfoProvider();
-        }
-        catch (RuntimeException e) {
-            throw new RuntimeException("Set the following system property to JVM running the test: -Dorg.joda.time.DateTimeZone.Provider=com.facebook.presto.tz.JdkBasedZoneInfoProvider");
-        }
-    }
-
     @Test
     public void test()
     {
         TimeZoneKey.getTimeZoneKey("GMT-13:00");
 
-        TreeSet<String> jodaZones = new TreeSet<>(DateTimeZone.getAvailableIDs());
         TreeSet<String> jdkZones = new TreeSet<>(ZoneId.getAvailableZoneIds());
-        // We use JdkBasedZoneInfoProvider for joda
-        assertEquals(jodaZones, jdkZones);
 
         for (String zoneId : new TreeSet<>(jdkZones)) {
             if (zoneId.startsWith("Etc/") || zoneId.startsWith("GMT") || zoneId.startsWith("SystemV/")) {

--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -31,12 +31,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -72,12 +72,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-raptor/pom.xml
+++ b/presto-raptor/pom.xml
@@ -103,12 +103,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>

--- a/presto-rcfile/pom.xml
+++ b/presto-rcfile/pom.xml
@@ -33,12 +33,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -52,12 +52,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>1.8.1</version>

--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -68,12 +68,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>

--- a/presto-teradata-functions/pom.xml
+++ b/presto-teradata-functions/pom.xml
@@ -32,12 +32,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
         </dependency>

--- a/presto-tpcds/pom.xml
+++ b/presto-tpcds/pom.xml
@@ -37,12 +37,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>


### PR DESCRIPTION
Same as https://github.com/prestosql/presto/pull/1222/files

- joda-to-java-time-bridge was added in https://github.com/prestodb/presto/commit/8ac4b8466a7db96d9941e27cecf7aaf64c85bfaf
- it was later removed in 6af161535aa6b7888d9e37e3cca8ad3c04dc22d5, but not completely. It is still registered for the tests

Some comments on Slack from @dain and @electrum:

> The bridge doesn’t work.  Turns out joda has a number of unspecified behaviors that break things unexpectedly
>
> It could be made to work but someone needs to dig into the code and figure out the undocumented behaviors
>
> My gut says to remove it unless someone wants to dig into making it work correctly
>
> We had hopes of fixing it soon after it was added but that never happened. Normally we wouldn’t keep such dead code around.

This PR removes the bridge completely