### PR TITLE
Inline LocalQueryRunner#translateExpressions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -138,11 +138,8 @@ import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.PlanFragmenter;
 import com.facebook.presto.sql.planner.PlanOptimizers;
-import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.SubPlan;
-import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
-import com.facebook.presto.sql.planner.optimizations.TranslateExpressions;
 import com.facebook.presto.sql.planner.planPrinter.PlanPrinter;
 import com.facebook.presto.sql.planner.sanity.PlanSanityChecker;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
@@ -913,17 +910,5 @@ public class LocalQueryRunner
         return searchFrom(node)
                 .where(TableScanNode.class::isInstance)
                 .findAll();
-    }
-
-    public PlanOptimizer translateExpressions()
-    {
-        // Translate all OriginalExpression in planNodes to RowExpression so that we can do plan pattern asserting and printing on RowExpression only.
-        return new IterativeOptimizer(
-                new RuleStatsRecorder(),
-                getStatsCalculator(),
-                getCostCalculator(),
-                new ImmutableSet.Builder()
-                        .addAll(new TranslateExpressions(getMetadata(), getSqlParser()).rules())
-                        .build());
     }
 }


### PR DESCRIPTION
This is only used in tests to construct a plan optimizer that
translates all OriginalExpression in planNodes to RowExpression.
And all the information obtained from public methods of
LocalQueryRunner. Thus it doesn't have to be a method of
LocalQueryRunner.


```
== NO RELEASE NOTE ==
```
