### PR TITLE
Fix grouped execution tagging for table scan

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -3417,6 +3417,9 @@ public class TestHiveIntegrationSmokeTest
 
             assertQuery(notColocated, tableScan, expectedTableScan);
             assertQuery(eligibleTableScans, tableScan, expectedTableScan);
+
+            // Input connector returns non-empty TablePartitioning for unpartitioned table.
+            assertQuery(eligibleTableScans, "SELECT orderkey FROM tpch.tiny.orders", "SELECT orderkey FROM orders");
         }
         finally {
             assertUpdate(session, "DROP TABLE IF EXISTS test_grouped_join1");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -1060,13 +1060,16 @@ public class PlanFragmenter
                 return GroupedExecutionProperties.notCapable();
             }
             List<ConnectorPartitionHandle> partitionHandles = nodePartitioningManager.listPartitionHandles(session, tablePartitioning.get().getPartitioningHandle());
-            boolean recoveryEligible = metadata.getConnectorCapabilities(session, node.getTable().getConnectorId()).contains(SUPPORTS_REWINDABLE_SPLIT_SOURCE);
-            boolean useful = isGroupedExecutionForEligibleTableScansEnabled(session);
             if (ImmutableList.of(NOT_PARTITIONED).equals(partitionHandles)) {
-                return new GroupedExecutionProperties(false, useful, ImmutableList.of(), 1, recoveryEligible);
+                return GroupedExecutionProperties.notCapable();
             }
             else {
-                return new GroupedExecutionProperties(true, useful, ImmutableList.of(node.getId()), partitionHandles.size(), recoveryEligible);
+                return new GroupedExecutionProperties(
+                        true,
+                        isGroupedExecutionForEligibleTableScansEnabled(session),
+                        ImmutableList.of(node.getId()),
+                        partitionHandles.size(),
+                        metadata.getConnectorCapabilities(session, node.getTable().getConnectorId()).contains(SUPPORTS_REWINDABLE_SPLIT_SOURCE));
             }
         }
 


### PR DESCRIPTION
Addresses #13322
We should return incapable for table scan in the following two cases:
- TablePartitioing is empty
- TablePartitioning is not empty but it only contains one
   NotPartitionedPartitionHandle in the partition handle list
    
The first case is already covered, and this commit is aiming
at fixing the second case.

```
== RELEASE NOTES ==

General Changes
* Fix bug that causes failure when reading unpartitioned table from some connectors with session property ``grouped_execution_for_eligible_table_scans`` turned on.
```
