### PR TITLE
Resolve SMILE encoding issue with JsonRaw value

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/TableFinishInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableFinishInfo.java
@@ -16,8 +16,6 @@ package com.facebook.presto.operator;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonRawValue;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -34,29 +32,28 @@ public class TableFinishInfo
 {
     private static final int JSON_LENGTH_LIMIT = toIntExact(new DataSize(10, MEGABYTE).toBytes());
     private static final JsonCodec<Object> INFO_CODEC = jsonCodec(Object.class);
-    private static final JsonCodec<JsonNode> JSON_NODE_CODEC = jsonCodec(JsonNode.class);
 
-    private final String connectorOutputMetadata;
+    private final String serializedConnectorOutputMetadata;
     private final boolean jsonLengthLimitExceeded;
     private final Duration statisticsWallTime;
     private final Duration statisticsCpuTime;
 
     public TableFinishInfo(Optional<ConnectorOutputMetadata> metadata, Duration statisticsWallTime, Duration statisticsCpuTime)
     {
-        String connectorOutputMetadata = null;
+        String serializedConnectorOutputMetadata = null;
         boolean jsonLengthLimitExceeded = false;
         if (metadata.isPresent()) {
             Optional<String> serializedMetadata = INFO_CODEC.toJsonWithLengthLimit(metadata.get().getInfo(), JSON_LENGTH_LIMIT);
             if (!serializedMetadata.isPresent()) {
-                connectorOutputMetadata = null;
+                serializedConnectorOutputMetadata = null;
                 jsonLengthLimitExceeded = true;
             }
             else {
-                connectorOutputMetadata = serializedMetadata.get();
+                serializedConnectorOutputMetadata = serializedMetadata.get();
                 jsonLengthLimitExceeded = false;
             }
         }
-        this.connectorOutputMetadata = connectorOutputMetadata;
+        this.serializedConnectorOutputMetadata = serializedConnectorOutputMetadata;
         this.jsonLengthLimitExceeded = jsonLengthLimitExceeded;
         this.statisticsWallTime = requireNonNull(statisticsWallTime, "statisticsWallTime is null");
         this.statisticsCpuTime = requireNonNull(statisticsCpuTime, "statisticsCpuTime is null");
@@ -64,22 +61,21 @@ public class TableFinishInfo
 
     @JsonCreator
     public TableFinishInfo(
-            @JsonProperty("connectorOutputMetadata") JsonNode connectorOutputMetadata,
+            @JsonProperty("connectorOutputMetadataWrapper") String serializedConnectorOutputMetadata,
             @JsonProperty("jsonLengthLimitExceeded") boolean jsonLengthLimitExceeded,
             @JsonProperty("statisticsWallTime") Duration statisticsWallTime,
             @JsonProperty("statisticsCpuTime") Duration statisticsCpuTime)
     {
-        this.connectorOutputMetadata = JSON_NODE_CODEC.toJson(connectorOutputMetadata);
+        this.serializedConnectorOutputMetadata = serializedConnectorOutputMetadata;
         this.jsonLengthLimitExceeded = jsonLengthLimitExceeded;
         this.statisticsWallTime = requireNonNull(statisticsWallTime, "statisticsWallTime is null");
         this.statisticsCpuTime = requireNonNull(statisticsCpuTime, "statisticsCpuTime is null");
     }
 
     @JsonProperty
-    @JsonRawValue
     public String getConnectorOutputMetadata()
     {
-        return connectorOutputMetadata;
+        return serializedConnectorOutputMetadata;
     }
 
     @JsonProperty


### PR DESCRIPTION
SMILE does not support serializing raw values. TaskFinishInfo has connectorOutputMetadata as a raw value and hence SMILE errors. Made code changes to workaround this. 

```
== NO RELEASE NOTE ==
```
