### PR TITLE
[TEST ONLY] Remove ArgumentBinding

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -272,6 +272,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Range.closedOpen;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.IntStream.range;
 
@@ -390,29 +391,27 @@ public class LocalExecutionPlanner
             partitionChannelTypes = ImmutableList.of(BIGINT);
         }
         else {
+            checkArgument(
+                    partitioningScheme.getPartitioning().getArguments().stream().allMatch(argument -> argument instanceof ConstantExpression || argument instanceof VariableReferenceExpression),
+                    format("Expect all partitioning arguments to be either ConstantExpression or VariableReferenceExpression, but get %s", partitioningScheme.getPartitioning().getArguments()));
             partitionChannels = partitioningScheme.getPartitioning().getArguments().stream()
                     .map(argument -> {
-                        if (argument.isConstant()) {
+                        if (argument instanceof ConstantExpression) {
                             return -1;
                         }
-                        return outputLayout.indexOf(argument.getVariableReference());
+                        return outputLayout.indexOf((VariableReferenceExpression) argument);
                     })
                     .collect(toImmutableList());
             partitionConstants = partitioningScheme.getPartitioning().getArguments().stream()
                     .map(argument -> {
-                        if (argument.isConstant()) {
-                            return Optional.of(argument.getConstant());
+                        if (argument instanceof ConstantExpression) {
+                            return Optional.of((ConstantExpression) argument);
                         }
                         return Optional.<ConstantExpression>empty();
                     })
                     .collect(toImmutableList());
             partitionChannelTypes = partitioningScheme.getPartitioning().getArguments().stream()
-                    .map(argument -> {
-                        if (argument.isConstant()) {
-                            return argument.getConstant().getType();
-                        }
-                        return argument.getVariableReference().getType();
-                    })
+                    .map(RowExpression::getType)
                     .collect(toImmutableList());
         }
 
@@ -2416,7 +2415,8 @@ public class LocalExecutionPlanner
 
             List<Type> types = getSourceOperatorTypes(node, context.getTypes());
             List<Integer> channels = node.getPartitioningScheme().getPartitioning().getArguments().stream()
-                    .map(argument -> node.getOutputVariables().indexOf(argument.getVariableReference()))
+                    .filter(VariableReferenceExpression.class::isInstance)
+                    .map(argument -> node.getOutputVariables().indexOf(argument))
                     .collect(toImmutableList());
             Optional<Integer> hashChannel = node.getPartitioningScheme().getHashColumn()
                     .map(variable -> node.getOutputVariables().indexOf(variable));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
@@ -34,18 +34,18 @@ import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
 public final class Partitioning
 {
     private final PartitioningHandle handle;
-    private final List<ArgumentBinding> arguments;
+    private final List<RowExpression> arguments;
 
-    private Partitioning(PartitioningHandle handle, List<ArgumentBinding> arguments)
+    private Partitioning(PartitioningHandle handle, List<RowExpression> arguments)
     {
         this.handle = requireNonNull(handle, "handle is null");
         this.arguments = ImmutableList.copyOf(requireNonNull(arguments, "arguments is null"));
@@ -54,7 +54,7 @@ public final class Partitioning
     public static Partitioning create(PartitioningHandle handle, List<VariableReferenceExpression> columns)
     {
         return new Partitioning(handle, columns.stream()
-                .map(ArgumentBinding::new)
+                .map(RowExpression.class::cast)
                 .collect(toImmutableList()));
     }
 
@@ -62,7 +62,7 @@ public final class Partitioning
     @JsonCreator
     public static Partitioning jsonCreate(
             @JsonProperty("handle") PartitioningHandle handle,
-            @JsonProperty("arguments") List<ArgumentBinding> arguments)
+            @JsonProperty("arguments") List<RowExpression> arguments)
     {
         return new Partitioning(handle, arguments);
     }
@@ -74,7 +74,7 @@ public final class Partitioning
     }
 
     @JsonProperty
-    public List<ArgumentBinding> getArguments()
+    public List<RowExpression> getArguments()
     {
         return arguments;
     }
@@ -82,8 +82,8 @@ public final class Partitioning
     public Set<VariableReferenceExpression> getVariableReferences()
     {
         return arguments.stream()
-                .filter(ArgumentBinding::isVariable)
-                .map(ArgumentBinding::getVariableReference)
+                .filter(VariableReferenceExpression.class::isInstance)
+                .map(VariableReferenceExpression.class::cast)
                 .collect(toImmutableSet());
     }
 
@@ -118,8 +118,8 @@ public final class Partitioning
         }
 
         for (int i = 0; i < arguments.size(); i++) {
-            ArgumentBinding leftArgument = arguments.get(i);
-            ArgumentBinding rightArgument = right.arguments.get(i);
+            RowExpression leftArgument = arguments.get(i);
+            RowExpression rightArgument = right.arguments.get(i);
 
             if (!isPartitionedWith(leftArgument, leftConstantMapping, rightArgument, rightConstantMapping, leftToRightMappings)) {
                 return false;
@@ -158,8 +158,8 @@ public final class Partitioning
         }
 
         for (int i = 0; i < arguments.size(); i++) {
-            ArgumentBinding leftArgument = arguments.get(i);
-            ArgumentBinding rightArgument = right.arguments.get(i);
+            RowExpression leftArgument = arguments.get(i);
+            RowExpression rightArgument = right.arguments.get(i);
 
             if (!isPartitionedWith(leftArgument, leftConstantMapping, rightArgument, rightConstantMapping, leftToRightMappings)) {
                 return false;
@@ -169,36 +169,36 @@ public final class Partitioning
     }
 
     private static boolean isPartitionedWith(
-            ArgumentBinding leftArgument,
+            RowExpression leftArgument,
             Function<VariableReferenceExpression, Optional<ConstantExpression>> leftConstantMapping,
-            ArgumentBinding rightArgument,
+            RowExpression rightArgument,
             Function<VariableReferenceExpression, Optional<ConstantExpression>> rightConstantMapping,
             Function<VariableReferenceExpression, Set<VariableReferenceExpression>> leftToRightMappings)
     {
-        if (leftArgument.isVariable()) {
-            if (rightArgument.isVariable()) {
+        if (leftArgument instanceof VariableReferenceExpression) {
+            if (rightArgument instanceof VariableReferenceExpression) {
                 // variable == variable
-                Set<VariableReferenceExpression> mappedColumns = leftToRightMappings.apply(leftArgument.getVariableReference());
-                return mappedColumns.contains(rightArgument.getVariableReference());
+                Set<VariableReferenceExpression> mappedColumns = leftToRightMappings.apply((VariableReferenceExpression) leftArgument);
+                return mappedColumns.contains(rightArgument);
             }
             else {
                 // variable == constant
                 // Normally, this would be a false condition, but if we happen to have an external
                 // mapping from the variable to a constant value and that constant value matches the
                 // right value, then we are co-partitioned.
-                Optional<ConstantExpression> leftConstant = leftConstantMapping.apply(leftArgument.getVariableReference());
-                return leftConstant.isPresent() && leftConstant.get().equals(rightArgument.getConstant());
+                Optional<ConstantExpression> leftConstant = leftConstantMapping.apply((VariableReferenceExpression) leftArgument);
+                return leftConstant.isPresent() && leftConstant.get().equals(rightArgument);
             }
         }
         else {
-            if (rightArgument.isConstant()) {
+            if (rightArgument instanceof ConstantExpression) {
                 // constant == constant
-                return leftArgument.getConstant().equals(rightArgument.getConstant());
+                return leftArgument.equals(rightArgument);
             }
             else {
                 // constant == variable
-                Optional<ConstantExpression> rightConstant = rightConstantMapping.apply(rightArgument.getVariableReference());
-                return rightConstant.isPresent() && rightConstant.get().equals(leftArgument.getConstant());
+                Optional<ConstantExpression> rightConstant = rightConstantMapping.apply((VariableReferenceExpression) rightArgument);
+                return rightConstant.isPresent() && rightConstant.get().equals(leftArgument);
             }
         }
     }
@@ -208,8 +208,8 @@ public final class Partitioning
         // partitioned on (k_1, k_2, ..., k_n) => partitioned on (k_1, k_2, ..., k_n, k_n+1, ...)
         // can safely ignore all constant columns when comparing partition properties
         return arguments.stream()
-                .filter(ArgumentBinding::isVariable)
-                .map(ArgumentBinding::getVariableReference)
+                .filter(VariableReferenceExpression.class::isInstance)
+                .map(VariableReferenceExpression.class::cast)
                 .filter(variable -> !knownConstants.contains(variable))
                 .allMatch(columns::contains);
     }
@@ -225,8 +225,8 @@ public final class Partitioning
                 .filter(variable -> !knownConstants.contains(variable))
                 .collect(toImmutableSet());
         Set<VariableReferenceExpression> nonConstantArgs = arguments.stream()
-                .filter(ArgumentBinding::isVariable)
-                .map(ArgumentBinding::getVariableReference)
+                .filter(VariableReferenceExpression.class::isInstance)
+                .map(VariableReferenceExpression.class::cast)
                 .filter(variable -> !knownConstants.contains(variable))
                 .collect(toImmutableSet());
         return !nonConstantArgs.equals(keysWithoutConstants);
@@ -235,15 +235,34 @@ public final class Partitioning
     public Partitioning translate(Function<VariableReferenceExpression, VariableReferenceExpression> translator)
     {
         return new Partitioning(handle, arguments.stream()
-                .map(argument -> argument.translate(translator))
+                .map(argument -> {
+                    if (argument instanceof ConstantExpression) {
+                        return argument;
+                    }
+                    return translator.apply((VariableReferenceExpression) argument);
+                })
                 .collect(toImmutableList()));
     }
 
     public Optional<Partitioning> translate(Function<VariableReferenceExpression, Optional<VariableReferenceExpression>> translator, Function<VariableReferenceExpression, Optional<ConstantExpression>> constants)
     {
-        ImmutableList.Builder<ArgumentBinding> newArguments = ImmutableList.builder();
-        for (ArgumentBinding argument : arguments) {
-            Optional<ArgumentBinding> newArgument = argument.translate(translator, constants);
+        ImmutableList.Builder<RowExpression> newArguments = ImmutableList.builder();
+        for (RowExpression argument : arguments) {
+            Optional<RowExpression> newArgument;
+            if (argument instanceof ConstantExpression) {
+                newArgument = Optional.of(argument);
+            }
+            else {
+                checkArgument(argument instanceof VariableReferenceExpression, format("Expect argument to be VariableReferenceExpression, but get %s (%s)", argument.getClass(), argument));
+                newArgument = translator.apply((VariableReferenceExpression) argument).map(RowExpression.class::cast);
+                if (!newArgument.isPresent()) {
+                    // As a last resort, check for a constant mapping for the variable
+                    // Note: this MUST be last because we want to favor the variable representation
+                    // as it makes further optimizations possible.
+                    newArgument = constants.apply((VariableReferenceExpression) argument).map(RowExpression.class::cast);
+                }
+            }
+
             if (!newArgument.isPresent()) {
                 return Optional.empty();
             }
@@ -285,101 +304,5 @@ public final class Partitioning
                 .add("handle", handle)
                 .add("arguments", arguments)
                 .toString();
-    }
-
-    @Immutable
-    public static final class ArgumentBinding
-    {
-        private final RowExpression rowExpression;
-
-        @JsonCreator
-        public ArgumentBinding(@JsonProperty("rowExpression") RowExpression rowExpression)
-        {
-            checkArgument(rowExpression instanceof VariableReferenceExpression || rowExpression instanceof ConstantExpression, "Expect either VariableReferenceExpression or ConstantExpression");
-            this.rowExpression = requireNonNull(rowExpression, "rowExpression is null");
-        }
-
-        @JsonProperty
-        public RowExpression getRowExpression()
-        {
-            return rowExpression;
-        }
-
-        public boolean isConstant()
-        {
-            return rowExpression instanceof ConstantExpression;
-        }
-
-        public boolean isVariable()
-        {
-            return rowExpression instanceof VariableReferenceExpression;
-        }
-
-        public VariableReferenceExpression getVariableReference()
-        {
-            verify(rowExpression instanceof VariableReferenceExpression, "Expect the rowExpression to be a VariableReferenceExpression");
-            return (VariableReferenceExpression) rowExpression;
-        }
-
-        public ConstantExpression getConstant()
-        {
-            verify(rowExpression instanceof ConstantExpression, "Expect the rowExpression to be a ConstantExpression");
-            return (ConstantExpression) rowExpression;
-        }
-
-        public ArgumentBinding translate(Function<VariableReferenceExpression, VariableReferenceExpression> translator)
-        {
-            if (isConstant()) {
-                return this;
-            }
-            return new ArgumentBinding(translator.apply((VariableReferenceExpression) rowExpression));
-        }
-
-        public Optional<ArgumentBinding> translate(Function<VariableReferenceExpression, Optional<VariableReferenceExpression>> translator, Function<VariableReferenceExpression, Optional<ConstantExpression>> constants)
-        {
-            if (isConstant()) {
-                return Optional.of(this);
-            }
-
-            Optional<ArgumentBinding> newColumn = translator.apply((VariableReferenceExpression) rowExpression)
-                    .map(ArgumentBinding::new);
-            if (newColumn.isPresent()) {
-                return newColumn;
-            }
-
-            // As a last resort, check for a constant mapping for the variable
-            // Note: this MUST be last because we want to favor the variable representation
-            // as it makes further optimizations possible.
-            return constants.apply((VariableReferenceExpression) rowExpression)
-                    .map(ArgumentBinding::new);
-        }
-
-        @Override
-        public String toString()
-        {
-            if (rowExpression instanceof ConstantExpression) {
-                return rowExpression.toString();
-            }
-            return "\"" + rowExpression.toString() + "\"";
-        }
-
-        @Override
-        public boolean equals(Object o)
-        {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            ArgumentBinding that = (ArgumentBinding) o;
-            return Objects.equals(rowExpression, that.rowExpression);
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(rowExpression);
-        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -46,7 +46,6 @@ import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.planner.Partitioning.ArgumentBinding;
 import com.facebook.presto.sql.planner.plan.AggregationNode;
 import com.facebook.presto.sql.planner.plan.Assignments;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
@@ -575,15 +574,15 @@ public class PlanFragmenter
         {
             ImmutableList.Builder<VariableReferenceExpression> variables = ImmutableList.builder();
             ImmutableMap.Builder<VariableReferenceExpression, RowExpression> constants = ImmutableMap.builder();
-            for (ArgumentBinding argumentBinding : partitioning.getArguments()) {
+            for (RowExpression argument : partitioning.getArguments()) {
+                checkArgument(argument instanceof ConstantExpression || argument instanceof VariableReferenceExpression, format("Expect argument to be ConstantExpression or VariableReferenceExpression, get %s (%s)", argument.getClass(), argument));
                 VariableReferenceExpression variable;
-                if (argumentBinding.isConstant()) {
-                    ConstantExpression constant = argumentBinding.getConstant();
-                    variable = variableAllocator.newVariable("constant_partition", constant.getType());
-                    constants.put(variable, constant);
+                if (argument instanceof ConstantExpression) {
+                    variable = variableAllocator.newVariable("constant_partition", argument.getType());
+                    constants.put(variable, argument);
                 }
                 else {
-                    variable = argumentBinding.getVariableReference();
+                    variable = (VariableReferenceExpression) argument;
                 }
                 variables.add(variable);
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.optimizations.SymbolMapper;
@@ -118,8 +117,8 @@ public class PushPartialAggregationThroughExchange
                     .getPartitioning()
                     .getArguments()
                     .stream()
-                    .filter(Partitioning.ArgumentBinding::isVariable)
-                    .map(Partitioning.ArgumentBinding::getVariableReference)
+                    .filter(VariableReferenceExpression.class::isInstance)
+                    .map(VariableReferenceExpression.class::cast)
                     .collect(Collectors.toList());
 
             if (!aggregationNode.getGroupingKeys().containsAll(partitioningColumns)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.planner.Partitioning.ArgumentBinding;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanVariableAllocator;
 import com.facebook.presto.sql.planner.TypeProvider;
@@ -490,11 +489,11 @@ public class HashGenerationOptimizer
             Optional<HashComputation> partitionVariables = Optional.empty();
             PartitioningScheme partitioningScheme = node.getPartitioningScheme();
             if (partitioningScheme.getPartitioning().getHandle().equals(FIXED_HASH_DISTRIBUTION) &&
-                    partitioningScheme.getPartitioning().getArguments().stream().allMatch(ArgumentBinding::isVariable)) {
+                    partitioningScheme.getPartitioning().getArguments().stream().allMatch(VariableReferenceExpression.class::isInstance)) {
                 // add precomputed hash for exchange
                 partitionVariables = computeHash(
                         partitioningScheme.getPartitioning().getArguments().stream()
-                                .map(ArgumentBinding::getVariableReference)
+                                .map(VariableReferenceExpression.class::cast)
                                 .collect(toImmutableList()),
                         functionManager);
                 preference = preference.withHashComputation(partitionVariables);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
@@ -18,7 +18,6 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.Partitioning;
-import com.facebook.presto.sql.planner.Partitioning.ArgumentBinding;
 import com.facebook.presto.sql.planner.PartitioningHandle;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -117,7 +116,7 @@ public class ExchangeNode
             checkArgument(sources.get(i).getOutputVariables().containsAll(inputs.get(i)), "Source does not supply all required input variables");
         }
 
-        checkArgument(!scope.isLocal() || partitioningScheme.getPartitioning().getArguments().stream().allMatch(ArgumentBinding::isVariable),
+        checkArgument(!scope.isLocal() || partitioningScheme.getPartitioning().getArguments().stream().allMatch(VariableReferenceExpression.class::isInstance),
                 "local exchanges do not support constant partition function arguments");
 
         checkArgument(!scope.isRemote() || type == REPARTITION || !partitioningScheme.isReplicateNullsAndAny(), "Only REPARTITION can replicate remotely");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -40,7 +40,6 @@ import com.facebook.presto.spi.predicate.Marker;
 import com.facebook.presto.spi.predicate.Range;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.relation.CallExpression;
-import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.type.Type;
@@ -273,28 +272,18 @@ public class PlanPrinter
                 .append(format("Output layout: [%s]\n",
                         Joiner.on(", ").join(partitioningScheme.getOutputLayout())));
 
-        boolean replicateNullsAndAny = partitioningScheme.isReplicateNullsAndAny();
-        List<String> arguments = partitioningScheme.getPartitioning().getArguments().stream()
-                .map(argument -> {
-                    if (argument.isConstant()) {
-                        ConstantExpression constant = argument.getConstant();
-                        String printableValue = castToVarchar(constant.getType(), constant.getValue(), functionManager, session);
-                        return constant.getType().getDisplayName() + "(" + printableValue + ")";
-                    }
-                    return argument.getVariableReference().toString();
-                })
-                .collect(toImmutableList());
         builder.append(indentString(1));
+        boolean replicateNullsAndAny = partitioningScheme.isReplicateNullsAndAny();
         if (replicateNullsAndAny) {
             builder.append(format("Output partitioning: %s (replicate nulls and any) [%s]%s\n",
                     partitioningScheme.getPartitioning().getHandle(),
-                    Joiner.on(", ").join(arguments),
+                    Joiner.on(", ").join(partitioningScheme.getPartitioning().getArguments()),
                     formatHash(partitioningScheme.getHashColumn())));
         }
         else {
             builder.append(format("Output partitioning: %s [%s]%s\n",
                     partitioningScheme.getPartitioning().getHandle(),
-                    Joiner.on(", ").join(arguments),
+                    Joiner.on(", ").join(partitioningScheme.getPartitioning().getArguments()),
                     formatHash(partitioningScheme.getHashColumn())));
         }
         builder.append(indentString(1)).append(format("Stage Execution Strategy: %s\n", fragment.getStageExecutionDescriptor().getStageExecutionStrategy()));


### PR DESCRIPTION
Now that all arguments of partitioning are RowExpression, the
abstraction of ArgumentBinding is no longer necessary.

Please fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
