### PR TITLE
Implement interfaces for RowExpressionTranslation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
         <module>presto-kudu</module>
         <module>presto-elasticsearch</module>
         <module>presto-sql-function</module>
+        <module>presto-expressions</module>
     </modules>
 
     <dependencyManagement>
@@ -374,6 +375,12 @@
             <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-elasticsearch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-expressions</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/presto-expressions/pom.xml
+++ b/presto-expressions/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.228-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-expressions</artifactId>
+    <name>presto-expressions</name>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/FunctionTranslator.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/FunctionTranslator.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.expressions.translator;
+
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class FunctionTranslator<T>
+{
+    private final Map<FunctionMetadata, MethodHandle> functionMapping;
+
+    public static <T> FunctionTranslator<T> buildFunctionTranslator(Set<Class<?>> translatorContainers)
+    {
+        ImmutableMap.Builder<FunctionMetadata, MethodHandle> functionMappingBuilder = new ImmutableMap.Builder<>();
+        translatorContainers.stream()
+                .map(TranslatorAnnotationParser::parseFunctionDefinitions)
+                .forEach(functionMappingBuilder::putAll);
+        return new FunctionTranslator<>(functionMappingBuilder.build());
+    }
+
+    public TranslatedExpression<T> translate(FunctionMetadata functionMetadata, RowExpression original, List<TranslatedExpression<T>> translatedArguments)
+            throws Throwable
+    {
+        if (!functionMapping.containsKey(functionMetadata)) {
+            return new TranslatedExpression<>(Optional.empty(), original, translatedArguments);
+        }
+        return new TranslatedExpression<>(Optional.of((T) functionMapping.get(functionMetadata).invokeWithArguments(translatedArguments)), original, translatedArguments);
+    }
+
+    public TranslatedExpression<T> translate(FunctionMetadata functionMetadata, RowExpression original, TranslatedExpression<T>... translatedArguments)
+            throws Throwable
+    {
+        return translate(functionMetadata, original, ImmutableList.copyOf(translatedArguments));
+    }
+
+    public TranslatedExpression<T> translate(FunctionMetadata functionMetadata, RowExpression original)
+            throws Throwable
+    {
+        return translate(functionMetadata, original, ImmutableList.of());
+    }
+
+    private FunctionTranslator(Map<FunctionMetadata, MethodHandle> functionMapping)
+    {
+        this.functionMapping = requireNonNull(functionMapping, "functionMapping is null");
+    }
+}

--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/RowExpressionTranslator.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/RowExpressionTranslator.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.expressions.translator;
+
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+
+import static com.facebook.presto.expressions.translator.TranslatedExpression.untranslated;
+
+public class RowExpressionTranslator<T, C>
+{
+    public TranslatedExpression<T> translateConstant(ConstantExpression literal, C context, RowExpressionTreeTranslator<T, C> rowExpressionTreeTranslator)
+    {
+        return untranslated(literal);
+    }
+
+    public TranslatedExpression<T> translateVariable(VariableReferenceExpression reference, C context, RowExpressionTreeTranslator<T, C> rowExpressionTreeTranslator)
+    {
+        return untranslated(reference);
+    }
+
+    public TranslatedExpression<T> translateLambda(LambdaDefinitionExpression reference, C context, RowExpressionTreeTranslator<T, C> rowExpressionTreeTranslator)
+    {
+        return untranslated(reference);
+    }
+
+    public TranslatedExpression<T> translateCall(CallExpression call, C context, RowExpressionTreeTranslator<T, C> rowExpressionTreeTranslator)
+    {
+        return untranslated(call);
+    }
+
+    public TranslatedExpression<T> translateSpecialForm(SpecialFormExpression specialForm, C context, RowExpressionTreeTranslator<T, C> rowExpressionTreeTranslator)
+    {
+        return untranslated(specialForm);
+    }
+}

--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/RowExpressionTreeTranslator.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/RowExpressionTreeTranslator.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.expressions.translator;
+
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+
+import static java.util.Objects.requireNonNull;
+
+public class RowExpressionTreeTranslator<T, C>
+{
+    private final RowExpressionTranslator<T, C> rowExpressionTranslator;
+    private final RowExpressionVisitor<TranslatedExpression<T>, C> visitor;
+
+    private RowExpressionTreeTranslator(RowExpressionTranslator<T, C> rowExpressionTranslator)
+    {
+        this.rowExpressionTranslator = requireNonNull(rowExpressionTranslator, "rowExpressionTranslator is null");
+        this.visitor = new TranslatingVisitor();
+    }
+
+    public TranslatedExpression<T> rewrite(RowExpression node, C context)
+    {
+        return node.accept(this.visitor, context);
+    }
+
+    public static <T, C> TranslatedExpression<T> translateWith(
+            RowExpression expression,
+            RowExpressionTranslator<T, C> translator,
+            C context)
+    {
+        return expression.accept(new RowExpressionTreeTranslator<>(translator).visitor, context);
+    }
+
+    private class TranslatingVisitor
+            implements RowExpressionVisitor<TranslatedExpression<T>, C>
+    {
+        @Override
+        public TranslatedExpression<T> visitCall(CallExpression call, C context)
+        {
+            return rowExpressionTranslator.translateCall(call, context, RowExpressionTreeTranslator.this);
+        }
+
+        @Override
+        public TranslatedExpression<T> visitInputReference(InputReferenceExpression reference, C context)
+        {
+            // InputReferenceExpression should only be used by Presto engine rather than connectors
+            throw new UnsupportedOperationException("Cannot translate RowExpression that contains inputReferenceExpression");
+        }
+
+        @Override
+        public TranslatedExpression<T> visitConstant(ConstantExpression literal, C context)
+        {
+            return rowExpressionTranslator.translateConstant(literal, context, RowExpressionTreeTranslator.this);
+        }
+
+        @Override
+        public TranslatedExpression<T> visitLambda(LambdaDefinitionExpression lambda, C context)
+        {
+            return rowExpressionTranslator.translateLambda(lambda, context, RowExpressionTreeTranslator.this);
+        }
+
+        @Override
+        public TranslatedExpression<T> visitVariableReference(VariableReferenceExpression reference, C context)
+        {
+            return rowExpressionTranslator.translateVariable(reference, context, RowExpressionTreeTranslator.this);
+        }
+
+        @Override
+        public TranslatedExpression<T> visitSpecialForm(SpecialFormExpression specialForm, C context)
+        {
+            return rowExpressionTranslator.translateSpecialForm(specialForm, context, RowExpressionTreeTranslator.this);
+        }
+    }
+}

--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/TranslatedExpression.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/TranslatedExpression.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.expressions.translator;
+
+import com.facebook.presto.spi.relation.RowExpression;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class TranslatedExpression<T>
+{
+    private final Optional<T> translated;
+    private final RowExpression originalExpression;
+    private final List<TranslatedExpression<T>> translatedArguments;
+
+    public TranslatedExpression(Optional<T> translated, RowExpression originalExpression, List<TranslatedExpression<T>> translatedArguments)
+    {
+        this.translated = requireNonNull(translated);
+        this.originalExpression = requireNonNull(originalExpression);
+        this.translatedArguments = requireNonNull(translatedArguments);
+    }
+
+    public Optional<T> getTranslated()
+    {
+        return translated;
+    }
+
+    public RowExpression getOriginalExpression()
+    {
+        return originalExpression;
+    }
+
+    public List<TranslatedExpression<T>> getTranslatedArguments()
+    {
+        return translatedArguments;
+    }
+
+    public static <T> TranslatedExpression<T> untranslated(RowExpression originalExpression)
+    {
+        return new TranslatedExpression<>(Optional.empty(), originalExpression, ImmutableList.of());
+    }
+}

--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/TranslatorAnnotationParser.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/TranslatorAnnotationParser.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.expressions.translator;
+
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.relation.FullyQualifiedName;
+import com.facebook.presto.spi.type.TypeSignature;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.google.common.base.CaseFormat.LOWER_CAMEL;
+import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+class TranslatorAnnotationParser
+{
+    private TranslatorAnnotationParser()
+    {
+    }
+
+    public static Map<FunctionMetadata, MethodHandle> parseFunctionDefinitions(Class<?> clazz)
+    {
+        ImmutableMap.Builder<FunctionMetadata, MethodHandle> translatorBuilder = ImmutableMap.builder();
+        for (ScalarHeaderAndMethods methods : findScalarsFromSetClass(clazz)) {
+            translatorBuilder.putAll(scalarToFunctionMetadata(methods));
+        }
+
+        return translatorBuilder.build();
+    }
+
+    private static TypeSignature removeTypeParameters(TypeSignature typeSignature)
+    {
+        return new TypeSignature(typeSignature.getBase());
+    }
+
+    private static FunctionMetadata removeTypeParameters(FunctionMetadata metadata)
+    {
+        ImmutableList.Builder<TypeSignature> argumentsBuilder = ImmutableList.builder();
+        for (TypeSignature typeSignature : metadata.getArgumentTypes()) {
+            argumentsBuilder.add(removeTypeParameters(typeSignature));
+        }
+
+        if (metadata.getOperatorType().isPresent()) {
+            return new FunctionMetadata(
+                    metadata.getOperatorType().get(),
+                    argumentsBuilder.build(),
+                    metadata.getReturnType(),
+                    metadata.getFunctionKind(),
+                    metadata.isDeterministic(),
+                    metadata.isCalledOnNullInput());
+        }
+        return new FunctionMetadata(
+                metadata.getName(),
+                argumentsBuilder.build(),
+                metadata.getReturnType(),
+                metadata.getFunctionKind(),
+                metadata.isDeterministic(),
+                metadata.isCalledOnNullInput());
+    }
+
+    private static MethodHandle getMethodHandle(Method method)
+    {
+        try {
+            return MethodHandles.lookup().unreflect(method);
+        }
+        catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static List<ScalarHeaderAndMethods> findScalarsFromSetClass(Class<?> clazz)
+    {
+        ImmutableList.Builder<ScalarHeaderAndMethods> builder = ImmutableList.builder();
+        for (Method method : findPublicMethodsWithAnnotation(clazz, SqlType.class, ScalarFunction.class, ScalarOperator.class)) {
+            boolean annotationCondition = (method.getAnnotation(ScalarFunction.class) != null) || (method.getAnnotation(ScalarOperator.class) != null);
+            checkArgument(annotationCondition, format("Method [%s] annotated with @SqlType is missing @ScalarFunction or @ScalarOperator", method));
+
+            for (ScalarTranslationHeader header : ScalarTranslationHeader.fromAnnotatedElement(method)) {
+                builder.add(new ScalarHeaderAndMethods(header, ImmutableSet.of(method)));
+            }
+        }
+        List<ScalarHeaderAndMethods> methods = builder.build();
+        checkArgument(!methods.isEmpty(), "Class [%s] does not have any methods annotated with @ScalarFunction or @ScalarOperator", clazz.getName());
+
+        return methods;
+    }
+
+    private static Map<FunctionMetadata, MethodHandle> scalarToFunctionMetadata(ScalarHeaderAndMethods scalar)
+    {
+        ScalarTranslationHeader header = scalar.getHeader();
+
+        ImmutableMap.Builder<FunctionMetadata, MethodHandle> metadataBuilder = ImmutableMap.builder();
+        for (Method method : scalar.getMethods()) {
+            FunctionMetadata metadata = methodToFunctionMetadata(header, method);
+            metadataBuilder.put(removeTypeParameters(metadata), getMethodHandle(method));
+        }
+
+        return metadataBuilder.build();
+    }
+
+    private static FunctionMetadata methodToFunctionMetadata(ScalarTranslationHeader header, Method method)
+    {
+        requireNonNull(header, "header is null");
+
+        // return type
+        SqlType annotatedReturnType = method.getAnnotation(SqlType.class);
+        checkArgument(annotatedReturnType != null, format("Method [%s] is missing @SqlType annotation", method));
+        TypeSignature returnType = parseTypeSignature(annotatedReturnType.value(), ImmutableSet.of());
+
+        // argument type
+        ImmutableList.Builder<TypeSignature> argumentTypes = new ImmutableList.Builder<>();
+        for (Parameter parameter : method.getParameters()) {
+            Annotation[] annotations = parameter.getAnnotations();
+
+            SqlType type = Stream.of(annotations)
+                    .filter(SqlType.class::isInstance)
+                    .map(SqlType.class::cast)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(format("Method [%s] is missing @SqlType annotation for parameter", method)));
+            TypeSignature typeSignature = parseTypeSignature(type.value(), ImmutableSet.of());
+            argumentTypes.add(typeSignature);
+        }
+
+        if (header.getOperatorType().isPresent()) {
+            return new FunctionMetadata(header.getOperatorType().get(), argumentTypes.build(), returnType, SCALAR, header.isDeterministic(), header.isCalledOnNullInput());
+        }
+        return new FunctionMetadata(header.getName(), argumentTypes.build(), returnType, SCALAR, header.isDeterministic(), header.isCalledOnNullInput());
+    }
+
+    @SafeVarargs
+    private static Set<Method> findPublicMethodsWithAnnotation(Class<?> clazz, Class<? extends Annotation>... annotationClasses)
+    {
+        ImmutableSet.Builder<Method> methods = ImmutableSet.builder();
+        for (Method method : clazz.getDeclaredMethods()) {
+            for (Annotation annotation : method.getAnnotations()) {
+                for (Class<?> annotationClass : annotationClasses) {
+                    if (annotationClass.isInstance(annotation)) {
+                        checkArgument(Modifier.isPublic(method.getModifiers()), "Method [%s] annotated with @%s must be public", method, annotationClass.getSimpleName());
+                        methods.add(method);
+                    }
+                }
+            }
+        }
+        return methods.build();
+    }
+
+    private static class ScalarHeaderAndMethods
+    {
+        private final ScalarTranslationHeader header;
+        private final Set<Method> methods;
+
+        public ScalarHeaderAndMethods(ScalarTranslationHeader header, Set<Method> methods)
+        {
+            this.header = requireNonNull(header, "header is null");
+            this.methods = requireNonNull(methods, "methods are null");
+        }
+
+        public ScalarTranslationHeader getHeader()
+        {
+            return header;
+        }
+
+        public Set<Method> getMethods()
+        {
+            return methods;
+        }
+    }
+
+    private static class ScalarTranslationHeader
+    {
+        private final FullyQualifiedName name;
+        private final Optional<OperatorType> operatorType;
+        private final boolean deterministic;
+        private final boolean calledOnNullInput;
+
+        public static List<ScalarTranslationHeader> fromAnnotatedElement(AnnotatedElement annotated)
+        {
+            ScalarFunction scalarFunction = annotated.getAnnotation(ScalarFunction.class);
+            ScalarOperator scalarOperator = annotated.getAnnotation(ScalarOperator.class);
+
+            ImmutableList.Builder<ScalarTranslationHeader> builder = ImmutableList.builder();
+
+            if (scalarFunction != null) {
+                String baseName = scalarFunction.value().isEmpty() ? camelToSnake(annotatedName(annotated)) : scalarFunction.value();
+                builder.add(new ScalarTranslationHeader(baseName, scalarFunction.deterministic(), scalarFunction.calledOnNullInput()));
+
+                for (String alias : scalarFunction.alias()) {
+                    builder.add(new ScalarTranslationHeader(alias, scalarFunction.deterministic(), scalarFunction.calledOnNullInput()));
+                }
+            }
+
+            if (scalarOperator != null) {
+                builder.add(new ScalarTranslationHeader(scalarOperator.value(), true, scalarOperator.value().isCalledOnNullInput()));
+            }
+
+            List<ScalarTranslationHeader> result = builder.build();
+            checkArgument(!result.isEmpty());
+            return result;
+        }
+
+        private ScalarTranslationHeader(String name, boolean deterministic, boolean calledOnNullInput)
+        {
+            // TODO This is a hack. Engine should provide an API for connectors to overwrite functions. Connector should not hard code the builtin function namespace.
+            this.name = requireNonNull(FullyQualifiedName.of("presto", "default", name));
+            this.operatorType = Optional.empty();
+            this.deterministic = deterministic;
+            this.calledOnNullInput = calledOnNullInput;
+        }
+
+        private ScalarTranslationHeader(OperatorType operatorType, boolean deterministic, boolean calledOnNullInput)
+        {
+            this.name = operatorType.getFunctionName();
+            this.operatorType = Optional.of(operatorType);
+            this.deterministic = deterministic;
+            this.calledOnNullInput = calledOnNullInput;
+        }
+
+        private static String annotatedName(AnnotatedElement annotatedElement)
+        {
+            if (annotatedElement instanceof Class<?>) {
+                return ((Class<?>) annotatedElement).getSimpleName();
+            }
+            else if (annotatedElement instanceof Method) {
+                return ((Method) annotatedElement).getName();
+            }
+
+            throw new UnsupportedOperationException("Only Classes and Methods are supported as annotated elements.");
+        }
+
+        private static String camelToSnake(String name)
+        {
+            return LOWER_CAMEL.to(LOWER_UNDERSCORE, name);
+        }
+
+        FullyQualifiedName getName()
+        {
+            return name;
+        }
+
+        Optional<OperatorType> getOperatorType()
+        {
+            return operatorType;
+        }
+
+        boolean isDeterministic()
+        {
+            return deterministic;
+        }
+
+        boolean isCalledOnNullInput()
+        {
+            return calledOnNullInput;
+        }
+    }
+}

--- a/presto-expressions/src/test/java/com/facebook/presto/expressions/translator/TestRowExpressionTranslator.java
+++ b/presto-expressions/src/test/java/com/facebook/presto/expressions/translator/TestRowExpressionTranslator.java
@@ -1,0 +1,300 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.expressions.translator;
+
+import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.OperatorType;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.sql.TestingRowExpressionTranslator;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.expressions.translator.FunctionTranslator.buildFunctionTranslator;
+import static com.facebook.presto.expressions.translator.RowExpressionTreeTranslator.translateWith;
+import static com.facebook.presto.expressions.translator.TranslatedExpression.untranslated;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestRowExpressionTranslator
+{
+    private static final Metadata METADATA = MetadataManager.createTestMetadataManager();
+
+    private final FunctionManager functionManager;
+    private final TestingRowExpressionTranslator sqlToRowExpressionTranslator;
+
+    public TestRowExpressionTranslator()
+    {
+        this.functionManager = METADATA.getFunctionManager();
+        this.sqlToRowExpressionTranslator = new TestingRowExpressionTranslator(METADATA);
+    }
+
+    @Test
+    public void testEndToEndFunctionTranslation()
+    {
+        String untranslated = "LN(bitwise_and(1, col1))";
+        TypeProvider typeProvider = TypeProvider.copyOf(ImmutableMap.of("col1", BIGINT));
+        CallExpression callExpression = (CallExpression) sqlToRowExpressionTranslator.translate(expression(untranslated), typeProvider);
+
+        TranslatedExpression translatedExpression = translateWith(
+                callExpression,
+                new TestFunctionTranslator(functionManager, buildFunctionTranslator(ImmutableSet.of(TestFunctions.class))),
+                emptyMap());
+        assertTrue(translatedExpression.getTranslated().isPresent());
+        assertEquals(translatedExpression.getTranslated().get(), "LNof(1 BITWISE_AND col1)");
+    }
+
+    @Test
+    public void testEndToEndSpecialFormTranslation()
+    {
+        String untranslated = "col1 AND col2";
+        TypeProvider typeProvider = TypeProvider.copyOf(ImmutableMap.of("col1", BOOLEAN, "col2", BOOLEAN));
+
+        RowExpression specialForm = sqlToRowExpressionTranslator.translate(expression(untranslated), typeProvider);
+
+        TranslatedExpression translatedExpression = translateWith(
+                specialForm,
+                new TestFunctionTranslator(functionManager, buildFunctionTranslator(ImmutableSet.of(TestFunctions.class))),
+                emptyMap());
+        assertTrue(translatedExpression.getTranslated().isPresent());
+        assertEquals(translatedExpression.getTranslated().get(), "col1 TEST_AND col2");
+    }
+
+    @Test
+    public void testMissingFunctionTranslator()
+    {
+        String untranslated = "ABS(col1)";
+        TypeProvider typeProvider = TypeProvider.copyOf(ImmutableMap.of("col1", DOUBLE));
+
+        RowExpression specialForm = sqlToRowExpressionTranslator.translate(expression(untranslated), typeProvider);
+
+        TranslatedExpression translatedExpression = translateWith(
+                specialForm,
+                new TestFunctionTranslator(functionManager, buildFunctionTranslator(ImmutableSet.of(TestFunctions.class))),
+                emptyMap());
+        assertFalse(translatedExpression.getTranslated().isPresent());
+    }
+
+    @Test
+    public void testIncorrectFunctionSignatureInDefinition()
+    {
+        String untranslated = "CEIL(col1)";
+        TypeProvider typeProvider = TypeProvider.copyOf(ImmutableMap.of("col1", DOUBLE));
+
+        RowExpression specialForm = sqlToRowExpressionTranslator.translate(expression(untranslated), typeProvider);
+
+        TranslatedExpression translatedExpression = translateWith(
+                specialForm,
+                new TestFunctionTranslator(functionManager, buildFunctionTranslator(ImmutableSet.of(TestFunctions.class))),
+                emptyMap());
+        assertFalse(translatedExpression.getTranslated().isPresent());
+    }
+
+    @Test
+    public void testHiddenFunctionNot()
+    {
+        String untranslated = "NOT true";
+        RowExpression specialForm = sqlToRowExpressionTranslator.translate(expression(untranslated), TypeProvider.empty());
+
+        TranslatedExpression translatedExpression = translateWith(
+                specialForm,
+                new TestFunctionTranslator(functionManager, buildFunctionTranslator(ImmutableSet.of(TestFunctions.class))),
+                emptyMap());
+        assertTrue(translatedExpression.getTranslated().isPresent());
+        assertEquals(translatedExpression.getTranslated().get(), "NOT_2 true");
+    }
+
+    @Test
+    public void testBasicOperator()
+    {
+        String untranslated = "col1 + col2";
+        TypeProvider typeProvider = TypeProvider.copyOf(ImmutableMap.of("col1", BIGINT, "col2", BIGINT));
+        RowExpression specialForm = sqlToRowExpressionTranslator.translate(expression(untranslated), typeProvider);
+
+        TranslatedExpression translatedExpression = translateWith(
+                specialForm,
+                new TestFunctionTranslator(functionManager, buildFunctionTranslator(ImmutableSet.of(TestFunctions.class))),
+                emptyMap());
+        assertTrue(translatedExpression.getTranslated().isPresent());
+        assertEquals(translatedExpression.getTranslated().get(), "col1 -|- col2");
+    }
+
+    @Test
+    public void testLessThanOperator()
+    {
+        String untranslated = "col1 < col2";
+        TypeProvider typeProvider = TypeProvider.copyOf(ImmutableMap.of("col1", BIGINT, "col2", BIGINT));
+        RowExpression specialForm = sqlToRowExpressionTranslator.translate(expression(untranslated), typeProvider);
+
+        TranslatedExpression translatedExpression = translateWith(
+                specialForm,
+                new TestFunctionTranslator(functionManager, buildFunctionTranslator(ImmutableSet.of(TestFunctions.class))),
+                emptyMap());
+        assertTrue(translatedExpression.getTranslated().isPresent());
+        assertEquals(translatedExpression.getTranslated().get(), "col1 LT col2");
+    }
+
+    @Test
+    public void testUntranslatableSpecialForm()
+    {
+        String untranslated = "col1 OR col2";
+        TypeProvider typeProvider = TypeProvider.copyOf(ImmutableMap.of("col1", BOOLEAN, "col2", BOOLEAN));
+        RowExpression specialForm = sqlToRowExpressionTranslator.translate(expression(untranslated), typeProvider);
+
+        TranslatedExpression translatedExpression = translateWith(
+                specialForm,
+                new TestFunctionTranslator(functionManager, buildFunctionTranslator(ImmutableSet.of(TestFunctions.class))),
+                emptyMap());
+        assertFalse(translatedExpression.getTranslated().isPresent());
+    }
+
+    private class TestFunctionTranslator
+            extends RowExpressionTranslator<String, Map<VariableReferenceExpression, ColumnHandle>>
+    {
+        private final FunctionManager functionManager;
+        private final FunctionTranslator<String> functionTranslator;
+
+        TestFunctionTranslator(FunctionManager functionManager, FunctionTranslator<String> functionTranslator)
+        {
+            this.functionTranslator = requireNonNull(functionTranslator);
+            this.functionManager = requireNonNull(functionManager);
+        }
+
+        @Override
+        public TranslatedExpression<String> translateConstant(ConstantExpression literal, Map<VariableReferenceExpression, ColumnHandle> context, RowExpressionTreeTranslator<String, Map<VariableReferenceExpression, ColumnHandle>> rowExpressionTreeTranslator)
+        {
+            return new TranslatedExpression<>(Optional.of(literal.toString()), literal, emptyList());
+        }
+
+        @Override
+        public TranslatedExpression<String> translateCall(CallExpression callExpression, Map<VariableReferenceExpression, ColumnHandle> context, RowExpressionTreeTranslator<String, Map<VariableReferenceExpression, ColumnHandle>> rowExpressionTreeTranslator)
+        {
+            List<TranslatedExpression<String>> translatedExpressions = callExpression.getArguments().stream()
+                    .map(expression -> rowExpressionTreeTranslator.rewrite(expression, context))
+                    .collect(Collectors.toList());
+            FunctionMetadata functionMetadata = functionManager.getFunctionMetadata(callExpression.getFunctionHandle());
+            try {
+                return functionTranslator.translate(functionMetadata, callExpression, translatedExpressions);
+            }
+            catch (Throwable t) {
+                return untranslated(callExpression);
+            }
+        }
+
+        @Override
+        public TranslatedExpression<String> translateSpecialForm(SpecialFormExpression specialFormExpression, Map<VariableReferenceExpression, ColumnHandle> context, RowExpressionTreeTranslator<String, Map<VariableReferenceExpression, ColumnHandle>> rowExpressionTreeTranslator)
+        {
+            if (!specialFormExpression.getForm().equals(SpecialFormExpression.Form.AND)) {
+                return untranslated(specialFormExpression);
+            }
+
+            List<TranslatedExpression<String>> translatedExpressions = specialFormExpression.getArguments().stream()
+                    .map(expression -> rowExpressionTreeTranslator.rewrite(expression, context))
+                    .collect(Collectors.toList());
+
+            assertTrue(translatedExpressions.get(0).getTranslated().isPresent());
+            assertTrue(translatedExpressions.get(1).getTranslated().isPresent());
+            return new TranslatedExpression<>(
+                    Optional.of(translatedExpressions.get(0).getTranslated().get() + " TEST_AND " + translatedExpressions.get(1).getTranslated().get()),
+                    specialFormExpression,
+                    translatedExpressions);
+        }
+
+        @Override
+        public TranslatedExpression<String> translateVariable(VariableReferenceExpression reference, Map<VariableReferenceExpression, ColumnHandle> context, RowExpressionTreeTranslator<String, Map<VariableReferenceExpression, ColumnHandle>> rowExpressionTreeTranslator)
+        {
+            return new TranslatedExpression<>(Optional.of(reference.getName()), reference, emptyList());
+        }
+    }
+
+    private static class TestFunctions
+    {
+        @ScalarFunction
+        @SqlType(StandardTypes.BIGINT)
+        public static String bitwiseAnd(@SqlType(StandardTypes.BIGINT) TranslatedExpression<String> left, @SqlType(StandardTypes.BIGINT) TranslatedExpression<String> right)
+        {
+            assertTrue(left.getTranslated().isPresent());
+            assertTrue(right.getTranslated().isPresent());
+            return left.getTranslated().get() + " BITWISE_AND " + right.getTranslated().get();
+        }
+
+        @ScalarFunction("ln")
+        @SqlType(StandardTypes.DOUBLE)
+        public static String ln(@SqlType(StandardTypes.DOUBLE) TranslatedExpression<String> sql)
+        {
+            assertTrue(sql.getTranslated().isPresent());
+            return "LNof(" + sql.getTranslated().get() + ")";
+        }
+
+        @ScalarFunction("ceil")
+        @SqlType(StandardTypes.DOUBLE)
+        public static String ceil(@SqlType(StandardTypes.BOOLEAN) TranslatedExpression<String> sql)
+        {
+            assertTrue(sql.getTranslated().isPresent());
+            return "CEILof(" + sql.getTranslated().get() + ")";
+        }
+
+        @ScalarFunction("not")
+        @SqlType(StandardTypes.BOOLEAN)
+        public static String not(@SqlType(StandardTypes.BOOLEAN) TranslatedExpression<String> sql)
+        {
+            assertTrue(sql.getTranslated().isPresent());
+            return "NOT_2 " + sql.getTranslated().get();
+        }
+
+        @ScalarOperator(OperatorType.ADD)
+        @SqlType(StandardTypes.BIGINT)
+        public static String plus(@SqlType(StandardTypes.BIGINT) TranslatedExpression<String> left, @SqlType(StandardTypes.BIGINT) TranslatedExpression<String> right)
+        {
+            assertTrue(left.getTranslated().isPresent());
+            assertTrue(right.getTranslated().isPresent());
+            return left.getTranslated().get() + " -|- " + right.getTranslated().get();
+        }
+
+        @ScalarOperator(OperatorType.LESS_THAN)
+        @SqlType(StandardTypes.BOOLEAN)
+        public static String lessThan(@SqlType(StandardTypes.BIGINT) TranslatedExpression<String> left, @SqlType(StandardTypes.BIGINT) TranslatedExpression<String> right)
+        {
+            assertTrue(left.getTranslated().isPresent());
+            assertTrue(right.getTranslated().isPresent());
+            return left.getTranslated().get() + " LT " + right.getTranslated().get();
+        }
+    }
+}


### PR DESCRIPTION
Implement Row Expression translation interfaces in new module presto-expression.

NOTE: See an example implementation using these interfaces in #13526 

```
== NO RELEASE NOTE ==
```
