### PR TITLE
Fix struct and map selective readers for filter-only columns

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -290,6 +290,9 @@ public class TestHivePushdownFilterQueries
 
             assertQueryUsingH2Cte("SELECT map_keys[1], map_flags[2] FROM test_maps WHERE map_keys IS NOT NULL AND map_flags IS NOT NULL AND map_keys[1] % 2 = 0", rewriter);
 
+            // filter-only map
+            assertQueryUsingH2Cte("SELECT linenumber FROM test_maps WHERE map_keys IS NOT NULL", rewriter);
+
             assertQueryFails("SELECT map_keys[5] FROM test_maps WHERE map_keys[1] % 2 = 0", "Key not present in map: 5");
             assertQueryFails("SELECT map_keys[5] FROM test_maps WHERE map_keys[4] % 2 = 0", "Key not present in map: 4");
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -411,6 +411,9 @@ public class TestHivePushdownFilterQueries
         assertQueryUsingH2Cte("SELECT dates FROM lineitem_ex WHERE dates[1].day % 2 = 0", rewriter);
 
         assertQueryUsingH2Cte("SELECT info.orderkey, dates FROM lineitem_ex WHERE info IS NOT NULL AND dates IS NOT NULL AND info.orderkey % 7 = 0", rewriter);
+
+        // filter-only struct
+        assertQueryUsingH2Cte("SELECT orderkey FROM lineitem_ex WHERE info IS NOT NULL");
     }
 
     private void assertFilterProject(String filter, String projections)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractDecimalSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractDecimalSelectiveStreamReader.java
@@ -83,6 +83,9 @@ public abstract class AbstractDecimalSelectiveStreamReader
             LocalMemoryContext systemMemoryContext,
             int valuesPerPosition)
     {
+        requireNonNull(filter, "filter is null");
+        requireNonNull(outputType, "outputType is null");
+        checkArgument(filter.isPresent() || outputType.isPresent(), "filter must be present if output is not required");
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
         this.filter = filter.orElse(null);
         this.outputRequired = outputType.isPresent();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractLongSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractLongSelectiveStreamReader.java
@@ -61,8 +61,8 @@ abstract class AbstractLongSelectiveStreamReader
 
     protected AbstractLongSelectiveStreamReader(Optional<Type> outputType)
     {
-        this.outputRequired = outputType.isPresent();
-        this.outputType = requireNonNull(outputType, "outputType is null").orElse(null);
+        this.outputRequired = requireNonNull(outputType, "outputType is null").isPresent();
+        this.outputType = outputType.orElse(null);
     }
 
     protected void prepareNextRead(int positionCount, boolean withNulls)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
@@ -86,6 +86,8 @@ public class ByteSelectiveStreamReader
             boolean outputRequired,
             LocalMemoryContext systemMemoryContext)
     {
+        requireNonNull(filter, "filter is null");
+        checkArgument(filter.isPresent() || outputRequired, "filter must be present if outputRequired is false");
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
         this.filter = filter.orElse(null);
         this.outputRequired = outputRequired;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatSelectiveStreamReader.java
@@ -79,6 +79,8 @@ public class FloatSelectiveStreamReader
             boolean outputRequired,
             LocalMemoryContext systemMemoryContext)
     {
+        requireNonNull(filter, "filter is null");
+        checkArgument(filter.isPresent() || outputRequired, "filter must be present if outputRequired is false");
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
         this.filter = filter.orElse(null);
         this.outputRequired = outputRequired;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
@@ -85,8 +85,10 @@ public class LongDictionarySelectiveStreamReader
             LocalMemoryContext systemMemoryContext)
     {
         super(outputType);
+        requireNonNull(filter, "filter is null");
+        checkArgument(filter.isPresent() || outputRequired, "filter must be present if output is not required");
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
-        this.filter = requireNonNull(filter, "filter is null").orElse(null);
+        this.filter = filter.orElse(null);
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
 
         nonDeterministicFilter = this.filter != null && !this.filter.isDeterministic();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
@@ -76,8 +76,10 @@ public class LongDirectSelectiveStreamReader
             LocalMemoryContext systemMemoryContext)
     {
         super(outputType);
+        requireNonNull(filter, "filter is null");
+        checkArgument(filter.isPresent() || outputRequired, "filter must be present if output is not required");
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
-        this.filter = requireNonNull(filter, "filter is null").orElse(null);
+        this.filter = filter.orElse(null);
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
 
         nonDeterministicFilter = this.filter != null && !this.filter.isDeterministic();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
@@ -92,6 +92,8 @@ public class TimestampSelectiveStreamReader
             boolean outputRequired,
             LocalMemoryContext systemMemoryContext)
     {
+        requireNonNull(filter, "filter is null");
+        checkArgument(filter.isPresent() || outputRequired, "filter must be present if outputRequired is false");
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
         this.filter = filter.orElse(null);
         this.outputRequired = outputRequired;


### PR DESCRIPTION
Fix queries where complex type columns are used for filtering but are not projected out. 

For example: `SELECT a FROM t WHERE b IS NOT NULL`, where `b` is a map or a struct.

```
== NO RELEASE NOTE ==
```
