### PR TITLE
Exclude commons-logging from util-hadoop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -957,6 +957,10 @@
                 <version>hadoop2-${dep.gcs.version}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>com.google.guava</groupId>
                         <artifactId>guava</artifactId>
                     </exclusion>


### PR DESCRIPTION
`commons-logging:commons-logging` collides with `org.slf4j:jcl-over-slf4j`, the logging library that we're using in Presto.

```
== NO RELEASE NOTE ==
```
