### PR TITLE
Add pushed down filter to the output of EXPLAIN

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1763,7 +1763,9 @@ public class HiveMetadata
                                 predicateColumns,
                                 hivePartitionResult.getEnforcedConstraint(),
                                 hivePartitionResult.getBucketHandle(),
-                                hivePartitionResult.getBucketFilter())),
+                                hivePartitionResult.getBucketFilter(),
+                                session,
+                                rowExpression -> rowExpressionService.formatRowExpression(session, rowExpression))),
                 TRUE_CONSTANT);
     }
 
@@ -1820,7 +1822,9 @@ public class HiveMetadata
                                 predicateColumns,
                                 hivePartitionResult.getEnforcedConstraint(),
                                 hiveBucketHandle,
-                                hivePartitionResult.getBucketFilter())),
+                                hivePartitionResult.getBucketFilter(),
+                                session,
+                                rowExpression -> rowExpressionService.formatRowExpression(session, rowExpression))),
                 hivePartitionResult.getUnenforcedConstraint()));
     }
 
@@ -1992,7 +1996,9 @@ public class HiveMetadata
                 hiveLayoutHandle.getPredicateColumns(),
                 hiveLayoutHandle.getPartitionColumnPredicate(),
                 Optional.of(new HiveBucketHandle(bucketHandle.getColumns(), bucketHandle.getTableBucketCount(), hivePartitioningHandle.getBucketCount())),
-                hiveLayoutHandle.getBucketFilter());
+                hiveLayoutHandle.getBucketFilter(),
+                session,
+                rowExpression -> rowExpressionService.formatRowExpression(session, rowExpression));
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -664,7 +664,9 @@ public abstract class AbstractTestHiveClient
                 ImmutableMap.of(),
                 TupleDomain.all(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                SESSION,
+                rowExpression -> ROW_EXPRESSION_SERVICE.formatRowExpression(SESSION, rowExpression));
 
         dsColumn = new HiveColumnHandle("ds", HIVE_STRING, parseTypeSignature(StandardTypes.VARCHAR), -1, PARTITION_KEY, Optional.empty());
         fileFormatColumn = new HiveColumnHandle("file_format", HIVE_STRING, parseTypeSignature(StandardTypes.VARCHAR), -1, PARTITION_KEY, Optional.empty());
@@ -708,7 +710,7 @@ public abstract class AbstractTestHiveClient
         TupleDomain<Subfield> domainPredicate = tupleDomain.transform(HiveColumnHandle.class::cast)
                 .transform(column -> new Subfield(column.getName(), ImmutableList.of()));
         tableLayout = new ConnectorTableLayout(
-                new HiveTableLayoutHandle(tablePartitionFormat, partitionColumns, partitions, domainPredicate, TRUE_CONSTANT, ImmutableMap.of(dsColumn.getName(), dsColumn), tupleDomain, Optional.empty(), Optional.empty()),
+                new HiveTableLayoutHandle(tablePartitionFormat, partitionColumns, partitions, domainPredicate, TRUE_CONSTANT, ImmutableMap.of(dsColumn.getName(), dsColumn), tupleDomain, Optional.empty(), Optional.empty(), SESSION, rowExpression -> ROW_EXPRESSION_SERVICE.formatRowExpression(SESSION, rowExpression)),
                 Optional.empty(),
                 TupleDomain.withColumnDomains(ImmutableMap.of(
                         dsColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("2012-12-29"))), false),
@@ -735,7 +737,7 @@ public abstract class AbstractTestHiveClient
                                 dummyColumn, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 4L)), false)))))),
                 ImmutableList.of());
         List<HivePartition> unpartitionedPartitions = ImmutableList.of(new HivePartition(tableUnpartitioned));
-        unpartitionedTableLayout = new ConnectorTableLayout(new HiveTableLayoutHandle(tableUnpartitioned, ImmutableList.of(), unpartitionedPartitions, TupleDomain.all(), TRUE_CONSTANT, ImmutableMap.of(), TupleDomain.all(), Optional.empty(), Optional.empty()));
+        unpartitionedTableLayout = new ConnectorTableLayout(new HiveTableLayoutHandle(tableUnpartitioned, ImmutableList.of(), unpartitionedPartitions, TupleDomain.all(), TRUE_CONSTANT, ImmutableMap.of(), TupleDomain.all(), Optional.empty(), Optional.empty(), SESSION, rowExpression -> ROW_EXPRESSION_SERVICE.formatRowExpression(SESSION, rowExpression)));
         timeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(timeZoneId));
     }
 
@@ -1673,7 +1675,9 @@ public abstract class AbstractTestHiveClient
                     layoutHandle.getPredicateColumns(),
                     layoutHandle.getPartitionColumnPredicate(),
                     Optional.of(new HiveBucketHandle(bucketHandle.getColumns(), bucketHandle.getTableBucketCount(), 2)),
-                    layoutHandle.getBucketFilter());
+                    layoutHandle.getBucketFilter(),
+                    session,
+                    rowExpression -> ROW_EXPRESSION_SERVICE.formatRowExpression(session, rowExpression));
 
             List<ConnectorSplit> splits = getAllSplits(session, transaction, modifiedReadBucketCountLayoutHandle);
             assertEquals(splits.size(), 16);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.PredicateCompiler;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.MapType;
@@ -45,6 +46,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.RowExpressionPredicateCompiler;
+import com.facebook.presto.sql.planner.planPrinter.RowExpressionFormatter;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
@@ -100,6 +102,12 @@ public final class HiveTestUtils
         public DeterminismEvaluator getDeterminismEvaluator()
         {
             return new RowExpressionDeterminismEvaluator(METADATA);
+        }
+
+        @Override
+        public String formatRowExpression(ConnectorSession session, RowExpression expression)
+        {
+            return new RowExpressionFormatter(METADATA.getFunctionManager()).formatRowExpression(session, expression);
         }
     };
 

--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -54,6 +54,7 @@ import com.facebook.presto.split.RecordPageSourceProvider;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
+import com.facebook.presto.sql.planner.planPrinter.RowExpressionFormatter;
 import com.facebook.presto.sql.relational.ConnectorRowExpressionService;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionOptimizer;
@@ -346,7 +347,12 @@ public class ConnectorManager
                 new FunctionResolution(metadataManager.getFunctionManager()),
                 pageSorter,
                 pageIndexerFactory,
-                new ConnectorRowExpressionService(domainTranslator, new RowExpressionOptimizer(metadataManager), predicateCompiler, determinismEvaluator));
+                new ConnectorRowExpressionService(
+                        domainTranslator,
+                        new RowExpressionOptimizer(metadataManager),
+                        predicateCompiler,
+                        determinismEvaluator,
+                        new RowExpressionFormatter(metadataManager.getFunctionManager())));
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(factory.getClass().getClassLoader())) {
             return factory.create(connectorId.getCatalogName(), properties, context);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -24,6 +24,7 @@ import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.OperatorNotFoundException;
 import com.facebook.presto.operator.StageExecutionDescriptor;
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.function.FunctionHandle;
@@ -109,6 +110,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -134,7 +136,7 @@ public class PlanPrinter
 {
     private final PlanRepresentation representation;
     private final FunctionManager functionManager;
-    private final RowExpressionFormatter formatter;
+    private final Function<RowExpression, String> formatter;
 
     private PlanPrinter(
             PlanNode planRoot,
@@ -162,7 +164,10 @@ public class PlanPrinter
                 .sum(), MILLISECONDS));
 
         this.representation = new PlanRepresentation(planRoot, types, totalCpuTime, totalScheduledTime);
-        this.formatter = new RowExpressionFormatter(session.toConnectorSession(), functionManager);
+
+        RowExpressionFormatter rowExpressionFormatter = new RowExpressionFormatter(functionManager);
+        ConnectorSession connectorSession = requireNonNull(session, "session is null").toConnectorSession();
+        this.formatter = rowExpression -> rowExpressionFormatter.formatRowExpression(connectorSession, rowExpression);
 
         Visitor visitor = new Visitor(stageExecutionStrategy, types, estimatedStatsAndCosts, session, stats);
         planRoot.accept(visitor, null);
@@ -363,7 +368,7 @@ public class PlanPrinter
             for (JoinNode.EquiJoinClause clause : node.getCriteria()) {
                 joinExpressions.add(JoinNodeUtils.toExpression(clause).toString());
             }
-            node.getFilter().map(formatter::formatRowExpression).ifPresent(joinExpressions::add);
+            node.getFilter().map(formatter::apply).ifPresent(joinExpressions::add);
 
             NodeRepresentation nodeOutput;
             if (node.isCrossJoin()) {
@@ -378,7 +383,7 @@ public class PlanPrinter
 
             node.getDistributionType().ifPresent(distributionType -> nodeOutput.appendDetails("Distribution: %s", distributionType));
             node.getSortExpressionContext(functionManager)
-                    .ifPresent(sortContext -> nodeOutput.appendDetails("SortExpression[%s]", formatter.formatRowExpression(sortContext.getSortExpression())));
+                    .ifPresent(sortContext -> nodeOutput.appendDetails("SortExpression[%s]", formatter.apply(sortContext.getSortExpression())));
             node.getLeft().accept(this, context);
             node.getRight().accept(this, context);
 
@@ -390,7 +395,7 @@ public class PlanPrinter
         {
             NodeRepresentation nodeOutput = addNode(node,
                     node.getType().getJoinLabel(),
-                    format("[%s]", formatter.formatRowExpression(node.getFilter())));
+                    format("[%s]", formatter.apply(node.getFilter())));
 
             nodeOutput.appendDetailsLine("Distribution: %s", node.getDistributionType());
             node.getLeft().accept(this, context);
@@ -506,10 +511,10 @@ public class PlanPrinter
                 builder.append("*");
             }
             else {
-                builder.append("(" + Joiner.on(",").join(aggregation.getArguments().stream().map(formatter::formatRowExpression).collect(toImmutableList())) + ")");
+                builder.append("(" + Joiner.on(",").join(aggregation.getArguments().stream().map(formatter::apply).collect(toImmutableList())) + ")");
             }
             builder.append(")");
-            aggregation.getFilter().ifPresent(filter -> builder.append(" WHERE " + formatter.formatRowExpression(filter)));
+            aggregation.getFilter().ifPresent(filter -> builder.append(" WHERE " + formatter.apply(filter)));
             aggregation.getOrderBy().ifPresent(orderingScheme -> builder.append(" ORDER BY " + orderingScheme.toString()));
             aggregation.getMask().ifPresent(mask -> builder.append(" (mask = " + mask + ")"));
             return builder.toString();
@@ -595,7 +600,7 @@ public class PlanPrinter
                         "%s := %s(%s) %s",
                         entry.getKey(),
                         call.getDisplayName(),
-                        Joiner.on(", ").join(call.getArguments().stream().map(formatter::formatRowExpression).collect(toImmutableList())),
+                        Joiner.on(", ").join(call.getArguments().stream().map(formatter::apply).collect(toImmutableList())),
                         frameInfo);
             }
             return processChildren(node, context);
@@ -668,7 +673,7 @@ public class PlanPrinter
         {
             NodeRepresentation nodeOutput = addNode(node, "Values");
             for (List<RowExpression> row : node.getRows()) {
-                nodeOutput.appendDetailsLine("(" + Joiner.on(", ").join(formatter.formatRowExpressions(row)) + ")");
+                nodeOutput.appendDetailsLine("(" + row.stream().map(formatter::apply).collect(Collectors.joining(", ")) + ")");
             }
             return null;
         }
@@ -731,7 +736,7 @@ public class PlanPrinter
             if (filterNode.isPresent()) {
                 operatorName += "Filter";
                 formatString += "filterPredicate = %s, ";
-                arguments.add(formatter.formatRowExpression(filterNode.get().getPredicate()));
+                arguments.add(formatter.apply(filterNode.get().getPredicate()));
             }
 
             if (formatString.length() > 1) {
@@ -1058,7 +1063,7 @@ public class PlanPrinter
                     // skip identity assignments
                     continue;
                 }
-                nodeOutput.appendDetailsLine("%s := %s", entry.getKey(), formatter.formatRowExpression(entry.getValue()));
+                nodeOutput.appendDetailsLine("%s := %s", entry.getKey(), formatter.apply(entry.getValue()));
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/RowExpressionFormatter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/RowExpressionFormatter.java
@@ -39,82 +39,80 @@ import static java.util.stream.Collectors.toList;
 
 public final class RowExpressionFormatter
 {
-    private final ConnectorSession session;
     private final FunctionMetadataManager functionMetadataManager;
     private final StandardFunctionResolution standardFunctionResolution;
 
-    public RowExpressionFormatter(ConnectorSession session, FunctionManager functionManager)
+    public RowExpressionFormatter(FunctionManager functionManager)
     {
-        this.session = requireNonNull(session, "session is null");
         this.functionMetadataManager = requireNonNull(functionManager, "function manager is null");
         this.standardFunctionResolution = new FunctionResolution(functionManager);
     }
 
-    public String formatRowExpression(RowExpression expression)
+    public String formatRowExpression(ConnectorSession session, RowExpression expression)
     {
-        return expression.accept(new Formatter(), null);
+        return expression.accept(new Formatter(), requireNonNull(session, "session is null"));
     }
 
-    public List<String> formatRowExpressions(List<RowExpression> rowExpressions)
+    private List<String> formatRowExpressions(ConnectorSession session, List<RowExpression> rowExpressions)
     {
-        return rowExpressions.stream().map(this::formatRowExpression).collect(toList());
+        return rowExpressions.stream().map(rowExpression -> formatRowExpression(session, rowExpression)).collect(toList());
     }
 
     public class Formatter
-            implements RowExpressionVisitor<String, Void>
+            implements RowExpressionVisitor<String, ConnectorSession>
     {
         @Override
-        public String visitCall(CallExpression node, Void context)
+        public String visitCall(CallExpression node, ConnectorSession session)
         {
             if (standardFunctionResolution.isArithmeticFunction(node.getFunctionHandle()) || standardFunctionResolution.isComparisonFunction(node.getFunctionHandle())) {
                 String operation = functionMetadataManager.getFunctionMetadata(node.getFunctionHandle()).getOperatorType().get().getOperator();
-                return String.join(" " + operation + " ", formatRowExpressions(node.getArguments()).stream().map(e -> "(" + e + ")").collect(toImmutableList()));
+                return String.join(" " + operation + " ", formatRowExpressions(session, node.getArguments()).stream().map(e -> "(" + e + ")").collect(toImmutableList()));
             }
             else if (standardFunctionResolution.isCastFunction(node.getFunctionHandle())) {
-                return String.format("CAST(%s AS %s)", formatRowExpression(node.getArguments().get(0)), node.getType().getDisplayName());
+                return String.format("CAST(%s AS %s)", formatRowExpression(session, node.getArguments().get(0)), node.getType().getDisplayName());
             }
             else if (standardFunctionResolution.isNegateFunction(node.getFunctionHandle())) {
-                return "-(" + formatRowExpression(node.getArguments().get(0)) + ")";
+                return "-(" + formatRowExpression(session, node.getArguments().get(0)) + ")";
             }
             else if (standardFunctionResolution.isSubscriptFunction(node.getFunctionHandle())) {
-                return formatRowExpression(node.getArguments().get(0)) + "[" + formatRowExpression(node.getArguments().get(1)) + "]";
+                return formatRowExpression(session, node.getArguments().get(0)) + "[" + formatRowExpression(session, node.getArguments().get(1)) + "]";
             }
             else if (standardFunctionResolution.isBetweenFunction(node.getFunctionHandle())) {
-                List<String> formattedExpresions = formatRowExpressions(node.getArguments());
+                List<String> formattedExpresions = formatRowExpressions(session, node.getArguments());
                 return String.format("%s BETWEEN (%s) AND (%s)", formattedExpresions.get(0), formattedExpresions.get(1), formattedExpresions.get(2));
             }
-            return node.getDisplayName() + "(" + String.join(", ", formatRowExpressions(node.getArguments())) + ")";
+            return node.getDisplayName() + "(" + String.join(", ", formatRowExpressions(session, node.getArguments())) + ")";
         }
 
         @Override
-        public String visitSpecialForm(SpecialFormExpression node, Void context)
+        public String visitSpecialForm(SpecialFormExpression node, ConnectorSession session)
         {
             if (node.getForm().equals(SpecialFormExpression.Form.AND) || node.getForm().equals(SpecialFormExpression.Form.OR)) {
-                return String.join(" " + node.getForm() + " ", formatRowExpressions(node.getArguments()).stream().map(e -> "(" + e + ")").collect(toImmutableList()));
+                return String.join(" " + node.getForm() + " ", formatRowExpressions(session, node.getArguments()).stream().map(e -> "(" + e + ")").collect(toImmutableList()));
             }
-            return node.getForm().name() + "(" + String.join(", ", formatRowExpressions(node.getArguments())) + ")";
+            return node.getForm().name() + "(" + String.join(", ", formatRowExpressions(session, node.getArguments())) + ")";
         }
 
         @Override
-        public String visitInputReference(InputReferenceExpression node, Void context)
+        public String visitInputReference(InputReferenceExpression node, ConnectorSession session)
         {
             return node.toString();
         }
 
         @Override
-        public String visitLambda(LambdaDefinitionExpression node, Void context)
+        public String visitLambda(LambdaDefinitionExpression node, ConnectorSession session)
         {
-            return "(" + String.join(", ", node.getArguments()) + ") -> " + formatRowExpression(node.getBody());
+            return "(" + String.join(", ", node.getArguments()) + ") -> " + formatRowExpression(session, node.getBody());
         }
 
         @Override
-        public String visitVariableReference(VariableReferenceExpression node, Void context)
+        public String visitVariableReference(VariableReferenceExpression node, ConnectorSession session)
         {
             return node.getName();
         }
 
         @Override
-        public String visitConstant(ConstantExpression node, Void context)
+        public String visitConstant(ConstantExpression node, ConnectorSession session)
         {
             Object value = LiteralInterpreter.evaluate(session, node);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/ConnectorRowExpressionService.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/ConnectorRowExpressionService.java
@@ -13,11 +13,14 @@
  */
 package com.facebook.presto.sql.relational;
 
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.PredicateCompiler;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionService;
+import com.facebook.presto.sql.planner.planPrinter.RowExpressionFormatter;
 
 import static java.util.Objects.requireNonNull;
 
@@ -28,13 +31,15 @@ public final class ConnectorRowExpressionService
     private final ExpressionOptimizer expressionOptimizer;
     private final PredicateCompiler predicateCompiler;
     private final DeterminismEvaluator determinismEvaluator;
+    private final RowExpressionFormatter rowExpressionFormatter;
 
-    public ConnectorRowExpressionService(DomainTranslator domainTranslator, ExpressionOptimizer expressionOptimizer, PredicateCompiler predicateCompiler, DeterminismEvaluator determinismEvaluator)
+    public ConnectorRowExpressionService(DomainTranslator domainTranslator, ExpressionOptimizer expressionOptimizer, PredicateCompiler predicateCompiler, DeterminismEvaluator determinismEvaluator, RowExpressionFormatter rowExpressionFormatter)
     {
         this.domainTranslator = requireNonNull(domainTranslator, "domainTranslator is null");
         this.expressionOptimizer = requireNonNull(expressionOptimizer, "expressionOptimizer is null");
         this.predicateCompiler = requireNonNull(predicateCompiler, "predicateCompiler is null");
         this.determinismEvaluator = requireNonNull(determinismEvaluator, "determinismEvaluator is null");
+        this.rowExpressionFormatter = requireNonNull(rowExpressionFormatter, "rowExpressionFormatter is null");
     }
 
     @Override
@@ -59,5 +64,11 @@ public final class ConnectorRowExpressionService
     public DeterminismEvaluator getDeterminismEvaluator()
     {
         return determinismEvaluator;
+    }
+
+    @Override
+    public String formatRowExpression(ConnectorSession session, RowExpression expression)
+    {
+        return rowExpressionFormatter.formatRowExpression(session, expression);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
@@ -23,6 +23,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
@@ -33,11 +34,13 @@ import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.PredicateCompiler;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.gen.RowExpressionPredicateCompiler;
+import com.facebook.presto.sql.planner.planPrinter.RowExpressionFormatter;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
@@ -121,6 +124,12 @@ public class TestingConnectorContext
             public DeterminismEvaluator getDeterminismEvaluator()
             {
                 return determinismEvaluator;
+            }
+
+            @Override
+            public String formatRowExpression(ConnectorSession session, RowExpression expression)
+            {
+                return new RowExpressionFormatter(functionManager).formatRowExpression(session, expression);
             }
         };
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionFormatter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionFormatter.java
@@ -84,7 +84,7 @@ public class TestRowExpressionFormatter
 {
     private static final TypeManager typeManager = new TypeRegistry();
     private static final FunctionManager functionManager = new FunctionManager(typeManager, new BlockEncodingManager(typeManager), new FeaturesConfig());
-    private static final RowExpressionFormatter FORMATTER = new RowExpressionFormatter(TEST_SESSION.toConnectorSession(), functionManager);
+    private static final RowExpressionFormatter FORMATTER = new RowExpressionFormatter(functionManager);
     private static final VariableReferenceExpression C_BIGINT = new VariableReferenceExpression("c_bigint", BIGINT);
     private static final VariableReferenceExpression C_BIGINT_ARRAY = new VariableReferenceExpression("c_bigint_array", new ArrayType(BIGINT));
 
@@ -320,6 +320,6 @@ public class TestRowExpressionFormatter
 
     private static String format(RowExpression expression)
     {
-        return FORMATTER.formatRowExpression(expression);
+        return FORMATTER.formatRowExpression(TEST_SESSION.toConnectorSession(), expression);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/RowExpressionService.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/RowExpressionService.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.spi.relation;
 
+import com.facebook.presto.spi.ConnectorSession;
+
 /**
  * A set of services/utilities that are helpful for connectors to operate on row expressions
  */
@@ -25,4 +27,9 @@ public interface RowExpressionService
     PredicateCompiler getPredicateCompiler();
 
     DeterminismEvaluator getDeterminismEvaluator();
+
+    /**
+     * @return user-friendly representation of the expression similar to original SQL
+     */
+    String formatRowExpression(ConnectorSession session, RowExpression expression);
 }


### PR DESCRIPTION
Add filters pushed down into the Hive connector (by setting `hive.pushdown-filter-enabled=true`) to the output of EXPLAIN command under `LAYOUT` section of `TableScan`.

```
EXPLAIN SELECT orderkey FROM lineitem WHERE linenumber % 2 = 0
            
- Output[orderkey] => [orderkey:bigint]
        Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 541575.00}
    - RemoteStreamingExchange[GATHER] => [orderkey:bigint]
            Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 541575.00}
        - TableScan[TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=lineitem, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.lineitem{filter=((linenumber) % (INTEGER 2)) = (INTEGER 0)}]'}] => [orderkey:bigint]
                Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 0.00}
                LAYOUT: tpch.lineitem{filter=((linenumber) % (INTEGER 2)) = (INTEGER 0)}
                orderkey := orderkey:bigint:0:REGULAR
)

EXPLAIN SELECT orderkey FROM lineitem WHERE orderkey < 1000 AND linenumber % 2 = 0
            
- Output[orderkey] => [orderkey:bigint]
        Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 541575.00}
    - RemoteStreamingExchange[GATHER] => [orderkey:bigint]
            Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 541575.00}
        - TableScan[TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=lineitem, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.lineitem{filter=((linenumber) % (INTEGER 2)) = (INTEGER 0), domains={orderkey=[ [(<min>, 1000)] ]}}]'}] => [orderkey:bigint]
                Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 0.00}
                LAYOUT: tpch.lineitem{filter=((linenumber) % (INTEGER 2)) = (INTEGER 0), domains={orderkey=[ [(<min>, 1000)] ]}}
                orderkey := orderkey:bigint:0:REGULAR
)

EXPLAIN SELECT orderkey FROM lineitem WHERE linenumber > 3
            
- Output[orderkey] => [orderkey:bigint]
        Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 541575.00}
    - RemoteStreamingExchange[GATHER] => [orderkey:bigint]
            Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 541575.00}
        - TableScan[TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=lineitem, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.lineitem{domains={linenumber=[ [(3, <max>)] ]}}]'}] => [orderkey:bigint]
                Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 0.00}
                LAYOUT: tpch.lineitem{domains={linenumber=[ [(3, <max>)] ]}}
                orderkey := orderkey:bigint:0:REGULAR
)

EXPLAIN SELECT orderkey FROM lineitem WHERE linenumber IN (1, 2, 3)
            
- Output[orderkey] => [orderkey:bigint]
        Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 541575.00}
    - RemoteStreamingExchange[GATHER] => [orderkey:bigint]
            Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 541575.00}
        - TableScan[TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=lineitem, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.lineitem{domains={linenumber=[ [[1], [2], [3]] ]}}]'}] => [orderkey:bigint]
                Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 0.00}
                LAYOUT: tpch.lineitem{domains={linenumber=[ [[1], [2], [3]] ]}}
                orderkey := orderkey:bigint:0:REGULAR
)

EXPLAIN SELECT orderkey FROM lineitem

- Output[orderkey] => [orderkey:bigint]
        Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 541575.00}
    - RemoteStreamingExchange[GATHER] => [orderkey:bigint]
            Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 541575.00}
        - TableScan[TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=lineitem, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.lineitem{}]'}] => [orderkey:bigint]
                Estimates: {rows: 60175 (528.88kB), cpu: 541575.00, memory: 0.00, network: 0.00}
                LAYOUT: tpch.lineitem{}
                orderkey := orderkey:bigint:0:REGULAR
)
```

```
== NO RELEASE NOTE ==
```
