### PR TITLE
Make PrestoS3InputStream#read comply with read method contract on EOF

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
@@ -876,7 +876,10 @@ public class PrestoS3FileSystem
                                 while (read < length) {
                                     int n = stream.read(buffer, offset + read, length - read);
                                     if (n <= 0) {
-                                        break;
+                                        if (read > 0) {
+                                            return read;
+                                        }
+                                        return -1;
                                     }
                                     read += n;
                                 }


### PR DESCRIPTION
Read should return -1 when no data was read but EOF is reached

Cherry-pick of https://github.com/prestosql/presto/pull/1293

Co-authored-by: Ariel Weisberg <aweisberg@fb.com>

```
== NO RELEASE NOTE ==
```
