### PR TITLE
Refactor to add PartitionObjectBuilder

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -113,6 +113,7 @@ public class HiveClientModule
         binder.bind(new TypeLiteral<Supplier<TransactionalMetadata>>() {}).to(HiveMetadataFactory.class).in(Scopes.SINGLETON);
         binder.bind(StagingFileCommitter.class).to(HiveStagingFileCommitter.class).in(Scopes.SINGLETON);
         binder.bind(ZeroRowFileCreator.class).to(HiveZeroRowFileCreator.class).in(Scopes.SINGLETON);
+        binder.bind(PartitionObjectBuilder.class).to(HivePartitionObjectBuilder.class).in(Scopes.SINGLETON);
         binder.bind(HiveTransactionManager.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorSplitManager.class).to(HiveSplitManager.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ConnectorSplitManager.class).as(generatedNameOf(HiveSplitManager.class, connectorId));

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -57,6 +57,7 @@ public class HiveMetadataFactory
     private final StagingFileCommitter stagingFileCommitter;
     private final ZeroRowFileCreator zeroRowFileCreator;
     private final String prestoVersion;
+    private final PartitionObjectBuilder partitionObjectBuilder;
 
     @Inject
     @SuppressWarnings("deprecation")
@@ -75,7 +76,8 @@ public class HiveMetadataFactory
             TypeTranslator typeTranslator,
             StagingFileCommitter stagingFileCommitter,
             ZeroRowFileCreator zeroRowFileCreator,
-            NodeVersion nodeVersion)
+            NodeVersion nodeVersion,
+            PartitionObjectBuilder partitionObjectBuilder)
     {
         this(
                 metastore,
@@ -98,7 +100,8 @@ public class HiveMetadataFactory
                 typeTranslator,
                 stagingFileCommitter,
                 zeroRowFileCreator,
-                nodeVersion.toString());
+                nodeVersion.toString(),
+                partitionObjectBuilder);
     }
 
     public HiveMetadataFactory(
@@ -122,7 +125,8 @@ public class HiveMetadataFactory
             TypeTranslator typeTranslator,
             StagingFileCommitter stagingFileCommitter,
             ZeroRowFileCreator zeroRowFileCreator,
-            String prestoVersion)
+            String prestoVersion,
+            PartitionObjectBuilder partitionObjectBuilder)
     {
         this.allowCorruptWritesForTesting = allowCorruptWritesForTesting;
         this.skipDeletionForAlter = skipDeletionForAlter;
@@ -146,6 +150,7 @@ public class HiveMetadataFactory
         this.stagingFileCommitter = requireNonNull(stagingFileCommitter, "stagingFileCommitter is null");
         this.zeroRowFileCreator = requireNonNull(zeroRowFileCreator, "zeroRowFileCreator is null");
         this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
+        this.partitionObjectBuilder = requireNonNull(partitionObjectBuilder, "partitionObjectBuilder is null");
 
         if (!allowCorruptWritesForTesting && !timeZone.equals(DateTimeZone.getDefault())) {
             log.warn("Hive writes are disabled. " +
@@ -183,6 +188,7 @@ public class HiveMetadataFactory
                 prestoVersion,
                 new MetastoreHiveStatisticsProvider(metastore),
                 stagingFileCommitter,
-                zeroRowFileCreator);
+                zeroRowFileCreator,
+                partitionObjectBuilder);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionObjectBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionObjectBuilder.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.StorageFormat;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.ConnectorSession;
+import com.google.common.collect.ImmutableMap;
+
+public class HivePartitionObjectBuilder
+        implements PartitionObjectBuilder
+{
+    @Override
+    public Partition buildPartitionObject(
+            ConnectorSession session,
+            Table table,
+            PartitionUpdate partitionUpdate,
+            String prestoVersion)
+    {
+        return Partition.builder()
+                .setDatabaseName(table.getDatabaseName())
+                .setTableName(table.getTableName())
+                .setColumns(table.getDataColumns())
+                .setValues(HivePartitionManager.extractPartitionValues(partitionUpdate.getName()))
+                .setParameters(ImmutableMap.<String, String>builder()
+                        .put(HiveMetadata.PRESTO_VERSION_NAME, prestoVersion)
+                        .put(HiveMetadata.PRESTO_QUERY_ID_NAME, session.getQueryId())
+                        .build())
+                .withStorage(storage -> storage
+                        .setStorageFormat(HiveSessionProperties.isRespectTableFormat(session) ?
+                                table.getStorage().getStorageFormat() :
+                                StorageFormat.fromHiveStorageFormat(HiveSessionProperties.getHiveStorageFormat(session)))
+                        .setLocation(partitionUpdate.getTargetPath().toString())
+                        .setBucketProperty(table.getStorage().getBucketProperty())
+                        .setSerdeParameters(table.getStorage().getSerdeParameters()))
+                .build();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PartitionObjectBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PartitionObjectBuilder.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.ConnectorSession;
+
+public interface PartitionObjectBuilder
+{
+    Partition buildPartitionObject(
+            ConnectorSession session,
+            Table table,
+            PartitionUpdate partitionUpdate,
+            String prestoVersion);
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -839,7 +839,8 @@ public abstract class AbstractTestHiveClient
                 new HiveTypeTranslator(),
                 new HiveStagingFileCommitter(hdfsEnvironment, listeningDecorator(executor)),
                 new HiveZeroRowFileCreator(hdfsEnvironment, listeningDecorator(executor)),
-                TEST_SERVER_VERSION);
+                TEST_SERVER_VERSION,
+                new HivePartitionObjectBuilder());
         transactionManager = new HiveTransactionManager();
         splitManager = new HiveSplitManager(
                 transactionHandle -> ((HiveMetadata) transactionManager.get(transactionHandle)).getMetastore(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -194,7 +194,8 @@ public abstract class AbstractTestHiveFileSystem
                 new HiveTypeTranslator(),
                 new HiveStagingFileCommitter(hdfsEnvironment, listeningDecorator(executor)),
                 new HiveZeroRowFileCreator(hdfsEnvironment, listeningDecorator(executor)),
-                new NodeVersion("test_version"));
+                new NodeVersion("test_version"),
+                new HivePartitionObjectBuilder());
         transactionManager = new HiveTransactionManager();
         splitManager = new HiveSplitManager(
                 transactionHandle -> ((HiveMetadata) transactionManager.get(transactionHandle)).getMetastore(),


### PR DESCRIPTION
Refactor to add PartitionObjectBuilder
Motivation :
This allows adding customized partition metadata (besides query id and presto version) during partition publishing so that different implementations can populate relevant metadata.

```
== NO RELEASE NOTE ==
```
