### PR TITLE
Reduce running time of presto-hive Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
     - TEST_SPECIFIC_MODULES=presto-hive
     - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-materialized"
     - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-recoverable-grouped-execution"
+    - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-pushdown-filter-queries"
+    - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-parquet"
     - TEST_SPECIFIC_MODULES=presto-main
     - TEST_SPECIFIC_MODULES=presto-mongodb
     - TEST_OTHER_MODULES=!presto-tests,!presto-raptor,!presto-accumulo,!presto-cassandra,!presto-hive,!presto-kudu,!presto-docs,!presto-server,!presto-server-rpm,!presto-main,!presto-mongodb

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -380,6 +380,8 @@
                                 <exclude>**/TestHiveDistributedAggregationsWithExchangeMaterialization.java</exclude>
                                 <exclude>**/TestHiveDistributedQueriesWithExchangeMaterialization.java</exclude>
                                 <exclude>**/TestHiveRecoverableGroupedExecution.java</exclude>
+                                <exclude>**/TestHivePushdownFilterQueries.java</exclude>
+                                <exclude>**/TestParquetDistributedQueries.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -429,6 +431,38 @@
                         <configuration>
                             <includes>
                                 <include>**/TestHiveRecoverableGroupedExecution.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-hive-pushdown-filter-queries</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/TestHivePushdownFilterQueries.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-hive-parquet</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/TestParquetDistributedQueries.java</include>
                             </includes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
presto-hive Travis job regularly times out after 1 hour and 20 minutes. This change is to move some of the longer running tests into separate jobs. Specifically, move TestHivePushdownFilterQueries and TestParquetDistributedQueries into their own jobs. With these changes presto-hive job completes in about 45 min.

<img width="1282" alt="Screen Shot 2019-09-18 at 10 42 10 PM" src="https://user-images.githubusercontent.com/27965151/65209301-ac5f7580-da65-11e9-9edc-1c4f11272b5a.png">


```
== NO RELEASE NOTE ==
```
