### PR TITLE
Add accuracy param to array weighted approx_percentile func

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -244,6 +244,17 @@ Approximate Aggregate Functions
     Each element of the array must be between zero and one, and the array must
     be constant for all input rows.
 
+.. function:: approx_percentile(x, w, percentages, accuracy) -> array<[same as x]>
+
+    Returns the approximate weighed percentile for all input values of ``x``
+    using the per-item weight ``w`` at each of the given percentages specified
+    in the array, with a maximum rank error of ``accuracy``. The weight must be
+    an integer value of at least one. It is effectively a replication count for
+    the value ``x`` in the percentile set. Each element of the array must be
+    between zero and one, and the array must be constant for all input rows.
+    ``accuracy`` must be a value greater than zero and less than one, and it
+    must be constant for all input rows.
+
 .. function:: approx_set(x) -> HyperLogLog
     :noindex:
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
@@ -48,6 +48,12 @@ public final class ApproximateDoublePercentileArrayAggregations
         ApproximateLongPercentileArrayAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentilesArrayBlock);
     }
 
+    @InputFunction
+    public static void weightedInput(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType("array(double)") Block percentilesArrayBlock, @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        ApproximateLongPercentileArrayAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentilesArrayBlock, accuracy);
+    }
+
     @CombineFunction
     public static void combine(@AggregationState DigestAndPercentileArrayState state, DigestAndPercentileArrayState otherState)
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileArrayAggregations.java
@@ -50,6 +50,12 @@ public class ApproximateRealPercentileArrayAggregations
         ApproximateLongPercentileArrayAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentilesArrayBlock);
     }
 
+    @InputFunction
+    public static void weightedInput(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType("array(double)") Block percentilesArrayBlock, @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        ApproximateLongPercentileArrayAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentilesArrayBlock, accuracy);
+    }
+
     @CombineFunction
     public static void combine(@AggregationState DigestAndPercentileArrayState state, @AggregationState DigestAndPercentileArrayState otherState)
     {

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
@@ -49,15 +49,18 @@ public class TestApproximatePercentileAggregation
 
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = getAggregation(DOUBLE, new ArrayType(DOUBLE));
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = getAggregation(DOUBLE, BIGINT, new ArrayType(DOUBLE));
+    private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION_WITH_ACCURACY = getAggregation(DOUBLE, BIGINT, new ArrayType(DOUBLE), DOUBLE);
 
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = getAggregation(BIGINT, new ArrayType(DOUBLE));
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = getAggregation(BIGINT, BIGINT, new ArrayType(DOUBLE));
+    private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION_WITH_ACCURACY = getAggregation(BIGINT, BIGINT, new ArrayType(DOUBLE), DOUBLE);
 
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_AGGREGATION = getAggregation(REAL, DOUBLE);
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION = getAggregation(REAL, BIGINT, DOUBLE);
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY = getAggregation(REAL, BIGINT, DOUBLE, DOUBLE);
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = getAggregation(REAL, new ArrayType(DOUBLE));
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = getAggregation(REAL, BIGINT, new ArrayType(DOUBLE));
+    private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION_WITH_ACCURACY = getAggregation(REAL, BIGINT, new ArrayType(DOUBLE), DOUBLE);
 
     @Test
     public void testLongPartialStep()
@@ -179,6 +182,14 @@ public class TestApproximatePercentileAggregation
                 createLongsBlock(1L, 2L, 3L),
                 createLongsBlock(4L, 2L, 1L),
                 createRLEBlock(ImmutableList.of(0.5, 0.8), 3));
+
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION_WITH_ACCURACY,
+                ImmutableList.of(9900L, 100L),
+                createLongSequenceBlock(0, 10000),
+                createLongRepeatBlock(1, 10000),
+                createRLEBlock(ImmutableList.of(0.99, 0.01), 10000),
+                createRLEBlock(0.001, 10000));
     }
 
     @Test
@@ -315,6 +326,14 @@ public class TestApproximatePercentileAggregation
                 createBlockOfReals(1.0f, 2.0f, 3.0f),
                 createLongsBlock(4L, 2L, 1L),
                 createRLEBlock(ImmutableList.of(0.5, 0.8), 3));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION_WITH_ACCURACY,
+                ImmutableList.of(9900.0f, 100.0f),
+                createSequenceBlockOfReal(0, 10000),
+                createLongRepeatBlock(1, 10000),
+                createRLEBlock(ImmutableList.of(0.99, 0.01), 10000),
+                createRLEBlock(0.001, 10000));
     }
 
     @Test
@@ -439,6 +458,14 @@ public class TestApproximatePercentileAggregation
                 createDoublesBlock(1.0, 2.0, 3.0),
                 createLongsBlock(4L, 2L, 1L),
                 createRLEBlock(ImmutableList.of(0.5, 0.8), 3));
+
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION_WITH_ACCURACY,
+                ImmutableList.of(9900.0, 100.0),
+                createDoubleSequenceBlock(0, 10000),
+                createLongRepeatBlock(1, 10000),
+                createRLEBlock(ImmutableList.of(0.99, 0.01), 10000),
+                createRLEBlock(0.001, 10000));
     }
 
     private static InternalAggregationFunction getAggregation(Type... arguments)


### PR DESCRIPTION
`approx_percentile` function now allows the accuracy to be specified
when used with weighted percentile arrays.

The new function has the form of:
`function:: approx_percentile(x, w, percentages, accuracy) -> array<[same as x]>`

Resolves #13143 

```
== RELEASE NOTES ==

General Changes
* The :func:`approx_percentile` aggregation now also optionally takes an ``accuracy`` parameter when used with an array of percentages.
```
