### PR TITLE
Support running Raptor on HDFS

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/RaptorHdfsConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/RaptorHdfsConfig.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.filesystem;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.HostAndPort;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.LegacyConfig;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.airlift.units.MaxDataSize;
+import io.airlift.units.MinDataSize;
+import io.airlift.units.MinDuration;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+
+public class RaptorHdfsConfig
+{
+    private HostAndPort socksProxy;
+
+    private Duration ipcPingInterval = new Duration(10, TimeUnit.SECONDS);
+    private Duration dfsTimeout = new Duration(60, TimeUnit.SECONDS);
+    private Duration dfsConnectTimeout = new Duration(500, TimeUnit.MILLISECONDS);
+    private int dfsConnectMaxRetries = 5;
+    private String domainSocketPath;
+
+    private List<String> resourceConfigFiles = ImmutableList.of();
+
+    private DataSize textMaxLineLength = new DataSize(100, MEGABYTE);
+
+    private boolean hdfsWireEncryptionEnabled;
+
+    private int fileSystemMaxCacheSize = 1000;
+
+    public HostAndPort getSocksProxy()
+    {
+        return socksProxy;
+    }
+
+    @Config("hive.thrift.client.socks-proxy")
+    public RaptorHdfsConfig setSocksProxy(HostAndPort socksProxy)
+    {
+        this.socksProxy = socksProxy;
+        return this;
+    }
+
+    @NotNull
+    public List<String> getResourceConfigFiles()
+    {
+        return resourceConfigFiles;
+    }
+
+    @NotNull
+    @MinDuration("1ms")
+    public Duration getIpcPingInterval()
+    {
+        return ipcPingInterval;
+    }
+
+    @Config("hive.dfs.ipc-ping-interval")
+    public RaptorHdfsConfig setIpcPingInterval(Duration pingInterval)
+    {
+        this.ipcPingInterval = pingInterval;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("1ms")
+    public Duration getDfsTimeout()
+    {
+        return dfsTimeout;
+    }
+
+    @Config("hive.dfs-timeout")
+    public RaptorHdfsConfig setDfsTimeout(Duration dfsTimeout)
+    {
+        this.dfsTimeout = dfsTimeout;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    @NotNull
+    public Duration getDfsConnectTimeout()
+    {
+        return dfsConnectTimeout;
+    }
+
+    @Config("hive.dfs.connect.timeout")
+    public RaptorHdfsConfig setDfsConnectTimeout(Duration dfsConnectTimeout)
+    {
+        this.dfsConnectTimeout = dfsConnectTimeout;
+        return this;
+    }
+
+    @Min(0)
+    public int getDfsConnectMaxRetries()
+    {
+        return dfsConnectMaxRetries;
+    }
+
+    @Config("hive.dfs.connect.max-retries")
+    public RaptorHdfsConfig setDfsConnectMaxRetries(int dfsConnectMaxRetries)
+    {
+        this.dfsConnectMaxRetries = dfsConnectMaxRetries;
+        return this;
+    }
+
+    public String getDomainSocketPath()
+    {
+        return domainSocketPath;
+    }
+
+    @Config("hive.dfs.domain-socket-path")
+    @LegacyConfig("dfs.domain-socket-path")
+    public RaptorHdfsConfig setDomainSocketPath(String domainSocketPath)
+    {
+        this.domainSocketPath = domainSocketPath;
+        return this;
+    }
+
+    @MinDataSize("1B")
+    @MaxDataSize("1GB")
+    @NotNull
+    public DataSize getTextMaxLineLength()
+    {
+        return textMaxLineLength;
+    }
+
+    @Config("hive.text.max-line-length")
+    @ConfigDescription("Maximum line length for text files")
+    public RaptorHdfsConfig setTextMaxLineLength(DataSize textMaxLineLength)
+    {
+        this.textMaxLineLength = textMaxLineLength;
+        return this;
+    }
+
+    public boolean isHdfsWireEncryptionEnabled()
+    {
+        return hdfsWireEncryptionEnabled;
+    }
+
+    @Config("hive.hdfs.wire-encryption.enabled")
+    @ConfigDescription("Should be turned on when HDFS wire encryption is enabled")
+    public RaptorHdfsConfig setHdfsWireEncryptionEnabled(boolean hdfsWireEncryptionEnabled)
+    {
+        this.hdfsWireEncryptionEnabled = hdfsWireEncryptionEnabled;
+        return this;
+    }
+
+    public int getFileSystemMaxCacheSize()
+    {
+        return fileSystemMaxCacheSize;
+    }
+
+    @Config("hive.fs.cache.max-size")
+    @ConfigDescription("Hadoop FileSystem cache size")
+    public RaptorHdfsConfig setFileSystemMaxCacheSize(int fileSystemMaxCacheSize)
+    {
+        this.fileSystemMaxCacheSize = fileSystemMaxCacheSize;
+        return this;
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/RaptorHdfsConfiguration.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/RaptorHdfsConfiguration.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.filesystem;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.HostAndPort;
+import io.airlift.units.Duration;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.lib.input.LineRecordReader;
+import org.apache.hadoop.net.DNSToSwitchMapping;
+import org.apache.hadoop.net.SocksSocketFactory;
+
+import javax.inject.Inject;
+import javax.net.SocketFactory;
+
+import java.util.List;
+
+import static com.facebook.presto.raptor.filesystem.FileSystemUtil.copy;
+import static com.facebook.presto.raptor.filesystem.FileSystemUtil.getInitialConfiguration;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.fs.CommonConfigurationKeys.IPC_PING_INTERVAL_KEY;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_RPC_PROTECTION;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_RPC_SOCKET_FACTORY_CLASS_DEFAULT_KEY;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SOCKS_SERVER_KEY;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_TIMEOUT_KEY;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_CLIENT_READ_SHORTCIRCUIT_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_CLIENT_SOCKET_TIMEOUT_KEY;
+import static org.apache.hadoop.hdfs.DFSConfigKeys.DFS_DOMAIN_SOCKET_PATH_KEY;
+
+public class RaptorHdfsConfiguration
+{
+    private static final Configuration INITIAL_CONFIGURATION = getInitialConfiguration();
+
+    @SuppressWarnings("ThreadLocalNotStaticFinal")
+    private final ThreadLocal<Configuration> hadoopConfiguration = new ThreadLocal<Configuration>()
+    {
+        @Override
+        protected Configuration initialValue()
+        {
+            Configuration configuration = new Configuration(false);
+            copy(INITIAL_CONFIGURATION, configuration);
+            initializer.updateConfiguration(configuration);
+            return configuration;
+        }
+    };
+
+    private final HdfsConfigurationInitializer initializer;
+
+    @Inject
+    public RaptorHdfsConfiguration(RaptorHdfsConfig config)
+    {
+        this.initializer = new HdfsConfigurationInitializer(requireNonNull(config, "config is null"));
+    }
+
+    public Configuration getConfiguration()
+    {
+        return hadoopConfiguration.get();
+    }
+
+    private static class HdfsConfigurationInitializer
+    {
+        private final HostAndPort socksProxy;
+        private final Duration ipcPingInterval;
+        private final Duration dfsTimeout;
+        private final Duration dfsConnectTimeout;
+        private final int dfsConnectMaxRetries;
+        private final String domainSocketPath;
+        private final Configuration resourcesConfiguration;
+        private final int fileSystemMaxCacheSize;
+        private final boolean isHdfsWireEncryptionEnabled;
+        private int textMaxLineLength;
+
+        public HdfsConfigurationInitializer(RaptorHdfsConfig config)
+        {
+            requireNonNull(config, "config is null");
+            checkArgument(config.getDfsTimeout().toMillis() >= 1, "dfsTimeout must be at least 1 ms");
+            checkArgument(toIntExact(config.getTextMaxLineLength().toBytes()) >= 1, "textMaxLineLength must be at least 1 byte");
+
+            this.socksProxy = config.getSocksProxy();
+            this.ipcPingInterval = config.getIpcPingInterval();
+            this.dfsTimeout = config.getDfsTimeout();
+            this.dfsConnectTimeout = config.getDfsConnectTimeout();
+            this.dfsConnectMaxRetries = config.getDfsConnectMaxRetries();
+            this.domainSocketPath = config.getDomainSocketPath();
+            this.resourcesConfiguration = readConfiguration(config.getResourceConfigFiles());
+            this.fileSystemMaxCacheSize = config.getFileSystemMaxCacheSize();
+            this.isHdfsWireEncryptionEnabled = config.isHdfsWireEncryptionEnabled();
+            this.textMaxLineLength = toIntExact(config.getTextMaxLineLength().toBytes());
+        }
+
+        private static Configuration readConfiguration(List<String> resourcePaths)
+        {
+            Configuration result = new Configuration(false);
+
+            for (String resourcePath : resourcePaths) {
+                Configuration resourceProperties = new Configuration(false);
+                resourceProperties.addResource(new Path(resourcePath));
+                copy(resourceProperties, result);
+            }
+
+            return result;
+        }
+
+        public void updateConfiguration(Configuration config)
+        {
+            copy(resourcesConfiguration, config);
+
+            // this is to prevent dfs client from doing reverse DNS lookups to determine whether nodes are rack local
+            config.setClass(NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY, NoOpDNSToSwitchMapping.class, DNSToSwitchMapping.class);
+
+            if (socksProxy != null) {
+                config.setClass(HADOOP_RPC_SOCKET_FACTORY_CLASS_DEFAULT_KEY, SocksSocketFactory.class, SocketFactory.class);
+                config.set(HADOOP_SOCKS_SERVER_KEY, socksProxy.toString());
+            }
+
+            if (domainSocketPath != null) {
+                config.setStrings(DFS_DOMAIN_SOCKET_PATH_KEY, domainSocketPath);
+            }
+
+            // only enable short circuit reads if domain socket path is properly configured
+            if (!config.get(DFS_DOMAIN_SOCKET_PATH_KEY, "").trim().isEmpty()) {
+                config.setBooleanIfUnset(DFS_CLIENT_READ_SHORTCIRCUIT_KEY, true);
+            }
+
+            config.setInt(DFS_CLIENT_SOCKET_TIMEOUT_KEY, toIntExact(dfsTimeout.toMillis()));
+            config.setInt(IPC_PING_INTERVAL_KEY, toIntExact(ipcPingInterval.toMillis()));
+            config.setInt(IPC_CLIENT_CONNECT_TIMEOUT_KEY, toIntExact(dfsConnectTimeout.toMillis()));
+            config.setInt(IPC_CLIENT_CONNECT_MAX_RETRIES_KEY, dfsConnectMaxRetries);
+
+            if (isHdfsWireEncryptionEnabled) {
+                config.set(HADOOP_RPC_PROTECTION, "privacy");
+                config.setBoolean("dfs.encrypt.data.transfer", true);
+            }
+
+            config.setInt("fs.cache.max-size", fileSystemMaxCacheSize);
+
+            config.setInt(LineRecordReader.MAX_LINE_LENGTH, textMaxLineLength);
+        }
+
+        public static class NoOpDNSToSwitchMapping
+                implements DNSToSwitchMapping
+        {
+            @Override
+            public List<String> resolve(List<String> names)
+            {
+                // dfs client expects an empty list as an indication that the host->switch mapping for the given names are not known
+                return ImmutableList.of();
+            }
+
+            @Override
+            public void reloadCachedMappings()
+            {
+                // no-op
+            }
+
+            @Override
+            public void reloadCachedMappings(List<String> names)
+            {
+                // no-op
+            }
+        }
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/HdfsOrcDataEnvironment.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/HdfsOrcDataEnvironment.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.storage;
+
+import com.facebook.presto.orc.OrcDataSink;
+import com.facebook.presto.orc.OrcDataSource;
+import com.facebook.presto.orc.OrcDataSourceId;
+import com.facebook.presto.orc.OutputStreamOrcDataSink;
+import com.facebook.presto.raptor.filesystem.RaptorHdfsConfiguration;
+import com.facebook.presto.spi.PrestoException;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+
+import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_LOCAL_FILE_SYSTEM_ERROR;
+
+public class HdfsOrcDataEnvironment
+        implements OrcDataEnvironment
+{
+    private final FileSystem fileSystem;
+
+    @Inject
+    public HdfsOrcDataEnvironment(Path baseLocation, RaptorHdfsConfiguration configuration)
+    {
+        try {
+            this.fileSystem = baseLocation.getFileSystem(configuration.getConfiguration());
+        }
+        catch (IOException e) {
+            throw new PrestoException(RAPTOR_LOCAL_FILE_SYSTEM_ERROR, "Raptor cannot create local file system", e);
+        }
+    }
+
+    @Override
+    public FileSystem getFileSystem()
+    {
+        return fileSystem;
+    }
+
+    @Override
+    public OrcDataSource createOrcDataSource(Path path, ReaderAttributes readerAttributes)
+            throws IOException
+    {
+        return new HdfsOrcDataSource(
+                new OrcDataSourceId(path.toString()),
+                fileSystem.getFileStatus(path).getLen(),
+                readerAttributes.getMaxMergeDistance(),
+                readerAttributes.getMaxReadSize(),
+                readerAttributes.getStreamBufferSize(),
+                readerAttributes.isLazyReadSmallRanges(),
+                fileSystem.open(path));
+    }
+
+    @Override
+    public OrcDataSink createOrcDataSink(Path path)
+            throws IOException
+    {
+        return new OutputStreamOrcDataSink(fileSystem.create(path));
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/HdfsOrcDataSource.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/HdfsOrcDataSource.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.storage;
+
+import com.facebook.presto.orc.AbstractOrcDataSource;
+import com.facebook.presto.orc.OrcDataSourceId;
+import com.facebook.presto.spi.PrestoException;
+import io.airlift.units.DataSize;
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.IOException;
+
+import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_ERROR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class HdfsOrcDataSource
+        extends AbstractOrcDataSource
+{
+    private final FSDataInputStream inputStream;
+
+    public HdfsOrcDataSource(
+            OrcDataSourceId id,
+            long size,
+            DataSize maxMergeDistance,
+            DataSize maxReadSize,
+            DataSize streamBufferSize,
+            boolean lazyReadSmallRanges,
+            FSDataInputStream inputStream)
+    {
+        super(id, size, maxMergeDistance, maxReadSize, streamBufferSize, lazyReadSmallRanges);
+        this.inputStream = requireNonNull(inputStream, "inputStream is null");
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        inputStream.close();
+    }
+
+    @Override
+    protected void readInternal(long position, byte[] buffer, int bufferOffset, int bufferLength)
+    {
+        try {
+            long readStart = System.nanoTime();
+            inputStream.readFully(position, buffer, bufferOffset, bufferLength);
+        }
+        catch (PrestoException e) {
+            // just in case there is a Presto wrapper or hook
+            throw e;
+        }
+        catch (Exception e) {
+            String message = format("Error reading from %s at position %s", this, position);
+            if (e.getClass().getSimpleName().equals("BlockMissingException")) {
+                throw new PrestoException(RAPTOR_ERROR, message, e);
+            }
+            if (e instanceof IOException) {
+                throw new PrestoException(RAPTOR_ERROR, message, e);
+            }
+            throw new PrestoException(RAPTOR_ERROR, message, e);
+        }
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/HdfsStorageService.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/HdfsStorageService.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.storage;
+
+import com.facebook.presto.spi.PrestoException;
+import io.airlift.log.Logger;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_ERROR;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+// TODO: this only works for hard file affinity; but good for a prototype
+// TODO: need to handle race condition on all workers
+public class HdfsStorageService
+        implements StorageService
+{
+    private static final Logger log = Logger.get(HdfsStorageService.class);
+
+    private static final String FILE_EXTENSION = ".orc";
+
+    private final FileSystem fileSystem;
+
+    private final Path baseStorageDir;
+    private final Path baseStagingDir;
+    private final Path baseQuarantineDir;
+
+    @Inject
+    public HdfsStorageService(OrcDataEnvironment environment, Path baseLocation)
+    {
+        this.fileSystem = requireNonNull(environment, "requireNonNull is null").getFileSystem();
+        Path baseDataDir = requireNonNull(baseLocation, "baseLocation is null");
+        this.baseStorageDir = new Path(baseDataDir, "storage");
+        this.baseStagingDir = new Path(baseDataDir, "staging");
+        this.baseQuarantineDir = new Path(baseDataDir, "quarantine");
+    }
+
+    @Override
+    @PostConstruct
+    public void start()
+    {
+        deleteStagingFilesAsync();
+        createDirectory(baseStagingDir);
+        createDirectory(baseStorageDir);
+        createDirectory(baseQuarantineDir);
+    }
+
+    @Override
+    public long getAvailableBytes()
+    {
+        return Long.MAX_VALUE;
+    }
+
+    @PreDestroy
+    public void stop()
+            throws IOException
+    {
+        fileSystem.delete(baseStagingDir, true);
+    }
+
+    @Override
+    public Path getStorageFile(UUID shardUuid)
+    {
+        return getFileSystemPath(baseStorageDir, shardUuid);
+    }
+
+    @Override
+    public Path getStagingFile(UUID shardUuid)
+    {
+        return getFileSystemPath(baseStagingDir, shardUuid);
+    }
+
+    @Override
+    public Path getQuarantineFile(UUID shardUuid)
+    {
+        return getFileSystemPath(baseQuarantineDir, shardUuid);
+    }
+
+    @Override
+    public Set<UUID> getStorageShards()
+    {
+        throw new UnsupportedOperationException("HDFS storage does not support list directory on purpose");
+    }
+
+    @Override
+    public void createParents(Path file)
+    {
+        createDirectory(file.getParent());
+    }
+
+    private static Path getFileSystemPath(Path base, UUID shardUuid)
+    {
+        String uuid = shardUuid.toString().toLowerCase(ENGLISH);
+        return new Path(base, uuid + FILE_EXTENSION);
+    }
+
+    private void deleteStagingFilesAsync()
+    {
+        FileStatus[] files;
+        try {
+            files = fileSystem.listStatus(baseStagingDir);
+        }
+        catch (IOException e) {
+            log.warn(e, "Failed to list director " + baseStagingDir);
+            return;
+        }
+
+        if (files.length > 0) {
+            new Thread(() -> {
+                for (FileStatus file : files) {
+                    try {
+                        fileSystem.delete(file.getPath(), false);
+                    }
+                    catch (IOException e) {
+                        log.warn(e, "Failed to delete file: %s", file);
+                    }
+                }
+            }, "background-staging-delete").start();
+        }
+    }
+
+    private static void deleteDirectory(File dir)
+            throws IOException
+    {
+        if (!dir.exists()) {
+            return;
+        }
+        File[] files = dir.listFiles();
+        if (files == null) {
+            throw new IOException("Failed to list directory: " + dir);
+        }
+        for (File file : files) {
+            Files.deleteIfExists(file.toPath());
+        }
+        Files.deleteIfExists(dir.toPath());
+    }
+
+    private void createDirectory(Path directory)
+    {
+        boolean madeDirectory;
+        try {
+            madeDirectory = fileSystem.mkdirs(directory) && fileSystem.isDirectory(directory);
+        }
+        catch (IOException e) {
+            madeDirectory = false;
+        }
+
+        if (!madeDirectory) {
+            throw new PrestoException(RAPTOR_ERROR, "Failed creating directories: " + directory);
+        }
+    }
+
+    private static Optional<UUID> uuidFromString(String value)
+    {
+        try {
+            return Optional.of(UUID.fromString(value));
+        }
+        catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
@@ -71,6 +71,8 @@ public class StorageManagerConfig
     private int oneSplitPerBucketThreshold;
     private String shardDayBoundaryTimeZone = TimeZoneKey.UTC_KEY.getId();
 
+    private boolean disaggregated;
+
     @NotNull
     public File getDataDirectory()
     {
@@ -415,6 +417,18 @@ public class StorageManagerConfig
     public StorageManagerConfig setShardDayBoundaryTimeZone(String timeZone)
     {
         this.shardDayBoundaryTimeZone = timeZone;
+        return this;
+    }
+
+    public boolean isDisaggregated()
+    {
+        return disaggregated;
+    }
+
+    @Config("storage.disaggregated")
+    public StorageManagerConfig setDisaggregated(boolean disaggregated)
+    {
+        this.disaggregated = disaggregated;
         return this;
     }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorDistributedQueries.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorDistributedQueries.java
@@ -24,7 +24,7 @@ public class TestRaptorDistributedQueries
     @SuppressWarnings("unused")
     public TestRaptorDistributedQueries()
     {
-        this(() -> createRaptorQueryRunner(ImmutableMap.of(), true, false, ImmutableMap.of("storage.orc.optimized-writer-stage", "ENABLED_AND_VALIDATED")));
+        this(() -> createRaptorQueryRunner(ImmutableMap.of(), true, false, false, ImmutableMap.of("storage.orc.optimized-writer-stage", "ENABLED_AND_VALIDATED")));
     }
 
     protected TestRaptorDistributedQueries(QueryRunnerSupplier supplier)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorDistributedQueriesDisaggregated.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorDistributedQueriesDisaggregated.java
@@ -17,12 +17,12 @@ import com.google.common.collect.ImmutableMap;
 
 import static com.facebook.presto.raptor.RaptorQueryRunner.createRaptorQueryRunner;
 
-public class TestRaptorDistributedQueriesBucketed
+public class TestRaptorDistributedQueriesDisaggregated
         extends TestRaptorDistributedQueries
 {
-    public TestRaptorDistributedQueriesBucketed()
+    public TestRaptorDistributedQueriesDisaggregated()
     {
-        super(() -> createRaptorQueryRunner(ImmutableMap.of(), true, true, false, ImmutableMap.of("storage.orc.optimized-writer-stage", "ENABLED_AND_VALIDATED")));
+        super(() -> createRaptorQueryRunner(ImmutableMap.of(), true, true, true, ImmutableMap.of()));
     }
 
     @Override

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTest.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTest.java
@@ -66,6 +66,7 @@ public class TestRaptorIntegrationSmokeTest
                 ImmutableMap.of(),
                 true,
                 false,
+                false,
                 ImmutableMap.of("storage.orc.optimized-writer-stage", "ENABLED_AND_VALIDATED")));
     }
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTestBucketed.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTestBucketed.java
@@ -23,7 +23,7 @@ public class TestRaptorIntegrationSmokeTestBucketed
 {
     public TestRaptorIntegrationSmokeTestBucketed()
     {
-        super(() -> createRaptorQueryRunner(ImmutableMap.of(), true, true, ImmutableMap.of("storage.orc.optimized-writer-stage", "ENABLED_AND_VALIDATED")));
+        super(() -> createRaptorQueryRunner(ImmutableMap.of(), true, true, false, ImmutableMap.of("storage.orc.optimized-writer-stage", "ENABLED_AND_VALIDATED")));
     }
 
     @Test

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTestDisaggregated.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTestDisaggregated.java
@@ -14,20 +14,26 @@
 package com.facebook.presto.raptor.integration;
 
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
 
 import static com.facebook.presto.raptor.RaptorQueryRunner.createRaptorQueryRunner;
 
-public class TestRaptorDistributedQueriesBucketed
-        extends TestRaptorDistributedQueries
+public class TestRaptorIntegrationSmokeTestDisaggregated
+        extends TestRaptorIntegrationSmokeTest
 {
-    public TestRaptorDistributedQueriesBucketed()
+    public TestRaptorIntegrationSmokeTestDisaggregated()
     {
-        super(() -> createRaptorQueryRunner(ImmutableMap.of(), true, true, false, ImmutableMap.of("storage.orc.optimized-writer-stage", "ENABLED_AND_VALIDATED")));
+        super(() -> createRaptorQueryRunner(ImmutableMap.of(), true, true, true, ImmutableMap.of()));
     }
 
-    @Override
-    protected boolean supportsNotNullColumns()
+    @Test
+    public void testShardsSystemTableBucketNumber()
     {
-        return false;
+        assertQuery("" +
+                        "SELECT count(DISTINCT bucket_number)\n" +
+                        "FROM system.shards\n" +
+                        "WHERE table_schema = 'tpch'\n" +
+                        "  AND table_name = 'orders'",
+                "SELECT 25");
     }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/security/TestRaptorFileBasedSecurity.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/security/TestRaptorFileBasedSecurity.java
@@ -39,6 +39,7 @@ public class TestRaptorFileBasedSecurity
                 ImmutableMap.of(),
                 true,
                 false,
+                false,
                 ImmutableMap.of("security.config-file", path, "raptor.security", "file"));
     }
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/security/TestRaptorReadOnlySecurity.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/security/TestRaptorReadOnlySecurity.java
@@ -29,7 +29,7 @@ public class TestRaptorReadOnlySecurity
     public void setUp()
             throws Exception
     {
-        queryRunner = createRaptorQueryRunner(ImmutableMap.of(), false, false, ImmutableMap.of("raptor.security", "read-only"));
+        queryRunner = createRaptorQueryRunner(ImmutableMap.of(), false, false, false, ImmutableMap.of("raptor.security", "read-only"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestRaptorHdfsConfig.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestRaptorHdfsConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.raptor.storage;
+
+import com.facebook.presto.raptor.filesystem.RaptorHdfsConfig;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
+import io.airlift.configuration.testing.ConfigAssertions;
+import io.airlift.units.DataSize;
+import io.airlift.units.DataSize.Unit;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class TestRaptorHdfsConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(RaptorHdfsConfig.class)
+                .setSocksProxy(null)
+                .setDfsTimeout(new Duration(60, TimeUnit.SECONDS))
+                .setIpcPingInterval(new Duration(10, TimeUnit.SECONDS))
+                .setDfsConnectTimeout(new Duration(500, TimeUnit.MILLISECONDS))
+                .setDfsConnectMaxRetries(5)
+                .setDomainSocketPath(null)
+                .setTextMaxLineLength(new DataSize(100, Unit.MEGABYTE))
+                .setFileSystemMaxCacheSize(1000)
+                .setHdfsWireEncryptionEnabled(false));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("hive.thrift.client.socks-proxy", "localhost:1080")
+                .put("hive.dfs.ipc-ping-interval", "34s")
+                .put("hive.dfs-timeout", "33s")
+                .put("hive.dfs.connect.timeout", "20s")
+                .put("hive.dfs.connect.max-retries", "10")
+                .put("hive.dfs.domain-socket-path", "/foo")
+                .put("hive.text.max-line-length", "13MB")
+                .put("hive.fs.cache.max-size", "1010")
+                .put("hive.hdfs.wire-encryption.enabled", "true")
+                .build();
+
+        RaptorHdfsConfig expected = new RaptorHdfsConfig()
+                .setSocksProxy(HostAndPort.fromParts("localhost", 1080))
+                .setIpcPingInterval(new Duration(34, TimeUnit.SECONDS))
+                .setDfsTimeout(new Duration(33, TimeUnit.SECONDS))
+                .setDfsConnectTimeout(new Duration(20, TimeUnit.SECONDS))
+                .setDfsConnectMaxRetries(10)
+                .setDomainSocketPath("/foo")
+                .setTextMaxLineLength(new DataSize(13, Unit.MEGABYTE))
+                .setFileSystemMaxCacheSize(1010)
+                .setHdfsWireEncryptionEnabled(true);
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
Raptor now can run with HDFS. However, each worker is still responsible
for the lifecycle of the files it creates. A compute node lost will lead
to all following queries to fail. To solve the problem, metastore,
scheduler, and storage service need to be updated accordingly.