### PR TITLE
Evalute filter once per Dictionary value

### DIFF
--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -709,7 +709,7 @@ public class TestSelectiveOrcReader
     {
         // dictionary
         tester.testRoundTrip(VARCHAR, newArrayList(limit(cycle(ImmutableList.of("apple", "apple pie", "apple\uD835\uDC03", "apple\uFFFD")), NUM_ROWS)),
-                stringEquals(false, "apple"));
+                stringIn(false, "apple", "apple pie"));
 
         // direct
         tester.testRoundTrip(VARCHAR,


### PR DESCRIPTION
```
# Before

Benchmark                                          (typeSignature)  (withNulls)  Mode  Cnt  Score   Error  Units
BenchmarkSelectiveStreamReaders.read            varchar_dictionary         true  avgt   20  0.053 ± 0.002   s/op
BenchmarkSelectiveStreamReaders.read            varchar_dictionary        false  avgt   20  0.053 ± 0.003   s/op
BenchmarkSelectiveStreamReaders.readAllNull     varchar_dictionary          N/A  avgt   20  0.009 ± 0.001   s/op
BenchmarkSelectiveStreamReaders.readWithFilter  varchar_dictionary         true  avgt   20  0.174 ± 0.006   s/op
BenchmarkSelectiveStreamReaders.readWithFilter  varchar_dictionary        false  avgt   20  0.311 ± 0.032   s/op

#With optimization

Benchmark                                          (typeSignature)  (withNulls)  Mode  Cnt  Score    Error  Units
BenchmarkSelectiveStreamReaders.read            varchar_dictionary         true  avgt   20  0.057 ±  0.004   s/op
BenchmarkSelectiveStreamReaders.read            varchar_dictionary        false  avgt   20  0.052 ±  0.002   s/op
BenchmarkSelectiveStreamReaders.readAllNull     varchar_dictionary          N/A  avgt   20  0.009 ±  0.001   s/op
BenchmarkSelectiveStreamReaders.readWithFilter  varchar_dictionary         true  avgt   20  0.078 ±  0.005   s/op
BenchmarkSelectiveStreamReaders.readWithFilter  varchar_dictionary        false  avgt   20  0.092 ±  0.006   s/op


== NO RELEASE NOTE ==
```
