### PR TITLE
Use empty Envelope instead of null in deserialization

### DIFF
--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/serde/GeometrySerde.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/serde/GeometrySerde.java
@@ -69,10 +69,7 @@ public class GeometrySerde
         verify(!envelope.isEmpty());
         DynamicSliceOutput output = new DynamicSliceOutput(100);
         output.appendByte(GeometrySerializationType.ENVELOPE.code());
-        output.appendDouble(envelope.getXMin());
-        output.appendDouble(envelope.getYMin());
-        output.appendDouble(envelope.getXMax());
-        output.appendDouble(envelope.getYMax());
+        writeEnvelopeCoordinates(output, envelope);
         return output.slice();
     }
 
@@ -307,7 +304,7 @@ public class GeometrySerde
 
     private static Envelope getGeometryCollectionOverallEnvelope(BasicSliceInput input)
     {
-        Envelope overallEnvelope = null;
+        Envelope overallEnvelope = new Envelope();
         while (input.available() > 0) {
             int length = input.readInt() - 1;
             GeometrySerializationType type = GeometrySerializationType.getForCode(input.readByte());
@@ -321,20 +318,12 @@ public class GeometrySerde
     {
         // skip type injected by esri
         input.readInt();
-
-        double xMin = input.readDouble();
-        double yMin = input.readDouble();
-        double xMax = input.readDouble();
-        double yMax = input.readDouble();
+        Envelope envelope = readEnvelope(input);
 
         int skipLength = length - (4 * Double.BYTES) - Integer.BYTES;
         verify(input.skip(skipLength) == skipLength);
 
-        if (isEsriNaN(xMin) || isEsriNaN(yMin) || isEsriNaN(xMax) || isEsriNaN(yMax)) {
-            // TODO: isn't it better to return empty envelope instead?
-            return null;
-        }
-        return new Envelope(xMin, yMin, xMax, yMax);
+        return envelope;
     }
 
     private static Envelope getPointEnvelope(BasicSliceInput input)
@@ -342,8 +331,7 @@ public class GeometrySerde
         double x = input.readDouble();
         double y = input.readDouble();
         if (isNaN(x) || isNaN(y)) {
-            // TODO: isn't it better to return empty envelope instead?
-            return null;
+            return new Envelope();
         }
         return new Envelope(x, y, x, y);
     }
@@ -355,7 +343,26 @@ public class GeometrySerde
         double yMin = input.readDouble();
         double xMax = input.readDouble();
         double yMax = input.readDouble();
+        if (isEsriNaN(xMin) || isEsriNaN(yMin) || isEsriNaN(xMin) || isEsriNaN(yMin)) {
+            return new Envelope();
+        }
         return new Envelope(xMin, yMin, xMax, yMax);
+    }
+
+    private static void writeEnvelopeCoordinates(DynamicSliceOutput output, Envelope envelope)
+    {
+        if (envelope.isEmpty()) {
+            output.appendDouble(NaN);
+            output.appendDouble(NaN);
+            output.appendDouble(NaN);
+            output.appendDouble(NaN);
+        }
+        else {
+            output.appendDouble(envelope.getXMin());
+            output.appendDouble(envelope.getYMin());
+            output.appendDouble(envelope.getXMax());
+            output.appendDouble(envelope.getYMax());
+        }
     }
 
     @Nullable

--- a/presto-geospatial-toolkit/src/test/java/com/facebook/presto/geospatial/serde/TestGeometrySerialization.java
+++ b/presto-geospatial-toolkit/src/test/java/com/facebook/presto/geospatial/serde/TestGeometrySerialization.java
@@ -154,9 +154,9 @@ public class TestGeometrySerialization
         assertDeserializeEnvelope("POLYGON ((0 0, 0 4, 4 0))", new Envelope(0, 0, 4, 4));
         assertDeserializeEnvelope("MULTIPOLYGON (((0 0 , 0 2, 2 2, 2 0)), ((2 2, 2 4, 4 4, 4 2)))", new Envelope(0, 0, 4, 4));
         assertDeserializeEnvelope("GEOMETRYCOLLECTION (POINT (3 7), LINESTRING (4 6, 7 10))", new Envelope(3, 6, 7, 10));
-        assertDeserializeEnvelope("POLYGON EMPTY", null);
+        assertDeserializeEnvelope("POLYGON EMPTY", new Envelope());
         assertDeserializeEnvelope("POINT (1 2)", new Envelope(1, 2, 1, 2));
-        assertDeserializeEnvelope("POINT EMPTY", null);
+        assertDeserializeEnvelope("POINT EMPTY", new Envelope());
         assertDeserializeEnvelope("GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (2 7), LINESTRING (4 6, 7 10)), POINT (3 7), LINESTRING (4 6, 7 10))", new Envelope(2, 6, 7, 10));
     }
 

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -290,7 +290,7 @@ public final class GeoFunctions
     {
         // "every point in input is in range" <=> "the envelope of input is in range"
         Envelope envelope = deserializeEnvelope(input);
-        if (envelope != null) {
+        if (!envelope.isEmpty()) {
             checkLatitude(envelope.getYMin());
             checkLatitude(envelope.getYMax());
             checkLongitude(envelope.getXMin());
@@ -443,8 +443,7 @@ public final class GeoFunctions
     @SqlType(BOOLEAN)
     public static Boolean stIsEmpty(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
-        Envelope envelope = deserializeEnvelope(input);
-        return envelope == null || envelope.isEmpty();
+        return deserializeEnvelope(input).isEmpty();
     }
 
     @Description("Returns TRUE if this Geometry has no anomalous geometric points, such as self intersection or self tangency")
@@ -555,7 +554,7 @@ public final class GeoFunctions
     public static Double stXMax(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
         Envelope envelope = deserializeEnvelope(input);
-        if (envelope == null) {
+        if (envelope.isEmpty()) {
             return null;
         }
         return envelope.getXMax();
@@ -568,7 +567,7 @@ public final class GeoFunctions
     public static Double stYMax(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
         Envelope envelope = deserializeEnvelope(input);
-        if (envelope == null) {
+        if (envelope.isEmpty()) {
             return null;
         }
         return envelope.getYMax();
@@ -581,7 +580,7 @@ public final class GeoFunctions
     public static Double stXMin(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
         Envelope envelope = deserializeEnvelope(input);
-        if (envelope == null) {
+        if (envelope.isEmpty()) {
             return null;
         }
         return envelope.getXMin();
@@ -594,7 +593,7 @@ public final class GeoFunctions
     public static Double stYMin(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
         Envelope envelope = deserializeEnvelope(input);
-        if (envelope == null) {
+        if (envelope.isEmpty()) {
             return null;
         }
         return envelope.getYMin();
@@ -931,7 +930,7 @@ public final class GeoFunctions
     public static Slice stEnvelope(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
         Envelope envelope = deserializeEnvelope(input);
-        if (envelope == null) {
+        if (envelope.isEmpty()) {
             return EMPTY_POLYGON;
         }
         return serialize(envelope);
@@ -944,7 +943,7 @@ public final class GeoFunctions
     public static Block stEnvelopeAsPts(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
         Envelope envelope = deserializeEnvelope(input);
-        if (envelope == null) {
+        if (envelope.isEmpty()) {
             return null;
         }
         BlockBuilder blockBuilder = GEOMETRY.createBlockBuilder(null, 2);
@@ -1182,7 +1181,7 @@ public final class GeoFunctions
     public static Block spatialPartitions(@SqlType(KdbTreeType.NAME) Object kdbTree, @SqlType(GEOMETRY_TYPE_NAME) Slice geometry)
     {
         Envelope envelope = deserializeEnvelope(geometry);
-        if (envelope == null) {
+        if (envelope.isEmpty()) {
             // Empty geometry
             return null;
         }
@@ -1209,7 +1208,7 @@ public final class GeoFunctions
         }
 
         Envelope envelope = deserializeEnvelope(geometry);
-        if (envelope == null) {
+        if (envelope.isEmpty()) {
             return null;
         }
 
@@ -1337,7 +1336,7 @@ public final class GeoFunctions
     {
         Envelope leftEnvelope = deserializeEnvelope(left);
         Envelope rightEnvelope = deserializeEnvelope(right);
-        if (leftEnvelope == null || rightEnvelope == null) {
+        if (leftEnvelope.isEmpty() || rightEnvelope.isEmpty()) {
             return false;
         }
         return predicate.apply(leftEnvelope, rightEnvelope);

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/SpatialPartitioningInternalAggregateFunction.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/SpatialPartitioningInternalAggregateFunction.java
@@ -50,7 +50,7 @@ public class SpatialPartitioningInternalAggregateFunction
     public static void input(SpatialPartitioningState state, @SqlType(GEOMETRY_TYPE_NAME) Slice slice, @SqlType(INTEGER) long partitionCount)
     {
         Envelope envelope = deserializeEnvelope(slice);
-        if (envelope == null) {
+        if (envelope.isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
When deserializing the envelope of an empty geometry, it's semantically
more intuitive to return an empty envelope, instead of a null.

== NO RELEASE NOTE ==
