### PR TITLE
Add default implementation for SelectiveStreamReader throwAnyError

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractLongSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractLongSelectiveStreamReader.java
@@ -80,11 +80,6 @@ abstract class AbstractLongSelectiveStreamReader
         return outputPositions;
     }
 
-    @Override
-    public void throwAnyError(int[] positions, int positionCount)
-    {
-    }
-
     protected BlockLease buildOutputBlockView(int[] positions, int positionCount, boolean includeNulls)
     {
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
@@ -395,11 +395,6 @@ public class BooleanSelectiveStreamReader
         return newLease(new ByteArrayBlock(positionCount, Optional.ofNullable(includeNulls ? nulls : null), values));
     }
 
-    @Override
-    public void throwAnyError(int[] positions, int positionCount)
-    {
-    }
-
     private BlockLease newLease(Block block)
     {
         valuesInUse = true;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
@@ -353,11 +353,6 @@ public class ByteSelectiveStreamReader
         return newLease(new ByteArrayBlock(positionCount, Optional.ofNullable(includeNulls ? nulls : null), values));
     }
 
-    @Override
-    public void throwAnyError(int[] positions, int positionCount)
-    {
-    }
-
     private BlockLease newLease(Block block)
     {
         valuesInUse = true;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReader.java
@@ -69,7 +69,9 @@ public interface SelectiveStreamReader
      *
      * Used by list and map readers to raise "subscript out of bounds" error.
      */
-    void throwAnyError(int[] positions, int positionCount);
+    default void throwAnyError(int[] positions, int positionCount)
+    {
+    }
 
     void close();
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
@@ -417,8 +417,4 @@ public class TimestampSelectiveStreamReader
         systemMemoryContext.close();
     }
 
-    @Override
-    public void throwAnyError(int[] positions, int positionCount)
-    {
-    }
 }


### PR DESCRIPTION
As of now only ListSelectiveStreamReader has a implementation for throwAnyError,
instead of having empty method, provided a default impl in the interface