### PR TITLE
Include full OrcType in StreamDescriptor

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -602,7 +602,7 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
             nestedStreams.add(createStreamDescriptor(parentStreamName, "key", type.getFieldTypeIndex(0), types, dataSource));
             nestedStreams.add(createStreamDescriptor(parentStreamName, "value", type.getFieldTypeIndex(1), types, dataSource));
         }
-        return new StreamDescriptor(parentStreamName, typeId, fieldName, type.getOrcTypeKind(), dataSource, nestedStreams.build());
+        return new StreamDescriptor(parentStreamName, typeId, fieldName, type, dataSource, nestedStreams.build());
     }
 
     protected boolean shouldValidateWritePageChecksum()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StreamDescriptor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StreamDescriptor.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
 import com.google.common.collect.ImmutableList;
 
@@ -27,23 +28,23 @@ public final class StreamDescriptor
     private final String streamName;
     private final int streamId;
     private final int sequence;
-    private final OrcTypeKind streamType;
+    private final OrcType orcType;
     private final String fieldName;
     private final OrcDataSource orcDataSource;
     private final List<StreamDescriptor> nestedStreams;
 
-    public StreamDescriptor(String streamName, int streamId, String fieldName, OrcTypeKind streamType, OrcDataSource orcDataSource, List<StreamDescriptor> nestedStreams)
+    public StreamDescriptor(String streamName, int streamId, String fieldName, OrcType orcType, OrcDataSource orcDataSource, List<StreamDescriptor> nestedStreams)
     {
-        this(streamName, streamId, fieldName, streamType, orcDataSource, nestedStreams, DEFAULT_SEQUENCE_ID);
+        this(streamName, streamId, fieldName, orcType, orcDataSource, nestedStreams, DEFAULT_SEQUENCE_ID);
     }
 
-    public StreamDescriptor(String streamName, int streamId, String fieldName, OrcTypeKind streamType, OrcDataSource orcDataSource, List<StreamDescriptor> nestedStreams, int sequence)
+    public StreamDescriptor(String streamName, int streamId, String fieldName, OrcType orcType, OrcDataSource orcDataSource, List<StreamDescriptor> nestedStreams, int sequence)
     {
         this.streamName = requireNonNull(streamName, "streamName is null");
         this.streamId = streamId;
         this.sequence = sequence;
         this.fieldName = requireNonNull(fieldName, "fieldName is null");
-        this.streamType = requireNonNull(streamType, "type is null");
+        this.orcType = requireNonNull(orcType, "orcType is null");
         this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
         this.nestedStreams = ImmutableList.copyOf(requireNonNull(nestedStreams, "nestedStreams is null"));
     }
@@ -65,7 +66,12 @@ public final class StreamDescriptor
 
     public OrcTypeKind getOrcTypeKind()
     {
-        return streamType;
+        return orcType.getOrcTypeKind();
+    }
+
+    public OrcType getOrcType()
+    {
+        return this.orcType;
     }
 
     public String getFieldName()
@@ -95,7 +101,7 @@ public final class StreamDescriptor
                 .add("streamName", streamName)
                 .add("streamId", streamId)
                 .add("sequence", sequence)
-                .add("streamType", streamType)
+                .add("orcType", orcType)
                 .add("dataSource", orcDataSource.getId())
                 .toString();
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StreamDescriptor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StreamDescriptor.java
@@ -63,7 +63,7 @@ public final class StreamDescriptor
         return sequence;
     }
 
-    public OrcTypeKind getStreamType()
+    public OrcTypeKind getOrcTypeKind()
     {
         return streamType;
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
@@ -26,7 +26,7 @@ public final class BatchStreamReaders
             StreamDescriptor streamDescriptor,
             DateTimeZone hiveStorageTimeZone)
     {
-        switch (streamDescriptor.getStreamType()) {
+        switch (streamDescriptor.getOrcTypeKind()) {
             case BOOLEAN:
                 return new BooleanBatchStreamReader(streamDescriptor);
             case BYTE:
@@ -57,7 +57,7 @@ public final class BatchStreamReaders
                 return new DecimalBatchStreamReader(streamDescriptor);
             case UNION:
             default:
-                throw new IllegalArgumentException("Unsupported type: " + streamDescriptor.getStreamType());
+                throw new IllegalArgumentException("Unsupported type: " + streamDescriptor.getOrcTypeKind());
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/HierarchicalFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/HierarchicalFilter.java
@@ -50,7 +50,7 @@ public interface HierarchicalFilter
 
     static HierarchicalFilter createHierarchicalFilter(StreamDescriptor streamDescriptor, Map<Subfield, TupleDomainFilter> subfieldFilters, int level, HierarchicalFilter parent)
     {
-        switch (streamDescriptor.getStreamType()) {
+        switch (streamDescriptor.getOrcTypeKind()) {
             case LIST:
                 return new ListFilter(streamDescriptor, subfieldFilters, level, parent);
             case MAP:

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectSelectiveStreamReader.java
@@ -128,7 +128,7 @@ public class MapDirectSelectiveStreamReader
         Optional<Type> keyOutputType = outputType.map(MapType.class::cast).map(MapType::getKeyType);
         Optional<Type> valueOutputType = outputType.map(MapType.class::cast).map(MapType::getValueType);
 
-        Map<Subfield, TupleDomainFilter> keyFilter = makeKeyFilter(nestedStreams.get(0).getStreamType(), requiredSubfields)
+        Map<Subfield, TupleDomainFilter> keyFilter = makeKeyFilter(nestedStreams.get(0).getOrcTypeKind(), requiredSubfields)
                 .map(f -> ImmutableMap.of(new Subfield("c"), f))
                 .orElse(ImmutableMap.of());
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatBatchStreamReader.java
@@ -95,7 +95,7 @@ public class MapFlatBatchStreamReader
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
         this.hiveStorageTimeZone = requireNonNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
-        this.keyOrcType = streamDescriptor.getNestedStreams().get(0).getStreamType();
+        this.keyOrcType = streamDescriptor.getNestedStreams().get(0).getOrcTypeKind();
         this.baseValueStreamDescriptor = streamDescriptor.getNestedStreams().get(1);
     }
 
@@ -269,7 +269,7 @@ public class MapFlatBatchStreamReader
                 streamDescriptor.getStreamName(),
                 streamDescriptor.getStreamId(),
                 streamDescriptor.getFieldName(),
-                streamDescriptor.getStreamType(),
+                streamDescriptor.getOrcTypeKind(),
                 streamDescriptor.getOrcDataSource(),
                 streamDescriptors,
                 sequence);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatBatchStreamReader.java
@@ -269,7 +269,7 @@ public class MapFlatBatchStreamReader
                 streamDescriptor.getStreamName(),
                 streamDescriptor.getStreamId(),
                 streamDescriptor.getFieldName(),
-                streamDescriptor.getOrcTypeKind(),
+                streamDescriptor.getOrcType(),
                 streamDescriptor.getOrcDataSource(),
                 streamDescriptors,
                 sequence);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
@@ -43,7 +43,7 @@ public final class SelectiveStreamReaders
             DateTimeZone hiveStorageTimeZone,
             AggregatedMemoryContext systemMemoryContext)
     {
-        OrcTypeKind type = streamDescriptor.getStreamType();
+        OrcTypeKind type = streamDescriptor.getOrcTypeKind();
         switch (type) {
             case BOOLEAN: {
                 checkArgument(requiredSubfields.isEmpty(), "Boolean stream reader doesn't support subfields");
@@ -71,7 +71,7 @@ public final class SelectiveStreamReaders
             case STRING:
             case VARCHAR:
             case CHAR:
-                throw new IllegalArgumentException("Unsupported type: " + streamDescriptor.getStreamType());
+                throw new IllegalArgumentException("Unsupported type: " + streamDescriptor.getOrcTypeKind());
             case TIMESTAMP: {
                 checkArgument(requiredSubfields.isEmpty(), "Timestamp stream reader doesn't support subfields");
                 return new TimestampSelectiveStreamReader(streamDescriptor, getOptionalOnlyFilter(type, filters), hiveStorageTimeZone, outputType.isPresent(), systemMemoryContext.newLocalMemoryContext(SelectiveStreamReaders.class.getSimpleName()));
@@ -107,7 +107,7 @@ public final class SelectiveStreamReaders
             DateTimeZone hiveStorageTimeZone,
             AggregatedMemoryContext systemMemoryContext)
     {
-        switch (streamDescriptor.getStreamType()) {
+        switch (streamDescriptor.getOrcTypeKind()) {
             case BOOLEAN:
             case BYTE:
             case SHORT:
@@ -142,7 +142,7 @@ public final class SelectiveStreamReaders
             case MAP:
             case UNION:
             default:
-                throw new IllegalArgumentException("Unsupported type: " + streamDescriptor.getStreamType());
+                throw new IllegalArgumentException("Unsupported type: " + streamDescriptor.getOrcTypeKind());
         }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
@@ -15,6 +15,7 @@ package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
 import com.facebook.presto.orc.TupleDomainFilter.PositionalFilter;
+import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.reader.ListFilter;
 import com.facebook.presto.spi.Subfield;
 import com.google.common.collect.ImmutableList;
@@ -196,9 +197,12 @@ public class TestListFilter
     {
         DummyOrcDataSource orcDataSource = new DummyOrcDataSource();
 
-        StreamDescriptor streamDescriptor = new StreamDescriptor("a", 0, "a", INT, orcDataSource, ImmutableList.of());
+        OrcType intType = new OrcType(INT, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty());
+        OrcType listType = new OrcType(LIST, ImmutableList.of(1), ImmutableList.of("item"), Optional.empty(), Optional.empty(), Optional.empty());
+
+        StreamDescriptor streamDescriptor = new StreamDescriptor("a", 0, "a", intType, orcDataSource, ImmutableList.of());
         for (int i = 0; i < levels; i++) {
-            streamDescriptor = new StreamDescriptor("a", 0, "a", LIST, orcDataSource, ImmutableList.of(streamDescriptor));
+            streamDescriptor = new StreamDescriptor("a", 0, "a", listType, orcDataSource, ImmutableList.of(streamDescriptor));
         }
 
         return streamDescriptor;


### PR DESCRIPTION
SelectiveStreamReaders for varchars and decimals need additional type information such as precision, scale and length. 
 
See #13306

```
== NO RELEASE NOTE ==
```