### PR TITLE
Add release note for 0.228

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.228
     release/release-0.227
     release/release-0.226
     release/release-0.225

--- a/presto-docs/src/main/sphinx/release/release-0.228.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.228.rst
@@ -1,0 +1,21 @@
+=============
+Release 0.228
+=============
+
+General Changes
+_______________
+* Reduce excessive memory usage by ExchangeClient.
+* Improve coordinator stability on parsing functions that may create large constant
+  arrays/maps/rows (e.g., ``SEQUENCE``, ``REPEAT``, ``ARRAY[...]``, etc) by delaying the
+  evaluation on these functions on workers.
+* Optimize queries with ``LIMIT 0``.
+* Allow Bing Tiles at zoom level 0.
+
+Hive Changes
+____________
+* Fix ORC writer rollback failure due to exception thrown during rollback.
+* Improve ORC read performance for variants and fixed width numbers.
+
+Spi Changes
+___________
+* Move most ``RowExpression`` utilities to the ``presto-expressions`` module.


### PR DESCRIPTION
# Missing Release Notes
## Rebecca Schlussel
- [x] all checked
- https://github.com/prestodb/presto/pull/13472 Allow zoom 0 Bing Tiles
## Wenlei Xie
- [x] all checked
- https://github.com/prestodb/presto/pull/13183 Optimize PartitionedOutputOperator

# Extracted Release Notes
- #13434 James Sun: Add common scalar reads to OrcInputStream
  - Streamline ORC read path for varints and fixed width numbers.
- #13452 Andrii Rosa: Reduce excessive memory usage by ExchangeClient
  - Reduce excessive memory usage by ExchangeClient
- #13499 Wenlei Xie: Limit size of Expression/RowExpression during constant folding
  - Improve coordinator stability on parsing functions that may create large constant arrays/maps/structs (e.g., `SEQUENCE`, `REPEAT`, `ARRAY[...]`, etc) by delaying the evaluation on these functions on workers.
- #13508 James Sun: Close ColumnWriters in OrcWriter when IOException is thrown
  - Fix ORC writer rollback failure due to exception thrown during rollback.
- #13519 Andrii Rosa: Move LIMIT 0 rule to its dedicated optimization phase
  - Optimization provided for LIMIT 0 queries
- #13551 James Sun: Remove RowExpression utils from SPI
  - Removed most `RowExpression` utilities to module presto-expressions.
