### PR TITLE
Parquet Dictionary Predicate Pushdown Fixes

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/Predicate.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/Predicate.java
@@ -32,7 +32,7 @@ public interface Predicate
         }
 
         @Override
-        public boolean matches(Map<ColumnDescriptor, DictionaryDescriptor> dictionaries)
+        public boolean matches(DictionaryDescriptor dictionary)
         {
             return true;
         }
@@ -51,9 +51,11 @@ public interface Predicate
             throws ParquetCorruptionException;
 
     /**
-     * Should the Parquet Reader process a file section with the specified dictionary.
+     * Should the Parquet Reader process a file section with the specified dictionary based on that
+     * single dictionary. This is safe to check repeatedly to avoid loading more parquet dictionaries
+     * if the section can already be eliminated.
      *
-     * @param dictionaries dictionaries per column
+     * @param dictionary The single column dictionary
      */
-    boolean matches(Map<ColumnDescriptor, DictionaryDescriptor> dictionaries);
+    boolean matches(DictionaryDescriptor dictionary);
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/PredicateUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/PredicateUtils.java
@@ -125,7 +125,6 @@ public final class PredicateUtils
                     dataSource.readFully(columnMetaData.getStartingPos(), buffer);
                     Optional<DictionaryPage> dictionaryPage = readDictionaryPage(buffer, columnMetaData.getCodec());
                     dictionaries.put(descriptor, new DictionaryDescriptor(descriptor, dictionaryPage));
-                    break;
                 }
             }
         }
@@ -157,7 +156,7 @@ public final class PredicateUtils
     private static boolean isColumnPredicate(ColumnDescriptor columnDescriptor, TupleDomain<ColumnDescriptor> parquetTupleDomain)
     {
         verify(parquetTupleDomain.getDomains().isPresent(), "parquetTupleDomain is empty");
-        return parquetTupleDomain.getDomains().get().keySet().contains(columnDescriptor);
+        return parquetTupleDomain.getDomains().get().containsKey(columnDescriptor);
     }
 
     @VisibleForTesting

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/PredicateUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/PredicateUtils.java
@@ -94,8 +94,7 @@ public final class PredicateUtils
             return false;
         }
 
-        Map<ColumnDescriptor, DictionaryDescriptor> dictionaries = getDictionaries(block, dataSource, descriptorsByPath, parquetTupleDomain);
-        return parquetPredicate.matches(dictionaries);
+        return dictionaryPredicatesMatch(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain);
     }
 
     private static Map<ColumnDescriptor, Statistics<?>> getStatistics(BlockMetaData blockMetadata, Map<List<String>, RichColumnDescriptor> descriptorsByPath)
@@ -113,22 +112,22 @@ public final class PredicateUtils
         return statistics.build();
     }
 
-    private static Map<ColumnDescriptor, DictionaryDescriptor> getDictionaries(BlockMetaData blockMetadata, ParquetDataSource dataSource, Map<List<String>, RichColumnDescriptor> descriptorsByPath, TupleDomain<ColumnDescriptor> parquetTupleDomain)
+    private static boolean dictionaryPredicatesMatch(Predicate parquetPredicate, BlockMetaData blockMetadata, ParquetDataSource dataSource, Map<List<String>, RichColumnDescriptor> descriptorsByPath, TupleDomain<ColumnDescriptor> parquetTupleDomain)
     {
-        ImmutableMap.Builder<ColumnDescriptor, DictionaryDescriptor> dictionaries = ImmutableMap.builder();
         for (ColumnChunkMetaData columnMetaData : blockMetadata.getColumns()) {
             RichColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
             if (descriptor != null) {
                 if (isOnlyDictionaryEncodingPages(columnMetaData) && isColumnPredicate(descriptor, parquetTupleDomain)) {
-                    int totalSize = toIntExact(columnMetaData.getTotalSize());
-                    byte[] buffer = new byte[totalSize];
+                    byte[] buffer = new byte[toIntExact(columnMetaData.getTotalSize())];
                     dataSource.readFully(columnMetaData.getStartingPos(), buffer);
-                    Optional<DictionaryPage> dictionaryPage = readDictionaryPage(buffer, columnMetaData.getCodec());
-                    dictionaries.put(descriptor, new DictionaryDescriptor(descriptor, dictionaryPage));
+                    //  Early abort, predicate already filters block so no more dictionaries need be read
+                    if (!parquetPredicate.matches(new DictionaryDescriptor(descriptor, readDictionaryPage(buffer, columnMetaData.getCodec())))) {
+                        return false;
+                    }
                 }
             }
         }
-        return dictionaries.build();
+        return true;
     }
 
     private static Optional<DictionaryPage> readDictionaryPage(byte[] data, CompressionCodecName codecName)

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
@@ -106,8 +106,9 @@ public class TupleDomainParquetPredicate
     }
 
     @Override
-    public boolean matches(Map<ColumnDescriptor, DictionaryDescriptor> dictionaries)
+    public boolean matches(DictionaryDescriptor dictionary)
     {
+        requireNonNull(dictionary, "dictionary is null");
         if (effectivePredicate.isNone()) {
             return false;
         }
@@ -115,18 +116,14 @@ public class TupleDomainParquetPredicate
         Map<ColumnDescriptor, Domain> effectivePredicateDomains = effectivePredicate.getDomains()
                 .orElseThrow(() -> new IllegalStateException("Effective predicate other than none should have domains"));
 
-        for (RichColumnDescriptor column : columns) {
-            Domain effectivePredicateDomain = effectivePredicateDomains.get(column);
-            if (effectivePredicateDomain == null) {
-                continue;
-            }
-            DictionaryDescriptor dictionaryDescriptor = dictionaries.get(column);
-            Domain domain = getDomain(effectivePredicateDomain.getType(), dictionaryDescriptor);
-            if (effectivePredicateDomain.intersect(domain).isNone()) {
-                return false;
-            }
-        }
-        return true;
+        Domain effectivePredicateDomain = effectivePredicateDomains.get(dictionary.getColumnDescriptor());
+
+        return effectivePredicateDomain == null || effectivePredicateMatches(effectivePredicateDomain, dictionary);
+    }
+
+    private static boolean effectivePredicateMatches(Domain effectivePredicateDomain, DictionaryDescriptor dictionary)
+    {
+        return !effectivePredicateDomain.intersect(getDomain(effectivePredicateDomain.getType(), dictionary)).isNone();
     }
 
     @VisibleForTesting

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/TestTupleDomainParquetPredicate.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/TestTupleDomainParquetPredicate.java
@@ -337,7 +337,7 @@ public class TestTupleDomainParquetPredicate
         TupleDomain<ColumnDescriptor> effectivePredicate = getEffectivePredicate(column, createVarcharType(255), EMPTY_SLICE);
         TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column));
         DictionaryPage page = new DictionaryPage(Slices.wrappedBuffer(new byte[] {0, 0, 0, 0}), 1, PLAIN_DICTIONARY);
-        assertTrue(parquetPredicate.matches(singletonMap(column, new DictionaryDescriptor(column, Optional.of(page)))));
+        assertTrue(parquetPredicate.matches(new DictionaryDescriptor(column, Optional.of(page))));
     }
 
     private TupleDomain<ColumnDescriptor> getEffectivePredicate(RichColumnDescriptor column, VarcharType type, Slice value)


### PR DESCRIPTION
Port of https://github.com/prestosql/presto/pull/1846.

Parquet dictionary pushdown was refactored in prestodb/presto#6892 to remove a nested loop iteration but accidentally left the inner loop break statement behind. This meant that dictionary predicate pushdown would read at most 1 dictionary.

In addition to fixing the pushdown behavior, this PR adds support for checking the dictionary pushdown on each column skipping additional dictionary reads once the block can already be filtered. 

```
== RELEASE NOTES ==
Hive Changes
* Fix parquet predicate pushdown on dictionaries to consider more than just the first predicate column
* Improve parquet predicate pushdown on dictionaries to avoid reading additional data after successfully eliminating a block 
```
