### PR TITLE
Do not extract range filters for complex types

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1725,7 +1725,7 @@ public class HiveMetadata
         //  - range filters that apply to subfields,
         //  - the rest
         ExtractionResult<Subfield> decomposedFilter = rowExpressionService.getDomainTranslator()
-                .fromPredicate(session, filter, new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(), session));
+                .fromPredicate(session, filter, new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(), session).toColumnExtractor());
 
         Map<String, ColumnHandle> columnHandles = getColumnHandles(session, tableHandle);
         TupleDomain<ColumnHandle> entireColumnDomain = decomposedFilter.getTupleDomain()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
@@ -23,7 +23,10 @@ import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.RowType;
+import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 
 import java.util.ArrayList;
@@ -37,7 +40,6 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 public final class SubfieldExtractor
-        implements DomainTranslator.ColumnExtractor<Subfield>
 {
     private final StandardFunctionResolution functionResolution;
     private final ExpressionOptimizer expressionOptimizer;
@@ -53,7 +55,21 @@ public final class SubfieldExtractor
         this.connectorSession = requireNonNull(connectorSession, "connectorSession is null");
     }
 
-    @Override
+    public DomainTranslator.ColumnExtractor toColumnExtractor()
+    {
+        return (expression, domain) -> {
+            // Only allow null checks on complex types
+            Type type = expression.getType();
+            if (type instanceof ArrayType || type instanceof MapType || type instanceof RowType) {
+                if (!domain.isOnlyNull() && !(domain.getValues().isAll() && !domain.isNullAllowed())) {
+                    return Optional.empty();
+                }
+            }
+
+            return extract(expression);
+        };
+    }
+
     public Optional<Subfield> extract(RowExpression expression)
     {
         return toSubfield(expression, functionResolution, expressionOptimizer, connectorSession);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.hive.HiveTestUtils.mapType;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.spi.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
@@ -56,7 +57,6 @@ import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.specialForm;
-import static com.facebook.presto.util.Reflection.methodHandle;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.testng.Assert.assertEquals;
 
@@ -142,22 +142,6 @@ public class TestDomainTranslator
                 operator(SUBSCRIPT, mapType(mapType.getKeyType(), mapType.getValueType()), mapType.getKeyType()),
                 mapType.getValueType(),
                 ImmutableList.of(mapExpression, keyExpression));
-    }
-
-    private static MapType mapType(Type keyType, Type valueType)
-    {
-        return new MapType(
-                keyType,
-                valueType,
-                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"),
-                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"),
-                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"),
-                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"));
-    }
-
-    public static void throwUnsupportedOperationException()
-    {
-        throw new UnsupportedOperationException();
     }
 
     private FunctionHandle operator(OperatorType operatorType, Type... types)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -293,6 +293,9 @@ public class TestHivePushdownFilterQueries
             // filter-only map
             assertQueryUsingH2Cte("SELECT linenumber FROM test_maps WHERE map_keys IS NOT NULL", rewriter);
 
+            // equality filter
+            assertQuery("SELECT orderkey FROM test_maps WHERE map_flags = MAP(ARRAY[1, 2], ARRAY[true, true])", "SELECT orderkey FROM lineitem WHERE orderkey % 17 <> 0 AND shipmode = 'AIR' AND returnflag = 'R'");
+
             assertQueryFails("SELECT map_keys[5] FROM test_maps WHERE map_keys[1] % 2 = 0", "Key not present in map: 5");
             assertQueryFails("SELECT map_keys[5] FROM test_maps WHERE map_keys[4] % 2 = 0", "Key not present in map: 4");
         }
@@ -376,6 +379,9 @@ public class TestHivePushdownFilterQueries
         assertFilterProject("nested_keys[3] IS NOT NULL AND nested_keys[1][2] > 10", "keys, flags");
         assertFilterProject("nested_keys IS NOT NULL AND nested_keys[3] IS NOT NULL AND nested_keys[1][1] > 0", "keys");
         assertFilterProject("nested_keys IS NOT NULL AND nested_keys[3] IS NULL AND nested_keys[1][1] > 0", "keys");
+
+        // equality filter
+        assertQuery("SELECT orderkey FROM lineitem_ex WHERE keys = ARRAY[1, 22, 48]", "SELECT orderkey FROM lineitem WHERE orderkey = 1 AND partkey = 22 AND suppkey = 48");
 
         assertFilterProjectFails("keys[5] > 0", "orderkey", "Array subscript out of bounds");
         assertFilterProjectFails("nested_keys[5][1] > 0", "orderkey", "Array subscript out of bounds");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestSubfieldExtractor.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestSubfieldExtractor.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static com.facebook.presto.hive.HiveTestUtils.mapType;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.spi.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.DEREFERENCE;
@@ -44,7 +45,6 @@ import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.specialForm;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
-import static com.facebook.presto.util.Reflection.methodHandle;
 
 public class TestSubfieldExtractor
 {
@@ -116,22 +116,6 @@ public class TestSubfieldExtractor
                 operator(SUBSCRIPT, mapType(mapType.getKeyType(), mapType.getValueType()), mapType.getKeyType()),
                 mapType.getValueType(),
                 ImmutableList.of(mapExpression, keyExpression));
-    }
-
-    private static MapType mapType(Type keyType, Type valueType)
-    {
-        return new MapType(
-                keyType,
-                valueType,
-                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"),
-                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"),
-                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"),
-                methodHandle(TestDomainTranslator.class, "throwUnsupportedOperationException"));
-    }
-
-    public static void throwUnsupportedOperationException()
-    {
-        throw new UnsupportedOperationException();
     }
 
     private FunctionHandle operator(OperatorType operatorType, Type... types)

--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 
@@ -28,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -43,6 +45,7 @@ import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_W
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static com.facebook.presto.util.StructuralTestUtil.appendToBlockBuilder;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.Float.floatToRawIntBits;
@@ -176,6 +179,18 @@ public final class BlockAssertions
         }
 
         return builder.build();
+    }
+
+    public static <K, V> Block createMapBlock(MapType type, Map<K, V> map)
+    {
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, map.size());
+        for (Map.Entry<K, V> entry : map.entrySet()) {
+            BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+            appendToBlockBuilder(BIGINT, entry.getKey(), entryBuilder);
+            appendToBlockBuilder(BIGINT, entry.getValue(), entryBuilder);
+            blockBuilder.closeEntry();
+        }
+        return blockBuilder.build();
     }
 
     public static Block createBooleansBlock(Boolean... values)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/DomainTranslator.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/DomainTranslator.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.relation;
 
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.TupleDomain;
 
 import java.util.Optional;
@@ -24,7 +25,13 @@ public interface DomainTranslator
 {
     interface ColumnExtractor<T>
     {
-        Optional<T> extract(RowExpression expression);
+        /**
+         * Given an expression and values domain, determine whether the expression qualifies as a
+         * "column" and return its desired representation.
+         *
+         * Return Optional.empty() if expression doesn't qualify.
+         */
+        Optional<T> extract(RowExpression expression, Domain domain);
     }
 
     RowExpression toPredicate(TupleDomain<VariableReferenceExpression> tupleDomain);
@@ -59,7 +66,7 @@ public interface DomainTranslator
         }
     }
 
-    ColumnExtractor<VariableReferenceExpression> BASIC_COLUMN_EXTRACTOR = expression -> {
+    ColumnExtractor<VariableReferenceExpression> BASIC_COLUMN_EXTRACTOR = (expression, domain) -> {
         if (expression instanceof VariableReferenceExpression) {
             return Optional.of((VariableReferenceExpression) expression);
         }


### PR DESCRIPTION
Selective readers cannot handle range filters other than null checks for
complex types (arrays, maps, and structs), e.g. a = ARRAY[1, 2, 3]. This
change extends DomainTranslator.ColumnExtractor to provide values domain
and updates HiveMetadata to provide an implementation of ColumnExtractor
that excludes non-null check filters for complex types.

Fixes #13295

```
== NO RELEASE NOTE ==
```
