### PR TITLE
Close ColumnWriters in OrcWriter when IOException is thrown

### DIFF
--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -123,9 +123,8 @@ public class TestOrcWriter
         }
     }
 
-    // TODO: the exception will be removed once the bug is fixed
-    @Test(expectedExceptions = IllegalStateException.class)
-    public void testVerifyIllegalStateException()
+    @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = "Dummy exception from mocked instance")
+    public void testVerifyNoIllegalStateException()
             throws IOException
     {
         OrcWriter writer = new OrcWriter(


### PR DESCRIPTION
If `OrcWriter` throws IOException its internal ColumnWriters can be marked as closed, while the `OrcFileWriter` and `OrcStorageManager` still view the writers as open. This can lead to `IllegalStateExceptions` from subsequent calls.

This fix adds Try-Catch-Finally logic to force ColumnWriters to reset when an IOException is thrown, and thus preventing `IllegalStateExceptions`.

Issue: #13400 

```
== RELEASE NOTES ==

Hive Changes
* Fix ORC writer rollback failure due to exception thrown during rollback.
```
