### PR TITLE
Add common scalar reads to OrcInputStream

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleInputStream.java
@@ -16,8 +16,6 @@ package com.facebook.presto.orc.stream;
 import com.facebook.presto.orc.checkpoint.DoubleStreamCheckpoint;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 
 import java.io.IOException;
 
@@ -27,8 +25,6 @@ public class DoubleInputStream
         implements ValueInputStream<DoubleStreamCheckpoint>
 {
     private final OrcInputStream input;
-    private final byte[] buffer = new byte[SIZE_OF_DOUBLE];
-    private final Slice slice = Slices.wrappedBuffer(buffer);
 
     public DoubleInputStream(OrcInputStream input)
     {
@@ -59,8 +55,7 @@ public class DoubleInputStream
     public double next()
             throws IOException
     {
-        input.readFully(buffer, 0, SIZE_OF_DOUBLE);
-        return slice.getDouble(0);
+        return input.readDouble();
     }
 
     public void nextVector(Type type, int items, BlockBuilder builder)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatInputStream.java
@@ -16,8 +16,6 @@ package com.facebook.presto.orc.stream;
 import com.facebook.presto.orc.checkpoint.FloatStreamCheckpoint;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 
 import java.io.IOException;
 
@@ -28,8 +26,6 @@ public class FloatInputStream
         implements ValueInputStream<FloatStreamCheckpoint>
 {
     private final OrcInputStream input;
-    private final byte[] buffer = new byte[SIZE_OF_FLOAT];
-    private final Slice slice = Slices.wrappedBuffer(buffer);
 
     public FloatInputStream(OrcInputStream input)
     {
@@ -60,8 +56,7 @@ public class FloatInputStream
     public float next()
             throws IOException
     {
-        input.readFully(buffer, 0, SIZE_OF_FLOAT);
-        return slice.getFloat(0);
+        return input.readFloat();
     }
 
     public void nextVector(Type type, int items, BlockBuilder builder)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcInputStream.java
@@ -18,6 +18,7 @@ import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.OrcDecompressor;
+import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
 import io.airlift.slice.ByteArrays;
 import io.airlift.slice.FixedLengthSliceInput;
 import io.airlift.slice.Slice;
@@ -30,10 +31,14 @@ import java.util.Optional;
 import static com.facebook.presto.orc.checkpoint.InputStreamCheckpoint.createInputStreamCheckpoint;
 import static com.facebook.presto.orc.checkpoint.InputStreamCheckpoint.decodeCompressedBlockOffset;
 import static com.facebook.presto.orc.checkpoint.InputStreamCheckpoint.decodeDecompressedOffset;
+import static com.facebook.presto.orc.stream.LongDecode.zigzagDecode;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
 import static io.airlift.slice.SizeOf.SIZE_OF_FLOAT;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -42,6 +47,9 @@ import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 public final class OrcInputStream
         extends InputStream
 {
+    private static final long VARINT_MASK = 0x8080_8080_8080_8080L;
+    private static final int MAX_VARINT_LENGTH = 10;
+
     private final OrcDataSourceId orcDataSourceId;
     private final FixedLengthSliceInput compressedSliceInput;
     private final Optional<OrcDecompressor> decompressor;
@@ -244,6 +252,153 @@ public final class OrcInputStream
         result = Math.min(available(), n - 1);
         position += toIntExact(result);
         return 1 + result;
+    }
+
+    public long readDwrfLong(OrcTypeKind type)
+            throws IOException
+    {
+        switch (type) {
+            case SHORT:
+                return read() | (read() << 8);
+            case INT:
+                return read() | (read() << 8) | (read() << 16) | (read() << 24);
+            case LONG:
+                return ((long) read()) |
+                        (((long) read()) << 8) |
+                        (((long) read()) << 16) |
+                        (((long) read()) << 24) |
+                        (((long) read()) << 32) |
+                        (((long) read()) << 40) |
+                        (((long) read()) << 48) |
+                        (((long) read()) << 56);
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    public void skipDwrfLong(OrcTypeKind type, long items)
+            throws IOException
+    {
+        if (items == 0) {
+            return;
+        }
+        long bytes = items;
+        switch (type) {
+            case SHORT:
+                bytes *= SIZE_OF_SHORT;
+                break;
+            case INT:
+                bytes *= SIZE_OF_INT;
+                break;
+            case LONG:
+                bytes *= SIZE_OF_LONG;
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+        skip(bytes);
+    }
+
+    public long readVarint(boolean signed)
+            throws IOException
+    {
+        long result = 0;
+        int shift = 0;
+        int available = available();
+        if (available >= 2 * Long.BYTES) {
+            long word = ByteArrays.getLong(buffer, position);
+            int count = 1;
+            boolean atEnd = false;
+            result = word & 0x7f;
+            if ((word & 0x80) != 0) {
+                long control = word >>> 8;
+                long mask = 0x7f << 7;
+                while (true) {
+                    word = word >>> 1;
+                    result |= word & mask;
+                    count++;
+                    if ((control & 0x80) == 0) {
+                        atEnd = true;
+                        break;
+                    }
+                    if (mask == 0x7fL << (7 * 7)) {
+                        break;
+                    }
+                    mask = mask << 7;
+                    control = control >>> 8;
+                }
+                if (!atEnd) {
+                    word = ByteArrays.getLong(buffer, position + 8);
+                    result |= (word & 0x7f) << 56;
+                    if ((word & 0x80) == 0) {
+                        count++;
+                    }
+                    else {
+                        result |= 1L << 63;
+                        count += 2;
+                    }
+                }
+            }
+            position += count;
+        }
+        else {
+            do {
+                if (available == 0) {
+                    advance();
+                    available = available();
+                    if (available == 0) {
+                        throw new OrcCorruptionException(orcDataSourceId, "End of stream in RLE Integer");
+                    }
+                }
+                available--;
+                result |= (long) (buffer[position] & 0x7f) << shift;
+                shift += 7;
+            }
+            while ((buffer[position++] & 0x80) != 0);
+        }
+        if (signed) {
+            return zigzagDecode(result);
+        }
+        else {
+            return result;
+        }
+    }
+
+    public void skipVarints(long items)
+            throws IOException
+    {
+        if (items == 0) {
+            return;
+        }
+
+        while (items > 0) {
+            items -= skipVarintsInBuffer(items);
+        }
+    }
+
+    private long skipVarintsInBuffer(long items)
+            throws IOException
+    {
+        if (available() == 0) {
+            advance();
+            if (available() == 0) {
+                throw new OrcCorruptionException(orcDataSourceId, "Unexpected end of stream");
+            }
+        }
+        long skipped = 0;
+        // If items to skip is > SIZE_OF_LONG it is safe to skip entire longs
+        while (items - skipped > SIZE_OF_LONG && available() > MAX_VARINT_LENGTH) {
+            long value = ByteArrays.getLong(buffer, position);
+            position += SIZE_OF_LONG;
+            long mask = (value & VARINT_MASK) ^ VARINT_MASK;
+            skipped += Long.bitCount(mask);
+        }
+        while (skipped < items && available() > 0) {
+            if ((buffer[position++] & 0x80) == 0) {
+                skipped++;
+            }
+        }
+        return skipped;
     }
 
     public double readDouble()

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -265,6 +265,15 @@ public class TestSelectiveOrcReader
     }
 
     @Test
+    public void testLongDirectVarintScale()
+            throws Exception
+    {
+        List<Long> values = varintScaleSequence(NUM_ROWS);
+        Collections.shuffle(values, new Random(0));
+        testRoundTripNumeric(values, BigintRange.of(0, 1L << 60, false));
+    }
+
+    @Test
     public void testLongShortRepeat()
             throws Exception
     {
@@ -858,7 +867,7 @@ public class TestSelectiveOrcReader
                 .collect(toList());
 
         List<SqlTimestamp> timestamps = longValues.stream()
-                .map(timestamp -> sqlTimestampOf(timestamp, SESSION))
+                .map(timestamp -> sqlTimestampOf(timestamp & Integer.MAX_VALUE, SESSION))
                 .collect(toList());
 
         tester.testRoundTrip(BIGINT, longValues, toSubfieldFilters(filter));
@@ -1020,6 +1029,17 @@ public class TestSelectiveOrcReader
         for (int i = 0; i < items; i++) {
             values.add(new SqlDecimal(nextValue, precision, scale));
             nextValue = nextValue.add(decimalStep);
+        }
+        return values;
+    }
+
+    private static List<Long> varintScaleSequence(int rows)
+    {
+        List<Long> values = new ArrayList();
+        long[] numbers = new long[] {1L, 1L << 8, 1L << 13, 1L << 20, 1L << 27, 1L << 34, 1L << 40, 1L << 47, 1L << 53, 1L << 60, 1L << 63};
+        for (int i = 0; i < rows; i++) {
+            values.add(numbers[i % numbers.length] + i);
+            values.add(-numbers[i % numbers.length] + i);
         }
         return values;
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
@@ -380,7 +380,7 @@ public final class TestingOrcPredicate
                         .filter(Objects::nonNull)
                         .mapToLong(Long::longValue)
                         .sum();
-                if (columnStatistics.getIntegerStatistics().getSum() != sum) {
+                if (columnStatistics.getIntegerStatistics().getSum() != null && columnStatistics.getIntegerStatistics().getSum() != sum) {
                     return false;
                 }
                 HiveBloomFilter bloomFilter = columnStatistics.getBloomFilter();


### PR DESCRIPTION
Adds an optimized read path for varints, floats and doubles. This
avoids copying and bounds checking for consecutive bytes.

Removes the use of Slice from OrcInputStream. Keeps the decompression
buffer separate from the Slice read from the compressed input. The
backing byte[] of the compressed input Slice is directly used as the
buffer when there is no compression, avoiding needless copy.

```
== RELEASE NOTES ==

Hive Changes
--------------
 * Streamline ORC read path for varints and fixed width numbers.
```