### PR TITLE
Limit size of Expression/RowExpression during constant folding

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.StatsProvider;
-import com.facebook.presto.metadata.CastType;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.ColumnHandle;
@@ -43,7 +42,6 @@ import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -57,13 +55,11 @@ import static com.facebook.presto.hive.HiveQueryRunner.createQueryRunner;
 import static com.facebook.presto.hive.HiveSessionProperties.COLLECT_COLUMN_STATISTICS_ON_WRITE;
 import static com.facebook.presto.hive.HiveSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static com.facebook.presto.hive.TestHiveIntegrationSmokeTest.assertRemoteExchangesCount;
-import static com.facebook.presto.spi.function.OperatorType.CAST;
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
 import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
 import static com.facebook.presto.spi.relation.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
-import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
@@ -626,10 +622,7 @@ public class TestHiveLogicalPlanner
 
     private RowExpression constant(long value)
     {
-        return new CallExpression(CAST.name(),
-                getQueryRunner().getMetadata().getFunctionManager().lookupCast(CastType.CAST, VARCHAR.getTypeSignature(), BIGINT.getTypeSignature()),
-                BIGINT,
-                ImmutableList.of(new ConstantExpression(Slices.utf8Slice(String.valueOf(value)), VARCHAR)));
+        return new ConstantExpression(value, BIGINT);
     }
 
     private static Map<String, String> identityMap(String...values)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestSmallintOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestSmallintOperators.java
@@ -17,7 +17,6 @@ import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
-import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.function.OperatorType.INDETERMINATE;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -27,6 +26,7 @@ import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_LITERAL;
 import static java.lang.String.format;
 
 public class TestSmallintOperators
@@ -37,7 +37,7 @@ public class TestSmallintOperators
     {
         assertFunction("SMALLINT'37'", SMALLINT, (short) 37);
         assertFunction("SMALLINT'17'", SMALLINT, (short) 17);
-        assertInvalidCast("SMALLINT'" + ((long) Short.MAX_VALUE + 1L) + "'");
+        assertInvalidFunction("SMALLINT'" + ((long) Short.MAX_VALUE + 1L) + "'", INVALID_LITERAL);
     }
 
     @Test
@@ -52,7 +52,7 @@ public class TestSmallintOperators
     {
         assertFunction("SMALLINT'-37'", SMALLINT, (short) -37);
         assertFunction("SMALLINT'-17'", SMALLINT, (short) -17);
-        assertInvalidFunction("SMALLINT'-" + Short.MIN_VALUE + "'", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("SMALLINT'-" + Short.MIN_VALUE + "'", INVALID_LITERAL);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTinyintOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTinyintOperators.java
@@ -17,7 +17,6 @@ import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
-import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.function.OperatorType.INDETERMINATE;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -27,6 +26,7 @@ import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_LITERAL;
 import static java.lang.String.format;
 
 public class TestTinyintOperators
@@ -37,7 +37,7 @@ public class TestTinyintOperators
     {
         assertFunction("TINYINT'37'", TINYINT, (byte) 37);
         assertFunction("TINYINT'17'", TINYINT, (byte) 17);
-        assertInvalidCast("TINYINT'" + ((long) Byte.MAX_VALUE + 1L) + "'");
+        assertInvalidFunction("TINYINT'" + ((long) Byte.MAX_VALUE + 1L) + "'", INVALID_LITERAL);
     }
 
     @Test
@@ -52,7 +52,7 @@ public class TestTinyintOperators
     {
         assertFunction("TINYINT'-37'", TINYINT, (byte) -37);
         assertFunction("TINYINT'-17'", TINYINT, (byte) -17);
-        assertInvalidFunction("TINYINT'-" + Byte.MIN_VALUE + "'", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("TINYINT'-" + Byte.MIN_VALUE + "'", INVALID_LITERAL);
     }
 
     @Test


### PR DESCRIPTION
This PR put a limit on the size of constant we can generate when we do constant folding.  

Fixes issue: https://github.com/prestodb/presto/issues/13360

```
== RELEASE NOTES ==

General Changes
* Improve coordinator stability on parsing functions that may create large constant arrays/maps/structs (e.g., `SEQUENCE`, `REPEAT`, `ARRAY[...]`, etc) by delaying the evaluation on these functions on workers.
```
