### PR TITLE
Cache row group column stats in ORC column writer

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
@@ -57,6 +57,7 @@ public class BooleanColumnWriter
     private final PresentOutputStream presentStream;
 
     private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
+    private long columnStatisticsRetainedSizeInBytes;
 
     private BooleanStatisticsBuilder statisticsBuilder = new BooleanStatisticsBuilder();
 
@@ -112,6 +113,7 @@ public class BooleanColumnWriter
         checkState(!closed);
         ColumnStatistics statistics = statisticsBuilder.buildColumnStatistics();
         rowGroupColumnStatistics.add(statistics);
+        columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         statisticsBuilder = new BooleanStatisticsBuilder();
         return ImmutableMap.of(column, statistics);
     }
@@ -186,11 +188,7 @@ public class BooleanColumnWriter
     @Override
     public long getRetainedBytes()
     {
-        long retainedBytes = INSTANCE_SIZE + dataStream.getRetainedBytes() + presentStream.getRetainedBytes();
-        for (ColumnStatistics statistics : rowGroupColumnStatistics) {
-            retainedBytes += statistics.getRetainedSizeInBytes();
-        }
-        return retainedBytes;
+        return INSTANCE_SIZE + dataStream.getRetainedBytes() + presentStream.getRetainedBytes() + columnStatisticsRetainedSizeInBytes;
     }
 
     @Override
@@ -200,6 +198,7 @@ public class BooleanColumnWriter
         dataStream.reset();
         presentStream.reset();
         rowGroupColumnStatistics.clear();
+        columnStatisticsRetainedSizeInBytes = 0;
         statisticsBuilder = new BooleanStatisticsBuilder();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
@@ -68,6 +68,7 @@ public class DecimalColumnWriter
     private final PresentOutputStream presentStream;
 
     private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
+    private long columnStatisticsRetainedSizeInBytes;
 
     private ShortDecimalStatisticsBuilder shortDecimalStatisticsBuilder;
     private LongDecimalStatisticsBuilder longDecimalStatisticsBuilder;
@@ -159,6 +160,7 @@ public class DecimalColumnWriter
             longDecimalStatisticsBuilder = new LongDecimalStatisticsBuilder();
         }
         rowGroupColumnStatistics.add(statistics);
+        columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
 
         return ImmutableMap.of(column, statistics);
     }
@@ -239,11 +241,7 @@ public class DecimalColumnWriter
     @Override
     public long getRetainedBytes()
     {
-        long retainedBytes = INSTANCE_SIZE + dataStream.getRetainedBytes() + scaleStream.getRetainedBytes() + presentStream.getRetainedBytes();
-        for (ColumnStatistics statistics : rowGroupColumnStatistics) {
-            retainedBytes += statistics.getRetainedSizeInBytes();
-        }
-        return retainedBytes;
+        return INSTANCE_SIZE + dataStream.getRetainedBytes() + scaleStream.getRetainedBytes() + presentStream.getRetainedBytes() + columnStatisticsRetainedSizeInBytes;
     }
 
     @Override
@@ -254,6 +252,7 @@ public class DecimalColumnWriter
         scaleStream.reset();
         presentStream.reset();
         rowGroupColumnStatistics.clear();
+        columnStatisticsRetainedSizeInBytes = 0;
         shortDecimalStatisticsBuilder = new ShortDecimalStatisticsBuilder(this.type.getScale());
         longDecimalStatisticsBuilder = new LongDecimalStatisticsBuilder();
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -61,6 +61,7 @@ public class ListColumnWriter
     private final ColumnWriter elementWriter;
 
     private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
+    private long columnStatisticsRetainedSizeInBytes;
 
     private int nonNullValueCount;
 
@@ -140,6 +141,7 @@ public class ListColumnWriter
 
         ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
+        columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;
 
         ImmutableMap.Builder<Integer, ColumnStatistics> columnStatistics = ImmutableMap.builder();
@@ -227,11 +229,7 @@ public class ListColumnWriter
     @Override
     public long getRetainedBytes()
     {
-        long retainedBytes = INSTANCE_SIZE + lengthStream.getRetainedBytes() + presentStream.getRetainedBytes() + elementWriter.getRetainedBytes();
-        for (ColumnStatistics statistics : rowGroupColumnStatistics) {
-            retainedBytes += statistics.getRetainedSizeInBytes();
-        }
-        return retainedBytes;
+        return INSTANCE_SIZE + lengthStream.getRetainedBytes() + presentStream.getRetainedBytes() + elementWriter.getRetainedBytes() + columnStatisticsRetainedSizeInBytes;
     }
 
     @Override
@@ -242,6 +240,7 @@ public class ListColumnWriter
         presentStream.reset();
         elementWriter.reset();
         rowGroupColumnStatistics.clear();
+        columnStatisticsRetainedSizeInBytes = 0;
         nonNullValueCount = 0;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
@@ -64,6 +64,7 @@ public class LongColumnWriter
     private final PresentOutputStream presentStream;
 
     private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
+    private long columnStatisticsRetainedSizeInBytes;
 
     private final Supplier<LongValueStatisticsBuilder> statisticsBuilderSupplier;
     private LongValueStatisticsBuilder statisticsBuilder;
@@ -129,6 +130,7 @@ public class LongColumnWriter
         checkState(!closed);
         ColumnStatistics statistics = statisticsBuilder.buildColumnStatistics();
         rowGroupColumnStatistics.add(statistics);
+        columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         statisticsBuilder = statisticsBuilderSupplier.get();
         return ImmutableMap.of(column, statistics);
     }
@@ -203,11 +205,7 @@ public class LongColumnWriter
     @Override
     public long getRetainedBytes()
     {
-        long retainedBytes = INSTANCE_SIZE + dataStream.getRetainedBytes() + presentStream.getRetainedBytes();
-        for (ColumnStatistics statistics : rowGroupColumnStatistics) {
-            retainedBytes += statistics.getRetainedSizeInBytes();
-        }
-        return retainedBytes;
+        return INSTANCE_SIZE + dataStream.getRetainedBytes() + presentStream.getRetainedBytes() + columnStatisticsRetainedSizeInBytes;
     }
 
     @Override
@@ -217,6 +215,7 @@ public class LongColumnWriter
         dataStream.reset();
         presentStream.reset();
         rowGroupColumnStatistics.clear();
+        columnStatisticsRetainedSizeInBytes = 0;
         statisticsBuilder = statisticsBuilderSupplier.get();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -62,6 +62,7 @@ public class MapColumnWriter
     private final ColumnWriter valueWriter;
 
     private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
+    private long columnStatisticsRetainedSizeInBytes;
 
     private int nonNullValueCount;
 
@@ -147,6 +148,7 @@ public class MapColumnWriter
 
         ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
+        columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;
 
         ImmutableMap.Builder<Integer, ColumnStatistics> columnStatistics = ImmutableMap.builder();
@@ -239,11 +241,7 @@ public class MapColumnWriter
     @Override
     public long getRetainedBytes()
     {
-        long retainedBytes = INSTANCE_SIZE + lengthStream.getRetainedBytes() + presentStream.getRetainedBytes() + keyWriter.getRetainedBytes() + valueWriter.getRetainedBytes();
-        for (ColumnStatistics statistics : rowGroupColumnStatistics) {
-            retainedBytes += statistics.getRetainedSizeInBytes();
-        }
-        return retainedBytes;
+        return INSTANCE_SIZE + lengthStream.getRetainedBytes() + presentStream.getRetainedBytes() + keyWriter.getRetainedBytes() + valueWriter.getRetainedBytes() + columnStatisticsRetainedSizeInBytes;
     }
 
     @Override
@@ -255,6 +253,7 @@ public class MapColumnWriter
         keyWriter.reset();
         valueWriter.reset();
         rowGroupColumnStatistics.clear();
+        columnStatisticsRetainedSizeInBytes = 0;
         nonNullValueCount = 0;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -55,6 +55,7 @@ public class StructColumnWriter
     private final List<ColumnWriter> structFields;
 
     private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
+    private long columnStatisticsRetainedSizeInBytes;
 
     private int nonNullValueCount;
 
@@ -137,6 +138,7 @@ public class StructColumnWriter
         checkState(!closed);
         ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null, null, null, null, null, null, null, null);
         rowGroupColumnStatistics.add(statistics);
+        columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;
 
         ImmutableMap.Builder<Integer, ColumnStatistics> columnStatistics = ImmutableMap.builder();
@@ -234,9 +236,7 @@ public class StructColumnWriter
         for (ColumnWriter structField : structFields) {
             retainedBytes += structField.getRetainedBytes();
         }
-        for (ColumnStatistics statistics : rowGroupColumnStatistics) {
-            retainedBytes += statistics.getRetainedSizeInBytes();
-        }
+        retainedBytes += columnStatisticsRetainedSizeInBytes;
         return retainedBytes;
     }
 
@@ -247,6 +247,7 @@ public class StructColumnWriter
         presentStream.reset();
         structFields.forEach(ColumnWriter::reset);
         rowGroupColumnStatistics.clear();
+        columnStatisticsRetainedSizeInBytes = 0;
         nonNullValueCount = 0;
     }
 }


### PR DESCRIPTION
**We found huge regression in prod due to column stats calculation when writing large files**

An ORC file can be large containing thousands of row groups. In some
cases, 50% CPU is spent on getting the retained size for column writers.
Cache the row group stats to save CPU.

Please fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

Hive Changes
* Fix high CPU usage when writing ORC files with too many row groups.
```
