### PR TITLE
Move LIMIT 0 rule to its dedicated optimization phase

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -279,13 +279,17 @@ public class PlanOptimizers
                         ruleStats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
+                        ImmutableSet.of(new EvaluateZeroLimit())),
+                new IterativeOptimizer(
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
                         ImmutableSet.<Rule<?>>builder()
                                 .addAll(predicatePushDownRules)
                                 .addAll(columnPruningRules)
                                 .addAll(ImmutableSet.of(
                                         new RemoveRedundantIdentityProjections(),
                                         new RemoveFullSample(),
-                                        new EvaluateZeroLimit(),
                                         new EvaluateZeroSample(),
                                         new PushLimitThroughProject(),
                                         new MergeLimits(),


### PR DESCRIPTION
Presto has the `MergeLimitWithSort`, `MergeLimitWithTopN` optimizer rules that
are transforming ORDER BY + LIMIT into specialized nodes (e.g: `TopNNode`,
`MergeLimitWithDistinct`) that are then expanded into specialized operators
(such as `TopNOperator`) that can execute TopN operation (ORDER BY + LIMIT)
efficiently.

There's another rule, the `EvaluateZeroLimit` that replaces the LimitNode with
a static empty values tupple.

The problem is that these rules have non deterministic order as all of them are
executed within a single iterative optimizer loop. If the replacement of the
`LimitNode` happens before the `EvaluateZeroLimit`, the `LIMIT 0` operation is
not getting optimized.

This commit fixes the issue by moving the `EvaluateZeroLimit` to its own
optimization phase. We also eliminate the plan time construction of the
TopNNode and allow the optimization phase to determine the best way to combine
LIMIT nodes with ORDER BY node.

```
== RELEASE NOTES ==

General Changes
* Optimization provided for LIMIT 0 queries
```