### PR TITLE
Fix MapTransformValueFunction to handle exceptions and reset Blockbuilder before throwing

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformValueFunction.java
@@ -23,6 +23,7 @@ import com.facebook.presto.bytecode.Scope;
 import com.facebook.presto.bytecode.Variable;
 import com.facebook.presto.bytecode.control.ForLoop;
 import com.facebook.presto.bytecode.control.IfStatement;
+import com.facebook.presto.bytecode.control.TryCatch;
 import com.facebook.presto.metadata.BoundVariables;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.SqlScalarFunction;
@@ -42,6 +43,7 @@ import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.facebook.presto.sql.gen.CallSiteBinder;
 import com.facebook.presto.sql.gen.SqlTypeBytecodeExpression;
 import com.facebook.presto.sql.gen.lambda.BinaryFunctionInterface;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Primitives;
 
@@ -61,6 +63,7 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.consta
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantString;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.equal;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.getStatic;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.invokeStatic;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.lessThan;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newInstance;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.subtract;
@@ -230,6 +233,7 @@ public final class MapTransformValueFunction
             writeTransformedValueElement = new BytecodeBlock().append(blockBuilder.invoke("appendNull", BlockBuilder.class).pop());
         }
 
+        Variable transformationException = scope.declareVariable(Throwable.class, "transformationException");
         body.append(new ForLoop()
                 .initialize(position.set(constantInt(0)))
                 .condition(lessThan(position, positionCount))
@@ -237,7 +241,19 @@ public final class MapTransformValueFunction
                 .body(new BytecodeBlock()
                         .append(loadKeyElement)
                         .append(loadValueElement)
-                        .append(transformedValueElement.set(function.invoke("apply", Object.class, keyElement.cast(Object.class), valueElement.cast(Object.class)).cast(transformedValueJavaType)))
+                        .append(
+                                new TryCatch(
+                                        "Close builder before throwing to avoid subsequent calls finding it in an inconsistent state if we are in in a TRY() call.",
+                                        transformedValueElement.set(function.invoke("apply", Object.class, keyElement.cast(Object.class), valueElement.cast(Object.class))
+                                                .cast(transformedValueJavaType)),
+                                        new BytecodeBlock()
+                                                .append(mapBlockBuilder.invoke("closeEntry", BlockBuilder.class).pop())
+                                                .append(pageBuilder.invoke("declarePosition", void.class))
+                                                .putVariable(transformationException)
+                                                .append(invokeStatic(Throwables.class, "throwIfUnchecked", void.class, transformationException))
+                                                .append(newInstance(RuntimeException.class, transformationException))
+                                                .throwObject(),
+                                        type(Throwable.class)))
                         .append(keySqlType.invoke("appendTo", void.class, block, position, blockBuilder))
                         .append(writeTransformedValueElement)));
 


### PR DESCRIPTION
TRANSFORM_VALUES fails even when put inside a TRY block. So add code in MapTransformValueFunction to try-catch exceptions that occur during transform and handle it gracefully (by reseting/closing the BlockBuilder ) so that the next transform of the TRY doesn't see an inconsistent state.

```
== NO RELEASE NOTE ==
```
