### PR TITLE
Fix issue "PlanPrinter prints "PartialSort" for the only sort when distributed sort is enabled"

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -908,7 +908,7 @@ class QueryPlanner
             planNode = new TopNNode(idAllocator.getNextId(), subPlan.getRoot(), Long.parseLong(limit.get()), orderingScheme, TopNNode.Step.SINGLE);
         }
         else {
-            planNode = new SortNode(idAllocator.getNextId(), subPlan.getRoot(), orderingScheme);
+            planNode = new SortNode(idAllocator.getNextId(), subPlan.getRoot(), orderingScheme, false);
         }
 
         return subPlan.withNewRoot(planNode);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -490,7 +490,8 @@ public class AddExchanges
                                 new SortNode(
                                         idAllocator.getNextId(),
                                         source,
-                                        node.getOrderingScheme()),
+                                        node.getOrderingScheme(),
+                                        true),
                                 node.getOrderingScheme()),
                         child.getProperties());
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/LimitPushDown.java
@@ -194,7 +194,7 @@ public class LimitPushDown
                 return new TopNNode(node.getId(), rewrittenSource, limit.getCount(), node.getOrderingScheme(), TopNNode.Step.SINGLE);
             }
             else if (rewrittenSource != node.getSource()) {
-                return new SortNode(node.getId(), rewrittenSource, node.getOrderingScheme());
+                return new SortNode(node.getId(), rewrittenSource, node.getOrderingScheme(), node.isPartial());
             }
             return node;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -659,7 +659,7 @@ public class PruneUnreferencedOutputs
 
             PlanNode source = context.rewrite(node.getSource(), expectedInputs);
 
-            return new SortNode(node.getId(), source, node.getOrderingScheme());
+            return new SortNode(node.getId(), source, node.getOrderingScheme(), node.isPartial());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -513,7 +513,7 @@ public class UnaliasSymbolReferences
         {
             PlanNode source = context.rewrite(node.getSource());
 
-            return new SortNode(node.getId(), source, canonicalizeAndDistinct(node.getOrderingScheme()));
+            return new SortNode(node.getId(), source, canonicalizeAndDistinct(node.getOrderingScheme()), node.isPartial());
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SortNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SortNode.java
@@ -31,11 +31,13 @@ public class SortNode
 {
     private final PlanNode source;
     private final OrderingScheme orderingScheme;
+    private final boolean isPartial;
 
     @JsonCreator
     public SortNode(@JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
-            @JsonProperty("orderingScheme") OrderingScheme orderingScheme)
+            @JsonProperty("orderingScheme") OrderingScheme orderingScheme,
+            @JsonProperty("isPartial") boolean isPartial)
     {
         super(id);
 
@@ -44,6 +46,7 @@ public class SortNode
 
         this.source = source;
         this.orderingScheme = orderingScheme;
+        this.isPartial = isPartial;
     }
 
     @Override
@@ -70,6 +73,12 @@ public class SortNode
         return orderingScheme;
     }
 
+    @JsonProperty("isPartial")
+    public boolean isPartial()
+    {
+        return isPartial;
+    }
+
     @Override
     public <R, C> R accept(InternalPlanVisitor<R, C> visitor, C context)
     {
@@ -79,6 +88,6 @@ public class SortNode
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
-        return new SortNode(getId(), Iterables.getOnlyElement(newChildren), orderingScheme);
+        return new SortNode(getId(), Iterables.getOnlyElement(newChildren), orderingScheme, isPartial);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.sql.planner.planPrinter;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.cost.PlanCostEstimate;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.cost.StatsAndCosts;
@@ -861,13 +860,9 @@ public class PlanPrinter
         public Void visitSort(SortNode node, Void context)
         {
             Iterable<String> keys = Iterables.transform(node.getOrderingScheme().getOrderByVariables(), input -> input + " " + node.getOrderingScheme().getOrdering(input));
-            boolean isPartial = false;
-            if (SystemSessionProperties.isDistributedSortEnabled(session)) {
-                isPartial = true;
-            }
 
             addNode(node,
-                    format("%sSort", isPartial ? "Partial" : ""),
+                    format("%sSort", node.isPartial() ? "Partial" : ""),
                     format("[%s]", Joiner.on(", ").join(keys)));
 
             return processChildren(node, context);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -286,7 +286,8 @@ public class TestEffectivePredicateExtractor
                                 equals(AE, BE),
                                 equals(BE, CE),
                                 lessThan(CE, bigintLiteral(10)))),
-                new OrderingScheme(ImmutableList.of(new Ordering(AV, SortOrder.ASC_NULLS_LAST))));
+                new OrderingScheme(ImmutableList.of(new Ordering(AV, SortOrder.ASC_NULLS_LAST))),
+                false);
 
         Expression effectivePredicate = effectivePredicateExtractor.extract(node, types);
 


### PR DESCRIPTION
Fix issue related in https://github.com/prestodb/presto/issues/12087

The logic can be explained like if there is no AddExchange happened (no data exchange between the node), the plan display should be Sort. Otherwise, it would display PartialSort. From my understanding, this way we don't need to fetch any information from session property to do the validation.

@rschlussel 

General Changes
* Add isPartial (default `false`) in SortNode constructor and keep it immutable.
* The value `true` would be only set by AddExchanges, so it would display PartialSort in this case.
* Remove session property checking in PlanPrinter, since the value is extracted from SortNode directly.

```
== NO RELEASE NOTE ==
```
