### PR TITLE
Update JDBC Identity to include query id (WIP)

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcIdentity.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcIdentity.java
@@ -26,21 +26,28 @@ public class JdbcIdentity
 {
     public static JdbcIdentity from(ConnectorSession session)
     {
-        return new JdbcIdentity(session.getIdentity().getUser(), session.getIdentity().getExtraCredentials());
+        return new JdbcIdentity(session.getIdentity().getUser(), session.getQueryId(), session.getIdentity().getExtraCredentials());
     }
 
     private final String user;
+    private final String queryId;
     private final Map<String, String> extraCredentials;
 
-    public JdbcIdentity(String user, Map<String, String> extraCredentials)
+    public JdbcIdentity(String user, String queryId, Map<String, String> extraCredentials)
     {
         this.user = requireNonNull(user, "user is null");
+        this.queryId = queryId;
         this.extraCredentials = ImmutableMap.copyOf(requireNonNull(extraCredentials, "extraCredentials is null"));
     }
 
     public String getUser()
     {
         return user;
+    }
+
+    public String getQueryId()
+    {
+        return queryId;
     }
 
     public Map<String, String> getExtraCredentials()
@@ -73,6 +80,7 @@ public class JdbcIdentity
     {
         return toStringHelper(this)
                 .add("user", user)
+                .add("queryId", queryId)
                 .add("extraCredentials", extraCredentials.keySet())
                 .toString();
     }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcRecordSetProvider.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcRecordSetProvider.java
@@ -47,7 +47,7 @@ import static org.testng.Assert.assertNotNull;
 @Test
 public class TestJdbcRecordSetProvider
 {
-    private static final JdbcIdentity IDENTITY = new JdbcIdentity("user", ImmutableMap.of());
+    private static final JdbcIdentity IDENTITY = new JdbcIdentity("user", "12345", ImmutableMap.of());
 
     private TestingDatabase database;
     private JdbcClient jdbcClient;


### PR DESCRIPTION
For: https://github.com/prestodb/presto-facebook/issues/484

I did not touch the equals/hashCode functions on JdbcIdentity as to avoid any issues with existing behaviour.

Please fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
