### PR TITLE
Add support for filters on struct subfields

### DIFF
--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -33,6 +33,7 @@ import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.NamedTypeSignature;
 import com.facebook.presto.spi.type.RowFieldName;
+import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.SqlDate;
 import com.facebook.presto.spi.type.SqlDecimal;
 import com.facebook.presto.spi.type.SqlTimestamp;
@@ -942,6 +943,24 @@ public class OrcTester
                 if (index >= ((List) nestedValue).size()) {
                     return true;
                 }
+                nestedValue = ((List) nestedValue).get(index);
+            }
+            else if (nestedType instanceof RowType) {
+                assertTrue(pathElement instanceof Subfield.NestedField);
+                if (nestedValue == null) {
+                    return filter.testNull();
+                }
+                String fieldName = ((Subfield.NestedField) pathElement).getName();
+                int index = -1;
+                List<RowType.Field> fields = ((RowType) nestedType).getFields();
+                for (int i = 0; i < fields.size(); i++) {
+                    if (fieldName.equalsIgnoreCase(fields.get(i).getName().get())) {
+                        index = i;
+                        nestedType = fields.get(i).getType();
+                        break;
+                    }
+                }
+                assertTrue(index >= 0, "Struct field not found: " + fieldName);
                 nestedValue = ((List) nestedValue).get(index);
             }
             else {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -532,17 +532,21 @@ public class TestSelectiveOrcReader
                 ImmutableList.of(
                         createList(NUM_ROWS, i -> random.nextInt()),
                         createList(NUM_ROWS, i -> ImmutableList.of(random.nextInt(), random.nextBoolean()))),
-                toSubfieldFilters(
-                        ImmutableMap.of(0, BigintRange.of(0, Integer.MAX_VALUE, false)),
-                        ImmutableMap.of(1, IS_NULL),
-                        ImmutableMap.of(1, IS_NOT_NULL)));
+                ImmutableList.of(
+                        ImmutableMap.of(0, toSubfieldFilter(BigintRange.of(0, Integer.MAX_VALUE, false))),
+                        ImmutableMap.of(1, toSubfieldFilter(IS_NULL)),
+                        ImmutableMap.of(1, toSubfieldFilter(IS_NOT_NULL)),
+                        ImmutableMap.of(1, toSubfieldFilter("c.field_0", BigintRange.of(0, Integer.MAX_VALUE, false))),
+                        ImmutableMap.of(1, toSubfieldFilter("c.field_0", IS_NULL))));
 
         tester.testRoundTripTypes(ImmutableList.of(rowType(INTEGER, BOOLEAN), INTEGER),
                 ImmutableList.of(
                         createList(NUM_ROWS, i -> i % 7 == 0 ? null : ImmutableList.of(random.nextInt(), random.nextBoolean())),
                         createList(NUM_ROWS, i -> i % 11 == 0 ? null : random.nextInt())),
-                toSubfieldFilters(
-                        ImmutableMap.of(0, IS_NOT_NULL, 1, IS_NULL)));
+                ImmutableList.of(
+                        ImmutableMap.of(0, toSubfieldFilter(IS_NOT_NULL), 1, toSubfieldFilter(IS_NULL)),
+                        ImmutableMap.of(0, toSubfieldFilter("c.field_0", BigintRange.of(0, Integer.MAX_VALUE, false))),
+                        ImmutableMap.of(0, toSubfieldFilter("c.field_0", BigintRange.of(0, Integer.MAX_VALUE, true)))));
     }
 
     @Test


### PR DESCRIPTION
Supports filters on struct subfields at any level, e.g. `a.b.c = 5`.

Support for structs nested inside an array or map, e.g. `a[1].b.c = 5`,
will come in future commits.

Depends on #13430 

```
== NO RELEASE NOTE ==
```
