### PR TITLE
Fix doc typos at Array Functions and Operators

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -94,7 +94,7 @@ Array Functions
 
 .. function:: arrays_overlap(x, y) -> boolean
 
-    Tests if arrays ``x`` and ``y`` have any any non-null elements in common.
+    Tests if arrays ``x`` and ``y`` have any non-null elements in common.
     Returns null if there are no non-null elements in common but either array contains null.
 
 .. function:: cardinality(x) -> bigint


### PR DESCRIPTION
I was reading the doc below and it seems to be typo.
https://prestodb.github.io/docs/current/functions/array.html

```
arrays_overlap(x, y) → boolean
Tests if arrays x and y have any any non-null elements in common. Returns null if there are no non-null elements in common but either array contains null.
                             ~~~~~~~
```

```
== NO RELEASE NOTE ==
```
