### PR TITLE
Reliable Resource Group With Versioning

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/ForQueryScheduling.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ForQueryScheduling.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForQueryScheduling
+{
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -33,6 +33,7 @@ import org.weakref.jmx.Nested;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -60,6 +61,7 @@ import static com.facebook.presto.spi.resourceGroups.SchedulingPolicy.WEIGHTED_F
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.math.LongMath.saturatedAdd;
 import static com.google.common.math.LongMath.saturatedMultiply;
@@ -88,6 +90,7 @@ public class InternalResourceGroup
     private final BiConsumer<InternalResourceGroup, Boolean> jmxExportListener;
     private final Executor executor;
     private final boolean staticResourceGroup;
+    private final int version;
 
     // Configuration
     // =============
@@ -140,15 +143,22 @@ public class InternalResourceGroup
     private long lastStartMillis;
     @GuardedBy("root")
     private final CounterStat timeBetweenStartsSec = new CounterStat();
+    @GuardedBy("root")
+    private Optional<InternalResourceGroup> next;
+    @GuardedBy("root")
+    private Optional<InternalResourceGroup> prev;
 
     protected InternalResourceGroup(
             Optional<InternalResourceGroup> parent,
             String name,
             BiConsumer<InternalResourceGroup, Boolean> jmxExportListener,
             Executor executor,
-            boolean staticResourceGroup)
+            boolean staticResourceGroup,
+            int version)
     {
         this.parent = requireNonNull(parent, "parent is null");
+        this.next = Optional.empty();
+        this.prev = Optional.empty();
         this.jmxExportListener = requireNonNull(jmxExportListener, "jmxExportListener is null");
         this.executor = requireNonNull(executor, "executor is null");
         requireNonNull(name, "name is null");
@@ -161,6 +171,34 @@ public class InternalResourceGroup
             root = this;
         }
         this.staticResourceGroup = staticResourceGroup;
+        this.version = version;
+    }
+
+    protected InternalResourceGroup(
+            Optional<InternalResourceGroup> parent,
+            String name,
+            BiConsumer<InternalResourceGroup, Boolean> jmxExportListener,
+            Executor executor,
+            InternalResourceGroup root,
+            boolean staticResourceGroup,
+            Integer version)
+    {
+        this.parent = requireNonNull(parent, "parent is null");
+        this.next = Optional.empty();
+        this.prev = Optional.empty();
+        this.jmxExportListener = requireNonNull(jmxExportListener, "jmxExportListener is null");
+        this.executor = requireNonNull(executor, "executor is null");
+        requireNonNull(name, "name is null");
+        if (parent.isPresent()) {
+            id = new ResourceGroupId(parent.get().id, name);
+            this.root = root;
+        }
+        else {
+            id = new ResourceGroupId(name);
+            this.root = root;
+        }
+        this.staticResourceGroup = staticResourceGroup;
+        this.version = version;
     }
 
     public ResourceGroupInfo getResourceGroupInfo(boolean includeQueryInfo, boolean summarizeSubgroups, boolean includeStaticSubgroupsOnly)
@@ -176,15 +214,55 @@ public class InternalResourceGroup
                     hardConcurrencyLimit,
                     maxQueuedQueries,
                     DataSize.succinctBytes(cachedMemoryUsageBytes),
-                    getQueuedQueries(),
-                    getRunningQueries(),
+                    getAllQueuedQueriesCount(),
+                    getAllRunningQueriesCount(),
                     eligibleSubGroups.size(),
                     subGroups.values().stream()
                             .filter(group -> group.getRunningQueries() + group.getQueuedQueries() > 0)
                             .filter(group -> !includeStaticSubgroupsOnly || group.isStaticResourceGroup())
                             .map(group -> summarizeSubgroups ? group.getSummaryInfo() : group.getResourceGroupInfo(includeQueryInfo, false, includeStaticSubgroupsOnly))
                             .collect(toImmutableList()),
-                    includeQueryInfo ? getAggregatedRunningQueriesInfo() : null);
+                    includeQueryInfo ? getAggregatedRunningQueriesInfo() : null,
+                    version);
+        }
+    }
+
+    public List<ResourceGroupInfo> getAllVersionResourceGroupInfo(boolean includeQueryInfo, boolean summarizeSubgroups, boolean includeStaticSubgroupsOnly)
+    {
+        synchronized (root) {
+            List<ResourceGroupInfo> allVersionResourceGroupinfo = new ArrayList<>();
+            InternalResourceGroup group = this;
+            while (group != null) {
+                ResourceGroupInfo resourceGroupInfo = new ResourceGroupInfo(
+                        group.id,
+                        group.getState(),
+                        group.schedulingPolicy,
+                        group.schedulingWeight,
+                        DataSize.succinctBytes(group.softMemoryLimitBytes),
+                        group.softConcurrencyLimit,
+                        group.hardConcurrencyLimit,
+                        group.maxQueuedQueries,
+                        DataSize.succinctBytes(group.cachedMemoryUsageBytes),
+                        group.getAllQueuedQueriesCount(),
+                        group.getAllRunningQueriesCount(),
+                        group.eligibleSubGroups.size(),
+                        group.subGroups.values().stream()
+                                .filter(subGroup -> subGroup.getRunningQueries() + subGroup.getQueuedQueries() > 0)
+                                .filter(subGroup -> !includeStaticSubgroupsOnly || subGroup.isStaticResourceGroup())
+                                .map(subGroup -> summarizeSubgroups ? subGroup.getSummaryInfo() : subGroup.getResourceGroupInfo(includeQueryInfo, false, includeStaticSubgroupsOnly))
+                                .collect(toImmutableList()),
+                        includeQueryInfo ? group.getAggregatedRunningQueriesInfo() : null,
+                        group.version);
+
+                allVersionResourceGroupinfo.add(resourceGroupInfo);
+                if (group.getPrev().isPresent()) {
+                    group = group.getPrev().get();
+                }
+                else {
+                    group = null;
+                }
+            }
+            return allVersionResourceGroupinfo;
         }
     }
 
@@ -208,7 +286,8 @@ public class InternalResourceGroup
                             .filter(group -> group.getRunningQueries() + group.getQueuedQueries() > 0)
                             .map(InternalResourceGroup::getSummaryInfo)
                             .collect(toImmutableList()),
-                    null);
+                    null,
+                    version);
         }
     }
 
@@ -225,11 +304,12 @@ public class InternalResourceGroup
                     hardConcurrencyLimit,
                     maxQueuedQueries,
                     DataSize.succinctBytes(cachedMemoryUsageBytes),
-                    getQueuedQueries(),
-                    getRunningQueries(),
+                    getAllQueuedQueriesCount(),
+                    getAllRunningQueriesCount(),
                     eligibleSubGroups.size(),
                     null,
-                    null);
+                    null,
+                    version);
         }
     }
 
@@ -270,6 +350,21 @@ public class InternalResourceGroup
         }
     }
 
+    private List<QueryStateInfo> getAllAggregatedRunningQueriesInfo()
+    {
+        synchronized (root) {
+            InternalResourceGroup resourceGroup = this;
+            ImmutableList.Builder<QueryStateInfo> result = ImmutableList.builder();
+            result.addAll(resourceGroup.getAggregatedRunningQueriesInfo());
+            while (resourceGroup.getPrev().isPresent()) {
+                resourceGroup = resourceGroup.getPrev().get();
+                result.addAll(resourceGroup.getAggregatedRunningQueriesInfo());
+            }
+
+            return result.build();
+        }
+    }
+
     public List<ResourceGroupInfo> getPathToRoot()
     {
         synchronized (root) {
@@ -298,11 +393,64 @@ public class InternalResourceGroup
         }
     }
 
+    private int getAllRunningQueriesCount()
+    {
+        synchronized (root) {
+            int allRunningQueries = getRunningQueries();
+            if (getPrev().isPresent()) {
+                allRunningQueries += getPrev().get().getRunningQueries();
+            }
+            return allRunningQueries;
+        }
+    }
+
+    public int getEligibleSubGroupsCount()
+    {
+        synchronized (root) {
+            return eligibleSubGroups.size();
+        }
+    }
+
+    public int getDirtySubGroupsCount()
+    {
+        synchronized (root) {
+            return dirtySubGroups.size();
+        }
+    }
+
     @Managed
     public int getQueuedQueries()
     {
         synchronized (root) {
             return queuedQueries.size() + descendantQueuedQueries;
+        }
+    }
+
+    public int getAllQueuedQueriesCount()
+    {
+        synchronized (root) {
+            int allQueuedQueries = getQueuedQueries();
+            if (getPrev().isPresent()) {
+                allQueuedQueries += getPrev().get().getQueuedQueries();
+            }
+            return allQueuedQueries;
+        }
+    }
+
+    public void requeueToNext()
+    {
+        synchronized (root) {
+            if (getQueuedQueries() == 0 || !next.isPresent() || !next.get().isLeafResourceGroup() || next.get().getHardConcurrencyLimit() == 0) {
+                return;
+            }
+
+            while (!queuedQueries.isEmpty()) {
+                next.get().enqueueQuery(queuedQueries.poll());
+                if (parent.isPresent()) {
+                    parent.get().descendantQueuedQueries--;
+                }
+            }
+            updateEligibility();
         }
     }
 
@@ -578,28 +726,104 @@ public class InternalResourceGroup
         jmxExportListener.accept(this, export);
     }
 
-    public InternalResourceGroup getOrCreateSubGroup(String name, boolean staticSegment)
+    @Override
+    public int getVersion()
+    {
+        return version;
+    }
+
+    public void setNext(InternalResourceGroup nextNeighbour)
+    {
+        synchronized (root) {
+            next = Optional.of(nextNeighbour);
+        }
+    }
+
+    public Optional<InternalResourceGroup> getNext()
+    {
+        synchronized (root) {
+            return next;
+        }
+    }
+
+    public void setPrev(InternalResourceGroup prevNeighbour)
+    {
+        synchronized (root) {
+            if (prevNeighbour == null) {
+                prev = Optional.empty();
+            }
+            else {
+                prev = Optional.of(prevNeighbour);
+            }
+        }
+    }
+
+    public Optional<InternalResourceGroup> getPrev()
+    {
+        synchronized (root) {
+            return prev;
+        }
+    }
+
+    //Get the latest version of the resource group
+    public InternalResourceGroup getLatest()
+    {
+        synchronized (root) {
+            InternalResourceGroup latest = this;
+            while (latest.next.isPresent()) {
+                latest = latest.next.get();
+            }
+            return latest;
+        }
+    }
+
+    private boolean isLeafResourceGroup()
+    {
+        synchronized (root) {
+            for (InternalResourceGroup group : subGroups.values()) {
+                if (group.getMaxQueuedQueries() != 0 || group.getHardConcurrencyLimit() != 0) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    public InternalResourceGroup getOrCreateSubGroup(String name, boolean staticSegment, int version)
     {
         requireNonNull(name, "name is null");
         synchronized (root) {
-            checkArgument(runningQueries.isEmpty() && queuedQueries.isEmpty(), "Cannot add sub group to %s while queries are running", id);
+            verify(getLatest().runningQueries.isEmpty() && getLatest().queuedQueries.isEmpty(), "Cannot add sub group to %s while queries are running", id);
             if (subGroups.containsKey(name)) {
-                return subGroups.get(name);
+                InternalResourceGroup subGroup = subGroups.get(name).getLatest();
+                if (subGroup.getVersion() == version) {
+                    return subGroup;
+                }
             }
             // parent segments size equals to subgroup segment index
             int subGroupSegmentIndex = id.getSegments().size();
-            InternalResourceGroup subGroup = new InternalResourceGroup(
+            InternalResourceGroup newSubGroup = new InternalResourceGroup(
                     Optional.of(this),
                     name,
                     jmxExportListener,
                     executor,
-                    staticResourceGroup && staticSegment);
+                    staticResourceGroup && staticSegment,
+                    version);
+
             // Sub group must use query priority to ensure ordering
             if (schedulingPolicy == QUERY_PRIORITY) {
-                subGroup.setSchedulingPolicy(QUERY_PRIORITY);
+                newSubGroup.setSchedulingPolicy(QUERY_PRIORITY);
             }
-            subGroups.put(name, subGroup);
-            return subGroup;
+            if (subGroups.containsKey(name)) {
+                InternalResourceGroup subGroup = subGroups.get(name).getLatest();
+                subGroup.setNext(newSubGroup);
+                newSubGroup.setPrev(subGroup);
+            }
+            else {
+                subGroups.put(name, newSubGroup);
+            }
+
+            return newSubGroup;
         }
     }
 
@@ -623,9 +847,10 @@ public class InternalResourceGroup
     public void run(ManagedQueryExecution query)
     {
         synchronized (root) {
-            if (!subGroups.isEmpty()) {
+            if (!isLeafResourceGroup()) {
                 throw new PrestoException(INVALID_RESOURCE_GROUP, format("Cannot add queries to %s. It is not a leaf group.", id));
             }
+
             // Check all ancestors for capacity
             InternalResourceGroup group = this;
             boolean canQueue = true;
@@ -684,6 +909,11 @@ public class InternalResourceGroup
             else {
                 parent.get().eligibleSubGroups.remove(this);
                 lastStartMillis = 0;
+            }
+            Optional<InternalResourceGroup> next = getNext();
+            while (next.isPresent()) {
+                next.get().updateEligibility();
+                next = next.get().getNext();
             }
             parent.get().updateEligibility();
         }
@@ -791,6 +1021,7 @@ public class InternalResourceGroup
             if (!canRunMore()) {
                 return false;
             }
+
             ManagedQueryExecution query = queuedQueries.poll();
             if (query != null) {
                 startInBackground(query);
@@ -869,7 +1100,7 @@ public class InternalResourceGroup
             if (!canRunMore()) {
                 return false;
             }
-            return !queuedQueries.isEmpty() || !eligibleSubGroups.isEmpty();
+            return !queuedQueries.isEmpty() || getEligibleSubGroupsCount() > 0;
         }
     }
 
@@ -889,7 +1120,27 @@ public class InternalResourceGroup
     {
         checkState(Thread.holdsLock(root), "Must hold lock");
         synchronized (root) {
-            return descendantQueuedQueries + queuedQueries.size() < maxQueuedQueries;
+            return getQueuedQueries() < maxQueuedQueries;
+        }
+    }
+
+    private long getCpuUsageMillis()
+    {
+        synchronized (root) {
+            if (getPrev().isPresent()) {
+                return cpuUsageMillis + getPrev().get().getCpuUsageMillis();
+            }
+            return cpuUsageMillis;
+        }
+    }
+
+    private long getCachedMemoryUsageBytes()
+    {
+        synchronized (root) {
+            if (getPrev().isPresent()) {
+                return cachedMemoryUsageBytes + getPrev().get().getCachedMemoryUsageBytes();
+            }
+            return cachedMemoryUsageBytes;
         }
     }
 
@@ -897,7 +1148,7 @@ public class InternalResourceGroup
     {
         checkState(Thread.holdsLock(root), "Must hold lock");
         synchronized (root) {
-            if (cpuUsageMillis >= hardCpuLimitMillis) {
+            if (getCpuUsageMillis() >= hardCpuLimitMillis) {
                 return false;
             }
 
@@ -906,18 +1157,18 @@ public class InternalResourceGroup
             }
 
             int hardConcurrencyLimit = this.hardConcurrencyLimit;
-            if (cpuUsageMillis >= softCpuLimitMillis) {
+            if (getCpuUsageMillis() >= softCpuLimitMillis) {
                 // TODO: Consider whether cpu limit math should be performed on softConcurrency or hardConcurrency
                 // Linear penalty between soft and hard limit
-                double penalty = (cpuUsageMillis - softCpuLimitMillis) / (double) (hardCpuLimitMillis - softCpuLimitMillis);
+                double penalty = (getCpuUsageMillis() - softCpuLimitMillis) / (double) (hardCpuLimitMillis - softCpuLimitMillis);
                 hardConcurrencyLimit = (int) Math.floor(hardConcurrencyLimit * (1 - penalty));
                 // Always penalize by at least one
                 hardConcurrencyLimit = min(this.hardConcurrencyLimit - 1, hardConcurrencyLimit);
                 // Always allow at least one running query
                 hardConcurrencyLimit = Math.max(1, hardConcurrencyLimit);
             }
-            return runningQueries.size() + descendantRunningQueries < hardConcurrencyLimit &&
-                    cachedMemoryUsageBytes <= softMemoryLimitBytes;
+            return getAllRunningQueriesCount() < hardConcurrencyLimit &&
+                    getCachedMemoryUsageBytes() <= softMemoryLimitBytes;
         }
     }
 
@@ -955,6 +1206,36 @@ public class InternalResourceGroup
         return Objects.hash(id);
     }
 
+    public InternalResourceGroup getRoot()
+    {
+        return root;
+    }
+
+    public void purgeExpiredResourceGroups()
+    {
+        synchronized (root) {
+            if (getRunningQueries() > 0 || getQueuedQueries() > 0) {
+                return;
+            }
+            for (InternalResourceGroup group : subGroups.values()) {
+                group.purgeExpiredResourceGroups();
+            }
+            if (!getPrev().isPresent()) {
+                if (getRunningQueries() == 0 && getQueuedQueries() == 0) {
+                    if (next.isPresent() && parent.isPresent()) {
+                        next.get().setPrev(null);
+                        next = Optional.empty();
+                    }
+                    subGroups.clear();
+                    while (!eligibleSubGroups.isEmpty()) {
+                        eligibleSubGroups.poll();
+                    }
+                    dirtySubGroups.clear();
+                }
+            }
+        }
+    }
+
     @ThreadSafe
     public static final class RootInternalResourceGroup
             extends InternalResourceGroup
@@ -964,23 +1245,33 @@ public class InternalResourceGroup
         public RootInternalResourceGroup(
                 String name,
                 BiConsumer<InternalResourceGroup, Boolean> jmxExportListener,
-                Executor executor)
+                Executor executor,
+                Integer version)
         {
-            super(Optional.empty(), name, jmxExportListener, executor, true);
+            super(Optional.empty(), name, jmxExportListener, executor, true, version);
         }
 
-        public synchronized void processQueuedQueries()
+        public RootInternalResourceGroup(String name, BiConsumer<InternalResourceGroup, Boolean> jmxExportListener, Executor executor, InternalResourceGroup root, Integer version)
         {
-            internalRefreshStats();
-            while (internalStartNext()) {
-                // start all the queries we can
+            super(Optional.empty(), name, jmxExportListener, executor, root, true, version);
+        }
+
+        public void processQueuedQueries()
+        {
+            synchronized (super.root) {
+                internalRefreshStats();
+                while (internalStartNext()) {
+                    // start all the queries we can
+                }
             }
         }
 
-        public synchronized void generateCpuQuota(long elapsedSeconds)
+        public void generateCpuQuota(long elapsedSeconds)
         {
-            if (elapsedSeconds > 0) {
-                internalGenerateCpuQuota(elapsedSeconds);
+            synchronized (super.root) {
+                if (elapsedSeconds > 0) {
+                    internalGenerateCpuQuota(elapsedSeconds);
+                }
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution.resourceGroups;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.node.NodeInfo;
+import com.facebook.presto.execution.ForQueryScheduling;
 import com.facebook.presto.execution.ManagedQueryExecution;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroup.RootInternalResourceGroup;
@@ -29,6 +30,7 @@ import com.facebook.presto.spi.resourceGroups.SelectionContext;
 import com.facebook.presto.spi.resourceGroups.SelectionCriteria;
 import com.facebook.presto.sql.tree.Statement;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.weakref.jmx.JmxException;
 import org.weakref.jmx.MBeanExporter;
@@ -49,6 +51,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -66,6 +69,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 @ThreadSafe
 public final class InternalResourceGroupManager<C>
@@ -75,7 +79,9 @@ public final class InternalResourceGroupManager<C>
     private static final File RESOURCE_GROUPS_CONFIGURATION = new File("etc/resource-groups.properties");
     private static final String CONFIGURATION_MANAGER_PROPERTY_NAME = "resource-groups.configuration-manager";
 
+    private final ExecutorService refreshResourceGroupExecutor;
     private final ScheduledExecutorService refreshExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("ResourceGroupManager"));
+    private final ScheduledExecutorService resourceGroupRefreshExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("ResourceGroupRefreshManager"));
     private final List<RootInternalResourceGroup> rootGroups = new CopyOnWriteArrayList<>();
     private final ConcurrentMap<ResourceGroupId, InternalResourceGroup> groups = new ConcurrentHashMap<>();
     private final AtomicReference<ResourceGroupConfigurationManager<C>> configurationManager;
@@ -95,7 +101,8 @@ public final class InternalResourceGroupManager<C>
             ClusterMemoryPoolManager memoryPoolManager,
             QueryManagerConfig queryManagerConfig,
             NodeInfo nodeInfo,
-            MBeanExporter exporter)
+            MBeanExporter exporter,
+            @ForQueryScheduling ExecutorService executorService)
     {
         requireNonNull(queryManagerConfig, "queryManagerConfig is null");
         this.exporter = requireNonNull(exporter, "exporter is null");
@@ -103,6 +110,7 @@ public final class InternalResourceGroupManager<C>
         this.legacyManager = requireNonNull(legacyManager, "legacyManager is null");
         this.configurationManager = new AtomicReference<>(cast(legacyManager));
         this.maxTotalRunningTaskCountToNotExecuteNewQuery = queryManagerConfig.getMaxTotalRunningTaskCountToNotExecuteNewQuery();
+        this.refreshResourceGroupExecutor = executorService;
     }
 
     @Override
@@ -124,7 +132,7 @@ public final class InternalResourceGroupManager<C>
     {
         checkState(configurationManager.get() != null, "configurationManager not set");
         createGroupIfNecessary(selectionContext, executor);
-        groups.get(selectionContext.getResourceGroupId()).run(queryExecution);
+        groups.get(selectionContext.getResourceGroupId()).getLatest().run(queryExecution);
     }
 
     @Override
@@ -154,6 +162,9 @@ public final class InternalResourceGroupManager<C>
                     "Resource groups configuration %s does not contain %s", RESOURCE_GROUPS_CONFIGURATION.getAbsoluteFile(), CONFIGURATION_MANAGER_PROPERTY_NAME);
 
             setConfigurationManager(configurationManagerName, properties);
+            if (configurationManager.get().dynamicReloadSupported()) {
+                resourceGroupRefreshExecutor.scheduleWithFixedDelay(this::refreshInternalResourceGroups, 1, 1, SECONDS);
+            }
         }
     }
 
@@ -187,6 +198,7 @@ public final class InternalResourceGroupManager<C>
     public void destroy()
     {
         refreshExecutor.shutdownNow();
+        resourceGroupRefreshExecutor.shutdownNow();
     }
 
     @PostConstruct
@@ -224,44 +236,149 @@ public final class InternalResourceGroupManager<C>
         }
 
         for (RootInternalResourceGroup group : rootGroups) {
-            try {
-                if (elapsedSeconds > 0) {
-                    group.generateCpuQuota(elapsedSeconds);
+            while (group != null) {
+                try {
+                    if (elapsedSeconds > 0) {
+                        group.generateCpuQuota(elapsedSeconds);
+                    }
                 }
-            }
-            catch (RuntimeException e) {
-                log.error(e, "Exception while generation cpu quota for %s", group);
-            }
-            try {
-                group.setTaskLimitExceeded(taskLimitExceeded.get());
-                group.processQueuedQueries();
-            }
-            catch (RuntimeException e) {
-                log.error(e, "Exception while processing queued queries for %s", group);
+                catch (RuntimeException e) {
+                    log.error(e, "Exception while generating cpu quota for %s", group);
+                }
+                try {
+                    group.setTaskLimitExceeded(taskLimitExceeded.get());
+                    group.processQueuedQueries();
+                }
+                catch (RuntimeException e) {
+                    log.error(e, "Exception while processing queued queries for %s version %s", group, group.getVersion());
+                }
+                if (group.getNext().isPresent()) {
+                    group = (RootInternalResourceGroup) group.getNext().get();
+                }
+                else {
+                    group = null;
+                }
             }
         }
     }
 
-    private synchronized void createGroupIfNecessary(SelectionContext<C> context, Executor executor)
+    @VisibleForTesting
+    public synchronized void refreshInternalResourceGroups()
     {
-        ResourceGroupId id = context.getResourceGroupId();
-        if (!groups.containsKey(id)) {
-            InternalResourceGroup group;
-            if (id.getParent().isPresent()) {
-                createGroupIfNecessary(new SelectionContext<>(id.getParent().get(), context.getContext()), executor);
-                InternalResourceGroup parent = groups.get(id.getParent().get());
-                requireNonNull(parent, "parent is null");
-                // parent segments size equals to subgroup segment index
-                int subGroupSegmentIndex = parent.getId().getSegments().size();
-                group = parent.getOrCreateSubGroup(id.getLastSegment(), !context.getFirstDynamicSegmentPosition().equals(OptionalInt.of(subGroupSegmentIndex)));
+        boolean requeue = false;
+        boolean versionChanged = false;
+        int specVersion = configurationManager.get().getSpecVersion();
+        for (InternalResourceGroup rootGroup : rootGroups) {
+            if (rootGroup.getLatest().getVersion() < specVersion) {
+                versionChanged = true;
+                break;
+            }
+        }
+
+        if (!versionChanged) {
+            return;
+        }
+
+        for (ResourceGroupId id : groups.keySet()) {
+            InternalResourceGroup group = groups.get(id).getLatest();
+            if (group.getVersion() != specVersion) {
+                requeue = true;
+            }
+            createGroupIfNecessary(group, refreshResourceGroupExecutor, specVersion);
+        }
+
+        if (requeue) {
+            for (ResourceGroupId id : groups.keySet()) {
+                InternalResourceGroup group = groups.get(id).getLatest();
+                if (group.getPrev().isPresent()) {
+                    group.getPrev().get().requeueToNext();
+                }
+            }
+        }
+        //Clean up process to remove old versions if they no longer have running/queued queries
+        for (InternalResourceGroup group : rootGroups) {
+            while (group.getNext().isPresent()) {
+                group.purgeExpiredResourceGroups();
+                group = group.getNext().get();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    public List<RootInternalResourceGroup> getRootGroups()
+    {
+        return ImmutableList.copyOf(rootGroups);
+    }
+
+    private void createGroupIfNecessary(InternalResourceGroup resourceGroup, Executor executor, int version)
+    {
+        synchronized (this) {
+            if (resourceGroup.getVersion() == version) {
+                return;
+            }
+
+            InternalResourceGroup newGroup;
+            ResourceGroupId resourceGroupId = resourceGroup.getId();
+            if (resourceGroupId.getParent().isPresent()) {
+                createGroupIfNecessary(groups.get(resourceGroupId.getParent().get()).getLatest(), executor, version);
+                InternalResourceGroup parent = groups.get(resourceGroupId.getParent().get()).getLatest();
+                newGroup = parent.getOrCreateSubGroup(resourceGroupId.getLastSegment(), resourceGroup.isStaticResourceGroup(), version);
             }
             else {
-                RootInternalResourceGroup root = new RootInternalResourceGroup(id.getSegments().get(0), this::exportGroup, executor);
-                group = root;
-                rootGroups.add(root);
+                newGroup = new RootInternalResourceGroup(resourceGroup.getId().getSegments().get(0), this::exportGroup, executor, resourceGroup.getRoot(), version);
             }
-            configurationManager.get().configure(group, context);
-            checkState(groups.put(id, group) == null, "Unexpected existing resource group");
+            configurationManager.get().configure(newGroup);
+            resourceGroup.setNext(newGroup);
+            newGroup.setPrev(resourceGroup);
+            groups.put(resourceGroupId, newGroup);
+        }
+    }
+
+    private void createGroupIfNecessary(SelectionContext<C> context, Executor executor)
+    {
+        synchronized (this) {
+            ResourceGroupId id = context.getResourceGroupId();
+            int specVersion = configurationManager.get().getSpecVersion();
+            if (!groups.containsKey(id)) {
+                InternalResourceGroup group;
+                if (id.getParent().isPresent()) {
+                    createGroupIfNecessary(new SelectionContext<>(id.getParent().get(), context.getContext()), executor);
+                    InternalResourceGroup parent = groups.get(id.getParent().get()).getLatest();
+                    requireNonNull(parent, "parent is null");
+                    // parent segments size equals to subgroup segment index
+                    int subGroupSegmentIndex = parent.getId().getSegments().size();
+                    group = parent.getOrCreateSubGroup(id.getLastSegment(), !context.getFirstDynamicSegmentPosition().equals(OptionalInt.of(subGroupSegmentIndex)), specVersion);
+                }
+                else {
+                    RootInternalResourceGroup root = new RootInternalResourceGroup(id.getSegments().get(0), this::exportGroup, executor, specVersion);
+                    group = root;
+                    rootGroups.add(root);
+                }
+                configurationManager.get().configure(group, context);
+                checkState(groups.put(id, group) == null, "Unexpected existing resource group");
+            }
+            else {
+                InternalResourceGroup group = groups.get(id).getLatest();
+
+                if (specVersion != group.getVersion()) {
+                    InternalResourceGroup newGroup;
+                    if (id.getParent().isPresent()) {
+                        createGroupIfNecessary(new SelectionContext<>(id.getParent().get(), context.getContext()), executor);
+                        InternalResourceGroup parent = groups.get(id.getParent().get()).getLatest();
+                        requireNonNull(parent, "parent is null");
+                        // parent segments size equals to subgroup segment index
+                        int subGroupSegmentIndex = parent.getId().getSegments().size();
+                        newGroup = parent.getOrCreateSubGroup(id.getLastSegment(), !context.getFirstDynamicSegmentPosition().equals(OptionalInt.of(subGroupSegmentIndex)), specVersion);
+                    }
+                    else {
+                        newGroup = new RootInternalResourceGroup(id.getSegments().get(0), this::exportGroup, executor, group.getRoot(), specVersion);
+                    }
+                    configurationManager.get().configure(newGroup, context);
+                    group.setNext(newGroup);
+                    newGroup.setPrev(group);
+                    groups.put(id, newGroup);
+                }
+            }
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/LegacyResourceGroupConfigurationManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/LegacyResourceGroupConfigurationManager.java
@@ -56,8 +56,25 @@ public class LegacyResourceGroupConfigurationManager
     }
 
     @Override
+    public void configure(ResourceGroup group)
+    {
+    }
+
+    @Override
+    public boolean dynamicReloadSupported()
+    {
+        return false;
+    }
+
+    @Override
     public Optional<SelectionContext<VoidContext>> match(SelectionCriteria criteria)
     {
         return Optional.of(new SelectionContext<>(GLOBAL, VoidContext.NONE));
+    }
+
+    @Override
+    public int getSpecVersion()
+    {
+        return 0;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -52,6 +52,7 @@ import com.facebook.presto.execution.DropTableTask;
 import com.facebook.presto.execution.DropViewTask;
 import com.facebook.presto.execution.ExplainAnalyzeContext;
 import com.facebook.presto.execution.ForQueryExecution;
+import com.facebook.presto.execution.ForQueryScheduling;
 import com.facebook.presto.execution.GrantRolesTask;
 import com.facebook.presto.execution.GrantTask;
 import com.facebook.presto.execution.PrepareTask;
@@ -294,6 +295,8 @@ public class CoordinatorModule
 
         binder.bind(ScheduledExecutorService.class).annotatedWith(ForScheduler.class)
                 .toInstance(newSingleThreadScheduledExecutor(threadsNamed("stage-scheduler")));
+        binder.bind(ExecutorService.class).annotatedWith(ForQueryScheduling.class)
+                .toInstance(newCachedThreadPool(threadsNamed("query-scheduler-%s")));
 
         // query execution
         binder.bind(ExecutorService.class).annotatedWith(ForQueryExecution.class)

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupInfo.java
@@ -52,6 +52,8 @@ public class ResourceGroupInfo
     private final List<ResourceGroupInfo> subGroups;
     private final List<QueryStateInfo> runningQueries;
 
+    private final int version;
+
     @JsonCreator
     public ResourceGroupInfo(
             @JsonProperty("id") ResourceGroupId id,
@@ -67,7 +69,8 @@ public class ResourceGroupInfo
             @JsonProperty("numRunningQueries") int numRunningQueries,
             @JsonProperty("numEligibleSubGroups") int numEligibleSubGroups,
             @JsonProperty("subGroups") List<ResourceGroupInfo> subGroups,
-            @JsonProperty("runningQueries") List<QueryStateInfo> runningQueries)
+            @JsonProperty("runningQueries") List<QueryStateInfo> runningQueries,
+            @JsonProperty("version") int version)
     {
         this.id = requireNonNull(id, "id is null");
         this.state = requireNonNull(state, "state is null");
@@ -89,6 +92,8 @@ public class ResourceGroupInfo
         this.runningQueries = runningQueries;
 
         this.subGroups = subGroups;
+
+        this.version = version;
     }
 
     @JsonProperty
@@ -189,5 +194,11 @@ public class ResourceGroupInfo
     public List<ResourceGroupInfo> getSubGroups()
     {
         return subGroups;
+    }
+
+    @JsonProperty
+    public int getVersion()
+    {
+        return version;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/BenchmarkResourceGroup.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/BenchmarkResourceGroup.java
@@ -71,13 +71,13 @@ public class BenchmarkResourceGroup
         @Setup
         public void setup()
         {
-            root = new RootInternalResourceGroup("root", (group, export) -> {}, executor);
+            root = new RootInternalResourceGroup("root", (group, export) -> {}, executor, 1);
             root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
             root.setMaxQueuedQueries(queries);
             root.setHardConcurrencyLimit(queries);
             InternalResourceGroup group = root;
             for (int i = 0; i < children; i++) {
-                group = root.getOrCreateSubGroup(String.valueOf(i), true);
+                group = root.getOrCreateSubGroup(String.valueOf(i), true, 1);
                 group.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
                 group.setMaxQueuedQueries(queries);
                 group.setHardConcurrencyLimit(queries);

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
@@ -62,7 +62,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testQueueFull()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(1);
         root.setHardConcurrencyLimit(1);
@@ -81,19 +81,19 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testFairEligibility()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(1);
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true, 0);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(4);
         group1.setHardConcurrencyLimit(1);
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true, 0);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(4);
         group2.setHardConcurrencyLimit(1);
-        InternalResourceGroup group3 = root.getOrCreateSubGroup("3", true);
+        InternalResourceGroup group3 = root.getOrCreateSubGroup("3", true, 0);
         group3.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group3.setMaxQueuedQueries(4);
         group3.setHardConcurrencyLimit(1);
@@ -136,15 +136,15 @@ public class TestResourceGroups
     @Test
     public void testSetSchedulingPolicy()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(1);
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true, 0);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(4);
         group1.setHardConcurrencyLimit(2);
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true, 0);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(4);
         group2.setHardConcurrencyLimit(2);
@@ -162,31 +162,31 @@ public class TestResourceGroups
         assertEquals(query2a.getState(), QUEUED);
 
         assertEquals(root.getInfo().getNumEligibleSubGroups(), 2);
-        assertEquals(root.getOrCreateSubGroup("1", true).getQueuedQueries(), 2);
-        assertEquals(root.getOrCreateSubGroup("2", true).getQueuedQueries(), 1);
+        assertEquals(root.getOrCreateSubGroup("1", true, 0).getQueuedQueries(), 2);
+        assertEquals(root.getOrCreateSubGroup("2", true, 0).getQueuedQueries(), 1);
         assertEquals(root.getSchedulingPolicy(), FAIR);
         root.setSchedulingPolicy(QUERY_PRIORITY);
         assertEquals(root.getInfo().getNumEligibleSubGroups(), 2);
-        assertEquals(root.getOrCreateSubGroup("1", true).getQueuedQueries(), 2);
-        assertEquals(root.getOrCreateSubGroup("2", true).getQueuedQueries(), 1);
+        assertEquals(root.getOrCreateSubGroup("1", true, 0).getQueuedQueries(), 2);
+        assertEquals(root.getOrCreateSubGroup("2", true, 0).getQueuedQueries(), 1);
 
         assertEquals(root.getSchedulingPolicy(), QUERY_PRIORITY);
-        assertEquals(root.getOrCreateSubGroup("1", true).getSchedulingPolicy(), QUERY_PRIORITY);
-        assertEquals(root.getOrCreateSubGroup("2", true).getSchedulingPolicy(), QUERY_PRIORITY);
+        assertEquals(root.getOrCreateSubGroup("1", true, 0).getSchedulingPolicy(), QUERY_PRIORITY);
+        assertEquals(root.getOrCreateSubGroup("2", true, 0).getSchedulingPolicy(), QUERY_PRIORITY);
     }
 
     @Test(timeOut = 10_000)
     public void testFairQueuing()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(1);
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true, 0);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(4);
         group1.setHardConcurrencyLimit(2);
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true, 0);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(4);
         group2.setHardConcurrencyLimit(2);
@@ -220,7 +220,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testMemoryLimit()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, BYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(3);
@@ -245,11 +245,11 @@ public class TestResourceGroups
     @Test
     public void testSubgroupMemoryLimit()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(10, BYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(3);
-        InternalResourceGroup subgroup = root.getOrCreateSubGroup("subgroup", true);
+        InternalResourceGroup subgroup = root.getOrCreateSubGroup("subgroup", true, 0);
         subgroup.setSoftMemoryLimit(new DataSize(1, BYTE));
         subgroup.setMaxQueuedQueries(4);
         subgroup.setHardConcurrencyLimit(3);
@@ -275,7 +275,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testSoftCpuLimit()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, BYTE));
         root.setSoftCpuLimit(new Duration(1, SECONDS));
         root.setHardCpuLimit(new Duration(2, SECONDS));
@@ -309,7 +309,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testHardCpuLimit()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, BYTE));
         root.setHardCpuLimit(new Duration(1, SECONDS));
         root.setCpuQuotaGenerationMillisPerSecond(2000);
@@ -334,17 +334,17 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testPriorityScheduling()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(100);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(QUERY_PRIORITY);
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true, 0);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(100);
         group1.setHardConcurrencyLimit(1);
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true, 0);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(100);
         group2.setHardConcurrencyLimit(1);
@@ -384,18 +384,18 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testWeightedScheduling()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(WEIGHTED);
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true, 0);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(2);
         group1.setHardConcurrencyLimit(2);
         group1.setSoftConcurrencyLimit(2);
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true, 0);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(2);
         group2.setHardConcurrencyLimit(2);
@@ -433,21 +433,21 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testWeightedFairScheduling()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(50);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(WEIGHTED_FAIR);
 
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true, 0);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(50);
         group1.setHardConcurrencyLimit(2);
         group1.setSoftConcurrencyLimit(2);
         group1.setSchedulingWeight(1);
 
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true, 0);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(50);
         group2.setHardConcurrencyLimit(2);
@@ -476,28 +476,28 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testWeightedFairSchedulingEqualWeights()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(50);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(WEIGHTED_FAIR);
 
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true, 0);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(50);
         group1.setHardConcurrencyLimit(2);
         group1.setSoftConcurrencyLimit(2);
         group1.setSchedulingWeight(1);
 
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true, 0);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(50);
         group2.setHardConcurrencyLimit(2);
         group2.setSoftConcurrencyLimit(2);
         group2.setSchedulingWeight(1);
 
-        InternalResourceGroup group3 = root.getOrCreateSubGroup("3", true);
+        InternalResourceGroup group3 = root.getOrCreateSubGroup("3", true, 0);
         group3.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group3.setMaxQueuedQueries(50);
         group3.setHardConcurrencyLimit(2);
@@ -535,21 +535,21 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testWeightedFairSchedulingNoStarvation()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(50);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(WEIGHTED_FAIR);
 
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true, 0);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(50);
         group1.setHardConcurrencyLimit(2);
         group1.setSoftConcurrencyLimit(2);
         group1.setSchedulingWeight(1);
 
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true, 0);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(50);
         group2.setHardConcurrencyLimit(2);
@@ -576,41 +576,41 @@ public class TestResourceGroups
     @Test
     public void testGetInfo()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(40);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(WEIGHTED);
 
-        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true);
+        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true, 0);
         rootA.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootA.setMaxQueuedQueries(20);
         rootA.setHardConcurrencyLimit(2);
 
-        InternalResourceGroup rootB = root.getOrCreateSubGroup("b", true);
+        InternalResourceGroup rootB = root.getOrCreateSubGroup("b", true, 0);
         rootB.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootB.setMaxQueuedQueries(20);
         rootB.setHardConcurrencyLimit(2);
         rootB.setSchedulingWeight(2);
         rootB.setSchedulingPolicy(QUERY_PRIORITY);
 
-        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", true);
+        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", true, 0);
         rootAX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAX.setMaxQueuedQueries(10);
         rootAX.setHardConcurrencyLimit(10);
 
-        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y", true);
+        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y", true, 0);
         rootAY.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAY.setMaxQueuedQueries(10);
         rootAY.setHardConcurrencyLimit(10);
 
-        InternalResourceGroup rootBX = rootB.getOrCreateSubGroup("x", true);
+        InternalResourceGroup rootBX = rootB.getOrCreateSubGroup("x", true, 0);
         rootBX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootBX.setMaxQueuedQueries(10);
         rootBX.setHardConcurrencyLimit(10);
 
-        InternalResourceGroup rootBY = rootB.getOrCreateSubGroup("y", true);
+        InternalResourceGroup rootBY = rootB.getOrCreateSubGroup("y", true, 0);
         rootBY.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootBY.setMaxQueuedQueries(10);
         rootBY.setHardConcurrencyLimit(10);
@@ -666,30 +666,30 @@ public class TestResourceGroups
     @Test
     public void testGetResourceGroupStateInfo()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, GIGABYTE));
         root.setMaxQueuedQueries(40);
         root.setHardConcurrencyLimit(10);
         root.setSchedulingPolicy(WEIGHTED);
 
-        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true);
+        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true, 0);
         rootA.setSoftMemoryLimit(new DataSize(10, MEGABYTE));
         rootA.setMaxQueuedQueries(20);
         rootA.setHardConcurrencyLimit(0);
 
-        InternalResourceGroup rootB = root.getOrCreateSubGroup("b", true);
+        InternalResourceGroup rootB = root.getOrCreateSubGroup("b", true, 0);
         rootB.setSoftMemoryLimit(new DataSize(5, MEGABYTE));
         rootB.setMaxQueuedQueries(20);
         rootB.setHardConcurrencyLimit(1);
         rootB.setSchedulingWeight(2);
         rootB.setSchedulingPolicy(QUERY_PRIORITY);
 
-        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", true);
+        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", true, 0);
         rootAX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAX.setMaxQueuedQueries(10);
         rootAX.setHardConcurrencyLimit(10);
 
-        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y", true);
+        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y", true, 0);
         rootAY.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAY.setMaxQueuedQueries(10);
         rootAY.setHardConcurrencyLimit(10);
@@ -734,18 +734,18 @@ public class TestResourceGroups
     @Test
     public void testGetStaticResourceGroupInfo()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 0);
         root.setSoftMemoryLimit(new DataSize(1, GIGABYTE));
         root.setMaxQueuedQueries(100);
         root.setHardConcurrencyLimit(10);
         root.setSchedulingPolicy(WEIGHTED);
 
-        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true);
+        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true, 0);
         rootA.setSoftMemoryLimit(new DataSize(10, MEGABYTE));
         rootA.setMaxQueuedQueries(100);
         rootA.setHardConcurrencyLimit(0);
 
-        InternalResourceGroup rootB = root.getOrCreateSubGroup("b", true);
+        InternalResourceGroup rootB = root.getOrCreateSubGroup("b", true, 0);
         rootB.setSoftMemoryLimit(new DataSize(5, MEGABYTE));
         rootB.setMaxQueuedQueries(100);
         rootB.setHardConcurrencyLimit(1);
@@ -753,25 +753,25 @@ public class TestResourceGroups
         rootB.setSchedulingPolicy(QUERY_PRIORITY);
 
         // x is a dynamic resource group
-        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", false);
+        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", false, 0);
         rootAX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAX.setMaxQueuedQueries(10);
         rootAX.setHardConcurrencyLimit(10);
 
-        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y", true);
+        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y", true, 0);
         rootAY.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAY.setMaxQueuedQueries(10);
         rootAY.setHardConcurrencyLimit(10);
 
         for (int i = 0; i < 10; i++) {
-            InternalResourceGroup subGroup = rootAX.getOrCreateSubGroup("ax" + i, false);
+            InternalResourceGroup subGroup = rootAX.getOrCreateSubGroup("ax" + i, false, 0);
             subGroup.setSoftMemoryLimit(new DataSize(i, MEGABYTE));
             subGroup.setMaxQueuedQueries(10);
             subGroup.setHardConcurrencyLimit(10);
         }
 
         for (int i = 0; i < 10; i++) {
-            fillGroupTo(rootAX.getOrCreateSubGroup("ax" + i, true), ImmutableSet.of(), 1, false);
+            fillGroupTo(rootAX.getOrCreateSubGroup("ax" + i, true, 0), ImmutableSet.of(), 1, false);
         }
         fillGroupTo(rootAY, ImmutableSet.of(), 5, false);
         fillGroupTo(rootB, ImmutableSet.of(), 10, true);
@@ -811,38 +811,38 @@ public class TestResourceGroups
     @Test
     public void testGetBlockedQueuedQueries()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(40);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
         root.setHardConcurrencyLimit(0);
 
-        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true);
+        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true, 0);
         rootA.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootA.setMaxQueuedQueries(20);
         rootA.setHardConcurrencyLimit(8);
 
-        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", true);
+        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", true, 0);
         rootAX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAX.setMaxQueuedQueries(10);
         rootAX.setHardConcurrencyLimit(8);
 
-        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y", true);
+        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y", true, 0);
         rootAY.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAY.setMaxQueuedQueries(10);
         rootAY.setHardConcurrencyLimit(5);
 
-        InternalResourceGroup rootB = root.getOrCreateSubGroup("b", true);
+        InternalResourceGroup rootB = root.getOrCreateSubGroup("b", true, 0);
         rootB.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootB.setMaxQueuedQueries(20);
         rootB.setHardConcurrencyLimit(8);
 
-        InternalResourceGroup rootBX = rootB.getOrCreateSubGroup("x", true);
+        InternalResourceGroup rootBX = rootB.getOrCreateSubGroup("x", true, 0);
         rootBX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootBX.setMaxQueuedQueries(10);
         rootBX.setHardConcurrencyLimit(8);
 
-        InternalResourceGroup rootBY = rootB.getOrCreateSubGroup("y", true);
+        InternalResourceGroup rootBY = rootB.getOrCreateSubGroup("y", true, 0);
         rootBY.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootBY.setMaxQueuedQueries(10);
         rootBY.setHardConcurrencyLimit(5);

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -45,18 +45,18 @@ public class TestQueryStateInfo
     @Test
     public void testQueryStateInfo()
     {
-        InternalResourceGroup.RootInternalResourceGroup root = new InternalResourceGroup.RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        InternalResourceGroup.RootInternalResourceGroup root = new InternalResourceGroup.RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), 1);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(40);
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(WEIGHTED);
 
-        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true);
+        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true, 0);
         rootA.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootA.setMaxQueuedQueries(20);
         rootA.setHardConcurrencyLimit(0);
 
-        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", true);
+        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", true, 0);
         rootAX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAX.setMaxQueuedQueries(10);
         rootAX.setHardConcurrencyLimit(0);

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/FileResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/FileResourceGroupConfigurationManager.java
@@ -109,6 +109,17 @@ public class FileResourceGroupConfigurationManager
     }
 
     @Override
+    public void configure(ResourceGroup group)
+    {
+    }
+
+    @Override
+    public boolean dynamicReloadSupported()
+    {
+        return false;
+    }
+
+    @Override
     public Optional<SelectionContext<VariableMap>> match(SelectionCriteria criteria)
     {
         return selectors.stream()
@@ -116,6 +127,12 @@ public class FileResourceGroupConfigurationManager
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .findFirst();
+    }
+
+    @Override
+    public int getSpecVersion()
+    {
+        return 0;
     }
 
     @VisibleForTesting

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestingResourceGroup.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestingResourceGroup.java
@@ -166,4 +166,10 @@ public class TestingResourceGroup
     {
         jmxExport = export;
     }
+
+    @Override
+    public int getVersion()
+    {
+        return 0;
+    }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -41,6 +41,7 @@ import com.facebook.presto.event.SplitMonitor;
 import com.facebook.presto.execution.DataDefinitionTask;
 import com.facebook.presto.execution.ExecutionFailureInfo;
 import com.facebook.presto.execution.ExplainAnalyzeContext;
+import com.facebook.presto.execution.ForQueryScheduling;
 import com.facebook.presto.execution.QueryIdGenerator;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.QueryManagerConfig;
@@ -281,6 +282,7 @@ public class PrestoSparkModule
         ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("presto-spark-executor-%s"));
         binder.bind(Executor.class).toInstance(executor);
         binder.bind(ExecutorService.class).toInstance(executor);
+        binder.bind(ExecutorService.class).annotatedWith(ForQueryScheduling.class).toInstance(executor);
         binder.bind(ScheduledExecutorService.class).toInstance(newScheduledThreadPool(0, daemonThreadsNamed("presto-spark-scheduled-executor-%s")));
 
         // task executor

--- a/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/ResourceGroup.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/ResourceGroup.java
@@ -95,4 +95,6 @@ public interface ResourceGroup
      * Whether to export statistics about this group and allow configuration via JMX.
      */
     void setJmxExport(boolean export);
+
+    int getVersion();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/ResourceGroupConfigurationManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/ResourceGroupConfigurationManager.java
@@ -37,8 +37,14 @@ public interface ResourceGroupConfigurationManager<C>
      */
     void configure(ResourceGroup group, SelectionContext<C> criteria);
 
+    void configure(ResourceGroup group);
+
+    boolean dynamicReloadSupported();
+
     /**
      * This method is called for every query that is submitted, so it should be fast.
      */
     Optional<SelectionContext<C>> match(SelectionCriteria criteria);
+
+    int getSpecVersion();
 }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution.resourceGroups.db;
 import com.facebook.presto.Session;
 import com.facebook.presto.dispatcher.DispatchManager;
 import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.resourceGroups.InternalResourceGroup;
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroupManager;
 import com.facebook.presto.resourceGroups.db.DbResourceGroupConfigurationManager;
 import com.facebook.presto.resourceGroups.db.H2ResourceGroupsDao;
@@ -31,6 +32,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -63,6 +65,7 @@ import static com.facebook.presto.spi.StandardErrorCode.QUERY_REJECTED;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -123,12 +126,20 @@ public class TestQueuesDb
         // Update db to allow for 1 more running query in dashboard resource group
         dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
         dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        SECONDS.sleep(1);
+        InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
+        DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
+        dbConfigurationManager.load();
+        manager.refreshInternalResourceGroups();
+        SECONDS.sleep(2);
         waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
         QueryId thirdDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
         waitForRunningQueryCount(queryRunner, 2);
+
         // submit first non "dashboard" query
         QueryId firstNonDashboardQuery = createQuery(queryRunner, adhocSession(), LONG_LASTING_QUERY);
+        SECONDS.sleep(1);
         // wait for the first non "dashboard" query to start
         waitForQueryState(queryRunner, firstNonDashboardQuery, RUNNING);
         waitForRunningQueryCount(queryRunner, 3);
@@ -140,6 +151,7 @@ public class TestQueuesDb
         // cancel first "dashboard" query, the second "dashboard" query and second non "dashboard" query should start running
         cancelQuery(queryRunner, firstDashboardQuery);
         waitForQueryState(queryRunner, firstDashboardQuery, FAILED);
+        SECONDS.sleep(5);
         waitForQueryState(queryRunner, thirdDashboardQuery, RUNNING);
         waitForRunningQueryCount(queryRunner, 4);
         waitForCompleteQueryCount(queryRunner, 1);
@@ -168,15 +180,17 @@ public class TestQueuesDb
         QueryId thirdDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, thirdDashboardQuery, FAILED);
 
+        InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
+        DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
+
         // Allow one more query to run and resubmit third query
         dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
         dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
 
-        InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
-        DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
-
         // Trigger reload to make the test more deterministic
         dbConfigurationManager.load();
+        manager.refreshInternalResourceGroups();
+
         waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
         thirdDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
@@ -184,6 +198,7 @@ public class TestQueuesDb
         // Lower running queries in dashboard resource groups and reload the config
         dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
+        manager.refreshInternalResourceGroups();
 
         // Cancel query and verify that third query is still queued
         cancelQuery(queryRunner, firstDashboardQuery);
@@ -281,6 +296,7 @@ public class TestQueuesDb
         // set max running queries to 0 for the dashboard resource group so that new queries get queued immediately
         dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 0, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
+        manager.refreshInternalResourceGroups();
         QueryId secondQuery = createQuery(
                 queryRunner,
                 testSessionBuilder()
@@ -299,6 +315,7 @@ public class TestQueuesDb
         // reconfigure the resource group to run the second query
         dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 1, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
+        manager.refreshInternalResourceGroups();
         // cancel the first one and let the second one start
         dispatchManager.cancelQuery(firstQuery);
         // wait until the second one is FAILED
@@ -337,13 +354,13 @@ public class TestQueuesDb
                 .setSchema("sf100000")
                 .setSource("non-leaf")
                 .build();
-        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
         InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
         int originalSize = getSelectors(queryRunner).size();
         // Add a selector for a non leaf group
         dao.insertSelector(3, 100, "user.*", "(?i).*non-leaf.*", null, null, null);
         dbConfigurationManager.load();
+        manager.refreshInternalResourceGroups();
         while (getSelectors(queryRunner).size() != originalSize + 1) {
             MILLISECONDS.sleep(500);
         }
@@ -356,6 +373,163 @@ public class TestQueuesDb
         QueryId invalidResourceGroupQuery = createQuery(queryRunner, session, LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, invalidResourceGroupQuery, FAILED);
         assertEquals(queryRunner.getCoordinator().getDispatchManager().getQueryInfo(invalidResourceGroupQuery).getErrorCode(), INVALID_RESOURCE_GROUP.toErrorCode());
+    }
+
+    @Test
+    public void testNonLeafToLeafTransition()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema("sf100000")
+                .setSource("leaf")
+                .build();
+        InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
+        DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
+        // Submit query with side effect of creating resource groups
+        QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
+        cancelQuery(queryRunner, firstDashboardQuery);
+        waitForQueryState(queryRunner, firstDashboardQuery, FAILED);
+        //Removing leaf resource group and making non leaf resource group a leaf one
+        dao.deleteSelectors(4);
+        dao.deleteSelectors(5);
+        dao.deleteResourceGroup(4);
+        dao.deleteResourceGroup(5);
+        // Add a selector for a non leaf group
+        dao.insertSelector(3, 100, "user.*", "(?i).*leaf.*", null, null, null);
+        dbConfigurationManager.load();
+        manager.refreshInternalResourceGroups();
+        // Submit a query to a leaf resource group
+        QueryId leafResourceGroupQuery = createQuery(queryRunner, session, LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, leafResourceGroupQuery, RUNNING);
+    }
+
+    @Test
+    public void testNonLeafToLeafTransitionShouldBumpSpecVersionOnlyOnce()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema("sf100000")
+                .setSource("leaf")
+                .build();
+        InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
+        DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
+        // Submit query with side effect of creating resource groups
+        QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
+        cancelQuery(queryRunner, firstDashboardQuery);
+        waitForQueryState(queryRunner, firstDashboardQuery, FAILED);
+        //Removing leaf resource group and making non leaf resource group a leaf one
+        dao.deleteSelectors(4);
+        dao.deleteSelectors(5);
+        dao.deleteResourceGroup(4);
+        dao.deleteResourceGroup(5);
+        // Add a selector for a non leaf group
+        dao.insertSelector(3, 100, "user.*", "(?i).*leaf.*", null, null, null);
+        assertEquals(dbConfigurationManager.getSpecVersion(), 1);
+        dbConfigurationManager.load();
+        manager.refreshInternalResourceGroups();
+        assertEquals(dbConfigurationManager.getSpecVersion(), 2);
+        dbConfigurationManager.load();
+        assertEquals(dbConfigurationManager.getSpecVersion(), 2);
+    }
+
+    @Test
+    public void testLeafToNonLeafTransition()
+            throws Exception
+    {
+        Session leafSession = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema("sf100000")
+                .setSource("leaf")
+                .build();
+
+        QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
+
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 2, null, 2, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(8, "dashboard-${USER}-leaf", "1MB", 1, 1, 1, null, null, null, null, null, 5L, TEST_ENVIRONMENT);
+        dao.insertSelector(8, 100, "user.*", "(?i).*leaf.*", null, null, null);
+
+        InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
+        DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
+
+        dbConfigurationManager.load();
+        manager.refreshInternalResourceGroups();
+
+        QueryId leafQuery = createQuery(queryRunner, leafSession, LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, leafQuery, RUNNING);
+
+        QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, secondDashboardQuery, FAILED);
+        assertEquals(queryRunner.getQueryInfo(secondDashboardQuery).getErrorCode(), INVALID_RESOURCE_GROUP.toErrorCode());
+    }
+
+    @Test
+    public void testResourceGroupVersioning()
+            throws Exception
+    {
+        QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
+
+        QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
+
+        InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
+        DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
+
+        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+
+        // Trigger reload to make the test more deterministic
+        dbConfigurationManager.load();
+        manager.refreshInternalResourceGroups();
+
+        //Previously queued query start running due to new version being introduced with higher concurrency
+        waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
+
+        QueryId thirdDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
+
+        QueryId forthDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, forthDashboardQuery, FAILED);
+    }
+
+    @Test
+    public void testOldResourceGroupVersionCleanup()
+            throws Exception
+    {
+        QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
+
+        QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+        waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
+
+        cancelQuery(queryRunner, firstDashboardQuery);
+        waitForQueryState(queryRunner, firstDashboardQuery, FAILED);
+
+        cancelQuery(queryRunner, secondDashboardQuery);
+        waitForQueryState(queryRunner, secondDashboardQuery, FAILED);
+
+        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+
+        InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
+        DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
+
+        // Trigger reload to make the test more deterministic
+        dbConfigurationManager.load();
+        manager.refreshInternalResourceGroups();
+
+        List<InternalResourceGroup.RootInternalResourceGroup> rootGroups = manager.getRootGroups();
+
+        for (InternalResourceGroup.RootInternalResourceGroup rootGroup : rootGroups) {
+            assertEquals(rootGroup.subGroups().size(), 0);
+            assertEquals(rootGroup.getEligibleSubGroupsCount(), 0);
+            assertEquals(rootGroup.getDirtySubGroupsCount(), 0);
+        }
     }
 
     private void assertResourceGroupWithClientTags(Set<String> clientTags, ResourceGroupId expectedResourceGroup)


### PR DESCRIPTION
Problem:
In case of resource group changes, if we make any leaf resource group to be intermediate resource group by introducing new resource group, all the queries assigned to the old resource group before the change and are queued, will fail when they are being processed. And the reason for that, we fail all queries which try to run on an intermediate resource group. But in this scenario, we should allow those queries to be run on intermediate resource group and not fail.

Solution:
Introducing versioning to Resource Groups. Please find more information on the behavior of the resource group versioning as below. 
- With every change in the resource group, Resource group manager will create a new version of each of the resource groups. 
- Queries queued on the old version will move to the new version if the new version resource group is still a leaf node. Otherwise, queued queries stays with old version and continue getting executed as per the old resource group contraints (i.e. hard concurrency)
- For every new query to run, resource group manager first checks in the older version if any pending query eligible to run and runs them first before moving to the new version.
- For any new resource group, when running query it checks total running query which includes all previous version queries as well. And if that still within the constraint, then only allow the new resource group. While queuing queries, it only checks it's existing limit and queue query accordingly. 

```
== RELEASE NOTES ==

General Changes
* Introducing Resource Group Versioning

Bug Fixes
* Existing resource group was not reliably handle transition of leaf resource group internal and vice versa. Coordinator restart was needed to handle it reliably. 