### PR TITLE
Support transaction in FunctionNamespaceManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,6 +426,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-sql-function</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-afterburner</artifactId>
                 <version>${dep.jackson.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
         <module>presto-proxy</module>
         <module>presto-kudu</module>
         <module>presto-elasticsearch</module>
+        <module>presto-sql-function</module>
     </modules>
 
     <dependencyManagement>

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestBingTileFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestBingTileFunctions.java
@@ -60,8 +60,8 @@ public class TestBingTileFunctions
         for (Type type : plugin.getTypes()) {
             functionAssertions.getTypeRegistry().addType(type);
         }
-        functionAssertions.getMetadata().addFunctions(extractFunctions(plugin.getFunctions()));
-        functionAssertions.getMetadata().addFunctions(ImmutableList.of(APPLY_FUNCTION));
+        functionAssertions.getMetadata().registerBuiltInFunctions(extractFunctions(plugin.getFunctions()));
+        functionAssertions.getMetadata().registerBuiltInFunctions(ImmutableList.of(APPLY_FUNCTION));
         FunctionManager functionManager = functionAssertions.getMetadata().getFunctionManager();
         approxDistinct = functionManager.getAggregateFunctionImplementation(
                 functionManager.lookupFunction("approx_distinct", fromTypes(BING_TILE)));

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSphericalGeoFunctions.java
@@ -47,7 +47,7 @@ public class TestSphericalGeoFunctions
         for (Type type : plugin.getTypes()) {
             functionAssertions.getTypeRegistry().addType(type);
         }
-        functionAssertions.getMetadata().addFunctions(extractFunctions(plugin.getFunctions()));
+        functionAssertions.getMetadata().registerBuiltInFunctions(extractFunctions(plugin.getFunctions()));
     }
 
     @Test

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/AbstractTestGeoAggregationFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/AbstractTestGeoAggregationFunctions.java
@@ -48,7 +48,7 @@ public abstract class AbstractTestGeoAggregationFunctions
         for (Type type : plugin.getTypes()) {
             functionAssertions.getTypeRegistry().addType(type);
         }
-        functionAssertions.getMetadata().addFunctions(extractFunctions(plugin.getFunctions()));
+        functionAssertions.getMetadata().registerBuiltInFunctions(extractFunctions(plugin.getFunctions()));
         FunctionManager functionManager = functionAssertions.getMetadata().getFunctionManager();
         function = functionManager.getAggregateFunctionImplementation(
                 functionManager.lookupFunction(getFunctionName(), fromTypes(GEOMETRY)));

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -72,6 +72,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-sql-function</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunction.java
@@ -11,17 +11,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.spi.function;
+package com.facebook.presto.metadata;
 
-public interface SqlFunction
+import com.facebook.presto.spi.function.SqlFunction;
+
+public abstract class BuiltInFunction
+        implements SqlFunction
 {
-    Signature getSignature();
-
-    boolean isHidden();
-
-    boolean isDeterministic();
-
-    boolean isCalledOnNullInput();
-
-    String getDescription();
+    @Override
+    public boolean isCalledOnNullInput()
+    {
+        return false;
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
@@ -690,9 +690,9 @@ public class BuiltInFunctionNamespaceManager
     }
 
     @Override
-    public Collection<BuiltInFunction> getCandidates(QueryId queryId, FullyQualifiedName name)
+    public Collection<BuiltInFunction> getFunctions(QueryId queryId, FullyQualifiedName functionName)
     {
-        return functions.get(name);
+        return functions.get(functionName);
     }
 
     @Override
@@ -801,7 +801,7 @@ public class BuiltInFunctionNamespaceManager
 
     private SpecializedFunctionKey doGetSpecializedFunctionKey(Signature signature)
     {
-        Iterable<BuiltInFunction> candidates = getCandidates(null, signature.getName());
+        Iterable<BuiltInFunction> candidates = getFunctions(null, signature.getName());
         // search for exact match
         Type returnType = typeManager.getType(signature.getReturnType());
         List<TypeSignatureProvider> argumentTypeSignatureProviders = fromTypeSignatures(signature.getArgumentTypes());

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
@@ -664,11 +664,10 @@ public class BuiltInFunctionNamespaceManager
             builder.scalar(LegacyLogFunction.class);
         }
 
-        addFunctions(builder.getFunctions());
+        registerBuiltInFunctions(builder.getFunctions());
     }
 
-    @Override
-    public final synchronized void addFunctions(List<? extends SqlFunction> functions)
+    public synchronized void registerBuiltInFunctions(List<? extends SqlFunction> functions)
     {
         for (SqlFunction function : functions) {
             for (SqlFunction existingFunction : this.functions.list()) {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
@@ -684,7 +684,7 @@ public class BuiltInFunctionNamespaceManager
     }
 
     @Override
-    public List<BuiltInFunction> listFunctions()
+    public Collection<BuiltInFunction> listFunctions()
     {
         return functions.list();
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionExtractor.java
@@ -18,7 +18,6 @@ import com.facebook.presto.operator.window.WindowAnnotationsParser;
 import com.facebook.presto.spi.function.AggregationFunction;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.ScalarOperator;
-import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.function.WindowFunction;
 
 import java.util.Collection;
@@ -30,7 +29,7 @@ public final class FunctionExtractor
 {
     private FunctionExtractor() {}
 
-    public static List<? extends SqlFunction> extractFunctions(Collection<Class<?>> classes)
+    public static List<BuiltInFunction> extractFunctions(Collection<Class<?>> classes)
     {
         return classes.stream()
                 .map(FunctionExtractor::extractFunctions)
@@ -38,7 +37,7 @@ public final class FunctionExtractor
                 .collect(toImmutableList());
     }
 
-    public static List<? extends SqlFunction> extractFunctions(Class<?> clazz)
+    public static List<? extends BuiltInFunction> extractFunctions(Class<?> clazz)
     {
         if (WindowFunction.class.isAssignableFrom(clazz)) {
             @SuppressWarnings("unchecked")

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
@@ -15,7 +15,6 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.operator.scalar.annotations.ScalarFromAnnotationsParser;
 import com.facebook.presto.operator.window.WindowAnnotationsParser;
-import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.function.WindowFunction;
 import com.google.common.collect.ImmutableList;
 
@@ -26,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 public class FunctionListBuilder
 {
-    private final List<SqlFunction> functions = new ArrayList<>();
+    private final List<BuiltInFunction> functions = new ArrayList<>();
 
     public FunctionListBuilder window(Class<? extends WindowFunction> clazz)
     {
@@ -58,22 +57,22 @@ public class FunctionListBuilder
         return this;
     }
 
-    public FunctionListBuilder functions(SqlFunction... sqlFunctions)
+    public FunctionListBuilder functions(BuiltInFunction... sqlFunctions)
     {
-        for (SqlFunction sqlFunction : sqlFunctions) {
+        for (BuiltInFunction sqlFunction : sqlFunctions) {
             function(sqlFunction);
         }
         return this;
     }
 
-    public FunctionListBuilder function(SqlFunction sqlFunction)
+    public FunctionListBuilder function(BuiltInFunction sqlFunction)
     {
         requireNonNull(sqlFunction, "parametricFunction is null");
         functions.add(sqlFunction);
         return this;
     }
 
-    public List<SqlFunction> getFunctions()
+    public List<BuiltInFunction> getFunctions()
     {
         return ImmutableList.copyOf(functions);
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
@@ -135,9 +135,9 @@ public class FunctionManager
         handleResolver.addFunctionNamespace(factory.getName(), factory.getHandleResolver());
     }
 
-    public void addFunctions(List<? extends SqlFunction> functions)
+    public void registerBuiltInFunctions(List<? extends BuiltInFunction> functions)
     {
-        builtInFunctionNamespaceManager.addFunctions(functions);
+        builtInFunctionNamespaceManager.registerBuiltInFunctions(functions);
     }
 
     public List<SqlFunction> listFunctions()

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
@@ -157,6 +157,11 @@ public class FunctionManager
      */
     public FunctionHandle resolveFunction(Session session, QualifiedName name, List<TypeSignatureProvider> parameterTypes)
     {
+        return resolveFunction(Optional.of(session), name, parameterTypes);
+    }
+
+    private FunctionHandle resolveFunction(Optional<Session> session, QualifiedName name, List<TypeSignatureProvider> parameterTypes)
+    {
         FullyQualifiedName functionName;
         if (!name.getPrefix().isPresent()) {
             functionName = FullyQualifiedName.of(DEFAULT_NAMESPACE, name.getSuffix());
@@ -170,7 +175,7 @@ public class FunctionManager
             throw new PrestoException(FUNCTION_NOT_FOUND, format("Cannot find function namespace for function %s", name));
         }
 
-        QueryId queryId = session == null ? null : session.getQueryId();
+        QueryId queryId = session.map(Session::getQueryId).orElse(null);
         Collection<? extends SqlFunction> candidates = functionNamespaceManager.get().getFunctions(queryId, functionName);
 
         try {
@@ -239,7 +244,7 @@ public class FunctionManager
     public FunctionHandle resolveOperator(OperatorType operatorType, List<TypeSignatureProvider> argumentTypes)
     {
         try {
-            return resolveFunction(null, QualifiedName.of(operatorType.getFunctionName().getParts()), argumentTypes);
+            return resolveFunction(Optional.empty(), QualifiedName.of(operatorType.getFunctionName().getParts()), argumentTypes);
         }
         catch (PrestoException e) {
             if (e.getErrorCode().getCode() == FUNCTION_NOT_FOUND.toErrorCode().getCode()) {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
@@ -171,7 +171,7 @@ public class FunctionManager
         }
 
         QueryId queryId = session == null ? null : session.getQueryId();
-        Collection<? extends SqlFunction> candidates = functionNamespaceManager.get().getCandidates(queryId, functionName);
+        Collection<? extends SqlFunction> candidates = functionNamespaceManager.get().getFunctions(queryId, functionName);
 
         try {
             return lookupFunction(functionNamespaceManager.get(), queryId, functionName, parameterTypes, candidates);
@@ -264,7 +264,7 @@ public class FunctionManager
     public FunctionHandle lookupFunction(String name, List<TypeSignatureProvider> parameterTypes)
     {
         FullyQualifiedName functionName = FullyQualifiedName.of(DEFAULT_NAMESPACE, name);
-        Collection<? extends SqlFunction> candidates = builtInFunctionNamespaceManager.getCandidates(null, functionName);
+        Collection<? extends SqlFunction> candidates = builtInFunctionNamespaceManager.getFunctions(null, functionName);
         return lookupFunction(builtInFunctionNamespaceManager, null, functionName, parameterTypes, candidates);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -60,7 +60,7 @@ public interface Metadata
 
     List<SqlFunction> listFunctions();
 
-    void addFunctions(List<? extends SqlFunction> functions);
+    void registerBuiltInFunctions(List<? extends BuiltInFunction> functions);
 
     boolean schemaExists(Session session, CatalogSchemaName schema);
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -271,10 +271,9 @@ public class MetadataManager
     }
 
     @Override
-    public void addFunctions(List<? extends SqlFunction> functionInfos)
+    public void registerBuiltInFunctions(List<? extends BuiltInFunction> functionInfos)
     {
-        // TODO: transactional when FunctionManager is made transactional
-        functions.addFunctions(functionInfos);
+        functions.registerBuiltInFunctions(functionInfos);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -155,7 +155,7 @@ public class MetadataManager
                 columnPropertyManager,
                 analyzePropertyManager,
                 transactionManager,
-                new FunctionManager(typeManager, blockEncodingSerde, featuresConfig));
+                new FunctionManager(typeManager, transactionManager, blockEncodingSerde, featuresConfig, new HandleResolver()));
     }
 
     @Inject

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SpecializedFunctionKey.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SpecializedFunctionKey.java
@@ -13,26 +13,24 @@
  */
 package com.facebook.presto.metadata;
 
-import com.facebook.presto.spi.function.SqlFunction;
-
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
 public class SpecializedFunctionKey
 {
-    private final SqlFunction function;
+    private final BuiltInFunction function;
     private final BoundVariables boundVariables;
     private final int arity;
 
-    public SpecializedFunctionKey(SqlFunction function, BoundVariables boundVariables, int arity)
+    public SpecializedFunctionKey(BuiltInFunction function, BoundVariables boundVariables, int arity)
     {
         this.function = requireNonNull(function, "function is null");
         this.boundVariables = requireNonNull(boundVariables, "boundVariables is null");
         this.arity = arity;
     }
 
-    public SqlFunction getFunction()
+    public BuiltInFunction getFunction()
     {
         return function;
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SqlAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SqlAggregationFunction.java
@@ -18,7 +18,6 @@ import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.function.LongVariableConstraint;
 import com.facebook.presto.spi.function.Signature;
-import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.function.TypeVariableConstraint;
 import com.facebook.presto.spi.relation.FullyQualifiedName;
 import com.facebook.presto.spi.type.TypeManager;
@@ -34,7 +33,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public abstract class SqlAggregationFunction
-        implements SqlFunction
+        extends BuiltInFunction
 {
     private final Signature signature;
     private final boolean hidden;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SqlScalarFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SqlScalarFunction.java
@@ -16,7 +16,6 @@ package com.facebook.presto.metadata;
 import com.facebook.presto.operator.scalar.ScalarFunctionImplementation;
 import com.facebook.presto.spi.function.OperatorType;
 import com.facebook.presto.spi.function.Signature;
-import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.type.TypeManager;
 
 import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
@@ -24,7 +23,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public abstract class SqlScalarFunction
-        implements SqlFunction
+        extends BuiltInFunction
 {
     private final Signature signature;
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/SqlWindowFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/SqlWindowFunction.java
@@ -14,15 +14,15 @@
 package com.facebook.presto.operator.window;
 
 import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.BuiltInFunction;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.spi.function.Signature;
-import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.type.TypeManager;
 
 import static java.util.Objects.requireNonNull;
 
 public class SqlWindowFunction
-        implements SqlFunction
+        extends BuiltInFunction
 {
     private final WindowFunctionSupplier supplier;
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -208,7 +208,7 @@ public class PluginManager
 
         for (Class<?> functionClass : plugin.getFunctions()) {
             log.info("Registering functions from %s", functionClass.getName());
-            metadata.addFunctions(extractFunctions(functionClass));
+            metadata.registerBuiltInFunctions(extractFunctions(functionClass));
         }
 
         for (FunctionNamespaceManagerFactory functionNamespaceManagerFactory : plugin.getFunctionNamespaceManagerFactories()) {

--- a/presto-main/src/main/java/com/facebook/presto/testing/InMemoryFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/InMemoryFunctionNamespaceManager.java
@@ -14,12 +14,10 @@
 package com.facebook.presto.testing;
 
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionMetadata;
-import com.facebook.presto.spi.function.FunctionNamespaceManager;
-import com.facebook.presto.spi.function.Signature;
 import com.facebook.presto.spi.relation.FullyQualifiedName;
+import com.facebook.presto.sqlfunction.AbstractSqlInvokedFunctionNamespaceManager;
 import com.facebook.presto.sqlfunction.SqlFunctionId;
 import com.facebook.presto.sqlfunction.SqlInvokedRegularFunction;
 
@@ -36,9 +34,16 @@ import static java.lang.String.format;
 
 @ThreadSafe
 public class InMemoryFunctionNamespaceManager
-        implements FunctionNamespaceManager<SqlInvokedRegularFunction>
+        extends AbstractSqlInvokedFunctionNamespaceManager
 {
+    private static final String NAME = "_in_memory";
     private final Map<SqlFunctionId, SqlInvokedRegularFunction> latestFunctions = new ConcurrentHashMap<>();
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
 
     @Override
     public synchronized void createFunction(SqlInvokedRegularFunction function, boolean replace)
@@ -65,17 +70,11 @@ public class InMemoryFunctionNamespaceManager
     }
 
     @Override
-    public Collection<SqlInvokedRegularFunction> getFunctions(QueryId queryId, FullyQualifiedName name)
+    public Collection<SqlInvokedRegularFunction> fetchFunctions(FullyQualifiedName name)
     {
         return latestFunctions.values().stream()
                 .filter(function -> function.getSignature().getName().equals(name))
                 .collect(toImmutableList());
-    }
-
-    @Override
-    public FunctionHandle getFunctionHandle(QueryId queryId, Signature signature)
-    {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/testing/InMemoryFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/InMemoryFunctionNamespaceManager.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testing;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.FunctionNamespaceManager;
+import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.relation.FullyQualifiedName;
+import com.facebook.presto.sqlfunction.SqlFunctionId;
+import com.facebook.presto.sqlfunction.SqlInvokedRegularFunction;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+
+@ThreadSafe
+public class InMemoryFunctionNamespaceManager
+        implements FunctionNamespaceManager<SqlInvokedRegularFunction>
+{
+    private final Map<SqlFunctionId, SqlInvokedRegularFunction> latestFunctions = new ConcurrentHashMap<>();
+
+    @Override
+    public synchronized void createFunction(SqlInvokedRegularFunction function, boolean replace)
+    {
+        SqlFunctionId functionId = new SqlFunctionId(function.getSignature().getName(), function.getSignature().getArgumentTypes());
+        if (!replace && latestFunctions.containsKey(functionId)) {
+            throw new PrestoException(GENERIC_USER_ERROR, format("Function '%s' already exists", functionId.getName()));
+        }
+
+        SqlInvokedRegularFunction replacedFunction = latestFunctions.get(functionId);
+        long version = 1;
+        if (replacedFunction != null) {
+            checkArgument(replacedFunction.getVersion().isPresent(), "missing version in replaced function");
+            version = replacedFunction.getVersion().get() + 1;
+        }
+        function = SqlInvokedRegularFunction.versioned(function, version);
+        latestFunctions.put(functionId, function);
+    }
+
+    @Override
+    public Collection<SqlInvokedRegularFunction> listFunctions()
+    {
+        return latestFunctions.values();
+    }
+
+    @Override
+    public Collection<SqlInvokedRegularFunction> getFunctions(QueryId queryId, FullyQualifiedName name)
+    {
+        return latestFunctions.values().stream()
+                .filter(function -> function.getSignature().getName().equals(name))
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public FunctionHandle getFunctionHandle(QueryId queryId, Signature signature)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FunctionMetadata getFunctionMetadata(FunctionHandle functionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/transaction/NoOpTransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/NoOpTransactionManager.java
@@ -16,6 +16,8 @@ package com.facebook.presto.transaction;
 import com.facebook.presto.metadata.CatalogMetadata;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.function.FunctionNamespaceManager;
+import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
 import com.facebook.presto.spi.transaction.IsolationLevel;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -91,6 +93,17 @@ public class NoOpTransactionManager
 
     @Override
     public ConnectorTransactionHandle getConnectorTransaction(TransactionId transactionId, ConnectorId connectorId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void registerFunctionNamespaceManager(String functionNamespaceManagerName, FunctionNamespaceManager<?> functionNamespaceManager)
+    {
+    }
+
+    @Override
+    public FunctionNamespaceTransactionHandle getFunctionNamespaceTransaction(TransactionId transactionId, String functionNamespaceManagerName)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/main/java/com/facebook/presto/transaction/TransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/TransactionManager.java
@@ -18,6 +18,8 @@ import com.facebook.presto.metadata.CatalogMetadata;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.function.FunctionNamespaceManager;
+import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
 import com.facebook.presto.spi.transaction.IsolationLevel;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -56,6 +58,10 @@ public interface TransactionManager
     CatalogMetadata getCatalogMetadataForWrite(TransactionId transactionId, String catalogName);
 
     ConnectorTransactionHandle getConnectorTransaction(TransactionId transactionId, ConnectorId connectorId);
+
+    void registerFunctionNamespaceManager(String functionNamespaceManagerName, FunctionNamespaceManager<?> functionNamespaceManager);
+
+    FunctionNamespaceTransactionHandle getFunctionNamespaceTransaction(TransactionId transactionId, String functionNamespaceManagerName);
 
     void checkAndSetActive(TransactionId transactionId);
 

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -75,7 +75,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public void addFunctions(List<? extends SqlFunction> functions)
+    public void registerBuiltInFunctions(List<? extends BuiltInFunction> functions)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/SqlInvokedRegularFunctionTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/SqlInvokedRegularFunctionTestUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.spi.relation.FullyQualifiedName;
+import com.facebook.presto.sqlfunction.RoutineCharacteristics;
+import com.facebook.presto.sqlfunction.SqlInvokedRegularFunction;
+import com.facebook.presto.sqlfunction.SqlParameter;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+import static com.facebook.presto.spi.type.StandardTypes.DOUBLE;
+import static com.facebook.presto.spi.type.StandardTypes.INTEGER;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.sqlfunction.RoutineCharacteristics.Determinism.DETERMINISTIC;
+import static com.facebook.presto.sqlfunction.RoutineCharacteristics.Language.SQL;
+import static com.facebook.presto.sqlfunction.RoutineCharacteristics.NullCallClause.CALLED_ON_NULL_INPUT;
+import static com.facebook.presto.sqlfunction.RoutineCharacteristics.NullCallClause.RETURNS_NULL_ON_NULL_INPUT;
+
+public class SqlInvokedRegularFunctionTestUtils
+{
+    private SqlInvokedRegularFunctionTestUtils()
+    {
+    }
+
+    public static final FullyQualifiedName POWER_TOWER = FullyQualifiedName.of("unittest.memory.power_tower");
+
+    public static final SqlInvokedRegularFunction FUNCTION_POWER_TOWER_DOUBLE = new SqlInvokedRegularFunction(
+            POWER_TOWER,
+            ImmutableList.of(new SqlParameter("x", parseTypeSignature(DOUBLE))),
+            parseTypeSignature(DOUBLE),
+            Optional.of("power tower"),
+            new RoutineCharacteristics(SQL, DETERMINISTIC, CALLED_ON_NULL_INPUT),
+            "pow(x, x)",
+            Optional.empty());
+
+    public static final SqlInvokedRegularFunction FUNCTION_POWER_TOWER_DOUBLE_UPDATED = new SqlInvokedRegularFunction(
+            POWER_TOWER,
+            ImmutableList.of(new SqlParameter("x", parseTypeSignature(DOUBLE))),
+            parseTypeSignature(DOUBLE),
+            Optional.of("power tower"),
+            new RoutineCharacteristics(SQL, DETERMINISTIC, RETURNS_NULL_ON_NULL_INPUT),
+            "pow(x, x)",
+            Optional.empty());
+
+    public static final SqlInvokedRegularFunction FUNCTION_POWER_TOWER_INT = new SqlInvokedRegularFunction(
+            POWER_TOWER,
+            ImmutableList.of(new SqlParameter("x", parseTypeSignature(INTEGER))),
+            parseTypeSignature(INTEGER),
+            Optional.of("power tower"),
+            new RoutineCharacteristics(SQL, DETERMINISTIC, RETURNS_NULL_ON_NULL_INPUT),
+            "pow(x, x)",
+            Optional.empty());
+}

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionManager.java
@@ -117,7 +117,7 @@ public class TestFunctionManager
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "\\QFunction already registered: presto.default.custom_add(bigint,bigint):bigint\\E")
     public void testDuplicateFunctions()
     {
-        List<SqlFunction> functions = new FunctionListBuilder()
+        List<BuiltInFunction> functions = new FunctionListBuilder()
                 .scalars(CustomFunctions.class)
                 .getFunctions()
                 .stream()
@@ -133,7 +133,7 @@ public class TestFunctionManager
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "'presto.default.sum' is both an aggregation and a scalar function")
     public void testConflictingScalarAggregation()
     {
-        List<SqlFunction> functions = new FunctionListBuilder()
+        List<BuiltInFunction> functions = new FunctionListBuilder()
                 .scalars(ScalarSum.class)
                 .getFunctions();
 
@@ -403,9 +403,9 @@ public class TestFunctionManager
             return functionManager.resolveFunction(TEST_SESSION, QualifiedName.of("presto", "default", TEST_FUNCTION_NAME), fromTypeSignatures(parameterTypes));
         }
 
-        private List<SqlFunction> createFunctionsFromSignatures()
+        private List<BuiltInFunction> createFunctionsFromSignatures()
         {
-            ImmutableList.Builder<SqlFunction> functions = ImmutableList.builder();
+            ImmutableList.Builder<BuiltInFunction> functions = ImmutableList.builder();
             for (SignatureBuilder functionSignature : functionSignatures) {
                 Signature signature = functionSignature.name(TEST_FUNCTION_NAME).build();
                 functions.add(new SqlScalarFunction(signature)

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionManager.java
@@ -126,8 +126,8 @@ public class TestFunctionManager
 
         TypeRegistry typeManager = new TypeRegistry();
         FunctionManager functionManager = createFunctionManager(typeManager);
-        functionManager.addFunctions(functions);
-        functionManager.addFunctions(functions);
+        functionManager.registerBuiltInFunctions(functions);
+        functionManager.registerBuiltInFunctions(functions);
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "'presto.default.sum' is both an aggregation and a scalar function")
@@ -139,7 +139,7 @@ public class TestFunctionManager
 
         TypeRegistry typeManager = new TypeRegistry();
         FunctionManager functionManager = createFunctionManager(typeManager);
-        functionManager.addFunctions(functions);
+        functionManager.registerBuiltInFunctions(functions);
     }
 
     @Test
@@ -399,7 +399,7 @@ public class TestFunctionManager
         {
             FeaturesConfig featuresConfig = new FeaturesConfig();
             FunctionManager functionManager = new FunctionManager(typeRegistry, blockEncoding, featuresConfig);
-            functionManager.addFunctions(createFunctionsFromSignatures());
+            functionManager.registerBuiltInFunctions(createFunctionsFromSignatures());
             return functionManager.resolveFunction(TEST_SESSION, QualifiedName.of("presto", "default", TEST_FUNCTION_NAME), fromTypeSignatures(parameterTypes));
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionNamespaceManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionNamespaceManager.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.spi.ErrorCodeSupplier;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.testing.InMemoryFunctionNamespaceManager;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.metadata.SqlInvokedRegularFunctionTestUtils.FUNCTION_POWER_TOWER_DOUBLE;
+import static com.facebook.presto.metadata.SqlInvokedRegularFunctionTestUtils.FUNCTION_POWER_TOWER_DOUBLE_UPDATED;
+import static com.facebook.presto.metadata.SqlInvokedRegularFunctionTestUtils.FUNCTION_POWER_TOWER_INT;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
+import static com.facebook.presto.sqlfunction.SqlInvokedRegularFunction.versioned;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static java.lang.String.format;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestFunctionNamespaceManager
+{
+    @Test
+    public void testCreateFunction()
+    {
+        InMemoryFunctionNamespaceManager functionNamespaceManager = createFunctionNamespaceManager();
+        functionNamespaceManager.createFunction(FUNCTION_POWER_TOWER_DOUBLE, false);
+        assertEquals(functionNamespaceManager.listFunctions(), ImmutableSet.of(versioned(FUNCTION_POWER_TOWER_DOUBLE, 1)));
+
+        functionNamespaceManager.createFunction(FUNCTION_POWER_TOWER_INT, false);
+        assertEquals(
+                ImmutableSet.copyOf(functionNamespaceManager.listFunctions()),
+                ImmutableSet.of(versioned(FUNCTION_POWER_TOWER_DOUBLE, 1), versioned(FUNCTION_POWER_TOWER_INT, 1)));
+
+        functionNamespaceManager.createFunction(FUNCTION_POWER_TOWER_DOUBLE_UPDATED, true);
+        assertEquals(
+                ImmutableSet.copyOf(functionNamespaceManager.listFunctions()),
+                ImmutableSet.of(versioned(FUNCTION_POWER_TOWER_DOUBLE_UPDATED, 2), versioned(FUNCTION_POWER_TOWER_INT, 1)));
+
+        System.out.println(FUNCTION_POWER_TOWER_DOUBLE);
+    }
+
+    @Test
+    public void testCreateFunctionFailed()
+    {
+        InMemoryFunctionNamespaceManager functionNamespaceManager = createFunctionNamespaceManager();
+        functionNamespaceManager.createFunction(FUNCTION_POWER_TOWER_DOUBLE, false);
+        assertPrestoException(
+                () -> functionNamespaceManager.createFunction(FUNCTION_POWER_TOWER_DOUBLE_UPDATED, false),
+                GENERIC_USER_ERROR,
+                ".*Function 'unittest.memory.power_tower' already exists");
+    }
+
+    private static InMemoryFunctionNamespaceManager createFunctionNamespaceManager()
+    {
+        return new InMemoryFunctionNamespaceManager();
+    }
+
+    private static void assertPrestoException(Runnable runnable, ErrorCodeSupplier expectedErrorCode, String expectedMessageRegex)
+    {
+        try {
+            runnable.run();
+            fail(format("Expected PrestoException with error code '%s', but not Exception is thrown", expectedErrorCode.toErrorCode().getName()));
+        }
+        catch (PrestoException e) {
+            assertEquals(e.getErrorCode(), expectedErrorCode.toErrorCode());
+            assertTrue(e.getMessage().matches(expectedMessageRegex));
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionNamespaceManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionNamespaceManager.java
@@ -15,16 +15,23 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
+import com.facebook.presto.sqlfunction.SqlInvokedRegularFunction;
 import com.facebook.presto.testing.InMemoryFunctionNamespaceManager;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
+import java.util.Collection;
+import java.util.Optional;
+
 import static com.facebook.presto.metadata.SqlInvokedRegularFunctionTestUtils.FUNCTION_POWER_TOWER_DOUBLE;
 import static com.facebook.presto.metadata.SqlInvokedRegularFunctionTestUtils.FUNCTION_POWER_TOWER_DOUBLE_UPDATED;
 import static com.facebook.presto.metadata.SqlInvokedRegularFunctionTestUtils.FUNCTION_POWER_TOWER_INT;
+import static com.facebook.presto.metadata.SqlInvokedRegularFunctionTestUtils.POWER_TOWER;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static com.facebook.presto.sqlfunction.SqlInvokedRegularFunction.versioned;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -60,6 +67,42 @@ public class TestFunctionNamespaceManager
                 () -> functionNamespaceManager.createFunction(FUNCTION_POWER_TOWER_DOUBLE_UPDATED, false),
                 GENERIC_USER_ERROR,
                 ".*Function 'unittest.memory.power_tower' already exists");
+    }
+
+    @Test
+    public void testTransactionalGetFunction()
+    {
+        InMemoryFunctionNamespaceManager functionNamespaceManager = createFunctionNamespaceManager();
+
+        // begin first transaction
+        FunctionNamespaceTransactionHandle transaction1 = functionNamespaceManager.beginTransaction();
+        assertEquals(functionNamespaceManager.getFunctions(Optional.of(transaction1), POWER_TOWER).size(), 0);
+
+        // create function, first transaction still sees no functions
+        functionNamespaceManager.createFunction(FUNCTION_POWER_TOWER_DOUBLE, false);
+        assertEquals(functionNamespaceManager.getFunctions(Optional.of(transaction1), POWER_TOWER).size(), 0);
+
+        // second transaction sees newly created function
+        FunctionNamespaceTransactionHandle transaction2 = functionNamespaceManager.beginTransaction();
+        Collection<SqlInvokedRegularFunction> functions2 = functionNamespaceManager.getFunctions(Optional.of(transaction2), POWER_TOWER);
+        assertEquals(functions2.size(), 1);
+        assertEquals(getOnlyElement(functions2), versioned(FUNCTION_POWER_TOWER_DOUBLE, 1));
+
+        // update the function, second transaction still sees the old functions
+        functionNamespaceManager.createFunction(FUNCTION_POWER_TOWER_DOUBLE_UPDATED, true);
+        functions2 = functionNamespaceManager.getFunctions(Optional.of(transaction2), POWER_TOWER);
+        assertEquals(functions2.size(), 1);
+        assertEquals(getOnlyElement(functions2), versioned(FUNCTION_POWER_TOWER_DOUBLE, 1));
+
+        // third transaction sees the updated function
+        FunctionNamespaceTransactionHandle transaction3 = functionNamespaceManager.beginTransaction();
+        Collection<SqlInvokedRegularFunction> functions3 = functionNamespaceManager.getFunctions(Optional.of(transaction3), POWER_TOWER);
+        assertEquals(functions3.size(), 1);
+        assertEquals(getOnlyElement(functions3), versioned(FUNCTION_POWER_TOWER_DOUBLE_UPDATED, 2));
+
+        functionNamespaceManager.commit(transaction1);
+        functionNamespaceManager.commit(transaction2);
+        functionNamespaceManager.commit(transaction3);
     }
 
     private static InMemoryFunctionNamespaceManager createFunctionNamespaceManager()

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
@@ -274,7 +274,7 @@ public class TestScanFilterAndProjectOperator
         }
         Metadata metadata = functionAssertions.getMetadata();
         FunctionManager functionManager = metadata.getFunctionManager();
-        functionManager.addFunctions(functions.build());
+        functionManager.registerBuiltInFunctions(functions.build());
 
         // match each column with a projection
         ExpressionCompiler expressionCompiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
@@ -338,7 +338,7 @@ public class TestScanFilterAndProjectOperator
         // set up generic long function with a callback to force yield
         Metadata metadata = functionAssertions.getMetadata();
         FunctionManager functionManager = metadata.getFunctionManager();
-        functionManager.addFunctions(ImmutableList.of(new GenericLongFunction("record_cursor", value -> {
+        functionManager.registerBuiltInFunctions(ImmutableList.of(new GenericLongFunction("record_cursor", value -> {
             driverContext.getYieldSignal().forceYieldForTesting();
             return value;
         })));

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/AbstractTestAggregationFunction.java
@@ -64,7 +64,7 @@ public abstract class AbstractTestAggregationFunction
 
     protected void registerFunctions(Plugin plugin)
     {
-        functionManager.addFunctions(extractFunctions(plugin.getFunctions()));
+        functionManager.registerBuiltInFunctions(extractFunctions(plugin.getFunctions()));
     }
 
     protected void registerTypes(Plugin plugin)

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCountNullAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestCountNullAggregation.java
@@ -39,7 +39,7 @@ public class TestCountNullAggregation
     @BeforeClass
     public void setup()
     {
-        functionManager.addFunctions(new FunctionListBuilder().aggregates(CountNull.class).getFunctions());
+        functionManager.registerBuiltInFunctions(new FunctionListBuilder().aggregates(CountNull.class).getFunctions());
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.metadata.BuiltInFunction;
 import com.facebook.presto.metadata.FunctionListBuilder;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.SqlScalarFunction;
@@ -22,7 +23,6 @@ import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.function.OperatorType;
-import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.type.DecimalParseResult;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.SqlDecimal;
@@ -192,7 +192,7 @@ public abstract class AbstractTestFunctions
     protected void registerScalar(Class<?> clazz)
     {
         Metadata metadata = functionAssertions.getMetadata();
-        List<SqlFunction> functions = new FunctionListBuilder()
+        List<BuiltInFunction> functions = new FunctionListBuilder()
                 .scalars(clazz)
                 .getFunctions();
         metadata.getFunctionManager().registerBuiltInFunctions(functions);
@@ -201,7 +201,7 @@ public abstract class AbstractTestFunctions
     protected void registerParametricScalar(Class<?> clazz)
     {
         Metadata metadata = functionAssertions.getMetadata();
-        List<SqlFunction> functions = new FunctionListBuilder()
+        List<BuiltInFunction> functions = new FunctionListBuilder()
                 .scalar(clazz)
                 .getFunctions();
         metadata.getFunctionManager().registerBuiltInFunctions(functions);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -186,7 +186,7 @@ public abstract class AbstractTestFunctions
     protected void registerScalarFunction(SqlScalarFunction sqlScalarFunction)
     {
         Metadata metadata = functionAssertions.getMetadata();
-        metadata.getFunctionManager().addFunctions(ImmutableList.of(sqlScalarFunction));
+        metadata.getFunctionManager().registerBuiltInFunctions(ImmutableList.of(sqlScalarFunction));
     }
 
     protected void registerScalar(Class<?> clazz)
@@ -195,7 +195,7 @@ public abstract class AbstractTestFunctions
         List<SqlFunction> functions = new FunctionListBuilder()
                 .scalars(clazz)
                 .getFunctions();
-        metadata.getFunctionManager().addFunctions(functions);
+        metadata.getFunctionManager().registerBuiltInFunctions(functions);
     }
 
     protected void registerParametricScalar(Class<?> clazz)
@@ -204,12 +204,12 @@ public abstract class AbstractTestFunctions
         List<SqlFunction> functions = new FunctionListBuilder()
                 .scalar(clazz)
                 .getFunctions();
-        metadata.getFunctionManager().addFunctions(functions);
+        metadata.getFunctionManager().registerBuiltInFunctions(functions);
     }
 
     protected void registerFunctions(Plugin plugin)
     {
-        functionAssertions.getMetadata().addFunctions(extractFunctions(plugin.getFunctions()));
+        functionAssertions.getMetadata().registerBuiltInFunctions(extractFunctions(plugin.getFunctions()));
     }
 
     protected void registerTypes(Plugin plugin)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayDistinct.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayDistinct.java
@@ -107,7 +107,7 @@ public class BenchmarkArrayDistinct
         {
             MetadataManager metadata = MetadataManager.createTestMetadataManager();
             FunctionManager functionManager = metadata.getFunctionManager();
-            metadata.addFunctions(extractFunctions(BenchmarkArrayDistinct.class));
+            metadata.registerBuiltInFunctions(extractFunctions(BenchmarkArrayDistinct.class));
             ExpressionCompiler compiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
             ImmutableList.Builder<RowExpression> projectionsBuilder = ImmutableList.builder();
             Block[] blocks = new Block[TYPES.size()];

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayFilter.java
@@ -126,7 +126,7 @@ public class BenchmarkArrayFilter
         {
             MetadataManager metadata = MetadataManager.createTestMetadataManager();
             FunctionManager functionManager = metadata.getFunctionManager();
-            metadata.addFunctions(new FunctionListBuilder().function(EXACT_ARRAY_FILTER_FUNCTION).getFunctions());
+            metadata.registerBuiltInFunctions(new FunctionListBuilder().function(EXACT_ARRAY_FILTER_FUNCTION).getFunctions());
             ExpressionCompiler compiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
             ImmutableList.Builder<RowExpression> projectionsBuilder = ImmutableList.builder();
             Block[] blocks = new Block[TYPES.size()];

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayHashCodeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArrayHashCodeOperator.java
@@ -117,8 +117,8 @@ public class BenchmarkArrayHashCodeOperator
         {
             MetadataManager metadata = MetadataManager.createTestMetadataManager();
             FunctionManager functionManager = metadata.getFunctionManager();
-            metadata.addFunctions(new FunctionListBuilder().scalar(BenchmarkOldArrayHash.class).getFunctions());
-            metadata.addFunctions(new FunctionListBuilder().scalar(BenchmarkAnotherArrayHash.class).getFunctions());
+            metadata.registerBuiltInFunctions(new FunctionListBuilder().scalar(BenchmarkOldArrayHash.class).getFunctions());
+            metadata.registerBuiltInFunctions(new FunctionListBuilder().scalar(BenchmarkAnotherArrayHash.class).getFunctions());
             ExpressionCompiler compiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
             ImmutableList.Builder<RowExpression> projectionsBuilder = ImmutableList.builder();
             Block[] blocks = new Block[1];

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySort.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraySort.java
@@ -105,7 +105,7 @@ public class BenchmarkArraySort
         public void setup()
         {
             MetadataManager metadata = MetadataManager.createTestMetadataManager();
-            metadata.addFunctions(extractFunctions(BenchmarkArraySort.class));
+            metadata.registerBuiltInFunctions(extractFunctions(BenchmarkArraySort.class));
             ExpressionCompiler compiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
             ImmutableList.Builder<RowExpression> projectionsBuilder = ImmutableList.builder();
             Block[] blocks = new Block[TYPES.size()];

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.warnings.WarningCollector;
+import com.facebook.presto.metadata.BuiltInFunction;
 import com.facebook.presto.metadata.FunctionListBuilder;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.Split;
@@ -47,7 +48,6 @@ import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.predicate.Utils;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -219,7 +219,7 @@ public final class FunctionAssertions
         return metadata;
     }
 
-    public FunctionAssertions addFunctions(List<? extends SqlFunction> functionInfos)
+    public FunctionAssertions addFunctions(List<? extends BuiltInFunction> functionInfos)
     {
         metadata.registerBuiltInFunctions(functionInfos);
         return this;

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -221,13 +221,13 @@ public final class FunctionAssertions
 
     public FunctionAssertions addFunctions(List<? extends SqlFunction> functionInfos)
     {
-        metadata.addFunctions(functionInfos);
+        metadata.registerBuiltInFunctions(functionInfos);
         return this;
     }
 
     public FunctionAssertions addScalarFunctions(Class<?> clazz)
     {
-        metadata.addFunctions(new FunctionListBuilder().scalars(clazz).getFunctions());
+        metadata.registerBuiltInFunctions(new FunctionListBuilder().scalars(clazz).getFunctions());
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestLambdaExpression.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestLambdaExpression.java
@@ -50,7 +50,7 @@ public class TestLambdaExpression
     @BeforeClass
     public void setUp()
     {
-        functionAssertions.getMetadata().addFunctions(ImmutableList.of(APPLY_FUNCTION, INVOKE_FUNCTION));
+        functionAssertions.getMetadata().registerBuiltInFunctions(ImmutableList.of(APPLY_FUNCTION, INVOKE_FUNCTION));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -144,7 +144,7 @@ public class TestExpressionInterpreter
     @BeforeClass
     public void setup()
     {
-        METADATA.getFunctionManager().addFunctions(ImmutableList.of(APPLY_FUNCTION));
+        METADATA.getFunctionManager().registerBuiltInFunctions(ImmutableList.of(APPLY_FUNCTION));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -1562,7 +1562,7 @@ public class TestAnalyzer
                 new AnalyzePropertyManager(),
                 transactionManager);
 
-        metadata.getFunctionManager().addFunctions(ImmutableList.of(APPLY_FUNCTION));
+        metadata.getFunctionManager().registerBuiltInFunctions(ImmutableList.of(APPLY_FUNCTION));
 
         Catalog tpchTestCatalog = createTestingCatalog(TPCH_CATALOG, TPCH_CONNECTOR_ID);
         catalogManager.registerCatalog(tpchTestCatalog);

--- a/presto-ml/src/test/java/com/facebook/presto/ml/AbstractTestMLFunctions.java
+++ b/presto-ml/src/test/java/com/facebook/presto/ml/AbstractTestMLFunctions.java
@@ -25,7 +25,7 @@ abstract class AbstractTestMLFunctions
     @BeforeClass
     protected void registerFunctions()
     {
-        functionAssertions.getMetadata().addFunctions(
+        functionAssertions.getMetadata().registerBuiltInFunctions(
                 extractFunctions(new MLPlugin().getFunctions()));
     }
 }

--- a/presto-ml/src/test/java/com/facebook/presto/ml/TestEvaluateClassifierPredictions.java
+++ b/presto-ml/src/test/java/com/facebook/presto/ml/TestEvaluateClassifierPredictions.java
@@ -42,7 +42,7 @@ public class TestEvaluateClassifierPredictions
     @Test
     public void testEvaluateClassifierPredictions()
     {
-        metadata.addFunctions(extractFunctions(new MLPlugin().getFunctions()));
+        metadata.registerBuiltInFunctions(extractFunctions(new MLPlugin().getFunctions()));
         InternalAggregationFunction aggregation = functionManager.getAggregateFunctionImplementation(
                 functionManager.lookupFunction("evaluate_classifier_predictions", fromTypes(BIGINT, BIGINT)));
         Accumulator accumulator = aggregation.bind(ImmutableList.of(0, 1), Optional.empty()).createAccumulator();

--- a/presto-ml/src/test/java/com/facebook/presto/ml/TestMLQueries.java
+++ b/presto-ml/src/test/java/com/facebook/presto/ml/TestMLQueries.java
@@ -71,7 +71,7 @@ public class TestMLQueries
         for (ParametricType parametricType : plugin.getParametricTypes()) {
             localQueryRunner.getTypeManager().addParametricType(parametricType);
         }
-        localQueryRunner.getMetadata().addFunctions(extractFunctions(new MLPlugin().getFunctions()));
+        localQueryRunner.getMetadata().registerBuiltInFunctions(extractFunctions(new MLPlugin().getFunctions()));
 
         return localQueryRunner;
     }

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -56,8 +56,10 @@ statement
     | CREATE (OR REPLACE)? VIEW qualifiedName AS query                 #createView
     | DROP VIEW (IF EXISTS)? qualifiedName                             #dropView
     | CREATE (OR REPLACE)? FUNCTION functionName=qualifiedName
-      '(' (sqlParameterDeclaration (',' sqlParameterDeclaration)*)? ')'
-      RETURNS returnType=type routineCharacteristics routineBody       #createFunction
+        '(' (sqlParameterDeclaration (',' sqlParameterDeclaration)*)? ')'
+        RETURNS returnType=type
+        (COMMENT string)?
+        routineCharacteristics routineBody                             #createFunction
     | CALL qualifiedName '(' (callArgument (',' callArgument)*)? ')'   #call
     | CREATE ROLE name=identifier
         (WITH ADMIN grantor)?                                          #createRole

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -561,8 +561,12 @@ public final class SqlFormatter
                     .append(formatSqlParameterDeclarations(node.getParameters()))
                     .append("\nRETURNS ")
                     .append(node.getReturnType())
-                    .append("\n")
-                    .append(formatRoutineCharacteristics(node.getCharacteristics()))
+                    .append("\n");
+            if (node.getComment().isPresent()) {
+                builder.append("\nCOMMENT ")
+                        .append(formatStringLiteral(node.getComment().get()));
+            }
+            builder.append(formatRoutineCharacteristics(node.getCharacteristics()))
                     .append("\nRETURN ")
                     .append(formatExpression(node.getBody(), parameters));
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -404,6 +404,11 @@ class AstBuilder
     @Override
     public Node visitCreateFunction(SqlBaseParser.CreateFunctionContext context)
     {
+        Optional<String> comment = Optional.empty();
+        if (context.COMMENT() != null) {
+            comment = Optional.of(((StringLiteral) visit(context.string())).getValue());
+        }
+
         return new CreateFunction(
                 getQualifiedName(context.functionName),
                 context.REPLACE() != null,
@@ -411,6 +416,7 @@ class AstBuilder
                         .map(this::getParameterDeclarations)
                         .collect(toImmutableList()),
                 getType(context.returnType),
+                comment,
                 getRoutineCharacteristics(context.routineCharacteristics()),
                 (Expression) visit(context.routineBody()));
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateFunction.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateFunction.java
@@ -29,26 +29,28 @@ public class CreateFunction
     private final boolean replace;
     private final List<SqlParameterDeclaration> parameters;
     private final String returnType;
+    private final Optional<String> comment;
     private final RoutineCharacteristics characteristics;
     private final Expression body;
 
-    public CreateFunction(QualifiedName functionName, boolean replace, List<SqlParameterDeclaration> parameters, String returnType, RoutineCharacteristics characteristics, Expression body)
+    public CreateFunction(QualifiedName functionName, boolean replace, List<SqlParameterDeclaration> parameters, String returnType, Optional<String> comment, RoutineCharacteristics characteristics, Expression body)
     {
-        this(Optional.empty(), replace, functionName, parameters, returnType, characteristics, body);
+        this(Optional.empty(), replace, functionName, parameters, returnType, comment, characteristics, body);
     }
 
-    public CreateFunction(NodeLocation location, boolean replace, QualifiedName functionName, List<SqlParameterDeclaration> parameters, String returnType, RoutineCharacteristics characteristics, Expression body)
+    public CreateFunction(NodeLocation location, boolean replace, QualifiedName functionName, List<SqlParameterDeclaration> parameters, String returnType, Optional<String> comment, RoutineCharacteristics characteristics, Expression body)
     {
-        this(Optional.of(location), replace, functionName, parameters, returnType, characteristics, body);
+        this(Optional.of(location), replace, functionName, parameters, returnType, comment, characteristics, body);
     }
 
-    private CreateFunction(Optional<NodeLocation> location, boolean replace, QualifiedName functionName, List<SqlParameterDeclaration> parameters, String returnType, RoutineCharacteristics characteristics, Expression body)
+    private CreateFunction(Optional<NodeLocation> location, boolean replace, QualifiedName functionName, List<SqlParameterDeclaration> parameters, String returnType, Optional<String> comment, RoutineCharacteristics characteristics, Expression body)
     {
         super(location);
         this.functionName = requireNonNull(functionName, "functionName is null");
         this.replace = replace;
         this.parameters = ImmutableList.copyOf(requireNonNull(parameters, "parameters is null"));
         this.returnType = requireNonNull(returnType, "returnType is null");
+        this.comment = requireNonNull(comment, "comment is null");
         this.characteristics = requireNonNull(characteristics, "routineCharacteristics is null");
         this.body = requireNonNull(body, "body is null");
     }
@@ -71,6 +73,11 @@ public class CreateFunction
     public String getReturnType()
     {
         return returnType;
+    }
+
+    public Optional<String> getComment()
+    {
+        return comment;
     }
 
     public RoutineCharacteristics getCharacteristics()
@@ -100,7 +107,7 @@ public class CreateFunction
     @Override
     public int hashCode()
     {
-        return Objects.hash(functionName, parameters, returnType, characteristics, body);
+        return Objects.hash(functionName, parameters, returnType, comment, characteristics, body);
     }
 
     @Override
@@ -116,6 +123,7 @@ public class CreateFunction
         return Objects.equals(functionName, o.functionName) &&
                 Objects.equals(parameters, o.parameters) &&
                 Objects.equals(returnType, o.returnType) &&
+                Objects.equals(comment, o.comment) &&
                 Objects.equals(characteristics, o.characteristics) &&
                 Objects.equals(body, o.body);
     }
@@ -127,6 +135,7 @@ public class CreateFunction
                 .add("functionName", functionName)
                 .add("parameters", parameters)
                 .add("returnType", returnType)
+                .add("comment", comment)
                 .add("characteristics", characteristics)
                 .add("body", body)
                 .toString();

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1428,6 +1428,7 @@ public class TestSqlParser
         assertStatement(
                 "CREATE FUNCTION tan (x double)\n" +
                         "RETURNS double\n" +
+                        "COMMENT 'tangent trigonometric function'\n" +
                         "LANGUAGE SQL\n" +
                         "DETERMINISTIC\n" +
                         "RETURNS NULL ON NULL INPUT\n" +
@@ -1437,6 +1438,7 @@ public class TestSqlParser
                         false,
                         ImmutableList.of(new SqlParameterDeclaration(identifier("x"), "double")),
                         "double",
+                        Optional.of("tangent trigonometric function"),
                         new RoutineCharacteristics(SQL, DETERMINISTIC, RETURNS_NULL_ON_NULL_INPUT),
                         new ArithmeticBinaryExpression(
                                 DIVIDE,
@@ -1448,6 +1450,7 @@ public class TestSqlParser
                 true,
                 ImmutableList.of(),
                 "double",
+                Optional.empty(),
                 new RoutineCharacteristics(SQL, NOT_DETERMINISTIC, CALLED_ON_NULL_INPUT),
                 new FunctionCall(QualifiedName.of("rand"), ImmutableList.of()));
         assertStatement(

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
@@ -18,14 +18,13 @@ import com.facebook.presto.spi.api.Experimental;
 import com.facebook.presto.spi.relation.FullyQualifiedName;
 
 import java.util.Collection;
-import java.util.List;
 
 @Experimental
 public interface FunctionNamespaceManager<F extends SqlFunction>
 {
     void createFunction(F function, boolean replace);
 
-    List<F> listFunctions();
+    Collection<F> listFunctions();
 
     /**
      * Ideally function namespaces should support transactions like connectors do, and getCandidates should be transaction-aware.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
@@ -23,8 +23,6 @@ import java.util.List;
 @Experimental
 public interface FunctionNamespaceManager
 {
-    void addFunctions(List<? extends SqlFunction> functions);
-
     List<SqlFunction> listFunctions();
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
@@ -21,16 +21,18 @@ import java.util.Collection;
 import java.util.List;
 
 @Experimental
-public interface FunctionNamespaceManager
+public interface FunctionNamespaceManager<F extends SqlFunction>
 {
-    List<SqlFunction> listFunctions();
+    void createFunction(F function, boolean replace);
+
+    List<F> listFunctions();
 
     /**
      * Ideally function namespaces should support transactions like connectors do, and getCandidates should be transaction-aware.
      * queryId serves as a transaction ID before proper support for transaction is introduced.
      * TODO Support transaction in function namespaces
      */
-    Collection<SqlFunction> getCandidates(QueryId queryId, FullyQualifiedName name);
+    Collection<F> getCandidates(QueryId queryId, FullyQualifiedName name);
 
     /**
      * If a SqlFunction for a given signature is returned from {@link #getCandidates(QueryId, FullyQualifiedName)}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
@@ -32,10 +32,10 @@ public interface FunctionNamespaceManager<F extends SqlFunction>
      * queryId serves as a transaction ID before proper support for transaction is introduced.
      * TODO Support transaction in function namespaces
      */
-    Collection<F> getCandidates(QueryId queryId, FullyQualifiedName name);
+    Collection<F> getFunctions(QueryId queryId, FullyQualifiedName functionName);
 
     /**
-     * If a SqlFunction for a given signature is returned from {@link #getCandidates(QueryId, FullyQualifiedName)}
+     * If a SqlFunction for a given signature is returned from {@link #getFunctions(QueryId, FullyQualifiedName)}
      * for a given queryId, getFunctionHandle with the same queryId should return a valid FunctionHandle, even if the function
      * is deleted. Multiple calls of this function with the same parameters should return the same FunctionHandle.
      * queryId serves as a transaction ID before proper support for transaction is introduced.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
@@ -13,35 +13,49 @@
  */
 package com.facebook.presto.spi.function;
 
-import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.api.Experimental;
 import com.facebook.presto.spi.relation.FullyQualifiedName;
 
 import java.util.Collection;
+import java.util.Optional;
 
 @Experimental
 public interface FunctionNamespaceManager<F extends SqlFunction>
 {
+    String getName();
+
+    /**
+     * Start a transaction.
+     */
+    FunctionNamespaceTransactionHandle beginTransaction();
+
+    /**
+     * Commit the transaction. Will be called at most once and will not be called if
+     * {@link #rollback(FunctionNamespaceTransactionHandle)} is called.
+     */
+    void commit(FunctionNamespaceTransactionHandle transactionHandle);
+
+    /**
+     * Rollback the transaction. Will be called at most once and will not be called if
+     * {@link #commit(FunctionNamespaceTransactionHandle)} is called.
+     */
+    void rollback(FunctionNamespaceTransactionHandle transactionHandle);
+
+    /**
+     * Create or replace the specified function.
+     * TODO: Support transaction
+     */
     void createFunction(F function, boolean replace);
 
+    /**
+     * List all functions managed by the {@link FunctionNamespaceManager}.
+     * TODO: Support transaction
+     */
     Collection<F> listFunctions();
 
-    /**
-     * Ideally function namespaces should support transactions like connectors do, and getCandidates should be transaction-aware.
-     * queryId serves as a transaction ID before proper support for transaction is introduced.
-     * TODO Support transaction in function namespaces
-     */
-    Collection<F> getFunctions(QueryId queryId, FullyQualifiedName functionName);
+    Collection<F> getFunctions(Optional<? extends FunctionNamespaceTransactionHandle> transactionHandle, FullyQualifiedName functionName);
 
-    /**
-     * If a SqlFunction for a given signature is returned from {@link #getFunctions(QueryId, FullyQualifiedName)}
-     * for a given queryId, getFunctionHandle with the same queryId should return a valid FunctionHandle, even if the function
-     * is deleted. Multiple calls of this function with the same parameters should return the same FunctionHandle.
-     * queryId serves as a transaction ID before proper support for transaction is introduced.
-     * TODO Support transaction in function namespaces
-     * @return FunctionHandle or null if the namespace manager does not manage any function with the given signature.
-     */
-    FunctionHandle getFunctionHandle(QueryId queryId, Signature signature);
+    FunctionHandle getFunctionHandle(Optional<? extends FunctionNamespaceTransactionHandle> transactionHandle, Signature signature);
 
     FunctionMetadata getFunctionMetadata(FunctionHandle functionHandle);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManagerFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManagerFactory.java
@@ -21,5 +21,5 @@ public interface FunctionNamespaceManagerFactory
 
     FunctionHandleResolver getHandleResolver();
 
-    FunctionNamespaceManager create(Map<String, String> config);
+    FunctionNamespaceManager<?> create(Map<String, String> config);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceTransactionHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceTransactionHandle.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.function;
+
+public interface FunctionNamespaceTransactionHandle
+{
+}

--- a/presto-sql-function/pom.xml
+++ b/presto-sql-function/pom.xml
@@ -37,6 +37,16 @@
             <artifactId>guava</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/presto-sql-function/pom.xml
+++ b/presto-sql-function/pom.xml
@@ -27,6 +27,16 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/presto-sql-function/pom.xml
+++ b/presto-sql-function/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>presto-root</artifactId>
+        <groupId>com.facebook.presto</groupId>
+        <version>0.228-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>presto-sql-function</artifactId>
+    <name>presto-sql-function</name>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/AbstractSqlInvokedFunctionNamespaceManager.java
+++ b/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/AbstractSqlInvokedFunctionNamespaceManager.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sqlfunction;
+
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionNamespaceManager;
+import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
+import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.relation.FullyQualifiedName;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+public abstract class AbstractSqlInvokedFunctionNamespaceManager
+        implements FunctionNamespaceManager<SqlInvokedRegularFunction>
+{
+    private final ConcurrentMap<FunctionNamespaceTransactionHandle, FunctionCollection> transactions = new ConcurrentHashMap<>();
+
+    protected abstract Collection<SqlInvokedRegularFunction> fetchFunctions(FullyQualifiedName functionName);
+
+    @Override
+    public final FunctionNamespaceTransactionHandle beginTransaction()
+    {
+        UuidFunctionNamespaceTransactionHandle transactionHandle = UuidFunctionNamespaceTransactionHandle.create();
+        transactions.put(transactionHandle, new FunctionCollection());
+        return transactionHandle;
+    }
+
+    @Override
+    public final void commit(FunctionNamespaceTransactionHandle transactionHandle)
+    {
+        // Transactional commit is not supported yet.
+        transactions.remove(transactionHandle);
+    }
+
+    @Override
+    public final void rollback(FunctionNamespaceTransactionHandle transactionHandle)
+    {
+        // Transactional rollback is not supported yet.
+        transactions.remove(transactionHandle);
+    }
+
+    @Override
+    public final Collection<SqlInvokedRegularFunction> getFunctions(Optional<? extends FunctionNamespaceTransactionHandle> transactionHandle, FullyQualifiedName functionName)
+    {
+        checkArgument(transactionHandle.isPresent(), "missing transactionHandle");
+        return transactions.get(transactionHandle.get()).loadAndGetFunctionsTransactional(functionName);
+    }
+
+    @Override
+    public final FunctionHandle getFunctionHandle(Optional<? extends FunctionNamespaceTransactionHandle> transactionHandle, Signature signature)
+    {
+        checkArgument(transactionHandle.isPresent(), "missing transactionHandle");
+        SqlFunctionId functionId = new SqlFunctionId(signature.getName(), signature.getArgumentTypes());
+        return transactions.get(transactionHandle.get()).getFunctionHandle(functionId);
+    }
+
+    private class FunctionCollection
+    {
+        @GuardedBy("this")
+        private final Map<FullyQualifiedName, Collection<SqlInvokedRegularFunction>> functions = new ConcurrentHashMap<>();
+
+        @GuardedBy("this")
+        private final Map<SqlFunctionId, SqlInvokedRegularFunctionHandle> functionHandles = new ConcurrentHashMap<>();
+
+        public synchronized Collection<SqlInvokedRegularFunction> loadAndGetFunctionsTransactional(FullyQualifiedName functionName)
+        {
+            Collection<SqlInvokedRegularFunction> functions = this.functions.computeIfAbsent(functionName, AbstractSqlInvokedFunctionNamespaceManager.this::fetchFunctions);
+            functionHandles.putAll(functions.stream().collect(toImmutableMap(SqlInvokedRegularFunction::getFunctionId, SqlInvokedRegularFunction::getRequiredFunctionHandle)));
+            return functions;
+        }
+
+        public synchronized FunctionHandle getFunctionHandle(SqlFunctionId functionId)
+        {
+            return functionHandles.get(functionId);
+        }
+    }
+}

--- a/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/RoutineCharacteristics.java
+++ b/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/RoutineCharacteristics.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sqlfunction;
+
+import java.util.Objects;
+
+import static com.facebook.presto.sqlfunction.RoutineCharacteristics.Determinism.DETERMINISTIC;
+import static com.facebook.presto.sqlfunction.RoutineCharacteristics.NullCallClause.CALLED_ON_NULL_INPUT;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class RoutineCharacteristics
+{
+    public enum Language
+    {
+        SQL;
+    }
+
+    public enum Determinism
+    {
+        DETERMINISTIC,
+        NOT_DETERMINISTIC;
+    }
+
+    public enum NullCallClause
+    {
+        RETURNS_NULL_ON_NULL_INPUT,
+        CALLED_ON_NULL_INPUT;
+    }
+
+    private final Language language;
+    private final Determinism determinism;
+    private final NullCallClause nullCallClause;
+
+    public RoutineCharacteristics(
+            Language language,
+            Determinism determinism,
+            NullCallClause nullCallClause)
+    {
+        this.language = requireNonNull(language, "language is null");
+        this.determinism = requireNonNull(determinism, "determinism is null");
+        this.nullCallClause = requireNonNull(nullCallClause, "nullCallClause is null");
+    }
+
+    public Language getLanguage()
+    {
+        return language;
+    }
+
+    public boolean isDeterministic()
+    {
+        return determinism == DETERMINISTIC;
+    }
+
+    public boolean isCalledOnNullInput()
+    {
+        return nullCallClause == CALLED_ON_NULL_INPUT;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RoutineCharacteristics that = (RoutineCharacteristics) o;
+        return language == that.language
+                && determinism == that.determinism
+                && nullCallClause == that.nullCallClause;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(language, determinism, nullCallClause);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("(%s, %s, %s)", language, determinism, nullCallClause);
+    }
+}

--- a/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/SqlFunctionId.java
+++ b/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/SqlFunctionId.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sqlfunction;
+
+import com.facebook.presto.spi.relation.FullyQualifiedName;
+import com.facebook.presto.spi.type.TypeSignature;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+public class SqlFunctionId
+{
+    private final FullyQualifiedName name;
+    private final List<TypeSignature> argumentTypes;
+
+    public SqlFunctionId(
+            FullyQualifiedName name,
+            List<TypeSignature> argumentTypes)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.argumentTypes = requireNonNull(argumentTypes, "argumentTypes is null");
+    }
+
+    public FullyQualifiedName getName()
+    {
+        return name;
+    }
+
+    public List<TypeSignature> getArgumentTypes()
+    {
+        return argumentTypes;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        SqlFunctionId o = (SqlFunctionId) obj;
+        return Objects.equals(name, o.name)
+                && Objects.equals(argumentTypes, o.argumentTypes);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, argumentTypes);
+    }
+
+    @Override
+    public String toString()
+    {
+        String arguments = argumentTypes.stream()
+                .map(Object::toString)
+                .collect(joining(", "));
+        return format("%s(%s)", name, arguments);
+    }
+}

--- a/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/SqlInvokedFunctionNamespaceManagerConfig.java
+++ b/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/SqlInvokedFunctionNamespaceManagerConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sqlfunction;
+
+import io.airlift.configuration.Config;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class SqlInvokedFunctionNamespaceManagerConfig
+{
+    private Duration functionCacheExpiration = new Duration(5, MINUTES);
+    private Duration metadataCacheExpiration = new Duration(8, HOURS);
+
+    @MinDuration("0ns")
+    public Duration getFunctionCacheExpiration()
+    {
+        return functionCacheExpiration;
+    }
+
+    @Config("function-cache-expiration")
+    public SqlInvokedFunctionNamespaceManagerConfig setFunctionCacheExpiration(Duration functionCacheExpiration)
+    {
+        this.functionCacheExpiration = functionCacheExpiration;
+        return this;
+    }
+
+    @MinDuration("0ns")
+    public Duration getMetadataCacheExpiration()
+    {
+        return metadataCacheExpiration;
+    }
+
+    @Config("metadata-cache-expiration")
+    public SqlInvokedFunctionNamespaceManagerConfig setMetadataCacheExpiration(Duration metadataCacheExpiration)
+    {
+        this.metadataCacheExpiration = metadataCacheExpiration;
+        return this;
+    }
+}

--- a/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/SqlInvokedRegularFunction.java
+++ b/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/SqlInvokedRegularFunction.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sqlfunction;
+
+import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.function.SqlFunction;
+import com.facebook.presto.spi.relation.FullyQualifiedName;
+import com.facebook.presto.spi.type.TypeSignature;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+public class SqlInvokedRegularFunction
+        implements SqlFunction
+{
+    private final List<SqlParameter> parameters;
+    private final Optional<String> comment;
+    private final RoutineCharacteristics routineCharacteristics;
+    private final String body;
+
+    private final Signature signature;
+    private final SqlFunctionId functionId;
+    private final Optional<SqlInvokedRegularFunctionHandle> functionHandle;
+
+    public SqlInvokedRegularFunction(
+            FullyQualifiedName functionName,
+            List<SqlParameter> parameters,
+            TypeSignature returnType,
+            Optional<String> comment,
+            RoutineCharacteristics routineCharacteristics,
+            String body,
+            Optional<Long> version)
+    {
+        this.parameters = requireNonNull(parameters, "parameters is null");
+        this.comment = requireNonNull(comment, "comment is null");
+        this.routineCharacteristics = requireNonNull(routineCharacteristics, "routineCharacteristics is null");
+        this.body = requireNonNull(body, "body is null");
+
+        List<TypeSignature> argumentTypes = parameters.stream()
+                .map(SqlParameter::getType)
+                .collect(collectingAndThen(toList(), Collections::unmodifiableList));
+        this.signature = new Signature(functionName, SCALAR, returnType, argumentTypes);
+        this.functionId = new SqlFunctionId(functionName, argumentTypes);
+        this.functionHandle = version.map(v -> new SqlInvokedRegularFunctionHandle(functionName, argumentTypes, v));
+    }
+
+    public static SqlInvokedRegularFunction versioned(SqlInvokedRegularFunction function, long version)
+    {
+        if (function.getVersion().isPresent()) {
+            throw new IllegalArgumentException(format("function %s is already versioned", function.getVersion().get()));
+        }
+        return new SqlInvokedRegularFunction(
+                function.getSignature().getName(),
+                function.getParameters(),
+                function.getSignature().getReturnType(),
+                function.comment,
+                function.getRoutineCharacteristics(),
+                function.getBody(),
+                Optional.of(version));
+    }
+
+    @Override
+    public Signature getSignature()
+    {
+        return signature;
+    }
+
+    @Override
+    public boolean isHidden()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return routineCharacteristics.isDeterministic();
+    }
+
+    @Override
+    public boolean isCalledOnNullInput()
+    {
+        return routineCharacteristics.isCalledOnNullInput();
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return comment.orElse("");
+    }
+
+    public List<SqlParameter> getParameters()
+    {
+        return parameters;
+    }
+
+    public Optional<String> getComment()
+    {
+        return comment;
+    }
+
+    public RoutineCharacteristics getRoutineCharacteristics()
+    {
+        return routineCharacteristics;
+    }
+
+    public String getBody()
+    {
+        return body;
+    }
+
+    public SqlFunctionId getFunctionId()
+    {
+        return functionId;
+    }
+
+    public SqlInvokedRegularFunctionHandle getRequiredFunctionHandle()
+    {
+        checkState(functionHandle.isPresent(), "missing function handle");
+        return functionHandle.get();
+    }
+
+    public Optional<Long> getVersion()
+    {
+        return functionHandle.map(SqlInvokedRegularFunctionHandle::getVersion);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        SqlInvokedRegularFunction o = (SqlInvokedRegularFunction) obj;
+        return Objects.equals(parameters, o.parameters)
+                && Objects.equals(comment, o.comment)
+                && Objects.equals(routineCharacteristics, o.routineCharacteristics)
+                && Objects.equals(body, o.body)
+                && Objects.equals(signature, o.signature)
+                && Objects.equals(functionId, o.functionId)
+                && Objects.equals(functionHandle, o.functionHandle);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(parameters, comment, routineCharacteristics, body, signature, functionId, functionHandle);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format(
+                "%s(%s):%s%s {%s} %s",
+                signature.getName(),
+                parameters.stream()
+                        .map(Object::toString)
+                        .collect(joining(",")),
+                signature.getReturnType(),
+                getVersion().map(version -> ":" + version).orElse(""),
+                body,
+                routineCharacteristics);
+    }
+}

--- a/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/SqlInvokedRegularFunctionHandle.java
+++ b/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/SqlInvokedRegularFunctionHandle.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sqlfunction;
+
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.relation.FullyQualifiedName;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+public class SqlInvokedRegularFunctionHandle
+        implements FunctionHandle
+{
+    private final FullyQualifiedName name;
+    private final List<TypeSignature> argumentTypes;
+    private final long version;
+
+    @JsonCreator
+    public SqlInvokedRegularFunctionHandle(
+            @JsonProperty("name") FullyQualifiedName name,
+            @JsonProperty("argumentTypes") List<TypeSignature> argumentTypes,
+            @JsonProperty("version") long version)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.argumentTypes = requireNonNull(argumentTypes, "argumentTypes is null");
+        this.version = version;
+    }
+
+    @JsonProperty
+    public FullyQualifiedName getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public List<TypeSignature> getArgumentTypes()
+    {
+        return argumentTypes;
+    }
+
+    @JsonProperty
+    public long getVersion()
+    {
+        return version;
+    }
+
+    @Override
+    public FullyQualifiedName.Prefix getFunctionNamespace()
+    {
+        return name.getPrefix();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        SqlInvokedRegularFunctionHandle o = (SqlInvokedRegularFunctionHandle) obj;
+        return Objects.equals(name, o.name)
+                && Objects.equals(argumentTypes, o.argumentTypes)
+                && Objects.equals(version, o.version);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, argumentTypes, version);
+    }
+
+    @Override
+    public String toString()
+    {
+        String arguments = argumentTypes.stream()
+                .map(Object::toString)
+                .collect(joining(", "));
+        return String.format("%s(%s):%s", name, arguments, version);
+    }
+}

--- a/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/SqlParameter.java
+++ b/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/SqlParameter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sqlfunction;
+
+import com.facebook.presto.spi.type.TypeSignature;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class SqlParameter
+{
+    private final String name;
+    private final TypeSignature type;
+
+    public SqlParameter(String name, TypeSignature type)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public TypeSignature getType()
+    {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        SqlParameter o = (SqlParameter) obj;
+        return Objects.equals(name, o.name)
+                && Objects.equals(type, o.type);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, type);
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s %s", name, type);
+    }
+}

--- a/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/UuidFunctionNamespaceTransactionHandle.java
+++ b/presto-sql-function/src/main/java/com/facebook/presto/sqlfunction/UuidFunctionNamespaceTransactionHandle.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sqlfunction;
+
+import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import static java.util.Objects.requireNonNull;
+
+public class UuidFunctionNamespaceTransactionHandle
+        implements FunctionNamespaceTransactionHandle
+{
+    private final UUID uuid;
+
+    private UuidFunctionNamespaceTransactionHandle(UUID uuid)
+    {
+        this.uuid = requireNonNull(uuid, "uuid is null");
+    }
+
+    public static UuidFunctionNamespaceTransactionHandle create()
+    {
+        return new UuidFunctionNamespaceTransactionHandle(UUID.randomUUID());
+    }
+
+    @JsonCreator
+    public static UuidFunctionNamespaceTransactionHandle valueOf(String value)
+    {
+        return new UuidFunctionNamespaceTransactionHandle(UUID.fromString(value));
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final UuidFunctionNamespaceTransactionHandle o = (UuidFunctionNamespaceTransactionHandle) obj;
+        return Objects.equals(uuid, o.uuid);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(uuid);
+    }
+
+    @Override
+    @JsonValue
+    public String toString()
+    {
+        return uuid.toString();
+    }
+}

--- a/presto-sql-function/src/test/java/com/facebook/presto/sqlfunction/TestSqlInvokedFunctionNamespaceManagerConfig.java
+++ b/presto-sql-function/src/test/java/com/facebook/presto/sqlfunction/TestSqlInvokedFunctionNamespaceManagerConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sqlfunction;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class TestSqlInvokedFunctionNamespaceManagerConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(SqlInvokedFunctionNamespaceManagerConfig.class)
+                .setFunctionCacheExpiration(new Duration(5, MINUTES))
+                .setMetadataCacheExpiration(new Duration(8, HOURS)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("function-cache-expiration", "10m")
+                .put("metadata-cache-expiration", "4h")
+                .build();
+        SqlInvokedFunctionNamespaceManagerConfig expected = new SqlInvokedFunctionNamespaceManagerConfig()
+                .setFunctionCacheExpiration(new Duration(10, MINUTES))
+                .setMetadataCacheExpiration(new Duration(4, HOURS));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -15,9 +15,9 @@ package com.facebook.presto.tests;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.metadata.BuiltInFunction;
 import com.facebook.presto.metadata.FunctionListBuilder;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.SqlTimestampWithTimeZone;
@@ -103,7 +103,7 @@ public abstract class AbstractTestQueries
         extends AbstractTestQueryFramework
 {
     // We can just use the default type registry, since we don't use any parametric types
-    protected static final List<SqlFunction> CUSTOM_FUNCTIONS = new FunctionListBuilder()
+    protected static final List<BuiltInFunction> CUSTOM_FUNCTIONS = new FunctionListBuilder()
             .aggregates(CustomSum.class)
             .window(CustomRank.class)
             .scalars(CustomAdd.class)
@@ -4107,7 +4107,7 @@ public abstract class AbstractTestQueries
     public void testInvalidWindowFunction()
     {
         assertQueryFails("SELECT abs(x) OVER ()\n" +
-                "FROM (VALUES (1), (2), (3)) t(x)",
+                        "FROM (VALUES (1), (2), (3)) t(x)",
                 "line 1:1: Not a window function: abs");
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -167,7 +167,7 @@ public class DistributedQueryRunner
 
         start = System.nanoTime();
         for (TestingPrestoServer server : servers) {
-            server.getMetadata().addFunctions(AbstractTestQueries.CUSTOM_FUNCTIONS);
+            server.getMetadata().registerBuiltInFunctions(AbstractTestQueries.CUSTOM_FUNCTIONS);
         }
         log.info("Added functions in %s", nanosSince(start).convertToMostSuccinctTimeUnit());
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -75,7 +75,7 @@ public final class StandaloneQueryRunner
 
         refreshNodes();
 
-        server.getMetadata().addFunctions(AbstractTestQueries.CUSTOM_FUNCTIONS);
+        server.getMetadata().registerBuiltInFunctions(AbstractTestQueries.CUSTOM_FUNCTIONS);
 
         SessionPropertyManager sessionPropertyManager = server.getMetadata().getSessionPropertyManager();
         sessionPropertyManager.addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -70,7 +70,7 @@ public class TestLocalQueries
                 new TpchConnectorFactory(1),
                 ImmutableMap.of());
 
-        localQueryRunner.getMetadata().addFunctions(CUSTOM_FUNCTIONS);
+        localQueryRunner.getMetadata().registerBuiltInFunctions(CUSTOM_FUNCTIONS);
 
         SessionPropertyManager sessionPropertyManager = localQueryRunner.getMetadata().getSessionPropertyManager();
         sessionPropertyManager.addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryPlanDeterminism.java
@@ -71,7 +71,7 @@ public class TestQueryPlanDeterminism
                 new TpchConnectorFactory(1),
                 ImmutableMap.of());
 
-        localQueryRunner.getMetadata().addFunctions(CUSTOM_FUNCTIONS);
+        localQueryRunner.getMetadata().registerBuiltInFunctions(CUSTOM_FUNCTIONS);
 
         SessionPropertyManager sessionPropertyManager = localQueryRunner.getMetadata().getSessionPropertyManager();
         sessionPropertyManager.addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);

--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -96,6 +96,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/Column.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/Column.java
@@ -13,14 +13,10 @@
  */
 package com.facebook.presto.verifier.framework;
 
-import com.facebook.presto.block.BlockEncodingManager;
-import com.facebook.presto.metadata.FunctionManager;
-import com.facebook.presto.metadata.HandleResolver;
 import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.Type;
-import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.tree.Identifier;
-import com.facebook.presto.type.TypeRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 
@@ -48,11 +44,6 @@ public class Column
     }
 
     private static final Set<Type> FLOATING_POINT_TYPES = ImmutableSet.of(DOUBLE, REAL);
-    private static final TypeRegistry typeRegistry = new TypeRegistry();
-
-    static {
-        new FunctionManager(typeRegistry, new BlockEncodingManager(typeRegistry), new FeaturesConfig(), new HandleResolver());
-    }
 
     private final String name;
     private final Category category;
@@ -86,10 +77,10 @@ public class Column
         return type;
     }
 
-    public static Column fromResultSet(ResultSet resultSet)
+    public static Column fromResultSet(TypeManager typeManager, ResultSet resultSet)
             throws SQLException
     {
-        Type type = typeRegistry.getType(parseTypeSignature(resultSet.getString("Type")));
+        Type type = typeManager.getType(parseTypeSignature(resultSet.getString("Type")));
         Category category;
         if (FLOATING_POINT_TYPES.contains(type)) {
             category = FLOATING_POINT;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.verifier.framework;
 
+import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.ShowColumns;
@@ -52,6 +53,7 @@ import static java.util.Objects.requireNonNull;
 public class DataVerification
         extends AbstractVerification
 {
+    private final TypeManager typeManager;
     private final ChecksumValidator checksumValidator;
     private final LimitQueryDeterminismAnalyzer limitQueryDeterminismAnalyzer;
 
@@ -63,10 +65,12 @@ public class DataVerification
             FailureResolverManager failureResolverManager,
             VerificationContext verificationContext,
             VerifierConfig verifierConfig,
+            TypeManager typeManager,
             ChecksumValidator checksumValidator,
             LimitQueryDeterminismAnalyzer limitQueryDeterminismAnalyzer)
     {
         super(verificationResubmitter, prestoAction, sourceQuery, queryRewriter, failureResolverManager, verificationContext, verifierConfig);
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.checksumValidator = requireNonNull(checksumValidator, "checksumValidator is null");
         this.limitQueryDeterminismAnalyzer = requireNonNull(limitQueryDeterminismAnalyzer, "limitQueryDeterminismAnalyzer is null");
     }
@@ -192,7 +196,7 @@ public class DataVerification
     private List<Column> getColumns(QualifiedName tableName)
     {
         return getPrestoAction()
-                .execute(new ShowColumns(tableName), DESCRIBE, Column::fromResultSet)
+                .execute(new ShowColumns(tableName), DESCRIBE, resultSet -> Column.fromResultSet(typeManager, resultSet))
                 .getResults();
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.verifier.framework;
 
+import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.verifier.annotation.ForTest;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
@@ -41,6 +42,7 @@ public class VerificationFactory
     private final PrestoResourceClient testResourceClient;
     private final ChecksumValidator checksumValidator;
     private final VerifierConfig verifierConfig;
+    private final TypeManager typeManager;
     private final FailureResolverConfig failureResolverConfig;
 
     @Inject
@@ -52,6 +54,7 @@ public class VerificationFactory
             @ForTest PrestoResourceClient testResourceClient,
             ChecksumValidator checksumValidator,
             VerifierConfig verifierConfig,
+            TypeManager typeManager,
             FailureResolverConfig failureResolverConfig)
     {
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
@@ -61,6 +64,7 @@ public class VerificationFactory
         this.testResourceClient = requireNonNull(testResourceClient, "testResourceClient is null");
         this.checksumValidator = requireNonNull(checksumValidator, "checksumValidator is null");
         this.verifierConfig = requireNonNull(verifierConfig, "config is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.failureResolverConfig = requireNonNull(failureResolverConfig, "failureResolverConfig is null");
     }
 
@@ -86,6 +90,7 @@ public class VerificationFactory
                         failureResolverManager,
                         verificationContext,
                         verifierConfig,
+                        typeManager,
                         checksumValidator,
                         limitQueryDeterminismAnalyzer);
             default:

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -17,6 +17,7 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.tests.StandaloneQueryRunner;
+import com.facebook.presto.type.TypeRegistry;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.checksum.FloatingPointColumnValidator;
 import com.facebook.presto.verifier.checksum.OrderableArrayColumnValidator;
@@ -109,6 +110,7 @@ public class TestDataVerification
                 new FailureResolverManager(ImmutableList.of()),
                 verificationContext,
                 verifierConfig,
+                new TypeRegistry(),
                 checksumValidator,
                 new LimitQueryDeterminismAnalyzer(prestoAction, verifierConfig));
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.type.TypeRegistry;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.checksum.FloatingPointColumnValidator;
 import com.facebook.presto.verifier.checksum.OrderableArrayColumnValidator;
@@ -137,6 +138,7 @@ public class TestVerificationManager
                         new MockPrestoResourceClient(),
                         new ChecksumValidator(new SimpleColumnValidator(), new FloatingPointColumnValidator(verifierConfig), new OrderableArrayColumnValidator()),
                         verifierConfig,
+                        new TypeRegistry(),
                         new FailureResolverConfig().setEnabled(false)),
                 SQL_PARSER,
                 ImmutableSet.of(),


### PR DESCRIPTION
Highlights of the PR:
- `InMemoryFunctionNamespaceManager` for testing purpose.
  - Requires proper definition for `createFunction`.
  - Requires proper definition for `SqlInvokedRegularFunction`
- Transaction support for `FunctionNamespaceManager`.
  - For this PR, transaction support is limited to the read-only method `#getFunctions`.
- Caching support for `FunctionNamespaceManager<SqlInvokedRegularFunction>`
  - Covers both `#getFunctions` and `#getFunctionMetadata`
```
== NO RELEASE NOTE ==
```
