### PR TITLE
Use TableWriterMergeNode to check recoverability

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableGroupedExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableGroupedExecution.java
@@ -64,7 +64,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-@Test(singleThreaded = true, enabled = false)
+@Test(singleThreaded = true)
 public class TestHiveRecoverableGroupedExecution
 {
     private static final Set<StageState> SPLIT_SCHEDULING_STARTED_STATES = ImmutableSet.of(StageState.SCHEDULING_SPLITS, StageState.SCHEDULED, StageState.RUNNING, StageState.FINISHED);
@@ -101,7 +101,7 @@ public class TestHiveRecoverableGroupedExecution
         executor.shutdownNow();
     }
 
-    @Test(timeOut = 60_000, enabled = false)
+    @Test(timeOut = 60_000)
     public void testCreateBucketedTable()
             throws Exception
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -219,7 +219,7 @@ public class PlanFragmenter
                  * We currently only support recoverable grouped execution if the following statements hold true:
                  *   - Current session enables recoverable grouped execution
                  *   - Parent sub plan contains TableFinishNode
-                 *   - Current sub plan's root is TableWriterNode
+                 *   - Current sub plan's root is TableWriterMergeNode
                  *   - Input connectors supports split source rewind
                  *   - Output connectors supports partition commit
                  *   - Bucket node map uses dynamic scheduling
@@ -227,7 +227,7 @@ public class PlanFragmenter
                  */
                 boolean recoverable = isRecoverableGroupedExecutionEnabled(session) &&
                         parentContainsTableFinish &&
-                        fragment.getRoot() instanceof TableWriterNode &&
+                        fragment.getRoot() instanceof TableWriterMergeNode &&
                         properties.isRecoveryEligible();
                 if (recoverable) {
                     fragment = fragment.withRecoverableGroupedExecution(properties.getCapableTableScanNodes(), properties.getTotalLifespans());


### PR DESCRIPTION
After we introduced TableWriterMergeNode, the root node of writer
fragment is TableWriterMergeNode, so we should use TableWriterMergeNode
to check recoverability.

To make sure this is properly tested, this change would also enable
only two tests in TestHiveRecoverableGroupedExecution. This test is
known to be flaky when we run too many tests because GC would slow
down query execution and cause timeout. Only enabling one seems
a reasonable compromise.


```
== NO RELEASE NOTE ==
```
