### PR TITLE
Move request slug from path to query

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -579,9 +579,9 @@ class Query
                 .scheme(scheme)
                 .replacePath("/v1/statement")
                 .path(queryId.toString())
-                .path(slug)
                 .path(String.valueOf(resultId.incrementAndGet()))
                 .replaceQuery("")
+                .queryParam("slug", slug)
                 .build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/StatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/StatementResource.java
@@ -172,12 +172,12 @@ public class StatementResource
     }
 
     @GET
-    @Path("{queryId}/{slug}/{token}")
+    @Path("{queryId}/{token}")
     @Produces(MediaType.APPLICATION_JSON)
     public void getQueryResults(
             @PathParam("queryId") QueryId queryId,
-            @PathParam("slug") String slug,
             @PathParam("token") long token,
+            @QueryParam("slug") String slug,
             @QueryParam("maxWait") Duration maxWait,
             @QueryParam("targetResultSize") DataSize targetResultSize,
             @HeaderParam(X_FORWARDED_PROTO) String proto,
@@ -274,12 +274,12 @@ public class StatementResource
     }
 
     @DELETE
-    @Path("{queryId}/{slug}/{token}")
+    @Path("{queryId}/{token}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response cancelQuery(
             @PathParam("queryId") QueryId queryId,
-            @PathParam("slug") String slug,
-            @PathParam("token") long token)
+            @PathParam("token") long token,
+            @QueryParam("slug") String slug)
     {
         Query query = getQuery(queryId, slug);
         if (query == null) {


### PR DESCRIPTION
This prevents the airlift HTTP server from logging the slug in the http request log.

This turns out to work because if you look at io.airlift.http.server.HttpRequestEvent it invokes org.eclipse.jetty.server.Request.getRequestURI which does not as its name implies retrieve the entire URI.

```
== NO RELEASE NOTE ==
```
