### PR TITLE
Add DecimalSelectiveReader

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -49,6 +49,9 @@ public class TestHivePushdownFilterQueries
             "   CASE WHEN orderkey % 43  = 0 THEN null ELSE discount END as discount, \n" +
             "   CASE WHEN orderkey % 7 = 0 THEN null ELSE CAST(tax AS REAL) END AS tax_real, \n" +
             "   CASE WHEN linenumber % 2 = 0 THEN null ELSE (CAST(day(shipdate) AS TINYINT) , CAST(month(shipdate) AS TINYINT)) END AS ship_day_month, " +
+            "   CASE WHEN orderkey % 37 = 0 THEN null ELSE CAST(discount AS DECIMAL(20, 8)) END AS discount_long_decimal, " +
+            "   CASE WHEN orderkey % 41 = 0 THEN null ELSE CAST(tax AS DECIMAL(3, 2)) END AS tax_short_decimal, " +
+            "   CASE WHEN orderkey % 43 = 0 THEN null ELSE (CAST(discount AS DECIMAL(20, 8)), CAST(tax AS DECIMAL(20, 8))) END AS long_decimals, " +
             "   CASE WHEN orderkey % 11 = 0 THEN null ELSE (orderkey, partkey, suppkey) END AS keys, \n" +
             "   CASE WHEN orderkey % 41 = 0 THEN null ELSE (extendedprice, discount, tax) END AS doubles, \n" +
             "   CASE WHEN orderkey % 13 = 0 THEN null ELSE ((orderkey, partkey), (suppkey,), CASE WHEN orderkey % 17 = 0 THEN null ELSE (orderkey, partkey) END) END AS nested_keys, \n" +
@@ -78,7 +81,7 @@ public class TestHivePushdownFilterQueries
                 Optional.empty());
 
         queryRunner.execute(noPushdownFilter(queryRunner.getDefaultSession()),
-                "CREATE TABLE lineitem_ex (linenumber, orderkey, partkey, suppkey, quantity, extendedprice, tax, ship_by_air, is_returned, ship_day, ship_month, ship_timestamp, commit_timestamp, discount_real, discount, tax_real, ship_day_month, keys, doubles, nested_keys, flags, reals, info, dates, timestamps) AS " +
+                "CREATE TABLE lineitem_ex (linenumber, orderkey, partkey, suppkey, quantity, extendedprice, tax, ship_by_air, is_returned, ship_day, ship_month, ship_timestamp, commit_timestamp, discount_real, discount, tax_real, ship_day_month, discount_long_decimal, tax_short_decimal, long_decimals, keys, doubles, nested_keys, flags, reals, info, dates, timestamps) AS " +
                         "SELECT linenumber, orderkey, partkey, suppkey, quantity, extendedprice, tax, " +
                         "   IF (linenumber % 5 = 0, null, shipmode = 'AIR') AS ship_by_air, " +
                         "   IF (linenumber % 7 = 0, null, returnflag = 'R') AS is_returned, " +
@@ -90,6 +93,9 @@ public class TestHivePushdownFilterQueries
                         "   IF (orderkey % 43 = 0, null, discount) AS discount, " +
                         "   IF (orderkey % 7 = 0, null, CAST(tax AS REAL)) AS tax_real, " +
                         "   IF (linenumber % 2 = 0, null, ARRAY[CAST(day(shipdate) AS TINYINT), CAST(month(shipdate) AS TINYINT)]) AS ship_day_month, " +
+                        "   IF (orderkey % 37 = 0, null, CAST(discount AS DECIMAL(20, 8))) AS discount_long_decimal, " +
+                        "   IF (orderkey % 41 = 0, null, CAST(tax AS DECIMAL(3, 2))) AS tax_short_decimal, " +
+                        "   IF (orderkey % 43 = 0, null, ARRAY[CAST(discount AS DECIMAL(20, 8)), CAST(tax AS DECIMAL(20, 8))]) AS long_decimals, " +
                         "   IF (orderkey % 11 = 0, null, ARRAY[orderkey, partkey, suppkey]) AS keys, " +
                         "   IF (orderkey % 41 = 0, null, ARRAY[extendedprice, discount, tax]) AS doubles, " +
                         "   IF (orderkey % 13 = 0, null, ARRAY[ARRAY[orderkey, partkey], ARRAY[suppkey], IF (orderkey % 17 = 0, null, ARRAY[orderkey, partkey])]) AS nested_keys, " +
@@ -280,6 +286,28 @@ public class TestHivePushdownFilterQueries
         finally {
             getQueryRunner().execute("DROP TABLE test_maps");
         }
+    }
+
+    @Test
+    public void testDecimals()
+    {
+        assertQueryUsingH2Cte("SELECT discount_long_decimal, tax_short_decimal FROM lineitem_ex");
+
+        assertFilterProject("discount_long_decimal IS NOT NULL", "count(*)");
+
+        assertFilterProject("discount_long_decimal IS NULL", "discount_long_decimal");
+
+        assertFilterProject("discount_long_decimal > 0.05", "discount_long_decimal");
+
+        assertFilterProject("tax_short_decimal < 0.03", "tax_short_decimal");
+
+        assertFilterProject("tax_short_decimal < 0.05  AND discount_long_decimal > 0.05", "discount_long_decimal");
+
+        assertFilterProject("tax_short_decimal < discount_long_decimal", "discount_long_decimal");
+
+        assertFilterProject("discount_long_decimal > 0.01 AND tax_short_decimal > 0.01 AND (discount_long_decimal + tax_short_decimal) < 0.03", "discount_long_decimal");
+
+        assertFilterProject("long_decimals[1] > 0.01", "count(*)");
     }
 
     @Test

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractDecimalSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractDecimalSelectiveStreamReader.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.orc.TupleDomainFilter;
+import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.stream.BooleanInputStream;
+import com.facebook.presto.orc.stream.DecimalInputStream;
+import com.facebook.presto.orc.stream.InputStreamSource;
+import com.facebook.presto.orc.stream.InputStreamSources;
+import com.facebook.presto.orc.stream.LongInputStream;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockLease;
+import com.facebook.presto.spi.block.ClosingBlockLease;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.Type;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.array.Arrays.ensureCapacity;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.SECONDARY;
+import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.util.Objects.requireNonNull;
+
+public abstract class AbstractDecimalSelectiveStreamReader
+        implements SelectiveStreamReader
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(AbstractDecimalSelectiveStreamReader.class).instanceSize();
+
+    protected final TupleDomainFilter filter;
+    protected final boolean nullsAllowed;
+    protected final boolean outputRequired;
+    protected final boolean nonDeterministicFilter;
+    protected final int scale;
+
+    protected long[] values;
+    protected boolean[] nulls;
+    protected int[] outputPositions;
+    protected int outputPositionCount;
+    protected BooleanInputStream presentStream;
+    protected DecimalInputStream dataStream;
+    protected LongInputStream scaleStream;
+
+    private final int valuesPerPosition;
+    private final Block nullBlock;
+    private final StreamDescriptor streamDescriptor;
+    private final LocalMemoryContext systemMemoryContext;
+
+    private int readOffset;
+    private boolean rowGroupOpen;
+    private boolean allNulls;
+    private boolean valuesInUse;
+    private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
+    private InputStreamSource<DecimalInputStream> dataStreamSource = missingStreamSource(DecimalInputStream.class);
+    private InputStreamSource<LongInputStream> scaleStreamSource = missingStreamSource(LongInputStream.class);
+
+    public AbstractDecimalSelectiveStreamReader(
+            StreamDescriptor streamDescriptor,
+            Optional<TupleDomainFilter> filter,
+            Optional<Type> outputType,
+            LocalMemoryContext systemMemoryContext,
+            int valuesPerPosition)
+    {
+        this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
+        this.filter = filter.orElse(null);
+        this.outputRequired = outputType.isPresent();
+        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
+        this.nonDeterministicFilter = this.filter != null && !this.filter.isDeterministic();
+        this.nullsAllowed = this.filter == null || this.nonDeterministicFilter || this.filter.testNull();
+        this.scale = streamDescriptor.getOrcType().getScale().get();
+        this.nullBlock = outputType.map(type -> type.createBlockBuilder(null, 1).appendNull().build()).orElse(null);
+        this.valuesPerPosition = valuesPerPosition;
+    }
+
+    @Override
+    public void startStripe(InputStreamSources dictionaryStreamSources, List<ColumnEncoding> encoding)
+    {
+        presentStreamSource = missingStreamSource(BooleanInputStream.class);
+        dataStreamSource = missingStreamSource(DecimalInputStream.class);
+        scaleStreamSource = missingStreamSource(LongInputStream.class);
+        readOffset = 0;
+        presentStream = null;
+        dataStream = null;
+        rowGroupOpen = false;
+    }
+
+    @Override
+    public void startRowGroup(InputStreamSources dataStreamSources)
+    {
+        presentStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, PRESENT, BooleanInputStream.class);
+        dataStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, DATA, DecimalInputStream.class);
+        scaleStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, SECONDARY, LongInputStream.class);
+        readOffset = 0;
+        presentStream = null;
+        dataStream = null;
+        scaleStream = null;
+        rowGroupOpen = false;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + sizeOf(values) + sizeOf(nulls) + sizeOf(outputPositions);
+    }
+
+    private void openRowGroup()
+            throws IOException
+    {
+        presentStream = presentStreamSource.openStream();
+        dataStream = dataStreamSource.openStream();
+        scaleStream = scaleStreamSource.openStream();
+        rowGroupOpen = true;
+    }
+
+    @Override
+    public int read(int offset, int[] positions, int positionCount)
+            throws IOException
+    {
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
+        if (!rowGroupOpen) {
+            openRowGroup();
+        }
+
+        allNulls = false;
+
+        if (outputRequired) {
+            ensureValuesCapacity(positionCount, nullsAllowed && presentStream != null);
+        }
+
+        if (filter != null) {
+            outputPositions = ensureCapacity(outputPositions, positionCount);
+        }
+        else {
+            outputPositions = positions;
+        }
+
+        // account memory used by values, nulls and outputPositions
+        systemMemoryContext.setBytes(getRetainedSizeInBytes());
+
+        if (readOffset < offset) {
+            skip(offset - readOffset);
+        }
+
+        int streamPosition = 0;
+        outputPositionCount = 0;
+        if (dataStream == null && scaleStream == null && presentStream != null) {
+            streamPosition = readAllNulls(positions, positionCount);
+        }
+        else if (filter == null) {
+            streamPosition = readNoFilter(positions, positionCount);
+        }
+        else {
+            streamPosition = readWithFilter(positions, positionCount);
+        }
+
+        readOffset = offset + streamPosition;
+        return outputPositionCount;
+    }
+
+    private int readAllNulls(int[] positions, int positionCount)
+            throws IOException
+    {
+        presentStream.skip(positions[positionCount - 1]);
+
+        if (nonDeterministicFilter) {
+            outputPositionCount = 0;
+            for (int i = 0; i < positionCount; i++) {
+                if (filter.testNull()) {
+                    outputPositionCount++;
+                }
+                else {
+                    outputPositionCount -= filter.getPrecedingPositionsToFail();
+                    i += filter.getSucceedingPositionsToFail();
+                }
+            }
+        }
+        else if (nullsAllowed) {
+            outputPositionCount = positionCount;
+        }
+        else {
+            outputPositionCount = 0;
+        }
+
+        allNulls = true;
+        return positions[positionCount - 1] + 1;
+    }
+
+    protected void skip(int items)
+            throws IOException
+    {
+        if (dataStream == null) {
+            presentStream.skip(items);
+        }
+        else if (presentStream != null) {
+            int dataToSkip = presentStream.countBitsSet(items);
+            dataStream.skip(dataToSkip);
+            scaleStream.skip(dataToSkip);
+        }
+        else {
+            dataStream.skip(items);
+            scaleStream.skip(items);
+        }
+    }
+
+    @Override
+    public int[] getReadPositions()
+    {
+        return outputPositions;
+    }
+
+    @Override
+    public void throwAnyError(int[] positions, int positionCount)
+    {
+    }
+
+    private BlockLease newLease(Block block)
+    {
+        valuesInUse = true;
+        return ClosingBlockLease.newLease(block, () -> valuesInUse = false);
+    }
+
+    @Override
+    public Block getBlock(int[] positions, int positionCount)
+    {
+        checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
+        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(positionCount <= outputPositionCount, "Not enough values");
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
+        if (allNulls) {
+            return new RunLengthEncodedBlock(nullBlock, outputPositionCount);
+        }
+
+        boolean includeNulls = nullsAllowed && presentStream != null;
+
+        if (positionCount == outputPositionCount) {
+            Block block = makeBlock(positionCount, nullsAllowed, nulls, values);
+            nulls = null;
+            values = null;
+            return block;
+        }
+
+        long[] valuesCopy = new long[valuesPerPosition * positionCount];
+        boolean[] nullsCopy = null;
+
+        if (includeNulls) {
+            nullsCopy = new boolean[positionCount];
+        }
+
+        copyValues(positions, positionCount, valuesCopy, nullsCopy);
+
+        return makeBlock(positionCount, includeNulls, nullsCopy, valuesCopy);
+    }
+
+    @Override
+    public BlockLease getBlockView(int[] positions, int positionCount)
+    {
+        checkArgument(outputPositionCount > 0, "outputPositionCount must be greater than zero");
+        checkState(outputRequired, "This stream reader doesn't produce output");
+        checkState(positionCount <= outputPositionCount, "Not enough values");
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
+        if (allNulls) {
+            return newLease(new RunLengthEncodedBlock(nullBlock, outputPositionCount));
+        }
+
+        boolean includeNulls = nullsAllowed && presentStream != null;
+        if (positionCount != outputPositionCount) {
+            compactValues(positions, positionCount, includeNulls);
+        }
+
+        return newLease(makeBlock(positionCount, includeNulls, nulls, values));
+    }
+
+    private void ensureValuesCapacity(int capacity, boolean nullAllowed)
+    {
+        int valuesCapacity = valuesPerPosition * capacity;
+        if (values == null || values.length < valuesCapacity) {
+            values = new long[valuesCapacity];
+        }
+
+        if (nullAllowed) {
+            if (nulls == null || nulls.length < capacity) {
+                nulls = new boolean[capacity];
+            }
+        }
+    }
+
+    abstract void copyValues(int[] positions, int positionsCount, long[] valuesCopy, boolean[] nullsCopy);
+
+    abstract Block makeBlock(int positionCount, boolean includeNulls, boolean[] nulls, long[] values);
+
+    abstract void compactValues(int[] positions, int positionCount, boolean compactNulls);
+
+    abstract int readNoFilter(int[] positions, int position)
+            throws IOException;
+
+    abstract int readWithFilter(int[] positions, int position)
+            throws IOException;
+
+    @Override
+    public void close()
+    {
+        systemMemoryContext.close();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(streamDescriptor)
+                .toString();
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDecimalSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDecimalSelectiveStreamReader.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.orc.TupleDomainFilter;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.Int128ArrayBlock;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic;
+import io.airlift.slice.Slice;
+import io.airlift.slice.UnsafeSlice;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.rescale;
+
+public class LongDecimalSelectiveStreamReader
+        extends AbstractDecimalSelectiveStreamReader
+{
+    public LongDecimalSelectiveStreamReader(
+            StreamDescriptor streamDescriptor,
+            Optional<TupleDomainFilter> filter,
+            Optional<Type> outputType,
+            LocalMemoryContext systemMemoryContext)
+    {
+        super(streamDescriptor, filter, outputType, systemMemoryContext, 2);
+    }
+
+    @Override
+    protected int readNoFilter(int[] positions, int positionCount)
+            throws IOException
+    {
+        Slice decimal = UnscaledDecimal128Arithmetic.unscaledDecimal();
+        Slice rescaledDecimal = UnscaledDecimal128Arithmetic.unscaledDecimal();
+
+        int streamPosition = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            if (position > streamPosition) {
+                skip(position - streamPosition);
+                streamPosition = position;
+            }
+
+            if (presentStream != null && !presentStream.nextBit()) {
+                nulls[i] = true;
+            }
+            else {
+                int scale = (int) scaleStream.next();
+                dataStream.nextLongDecimal(decimal);
+                rescale(decimal, this.scale - scale, rescaledDecimal);
+                values[2 * i] = UnsafeSlice.getLongUnchecked(rescaledDecimal, 0);
+                values[2 * i + 1] = UnsafeSlice.getLongUnchecked(rescaledDecimal, Long.BYTES);
+                if (presentStream != null) {
+                    nulls[i] = false;
+                }
+            }
+            streamPosition++;
+        }
+        outputPositionCount = positionCount;
+        return streamPosition;
+    }
+
+    @Override
+    protected int readWithFilter(int[] positions, int positionCount)
+            throws IOException
+    {
+        int streamPosition = 0;
+        outputPositionCount = 0;
+        Slice decimal = UnscaledDecimal128Arithmetic.unscaledDecimal();
+        Slice rescaledDecimal = UnscaledDecimal128Arithmetic.unscaledDecimal();
+
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            if (position > streamPosition) {
+                skip(position - streamPosition);
+                streamPosition = position;
+            }
+
+            if (presentStream != null && !presentStream.nextBit()) {
+                if ((nonDeterministicFilter && filter.testNull()) || nullsAllowed) {
+                    if (outputRequired) {
+                        nulls[outputPositionCount] = true;
+                    }
+                    outputPositions[outputPositionCount] = position;
+                    outputPositionCount++;
+                }
+            }
+            else {
+                int scale = (int) scaleStream.next();
+                dataStream.nextLongDecimal(decimal);
+                rescale(decimal, this.scale - scale, rescaledDecimal);
+                long low = UnsafeSlice.getLongUnchecked(rescaledDecimal, 0);
+                long high = UnsafeSlice.getLongUnchecked(rescaledDecimal, Long.BYTES);
+                if (filter.testDecimal(low, high)) {
+                    if (outputRequired) {
+                        values[2 * outputPositionCount] = low;
+                        values[2 * outputPositionCount + 1] = high;
+                        if (nullsAllowed && presentStream != null) {
+                            nulls[outputPositionCount] = false;
+                        }
+                    }
+                    outputPositions[outputPositionCount] = position;
+                    outputPositionCount++;
+                }
+            }
+            streamPosition++;
+
+            if (filter != null) {
+                outputPositionCount -= filter.getPrecedingPositionsToFail();
+                int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
+                if (succeedingPositionsToFail > 0) {
+                    int positionsToSkip = 0;
+                    for (int j = 0; j < succeedingPositionsToFail; j++) {
+                        i++;
+                        int nextPosition = positions[i];
+                        positionsToSkip += 1 + nextPosition - streamPosition;
+                        streamPosition = nextPosition + 1;
+                    }
+                    skip(positionsToSkip);
+                }
+            }
+        }
+        return streamPosition;
+    }
+
+    @Override
+    protected void copyValues(int[] positions, int positionsCount, long[] valuesCopy, boolean[] nullsCopy)
+    {
+        int positionIndex = 0;
+        int nextPosition = positions[positionIndex];
+        for (int i = 0; i < outputPositionCount; i++) {
+            if (outputPositions[i] < nextPosition) {
+                continue;
+            }
+
+            assert outputPositions[i] == nextPosition;
+
+            valuesCopy[2 * positionIndex] = this.values[2 * i];
+            valuesCopy[2 * positionIndex + 1] = this.values[2 * i + 1];
+
+            if (nullsCopy != null) {
+                nullsCopy[positionIndex] = this.nulls[i];
+            }
+            positionIndex++;
+
+            if (positionIndex >= positionsCount) {
+                break;
+            }
+
+            nextPosition = positions[positionIndex];
+        }
+    }
+
+    @Override
+    protected void compactValues(int[] positions, int positionCount, boolean compactNulls)
+    {
+        int positionIndex = 0;
+        int nextPosition = positions[positionIndex];
+        for (int i = 0; i < outputPositionCount; i++) {
+            if (outputPositions[i] < nextPosition) {
+                continue;
+            }
+
+            assert outputPositions[i] == nextPosition;
+
+            values[2 * positionIndex] = values[2 * i];
+            values[2 * positionIndex + 1] = values[2 * i + 1];
+            if (compactNulls) {
+                nulls[positionIndex] = nulls[i];
+            }
+            outputPositions[positionIndex] = nextPosition;
+
+            positionIndex++;
+            if (positionIndex >= positionCount) {
+                break;
+            }
+            nextPosition = positions[positionIndex];
+        }
+
+        outputPositionCount = positionCount;
+    }
+
+    @Override
+    protected Block makeBlock(int positionCount, boolean includeNulls, boolean[] nulls, long[] values)
+    {
+        return new Int128ArrayBlock(positionCount, Optional.ofNullable(includeNulls ? nulls : null), values);
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ShortDecimalSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ShortDecimalSelectiveStreamReader.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.orc.TupleDomainFilter;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.LongArrayBlock;
+import com.facebook.presto.spi.type.Decimals;
+import com.facebook.presto.spi.type.Type;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class ShortDecimalSelectiveStreamReader
+        extends AbstractDecimalSelectiveStreamReader
+{
+    public ShortDecimalSelectiveStreamReader(
+            StreamDescriptor streamDescriptor,
+            Optional<TupleDomainFilter> filter,
+            Optional<Type> outputType,
+            LocalMemoryContext systemMemoryContext)
+    {
+        super(streamDescriptor, filter, outputType, systemMemoryContext, 1);
+    }
+
+    @Override
+    protected int readNoFilter(int[] positions, int positionCount)
+            throws IOException
+    {
+        int streamPosition = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            if (position > streamPosition) {
+                skip(position - streamPosition);
+                streamPosition = position;
+            }
+            if (presentStream != null && !presentStream.nextBit()) {
+                nulls[i] = true;
+            }
+            else {
+                values[i] = Decimals.rescale(dataStream.nextLong(), (int) scaleStream.next(), this.scale);
+                if (presentStream != null) {
+                    nulls[i] = false;
+                }
+            }
+            streamPosition++;
+        }
+        outputPositionCount = positionCount;
+        return streamPosition;
+    }
+
+    @Override
+    protected int readWithFilter(int[] positions, int positionCount)
+            throws IOException
+    {
+        int streamPosition = 0;
+        outputPositionCount = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            if (position > streamPosition) {
+                skip(position - streamPosition);
+                streamPosition = position;
+            }
+
+            if (presentStream != null && !presentStream.nextBit()) {
+                if ((nonDeterministicFilter && filter.testNull()) || nullsAllowed) {
+                    if (outputRequired) {
+                        nulls[outputPositionCount] = true;
+                    }
+                    outputPositions[outputPositionCount] = position;
+                    outputPositionCount++;
+                }
+            }
+            else {
+                long rescale = Decimals.rescale(dataStream.nextLong(), (int) scaleStream.next(), this.scale);
+                if (filter.testLong(rescale)) {
+                    if (outputRequired) {
+                        values[outputPositionCount] = rescale;
+                        if (nullsAllowed && presentStream != null) {
+                            nulls[outputPositionCount] = false;
+                        }
+                    }
+                    outputPositions[outputPositionCount] = position;
+                    outputPositionCount++;
+                }
+            }
+            streamPosition++;
+
+            if (filter != null) {
+                outputPositionCount -= filter.getPrecedingPositionsToFail();
+                int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
+                if (succeedingPositionsToFail > 0) {
+                    int positionsToSkip = 0;
+                    for (int j = 0; j < succeedingPositionsToFail; j++) {
+                        i++;
+                        int nextPosition = positions[i];
+                        positionsToSkip += 1 + nextPosition - streamPosition;
+                        streamPosition = nextPosition + 1;
+                    }
+                    skip(positionsToSkip);
+                }
+            }
+        }
+        return streamPosition;
+    }
+
+    @Override
+    protected void copyValues(int[] positions, int positionCount, long[] valuesCopy, boolean[] nullsCopy)
+    {
+        int positionIndex = 0;
+        int nextPosition = positions[positionIndex];
+        for (int i = 0; i < outputPositionCount; i++) {
+            if (outputPositions[i] < nextPosition) {
+                continue;
+            }
+            assert outputPositions[i] == nextPosition;
+
+            valuesCopy[positionIndex] = this.values[i];
+            if (nullsCopy != null) {
+                nullsCopy[positionIndex] = this.nulls[i];
+            }
+            positionIndex++;
+
+            if (positionIndex >= positionCount) {
+                break;
+            }
+            nextPosition = positions[positionIndex];
+        }
+    }
+
+    @Override
+    protected void compactValues(int[] positions, int positionCount, boolean compactNulls)
+    {
+        int positionIndex = 0;
+        int nextPosition = positions[positionIndex];
+        for (int i = 0; i < outputPositionCount; i++) {
+            if (outputPositions[i] < nextPosition) {
+                continue;
+            }
+
+            assert outputPositions[i] == nextPosition;
+
+            values[positionIndex] = values[i];
+            if (compactNulls) {
+                nulls[positionIndex] = nulls[i];
+            }
+            outputPositions[positionIndex] = nextPosition;
+
+            positionIndex++;
+            if (positionIndex >= positionCount) {
+                break;
+            }
+            nextPosition = positions[positionIndex];
+        }
+
+        outputPositionCount = positionCount;
+    }
+
+    @Override
+    protected Block makeBlock(int positionCount, boolean includeNulls, boolean[] nulls, long[] values)
+    {
+        return new LongArrayBlock(positionCount, Optional.ofNullable(includeNulls ? nulls : null), values);
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -92,6 +92,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.Timestamp;
@@ -309,7 +310,7 @@ public class OrcTester
         testRoundTrip(type, readValues, ImmutableList.of());
     }
 
-    public void testRoundTrip(Type type, List<?> readValues, TupleDomainFilter...filters)
+    public void testRoundTrip(Type type, List<?> readValues, TupleDomainFilter... filters)
             throws Exception
     {
         testRoundTrip(type, readValues, Arrays.stream(filters).map(filter -> ImmutableMap.of(new Subfield("c"), filter)).collect(toImmutableList()));
@@ -795,6 +796,18 @@ public class OrcTester
 
         if (type == TIMESTAMP) {
             return filter.testLong(((SqlTimestamp) value).getMillisUtc());
+        }
+
+        if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            BigDecimal bigDecimal = ((SqlDecimal) value).toBigDecimal();
+            if (decimalType.isShort()) {
+                return filter.testLong(bigDecimal.unscaledValue().longValue());
+            }
+            else {
+                Slice encodedDecimal = Decimals.encodeScaledValue(bigDecimal);
+                return filter.testDecimal(encodedDecimal.getLong(0), encodedDecimal.getLong(Long.BYTES));
+            }
         }
 
         fail("Unsupported type: " + type);


### PR DESCRIPTION
```
===NEW===
Benchmark                                       (typeSignature)  (withNulls)  Mode  Cnt  Score    Error  Units
BenchmarkSelectiveStreamReaders.read              decimal(10,5)         true  avgt   20  0.234 ±  0.008   s/op
BenchmarkSelectiveStreamReaders.read              decimal(10,5)        false  avgt   20  0.471 ±  0.015   s/op
BenchmarkSelectiveStreamReaders.readAllNull       decimal(10,5)          N/A  avgt   20  0.002 ±  0.001   s/op
BenchmarkSelectiveStreamReaders.readWithFilter    decimal(10,5)         true  avgt   20  0.277 ±  0.009   s/op
BenchmarkSelectiveStreamReaders.readWithFilter    decimal(10,5)        false  avgt   20  0.466 ±  0.018   s/op

Benchmark                                             Mode  Cnt  Score   Error  Units
BenchmarkBatchStreamReaders.readShortDecimalNoNull    avgt   60  0.481 ± 0.009   s/op
BenchmarkBatchStreamReaders.readShortDecimalWithNull  avgt   60  0.301 ± 0.005   s/op

Benchmark                                       (typeSignature)  (withNulls)  Mode  Cnt  Score    Error  Units
BenchmarkSelectiveStreamReaders.read             decimal(30,10)         true  avgt   20  0.288 ±  0.008   s/op
BenchmarkSelectiveStreamReaders.read             decimal(30,10)        false  avgt   20  0.446 ±  0.025   s/op
BenchmarkSelectiveStreamReaders.readAllNull      decimal(30,10)          N/A  avgt   20  0.002 ±  0.001   s/op
BenchmarkSelectiveStreamReaders.readWithFilter   decimal(30,10)         true  avgt   20  0.350 ±  0.011   s/op
BenchmarkSelectiveStreamReaders.readWithFilter   decimal(30,10)        false  avgt   20  0.585 ±  0.036   s/op

Benchmark                                            Mode  Cnt  Score   Error  Units
BenchmarkBatchStreamReaders.readLongDecimalNoNull    avgt   60  0.645 ± 0.013   s/op
BenchmarkBatchStreamReaders.readLongDecimalWithNull  avgt   60  0.483 ± 0.010   s/op

===OLD===
Benchmark                                       (typeSignature)  (withNulls)  Mode  Cnt  Score    Error  Units
BenchmarkSelectiveStreamReaders.read              decimal(10,5)         true  avgt   20  0.255 ±  0.008   s/op
BenchmarkSelectiveStreamReaders.read              decimal(10,5)        false  avgt   20  0.465 ±  0.022   s/op
BenchmarkSelectiveStreamReaders.readAllNull       decimal(10,5)          N/A  avgt   20  0.002 ±  0.001   s/op
BenchmarkSelectiveStreamReaders.readWithFilter    decimal(10,5)         true  avgt   20  0.466 ±  0.013   s/op


# Run complete. Total time: 00:04:09

Benchmark                                             Mode  Cnt  Score   Error  Units
BenchmarkBatchStreamReaders.readShortDecimalNoNull    avgt   60  0.490 ± 0.014   s/op
BenchmarkBatchStreamReaders.readShortDecimalWithNull  avgt   60  0.344 ± 0.026   s/op



BenchmarkSelectiveStreamReaders.read             decimal(30,10)         true  avgt   20  0.385 ±  0.009   s/op
BenchmarkSelectiveStreamReaders.read             decimal(30,10)        false  avgt   20  0.611 ±  0.012   s/op
BenchmarkSelectiveStreamReaders.readAllNull      decimal(30,10)          N/A  avgt   20  0.003 ±  0.001   s/op
BenchmarkSelectiveStreamReaders.readWithFilter   decimal(30,10)         true  avgt   20  0.430 ±  0.011   s/op
BenchmarkSelectiveStreamReaders.readWithFilter   decimal(30,10)        false  avgt   20  0.678 ±  0.008   s/op


Benchmark                                            Mode  Cnt  Score   Error  Units
BenchmarkBatchStreamReaders.readLongDecimalNoNull    avgt   60  0.636 ± 0.009   s/op
BenchmarkBatchStreamReaders.readLongDecimalWithNull  avgt   60  0.437 ± 0.013   s/op
```
====NO RELEASE NOTES====