### PR TITLE
Update fixed-precision docs to reflect constants parsed as DECIMAL

### DIFF
--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -88,8 +88,8 @@ Fixed-Precision
     .. note::
 
         For compatibility reasons decimal literals without explicit type specifier (e.g. ``1.2``)
-        are treated as the values of the ``DOUBLE`` type by default, but this is subject to change
-        in future releases. This behavior is controlled by:
+        are treated as values of the ``DOUBLE`` type by default up to version 0.198. 
+        After 0.198 they are parsed as DECIMAL.
 
           - System wide property: ``parse-decimal-literals-as-double``
           - Session wide property: ``parse_decimal_literals_as_double``


### PR DESCRIPTION
Since 0.198 the default behavior is that decimal literals without an
explicit type specifier (e.g. 1.2) are treated as DECIMAL where
prior to 0.198 they were treated as DOUBLE.

```
== NO RELEASE NOTE ==
```

This has been tripping up users see #13256 and #13150.