### PR TITLE
Include error message in SimpleHttpResonseHandler for SMILE

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/SimpleHttpResponseHandler.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/SimpleHttpResponseHandler.java
@@ -91,7 +91,8 @@ public class SimpleHttpResponseHandler<T>
                 uri,
                 OK.code(),
                 response.getStatusCode(),
-                response.getStatusMessage());
+                response.getStatusMessage(),
+                new String(response.getResponseBytes()));
     }
 
     @Override


### PR DESCRIPTION
This resolves github issue #12835 . When exception occurs, the responsebytes of the Response have the stack trace. Including this trace in the error message helps debugging the cause when SMILE encoding is enabled.

```
== NO RELEASE NOTE ==
```
