### PR TITLE
Reuse compressionBuffer when serializing pages

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedOutputOperator.java
@@ -350,7 +350,7 @@ public class PartitionedOutputOperator
         {
             // We use a foreach loop instead of streams
             // as it has much better performance.
-            long sizeInBytes = 0;
+            long sizeInBytes = serde.getSizeInBytes();
             for (PageBuilder pageBuilder : pageBuilders) {
                 sizeInBytes += pageBuilder.getSizeInBytes();
             }
@@ -362,7 +362,7 @@ public class PartitionedOutputOperator
          */
         public long getRetainedSizeInBytes()
         {
-            long sizeInBytes = 0;
+            long sizeInBytes = serde.getRetainedSizeInBytes();
             for (PageBuilder pageBuilder : pageBuilders) {
                 sizeInBytes += pageBuilder.getRetainedSizeInBytes();
             }

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkCompressToByteBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkCompressToByteBuffer.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import io.airlift.compress.Compressor;
+import io.airlift.compress.lz4.Lz4Compressor;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@State(Scope.Thread)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(3)
+@Warmup(iterations = 20, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 20, time = 500, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkCompressToByteBuffer
+{
+    @Benchmark
+    public void compressToByteBuffer(BenchmarkData data)
+    {
+        data.byteBuffer.mark();
+        data.COMPRESSOR.compress(data.slice.toByteBuffer(), data.byteBuffer);
+        data.byteBuffer.reset();
+    }
+
+    @Benchmark
+    public void compressToByteArray(BenchmarkData data)
+    {
+        data.COMPRESSOR.compress((byte[]) data.slice.getBase(), 0, data.slice.length(), data.bytes, 0, data.MAX_COMPRESSED_SIZE);
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private static final Random RANDOM = new Random(0);
+        private static final Compressor COMPRESSOR = new Lz4Compressor();
+        private static final int UNCOMPRESSED_SIZE = 1_000_000;
+        private static final int MAX_COMPRESSED_SIZE = COMPRESSOR.maxCompressedLength(UNCOMPRESSED_SIZE);
+
+        private final byte[] byteValues = new byte[UNCOMPRESSED_SIZE];
+        private final Slice slice = Slices.wrappedBuffer(byteValues);
+
+        private final byte[] bytes = new byte[MAX_COMPRESSED_SIZE];
+        private final ByteBuffer byteBuffer = ByteBuffer.allocate(MAX_COMPRESSED_SIZE);
+
+        @Setup
+        public void setup()
+        {
+            // Generate discontinuous runs of random values and 0's to avoid LZ4 enters uncompressible fast-path
+            int runLength = UNCOMPRESSED_SIZE / 10;
+            byte[] randomBytes = new byte[runLength];
+            for (int i = 0; i < 10; i += 2) {
+                RANDOM.nextBytes(randomBytes);
+                System.arraycopy(randomBytes, 0, byteValues, i * runLength, runLength);
+            }
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkCompressToByteBuffer.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkPartitionedOutputOperator.java
@@ -37,6 +37,7 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -73,9 +74,9 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @State(Scope.Thread)
 @OutputTimeUnit(MILLISECONDS)
-@Fork(2)
-@Warmup(iterations = 20, time = 500, timeUnit = MILLISECONDS)
-@Measurement(iterations = 20, time = 500, timeUnit = MILLISECONDS)
+@Fork(3)
+@Warmup(iterations = 10, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = MILLISECONDS)
 @BenchmarkMode(Mode.AverageTime)
 public class BenchmarkPartitionedOutputOperator
 {
@@ -101,6 +102,9 @@ public class BenchmarkPartitionedOutputOperator
         private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-EXECUTOR-%s"));
         private static final ScheduledExecutorService SCHEDULER = newScheduledThreadPool(1, daemonThreadsNamed("test-%s"));
 
+        @Param({"true", "false"})
+        private boolean enableCompression;
+
         private final Page dataPage = createPage();
 
         private int getPageCount()
@@ -116,7 +120,7 @@ public class BenchmarkPartitionedOutputOperator
         private PartitionedOutputOperator createPartitionedOutputOperator()
         {
             PartitionFunction partitionFunction = new LocalPartitionGenerator(new InterpretedHashGenerator(ImmutableList.of(BIGINT), new int[] {0}), PARTITION_COUNT);
-            PagesSerdeFactory serdeFactory = new PagesSerdeFactory(new BlockEncodingManager(new TypeRegistry()), false);
+            PagesSerdeFactory serdeFactory = new PagesSerdeFactory(new BlockEncodingManager(new TypeRegistry()), enableCompression);
             OutputBuffers buffers = createInitialEmptyOutputBuffers(PARTITIONED);
             for (int partition = 0; partition < PARTITION_COUNT; partition++) {
                 buffers = buffers.withBuffer(new OutputBuffers.OutputBufferId(partition), partition);


### PR DESCRIPTION
BenchmarkPartitionedOutputOperator shows 8% gain in elapsed time:

Always allocate compressionBuffer (existing behavior):
Benchmark                                   Mode  Cnt     Score     Error  Units
BenchmarkPartitionedOutputOperator.addPage  avgt   20  4749.447 ± 380.463  ms/op

Reuse compressionBuffer (current commit):
Benchmark                                   Mode  Cnt     Score     Error  Units
BenchmarkPartitionedOutputOperator.addPage  avgt   30  4380.171 ± 148.011  ms/op

BenchmarkCompressToByteBuffer shows using ByteBuffer and byte[] as compression
buffer has similar performance. We used byte[] because the code is cleaner.

Benchmark                                          Mode  Cnt    Score   Error  Units
BenchmarkCompressToByteBuffer.compressToByteArray  avgt   60  181.677 ± 9.927  us/op
BenchmarkCompressToByteBuffer.compressToByteBuffer  avgt   60  189.371 ± 3.747  us/op


```
== RELEASE NOTES ==
General Changes
* Reuse compression buffer in PagesSerde when serializing pages.
```
