### PR TITLE
Add clientInfo to HdfsContext

### DIFF
--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
@@ -85,7 +85,8 @@ public class TestCassandraConnector
             System.currentTimeMillis(),
             new CassandraSessionProperties(new CassandraClientConfig()).getSessionProperties(),
             ImmutableMap.of(),
-            true);
+            true,
+            Optional.empty());
     protected String database;
     protected SchemaTableName table;
     protected SchemaTableName tableUnpartitioned;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HdfsEnvironment.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HdfsEnvironment.java
@@ -92,6 +92,7 @@ public class HdfsEnvironment
         private final Optional<String> queryId;
         private final Optional<String> schemaName;
         private final Optional<String> tableName;
+        private final Optional<String> clientInfo;
 
         public HdfsContext(ConnectorIdentity identity)
         {
@@ -100,6 +101,7 @@ public class HdfsEnvironment
             this.queryId = Optional.empty();
             this.schemaName = Optional.empty();
             this.tableName = Optional.empty();
+            this.clientInfo = Optional.empty();
         }
 
         public HdfsContext(ConnectorSession session, String schemaName)
@@ -111,6 +113,7 @@ public class HdfsEnvironment
             this.queryId = Optional.of(session.getQueryId());
             this.schemaName = Optional.of(schemaName);
             this.tableName = Optional.empty();
+            this.clientInfo = session.getClientInfo();
         }
 
         public HdfsContext(ConnectorSession session, String schemaName, String tableName)
@@ -123,6 +126,7 @@ public class HdfsEnvironment
             this.queryId = Optional.of(session.getQueryId());
             this.schemaName = Optional.of(schemaName);
             this.tableName = Optional.of(tableName);
+            this.clientInfo = session.getClientInfo();
         }
 
         public ConnectorIdentity getIdentity()
@@ -150,6 +154,11 @@ public class HdfsEnvironment
             return tableName;
         }
 
+        public Optional<String> getClientInfo()
+        {
+            return clientInfo;
+        }
+
         @Override
         public String toString()
         {
@@ -160,6 +169,7 @@ public class HdfsEnvironment
                     .add("queryId", queryId.orElse(null))
                     .add("schemaName", schemaName.orElse(null))
                     .add("tableName", tableName.orElse(null))
+                    .add("clientInfo", clientInfo.orElse(null))
                     .toString();
         }
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -888,6 +888,12 @@ public abstract class AbstractTestHiveClient
             }
 
             @Override
+            public Optional<String> getClientInfo()
+            {
+                return session.getClientInfo();
+            }
+
+            @Override
             public long getStartTime()
             {
                 return session.getStartTime();

--- a/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
@@ -117,6 +117,12 @@ public class FullConnectorSession
     }
 
     @Override
+    public Optional<String> getClientInfo()
+    {
+        return session.getClientInfo();
+    }
+
+    @Override
     public boolean isLegacyTimestamp()
     {
         return isLegacyTimestamp;

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -51,10 +51,11 @@ public class TestingConnectorSession
     private final Map<String, PropertyMetadata<?>> properties;
     private final Map<String, Object> propertyValues;
     private final boolean isLegacyTimestamp;
+    private final Optional<String> clientInfo;
 
     public TestingConnectorSession(List<PropertyMetadata<?>> properties)
     {
-        this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of(), new FeaturesConfig().isLegacyTimestamp());
+        this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of(), new FeaturesConfig().isLegacyTimestamp(), Optional.empty());
     }
 
     public TestingConnectorSession(
@@ -66,7 +67,8 @@ public class TestingConnectorSession
             long startTime,
             List<PropertyMetadata<?>> propertyMetadatas,
             Map<String, Object> propertyValues,
-            boolean isLegacyTimestamp)
+            boolean isLegacyTimestamp,
+            Optional<String> clientInfo)
     {
         this.queryId = queryIdGenerator.createNextQueryId().toString();
         this.identity = new ConnectorIdentity(requireNonNull(user, "user is null"), Optional.empty(), Optional.empty());
@@ -78,6 +80,7 @@ public class TestingConnectorSession
         this.properties = Maps.uniqueIndex(propertyMetadatas, PropertyMetadata::getName);
         this.propertyValues = ImmutableMap.copyOf(propertyValues);
         this.isLegacyTimestamp = isLegacyTimestamp;
+        this.clientInfo = clientInfo;
     }
 
     @Override
@@ -123,6 +126,12 @@ public class TestingConnectorSession
     }
 
     @Override
+    public Optional<String> getClientInfo()
+    {
+        return clientInfo;
+    }
+
+    @Override
     public boolean isLegacyTimestamp()
     {
         return isLegacyTimestamp;
@@ -153,6 +162,7 @@ public class TestingConnectorSession
                 .add("locale", locale)
                 .add("startTime", startTime)
                 .add("properties", propertyValues)
+                .add("clientInfo", clientInfo)
                 .omitNullValues()
                 .toString();
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
@@ -160,7 +160,7 @@ public abstract class TestDateTimeFunctionsBase
     private void assertCurrentDateAtInstant(TimeZoneKey timeZoneKey, long instant)
     {
         long expectedDays = epochDaysInZone(timeZoneKey, instant);
-        long dateTimeCalculation = currentDate(new TestingConnectorSession("test", Optional.empty(), Optional.empty(), timeZoneKey, US, instant, ImmutableList.of(), ImmutableMap.of(), isLegacyTimestamp(session)));
+        long dateTimeCalculation = currentDate(new TestingConnectorSession("test", Optional.empty(), Optional.empty(), timeZoneKey, US, instant, ImmutableList.of(), ImmutableMap.of(), isLegacyTimestamp(session), Optional.empty()));
         assertEquals(dateTimeCalculation, expectedDays);
     }
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
@@ -225,7 +225,8 @@ public class TestRaptorConnector
                 System.currentTimeMillis(),
                 new RaptorSessionProperties(new StorageManagerConfig()).getSessionProperties(),
                 ImmutableMap.of(),
-                true);
+                true,
+                Optional.empty());
 
         ConnectorTransactionHandle transaction = connector.beginTransaction(READ_COMMITTED, false);
         connector.getMetadata(transaction).createTable(

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
@@ -38,6 +38,8 @@ public interface ConnectorSession
 
     Optional<String> getTraceToken();
 
+    Optional<String> getClientInfo();
+
     long getStartTime();
 
     @Deprecated

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingSession.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingSession.java
@@ -54,6 +54,12 @@ public final class TestingSession
         }
 
         @Override
+        public Optional<String> getClientInfo()
+        {
+            return Optional.of("TestClientInfo");
+        }
+
+        @Override
         public Locale getLocale()
         {
             return ENGLISH;


### PR DESCRIPTION
Send additional client Info as part of the HdfsContext. This will help the underlying system to get more info about the requesting client. This is an optional field in HdfsContext. 
Also expose getClientInfo() method in ConnectSession SPI to help retrieve this new client info.
```
== RELEASE NOTES ==

Connectors
* Add getClientInfo() method to Connector Session SPI
```
