### PR TITLE
Improve condition for ignoring bucketing for hive

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePartitionManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePartitionManager.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.PrestoTableType;
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.TestingTypeManager;
+import com.facebook.presto.testing.TestingConnectorSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
+import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static com.facebook.presto.hive.HiveColumnHandle.bucketColumnHandle;
+import static com.facebook.presto.hive.HiveStorageFormat.ORC;
+import static com.facebook.presto.hive.HiveType.HIVE_INT;
+import static com.facebook.presto.hive.HiveType.HIVE_STRING;
+import static com.facebook.presto.hive.metastore.StorageFormat.fromHiveStorageFormat;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestHivePartitionManager
+{
+    private static final String SCHEMA_NAME = "schema";
+    private static final String TABLE_NAME = "table";
+    private static final String USER_NAME = "user";
+    private static final String LOCATION = "somewhere/over/the/rainbow";
+    private static final Column PARTITION_COLUMN = new Column("ds", HIVE_STRING, Optional.empty());
+    private static final Column BUCKET_COLUMN = new Column("c1", HIVE_INT, Optional.empty());
+    private static final Table TABLE = new Table(
+            SCHEMA_NAME,
+            TABLE_NAME,
+            USER_NAME,
+            PrestoTableType.MANAGED_TABLE,
+            new Storage(fromHiveStorageFormat(ORC), LOCATION, Optional.of(new HiveBucketProperty(ImmutableList.of(BUCKET_COLUMN.getName()), 100, ImmutableList.of())), false, ImmutableMap.of()),
+            ImmutableList.of(BUCKET_COLUMN),
+            ImmutableList.of(PARTITION_COLUMN),
+            ImmutableMap.of(),
+            Optional.empty(),
+            Optional.empty());
+
+    private static final List<String> PARTITIONS = ImmutableList.of("ds=2019-07-23", "ds=2019-08-23");
+
+    private HivePartitionManager hivePartitionManager = new HivePartitionManager(new TestingTypeManager(), new HiveClientConfig());
+    private final TestingSemiTransactionalHiveMetastore metastore = TestingSemiTransactionalHiveMetastore.create();
+
+    @BeforeClass
+    public void setUp()
+    {
+        metastore.addTable(SCHEMA_NAME, TABLE_NAME, TABLE, PARTITIONS);
+    }
+
+    @Test
+    public void testUsesBucketingIfSmallEnough()
+    {
+        HiveTableHandle tableHandle = new HiveTableHandle(SCHEMA_NAME, TABLE_NAME);
+        HivePartitionResult result = hivePartitionManager.getPartitions(
+                metastore,
+                tableHandle,
+                Constraint.alwaysTrue(),
+                new TestingConnectorSession(new HiveSessionProperties(new HiveClientConfig(), new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties()));
+        assertTrue(result.getBucketHandle().isPresent(), "bucketHandle is not present");
+        assertFalse(result.getBucketFilter().isPresent(), "bucketFilter is present");
+    }
+
+    @Test
+    public void testIgnoresBucketingWhenTooManyBuckets()
+    {
+        ConnectorSession session = new TestingConnectorSession(
+                new HiveSessionProperties(
+                        new HiveClientConfig().setMaxBucketsForGroupedExecution(100),
+                        new OrcFileWriterConfig(),
+                        new ParquetFileWriterConfig())
+                        .getSessionProperties());
+        HivePartitionResult result = hivePartitionManager.getPartitions(metastore, new HiveTableHandle(SCHEMA_NAME, TABLE_NAME), Constraint.alwaysTrue(), session);
+        assertFalse(result.getBucketHandle().isPresent(), "bucketHandle is present");
+        assertFalse(result.getBucketFilter().isPresent(), "bucketFilter is present");
+    }
+
+    @Test
+    public void testUsesBucketingWithPartitionFilters()
+    {
+        ConnectorSession session = new TestingConnectorSession(new HiveSessionProperties(new HiveClientConfig().setMaxBucketsForGroupedExecution(100), new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties());
+        HiveTableHandle tableHandle = new HiveTableHandle(SCHEMA_NAME, TABLE_NAME);
+        HivePartitionResult result = hivePartitionManager.getPartitions(
+                metastore,
+                tableHandle,
+                new Constraint<>(TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                new HiveColumnHandle(
+                                        PARTITION_COLUMN.getName(),
+                                        PARTITION_COLUMN.getType(),
+                                        parseTypeSignature(StandardTypes.VARCHAR),
+                                        -1,
+                                        PARTITION_KEY,
+                                        Optional.empty()),
+                                Domain.singleValue(VARCHAR, utf8Slice("2019-07-23"))))),
+                session);
+        assertTrue(result.getBucketHandle().isPresent(), "bucketHandle is not present");
+        assertFalse(result.getBucketFilter().isPresent(), "bucketFilter is present");
+    }
+
+    @Test
+    public void testUsesBucketingWithBucketFilters()
+    {
+        ConnectorSession session = new TestingConnectorSession(new HiveSessionProperties(new HiveClientConfig().setMaxBucketsForGroupedExecution(100), new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties());
+        HiveTableHandle tableHandle = new HiveTableHandle(SCHEMA_NAME, TABLE_NAME);
+        HivePartitionResult result = hivePartitionManager.getPartitions(
+                metastore,
+                tableHandle,
+                new Constraint<>(TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                new HiveColumnHandle(
+                                        BUCKET_COLUMN.getName(),
+                                        BUCKET_COLUMN.getType(),
+                                        parseTypeSignature(StandardTypes.VARCHAR),
+                                        0,
+                                        REGULAR,
+                                        Optional.empty()),
+                                Domain.singleValue(INTEGER, 1L)))),
+                session);
+        assertTrue(result.getBucketHandle().isPresent(), "bucketHandle is not present");
+        assertTrue(result.getBucketFilter().isPresent(), "bucketFilter is present");
+    }
+
+    @Test
+    public void testUsesBucketingWithBucketColumn()
+    {
+        ConnectorSession session = new TestingConnectorSession(new HiveSessionProperties(new HiveClientConfig().setMaxBucketsForGroupedExecution(1), new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties());
+        HiveTableHandle tableHandle = new HiveTableHandle(SCHEMA_NAME, TABLE_NAME);
+        HivePartitionResult result = hivePartitionManager.getPartitions(
+                metastore,
+                tableHandle,
+                new Constraint<>(TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                bucketColumnHandle(),
+                                Domain.singleValue(INTEGER, 1L)))),
+                session);
+        assertTrue(result.getBucketHandle().isPresent(), "bucketHandle is not present");
+        assertTrue(result.getBucketFilter().isPresent(), "bucketFilter is present");
+    }
+
+    @Test
+    public void testIgnoresBucketingWhenConfigured()
+    {
+        ConnectorSession session = new TestingConnectorSession(
+                new HiveSessionProperties(
+                        new HiveClientConfig().setIgnoreTableBucketing(true),
+                        new OrcFileWriterConfig(),
+                        new ParquetFileWriterConfig())
+                        .getSessionProperties());
+        HivePartitionResult result = hivePartitionManager.getPartitions(metastore, new HiveTableHandle(SCHEMA_NAME, TABLE_NAME), Constraint.alwaysTrue(), session);
+        assertFalse(result.getBucketHandle().isPresent(), "bucketHandle is present");
+        assertFalse(result.getBucketFilter().isPresent(), "bucketFilter is present");
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
+import com.facebook.presto.hive.metastore.Database;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.HivePageSinkMetadata;
+import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
+import com.facebook.presto.hive.metastore.HiveTableName;
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.PrincipalPrivileges;
+import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
+import com.facebook.presto.hive.metastore.thrift.HiveCluster;
+import com.facebook.presto.hive.metastore.thrift.TestingHiveCluster;
+import com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.security.PrestoPrincipal;
+import com.facebook.presto.spi.security.RoleGrant;
+import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import org.apache.hadoop.fs.Path;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+
+public class TestingSemiTransactionalHiveMetastore
+        extends SemiTransactionalHiveMetastore
+{
+    private static final String HOST = "dummy";
+    private static final int PORT = 1111;
+
+    private final Map<HiveTableName, Table> tablesMap = new HashMap<>();
+    private final Map<HiveTableName, List<String>> partitionsMap = new HashMap<>();
+
+    private TestingSemiTransactionalHiveMetastore(HdfsEnvironment hdfsEnvironment, ExtendedHiveMetastore delegate, ListeningExecutorService renameExecutor, boolean skipDeletionForAlter, boolean skipTargetCleanupOnRollback)
+    {
+        super(hdfsEnvironment, delegate, renameExecutor, skipDeletionForAlter, skipTargetCleanupOnRollback);
+    }
+
+    public static TestingSemiTransactionalHiveMetastore create()
+    {
+        // none of these values matter, as we never use them
+        HiveClientConfig config = new HiveClientConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config), ImmutableSet.of());
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, config, new NoHdfsAuthentication());
+        HiveCluster hiveCluster = new TestingHiveCluster(config, HOST, PORT);
+        ExtendedHiveMetastore delegate = new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster));
+        ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("hive-%s"));
+        ListeningExecutorService renameExecutor = listeningDecorator(executor);
+
+        return new TestingSemiTransactionalHiveMetastore(hdfsEnvironment, delegate, renameExecutor, false, false);
+    }
+
+    public void addTable(String database, String tableName, Table table, List<String> partitions)
+    {
+        HiveTableName hiveTableName = new HiveTableName(database, tableName);
+        tablesMap.put(hiveTableName, table);
+        partitionsMap.put(hiveTableName, partitions);
+    }
+
+    @Override
+    public synchronized List<String> getAllDatabases()
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized Optional<Database> getDatabase(String databaseName)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized Optional<List<String>> getAllTables(String databaseName)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized Optional<Table> getTable(String databaseName, String tableName)
+    {
+        return Optional.ofNullable(tablesMap.get(new HiveTableName(databaseName, tableName)));
+    }
+
+    @Override
+    public synchronized Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized PartitionStatistics getTableStatistics(String databaseName, String tableName)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized Map<String, PartitionStatistics> getPartitionStatistics(String databaseName, String tableName, Set<String> partitionNames)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized HivePageSinkMetadata generatePageSinkMetadata(SchemaTableName schemaTableName)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized Optional<List<String>> getAllViews(String databaseName)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void createDatabase(Database database)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void dropDatabase(String schemaName)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void renameDatabase(String source, String target)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void setTableStatistics(Table table, PartitionStatistics tableStatistics)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void setPartitionStatistics(Table table, Map<List<String>, PartitionStatistics> partitionStatisticsMap)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void createTable(ConnectorSession session, Table table, PrincipalPrivileges principalPrivileges, Optional<Path> currentPath, boolean ignoreExisting, PartitionStatistics statistics)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void dropTable(ConnectorSession session, String databaseName, String tableName)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void replaceView(String databaseName, String tableName, Table table, PrincipalPrivileges principalPrivileges)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void renameTable(String databaseName, String tableName, String newDatabaseName, String newTableName)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void addColumn(String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void renameColumn(String databaseName, String tableName, String oldColumnName, String newColumnName)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void dropColumn(String databaseName, String tableName, String columnName)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void finishInsertIntoExistingTable(ConnectorSession session, String databaseName, String tableName, Path currentLocation, List<String> fileNames, PartitionStatistics statisticsUpdate)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void truncateUnpartitionedTable(ConnectorSession session, String databaseName, String tableName)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized Optional<List<String>> getPartitionNames(String databaseName, String tableName)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized Optional<List<String>> getPartitionNamesByParts(String databaseName, String tableName, List<String> parts)
+    {
+        return Optional.ofNullable(partitionsMap.get(new HiveTableName(databaseName, tableName)));
+    }
+
+    @Override
+    public synchronized Optional<Partition> getPartition(String databaseName, String tableName, List<String> partitionValues)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized Map<String, Optional<Partition>> getPartitionsByNames(String databaseName, String tableName, List<String> partitionNames)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void addPartition(ConnectorSession session, String databaseName, String tableName, Partition partition, Path currentLocation, PartitionStatistics statistics)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void dropPartition(ConnectorSession session, String databaseName, String tableName, List<String> partitionValues)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void finishInsertIntoExistingPartition(ConnectorSession session, String databaseName, String tableName, List<String> partitionValues, Path currentLocation, List<String> fileNames, PartitionStatistics statisticsUpdate)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void createRole(String role, String grantor)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void dropRole(String role)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized Set<String> listRoles()
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void grantRoles(Set<String> roles, Set<PrestoPrincipal> grantees, boolean withAdminOption, PrestoPrincipal grantor)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void revokeRoles(Set<String> roles, Set<PrestoPrincipal> grantees, boolean adminOptionFor, PrestoPrincipal grantor)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized Set<RoleGrant> listRoleGrants(PrestoPrincipal principal)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, PrestoPrincipal principal)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void grantTablePrivileges(String databaseName, String tableName, PrestoPrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void revokeTablePrivileges(String databaseName, String tableName, PrestoPrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void declareIntentionToWrite(ConnectorSession session, LocationHandle.WriteMode writeMode, Path stagingPathRoot, String filePrefix, SchemaTableName schemaTableName, boolean temporaryTable)
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void commit()
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+    @Override
+    public synchronized void rollback()
+    {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+}


### PR DESCRIPTION
Don't ignore bucketing for queries that use the bucket column and consider the
bucket filter when calculating the total number of buckets

Please fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

Hive Changes
* Fix computation for number of buckets accessed for `max_buckets_for_grouped_execution`
* Fix a bug where the bucket column was not available if `max_buckets_for_grouped_execution` was exceeded
```