### PR TITLE
Reduce excessive memory usage by ExchangeClient

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientConfig.java
@@ -36,6 +36,7 @@ public class ExchangeClientConfig
     private int clientThreads = 25;
     private int pageBufferClientMaxCallbackThreads = 25;
     private boolean acknowledgePages = true;
+    private double responseSizeExponentialMovingAverageDecayingAlpha = 0.1;
 
     @NotNull
     public DataSize getMaxBufferSize()
@@ -140,5 +141,17 @@ public class ExchangeClientConfig
     {
         this.acknowledgePages = acknowledgePages;
         return this;
+    }
+
+    @Config("exchange.response-size-exponential-moving-average-decaying-alpha")
+    public ExchangeClientConfig setResponseSizeExponentialMovingAverageDecayingAlpha(double responseSizeExponentialMovingAverageDecayingAlpha)
+    {
+        this.responseSizeExponentialMovingAverageDecayingAlpha = responseSizeExponentialMovingAverageDecayingAlpha;
+        return this;
+    }
+
+    public double getResponseSizeExponentialMovingAverageDecayingAlpha()
+    {
+        return responseSizeExponentialMovingAverageDecayingAlpha;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClientConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClientConfig.java
@@ -40,7 +40,8 @@ public class TestExchangeClientConfig
                 .setMaxResponseSize(new HttpClientConfig().getMaxContentLength())
                 .setPageBufferClientMaxCallbackThreads(25)
                 .setClientThreads(25)
-                .setAcknowledgePages(true));
+                .setAcknowledgePages(true)
+                .setResponseSizeExponentialMovingAverageDecayingAlpha(0.1));
     }
 
     @Test
@@ -55,6 +56,7 @@ public class TestExchangeClientConfig
                 .put("exchange.client-threads", "2")
                 .put("exchange.page-buffer-client.max-callback-threads", "16")
                 .put("exchange.acknowledge-pages", "false")
+                .put("exchange.response-size-exponential-moving-average-decaying-alpha", "0.42")
                 .build();
 
         ExchangeClientConfig expected = new ExchangeClientConfig()
@@ -65,7 +67,8 @@ public class TestExchangeClientConfig
                 .setMaxResponseSize(new DataSize(1, Unit.MEGABYTE))
                 .setClientThreads(2)
                 .setPageBufferClientMaxCallbackThreads(16)
-                .setAcknowledgePages(false);
+                .setAcknowledgePages(false)
+                .setResponseSizeExponentialMovingAverageDecayingAlpha(0.42);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
@@ -90,6 +90,7 @@ public class TestExchangeOperator
                 3,
                 new Duration(1, TimeUnit.MINUTES),
                 true,
+                0.2,
                 httpClient,
                 scheduler,
                 systemMemoryUsageListener,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
@@ -102,7 +102,6 @@ public class TestHttpPageBufferClient
 
         URI location = URI.create("http://localhost:8080");
         HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
-                expectedMaxSize,
                 new Duration(1, TimeUnit.MINUTES),
                 true,
                 location,
@@ -115,7 +114,7 @@ public class TestHttpPageBufferClient
         // fetch a page and verify
         processor.addPage(location, expectedPage);
         callback.resetStats();
-        client.scheduleRequest();
+        client.scheduleRequest(expectedMaxSize);
         requestComplete.await(10, TimeUnit.SECONDS);
 
         assertEquals(callback.getPages().size(), 1);
@@ -126,7 +125,7 @@ public class TestHttpPageBufferClient
 
         // fetch no data and verify
         callback.resetStats();
-        client.scheduleRequest();
+        client.scheduleRequest(expectedMaxSize);
         requestComplete.await(10, TimeUnit.SECONDS);
 
         assertEquals(callback.getPages().size(), 0);
@@ -138,7 +137,7 @@ public class TestHttpPageBufferClient
         processor.addPage(location, expectedPage);
         processor.addPage(location, expectedPage);
         callback.resetStats();
-        client.scheduleRequest();
+        client.scheduleRequest(expectedMaxSize);
         requestComplete.await(10, TimeUnit.SECONDS);
 
         assertEquals(callback.getPages().size(), 2);
@@ -153,7 +152,7 @@ public class TestHttpPageBufferClient
         // finish and verify
         callback.resetStats();
         processor.setComplete(location);
-        client.scheduleRequest();
+        client.scheduleRequest(expectedMaxSize);
         requestComplete.await(10, TimeUnit.SECONDS);
 
         // get the buffer complete signal
@@ -162,7 +161,7 @@ public class TestHttpPageBufferClient
 
         // schedule the delete call to the buffer
         callback.resetStats();
-        client.scheduleRequest();
+        client.scheduleRequest(expectedMaxSize);
         requestComplete.await(10, TimeUnit.SECONDS);
         assertEquals(callback.getFinishedBuffers(), 1);
 
@@ -177,6 +176,7 @@ public class TestHttpPageBufferClient
     public void testLifecycle()
             throws Exception
     {
+        DataSize expectedMaxSize = new DataSize(10, Unit.MEGABYTE);
         CyclicBarrier beforeRequest = new CyclicBarrier(2);
         CyclicBarrier afterRequest = new CyclicBarrier(2);
         StaticRequestProcessor processor = new StaticRequestProcessor(beforeRequest, afterRequest);
@@ -187,7 +187,6 @@ public class TestHttpPageBufferClient
 
         URI location = URI.create("http://localhost:8080");
         HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
-                new DataSize(10, Unit.MEGABYTE),
                 new Duration(1, TimeUnit.MINUTES),
                 true,
                 location,
@@ -197,7 +196,7 @@ public class TestHttpPageBufferClient
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
-        client.scheduleRequest();
+        client.scheduleRequest(expectedMaxSize);
         beforeRequest.await(10, TimeUnit.SECONDS);
         assertStatus(client, location, "running", 0, 1, 0, 0, "PROCESSING_REQUEST");
         assertEquals(client.isRunning(), true);
@@ -218,6 +217,7 @@ public class TestHttpPageBufferClient
     public void testInvalidResponses()
             throws Exception
     {
+        DataSize expectedMaxSize = new DataSize(10, Unit.MEGABYTE);
         CyclicBarrier beforeRequest = new CyclicBarrier(1);
         CyclicBarrier afterRequest = new CyclicBarrier(1);
         StaticRequestProcessor processor = new StaticRequestProcessor(beforeRequest, afterRequest);
@@ -227,7 +227,6 @@ public class TestHttpPageBufferClient
 
         URI location = URI.create("http://localhost:8080");
         HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
-                new DataSize(10, Unit.MEGABYTE),
                 new Duration(1, TimeUnit.MINUTES),
                 true,
                 location,
@@ -239,7 +238,7 @@ public class TestHttpPageBufferClient
 
         // send not found response and verify response was ignored
         processor.setResponse(new TestingResponse(HttpStatus.NOT_FOUND, ImmutableListMultimap.of(CONTENT_TYPE, PRESTO_PAGES), new byte[0]));
-        client.scheduleRequest();
+        client.scheduleRequest(expectedMaxSize);
         requestComplete.await(10, TimeUnit.SECONDS);
         assertEquals(callback.getPages().size(), 0);
         assertEquals(callback.getCompletedRequests(), 1);
@@ -252,7 +251,7 @@ public class TestHttpPageBufferClient
         // send invalid content type response and verify response was ignored
         callback.resetStats();
         processor.setResponse(new TestingResponse(HttpStatus.OK, ImmutableListMultimap.of(CONTENT_TYPE, "INVALID_TYPE"), new byte[0]));
-        client.scheduleRequest();
+        client.scheduleRequest(expectedMaxSize);
         requestComplete.await(10, TimeUnit.SECONDS);
         assertEquals(callback.getPages().size(), 0);
         assertEquals(callback.getCompletedRequests(), 1);
@@ -265,7 +264,7 @@ public class TestHttpPageBufferClient
         // send unexpected content type response and verify response was ignored
         callback.resetStats();
         processor.setResponse(new TestingResponse(HttpStatus.OK, ImmutableListMultimap.of(CONTENT_TYPE, "text/plain"), new byte[0]));
-        client.scheduleRequest();
+        client.scheduleRequest(expectedMaxSize);
         requestComplete.await(10, TimeUnit.SECONDS);
         assertEquals(callback.getPages().size(), 0);
         assertEquals(callback.getCompletedRequests(), 1);
@@ -285,6 +284,7 @@ public class TestHttpPageBufferClient
     public void testCloseDuringPendingRequest()
             throws Exception
     {
+        DataSize expectedMaxSize = new DataSize(10, Unit.MEGABYTE);
         CyclicBarrier beforeRequest = new CyclicBarrier(2);
         CyclicBarrier afterRequest = new CyclicBarrier(2);
         StaticRequestProcessor processor = new StaticRequestProcessor(beforeRequest, afterRequest);
@@ -295,7 +295,6 @@ public class TestHttpPageBufferClient
 
         URI location = URI.create("http://localhost:8080");
         HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
-                new DataSize(10, Unit.MEGABYTE),
                 new Duration(1, TimeUnit.MINUTES),
                 true,
                 location,
@@ -306,7 +305,7 @@ public class TestHttpPageBufferClient
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
         // send request
-        client.scheduleRequest();
+        client.scheduleRequest(expectedMaxSize);
         beforeRequest.await(10, TimeUnit.SECONDS);
         assertStatus(client, location, "running", 0, 1, 0, 0, "PROCESSING_REQUEST");
         assertEquals(client.isRunning(), true);
@@ -335,6 +334,7 @@ public class TestHttpPageBufferClient
     public void testExceptionFromResponseHandler()
             throws Exception
     {
+        DataSize expectedMaxSize = new DataSize(10, Unit.MEGABYTE);
         TestingTicker ticker = new TestingTicker();
         AtomicReference<Duration> tickerIncrement = new AtomicReference<>(new Duration(0, TimeUnit.SECONDS));
 
@@ -349,7 +349,6 @@ public class TestHttpPageBufferClient
 
         URI location = URI.create("http://localhost:8080");
         HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
-                new DataSize(10, Unit.MEGABYTE),
                 new Duration(30, TimeUnit.SECONDS),
                 true,
                 location,
@@ -362,7 +361,7 @@ public class TestHttpPageBufferClient
 
         // request processor will throw exception, verify the request is marked a completed
         // this starts the error stopwatch
-        client.scheduleRequest();
+        client.scheduleRequest(expectedMaxSize);
         requestComplete.await(10, TimeUnit.SECONDS);
         assertEquals(callback.getPages().size(), 0);
         assertEquals(callback.getCompletedRequests(), 1);
@@ -374,7 +373,7 @@ public class TestHttpPageBufferClient
         tickerIncrement.set(new Duration(30, TimeUnit.SECONDS));
 
         // verify that the client has not failed
-        client.scheduleRequest();
+        client.scheduleRequest(expectedMaxSize);
         requestComplete.await(10, TimeUnit.SECONDS);
         assertEquals(callback.getPages().size(), 0);
         assertEquals(callback.getCompletedRequests(), 2);
@@ -386,7 +385,7 @@ public class TestHttpPageBufferClient
         tickerIncrement.set(new Duration(31, TimeUnit.SECONDS));
 
         // verify that the client has failed
-        client.scheduleRequest();
+        client.scheduleRequest(expectedMaxSize);
         requestComplete.await(10, TimeUnit.SECONDS);
         assertEquals(callback.getPages().size(), 0);
         assertEquals(callback.getCompletedRequests(), 3);


### PR DESCRIPTION
ExchangeClient when it first runs will send a request for a page to hash_partition_count nodes in the cluster. This resulted in an instance with 10 gigabytes of data in ExchangeClients and another 8 gigabytes in flight in jetty. This was causing full GCs since I was testing with a 40 gigabyte heap.

Previously the average response size calculation would reset to 0 every time a 0 is sampled. This occurs quite often when a 0 response is received from any partition that doesn't have data. This is expected to cause ExchangeClient to poll very aggressively.

This change has ExchangeClient track the expected averageResponseSize using an [exponential moving average](https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average). This is initialized to 1 megabyte (default page size). The alpha is defaults to 0.1.

When deciding how many nodes to contact the EMA is used and can function as a proxy for how hard it is to find more data. The lower the value returned by the EMA the more nodes will be contacted. This mimics the current behavior which might not be ideal, but at least now a 0 doesn't bring the average down to 0 immediately.

The number of bytes requested is set to `min(averageResponseSize * 2, maxResponseSize)`. This makes the exchange client more likely to only request a single (or fewer) pages if it ends up contacting many nodes. Previously it would always use maxResponseSize which poorly bounded the amount of data that could be returned.

```
== RELEASE NOTES ==

General Changes
* Reduce excessive memory usage by ExchangeClient
```