### PR TITLE
Fix testBytes in TupleDomainFilter

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
@@ -914,8 +914,8 @@ public interface TupleDomainFilter
                     if (buffer[i + offset] != lower[i]) {
                         return false;
                     }
-                    return true;
                 }
+                return true;
             }
 
             if (lower != null) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilter.java
@@ -200,6 +200,7 @@ public class TestTupleDomainFilter
     {
         TupleDomainFilter filter = BytesRange.of(toBytes("abc"), false, toBytes("abc"), false, false);
         assertTrue(filter.testBytes(toBytes("abc"), 0, 3));
+        assertFalse(filter.testBytes(toBytes("acb"), 0, 3));
         assertTrue(filter.testLength(3));
 
         assertFalse(filter.testNull());


### PR DESCRIPTION
This was causing incorrect rows to be selected.
The testBytes check was incorrectly returning true if the length matches and first char is same.
changed the place where we return.
```
== NO RELEASE NOTE ==
```
