### PR TITLE
Improve performance of bucketed table inserts

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -131,6 +131,7 @@ public final class SystemSessionProperties
     public static final String MAX_CONCURRENT_MATERIALIZATIONS = "max_concurrent_materializations";
     public static final String PUSHDOWN_SUBFIELDS_ENABLED = "pushdown_subfields_enabled";
     public static final String TABLE_WRITER_MERGE_OPERATOR_ENABLED = "table_writer_merge_operator_enabled";
+    public static final String CONCURRENT_WRITES_TO_PARTITIONED_TABLE_ENABLED = "concurrent_writes_to_partitioned_table_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -632,6 +633,11 @@ public final class SystemSessionProperties
                         TABLE_WRITER_MERGE_OPERATOR_ENABLED,
                         "Experimental: enable table writer merge operator",
                         featuresConfig.isTableWriterMergeOperatorEnabled(),
+                        false),
+                booleanProperty(
+                        CONCURRENT_WRITES_TO_PARTITIONED_TABLE_ENABLED,
+                        "Experimental: enable concurrent writes to partitioned table",
+                        featuresConfig.isConcurrentWritesToPartitionedTableEnabled(),
                         false));
     }
 
@@ -1073,5 +1079,10 @@ public final class SystemSessionProperties
     public static boolean isTableWriterMergeOperatorEnabled(Session session)
     {
         return session.getSystemProperty(TABLE_WRITER_MERGE_OPERATOR_ENABLED, Boolean.class);
+    }
+
+    public static boolean isConcurrentWritesToPartitionedTableEnabled(Session session)
+    {
+        return session.getSystemProperty(CONCURRENT_WRITES_TO_PARTITIONED_TABLE_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -53,7 +53,7 @@ import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.RecordPageSourceProvider;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
-import com.facebook.presto.sql.planner.NodePartitioningManager;
+import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.relational.ConnectorRowExpressionService;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionOptimizer;
@@ -94,7 +94,7 @@ public class ConnectorManager
     private final SplitManager splitManager;
     private final PageSourceManager pageSourceManager;
     private final IndexManager indexManager;
-    private final NodePartitioningManager nodePartitioningManager;
+    private final PartitioningProviderManager partitioningProviderManager;
     private final ConnectorPlanOptimizerManager connectorPlanOptimizerManager;
 
     private final PageSinkManager pageSinkManager;
@@ -125,7 +125,7 @@ public class ConnectorManager
             SplitManager splitManager,
             PageSourceManager pageSourceManager,
             IndexManager indexManager,
-            NodePartitioningManager nodePartitioningManager,
+            PartitioningProviderManager partitioningProviderManager,
             ConnectorPlanOptimizerManager connectorPlanOptimizerManager,
             PageSinkManager pageSinkManager,
             HandleResolver handleResolver,
@@ -145,7 +145,7 @@ public class ConnectorManager
         this.splitManager = splitManager;
         this.pageSourceManager = pageSourceManager;
         this.indexManager = indexManager;
-        this.nodePartitioningManager = nodePartitioningManager;
+        this.partitioningProviderManager = partitioningProviderManager;
         this.connectorPlanOptimizerManager = connectorPlanOptimizerManager;
         this.pageSinkManager = pageSinkManager;
         this.handleResolver = handleResolver;
@@ -279,7 +279,7 @@ public class ConnectorManager
                 .ifPresent(indexProvider -> indexManager.addIndexProvider(connectorId, indexProvider));
 
         connector.getPartitioningProvider()
-                .ifPresent(partitioningProvider -> nodePartitioningManager.addPartitioningProvider(connectorId, partitioningProvider));
+                .ifPresent(partitioningProvider -> partitioningProviderManager.addPartitioningProvider(connectorId, partitioningProvider));
 
         if (nodeManager.getCurrentNode().isCoordinator()) {
             connector.getPlanOptimizerProvider()
@@ -316,7 +316,7 @@ public class ConnectorManager
         pageSourceManager.removeConnectorPageSourceProvider(connectorId);
         pageSinkManager.removeConnectorPageSinkProvider(connectorId);
         indexManager.removeIndexProvider(connectorId);
-        nodePartitioningManager.removePartitioningProvider(connectorId);
+        partitioningProviderManager.removePartitioningProvider(connectorId);
         metadataManager.getProcedureRegistry().removeProcedures(connectorId);
         accessControlManager.removeCatalogAccessControl(connectorId);
         metadataManager.getTablePropertyManager().removeProperties(connectorId);

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchange.java
@@ -13,10 +13,21 @@
  */
 package com.facebook.presto.operator.exchange;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.operator.BucketPartitionFunction;
+import com.facebook.presto.operator.HashGenerator;
+import com.facebook.presto.operator.InterpretedHashGenerator;
+import com.facebook.presto.operator.PartitionFunction;
 import com.facebook.presto.operator.PipelineExecutionStrategy;
+import com.facebook.presto.operator.PrecomputedHashGenerator;
+import com.facebook.presto.spi.BucketFunction;
+import com.facebook.presto.spi.connector.ConnectorBucketNodeMap;
+import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.planner.PartitioningHandle;
+import com.facebook.presto.sql.planner.PartitioningProviderManager;
+import com.facebook.presto.sql.planner.SystemPartitioningHandle;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 
@@ -34,6 +45,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
@@ -76,11 +88,13 @@ public class LocalExchange
     private int nextSourceIndex;
 
     public LocalExchange(
+            PartitioningProviderManager partitioningProviderManager,
+            Session session,
             int sinkFactoryCount,
             int bufferCount,
             PartitioningHandle partitioning,
-            List<? extends Type> types,
             List<Integer> partitionChannels,
+            List<Type> partitioningChannelTypes,
             Optional<Integer> partitionHashChannel,
             DataSize maxBufferedBytes)
     {
@@ -110,9 +124,6 @@ public class LocalExchange
         else if (partitioning.equals(FIXED_ARBITRARY_DISTRIBUTION)) {
             exchangerSupplier = () -> new RandomExchanger(buffers, memoryManager);
         }
-        else if (partitioning.equals(FIXED_HASH_DISTRIBUTION)) {
-            exchangerSupplier = () -> new PartitioningExchanger(buffers, memoryManager, types, partitionChannels, partitionHashChannel);
-        }
         else if (partitioning.equals(FIXED_PASSTHROUGH_DISTRIBUTION)) {
             Iterator<LocalExchangeSource> sourceIterator = this.sources.iterator();
             exchangerSupplier = () -> {
@@ -120,9 +131,67 @@ public class LocalExchange
                 return new PassthroughExchanger(sourceIterator.next(), maxBufferedBytes.toBytes() / bufferCount, memoryManager::updateMemoryUsage);
             };
         }
+        else if (partitioning.equals(FIXED_HASH_DISTRIBUTION) || partitioning.getConnectorId().isPresent()) {
+            // partitioned exchange
+            exchangerSupplier = () -> new PartitioningExchanger(
+                    buffers,
+                    memoryManager,
+                    createPartitionFunction(
+                            partitioningProviderManager,
+                            session,
+                            partitioning,
+                            bufferCount,
+                            partitioningChannelTypes,
+                            partitionHashChannel.isPresent()),
+                    partitionChannels,
+                    partitionHashChannel);
+        }
         else {
             throw new IllegalArgumentException("Unsupported local exchange partitioning " + partitioning);
         }
+    }
+
+    private static PartitionFunction createPartitionFunction(
+            PartitioningProviderManager partitioningProviderManager,
+            Session session,
+            PartitioningHandle partitioning,
+            int partitionCount,
+            List<Type> partitioningChannelTypes,
+            boolean isHashPrecomputed)
+    {
+        if (partitioning.getConnectorHandle() instanceof SystemPartitioningHandle) {
+            HashGenerator hashGenerator;
+            if (isHashPrecomputed) {
+                hashGenerator = new PrecomputedHashGenerator(0);
+            }
+            else {
+                hashGenerator = new InterpretedHashGenerator(partitioningChannelTypes, IntStream.range(0, partitioningChannelTypes.size()).toArray());
+            }
+            return new LocalPartitionGenerator(hashGenerator, partitionCount);
+        }
+
+        ConnectorNodePartitioningProvider partitioningProvider = partitioningProviderManager.getPartitioningProvider(partitioning.getConnectorId().get());
+        ConnectorBucketNodeMap connectorBucketNodeMap = partitioningProvider.getBucketNodeMap(
+                partitioning.getTransactionHandle().orElse(null),
+                session.toConnectorSession(),
+                partitioning.getConnectorHandle());
+        checkArgument(connectorBucketNodeMap != null, "No partition map %s", partitioning);
+
+        int bucketCount = connectorBucketNodeMap.getBucketCount();
+        int[] bucketToPartition = new int[bucketCount];
+        for (int bucket = 0; bucket < bucketCount; bucket++) {
+            bucketToPartition[bucket] = bucket % partitionCount;
+        }
+
+        BucketFunction bucketFunction = partitioningProvider.getBucketFunction(
+                partitioning.getTransactionHandle().orElse(null),
+                session.toConnectorSession(),
+                partitioning.getConnectorHandle(),
+                partitioningChannelTypes,
+                bucketCount);
+
+        checkArgument(bucketFunction != null, "No bucket function for partitioning: %s", partitioning);
+        return new BucketPartitionFunction(bucketFunction, bucketToPartition);
     }
 
     public int getBufferCount()
@@ -255,9 +324,11 @@ public class LocalExchange
     @ThreadSafe
     public static class LocalExchangeFactory
     {
+        private final PartitioningProviderManager partitioningProviderManager;
+        private final Session session;
         private final PartitioningHandle partitioning;
-        private final List<Type> types;
         private final List<Integer> partitionChannels;
+        private final List<Type> partitioningChannelTypes;
         private final Optional<Integer> partitionHashChannel;
         private final PipelineExecutionStrategy exchangeSourcePipelineExecutionStrategy;
         private final DataSize maxBufferedBytes;
@@ -276,6 +347,8 @@ public class LocalExchange
         private final List<LocalExchangeSinkFactoryId> closedSinkFactories = new ArrayList<>();
 
         public LocalExchangeFactory(
+                PartitioningProviderManager partitioningProviderManager,
+                Session session,
                 PartitioningHandle partitioning,
                 int defaultConcurrency,
                 List<Type> types,
@@ -284,14 +357,18 @@ public class LocalExchange
                 PipelineExecutionStrategy exchangeSourcePipelineExecutionStrategy,
                 DataSize maxBufferedBytes)
         {
+            this.partitioningProviderManager = requireNonNull(partitioningProviderManager, "partitioningProviderManager is null");
+            this.session = requireNonNull(session, "session is null");
             this.partitioning = requireNonNull(partitioning, "partitioning is null");
-            this.types = requireNonNull(types, "types is null");
-            this.partitionChannels = requireNonNull(partitionChannels, "partitioningChannels is null");
+            this.bufferCount = computeBufferCount(partitioning, defaultConcurrency, partitionChannels);
+            this.partitionChannels = ImmutableList.copyOf(requireNonNull(partitionChannels, "partitionChannels is null"));
+            requireNonNull(types, "types is null");
+            this.partitioningChannelTypes = partitionChannels.stream()
+                    .map(types::get)
+                    .collect(toImmutableList());
             this.partitionHashChannel = requireNonNull(partitionHashChannel, "partitionHashChannel is null");
             this.exchangeSourcePipelineExecutionStrategy = requireNonNull(exchangeSourcePipelineExecutionStrategy, "exchangeSourcePipelineExecutionStrategy is null");
             this.maxBufferedBytes = requireNonNull(maxBufferedBytes, "maxBufferedBytes is null");
-
-            this.bufferCount = computeBufferCount(partitioning, defaultConcurrency, partitionChannels);
         }
 
         public synchronized LocalExchangeSinkFactoryId newSinkFactoryId()
@@ -322,8 +399,16 @@ public class LocalExchange
             }
             return localExchangeMap.computeIfAbsent(lifespan, ignored -> {
                 checkState(noMoreSinkFactories);
-                LocalExchange localExchange =
-                        new LocalExchange(numSinkFactories, bufferCount, partitioning, types, partitionChannels, partitionHashChannel, maxBufferedBytes);
+                LocalExchange localExchange = new LocalExchange(
+                        partitioningProviderManager,
+                        session,
+                        numSinkFactories,
+                        bufferCount,
+                        partitioning,
+                        partitionChannels,
+                        partitioningChannelTypes,
+                        partitionHashChannel,
+                        maxBufferedBytes);
                 for (LocalExchangeSinkFactoryId closedSinkFactoryId : closedSinkFactories) {
                     localExchange.getSinkFactory(closedSinkFactoryId).close();
                 }
@@ -355,13 +440,13 @@ public class LocalExchange
             bufferCount = defaultConcurrency;
             checkArgument(partitionChannels.isEmpty(), "Arbitrary exchange must not have partition channels");
         }
-        else if (partitioning.equals(FIXED_HASH_DISTRIBUTION)) {
-            bufferCount = defaultConcurrency;
-            checkArgument(!partitionChannels.isEmpty(), "Partitioned exchange must have partition channels");
-        }
         else if (partitioning.equals(FIXED_PASSTHROUGH_DISTRIBUTION)) {
             bufferCount = defaultConcurrency;
             checkArgument(partitionChannels.isEmpty(), "Passthrough exchange must not have partition channels");
+        }
+        else if (partitioning.equals(FIXED_HASH_DISTRIBUTION) || partitioning.getConnectorId().isPresent()) {
+            // partitioned exchange
+            bufferCount = defaultConcurrency;
         }
         else {
             throw new IllegalArgumentException("Unsupported local exchange partitioning " + partitioning);

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -126,6 +126,7 @@ import com.facebook.presto.sql.planner.CompilerConfig;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
+import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.tree.Expression;
@@ -393,6 +394,9 @@ public class ServerMainModule
 
         // split manager
         binder.bind(SplitManager.class).in(Scopes.SINGLETON);
+
+        // partitioning provider manager
+        binder.bind(PartitioningProviderManager.class).in(Scopes.SINGLETON);
 
         // node partitioning manager
         binder.bind(NodePartitioningManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -137,6 +137,7 @@ public class FeaturesConfig
     private boolean pushdownSubfieldsEnabled;
 
     private boolean tableWriterMergeOperatorEnabled = true;
+    private boolean concurrentWritesToPartitionedTableEnabled = true;
 
     public enum JoinReorderingStrategy
     {
@@ -1056,6 +1057,18 @@ public class FeaturesConfig
     public FeaturesConfig setTableWriterMergeOperatorEnabled(boolean tableWriterMergeOperatorEnabled)
     {
         this.tableWriterMergeOperatorEnabled = tableWriterMergeOperatorEnabled;
+        return this;
+    }
+
+    public boolean isConcurrentWritesToPartitionedTableEnabled()
+    {
+        return concurrentWritesToPartitionedTableEnabled;
+    }
+
+    @Config("experimental.concurrent-writes-to-partitioned-table-enabled")
+    public FeaturesConfig setConcurrentWritesToPartitionedTableEnabled(boolean concurrentWritesToPartitionedTableEnabled)
+    {
+        this.concurrentWritesToPartitionedTableEnabled = concurrentWritesToPartitionedTableEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -220,6 +220,7 @@ import static com.facebook.presto.SystemSessionProperties.getFilterAndProjectMin
 import static com.facebook.presto.SystemSessionProperties.getFilterAndProjectMinOutputPageSize;
 import static com.facebook.presto.SystemSessionProperties.getTaskConcurrency;
 import static com.facebook.presto.SystemSessionProperties.getTaskWriterCount;
+import static com.facebook.presto.SystemSessionProperties.isConcurrentWritesToPartitionedTableEnabled;
 import static com.facebook.presto.SystemSessionProperties.isExchangeCompressionEnabled;
 import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
 import static com.facebook.presto.operator.DistinctLimitOperator.DistinctLimitOperatorFactory;
@@ -2144,7 +2145,7 @@ public class LocalExecutionPlanner
         public PhysicalOperation visitTableWriter(TableWriterNode node, LocalExecutionPlanContext context)
         {
             // Set table writer count
-            if (node.getPartitioningScheme().isPresent()) {
+            if (node.getPartitioningScheme().isPresent() && !isConcurrentWritesToPartitionedTableEnabled(session)) {
                 context.setDriverInstanceCount(1);
             }
             else {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -285,6 +285,7 @@ public class LocalExecutionPlanner
     private final Optional<ExplainAnalyzeContext> explainAnalyzeContext;
     private final PageSourceProvider pageSourceProvider;
     private final IndexManager indexManager;
+    private final PartitioningProviderManager partitioningProviderManager;
     private final NodePartitioningManager nodePartitioningManager;
     private final PageSinkManager pageSinkManager;
     private final ExpressionCompiler expressionCompiler;
@@ -312,6 +313,7 @@ public class LocalExecutionPlanner
             Optional<ExplainAnalyzeContext> explainAnalyzeContext,
             PageSourceProvider pageSourceProvider,
             IndexManager indexManager,
+            PartitioningProviderManager partitioningProviderManager,
             NodePartitioningManager nodePartitioningManager,
             PageSinkManager pageSinkManager,
             ExpressionCompiler expressionCompiler,
@@ -332,6 +334,7 @@ public class LocalExecutionPlanner
         this.explainAnalyzeContext = requireNonNull(explainAnalyzeContext, "explainAnalyzeContext is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.indexManager = requireNonNull(indexManager, "indexManager is null");
+        this.partitioningProviderManager = requireNonNull(partitioningProviderManager, "partitioningProviderManager is null");
         this.nodePartitioningManager = requireNonNull(nodePartitioningManager, "nodePartitioningManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
@@ -2422,6 +2425,8 @@ public class LocalExecutionPlanner
             int operatorsCount = subContext.getDriverInstanceCount().orElse(1);
             List<Type> types = getSourceOperatorTypes(node, context.getTypes());
             LocalExchangeFactory exchangeFactory = new LocalExchangeFactory(
+                    partitioningProviderManager,
+                    session,
                     node.getPartitioningScheme().getPartitioning().getHandle(),
                     operatorsCount,
                     types,
@@ -2495,6 +2500,8 @@ public class LocalExecutionPlanner
             }
 
             LocalExchangeFactory localExchangeFactory = new LocalExchangeFactory(
+                    partitioningProviderManager,
+                    session,
                     node.getPartitioningScheme().getPartitioning().getHandle(),
                     driverInstanceCount,
                     types,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PartitioningProviderManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PartitioningProviderManager.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class PartitioningProviderManager
+{
+    private final ConcurrentMap<ConnectorId, ConnectorNodePartitioningProvider> partitioningProviders = new ConcurrentHashMap<>();
+
+    public ConnectorNodePartitioningProvider getPartitioningProvider(ConnectorId connectorId)
+    {
+        ConnectorNodePartitioningProvider partitioningProvider = partitioningProviders.get(connectorId);
+        checkArgument(partitioningProvider != null, "No partitioning provider for connector %s", connectorId);
+        return partitioningProvider;
+    }
+
+    public void addPartitioningProvider(ConnectorId connectorId, ConnectorNodePartitioningProvider nodePartitioningProvider)
+    {
+        requireNonNull(connectorId, "connectorId is null");
+        requireNonNull(nodePartitioningProvider, "nodePartitioningProvider is null");
+        checkArgument(partitioningProviders.putIfAbsent(connectorId, nodePartitioningProvider) == null,
+                "NodePartitioningProvider for connector '%s' is already registered", connectorId);
+    }
+
+    public void removePartitioningProvider(ConnectorId connectorId)
+    {
+        partitioningProviders.remove(connectorId);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -1063,8 +1063,7 @@ public class PlanFragmenter
         public GroupedExecutionProperties visitTableWriter(TableWriterNode node, Void context)
         {
             GroupedExecutionProperties properties = node.getSource().accept(this, null);
-            // TODO (#13098): Remove partitioning and task writer count check after we have TableWriterMergeOperator
-            boolean recoveryEligible = properties.isRecoveryEligible() && (node.getPartitioningScheme().isPresent() || getTaskWriterCount(session) == 1);
+            boolean recoveryEligible = properties.isRecoveryEligible();
             if (node.getTarget() instanceof CreateHandle) {
                 recoveryEligible &= metadata.getConnectorCapabilities(session, ((CreateHandle) node.getTarget()).getHandle().getConnectorId()).contains(SUPPORTS_PARTITION_COMMIT);
             }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -135,6 +135,7 @@ import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import com.facebook.presto.sql.planner.LogicalPlanner;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
+import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.PlanFragmenter;
 import com.facebook.presto.sql.planner.PlanOptimizers;
@@ -238,6 +239,7 @@ public class LocalQueryRunner
     private final BlockEncodingManager blockEncodingManager;
     private final PageSourceManager pageSourceManager;
     private final IndexManager indexManager;
+    private final PartitioningProviderManager partitioningProviderManager;
     private final NodePartitioningManager nodePartitioningManager;
     private final ConnectorPlanOptimizerManager planOptimizerManager;
     private final PageSinkManager pageSinkManager;
@@ -306,7 +308,8 @@ public class LocalQueryRunner
                 yieldExecutor,
                 catalogManager,
                 notificationExecutor);
-        this.nodePartitioningManager = new NodePartitioningManager(nodeScheduler);
+        this.partitioningProviderManager = new PartitioningProviderManager();
+        this.nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager);
         this.planOptimizerManager = new ConnectorPlanOptimizerManager();
 
         this.blockEncodingManager = new BlockEncodingManager(typeRegistry);
@@ -343,7 +346,7 @@ public class LocalQueryRunner
                 splitManager,
                 pageSourceManager,
                 indexManager,
-                nodePartitioningManager,
+                partitioningProviderManager,
                 planOptimizerManager,
                 pageSinkManager,
                 new HandleResolver(),

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -733,6 +733,7 @@ public class LocalQueryRunner
                 Optional.empty(),
                 pageSourceManager,
                 indexManager,
+                partitioningProviderManager,
                 nodePartitioningManager,
                 pageSinkManager,
                 expressionCompiler,

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -37,6 +37,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
+import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.PlanFragmenter;
 import com.facebook.presto.sql.planner.PlanVariableAllocator;
@@ -133,7 +134,8 @@ public class TestCostCalculator
                 new InMemoryNodeManager(),
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
                 new NodeTaskMap(finalizerService));
-        nodePartitioningManager = new NodePartitioningManager(nodeScheduler);
+        PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
+        nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager);
         planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new SqlParser());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -51,6 +51,7 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.Partitioning;
+import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
@@ -126,7 +127,8 @@ public final class TaskTestUtils
                 new InMemoryNodeManager(),
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
                 new NodeTaskMap(finalizerService));
-        NodePartitioningManager nodePartitioningManager = new NodePartitioningManager(nodeScheduler);
+        PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
+        NodePartitioningManager nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager);
 
         PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(metadata, 0);
         return new LocalExecutionPlanner(

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -137,6 +137,7 @@ public final class TaskTestUtils
                 Optional.empty(),
                 pageSourceManager,
                 new IndexManager(),
+                partitioningProviderManager,
                 nodePartitioningManager,
                 new PageSinkManager(),
                 new ExpressionCompiler(metadata, pageFunctionCompiler),

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.ExceededMemoryLimitException;
 import com.facebook.presto.RowPagesBuilder;
+import com.facebook.presto.Session;
 import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskStateMachine;
@@ -36,6 +37,7 @@ import com.facebook.presto.spiller.PartitioningSpillerFactory;
 import com.facebook.presto.spiller.SingleStreamSpiller;
 import com.facebook.presto.spiller.SingleStreamSpillerFactory;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunctionFactory;
+import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.TestingTaskContext;
 import com.google.common.collect.ImmutableList;
@@ -78,6 +80,7 @@ import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -112,6 +115,8 @@ public class TestHashJoinOperator
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;
+    private PartitioningProviderManager partitioningProviderManager;
+    private Session session;
 
     @BeforeMethod
     public void setUp()
@@ -131,6 +136,8 @@ public class TestHashJoinOperator
                 daemonThreadsNamed("test-executor-%s"),
                 new ThreadPoolExecutor.DiscardPolicy());
         scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        partitioningProviderManager = new PartitioningProviderManager();
+        session = testSessionBuilder().build();
     }
 
     @AfterMethod(alwaysRun = true)
@@ -138,6 +145,8 @@ public class TestHashJoinOperator
     {
         executor.shutdownNow();
         scheduledExecutor.shutdownNow();
+        partitioningProviderManager = null;
+        session = null;
     }
 
     @DataProvider(name = "hashJoinTestValues")
@@ -1294,6 +1303,8 @@ public class TestHashJoinOperator
 
         int partitionCount = parallelBuild ? PARTITION_COUNT : 1;
         LocalExchangeFactory localExchangeFactory = new LocalExchangeFactory(
+                partitioningProviderManager,
+                session,
                 FIXED_HASH_DISTRIBUTION,
                 partitionCount,
                 buildPages.getTypes(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -118,7 +118,8 @@ public class TestFeaturesConfig
                 .setPushLimitThroughOuterJoin(true)
                 .setMaxConcurrentMaterializations(3)
                 .setPushdownSubfieldsEnabled(false)
-                .setTableWriterMergeOperatorEnabled(true));
+                .setTableWriterMergeOperatorEnabled(true)
+                .setConcurrentWritesToPartitionedTableEnabled(true));
     }
 
     @Test
@@ -196,6 +197,7 @@ public class TestFeaturesConfig
                 .put("max-concurrent-materializations", "5")
                 .put("experimental.pushdown-subfields-enabled", "true")
                 .put("experimental.table-writer-merge-operator-enabled", "false")
+                .put("experimental.concurrent-writes-to-partitioned-table-enabled", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -269,7 +271,8 @@ public class TestFeaturesConfig
                 .setPushLimitThroughOuterJoin(false)
                 .setMaxConcurrentMaterializations(5)
                 .setPushdownSubfieldsEnabled(true)
-                .setTableWriterMergeOperatorEnabled(false);
+                .setTableWriterMergeOperatorEnabled(false)
+                .setConcurrentWritesToPartitionedTableEnabled(false);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
```
== RELEASE NOTES ==

Hive Changes
* Writing into Hive bucketed tables now done in parallel (multiple threads per node) with respect to the task.writer-count configuration property
```
