### PR TITLE
Add a check to update outputPositions

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -334,6 +334,8 @@ public class TestHivePushdownFilterQueries
         assertFilterProject("discount_long_decimal > 0.01 AND tax_short_decimal > 0.01 AND (discount_long_decimal + tax_short_decimal) < 0.03", "discount_long_decimal");
 
         assertFilterProject("long_decimals[1] > 0.01", "count(*)");
+
+        assertFilterProject("tax_real > 0.01 and tax_short_decimal > 0.02 and (discount_long_decimal + tax_short_decimal) < 0.05", "tax_short_decimal, discount_long_decimal");
     }
 
     @Test

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractDecimalSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractDecimalSelectiveStreamReader.java
@@ -62,6 +62,7 @@ public abstract class AbstractDecimalSelectiveStreamReader
     protected BooleanInputStream presentStream;
     protected DecimalInputStream dataStream;
     protected LongInputStream scaleStream;
+    protected boolean outputPositionsReadOnly;
 
     private final int valuesPerPosition;
     private final Block nullBlock;
@@ -158,6 +159,7 @@ public abstract class AbstractDecimalSelectiveStreamReader
         }
         else {
             outputPositions = positions;
+            outputPositionsReadOnly = true;
         }
 
         // account memory used by values, nulls and outputPositions

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDecimalSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDecimalSelectiveStreamReader.java
@@ -24,6 +24,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.UnsafeSlice;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.rescale;
@@ -168,6 +169,10 @@ public class LongDecimalSelectiveStreamReader
     @Override
     protected void compactValues(int[] positions, int positionCount, boolean compactNulls)
     {
+        if (outputPositionsReadOnly) {
+            outputPositions = Arrays.copyOf(outputPositions, outputPositionCount);
+            outputPositionsReadOnly = false;
+        }
         int positionIndex = 0;
         int nextPosition = positions[positionIndex];
         for (int i = 0; i < outputPositionCount; i++) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ShortDecimalSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ShortDecimalSelectiveStreamReader.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.Type;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Optional;
 
 public class ShortDecimalSelectiveStreamReader
@@ -144,6 +145,10 @@ public class ShortDecimalSelectiveStreamReader
     @Override
     protected void compactValues(int[] positions, int positionCount, boolean compactNulls)
     {
+        if (outputPositionsReadOnly) {
+            outputPositions = Arrays.copyOf(outputPositions, outputPositionCount);
+            outputPositionsReadOnly = false;
+        }
         int positionIndex = 0;
         int nextPosition = positions[positionIndex];
         for (int i = 0; i < outputPositionCount; i++) {


### PR DESCRIPTION
This check was missing for DecimalReaders. This is required check whether we can modify the outputPositions array while compacting values.

```
== NO RELEASE NOTE ==
```
