### PR TITLE
Fix ST_Centroid and ST_Buffer for tiny geometries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1145,7 +1145,7 @@
             <dependency>
                 <groupId>com.esri.geometry</groupId>
                 <artifactId>esri-geometry-api</artifactId>
-                <version>2.2.2</version>
+                <version>2.2.3</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.fasterxml.jackson.core</groupId>

--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -186,7 +186,9 @@ Operations
 .. function:: ST_Buffer(Geometry, distance) -> Geometry
 
     Returns the geometry that represents all points whose distance from the
-    specified geometry is less than or equal to the specified distance.
+    specified geometry is less than or equal to the specified distance.  If the
+    points of the geometry are extremely close together (``delta < 1e-8``), this
+    might return an empty geometry.
 
 .. function:: ST_Difference(Geometry, Geometry) -> Geometry
 

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestBingTileFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestBingTileFunctions.java
@@ -382,7 +382,7 @@ public class TestBingTileFunctions
     public void testBingTilePolygon()
     {
         assertFunction("ST_AsText(bing_tile_polygon(bing_tile('123030123010121')))", VARCHAR, "POLYGON ((59.996337890625 30.11662158281937, 60.00732421875 30.11662158281937, 60.00732421875 30.12612436422458, 59.996337890625 30.12612436422458, 59.996337890625 30.11662158281937))");
-        assertFunction("ST_AsText(ST_Centroid(bing_tile_polygon(bing_tile('123030123010121'))))", VARCHAR, "POINT (60.0018310442288 30.121372968273892)");
+        assertFunction("ST_AsText(ST_Centroid(bing_tile_polygon(bing_tile('123030123010121'))))", VARCHAR, "POINT (60.0018310546875 30.121372973521975)");
 
         // Check bottom right corner of a stack of tiles at different zoom levels
         assertFunction("ST_AsText(apply(bing_tile_polygon(bing_tile(1, 1, 1)), g -> ST_Point(ST_XMax(g), ST_YMin(g))))", VARCHAR, "POINT (180 -85.05112877980659)");

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -14,9 +14,11 @@
 package com.facebook.presto.plugin.geospatial;
 
 import com.esri.core.geometry.Point;
+import com.esri.core.geometry.ogc.OGCGeometry;
 import com.esri.core.geometry.ogc.OGCPoint;
 import com.facebook.presto.geospatial.KdbTreeUtils;
 import com.facebook.presto.geospatial.Rectangle;
+import com.facebook.presto.geospatial.serde.GeometrySerde;
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
@@ -30,6 +32,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.geospatial.KdbTree.buildKdbTree;
+import static com.facebook.presto.plugin.geospatial.GeoFunctions.stCentroid;
 import static com.facebook.presto.plugin.geospatial.GeometryType.GEOMETRY;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -219,12 +222,37 @@ public class TestGeoFunctions
         assertCentroid("POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))", new Point(2.5416666666666665, 2.5416666666666665));
 
         // invalid geometry
-        assertInvalidFunction("ST_Centroid(ST_GeometryFromText('MULTIPOLYGON (((4.903234300000006 52.08474289999999, 4.903234265193165 52.084742934806826, 4.903234299999999 52.08474289999999, 4.903234300000006 52.08474289999999)))'))", "Cannot compute centroid: .* Use ST_IsValid to confirm that input geometry is valid or compute centroid for a bounding box using ST_Envelope.");
+        assertApproximateCentroid("MULTIPOLYGON (((4.903234300000006 52.08474289999999, 4.903234265193165 52.084742934806826, 4.903234299999999 52.08474289999999, 4.903234300000006 52.08474289999999)))", new Point(4.9032343, 52.0847429), 1e-7);
+
+        // Numerical stability tests
+        assertApproximateCentroid(
+                "MULTIPOLYGON (((153.492818 -28.13729, 153.492821 -28.137291, 153.492816 -28.137289, 153.492818 -28.13729)))",
+                new Point(153.49282, -28.13729), 1e-5);
+        assertApproximateCentroid(
+                "MULTIPOLYGON (((153.112475 -28.360526, 153.1124759 -28.360527, 153.1124759 -28.360526, 153.112475 -28.360526)))",
+                new Point(153.112475, -28.360526), 1e-5);
+        assertApproximateCentroid(
+                "POLYGON ((4.903234300000006 52.08474289999999, 4.903234265193165 52.084742934806826, 4.903234299999999 52.08474289999999, 4.903234300000006 52.08474289999999))",
+                new Point(4.9032343, 52.0847429), 1e-6);
+        assertApproximateCentroid(
+                "MULTIPOLYGON (((4.903234300000006 52.08474289999999, 4.903234265193165 52.084742934806826, 4.903234299999999 52.08474289999999, 4.903234300000006 52.08474289999999)))",
+                new Point(4.9032343, 52.0847429), 1e-6);
+        assertApproximateCentroid(
+                "POLYGON ((-81.0387349 29.20822, -81.039974 29.210597, -81.0410331 29.2101579, -81.0404758 29.2090879, -81.0404618 29.2090609, -81.040433 29.209005, -81.0404269 29.208993, -81.0404161 29.2089729, -81.0398001 29.20779, -81.0387349 29.20822), (-81.0404229 29.208986, -81.04042 29.2089809, -81.0404269 29.208993, -81.0404229 29.208986))",
+                new Point(-81.039885, 29.209191), 1e-6);
     }
 
     private void assertCentroid(String wkt, Point centroid)
     {
         assertFunction(format("ST_AsText(ST_Centroid(ST_GeometryFromText('%s')))", wkt), VARCHAR, new OGCPoint(centroid, null).asText());
+    }
+
+    private void assertApproximateCentroid(String wkt, Point expectedCentroid, double epsilon)
+    {
+        OGCPoint actualCentroid = (OGCPoint) GeometrySerde.deserialize(
+                stCentroid(GeometrySerde.serialize(OGCGeometry.fromText(wkt))));
+        assertEquals(actualCentroid.X(), expectedCentroid.getX(), epsilon);
+        assertEquals(actualCentroid.Y(), expectedCentroid.getY(), epsilon);
     }
 
     @Test

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -193,6 +193,16 @@ public class TestGeoFunctions
         // infinity() and nan() distance
         assertFunction("ST_AsText(ST_Buffer(ST_Point(0, 0), infinity()))", VARCHAR, "MULTIPOLYGON EMPTY");
         assertInvalidFunction("ST_Buffer(ST_Point(0, 0), nan())", "distance is NaN");
+
+        // For small polygons, there was a bug in ESRI that throw an NPE.  This
+        // was fixed (https://github.com/Esri/geometry-api-java/pull/243) to
+        // return an empty geometry instead. Ideally, these would return
+        // something approximately like `ST_Buffer(ST_Centroid(geometry))`.
+        assertFunction("ST_IsEmpty(ST_Buffer(ST_Buffer(ST_Point(177.50102959662, 64.726807421691), 0.0000000001), 0.00005))",
+                BOOLEAN, true);
+        assertFunction("ST_IsEmpty(ST_Buffer(ST_GeometryFromText(" +
+                "'POLYGON ((177.0 64.0, 177.0000000001 64.0, 177.0000000001 64.0000000001, 177.0 64.0000000001, 177.0 64.0))'" +
+                "), 0.01))", BOOLEAN, true);
     }
 
     @Test


### PR DESCRIPTION
Version 2.2.3 has two fixes of interest: 
- correct computation of centroids of very small polygons - https://github.com/Esri/geometry-api-java/pull/227
- correct computation of buffers around small polygons - https://github.com/Esri/geometry-api-java/pull/243

Fixes #13194 and #10629

```
== RELEASE NOTES ==

General Changes
-----------------
* Fix ST_Buffer for tiny geometries (#13194)
* Fix ST_Centroid for tiny geometries (#10629)
```
