### PR TITLE
Fix MapBlock.ensureHashTableLoaded

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/MapBlock.java
@@ -333,9 +333,10 @@ public class MapBlock
                 return;
             }
 
-            int[] hashTables = new int[getRawKeyBlock().getPositionCount() * HASH_MULTIPLIER];
+            int keyPositionCount = getRawKeyBlock().getPositionCount();
+            int[] hashTables = new int[keyPositionCount * HASH_MULTIPLIER];
             Arrays.fill(hashTables, -1);
-            for (int i = startOffset; i < startOffset + positionCount; i++) {
+            for (int i = 0; i < offsets.length - 1; i++) {
                 int keyOffset = offsets[i];
                 int keyCount = offsets[i + 1] - keyOffset;
                 if (keyCount < 0) {
@@ -352,6 +353,10 @@ public class MapBlock
                         hashTables,
                         keyOffset * HASH_MULTIPLIER,
                         keyCount * HASH_MULTIPLIER);
+
+                if (offsets[i + 1] == keyPositionCount) {
+                    break;
+                }
             }
             this.hashTables.set(hashTables);
         }


### PR DESCRIPTION
Selective stream readers reuse `nulls` and `offsets` arrays and therefore may create `MapBlock`s where the size of `offsets` array is larger then the number of entries in the block. Hence, MapBlock logic cannot rely on offsets.length. #13277 changed ensureHashTableLoaded to only use `startOffset + positionCount` entries from `offsets`, but this is not correct. When `ensureHashTableLoaded` is invoked on a sub-region of a `MapBlock`, it will miss creating hash tables for the entries at the end of the block. This commit is changing the logic to iterate over `offsets` until `keyPositionCount` offset value is reached and adds test cases that reproduce the original bug.

```
== NO RELEASE NOTE ==
```
