### PR TITLE
Passing X_Forwarded_For in header from proxy server

### DIFF
--- a/presto-proxy/src/main/java/com/facebook/presto/proxy/ProxyResource.java
+++ b/presto-proxy/src/main/java/com/facebook/presto/proxy/ProxyResource.java
@@ -64,6 +64,7 @@ import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static com.google.common.net.HttpHeaders.COOKIE;
 import static com.google.common.net.HttpHeaders.SET_COOKIE;
 import static com.google.common.net.HttpHeaders.USER_AGENT;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_FOR;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
@@ -189,6 +190,7 @@ public class ProxyResource
             Request.Builder requestBuilder,
             Function<ProxyResponse, Response> responseBuilder)
     {
+        setupXForwardedFor(servletRequest, requestBuilder);
         setupBearerToken(servletRequest, requestBuilder);
 
         for (String name : list(servletRequest.getHeaderNames())) {
@@ -260,6 +262,16 @@ public class ProxyResource
 
         String accessToken = jwtHandler.getBearerToken(principal);
         requestBuilder.addHeader(AUTHORIZATION, "Bearer " + accessToken);
+    }
+
+    private void setupXForwardedFor(HttpServletRequest servletRequest, Request.Builder requestBuilder)
+    {
+        StringBuilder xForwardedFor = new StringBuilder();
+        if (servletRequest.getHeader(X_FORWARDED_FOR) != null) {
+            xForwardedFor.append(servletRequest.getHeader(X_FORWARDED_FOR) + ",");
+        }
+        xForwardedFor.append(servletRequest.getRemoteAddr());
+        requestBuilder.addHeader(X_FORWARDED_FOR, xForwardedFor.toString());
     }
 
     private static <T> T handleProxyException(Request request, ProxyException e)


### PR DESCRIPTION
Presto Proxy doesn't pass client address and so presto cluster thinks proxy being the initiating client. As part of this change, proxy will start sending client address in X_Forwarded_For header so it can be used by Presto cluster and log it correctly.
```
== RELEASE NOTES ==

General Changes
* start forwarding X_Forwarded_For in header from Proxy
