### PR TITLE
Add use-exact-partitioning-enabled session property

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -147,6 +147,16 @@ public class FeaturesConfig
 
     private boolean listBuiltInFunctionsOnly = true;
 
+    private PartitioningPrecisionStrategy partitioningPrecisionStrategy = PartitioningPrecisionStrategy.AUTOMATIC;
+
+    public enum PartitioningPrecisionStrategy
+    {
+        // Let Presto decide when to repartition
+        AUTOMATIC,
+        // Use exact partitioning until Presto becomes smarter WRT to picking when to repartition
+        PREFER_EXACT_PARTITIONING
+    }
+
     public enum JoinReorderingStrategy
     {
         NONE,
@@ -1144,6 +1154,19 @@ public class FeaturesConfig
     public FeaturesConfig setListBuiltInFunctionsOnly(boolean listBuiltInFunctionsOnly)
     {
         this.listBuiltInFunctionsOnly = listBuiltInFunctionsOnly;
+        return this;
+    }
+
+    public PartitioningPrecisionStrategy getPartitioningPrecisionStrategy()
+    {
+        return partitioningPrecisionStrategy;
+    }
+
+    @Config("partitioning-precision-strategy")
+    @ConfigDescription("Set strategy used to determine whether to repartition (AUTOMATIC, PREFER_EXACT)")
+    public FeaturesConfig setPartitioningPrecisionStrategy(PartitioningPrecisionStrategy partitioningPrecisionStrategy)
+    {
+        this.partitioningPrecisionStrategy = partitioningPrecisionStrategy;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableSet;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -239,6 +240,26 @@ public final class Partitioning
             }
         }
         return true;
+    }
+
+    public boolean isPartitionedOnExactly(Collection<VariableReferenceExpression> columns, Set<VariableReferenceExpression> knownConstants)
+    {
+        Set<VariableReferenceExpression> toCheck = new HashSet<>();
+        for (RowExpression argument : arguments) {
+            // partitioned on (k_1, k_2, ..., k_n) => partitioned on (k_1, k_2, ..., k_n, k_n+1, ...)
+            // can safely ignore all constant columns when comparing partition properties
+            if (argument instanceof ConstantExpression) {
+                continue;
+            }
+            if (!(argument instanceof VariableReferenceExpression)) {
+                return false;
+            }
+            if (knownConstants.contains(argument)) {
+                continue;
+            }
+            toCheck.add((VariableReferenceExpression) argument);
+        }
+        return ImmutableSet.copyOf(columns).equals(toCheck);
     }
 
     public boolean isEffectivelySinglePartition(Set<VariableReferenceExpression> knownConstants)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
@@ -378,6 +378,9 @@ public class ActualProperties
         // will be executed on multiple servers, but only one server will get all the data.
 
         // Description of whether rows with nulls in partitioning columns or some arbitrary rows have been replicated to all *nodes*
+        // When doing an IN query NULL in empty set is false, NULL in non-empty set is NULL. Say non-NULL element A (number 1) in
+        // a set that is missing A ( say 2, 3) is false, but A in (2, 3, NULL) is NULL.
+        // IN is equivalent to "a = b OR a = c OR a = d...).
         private final boolean nullsAndAnyReplicated;
 
         private Global(Optional<Partitioning> nodePartitioning, Optional<Partitioning> streamPartitioning, boolean nullsAndAnyReplicated)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
@@ -105,24 +105,34 @@ public class ActualProperties
         return global.isNullsAndAnyReplicated();
     }
 
-    public boolean isStreamPartitionedOn(Collection<VariableReferenceExpression> columns)
+    public boolean isStreamPartitionedOn(Collection<VariableReferenceExpression> columns, boolean exactly)
     {
-        return isStreamPartitionedOn(columns, false);
+        return isStreamPartitionedOn(columns, false, exactly);
     }
 
-    public boolean isStreamPartitionedOn(Collection<VariableReferenceExpression> columns, boolean nullsAndAnyReplicated)
+    public boolean isStreamPartitionedOn(Collection<VariableReferenceExpression> columns, boolean nullsAndAnyReplicated, boolean exactly)
     {
-        return global.isStreamPartitionedOn(columns, constants.keySet(), nullsAndAnyReplicated);
+        if (exactly) {
+            return global.isStreamPartitionedOnExactly(columns, constants.keySet(), nullsAndAnyReplicated);
+        }
+        else {
+            return global.isStreamPartitionedOn(columns, constants.keySet(), nullsAndAnyReplicated);
+        }
     }
 
-    public boolean isNodePartitionedOn(Collection<VariableReferenceExpression> columns)
+    public boolean isNodePartitionedOn(Collection<VariableReferenceExpression> columns, boolean exactly)
     {
-        return isNodePartitionedOn(columns, false);
+        return isNodePartitionedOn(columns, false, exactly);
     }
 
-    public boolean isNodePartitionedOn(Collection<VariableReferenceExpression> columns, boolean nullsAndAnyReplicated)
+    public boolean isNodePartitionedOn(Collection<VariableReferenceExpression> columns, boolean nullsAndAnyReplicated, boolean exactly)
     {
-        return global.isNodePartitionedOn(columns, constants.keySet(), nullsAndAnyReplicated);
+        if (exactly) {
+            return global.isNodePartitionedOnExactly(columns, constants.keySet(), nullsAndAnyReplicated);
+        }
+        else {
+            return global.isNodePartitionedOn(columns, constants.keySet(), nullsAndAnyReplicated);
+        }
     }
 
     @Deprecated
@@ -471,6 +481,11 @@ public class ActualProperties
             return nodePartitioning.isPresent() && nodePartitioning.get().isPartitionedOn(columns, constants) && this.nullsAndAnyReplicated == nullsAndAnyReplicated;
         }
 
+        private boolean isNodePartitionedOnExactly(Collection<VariableReferenceExpression> columns, Set<VariableReferenceExpression> constants, boolean nullsAndAnyReplicated)
+        {
+            return nodePartitioning.isPresent() && nodePartitioning.get().isPartitionedOnExactly(columns, constants) && this.nullsAndAnyReplicated == nullsAndAnyReplicated;
+        }
+
         private boolean isCompatibleTablePartitioningWith(Partitioning partitioning, boolean nullsAndAnyReplicated, Metadata metadata, Session session)
         {
             return nodePartitioning.isPresent() && nodePartitioning.get().isCompatibleWith(partitioning, metadata, session) && this.nullsAndAnyReplicated == nullsAndAnyReplicated;
@@ -529,6 +544,11 @@ public class ActualProperties
         private boolean isStreamPartitionedOn(Collection<VariableReferenceExpression> columns, Set<VariableReferenceExpression> constants, boolean nullsAndAnyReplicated)
         {
             return streamPartitioning.isPresent() && streamPartitioning.get().isPartitionedOn(columns, constants) && this.nullsAndAnyReplicated == nullsAndAnyReplicated;
+        }
+
+        private boolean isStreamPartitionedOnExactly(Collection<VariableReferenceExpression> columns, Set<VariableReferenceExpression> constants, boolean nullsAndAnyReplicated)
+        {
+            return streamPartitioning.isPresent() && streamPartitioning.get().isPartitionedOnExactly(columns, constants) && this.nullsAndAnyReplicated == nullsAndAnyReplicated;
         }
 
         /**

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.configuration.testing.ConfigAssertions;
 import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggGroupImplementation;
 import com.facebook.presto.operator.aggregation.histogram.HistogramGroupImplementation;
 import com.facebook.presto.operator.aggregation.multimapagg.MultimapAggGroupImplementation;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.PartitioningPrecisionStrategy;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -125,7 +126,8 @@ public class TestFeaturesConfig
                 .setOptimizeFullOuterJoinWithCoalesce(true)
                 .setIndexLoaderTimeout(new Duration(20, SECONDS))
                 .setOptimizedRepartitioningEnabled(false)
-                .setListBuiltInFunctionsOnly(true));
+                .setListBuiltInFunctionsOnly(true)
+                .setPartitioningPrecisionStrategy(PartitioningPrecisionStrategy.AUTOMATIC));
     }
 
     @Test
@@ -208,6 +210,7 @@ public class TestFeaturesConfig
                 .put("index-loader-timeout", "10s")
                 .put("experimental.optimized-repartitioning", "true")
                 .put("list-built-in-functions-only", "false")
+                .put("partitioning-precision-strategy", "PREFER_EXACT_PARTITIONING")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -286,7 +289,8 @@ public class TestFeaturesConfig
                 .setOptimizeFullOuterJoinWithCoalesce(false)
                 .setIndexLoaderTimeout(new Duration(10, SECONDS))
                 .setOptimizedRepartitioningEnabled(true)
-                .setListBuiltInFunctionsOnly(false);
+                .setListBuiltInFunctionsOnly(false)
+                .setPartitioningPrecisionStrategy(PartitioningPrecisionStrategy.PREFER_EXACT_PARTITIONING);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlans.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlans.java
@@ -15,29 +15,40 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.testing.TestingSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.SystemSessionProperties.AGGREGATION_PARTITIONING_MERGING_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.TASK_CONCURRENCY;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.SINGLE;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anySymbol;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
@@ -179,5 +190,242 @@ public class TestAddExchangesPlans
                                 anyTree(exchange(REMOTE_STREAMING, REPARTITION,
                                         anyTree(node(AggregationNode.class,
                                                 anyTree(tableScan("orders"))))))))));
+    }
+
+    @Test
+    public void testAggregateIsExactlyPartitioned()
+    {
+        assertExactDistributedPlan(
+                "SELECT\n" +
+                        "    AVG(1)\n" +
+                        "FROM (\n" +
+                        "    SELECT\n" +
+                        "        orderkey,\n" +
+                        "        orderstatus,\n" +
+                        "        COUNT(*)\n" +
+                        "    FROM orders\n" +
+                        "    WHERE\n" +
+                        "        orderdate > CAST('2042-01-01' AS DATE)\n" +
+                        "    GROUP BY\n" +
+                        "        orderkey,\n" +
+                        "        orderstatus\n" +
+                        ")\n" +
+                        "GROUP BY\n" +
+                        "    orderkey",
+                anyTree(
+                        exchange(REMOTE_STREAMING, REPARTITION,
+                                anyTree(
+                                        exchange(REMOTE_STREAMING, REPARTITION,
+                                                anyTree(
+                                                        tableScan("orders", ImmutableMap.of(
+                                                                "ordertatus", "orderstatus",
+                                                                "orderkey", "orderkey",
+                                                                "orderdate", "orderdate"))))))));
+    }
+
+    @Test
+    public void testWindowIsExactlyPartitioned()
+    {
+        assertExactDistributedPlan(
+                "SELECT\n" +
+                        "    AVG(otherwindow) OVER (\n" +
+                        "        PARTITION BY\n" +
+                        "            orderkey\n" +
+                        "    )\n" +
+                        "FROM (\n" +
+                        "    SELECT\n" +
+                        "        orderkey,\n" +
+                        "        orderstatus,\n" +
+                        "        COUNT(*) OVER (\n" +
+                        "            PARTITION BY\n" +
+                        "                orderkey,\n" +
+                        "                orderstatus\n" +
+                        "        ) AS otherwindow\n" +
+                        "    FROM orders\n" +
+                        "    WHERE\n" +
+                        "        orderdate > CAST('2042-01-01' AS DATE)\n" +
+                        ")",
+                anyTree(
+                        exchange(REMOTE_STREAMING, REPARTITION,
+                                anyTree(
+                                        exchange(REMOTE_STREAMING, REPARTITION,
+                                                anyTree(
+                                                        tableScan("orders", ImmutableMap.of(
+                                                                "orderkey", "orderkey",
+                                                                "orderdate", "orderdate"))))))));
+    }
+
+    @Test
+    public void testRowNumberIsExactlyPartitioned()
+    {
+        assertExactDistributedPlan(
+                "SELECT\n" +
+                        "    *\n" +
+                        "FROM (\n" +
+                        "    SELECT\n" +
+                        "        a,\n" +
+                        "        ROW_NUMBER() OVER (\n" +
+                        "            PARTITION BY\n" +
+                        "                a\n" +
+                        "        ) rn\n" +
+                        "    FROM (\n" +
+                        "        VALUES\n" +
+                        "            (1)\n" +
+                        "    ) t (a)\n" +
+                        ") t",
+                anyTree(
+                        exchange(REMOTE_STREAMING, REPARTITION,
+                                anyTree(
+                                        values("a")))));
+    }
+
+    @Test
+    public void testTopNRowNumberIsExactlyPartitioned()
+    {
+        assertExactDistributedPlan(
+                "SELECT\n" +
+                        "    a,\n" +
+                        "    ROW_NUMBER() OVER (\n" +
+                        "        PARTITION BY\n" +
+                        "            a\n" +
+                        "        ORDER BY\n" +
+                        "            a\n" +
+                        "    ) rn\n" +
+                        "FROM (\n" +
+                        "    SELECT\n" +
+                        "        a,\n" +
+                        "        b,\n" +
+                        "        COUNT(*)\n" +
+                        "    FROM (\n" +
+                        "        VALUES\n" +
+                        "            (1, 2)\n" +
+                        "    ) t (a, b)\n" +
+                        "    GROUP BY\n" +
+                        "        a,\n" +
+                        "        b\n" +
+                        ")\n" +
+                        "LIMIT\n" +
+                        "    2",
+                anyTree(
+                        exchange(REMOTE_STREAMING, REPARTITION,
+                                anyTree(
+                                        values("a", "b")))));
+    }
+
+    @Test
+    public void testJoinExactlyPartitioned()
+    {
+        ExpectedValueProvider<FunctionCall> arbitrary = PlanMatchPattern.functionCall("arbitrary", false, ImmutableList.of(anySymbol()));
+        assertExactDistributedPlan(
+                "SELECT\n" +
+                        "    orders.orderkey,\n" +
+                        "    orders.orderstatus\n" +
+                        "FROM (\n" +
+                        "    SELECT\n" +
+                        "        orderkey,\n" +
+                        "        ARBITRARY(orderstatus) AS orderstatus,\n" +
+                        "        COUNT(*)\n" +
+                        "    FROM orders\n" +
+                        "    GROUP BY\n" +
+                        "        orderkey\n" +
+                        ") t,\n" +
+                        "orders\n" +
+                        "WHERE\n" +
+                        "    orders.orderkey = t.orderkey\n" +
+                        "    AND orders.orderstatus = t.orderstatus",
+                anyTree(
+                        join(INNER, ImmutableList.of(
+                                equiJoinClause("ORDERKEY_LEFT", "ORDERKEY_RIGHT"),
+                                equiJoinClause("orderstatus", "ORDERSTATUS_RIGHT")),
+                                exchange(REMOTE_STREAMING, REPARTITION,
+                                        anyTree(
+                                                aggregation(
+                                                        singleGroupingSet("ORDERKEY_LEFT"),
+                                                        ImmutableMap.of(Optional.of("orderstatus"), arbitrary),
+                                                        ImmutableList.of("ORDERKEY_LEFT"),
+                                                        ImmutableMap.of(),
+                                                        Optional.empty(),
+                                                        SINGLE,
+                                                        tableScan("orders", ImmutableMap.of(
+                                                                "ORDERKEY_LEFT", "orderkey",
+                                                                "ORDERSTATUS_LEFT", "orderstatus"))))),
+                                exchange(LOCAL, REPARTITION,
+                                        exchange(REMOTE_STREAMING, REPARTITION,
+                                                anyTree(
+                                                        tableScan("orders", ImmutableMap.of(
+                                                                "ORDERKEY_RIGHT", "orderkey",
+                                                                "ORDERSTATUS_RIGHT", "orderstatus"))))))));
+    }
+
+    @Test
+    public void testSemiJoinExactlyPartitioned()
+    {
+        assertExactDistributedPlan(
+                "SELECT\n" +
+                        "    orderkey\n" +
+                        "FROM orders\n" +
+                        "WHERE\n" +
+                        "    orderkey IN (\n" +
+                        "        SELECT\n" +
+                        "            orderkey\n" +
+                        "        FROM orders\n" +
+                        "        WHERE\n" +
+                        "            orderkey IS NULL\n" +
+                        "            AND orderstatus IS NULL\n" +
+                        "    )",
+                anyTree(
+                        semiJoin("ORDERKEY_OK", "VALUE_ORDERKEY", "S",
+                                exchange(REMOTE_STREAMING, REPARTITION,
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of(
+                                                        "ORDERKEY_OK", "orderkey")))),
+                                anyTree(
+
+                                        exchange(REMOTE_STREAMING, REPARTITION,
+                                                anyTree(
+                                                        values("VALUE_ORDERKEY")))))));
+    }
+
+    @Test
+    public void testMarkDistinctIsExactlyPartitioned()
+    {
+        assertExactDistributedPlan(
+                "    SELECT\n" +
+                        "        orderkey,\n" +
+                        "        orderstatus,\n" +
+                        "        COUNT(DISTINCT orderdate),\n" +
+                        "        COUNT(DISTINCT clerk)\n" +
+                        "    FROM orders\n" +
+                        "    WHERE\n" +
+                        "        orderdate > CAST('2042-01-01' AS DATE)\n" +
+                        "    GROUP BY\n" +
+                        "        orderkey,\n" +
+                        "        orderstatus\n",
+                anyTree(
+                        exchange(REMOTE_STREAMING, REPARTITION,
+                                anyTree(
+                                        exchange(REMOTE_STREAMING, REPARTITION,
+                                                anyTree(
+                                                        exchange(REMOTE_STREAMING, REPARTITION,
+                                                                anyTree(
+                                                                        tableScan("orders", ImmutableMap.of(
+                                                                                "orderstatus", "orderstatus",
+                                                                                "orderkey", "orderkey",
+                                                                                "clerk", "clerk",
+                                                                                "orderdate", "orderdate"))))))))));
+    }
+
+    void assertExactDistributedPlan(String sql, PlanMatchPattern pattern)
+    {
+        assertDistributedPlan(
+                sql,
+                TestingSession.testSessionBuilder()
+                        .setCatalog("local")
+                        .setSchema("tiny")
+                        .setSystemProperty(
+                                SystemSessionProperties.PARTITIONING_PRECISION_STRATEGY,
+                                FeaturesConfig.PartitioningPrecisionStrategy.PREFER_EXACT_PARTITIONING.toString())
+                        .build(),
+                pattern);
     }
 }


### PR DESCRIPTION
When enabled this forces exchanges to occur unless the partitioning matches exactly

```
== RELEASE NOTES ==

General Changes
* Add use_exact_partitioning session property that forces repartitioning if repartitioning is possible
```