### PR TITLE
[TEST] Remove synchronized method in FixedSourcePartitionedScheduler

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableGroupedExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableGroupedExecution.java
@@ -100,7 +100,7 @@ public class TestHiveRecoverableGroupedExecution
         executor.shutdownNow();
     }
 
-    @Test(timeOut = 60_000, enabled = false)
+    @Test(timeOut = 60_000)
     public void testCreateBucketedTable()
             throws Exception
     {
@@ -138,7 +138,7 @@ public class TestHiveRecoverableGroupedExecution
                         "DROP TABLE IF EXISTS test_failure"));
     }
 
-    @Test(timeOut = 60_000, enabled = false)
+    @Test(timeOut = 60_000)
     public void testInsertBucketedTable()
             throws Exception
     {
@@ -180,7 +180,7 @@ public class TestHiveRecoverableGroupedExecution
                         "DROP TABLE IF EXISTS test_failure"));
     }
 
-    @Test(timeOut = 60_000, enabled = false)
+    @Test(timeOut = 60_000)
     public void testCreateUnbucketedTableWithGroupedExecution()
             throws Exception
     {
@@ -218,7 +218,7 @@ public class TestHiveRecoverableGroupedExecution
                         "DROP TABLE IF EXISTS test_failure"));
     }
 
-    @Test(timeOut = 60_000, enabled = false)
+    @Test(timeOut = 60_000)
     public void testInsertUnbucketedTableWithGroupedExecution()
             throws Exception
     {
@@ -260,7 +260,7 @@ public class TestHiveRecoverableGroupedExecution
                         "DROP TABLE IF EXISTS test_failure"));
     }
 
-    @Test(timeOut = 60_000, enabled = false)
+    @Test(timeOut = 60_000)
     public void testScanFilterProjectionOnlyQueryOnUnbucketedTable()
             throws Exception
     {


### PR DESCRIPTION
This would resolve a deadlock for the following scenario:

- SqlStageExecution#updateTaskStatus calls FixedSourcePartitionedScheduler#recover
- FixedSourcePartitionedScheduler#schedule calls SqlStageExecution#scheduleSplits

However, in SqlStageExecution, both updateTaskStatus and scheduleSplits
are synchronized, while in FixedSourcePartitionedScheduler, both
schedule and recover are both synchronized. Thus there is a
deadlock.

Instead of making schedule() and recover() synchronized, we could
do recover job at the begining of schedule(). We use a non-blocking
synchronous queue to store the tasks to be recovered, and make
recover() to be the producer and schedule() to be the consumer
of the queue.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
