### PR TITLE
Fix ArrayIndexOutOfBoundsException in LongDictionarySelectiveStreamReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractLongSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractLongSelectiveStreamReader.java
@@ -281,7 +281,7 @@ abstract class AbstractLongSelectiveStreamReader
         return new ShortArrayBlock(positionCount, Optional.ofNullable(nullsCopy), valuesCopy);
     }
 
-    protected void ensureValuesCapacity(int capacity, boolean recordNulls)
+    private void ensureValuesCapacity(int capacity, boolean recordNulls)
     {
         values = ensureCapacity(values, capacity);
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
@@ -151,7 +151,7 @@ public class LongDictionarySelectiveStreamReader
                 if (filter == null || filter.testLong(value)) {
                     if (outputRequired) {
                         values[outputPositionCount] = value;
-                        if (nulls != null) {
+                        if (presentStream != null && nullsAllowed) {
                             nulls[outputPositionCount] = false;
                         }
                     }


### PR DESCRIPTION
Fixed the following failure that occurred in a verifier run:

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: 15
    at com.facebook.presto.orc.reader.LongDictionarySelectiveStreamReader.read(LongDictionarySelectiveStreamReader.java:155)
    at com.facebook.presto.orc.reader.LongSelectiveStreamReader.read(LongSelectiveStreamReader.java:116)
    at com.facebook.presto.orc.OrcSelectiveRecordReader.getNextPage(OrcSelectiveRecordReader.java:298)
    at com.facebook.presto.hive.orc.OrcSelectivePageSource.getNextPage(OrcSelectivePageSource.java:84)
```

```
== NO RELEASE NOTE ==
```
