### PR TITLE
Support max_tasks_per_stage for scan

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeMap.java
@@ -18,24 +18,34 @@ import com.facebook.presto.spi.HostAddress;
 import com.google.common.collect.SetMultimap;
 
 import java.net.InetAddress;
+import java.util.Map;
 import java.util.Set;
 
 public class NodeMap
 {
+    private final Map<String, InternalNode> nodesByNodeId;
     private final SetMultimap<HostAddress, InternalNode> nodesByHostAndPort;
     private final SetMultimap<InetAddress, InternalNode> nodesByHost;
     private final SetMultimap<NetworkLocation, InternalNode> workersByNetworkPath;
     private final Set<String> coordinatorNodeIds;
 
-    public NodeMap(SetMultimap<HostAddress, InternalNode> nodesByHostAndPort,
+    public NodeMap(
+            Map<String, InternalNode> nodesByNodeId,
+            SetMultimap<HostAddress, InternalNode> nodesByHostAndPort,
             SetMultimap<InetAddress, InternalNode> nodesByHost,
             SetMultimap<NetworkLocation, InternalNode> workersByNetworkPath,
             Set<String> coordinatorNodeIds)
     {
+        this.nodesByNodeId = nodesByNodeId;
         this.nodesByHostAndPort = nodesByHostAndPort;
         this.nodesByHost = nodesByHost;
         this.workersByNetworkPath = workersByNetworkPath;
         this.coordinatorNodeIds = coordinatorNodeIds;
+    }
+
+    public Map<String, InternalNode> getNodesByNodeId()
+    {
+        return nodesByNodeId;
     }
 
     public SetMultimap<HostAddress, InternalNode> getNodesByHostAndPort()

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -22,7 +22,6 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.HostAddress;
 import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -30,6 +29,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.Duration;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
@@ -44,17 +44,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import static com.facebook.airlift.concurrent.MoreFutures.whenAnyCompleteCancelOthers;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType;
 import static com.facebook.presto.spi.NodeState.ACTIVE;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Suppliers.memoizeWithExpiration;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class NodeScheduler
 {
@@ -68,11 +70,12 @@ public class NodeScheduler
     private final int maxPendingSplitsPerTask;
     private final NodeTaskMap nodeTaskMap;
     private final boolean useNetworkTopology;
+    private final Duration nodeMapRefreshInterval;
 
     @Inject
     public NodeScheduler(NetworkTopology networkTopology, InternalNodeManager nodeManager, NodeSchedulerConfig config, NodeTaskMap nodeTaskMap)
     {
-        this(new NetworkLocationCache(networkTopology), networkTopology, nodeManager, config, nodeTaskMap);
+        this(new NetworkLocationCache(networkTopology), networkTopology, nodeManager, config, nodeTaskMap, new Duration(5, SECONDS));
     }
 
     public NodeScheduler(
@@ -80,7 +83,8 @@ public class NodeScheduler
             NetworkTopology networkTopology,
             InternalNodeManager nodeManager,
             NodeSchedulerConfig config,
-            NodeTaskMap nodeTaskMap)
+            NodeTaskMap nodeTaskMap,
+            Duration nodeMapRefreshInterval)
     {
         this.networkLocationCache = networkLocationCache;
         this.nodeManager = nodeManager;
@@ -103,6 +107,7 @@ public class NodeScheduler
             networkLocationSegmentNames = ImmutableList.of();
         }
         topologicalSplitCounters = builder.build();
+        this.nodeMapRefreshInterval = requireNonNull(nodeMapRefreshInterval, "nodeMapRefreshInterval is null");
     }
 
     @PreDestroy
@@ -122,9 +127,38 @@ public class NodeScheduler
 
     public NodeSelector createNodeSelector(ConnectorId connectorId)
     {
+        return createNodeSelector(connectorId, Integer.MAX_VALUE);
+    }
+
+    public NodeSelector createNodeSelector(ConnectorId connectorId, int maxTasksPerStage)
+    {
         // this supplier is thread-safe. TODO: this logic should probably move to the scheduler since the choice of which node to run in should be
         // done as close to when the the split is about to be scheduled
-        Supplier<NodeMap> nodeMap = Suppliers.memoizeWithExpiration(() -> {
+        Supplier<NodeMap> nodeMap = nodeMapRefreshInterval.toMillis() > 0 ?
+                memoizeWithExpiration(createNodeMapSupplier(connectorId), nodeMapRefreshInterval.toMillis(), MILLISECONDS) : createNodeMapSupplier(connectorId);
+
+        if (useNetworkTopology) {
+            return new TopologyAwareNodeSelector(
+                    nodeManager,
+                    nodeTaskMap,
+                    includeCoordinator,
+                    nodeMap,
+                    minCandidates,
+                    maxSplitsPerNode,
+                    maxPendingSplitsPerTask,
+                    topologicalSplitCounters,
+                    networkLocationSegmentNames,
+                    networkLocationCache);
+        }
+        else {
+            return new SimpleNodeSelector(nodeManager, nodeTaskMap, includeCoordinator, nodeMap, minCandidates, maxSplitsPerNode, maxPendingSplitsPerTask, maxTasksPerStage);
+        }
+    }
+
+    private Supplier<NodeMap> createNodeMapSupplier(ConnectorId connectorId)
+    {
+        return () -> {
+            ImmutableMap.Builder<String, InternalNode> byNodeId = ImmutableMap.builder();
             ImmutableSetMultimap.Builder<HostAddress, InternalNode> byHostAndPort = ImmutableSetMultimap.builder();
             ImmutableSetMultimap.Builder<InetAddress, InternalNode> byHost = ImmutableSetMultimap.builder();
             ImmutableSetMultimap.Builder<NetworkLocation, InternalNode> workersByNetworkPath = ImmutableSetMultimap.builder();
@@ -142,6 +176,7 @@ public class NodeScheduler
                     .collect(toImmutableSet());
 
             for (InternalNode node : nodes) {
+                byNodeId.put(node.getNodeIdentifier(), node);
                 if (useNetworkTopology && (includeCoordinator || !coordinatorNodeIds.contains(node.getNodeIdentifier()))) {
                     NetworkLocation location = networkLocationCache.get(node.getHostAndPort());
                     for (int i = 0; i <= location.getSegments().size(); i++) {
@@ -159,25 +194,8 @@ public class NodeScheduler
                 }
             }
 
-            return new NodeMap(byHostAndPort.build(), byHost.build(), workersByNetworkPath.build(), coordinatorNodeIds);
-        }, 5, TimeUnit.SECONDS);
-
-        if (useNetworkTopology) {
-            return new TopologyAwareNodeSelector(
-                    nodeManager,
-                    nodeTaskMap,
-                    includeCoordinator,
-                    nodeMap,
-                    minCandidates,
-                    maxSplitsPerNode,
-                    maxPendingSplitsPerTask,
-                    topologicalSplitCounters,
-                    networkLocationSegmentNames,
-                    networkLocationCache);
-        }
-        else {
-            return new SimpleNodeSelector(nodeManager, nodeTaskMap, includeCoordinator, nodeMap, minCandidates, maxSplitsPerNode, maxPendingSplitsPerTask);
-        }
+            return new NodeMap(byNodeId.build(), byHostAndPort.build(), byHost.build(), workersByNetworkPath.build(), coordinatorNodeIds);
+        };
     }
 
     public static List<InternalNode> selectNodes(int limit, ResettableRandomizedIterator<InternalNode> candidates)

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SimpleNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SimpleNodeSelector.java
@@ -24,7 +24,6 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -40,7 +39,9 @@ import static com.facebook.presto.execution.scheduler.NodeScheduler.selectExactN
 import static com.facebook.presto.execution.scheduler.NodeScheduler.selectNodes;
 import static com.facebook.presto.execution.scheduler.NodeScheduler.toWhenHasSplitQueueSpaceFuture;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
+import static com.google.common.collect.Sets.newHashSet;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 public class SimpleNodeSelector
         implements NodeSelector
@@ -54,6 +55,7 @@ public class SimpleNodeSelector
     private final int minCandidates;
     private final int maxSplitsPerNode;
     private final int maxPendingSplitsPerTask;
+    private final int maxTasksPerStage;
 
     public SimpleNodeSelector(
             InternalNodeManager nodeManager,
@@ -62,7 +64,8 @@ public class SimpleNodeSelector
             Supplier<NodeMap> nodeMap,
             int minCandidates,
             int maxSplitsPerNode,
-            int maxPendingSplitsPerTask)
+            int maxPendingSplitsPerTask,
+            int maxTasksPerStage)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
@@ -71,6 +74,7 @@ public class SimpleNodeSelector
         this.minCandidates = minCandidates;
         this.maxSplitsPerNode = maxSplitsPerNode;
         this.maxPendingSplitsPerTask = maxPendingSplitsPerTask;
+        this.maxTasksPerStage = maxTasksPerStage;
     }
 
     @Override
@@ -105,7 +109,7 @@ public class SimpleNodeSelector
         NodeMap nodeMap = this.nodeMap.get().get();
         NodeAssignmentStats assignmentStats = new NodeAssignmentStats(nodeTaskMap, nodeMap, existingTasks);
 
-        ResettableRandomizedIterator<InternalNode> randomCandidates = randomizedNodes(nodeMap, includeCoordinator, ImmutableSet.of());
+        ResettableRandomizedIterator<InternalNode> randomCandidates = getRandomCandidates(maxTasksPerStage, nodeMap, existingTasks);
         Set<InternalNode> blockedExactNodes = new HashSet<>();
         boolean splitWaitingForAnyNode = false;
         for (Split split : splits) {
@@ -166,6 +170,23 @@ public class SimpleNodeSelector
             blocked = toWhenHasSplitQueueSpaceFuture(blockedExactNodes, existingTasks, calculateLowWatermark(maxPendingSplitsPerTask));
         }
         return new SplitPlacementResult(blocked, assignment);
+    }
+
+    private ResettableRandomizedIterator<InternalNode> getRandomCandidates(int limit, NodeMap nodeMap, List<RemoteTask> existingTasks)
+    {
+        List<InternalNode> existingNodes = existingTasks.stream()
+                .map(remoteTask -> nodeMap.getNodesByNodeId().get(remoteTask.getNodeId()))
+                .collect(toList());
+
+        int alreadySelectedNodeCount = existingTasks.size();
+        int nodeCount = nodeMap.getNodesByNodeId().size();
+
+        if (alreadySelectedNodeCount < limit && alreadySelectedNodeCount < nodeCount) {
+            List<InternalNode> moreNodes =
+                    selectNodes(limit - alreadySelectedNodeCount, randomizedNodes(nodeMap, includeCoordinator, newHashSet(existingNodes)));
+            existingNodes.addAll(moreNodes);
+        }
+        return new ResettableRandomizedIterator<>(existingNodes);
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -21,6 +21,7 @@ import com.facebook.presto.execution.scheduler.NetworkTopology;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.NodeSelector;
+import com.facebook.presto.execution.scheduler.SplitPlacementResult;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Split;
@@ -37,6 +38,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import io.airlift.units.Duration;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -59,6 +61,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -161,7 +164,7 @@ public class TestNodeScheduler
                 }
             }
         };
-        NodeScheduler nodeScheduler = new NodeScheduler(locationCache, topology, nodeManager, nodeSchedulerConfig, nodeTaskMap);
+        NodeScheduler nodeScheduler = new NodeScheduler(locationCache, topology, nodeManager, nodeSchedulerConfig, nodeTaskMap, new Duration(5, SECONDS));
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(CONNECTOR_ID);
 
         // Fill up the nodes with non-local data
@@ -422,6 +425,97 @@ public class TestNodeScheduler
         assertEquals(nodeTaskMap.getPartitionedSplitsOnNode(chosenNode), 1);
         remoteTask2.abort();
         assertEquals(nodeTaskMap.getPartitionedSplitsOnNode(chosenNode), 0);
+    }
+
+    @Test
+    public void testMaxTasksPerStageWittLimit()
+    {
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        TestingTransactionHandle transactionHandle = TestingTransactionHandle.create();
+        NodeSchedulerConfig nodeSchedulerConfig = new NodeSchedulerConfig()
+                .setMaxSplitsPerNode(20)
+                .setIncludeCoordinator(false)
+                .setMaxPendingSplitsPerTask(10);
+
+        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, nodeSchedulerConfig, nodeTaskMap);
+        NodeSelector nodeSelector = nodeScheduler.createNodeSelector(CONNECTOR_ID, 2);
+
+        Set<Split> splits = new HashSet<>();
+
+        splits.add(new Split(CONNECTOR_ID, transactionHandle, new TestSplitRemote()));
+        SplitPlacementResult splitPlacementResult = nodeSelector.computeAssignments(splits, ImmutableList.of());
+        Set<InternalNode> internalNodes = splitPlacementResult.getAssignments().keySet();
+        assertEquals(internalNodes.size(), 1);
+
+        // adding one more split. Total 2
+        splits.add(new Split(CONNECTOR_ID, transactionHandle, new TestSplitRemote()));
+        splitPlacementResult = nodeSelector.computeAssignments(splits, getRemoteTableScanTask(splitPlacementResult));
+        Set<InternalNode> internalNodesSecondCall = splitPlacementResult.getAssignments().keySet();
+        assertEquals(internalNodesSecondCall.size(), 2);
+        assertTrue(internalNodesSecondCall.containsAll(internalNodes));
+
+        // adding one more split. Total 3
+        splits.add(new Split(CONNECTOR_ID, transactionHandle, new TestSplitRemote()));
+        splitPlacementResult = nodeSelector.computeAssignments(splits, getRemoteTableScanTask(splitPlacementResult));
+        assertEquals(splitPlacementResult.getAssignments().keySet().size(), 2);
+        assertEquals(splitPlacementResult.getAssignments().keySet(), internalNodesSecondCall);
+    }
+
+    @Test
+    public void testMaxTasksPerStageAddingNewNodes()
+    {
+        InMemoryNodeManager nodeManager = new InMemoryNodeManager();
+
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        TestingTransactionHandle transactionHandle = TestingTransactionHandle.create();
+        NodeSchedulerConfig nodeSchedulerConfig = new NodeSchedulerConfig()
+                .setMaxSplitsPerNode(20)
+                .setIncludeCoordinator(false)
+                .setMaxPendingSplitsPerTask(10);
+
+        LegacyNetworkTopology networkTopology = new LegacyNetworkTopology();
+        // refresh interval is 1 nanosecond
+        NodeScheduler nodeScheduler = new NodeScheduler(new NetworkLocationCache(networkTopology), networkTopology, nodeManager, nodeSchedulerConfig, nodeTaskMap, Duration.valueOf("0s"));
+        NodeSelector nodeSelector = nodeScheduler.createNodeSelector(CONNECTOR_ID, 2);
+
+        Set<Split> splits = new HashSet<>();
+        splits.add(new Split(CONNECTOR_ID, transactionHandle, new TestSplitRemote()));
+        splits.add(new Split(CONNECTOR_ID, transactionHandle, new TestSplitRemote()));
+        splits.add(new Split(CONNECTOR_ID, transactionHandle, new TestSplitRemote()));
+
+        nodeManager.addNode(CONNECTOR_ID, ImmutableList.of(new InternalNode("node1", URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN, false)));
+        SplitPlacementResult splitPlacementResult = nodeSelector.computeAssignments(splits, ImmutableList.of());
+        Set<InternalNode> internalNodes = splitPlacementResult.getAssignments().keySet();
+        assertEquals(internalNodes.size(), 1);
+
+        nodeManager.addNode(CONNECTOR_ID, ImmutableList.of(new InternalNode("node2", URI.create("http://127.0.0.1:12"), NodeVersion.UNKNOWN, false)));
+
+        splitPlacementResult = nodeSelector.computeAssignments(splits, getRemoteTableScanTask(splitPlacementResult));
+        Set<InternalNode> internalNodesSecondCall = splitPlacementResult.getAssignments().keySet();
+        assertEquals(internalNodesSecondCall.size(), 2);
+        assertTrue(internalNodesSecondCall.containsAll(internalNodes));
+
+        nodeManager.addNode(CONNECTOR_ID, ImmutableList.of(new InternalNode("node2", URI.create("http://127.0.0.1:13"), NodeVersion.UNKNOWN, false)));
+        internalNodes = splitPlacementResult.getAssignments().keySet();
+        assertEquals(internalNodes.size(), 2);
+        assertTrue(internalNodesSecondCall.containsAll(internalNodes));
+    }
+
+    private List<RemoteTask> getRemoteTableScanTask(SplitPlacementResult splitPlacementResult)
+    {
+        Map<InternalNode, RemoteTask> taskMap = new HashMap<>();
+        Multimap<InternalNode, Split> assignments = splitPlacementResult.getAssignments();
+        MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
+        int task = 0;
+        for (InternalNode node : assignments.keySet()) {
+            TaskId taskId = new TaskId("test", 1, 1, task);
+            task++;
+            MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, ImmutableList.copyOf(assignments.get(node)), nodeTaskMap.createPartitionedSplitCountTracker(node, taskId));
+            remoteTask.startSplits(25);
+            nodeTaskMap.addTask(node, remoteTask);
+            taskMap.put(node, remoteTask);
+        }
+        return ImmutableList.copyOf(taskMap.values());
     }
 
     private static class TestSplitLocal


### PR DESCRIPTION
stage.max-tasks-per-stage configuration property can be used by to limit the number of tasks for scan.  

== RELEASE NOTES ==

General Changes

- Respect stage.max-tasks-per-stage to limit number of tasks for scan.

