### PR TITLE
[WIP] Add ST_Centroid for points, lines and polygons on a sphere

### DIFF
--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -1476,10 +1476,8 @@ public final class GeoFunctions
         {
             double[] sum = {0, 0, 0};
             int pointCount = multiPoint.getPointCount();
-            Point point = new Point();
             for (int i = 0; i < pointCount; i++) {
-                multiPoint.getXY(i, point.getXY());
-                double[] cartesianCoordinate = toCartesian(point.getY(), point.getX());
+                double[] cartesianCoordinate = toCartesian(multiPoint.getPoint(i).getY(), multiPoint.getPoint(i).getX());
                 sum[0] += cartesianCoordinate[0];
                 sum[1] += cartesianCoordinate[1];
                 sum[2] += cartesianCoordinate[2];
@@ -1488,6 +1486,9 @@ public final class GeoFunctions
             // Lickely this point is the center of the sphere, so we can't find a centroid on the surface, as we are in balance with all the points
             if (sum[0] < Math.pow(10, -9) && sum[1] < Math.pow(10, -9) && sum[2] < Math.pow(10, -9)) {
                 return null;
+            }
+            if (sum[0] > 0) {
+                throw new UnsupportedOperationException("punti " + pointCount + " summa " + sum[0] + " " + sum[1] + " " + sum[2]);
             }
             double[] surfaceCoordinates = toSurfaceCoordinates(sum[0], sum[1], sum[2], pointCount);
             double[] latLon = toLatitudeLongitude(surfaceCoordinates[0], surfaceCoordinates[1], surfaceCoordinates[2]);

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.plugin.geospatial;
 
+import com.esri.core.geometry.Point;
+import com.esri.core.geometry.ogc.OGCPoint;
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
@@ -250,5 +252,46 @@ public class TestSphericalGeoFunctions
         else {
             assertFunction(format("ROUND(ABS((%s / %f) - 1.0) / %f, 0)", function, expectedLength, 1e-4), DOUBLE, 0.0);
         }
+    }
+
+    @Test
+    public void testCentroid()
+    {
+        Point centroid = new Point(0, 0);
+
+        // Empty linestring returns null
+        assertCentroid("LINESTRING EMPTY", null);
+
+        // Linestring with one point has length centroid to same point
+        assertCentroid("LINESTRING (0 0)", centroid);
+
+        // Linestring with only one distinct point centroid to same point
+        assertCentroid("LINESTRING (0 0, 0 0, 0 0)", centroid);
+
+        centroid = new Point(0, 0);
+
+        // ST_Length is equivalent to sums of ST_DISTANCE between points in the LineString
+        assertCentroid("LINESTRING (-71.05 42.36, -87.62 41.87, -122.41 37.77)", centroid);
+
+        // Linestring has same length as its reverse
+        assertCentroid("LINESTRING (-122.41 37.77, -87.62 41.87, -71.05 42.36)", centroid);
+
+        // special case, cannot determine the centroid in perfect equilibrium
+        assertCentroid("LINESTRING (0.0 90.0, 0.0 -90.0, 0.0 90.0)", null);
+
+        // Empty multi-linestring returns null
+        assertCentroid("MULTILINESTRING (EMPTY)", null);
+
+        // Multi-linestring with one path is equivalent to a single linestring
+        assertCentroid("MULTILINESTRING ((-71.05 42.36, -87.62 41.87, -122.41 37.77))", centroid);
+    }
+
+    private void assertCentroid(String lineString, Point expectedCentroid)
+    {
+        assertFunction(
+                format("ST_AsText(ST_Centroid(to_spherical_geography(ST_GeometryFromText('%s'))))", lineString),
+                VARCHAR,
+                expectedCentroid == null ? "POINT EMPTY" : new OGCPoint(expectedCentroid, null).asText()
+        );
     }
 }

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
@@ -268,7 +268,7 @@ public class TestSphericalGeoFunctions
         // Linestring with only one distinct point centroid to same point
         assertCentroid("LINESTRING (0 0, 0 0, 0 0)", centroid);
 
-        centroid = new Point(0, 0); // TODO: fix values here
+        centroid = new Point(42.71971773363295, -94.14122050592341);
 
         // ST_Length is equivalent to sums of ST_DISTANCE between points in the LineString
         assertCentroid("LINESTRING (-71.05 42.36, -87.62 41.87, -122.41 37.77)", centroid);
@@ -276,18 +276,29 @@ public class TestSphericalGeoFunctions
         // Linestring has same length as its reverse
         assertCentroid("LINESTRING (-122.41 37.77, -87.62 41.87, -71.05 42.36)", centroid);
 
-        // special case, cannot determine the centroid in perfect equilibrium
-        assertCentroid("LINESTRING (0.0 90.0, 0.0 -90.0, 0.0 90.0)", null);
-
         // Empty multi-linestring returns null
         assertCentroid("MULTILINESTRING (EMPTY)", null);
 
         // Multi-linestring with one path is equivalent to a single linestring
         assertCentroid("MULTILINESTRING ((-71.05 42.36, -87.62 41.87, -122.41 37.77))", centroid);
+
+        centroid = new Point(90, 0);
+        assertCentroid("LINESTRING (0.0 90.0, 0.0 -90.0, 0.0 90.0)", centroid);
+
+        centroid = new Point(45, 0);
+        assertCentroid("LINESTRING (0 0, 180.0 90.0)", centroid);
+
+        // special case, cannot determine the centroid in perfect equilibrium
     }
 
     private void assertCentroid(String lineString, Point expectedCentroid)
     {
-        assertFunction(format("ST_AsText(ST_Centroid(to_spherical_geography(ST_GeometryFromText('%s'))))", lineString), VARCHAR, expectedCentroid == null ? "POINT EMPTY" : new OGCPoint(expectedCentroid, null).asText());
+        String outcome = format("ST_AsText(ST_Centroid(to_spherical_geography(ST_GeometryFromText('%s'))))", lineString);
+        if (expectedCentroid == null) {
+            assertFunction(outcome, VARCHAR, "POINT EMPTY");
+        }
+        else {
+            assertFunction(outcome, VARCHAR, new OGCPoint(expectedCentroid, null).asText());
+        }
     }
 }

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
@@ -259,8 +259,23 @@ public class TestSphericalGeoFunctions
     {
         Point centroid = new Point(0, 0);
 
-        // Empty linestring returns null
+        // Empty linestring returns POINT EMPTY
+        assertCentroid("POINT EMPTY", null);
+
+        // A single point will return itself
+        assertCentroid("POINT (0 0)", centroid);
+
+        // Empty Multipoint returns POINT EMPTY
+        assertCentroid("MULTIPOINT (EMPTY)", null);
+
+        // Empty linestring returns POINT EMPTY
         assertCentroid("LINESTRING EMPTY", null);
+
+        // Empty multi-linestring returns POINT EMPTY
+        assertCentroid("MULTILINESTRING (EMPTY)", null);
+
+        // special case, cannot determine the centroid in perfect equilibrium, POINT EMPTY will be the outcome
+        assertCentroid("LINESTRING (0 0, 180.0 0.0)", null);
 
         // Linestring with one point has length centroid to same point
         assertCentroid("LINESTRING (0 0)", centroid);
@@ -270,25 +285,23 @@ public class TestSphericalGeoFunctions
 
         centroid = new Point(42.71971773363295, -94.14122050592341);
 
-        // ST_Length is equivalent to sums of ST_DISTANCE between points in the LineString
+        // St_Centroid for line string is equivalent to multipoint giving all the segments
         assertCentroid("LINESTRING (-71.05 42.36, -87.62 41.87, -122.41 37.77)", centroid);
 
-        // Linestring has same length as its reverse
+        // Linestring has same centroid as its reverse
         assertCentroid("LINESTRING (-122.41 37.77, -87.62 41.87, -71.05 42.36)", centroid);
-
-        // Empty multi-linestring returns null
-        assertCentroid("MULTILINESTRING (EMPTY)", null);
 
         // Multi-linestring with one path is equivalent to a single linestring
         assertCentroid("MULTILINESTRING ((-71.05 42.36, -87.62 41.87, -122.41 37.77))", centroid);
+
+        // Multipoint calculate the proper centroid similarly to multilines
+        assertCentroid("MULTIPOINT (-71.05 42.36, -87.62 41.87, -122.41 37.77)", centroid);
 
         centroid = new Point(90, 0);
         assertCentroid("LINESTRING (0.0 90.0, 0.0 -90.0, 0.0 90.0)", centroid);
 
         centroid = new Point(45, 0);
         assertCentroid("LINESTRING (0 0, 180.0 90.0)", centroid);
-
-        // special case, cannot determine the centroid in perfect equilibrium
     }
 
     private void assertCentroid(String lineString, Point expectedCentroid)

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
@@ -268,7 +268,7 @@ public class TestSphericalGeoFunctions
         // Linestring with only one distinct point centroid to same point
         assertCentroid("LINESTRING (0 0, 0 0, 0 0)", centroid);
 
-        centroid = new Point(0, 0);
+        centroid = new Point(0, 0); // TODO: fix values here
 
         // ST_Length is equivalent to sums of ST_DISTANCE between points in the LineString
         assertCentroid("LINESTRING (-71.05 42.36, -87.62 41.87, -122.41 37.77)", centroid);
@@ -288,10 +288,6 @@ public class TestSphericalGeoFunctions
 
     private void assertCentroid(String lineString, Point expectedCentroid)
     {
-        assertFunction(
-                format("ST_AsText(ST_Centroid(to_spherical_geography(ST_GeometryFromText('%s'))))", lineString),
-                VARCHAR,
-                expectedCentroid == null ? "POINT EMPTY" : new OGCPoint(expectedCentroid, null).asText()
-        );
+        assertFunction(format("ST_AsText(ST_Centroid(to_spherical_geography(ST_GeometryFromText('%s'))))", lineString), VARCHAR, expectedCentroid == null ? "POINT EMPTY" : new OGCPoint(expectedCentroid, null).asText());
     }
 }


### PR DESCRIPTION
Add ST_Centroid function support for handling spherical context:
- Point and Multipoint
- Line and multiline
[- Polyline and Polygon]

Related to: #11581
Contribute to: #11580

Behaviour defined to be consistent with 2D centroid: https://github.com/Esri/geometry-api-java/blob/master/src/main/java/com/esri/core/geometry/OperatorCentroid2DLocal.java#L34
```
== RELEASE NOTES ==

General Changes
* Add ST_Centroid for points, lines and polygons on a sphere
```
