### PR TITLE
Add Procedure in Raptor to trigger bucket balancer

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnector.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnector.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.procedure.Procedure;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.transaction.IsolationLevel;
 import com.google.common.collect.HashMultimap;
@@ -71,6 +72,7 @@ public class RaptorConnector
     private final MetadataDao dao;
     private final ConnectorAccessControl accessControl;
     private final boolean coordinator;
+    private final Set<Procedure> procedures;
 
     private final ConcurrentMap<ConnectorTransactionHandle, RaptorMetadata> transactions = new ConcurrentHashMap<>();
 
@@ -92,7 +94,8 @@ public class RaptorConnector
             RaptorTableProperties tableProperties,
             Set<SystemTable> systemTables,
             ConnectorAccessControl accessControl,
-            @ForMetadata IDBI dbi)
+            @ForMetadata IDBI dbi,
+            Set<Procedure> procedures)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
@@ -106,6 +109,7 @@ public class RaptorConnector
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.dao = onDemandDao(dbi, MetadataDao.class);
         this.coordinator = nodeManager.getCurrentNode().isCoordinator();
+        this.procedures = requireNonNull(procedures, "procedures is null");
     }
 
     @PostConstruct
@@ -201,6 +205,12 @@ public class RaptorConnector
     public ConnectorAccessControl getAccessControl()
     {
         return accessControl;
+    }
+
+    @Override
+    public Set<Procedure> getProcedures()
+    {
+        return procedures;
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnectorFactory.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnectorFactory.java
@@ -87,7 +87,8 @@ public class RaptorConnectorFactory
                     new BackupModule(backupProviders),
                     new StorageModule(catalogName),
                     new RaptorModule(catalogName),
-                    new RaptorSecurityModule());
+                    new RaptorSecurityModule(),
+                    new RaptorProcedureModule());
 
             Injector injector = app
                     .strictConfig()

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorProcedureModule.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorProcedureModule.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor;
+
+import com.facebook.presto.spi.procedure.Procedure;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+
+public class RaptorProcedureModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
+        procedures.addBinding().toProvider(TriggerBucketBalancerProcedure.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/TriggerBucketBalancerProcedure.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/TriggerBucketBalancerProcedure.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor;
+
+import com.facebook.presto.raptor.storage.BucketBalancer;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.spi.block.MethodHandleUtil.methodHandle;
+import static java.util.Objects.requireNonNull;
+
+public class TriggerBucketBalancerProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle TRIGGER_BUCKET_BALANCER = methodHandle(
+            TriggerBucketBalancerProcedure.class,
+            "createTriggerBucketBalancer");
+
+    private final BucketBalancer bucketBalancer;
+
+    @Inject
+    public TriggerBucketBalancerProcedure(BucketBalancer bucketBalancer)
+    {
+        this.bucketBalancer = requireNonNull(bucketBalancer, "bucketBalancer is null");
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "trigger_bucket_balancer",
+                ImmutableList.of(),
+                TRIGGER_BUCKET_BALANCER.bindTo(this));
+    }
+
+    public void createTriggerBucketBalancer()
+    {
+        bucketBalancer.startBalanceJob();
+    }
+}

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
@@ -118,7 +118,8 @@ public class TestRaptorConnector
                 new RaptorTableProperties(typeRegistry),
                 ImmutableSet.of(),
                 new AllowAllAccessControl(),
-                dbi);
+                dbi,
+                ImmutableSet.of());
     }
 
     @AfterMethod(alwaysRun = true)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTest.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTest.java
@@ -795,4 +795,10 @@ public class TestRaptorIntegrationSmokeTest
 
         assertUpdate("DROP TABLE test_delete_table");
     }
+
+    @Test
+    public void testTriggerBucketBalancer()
+    {
+        assertUpdate("CALL system.trigger_bucket_balancer()");
+    }
 }


### PR DESCRIPTION
```
== RELEASE NOTES ==
This PR is targetted to add a procedure in Raptor to trigger bucket balancer: trigger_bucket_balancer()
 
Raptor Changes
* Create a new Procedure: TriggerBucketBalancerProcedure that implements procedure interface.
* Modified the RaptorConnector & RaptorConnectorFactory to implement procedures.

No Hive Changes
```