### PR TITLE
Increase jvm heap for mvn build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 
 env:
   global:
-    - MAVEN_OPTS="-Xmx512M -XX:+ExitOnOutOfMemoryError"
+    - MAVEN_OPTS="-Xmx1024M -XX:+ExitOnOutOfMemoryError"
     - MAVEN_SKIP_CHECKS_AND_DOCS="-Dair.check.skip-all=true -Dmaven.javadoc.skip=true"
     - MAVEN_FAST_INSTALL="-DskipTests $MAVEN_SKIP_CHECKS_AND_DOCS -B -q -T C1"
     - ARTIFACTS_UPLOAD_PATH_BRANCH=travis_build_artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}


### PR DESCRIPTION
this should solve the occasional build error due to GC overhead

```
[INFO] Compiling 792 source files to /home/travis/build/prestodb/presto/presto-main/target/test-classes

Terminating due to java.lang.OutOfMemoryError: GC overhead limit exceeded
```