### PR TITLE
Fix queries on tables with multiple partitioning columns

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveColumnHandle.java
@@ -50,6 +50,9 @@ public class HiveColumnHandle
 
     private static final String UPDATE_ROW_ID_COLUMN_NAME = "$shard_row_id";
 
+    // Ids <= this can be used for distinguishing between different prefilled columns.
+    public static final int MAX_PARTITION_KEY_COLUMN_INDEX = -13;
+
     public enum ColumnType
     {
         PARTITION_KEY,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
+import static com.facebook.presto.hive.HiveColumnHandle.MAX_PARTITION_KEY_COLUMN_INDEX;
 import static com.facebook.presto.hive.HivePageSourceProvider.ColumnMapping.toColumnHandles;
 import static com.facebook.presto.hive.HiveSessionProperties.isPushdownFilterEnabled;
 import static com.facebook.presto.hive.HiveUtil.getPrefilledColumnValue;
@@ -108,7 +109,7 @@ public class HivePageSourceProvider
         Configuration configuration = hdfsEnvironment.getConfiguration(new HdfsContext(session, hiveSplit.getDatabase(), hiveSplit.getTable()), path);
 
         if (isPushdownFilterEnabled(session)) {
-            return createSelectivePageSource(selectivePageSourceFactories, configuration, session, hiveSplit, hiveLayout, hiveColumns, hiveStorageTimeZone, rowExpressionService);
+            return createSelectivePageSource(selectivePageSourceFactories, configuration, session, hiveSplit, hiveLayout, assignUniqueIndicesToPartitionColumns(hiveColumns), hiveStorageTimeZone, rowExpressionService);
         }
 
         Optional<ConnectorPageSource> pageSource = createHivePageSource(
@@ -203,6 +204,23 @@ public class HivePageSourceProvider
         }
 
         throw new IllegalStateException("Could not find a file reader for split " + split);
+    }
+
+    private static List<HiveColumnHandle> assignUniqueIndicesToPartitionColumns(List<HiveColumnHandle> columns)
+    {
+        // Gives a distinct hiveColumnIndex to partitioning columns. Columns are identified by these indices in the rest of the
+        // selective read path.
+        int nextIndex = MAX_PARTITION_KEY_COLUMN_INDEX;
+        ImmutableList.Builder<HiveColumnHandle> newColumns = ImmutableList.builder();
+        for (HiveColumnHandle column : columns) {
+            if (column.isPartitionKey()) {
+                newColumns.add(new HiveColumnHandle(column.getName(), column.getHiveType(), column.getTypeSignature(), nextIndex--, column.getColumnType(), column.getComment(), column.getRequiredSubfields()));
+            }
+            else {
+                newColumns.add(column);
+            }
+        }
+        return newColumns.build();
     }
 
     public static Optional<ConnectorPageSource> createHivePageSource(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -1035,10 +1035,16 @@ public final class HiveUtil
         for (HiveColumnHandle column : columns) {
             Integer physicalOrdinal = physicalNameOrdinalMap.get(column.getName());
             if (physicalOrdinal == null) {
-                // if the column is missing from the file, assign it a column number larger
-                // than the number of columns in the file so the reader will fill it with nulls
-                physicalOrdinal = nextMissingColumnIndex;
-                nextMissingColumnIndex++;
+                // if the column is missing from the file, assign it a column number larger than the number of columns in the
+                // file so the reader will fill it with nulls.  If the index is negative, i.e. this is a sythesized column like
+                // a partitioning key, $bucket or $path, leave it as is.
+                if (column.getHiveColumnIndex() < 0) {
+                    physicalOrdinal = column.getHiveColumnIndex();
+                }
+                else {
+                    physicalOrdinal = nextMissingColumnIndex;
+                    nextMissingColumnIndex++;
+                }
             }
             physicalColumns.add(new HiveColumnHandle(column.getName(), column.getHiveType(), column.getTypeSignature(), physicalOrdinal, column.getColumnType(), column.getComment(), column.getRequiredSubfields()));
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -506,16 +506,16 @@ public class TestHivePushdownFilterQueries
     @Test
     public void testPartitionColumns()
     {
-        assertUpdate("CREATE TABLE test_partition_columns WITH (partitioned_by = ARRAY['p']) AS\n" +
-                "SELECT * FROM (VALUES (1, 'abc'), (2, 'abc')) as t(x, p)", 2);
+        assertUpdate("CREATE TABLE test_partition_columns WITH (partitioned_by = ARRAY['p', 'q']) AS\n" +
+                "SELECT * FROM (VALUES (1, 'abc', 'cba'), (2, 'abc', 'def')) as t(x, p, q)", 2);
 
-        assertQuery("SELECT * FROM test_partition_columns", "SELECT 1, 'abc' UNION ALL SELECT 2, 'abc'");
+        assertQuery("SELECT * FROM test_partition_columns", "SELECT 1, 'abc', 'cba' UNION ALL SELECT 2, 'abc', 'def'");
 
-        assertQuery("SELECT * FROM test_partition_columns WHERE p = 'abc'", "SELECT 1, 'abc' UNION ALL SELECT 2, 'abc'");
+        assertQuery("SELECT * FROM test_partition_columns WHERE p = 'abc'", "SELECT 1, 'abc', 'cba' UNION ALL SELECT 2, 'abc', 'def'");
 
-        assertQuery("SELECT * FROM test_partition_columns WHERE p LIKE 'a%'", "SELECT 1, 'abc' UNION ALL SELECT 2, 'abc'");
+        assertQuery("SELECT * FROM test_partition_columns WHERE p LIKE 'a%'", "SELECT 1, 'abc', 'cba' UNION ALL SELECT 2, 'abc', 'def'");
 
-        assertQuery("SELECT * FROM test_partition_columns WHERE substr(p, x, 1) = 'a'", "SELECT 1, 'abc'");
+        assertQuery("SELECT * FROM test_partition_columns WHERE substr(p, x, 1) = 'a' and substr(q, 1, 1) = 'c'", "SELECT 1, 'abc', 'cba'");
 
         assertQueryReturnsEmptyResult("SELECT * FROM test_partition_columns WHERE p = 'xxx'");
 


### PR DESCRIPTION
Hive selective page source logic uses hiveColumnIndex to distinguish
between columns. All partitioning columns have a hiveColumnIndex of
-1. Therefore, assign consecutive negative column numbers to all
partitioning HiveColumnHandles.

Alternatively all references to columns in selective page sources
would have to be by name.