### PR TITLE
Implement json_extractor_jayway using Jayway JsonPath library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1036,6 +1036,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.jayway.jsonpath</groupId>
+                <artifactId>json-path</artifactId>
+                <version>2.4.0</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>3.4.13</version>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -112,6 +112,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonExtract.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonExtract.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import io.airlift.slice.Slice;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.io.IOException;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@State(Thread)
+@OutputTimeUnit(NANOSECONDS)
+@BenchmarkMode(AverageTime)
+@Fork(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class BenchmarkJsonExtract
+{
+    @Benchmark
+    public void benchmarkJsonExtract(Blackhole blackhole, JsonBenchmarksData data)
+    {
+        blackhole.consume(JsonFunctions.jsonExtract(data.getInputJson(), data.getJsonPath()));
+    }
+
+    @Benchmark
+    public void benchmarkJsonExtractJayway(Blackhole blackhole, JsonBenchmarksData data)
+            throws IOException
+    {
+        blackhole.consume(JsonFunctions.jsonExtractJayway(data.getInputJson(), data.getJsonPathAsSlice()));
+    }
+
+    @State(Thread)
+    public static class JsonBenchmarksData
+    {
+        private static final String JSON = "{\n" +
+                "  \"store\": {\n" +
+                "    \"book\": [\n" +
+                "      {\n" +
+                "        \"category\": \"reference\",\n" +
+                "        \"author\": \"Nigel Rees\",\n" +
+                "        \"title\": \"Sayings of the Century\",\n" +
+                "        \"price\": 8.95\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"category\": \"fiction\",\n" +
+                "        \"author\": \"Evelyn Waugh\",\n" +
+                "        \"title\": \"Sword of Honour\",\n" +
+                "        \"price\": 12.99\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"category\": \"fiction\",\n" +
+                "        \"author\": \"Herman Melville\",\n" +
+                "        \"title\": \"Moby Dick\",\n" +
+                "        \"isbn\": \"0-553-21311-3\",\n" +
+                "        \"price\": 8.99\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"category\": \"fiction\",\n" +
+                "        \"author\": \"J. R. R. Tolkien\",\n" +
+                "        \"title\": \"The Lord of the Rings\",\n" +
+                "        \"isbn\": \"0-395-19395-8\",\n" +
+                "        \"price\": 22.99\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"statuses\": [\n" +
+                "      {\n" +
+                "        \"metadata\": {\n" +
+                "          \"result_type\": \"recent\",\n" +
+                "          \"iso_language_code\": \"ja\"\n" +
+                "        },\n" +
+                "        \"user\": {\n" +
+                "          \"name\": \"AYUMI\",\n" +
+                "          \"screen_name\": \"ayuu0123\",\n" +
+                "          \"description\": \"元野球部マネージャー❤︎…最高の夏をありがとう…❤︎\"\n" +
+                "        },\n" +
+                "        \"entities\": {\n" +
+                "          \"user_mentions\": [\n" +
+                "            {\n" +
+                "              \"screen_name\": \"aym0566x\",\n" +
+                "              \"unicode_value\": \"前田あゆみ\",\n" +
+                "              \"名前:前田あゆみ\": \"unicode key\"\n" +
+                "            }\n" +
+                "          ]\n" +
+                "        }\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  }\n" +
+                "}";
+
+        @Param({
+                "$.store.book.doesnt_exist",
+                "$.store.book[3].author",
+                "$.store.book",
+                "$[\"store\"][\"book\"][0]",
+                "$.store.statuses[0].entities.user_mentions[0].unicode_value",
+                "$.store.statuses[0].entities.user_mentions[0].名前:前田あゆみ"
+        })
+        private String jsonPathString;
+
+        public JsonPath getJsonPath()
+        {
+            return new JsonPath(jsonPathString);
+        }
+
+        public Slice getJsonPathAsSlice()
+        {
+            return utf8Slice(jsonPathString);
+        }
+
+        public Slice getInputJson()
+        {
+            return utf8Slice(JSON);
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkJsonExtract.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtractJayway.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtractJayway.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.jayway.jsonpath.InvalidPathException;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestJsonExtractJayway
+        extends AbstractTestFunctions
+{
+    @BeforeClass
+    public void setUp()
+    {
+        // for "utf8" function
+        registerScalar(TestStringFunctions.class);
+    }
+
+    @Test
+    public void testArrayElementJsonExtractor()
+            throws Exception
+    {
+        String firstElemJsonPath = "$[0]";
+        String secondElemJsonPath = "$[1]";
+
+        assertEquals(doJsonExtract("[]", firstElemJsonPath), null);
+        assertEquals(doJsonExtract("[1, 2, 3]", firstElemJsonPath), "1");
+        assertEquals(doJsonExtract("[1, 2]", secondElemJsonPath), "2");
+        assertEquals(doJsonExtract("[1, null]", secondElemJsonPath), "null");
+        // Out of bounds
+        assertEquals(doJsonExtract("[1]", secondElemJsonPath), null);
+        // Check skipping complex structures
+        assertEquals(doJsonExtract("[{\"a\": 1}, 2, 3]", secondElemJsonPath), "2");
+
+        // Use wildcard to get multiple values
+        assertEquals(doJsonExtract("{name: Rose Kolodny, phoneNumbers: " +
+                        "[{type: home, number: 954-555-1234}, " +
+                        "{type: work, number: 754-555-5678}]}",
+                "$.phoneNumbers[*].number"),
+                "[\"954-555-1234\",\"754-555-5678\"]");
+
+        // Select multiple array indices
+        assertEquals(doJsonExtract("[0, 1, 2]", "$[1,2]"), "[1,2]");
+    }
+
+    @Test
+    public void testObjectFieldJsonExtractor()
+            throws Exception
+    {
+        String jsonPath = "$.fuu";
+
+        assertEquals(doJsonExtract("{}", jsonPath), null);
+        assertEquals(doJsonExtract("{\"a\": 1}", jsonPath), null);
+        assertEquals(doJsonExtract("{\"fuu\": 1}", jsonPath), "1");
+        assertEquals(doJsonExtract("{\"a\": 0, \"fuu\": 1}", jsonPath), "1");
+        // Check skipping complex structures
+        assertEquals(doJsonExtract("{\"a\": [1, 2, 3], \"fuu\": 1}", jsonPath), "1");
+    }
+
+    @Test
+    public void testFullJsonExtract() throws IOException
+    {
+        assertEquals(doJsonExtract("{}", "$"), "{}");
+        assertEquals(doJsonExtract("{\"fuu\": {\"bar\": 1}}", "$.fuu"), "{\"bar\":1}");
+        assertEquals(doJsonExtract("{\"fuu\": 1}", "$.fuu"), "1");
+        assertEquals(doJsonExtract("{\"fuu\": 1}", "$['fuu']"), "1");
+        assertEquals(doJsonExtract("{\"fuu\": 1}", "$[\"fuu\"]"), "1");
+        assertEquals(doJsonExtract("{\"fuu\": null}", "$.fuu"), "null");
+        assertEquals(doJsonExtract("{\"fuu\": 1}", "$.bar"), null);
+        assertEquals(doJsonExtract("{\"fuu\": [\"\\u0001\"]}", "$.fuu[0]"), "\"\\u0001\""); // Test escaped characters
+        assertEquals(doJsonExtract("{\"fuu\": 1, \"bar\": \"abc\"}", "$.bar"), "\"abc\"");
+        assertEquals(doJsonExtract("{\"fuu\": [0.1, 1, 2]}", "$.fuu[0]"), "0.1");
+        assertEquals(doJsonExtract("{\"fuu\": [0, [100, 101], 2]}", "$.fuu[1]"), "[100,101]");
+        assertEquals(doJsonExtract("{\"fuu\": [0, [100, 101], 2]}", "$.fuu[1][1]"), "101");
+
+        // Test non-object extraction
+        assertEquals(doJsonExtract("[0, 1, 2]", "$[0]"), "0");
+        assertEquals(doJsonExtract("\"abc\"", "$"), "\"abc\"");
+        assertEquals(doJsonExtract("123", "$"), "123");
+
+        // Test extraction using bracket json path
+        assertEquals(doJsonExtract("{\"fuu\": {\"bar\": 1}}", "$[\"fuu\"]"), "{\"bar\":1}");
+        assertEquals(doJsonExtract("{\"fuu\": {\"bar\": 1}}", "$[\"fuu\"][\"bar\"]"), "1");
+        assertEquals(doJsonExtract("{\"fuu\": 1}", "$[\"fuu\"]"), "1");
+        assertEquals(doJsonExtract("{\"fuu\": null}", "$[\"fuu\"]"), "null");
+        assertEquals(doJsonExtract("{\"fuu\": 1}", "$[\"bar\"]"), null);
+        assertEquals(doJsonExtract("{\"fuu\": [\"\\u0001\"]}", "$[\"fuu\"][0]"), "\"\\u0001\""); // Test escaped characters
+        assertEquals(doJsonExtract("{\"fuu\": 1, \"bar\": \"abc\"}", "$[\"bar\"]"), "\"abc\"");
+        assertEquals(doJsonExtract("{\"fuu\": [0.1, 1, 2]}", "$[\"fuu\"][0]"), "0.1");
+        assertEquals(doJsonExtract("{\"fuu\": [0, [100, 101], 2]}", "$[\"fuu\"][1]"), "[100,101]");
+        assertEquals(doJsonExtract("{\"fuu\": [0, [100, 101], 2]}", "$[\"fuu\"][1][1]"), "101");
+
+        // Test extraction using bracket json path with special json characters in path
+        assertEquals(doJsonExtract("{\"@$fuu\": {\".b.ar\": 1}}", "$[\"@$fuu\"]"), "{\".b.ar\":1}");
+        assertEquals(doJsonExtract("{\"fuu..\": 1}", "$[\"fuu..\"]"), "1");
+        assertEquals(doJsonExtract("{\"fu*u\": null}", "$[\"fu*u\"]"), "null");
+        assertEquals(doJsonExtract("{\",fuu\": 1}", "$[\"bar\"]"), null);
+        // Test escaped characters
+        assertEquals(doJsonExtract("{\",fuu\": [\"\\u0001\"]}", "$[\"\\,fuu\"][0]"), "\"\\u0001\"");
+        assertEquals(doJsonExtract("{\":fu:u:\": 1, \":b:ar:\": \"abc\"}", "$[\":b:ar:\"]"), "\"abc\"");
+        assertEquals(doJsonExtract("{\"?()fuu\": [0.1, 1, 2]}", "$[\"?()fuu\"][0]"), "0.1");
+        assertEquals(doJsonExtract("{\"f?uu\": [0, [100, 101], 2]}", "$[\"f?uu\"][1]"), "[100,101]");
+        assertEquals(doJsonExtract("{\"fuu()\": [0, [100, 101], 2]}", "$[\"fuu()\"][1][1]"), "101");
+
+        // Test extraction using mix of bracket and dot notation json path
+        assertEquals(doJsonExtract("{\"fuu\": {\"bar\": 1}}", "$[\"fuu\"].bar"), "1");
+        assertEquals(doJsonExtract("{\"fuu\": {\"bar\": 1}}", "$.fuu[\"bar\"]"), "1");
+        assertEquals(doJsonExtract("{\"fuu\": [\"\\u0001\"]}", "$[\"fuu\"][0]"), "\"\\u0001\""); // Test escaped characters
+        assertEquals(doJsonExtract("{\"fuu\": [\"\\u0001\"]}", "$.fuu[0]"), "\"\\u0001\""); // Test escaped characters
+
+        // Test extraction using  mix of bracket and dot notation json path with special json characters in path
+        assertEquals(doJsonExtract("{\"@$fuu\": {\"bar\": 1}}", "$[\"@$fuu\"].bar"), "1");
+        // Test escaped characters
+        assertEquals(doJsonExtract("{\",fuu\": {\"bar\": [\"\\u0001\"]}}", "$[\"\\,fuu\"].bar[0]"), "\"\\u0001\"");
+
+        // Test numeric path expression matches arrays and objects
+        assertEquals(doJsonExtract("[0, 1, 2]", "$.1"), null);
+        assertEquals(doJsonExtract("[0, 1, 2]", "$[1]"), "1");
+        assertEquals(doJsonExtract("[0, 1, 2]", "$[0,1]"), "[0,1]");
+        assertEquals(doJsonExtract("[0, 1, 2]", "$[\"1\"]"), null);
+        assertEquals(doJsonExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2, }", "$.1"), "1");
+        assertEquals(doJsonExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2, }", "$['1']"), "1");
+        assertEquals(doJsonExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2, }", "$[\"1\"]"), "1");
+        assertEquals(doJsonExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2, }", "$[1]"), null); // Looks at array position, not field name
+
+        // Test fields starting with a digit
+        assertEquals(doJsonExtract("{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2, }", "$.30day"), "1");
+        assertEquals(doJsonExtract("{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2, }", "$['30day']"), "1");
+        assertEquals(doJsonExtract("{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2, }", "$[\"30day\"]"), "1");
+
+        // Test selecting multiple fields at once
+        assertEquals(doJsonExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2, }", "$['1','2']"), "{\"1\":1,\"2\":2}");
+
+        // Test conditional in the jsonpath
+        assertEquals(doJsonExtract("{ \"store\": {\n" +
+                        "    \"book\": [ \n" +
+                        "      { \"category\": \"reference\",\n" +
+                        "        \"author\": \"Nigel Rees\",\n" +
+                        "        \"title\": \"Sayings of the Century\",\n" +
+                        "        \"price\": 8.95\n" +
+                        "      },\n" +
+                        "      { \"category\": \"fiction\",\n" +
+                        "        \"author\": \"Evelyn Waugh\",\n" +
+                        "        \"title\": \"Sword of Honour\",\n" +
+                        "        \"price\": 12.99\n" +
+                        "      },\n" +
+                        "      { \"category\": \"fiction\",\n" +
+                        "        \"author\": \"Herman Melville\",\n" +
+                        "        \"title\": \"Moby Dick\",\n" +
+                        "        \"isbn\": \"0-553-21311-3\",\n" +
+                        "        \"price\": 8.99\n" +
+                        "      }]}}",
+                "$.store.book[?(@.price<10)]"), // filter all books cheapier than 10
+                "[{\"author\":\"Nigel Rees\",\"category\":\"reference\",\"price\":8.95,\"title\":\"Sayings of the Century\"}," +
+                        "{\"author\":\"Herman Melville\",\"category\":\"fiction\",\"isbn\":\"0-553-21311-3\",\"price\":8.99,\"title\":\"Moby Dick\"}]");
+        assertEquals(doJsonExtract("{H:{1: a, 2: b}, I: {2: e, 3: f}}", "$.*.[?(@.3)]"), "[{\"2\":\"e\",\"3\":\"f\"}]");
+    }
+
+    @Test
+    public void testInvalidExtracts() throws IOException
+    {
+        assertInvalidExtract("", "");
+        assertInvalidExtract("{}", "$.");
+        assertInvalidExtract("", "$$");
+        assertInvalidExtract("", " ");
+        assertInvalidExtract("", ".");
+        assertInvalidExtract("{ \"store\": { \"book\": [{ \"title\": \"title\" }] } }", "$.store.book[]");
+    }
+
+    private static String doJsonExtract(String inputJson, String jsonPath)
+            throws IOException
+    {
+        Slice value = JsonFunctions.varcharJsonExtractJayway(Slices.utf8Slice(inputJson), Slices.utf8Slice(jsonPath));
+        return (value == null) ? null : value.toStringUtf8();
+    }
+
+    private static void assertInvalidExtract(String inputJson, String jsonPath)
+            throws IOException
+    {
+        try {
+            doJsonExtract(inputJson, jsonPath);
+        }
+        catch (IllegalArgumentException e) {
+            return;
+        }
+        catch (InvalidPathException e) {
+            return;
+        }
+        fail("Expected error for invalid json or jsonpath");
+    }
+}


### PR DESCRIPTION
The table below contains some of the differences between the jackson and jayway implementations of json path


JSON | JSON Path | Original | Jayway | Reason
-- | -- | -- | -- | --
[0, 1, 2] | $.1 | 1 | null | 1 is treated as a field name, not an index position. This is looking for field 1, as opposed to position 1
[0, 1, 2] | $[\"1\"] | 1 | null | 1 is treated as a field name, not an index position. This is looking for field 1, as opposed to position 1
[0, 1, 2] | $[1,2] | Invalid json path | [1,2] | Can select multiple array indices
{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2, } | $[30day] | 1 | Invalid path error | Must have quotes around 30day, otherwise treated as array index
[1, null] | $[1] | null | “null” | Treats null as string value
"{\"fuu\": 1}" | $[fuu] | 1 | Invalid json path | need to surround fuu with quotes, otherwise it believes it’s an array index
“null” | $ | “null” | Invalid json | Just a null string is invalid json
{\",fuu\": [\"\\u0001\"]} | $[\",fuu\"][0] | \"\\u0001\" | Invalid json path | Need to escape comma character in jsonpath, otherwise treates it like union of indices
{\",fuu\": {\"bar\": [\"\\u0001\"]}} | $[\",fuu\"].bar[0] | \"\\u0001\" | Invalid json path | Need to escape comma in jsonpath, otherwise treated like union of array indices
{\"0\" : 0, \"1\" : 1, \"2\" : 2, } | $[1] | 1 | null | Valid jsonpath should have quotes around 1, otherwise it's treated as array index
{\"0\" : 0, \"1\" : 1, \"2\" : 2, } | $['1','2'] | Invalid json path | {"1":1,"2":2} | Can select multiple field names
{X:{1: a, 2: b}, Y: {2: d, 3: e}} | $.*.[?(@.3)] | Invalid json path | {"2":"d","3":"e"}| Select fields where field '3' exists


```
Benchmark                                                                                   (jsonPathString)       Mode  Cnt      Score      Error  Units
BenchmarkJsonExtract.benchmarkJsonExtract                                          $.store.book.doesnt_exist       avgt   10  17565.865 ± 1046.035  ns/op
BenchmarkJsonExtract.benchmarkJsonExtract                                             $.store.book[3].author       avgt   10  20388.657 ± 1037.179  ns/op
BenchmarkJsonExtract.benchmarkJsonExtract                                                       $.store.book       avgt   10  14958.771 ±  667.105  ns/op
BenchmarkJsonExtract.benchmarkJsonExtract                                              $["store"]["book"][0]       avgt   10  14229.945 ±  620.223  ns/op
BenchmarkJsonExtract.benchmarkJsonExtract        $.store.statuses[0].entities.user_mentions[0].unicode_value       avgt   10  31469.797 ± 1071.636  ns/op
BenchmarkJsonExtract.benchmarkJsonExtract             $.store.statuses[0].entities.user_mentions[0].名前:前田あゆみ  avgt   10  30752.912 ± 1020.403  ns/op
BenchmarkJsonExtract.benchmarkJsonExtractJayway                                    $.store.book.doesnt_exist       avgt   10  29733.875 ±  868.078  ns/op
BenchmarkJsonExtract.benchmarkJsonExtractJayway                                       $.store.book[3].author       avgt   10  27158.861 ±  818.154  ns/op
BenchmarkJsonExtract.benchmarkJsonExtractJayway                                                 $.store.book       avgt   10  29528.123 ±  732.645  ns/op
BenchmarkJsonExtract.benchmarkJsonExtractJayway                                        $["store"]["book"][0]       avgt   10  26673.679 ± 1954.993  ns/op
BenchmarkJsonExtract.benchmarkJsonExtractJayway  $.store.statuses[0].entities.user_mentions[0].unicode_value       avgt   10  26651.871 ±  865.189  ns/op
BenchmarkJsonExtract.benchmarkJsonExtractJayway       $.store.statuses[0].entities.user_mentions[0].名前:前田あゆみ  avgt   10  26525.616 ± 1199.202  ns/op

Process finished with exit code 0
```