### PR TITLE
Fix selective readers output positions when reading null streams

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractDecimalSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractDecimalSelectiveStreamReader.java
@@ -62,6 +62,7 @@ public abstract class AbstractDecimalSelectiveStreamReader
     protected BooleanInputStream presentStream;
     protected DecimalInputStream dataStream;
     protected LongInputStream scaleStream;
+    protected boolean outputPositionsReadOnly;
 
     private final int valuesPerPosition;
     private final Block nullBlock;
@@ -202,6 +203,10 @@ public abstract class AbstractDecimalSelectiveStreamReader
         }
         else if (nullsAllowed) {
             outputPositionCount = positionCount;
+            if (filter != null) {
+                outputPositions = positions;
+                outputPositionsReadOnly = true;
+            }
         }
         else {
             outputPositionCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
@@ -266,6 +266,10 @@ public class BooleanSelectiveStreamReader
         }
         else if (nullsAllowed) {
             outputPositionCount = positionCount;
+            if (filter != null) {
+                outputPositions = positions;
+                outputPositionsReadOnly = true;
+            }
         }
         else {
             outputPositionCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
@@ -251,6 +251,10 @@ public class ByteSelectiveStreamReader
         }
         else if (nullsAllowed) {
             outputPositionCount = positionCount;
+            if (filter != null) {
+                outputPositions = positions;
+                outputPositionsReadOnly = true;
+            }
         }
         else {
             outputPositionCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleSelectiveStreamReader.java
@@ -215,6 +215,10 @@ public class DoubleSelectiveStreamReader
         }
         else if (nullsAllowed) {
             outputPositionCount = positionCount;
+            if (filter != null) {
+                outputPositions = positions;
+                outputPositionsReadOnly = true;
+            }
         }
         else {
             outputPositionCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatSelectiveStreamReader.java
@@ -245,6 +245,10 @@ public class FloatSelectiveStreamReader
         }
         else if (nullsAllowed) {
             outputPositionCount = positionCount;
+            if (filter != null) {
+                outputPositions = positions;
+                outputPositionsReadOnly = true;
+            }
         }
         else {
             outputPositionCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
@@ -199,6 +199,10 @@ public class LongDirectSelectiveStreamReader
         }
         else if (nullsAllowed) {
             outputPositionCount = positionCount;
+            if (filter != null) {
+                outputPositions = positions;
+                outputPositionsReadOnly = true;
+            }
         }
         else {
             outputPositionCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
@@ -326,6 +326,10 @@ public class SliceDictionarySelectiveReader
         }
         else if (nullsAllowed) {
             outputPositionCount = positionCount;
+            if (filter != null) {
+                outputPositions = positions;
+                outputPositionsReadOnly = true;
+            }
         }
         else {
             outputPositionCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
@@ -294,6 +294,10 @@ public class SliceDirectSelectiveStreamReader
         }
         else if (nullsAllowed) {
             outputPositionCount = positionCount;
+            if (filter != null) {
+                outputPositions = positions;
+                outputPositionsReadOnly = true;
+            }
         }
         else {
             outputPositionCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
@@ -265,6 +265,10 @@ public class TimestampSelectiveStreamReader
         }
         else if (nullsAllowed) {
             outputPositionCount = positionCount;
+            if (filter != null) {
+                outputPositions = positions;
+                outputPositionsReadOnly = true;
+            }
         }
         else {
             outputPositionCount = 0;


### PR DESCRIPTION
if there are 3 columns that have filters
1 col  ---> produced 1, 2, 3 positions
2 col ---> all nulls with filter(null allowed) should return back 1, 2, 3 positions but because of the bug that we are copying the positions in this case we are returning 0,0,0
3 col ---> apply filter on position output from 2nd col (1,2,3)

The fix is to copy copy the positions passed to outputPositions in this case.


```
== NO RELEASE NOTE ==
```
