### PR TITLE
Add StructSelectiveStreamReader

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -55,9 +55,9 @@ import static com.facebook.presto.hive.HiveUtil.getPrefilledColumnValue;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.MOST_OPTIMIZED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Predicates.not;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Maps.uniqueIndex;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -153,9 +153,11 @@ public class HivePageSourceProvider
                 .addAll(split.getBucketConversion().map(BucketConversion::getBucketColumnHandles).orElse(ImmutableList.of()))
                 .build();
 
+        Set<String> columnNames = columns.stream().map(HiveColumnHandle::getName).collect(toImmutableSet());
+
         List<HiveColumnHandle> allColumns = ImmutableList.<HiveColumnHandle>builder()
                 .addAll(columns)
-                .addAll(interimColumns.stream().filter(not(columns::contains)).collect(toImmutableList()))
+                .addAll(interimColumns.stream().filter(column -> !columnNames.contains(column.getName())).collect(toImmutableList()))
                 .build();
 
         Path path = new Path(split.getPath());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -67,7 +67,7 @@ public class TestHivePushdownFilterQueries
             throws Exception
     {
         DistributedQueryRunner queryRunner = HiveQueryRunner.createQueryRunner(getTables(),
-                ImmutableMap.of(),
+                ImmutableMap.of("experimental.pushdown-subfields-enabled", "true"),
                 "sql-standard",
                 ImmutableMap.of("hive.pushdown-filter-enabled", "true"),
                 Optional.empty());

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
@@ -150,6 +150,7 @@ public class BooleanSelectiveStreamReader
     public int read(int offset, int[] positions, int positionCount)
             throws IOException
     {
+        checkArgument(positionCount > 0, "positionCount must be greater than zero");
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (!rowGroupOpen) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
@@ -39,6 +39,7 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -389,6 +390,14 @@ public class ByteSelectiveStreamReader
         }
 
         outputPositionCount = positionCount;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(streamDescriptor)
+                .toString();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
@@ -189,6 +189,7 @@ public class ListSelectiveStreamReader
     public int read(int offset, int[] positions, int positionCount)
             throws IOException
     {
+        checkArgument(positionCount > 0, "positionCount must be greater than zero");
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (!rowGroupOpen) {
@@ -369,7 +370,7 @@ public class ListSelectiveStreamReader
             listFilter.populateElementFilters(outputPositionCount, nulls, elementLengths, elementPositionCount);
         }
 
-        if (elementStreamReader != null) {
+        if (elementStreamReader != null && elementPositionCount > 0) {
             elementStreamReader.read(elementReadOffset, elementPositions, elementPositionCount);
         }
         elementReadOffset += elementPositionCount + skippedElements;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
@@ -97,6 +97,8 @@ public class LongDictionarySelectiveStreamReader
     public int read(int offset, int[] positions, int positionCount)
             throws IOException
     {
+        checkArgument(positionCount > 0, "positionCount must be greater than zero");
+
         if (!rowGroupOpen) {
             openRowGroup();
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
@@ -88,6 +88,8 @@ public class LongDirectSelectiveStreamReader
     public int read(int offset, int[] positions, int positionCount)
             throws IOException
     {
+        checkArgument(positionCount > 0, "positionCount must be greater than zero");
+
         if (!rowGroupOpen) {
             openRowGroup();
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
@@ -77,6 +77,7 @@ public final class SelectiveStreamReaders
             case LIST:
                 return new ListSelectiveStreamReader(streamDescriptor, filters, requiredSubfields, null, 0, outputType, hiveStorageTimeZone, systemMemoryContext);
             case STRUCT:
+                return new StructSelectiveStreamReader(streamDescriptor, filters, requiredSubfields, outputType, hiveStorageTimeZone, systemMemoryContext);
             case MAP:
             case DECIMAL:
             case UNION:
@@ -134,6 +135,7 @@ public final class SelectiveStreamReaders
                 Optional<ListFilter> childFilter = parentFilter.map(HierarchicalFilter::getChild).map(ListFilter.class::cast);
                 return new ListSelectiveStreamReader(streamDescriptor, ImmutableMap.of(), ImmutableList.of(), childFilter.orElse(null), level, outputType, hiveStorageTimeZone, systemMemoryContext.newAggregatedMemoryContext());
             case STRUCT:
+                return new StructSelectiveStreamReader(streamDescriptor, ImmutableMap.of(), ImmutableList.of(), outputType, hiveStorageTimeZone, systemMemoryContext.newAggregatedMemoryContext());
             case MAP:
             case UNION:
             default:

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
@@ -1,0 +1,480 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.memory.context.AggregatedMemoryContext;
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.orc.TupleDomainFilter;
+import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.stream.BooleanInputStream;
+import com.facebook.presto.orc.stream.InputStreamSource;
+import com.facebook.presto.orc.stream.InputStreamSources;
+import com.facebook.presto.spi.Subfield;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockLease;
+import com.facebook.presto.spi.block.ClosingBlockLease;
+import com.facebook.presto.spi.block.RowBlock;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import org.joda.time.DateTimeZone;
+import org.openjdk.jol.info.ClassLayout;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.orc.TupleDomainFilter.IS_NOT_NULL;
+import static com.facebook.presto.orc.TupleDomainFilter.IS_NULL;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.Arrays.ensureCapacity;
+import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.util.Objects.requireNonNull;
+
+public class StructSelectiveStreamReader
+        implements SelectiveStreamReader
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(StructSelectiveStreamReader.class).instanceSize();
+
+    private final StreamDescriptor streamDescriptor;
+    private final boolean nullsAllowed;
+    private final boolean nonNullsAllowed;
+    private final boolean outputRequired;
+    @Nullable
+    private final Type outputType;
+
+    private final Map<String, SelectiveStreamReader> nestedReaders;
+
+    private final LocalMemoryContext systemMemoryContext;
+
+    private int readOffset;
+    private int nestedReadOffset;
+
+    private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
+    @Nullable
+    private BooleanInputStream presentStream;
+
+    private boolean rowGroupOpen;
+    private boolean[] nulls;
+    private int[] outputPositions;
+    private int outputPositionCount;
+    private boolean allNulls;
+    private int[] nestedPositions;
+    private int[] nestedOutputPositions;
+    private int nestedOutputPositionCount;
+
+    private boolean valuesInUse;
+
+    public StructSelectiveStreamReader(
+            StreamDescriptor streamDescriptor,
+            Map<Subfield, TupleDomainFilter> filters,
+            List<Subfield> requiredSubfields,
+            Optional<Type> outputType,
+            DateTimeZone hiveStorageTimeZone,
+            AggregatedMemoryContext systemMemoryContext)
+    {
+        checkArgument(filters.keySet().stream().map(Subfield::getPath).allMatch(List::isEmpty), "filters on nested columns are not supported yet");
+        checkArgument(requiredSubfields.isEmpty(), "requiredSubfields are not supported yet");
+
+        this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
+        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null").newLocalMemoryContext(StructSelectiveStreamReader.class.getSimpleName());
+        this.outputRequired = requireNonNull(outputType, "outputType is null").isPresent();
+        this.outputType = outputType.orElse(null);
+
+        TupleDomainFilter filter = getTopLevelFilter(filters).orElse(null);
+        this.nullsAllowed = filter == null || filter.testNull();
+        this.nonNullsAllowed = filter == null || filter.testNonNull();
+
+        Optional<List<Type>> nestedTypes = outputType.map(type -> type.getTypeParameters());
+        List<StreamDescriptor> nestedStreams = streamDescriptor.getNestedStreams();
+
+        // TODO streamDescriptor may be missing some fields (due to schema evolution, e.g. add field?)
+        // TODO fields in streamDescriptor may be out of order (due to schema evolution, e.g. remove field?)
+        this.nestedReaders = IntStream.range(0, nestedStreams.size())
+                .boxed()
+                .collect(toImmutableMap(
+                        i -> nestedStreams.get(i).getFieldName().toLowerCase(Locale.ENGLISH),
+                        i -> SelectiveStreamReaders.createStreamReader(nestedStreams.get(i), ImmutableMap.of(), nestedTypes.map(types -> types.get(i)), ImmutableList.of(), hiveStorageTimeZone, systemMemoryContext.newAggregatedMemoryContext())));
+    }
+
+    @Override
+    public int read(int offset, int[] positions, int positionCount)
+            throws IOException
+    {
+        checkArgument(positionCount > 0, "positionCount must be greater than zero");
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
+        if (!rowGroupOpen) {
+            openRowGroup();
+        }
+
+        allNulls = false;
+
+        if (!nullsAllowed || !nonNullsAllowed) {
+            outputPositions = ensureCapacity(outputPositions, positionCount);
+        }
+        else {
+            outputPositions = positions;
+        }
+
+        systemMemoryContext.setBytes(getRetainedSizeInBytes());
+
+        if (presentStream == null) {
+            // no nulls
+            if (nonNullsAllowed) {
+                readNestedStreams(offset, positions, positionCount);
+                readOffset = offset + positions[positionCount - 1];
+                outputPositions = positions;
+                outputPositionCount = positionCount;
+            }
+            else {
+                outputPositionCount = 0;
+            }
+        }
+        else {
+            // some or all nulls
+            if (readOffset < offset) {
+                nestedReadOffset += presentStream.countBitsSet(offset - readOffset);
+            }
+
+            nulls = ensureCapacity(nulls, positionCount);
+            nestedPositions = ensureCapacity(nestedPositions, positionCount);
+            outputPositionCount = 0;
+
+            int streamPosition = 0;
+            int nestedPositionCount = 0;
+            int nullCount = 0;
+
+            for (int i = 0; i < positionCount; i++) {
+                int position = positions[i];
+                if (position > streamPosition) {
+                    int nonNullCount = presentStream.countBitsSet(position - streamPosition);
+                    nullCount += position - streamPosition - nonNullCount;
+                    streamPosition = position;
+                }
+
+                streamPosition++;
+
+                if (presentStream.nextBit()) {
+                    // not null
+                    if (nonNullsAllowed) {
+                        nulls[outputPositionCount] = false;
+                        if (!nullsAllowed) {
+                            outputPositions[outputPositionCount] = position;
+                        }
+                        outputPositionCount++;
+                        nestedPositions[nestedPositionCount++] = position - nullCount;
+                    }
+                }
+                else {
+                    // null
+                    if (nullsAllowed) {
+                        nulls[outputPositionCount] = true;
+                        if (!nonNullsAllowed) {
+                            outputPositions[outputPositionCount] = position;
+                        }
+                        outputPositionCount++;
+                    }
+                    nullCount++;
+                }
+            }
+
+            if (nestedPositionCount > 0) {
+                readNestedStreams(nestedReadOffset, nestedPositions, nestedPositionCount);
+            }
+            else {
+                allNulls = true;
+            }
+
+            readOffset = offset + streamPosition;
+            nestedReadOffset += streamPosition - nullCount;
+        }
+
+        return outputPositionCount;
+    }
+
+    private void readNestedStreams(int offset, int[] positions, int positionCount)
+            throws IOException
+    {
+        for (SelectiveStreamReader reader : nestedReaders.values()) {
+            reader.read(offset, positions, positionCount);
+        }
+
+        nestedOutputPositions = ensureCapacity(nestedOutputPositions, positionCount);
+        System.arraycopy(positions, 0, nestedOutputPositions, 0, positionCount);
+        nestedOutputPositionCount = positionCount;
+    }
+
+    private void openRowGroup()
+            throws IOException
+    {
+        presentStream = presentStreamSource.openStream();
+
+        rowGroupOpen = true;
+    }
+
+    @Override
+    public int[] getReadPositions()
+    {
+        return outputPositions;
+    }
+
+    @Override
+    public Block getBlock(int[] positions, int positionCount)
+    {
+        checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
+        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(positionCount <= outputPositionCount, "Not enough values");
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
+        if (allNulls) {
+            return createNullBlock(outputType, positionCount);
+        }
+
+        boolean includeNulls = nullsAllowed && presentStream != null;
+        if (outputPositionCount == positionCount) {
+            Block block = RowBlock.fromFieldBlocks(positionCount, Optional.ofNullable(includeNulls ? nulls : null), getFieldBlocks());
+            nulls = null;
+            return block;
+        }
+
+        boolean[] nullsCopy = null;
+        if (includeNulls) {
+            nullsCopy = new boolean[positionCount];
+        }
+
+        int positionIndex = 0;
+        int nextPosition = positions[positionIndex];
+        int nestedIndex = 0;
+        nestedOutputPositionCount = 0;
+
+        for (int i = 0; i < outputPositionCount; i++) {
+            if (outputPositions[i] < nextPosition) {
+                if (!includeNulls || !nulls[i]) {
+                    nestedIndex++;
+                }
+                continue;
+            }
+
+            assert outputPositions[i] == nextPosition;
+
+            if (!includeNulls || !nulls[i]) {
+                nestedOutputPositions[nestedOutputPositionCount++] = nestedOutputPositions[nestedIndex];
+                nestedIndex++;
+            }
+            if (nullsCopy != null) {
+                nullsCopy[positionIndex] = this.nulls[i];
+            }
+
+            positionIndex++;
+            if (positionIndex >= positionCount) {
+                break;
+            }
+
+            nextPosition = positions[positionIndex];
+        }
+
+        if (nestedOutputPositionCount == 0) {
+            return createNullBlock(outputType, positionCount);
+        }
+
+        return RowBlock.fromFieldBlocks(positionCount, Optional.ofNullable(includeNulls ? nullsCopy : null), getFieldBlocks());
+    }
+
+    private Block[] getFieldBlocks()
+    {
+        Block[] blocks = new Block[nestedReaders.size()];
+        int i = 0;
+        for (SelectiveStreamReader reader : nestedReaders.values()) {
+            blocks[i++] = reader.getBlock(nestedOutputPositions, nestedOutputPositionCount);
+        }
+        return blocks;
+    }
+
+    private static RunLengthEncodedBlock createNullBlock(Type type, int positionCount)
+    {
+        return new RunLengthEncodedBlock(type.createBlockBuilder(null, 1).appendNull().build(), positionCount);
+    }
+
+    @Override
+    public BlockLease getBlockView(int[] positions, int positionCount)
+    {
+        checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
+        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(positionCount <= outputPositionCount, "Not enough values");
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
+        if (allNulls) {
+            return newLease(createNullBlock(outputType, positionCount));
+        }
+
+        boolean includeNulls = nullsAllowed && presentStream != null;
+        if (positionCount != outputPositionCount) {
+            compactValues(positions, positionCount, includeNulls);
+
+            if (nestedOutputPositionCount == 0) {
+                allNulls = true;
+                return newLease(createNullBlock(outputType, positionCount));
+            }
+        }
+
+        BlockLease[] fieldBlockLeases = new BlockLease[nestedReaders.size()];
+        Block[] fieldBlocks = new Block[nestedReaders.size()];
+        int i = 0;
+        for (SelectiveStreamReader reader : nestedReaders.values()) {
+            fieldBlockLeases[i] = reader.getBlockView(nestedOutputPositions, nestedOutputPositionCount);
+            fieldBlocks[i] = fieldBlockLeases[i].get();
+            i++;
+        }
+
+        return newLease(RowBlock.fromFieldBlocks(positionCount, Optional.ofNullable(includeNulls ? nulls : null), fieldBlocks), fieldBlockLeases);
+    }
+
+    private void compactValues(int[] positions, int positionCount, boolean compactNulls)
+    {
+        int positionIndex = 0;
+        int nextPosition = positions[positionIndex];
+        int nestedIndex = 0;
+        nestedOutputPositionCount = 0;
+        for (int i = 0; i < outputPositionCount; i++) {
+            if (outputPositions[i] < nextPosition) {
+                if (!compactNulls || !nulls[i]) {
+                    nestedIndex++;
+                }
+                continue;
+            }
+
+            assert outputPositions[i] == nextPosition;
+
+            if (!compactNulls || !nulls[i]) {
+                nestedOutputPositions[nestedOutputPositionCount++] = nestedOutputPositions[nestedIndex];
+                nestedIndex++;
+            }
+            if (compactNulls) {
+                nulls[positionIndex] = nulls[i];
+            }
+            outputPositions[positionIndex] = nextPosition;
+
+            positionIndex++;
+            if (positionIndex >= positionCount) {
+                break;
+            }
+            nextPosition = positions[positionIndex];
+        }
+
+        outputPositionCount = positionCount;
+    }
+
+    private BlockLease newLease(Block block, BlockLease...fieldBlockLeases)
+    {
+        valuesInUse = true;
+        return ClosingBlockLease.newLease(block, () -> {
+            for (BlockLease lease : fieldBlockLeases) {
+                lease.close();
+            }
+            valuesInUse = false;
+        });
+    }
+
+    @Override
+    public void throwAnyError(int[] positions, int positionCount)
+    {
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(streamDescriptor)
+                .toString();
+    }
+
+    @Override
+    public void close()
+    {
+        systemMemoryContext.close();
+    }
+
+    @Override
+    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+            throws IOException
+    {
+        presentStreamSource = missingStreamSource(BooleanInputStream.class);
+
+        readOffset = 0;
+        nestedReadOffset = 0;
+
+        presentStream = null;
+
+        rowGroupOpen = false;
+
+        for (SelectiveStreamReader reader : nestedReaders.values()) {
+            reader.startStripe(dictionaryStreamSources, encoding);
+        }
+    }
+
+    @Override
+    public void startRowGroup(InputStreamSources dataStreamSources)
+            throws IOException
+    {
+        presentStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, PRESENT, BooleanInputStream.class);
+
+        readOffset = 0;
+        nestedReadOffset = 0;
+
+        presentStream = null;
+
+        rowGroupOpen = false;
+
+        for (SelectiveStreamReader reader : nestedReaders.values()) {
+            reader.startRowGroup(dataStreamSources);
+        }
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(outputPositions) + sizeOf(nestedPositions) + sizeOf(nestedOutputPositions) + sizeOf(nulls) +
+                nestedReaders.values().stream()
+                        .mapToLong(SelectiveStreamReader::getRetainedSizeInBytes)
+                        .sum();
+    }
+
+    private static Optional<TupleDomainFilter> getTopLevelFilter(Map<Subfield, TupleDomainFilter> filters)
+    {
+        Map<Subfield, TupleDomainFilter> topLevelFilters = Maps.filterEntries(filters, entry -> entry.getKey().getPath().isEmpty());
+        if (topLevelFilters.isEmpty()) {
+            return Optional.empty();
+        }
+
+        checkArgument(topLevelFilters.size() == 1, "ROW column may have at most one top-level range filter");
+        TupleDomainFilter filter = Iterables.getOnlyElement(topLevelFilters.values());
+        checkArgument(filter == IS_NULL || filter == IS_NOT_NULL, "Top-level range filter on ROW column must be IS NULL or IS NOT NULL");
+        return Optional.of(filter);
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
@@ -144,6 +144,7 @@ public class TimestampSelectiveStreamReader
     public int read(int offset, int[] positions, int positionCount)
             throws IOException
     {
+        checkArgument(positionCount > 0, "positionCount must be greater than zero");
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (!rowGroupOpen) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1604,7 +1604,7 @@ public class OrcTester
         return baseTypes.contains(testBaseType);
     }
 
-    private static Type arrayType(Type elementType)
+    public static Type arrayType(Type elementType)
     {
         return TYPE_MANAGER.getParameterizedType(StandardTypes.ARRAY, ImmutableList.of(TypeSignatureParameter.of(elementType.getTypeSignature())));
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.testing.MaterializedResult;
@@ -55,7 +56,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -365,16 +365,16 @@ public class H2QueryRunner
                             row.add(null);
                         }
                         else {
-                            Object[] elements = (Object[]) array.getArray();
-                            Type elementType = ((ArrayType) type).getElementType();
-                            if (elementType instanceof ArrayType) {
-                                row.add(Arrays.stream(elements)
-                                        .map(v -> v == null ? null : newArrayList((Object[]) v))
-                                        .collect(Collectors.toList()));
-                            }
-                            else {
-                                row.add(newArrayList(elements));
-                            }
+                            row.add(newArrayList(mapArrayValues(((ArrayType) type), (Object[]) array.getArray())));
+                        }
+                    }
+                    else if (type instanceof RowType) {
+                        Array array = resultSet.getArray(i);
+                        if (resultSet.wasNull()) {
+                            row.add(null);
+                        }
+                        else {
+                            row.add(newArrayList(mapRowValues((RowType) type, (Object[]) array.getArray())));
                         }
                     }
                     else {
@@ -384,6 +384,41 @@ public class H2QueryRunner
                 return new MaterializedRow(MaterializedResult.DEFAULT_PRECISION, row);
             }
         };
+    }
+
+    private static Object[] mapArrayValues(ArrayType arrayType, Object[] values)
+    {
+        Type elementType = arrayType.getElementType();
+        if (elementType instanceof ArrayType) {
+            return Arrays.stream(values)
+                    .map(v -> v == null ? null : newArrayList((Object[]) v))
+                    .toArray();
+        }
+
+        if (elementType instanceof RowType) {
+            RowType rowType = (RowType) elementType;
+            return Arrays.stream(values)
+                    .map(v -> v == null ? null : newArrayList(mapRowValues(rowType, (Object[]) v)))
+                    .toArray();
+        }
+
+        return values;
+    }
+
+    private static Object[] mapRowValues(RowType rowType, Object[] values)
+    {
+        int fieldCount = rowType.getFields().size();
+        Object[] fields = new Object[fieldCount];
+        for (int j = 0; j < fieldCount; j++) {
+            Type fieldType = rowType.getTypeParameters().get(j);
+            if (fieldType instanceof RowType) {
+                fields[j] = newArrayList(mapRowValues((RowType) fieldType, (Object[]) values[j]));
+            }
+            else {
+                fields[j] = values[j];
+            }
+        }
+        return fields;
     }
 
     private static void insertRows(ConnectorTableMetadata tableMetadata, Handle handle, RecordSet data)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.SqlTimestamp;
 import com.facebook.presto.spi.type.SqlTimestampWithTimeZone;
 import com.facebook.presto.spi.type.Type;
@@ -237,6 +238,14 @@ public class TestingPrestoClient
                     .collect(Collectors.toMap(
                             e -> convertToRowValue(((MapType) type).getKeyType(), e.getKey()),
                             e -> convertToRowValue(((MapType) type).getValueType(), e.getValue())));
+        }
+        else if (type instanceof RowType) {
+            Map<String, Object> data = (Map<String, Object>) value;
+            RowType rowType = (RowType) type;
+
+            return rowType.getFields().stream()
+                    .map(field -> convertToRowValue(field.getType(), data.get(field.getName().get())))
+                    .collect(toList());
         }
         else if (type instanceof DecimalType) {
             return new BigDecimal((String) value);


### PR DESCRIPTION
This is basic implementation of SelectiveStreamReader for ROW type that 
supports the following:
- extracting only specified rows;
- top-level IS NULL and IS NOT NULL filters;
- subfield pruning
- structs nested within other structs or arrays.

Support for range filters on nested fields will be added in future PRs.

```
== NO RELEASE NOTE ==
```