### PR TITLE
Fix reading empty and all-nulls lists with filters

### DIFF
--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -745,9 +745,12 @@ public class OrcTester
                 if (nestedValue == null) {
                     return filter == IS_NULL;
                 }
-                int index = toIntExact(((Subfield.LongSubscript) pathElement).getIndex());
+                int index = toIntExact(((Subfield.LongSubscript) pathElement).getIndex()) - 1;
                 nestedType = ((ArrayType) nestedType).getElementType();
-                nestedValue = ((List) nestedValue).get(index - 1);
+                if (index >= ((List) nestedValue).size()) {
+                    return true;
+                }
+                nestedValue = ((List) nestedValue).get(index);
             }
             else {
                 fail("Unsupported type: " + type);
@@ -808,6 +811,7 @@ public class OrcTester
         if (StandardTypes.ARRAY.equals(baseType)) {
             List<?> actualArray = (List<?>) actual;
             List<?> expectedArray = (List<?>) expected;
+            assertEquals(actualArray == null, expectedArray == null);
             assertEquals(actualArray.size(), expectedArray.size());
 
             Type elementType = type.getTypeParameters().get(0);


### PR DESCRIPTION
Fixes #13253

Depends on #13335

```
== NO RELEASE NOTE ==
```
