### PR TITLE
Do not overcommit memory in HashBuilderOperator

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashBuilderOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashBuilderOperator.java
@@ -144,11 +144,11 @@ public class TestHashBuilderOperator
         // Are we using the memory we should be using?
         assertEquals(buildOperator.getState(), LOOKUP_SOURCE_BUILT);
         if (buildHashEnabled) {
-            assertEquals(estimatedFootprintBefore, 59656384);
+            assertEquals(estimatedFootprintBefore, 46147728);
             assertEquals(estimatedFootprintAfter, 59640024);
         }
         else {
-            assertEquals(estimatedFootprintBefore, 51396272);
+            assertEquals(estimatedFootprintBefore, 37887616);
             assertEquals(estimatedFootprintAfter, 51384016);
         }
     }


### PR DESCRIPTION
For the joins where the build side consumes the input from a stateful
operator (Aggregation, WindowFunction, etc...) overcomitting memory
results in overall peak memory increase leading to query failures
due to exceeding the overall distributed memory limit.

```
== NO RELEASE NOTE ==
```
