### PR TITLE
Improve BatchStreamReader - Part 1

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
@@ -144,12 +144,11 @@ public class OrcBatchPageSource
 
             Block[] blocks = new Block[hiveColumnIndexes.length];
             for (int fieldId = 0; fieldId < blocks.length; fieldId++) {
-                Type type = types.get(fieldId);
                 if (constantBlocks[fieldId] != null) {
                     blocks[fieldId] = constantBlocks[fieldId].getRegion(0, batchSize);
                 }
                 else {
-                    blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(hiveColumnIndexes[fieldId], type));
+                    blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(hiveColumnIndexes[fieldId]));
                 }
             }
             return new Page(batchSize, blocks);
@@ -220,13 +219,11 @@ public class OrcBatchPageSource
     {
         private final int expectedBatchId = batchId;
         private final int columnIndex;
-        private final Type type;
         private boolean loaded;
 
-        public OrcBlockLoader(int columnIndex, Type type)
+        public OrcBlockLoader(int columnIndex)
         {
             this.columnIndex = columnIndex;
-            this.type = requireNonNull(type, "type is null");
         }
 
         @Override
@@ -239,7 +236,7 @@ public class OrcBatchPageSource
             checkState(batchId == expectedBatchId);
 
             try {
-                Block block = recordReader.readBlock(type, columnIndex);
+                Block block = recordReader.readBlock(columnIndex);
                 lazyBlock.setBlock(block);
             }
             catch (OrcCorruptionException e) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.AbstractIterator;
-import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 
 import java.io.IOException;
@@ -44,12 +43,13 @@ import static org.joda.time.DateTimeZone.UTC;
 public class TempFileReader
         extends AbstractIterator<Page>
 {
-    private final List<Type> types;
+    private final int columnCount;
     private final OrcBatchRecordReader reader;
 
     public TempFileReader(List<Type> types, OrcDataSource dataSource)
     {
-        this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+        requireNonNull(types, "types is null");
+        this.columnCount = types.size();
 
         try {
             OrcReader orcReader = new OrcReader(
@@ -91,9 +91,9 @@ public class TempFileReader
                 return endOfData();
             }
 
-            Block[] blocks = new Block[types.size()];
-            for (int i = 0; i < types.size(); i++) {
-                blocks[i] = reader.readBlock(types.get(i), i).getLoadedBlock();
+            Block[] blocks = new Block[columnCount];
+            for (int i = 0; i < columnCount; i++) {
+                blocks[i] = reader.readBlock(i).getLoadedBlock();
             }
             return new Page(batchSize, blocks);
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -348,6 +348,11 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
     {
         try (Closer closer = Closer.create()) {
             closer.register(orcDataSource);
+            for (StreamReader column : streamReaders) {
+                if (column != null) {
+                    closer.register(column::close);
+                }
+            }
         }
 
         if (writeChecksumBuilder.isPresent()) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
@@ -76,7 +76,7 @@ public class OrcBatchRecordReader
                 // doesn't have a local buffer. All non-leaf level StreamReaders' (e.g. MapStreamReader, LongStreamReader,
                 // ListStreamReader and StructStreamReader) instance sizes were not counted, because calling setBytes() in
                 // their constructors is confusing.
-                createStreamReaders(orcDataSource, types, hiveStorageTimeZone, includedColumns),
+                createStreamReaders(orcDataSource, types, hiveStorageTimeZone, includedColumns, systemMemoryUsage.newAggregatedMemoryContext()),
                 predicate,
                 numberOfRows,
                 fileStripes,
@@ -157,7 +157,8 @@ public class OrcBatchRecordReader
             OrcDataSource orcDataSource,
             List<OrcType> types,
             DateTimeZone hiveStorageTimeZone,
-            Map<Integer, Type> includedColumns)
+            Map<Integer, Type> includedColumns,
+            AggregatedMemoryContext systemMemoryContext)
             throws OrcCorruptionException
     {
         List<StreamDescriptor> streamDescriptors = createStreamDescriptor("", "", 0, types, orcDataSource).getNestedStreams();
@@ -169,7 +170,7 @@ public class OrcBatchRecordReader
                 Type type = includedColumns.get(columnId);
                 if (type != null) {
                     StreamDescriptor streamDescriptor = streamDescriptors.get(columnId);
-                    streamReaders[columnId] = BatchStreamReaders.createStreamReader(type, streamDescriptor, hiveStorageTimeZone);
+                    streamReaders[columnId] = BatchStreamReaders.createStreamReader(type, streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
                 }
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
@@ -67,6 +67,8 @@ public class OrcBatchRecordReader
             Optional<OrcWriteValidation> writeValidation,
             int initialBatchSize,
             StripeMetadataSource stripeMetadataSource)
+            throws OrcCorruptionException
+
     {
         super(includedColumns,
                 // The streamReadersSystemMemoryContext covers the StreamReader local buffer sizes, plus leaf node StreamReaders'
@@ -120,10 +122,10 @@ public class OrcBatchRecordReader
         return batchSize;
     }
 
-    public Block readBlock(Type type, int columnIndex)
+    public Block readBlock(int columnIndex)
             throws IOException
     {
-        Block block = getStreamReaders()[columnIndex].readBlock(type);
+        Block block = getStreamReaders()[columnIndex].readBlock();
         updateMaxCombinedBytesPerRow(columnIndex, block);
         return block;
     }
@@ -144,7 +146,7 @@ public class OrcBatchRecordReader
         if (shouldValidateWritePageChecksum()) {
             Block[] blocks = new Block[getStreamReaders().length];
             for (int columnIndex = 0; columnIndex < getStreamReaders().length; columnIndex++) {
-                blocks[columnIndex] = readBlock(includedColumns.get(columnIndex), columnIndex);
+                blocks[columnIndex] = readBlock(columnIndex);
             }
             Page page = new Page(batchSize, blocks);
             validateWritePageChecksum(page);
@@ -156,6 +158,7 @@ public class OrcBatchRecordReader
             List<OrcType> types,
             DateTimeZone hiveStorageTimeZone,
             Map<Integer, Type> includedColumns)
+            throws OrcCorruptionException
     {
         List<StreamDescriptor> streamDescriptors = createStreamDescriptor("", "", 0, types, orcDataSource).getNestedStreams();
 
@@ -163,8 +166,11 @@ public class OrcBatchRecordReader
         BatchStreamReader[] streamReaders = new BatchStreamReader[rowType.getFieldCount()];
         for (int columnId = 0; columnId < rowType.getFieldCount(); columnId++) {
             if (includedColumns.containsKey(columnId)) {
-                StreamDescriptor streamDescriptor = streamDescriptors.get(columnId);
-                streamReaders[columnId] = BatchStreamReaders.createStreamReader(streamDescriptor, hiveStorageTimeZone);
+                Type type = includedColumns.get(columnId);
+                if (type != null) {
+                    StreamDescriptor streamDescriptor = streamDescriptors.get(columnId);
+                    streamReaders[columnId] = BatchStreamReaders.createStreamReader(type, streamDescriptor, hiveStorageTimeZone);
+                }
             }
         }
         return streamReaders;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -153,6 +153,7 @@ public class OrcReader
     }
 
     public OrcBatchRecordReader createBatchRecordReader(Map<Integer, Type> includedColumns, OrcPredicate predicate, DateTimeZone hiveStorageTimeZone, AggregatedMemoryContext systemMemoryUsage, int initialBatchSize)
+            throws OrcCorruptionException
     {
         return createBatchRecordReader(includedColumns, predicate, 0, orcDataSource.getSize(), hiveStorageTimeZone, systemMemoryUsage, initialBatchSize);
     }
@@ -165,6 +166,7 @@ public class OrcReader
             DateTimeZone hiveStorageTimeZone,
             AggregatedMemoryContext systemMemoryUsage,
             int initialBatchSize)
+            throws OrcCorruptionException
     {
         return new OrcBatchRecordReader(
                 requireNonNull(includedColumns, "includedColumns is null"),

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReader.java
@@ -14,14 +14,13 @@
 package com.facebook.presto.orc.reader;
 
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.type.Type;
 
 import java.io.IOException;
 
 public interface BatchStreamReader
         extends StreamReader
 {
-    Block readBlock(Type type)
+    Block readBlock()
             throws IOException;
 
     void prepareNextRead(int batchSize);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.spi.type.Type;
@@ -24,19 +25,19 @@ public final class BatchStreamReaders
     {
     }
 
-    public static BatchStreamReader createStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+    public static BatchStreamReader createStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone, AggregatedMemoryContext systemMemoryContext)
             throws OrcCorruptionException
     {
         switch (streamDescriptor.getOrcTypeKind()) {
             case BOOLEAN:
-                return new BooleanBatchStreamReader(type, streamDescriptor);
+                return new BooleanBatchStreamReader(type, streamDescriptor, systemMemoryContext.newLocalMemoryContext(BatchStreamReaders.class.getSimpleName()));
             case BYTE:
-                return new ByteBatchStreamReader(type, streamDescriptor);
+                return new ByteBatchStreamReader(type, streamDescriptor, systemMemoryContext.newLocalMemoryContext(BatchStreamReaders.class.getSimpleName()));
             case SHORT:
             case INT:
             case LONG:
             case DATE:
-                return new LongBatchStreamReader(type, streamDescriptor);
+                return new LongBatchStreamReader(type, streamDescriptor, systemMemoryContext);
             case FLOAT:
                 return new FloatBatchStreamReader(type, streamDescriptor);
             case DOUBLE:
@@ -45,15 +46,15 @@ public final class BatchStreamReaders
             case STRING:
             case VARCHAR:
             case CHAR:
-                return new SliceBatchStreamReader(type, streamDescriptor);
+                return new SliceBatchStreamReader(type, streamDescriptor, systemMemoryContext);
             case TIMESTAMP:
                 return new TimestampBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
             case LIST:
-                return new ListBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
+                return new ListBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
             case STRUCT:
-                return new StructBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
+                return new StructBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
             case MAP:
-                return new MapBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
+                return new MapBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
             case DECIMAL:
                 return new DecimalBatchStreamReader(type, streamDescriptor);
             case UNION:

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
@@ -13,7 +13,9 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTimeZone;
 
 public final class BatchStreamReaders
@@ -22,39 +24,38 @@ public final class BatchStreamReaders
     {
     }
 
-    public static BatchStreamReader createStreamReader(
-            StreamDescriptor streamDescriptor,
-            DateTimeZone hiveStorageTimeZone)
+    public static BatchStreamReader createStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+            throws OrcCorruptionException
     {
         switch (streamDescriptor.getOrcTypeKind()) {
             case BOOLEAN:
-                return new BooleanBatchStreamReader(streamDescriptor);
+                return new BooleanBatchStreamReader(type, streamDescriptor);
             case BYTE:
-                return new ByteBatchStreamReader(streamDescriptor);
+                return new ByteBatchStreamReader(type, streamDescriptor);
             case SHORT:
             case INT:
             case LONG:
             case DATE:
-                return new LongBatchStreamReader(streamDescriptor);
+                return new LongBatchStreamReader(type, streamDescriptor);
             case FLOAT:
-                return new FloatBatchStreamReader(streamDescriptor);
+                return new FloatBatchStreamReader(type, streamDescriptor);
             case DOUBLE:
-                return new DoubleBatchStreamReader(streamDescriptor);
+                return new DoubleBatchStreamReader(type, streamDescriptor);
             case BINARY:
             case STRING:
             case VARCHAR:
             case CHAR:
-                return new SliceBatchStreamReader(streamDescriptor);
+                return new SliceBatchStreamReader(type, streamDescriptor);
             case TIMESTAMP:
-                return new TimestampBatchStreamReader(streamDescriptor, hiveStorageTimeZone);
+                return new TimestampBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
             case LIST:
-                return new ListBatchStreamReader(streamDescriptor, hiveStorageTimeZone);
+                return new ListBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
             case STRUCT:
-                return new StructBatchStreamReader(streamDescriptor, hiveStorageTimeZone);
+                return new StructBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
             case MAP:
-                return new MapBatchStreamReader(streamDescriptor, hiveStorageTimeZone);
+                return new MapBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
             case DECIMAL:
-                return new DecimalBatchStreamReader(streamDescriptor);
+                return new DecimalBatchStreamReader(type, streamDescriptor);
             case UNION:
             default:
                 throw new IllegalArgumentException("Unsupported type: " + streamDescriptor.getOrcTypeKind());

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanBatchStreamReader.java
@@ -20,7 +20,7 @@ import com.facebook.presto.orc.stream.BooleanInputStream;
 import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.ByteArrayBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.Type;
@@ -30,13 +30,17 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.minNonNullValueSize;
+import static com.facebook.presto.orc.reader.ReaderUtils.unpackByteNulls;
 import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public class BooleanBatchStreamReader
@@ -58,6 +62,8 @@ public class BooleanBatchStreamReader
     private BooleanInputStream dataStream;
 
     private boolean rowGroupOpen;
+
+    private byte[] nonNullValueTemp = new byte[0];
 
     public BooleanBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
             throws OrcCorruptionException
@@ -104,28 +110,58 @@ public class BooleanBatchStreamReader
             return nullValueBlock;
         }
 
-        BlockBuilder builder = BOOLEAN.createBlockBuilder(null, nextBatchSize);
-        if (presentStream == null) {
-            if (dataStream == null) {
-                throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
+        Block block;
+        if (dataStream == null) {
+            if (presentStream == null) {
+                throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is null but present stream is missing");
             }
-            dataStream.getSetBits(BOOLEAN, nextBatchSize, builder);
+            presentStream.skip(nextBatchSize);
+            block = RunLengthEncodedBlock.create(BOOLEAN, null, nextBatchSize);
+        }
+        else if (presentStream == null) {
+            block = readNonNullBlock();
         }
         else {
-            for (int i = 0; i < nextBatchSize; i++) {
-                if (presentStream.nextBit()) {
-                    BOOLEAN.writeBoolean(builder, dataStream.nextBit());
-                }
-                else {
-                    builder.appendNull();
-                }
+            boolean[] isNull = new boolean[nextBatchSize];
+            int nullCount = presentStream.getUnsetBits(nextBatchSize, isNull);
+            if (nullCount == 0) {
+                block = readNonNullBlock();
+            }
+            else if (nullCount != nextBatchSize) {
+                block = readNullBlock(isNull, nextBatchSize - nullCount);
+            }
+            else {
+                block = RunLengthEncodedBlock.create(BOOLEAN, null, nextBatchSize);
             }
         }
-
         readOffset = 0;
         nextBatchSize = 0;
 
-        return builder.build();
+        return block;
+    }
+
+    private Block readNonNullBlock()
+            throws IOException
+    {
+        verify(dataStream != null);
+        byte[] values = dataStream.getSetBits(nextBatchSize);
+        return new ByteArrayBlock(nextBatchSize, Optional.empty(), values);
+    }
+
+    private Block readNullBlock(boolean[] isNull, int nonNullCount)
+            throws IOException
+    {
+        verify(dataStream != null);
+        int minNonNullValueSize = minNonNullValueSize(nonNullCount);
+        if (nonNullValueTemp.length < minNonNullValueSize) {
+            nonNullValueTemp = new byte[minNonNullValueSize];
+        }
+
+        dataStream.getSetBits(nonNullCount, nonNullValueTemp);
+
+        byte[] result = unpackByteNulls(nonNullValueTemp, isNull);
+
+        return new ByteArrayBlock(nextBatchSize, Optional.of(isNull), result);
     }
 
     private void openRowGroup()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteBatchStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
@@ -41,6 +42,7 @@ import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStr
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
 public class ByteBatchStreamReader
@@ -65,12 +67,15 @@ public class ByteBatchStreamReader
 
     private byte[] nonNullValueTemp = new byte[0];
 
-    public ByteBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
+    private final LocalMemoryContext systemMemoryContext;
+
+    public ByteBatchStreamReader(Type type, StreamDescriptor streamDescriptor, LocalMemoryContext systemMemoryContext)
             throws OrcCorruptionException
     {
         requireNonNull(type, "type is null");
         verifyStreamType(streamDescriptor, type, TinyintType.class::isInstance);
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
+        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
     }
 
     @Override
@@ -148,6 +153,7 @@ public class ByteBatchStreamReader
         int minNonNullValueSize = minNonNullValueSize(nonNullCount);
         if (nonNullValueTemp.length < minNonNullValueSize) {
             nonNullValueTemp = new byte[minNonNullValueSize];
+            systemMemoryContext.setBytes(sizeOf(nonNullValueTemp));
         }
 
         dataStream.next(nonNullValueTemp, nonNullCount);
@@ -202,6 +208,13 @@ public class ByteBatchStreamReader
         return toStringHelper(this)
                 .addValue(streamDescriptor)
                 .toString();
+    }
+
+    @Override
+    public void close()
+    {
+        systemMemoryContext.close();
+        nonNullValueTemp = null;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteBatchStreamReader.java
@@ -21,7 +21,7 @@ import com.facebook.presto.orc.stream.ByteInputStream;
 import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.ByteArrayBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.TinyintType;
 import com.facebook.presto.spi.type.Type;
@@ -31,13 +31,16 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.minNonNullValueSize;
 import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public class ByteBatchStreamReader
@@ -59,6 +62,8 @@ public class ByteBatchStreamReader
     private ByteInputStream dataStream;
 
     private boolean rowGroupOpen;
+
+    private byte[] nonNullValueTemp = new byte[0];
 
     public ByteBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
             throws OrcCorruptionException
@@ -91,42 +96,65 @@ public class ByteBatchStreamReader
             }
             if (readOffset > 0) {
                 if (dataStream == null) {
-                    throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
+                    throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is missing");
                 }
                 dataStream.skip(readOffset);
             }
         }
 
-        if (dataStream == null && presentStream != null) {
-            presentStream.skip(nextBatchSize);
-            Block nullValueBlock = RunLengthEncodedBlock.create(TINYINT, null, nextBatchSize);
-            readOffset = 0;
-            nextBatchSize = 0;
-            return nullValueBlock;
-        }
-
-        BlockBuilder builder = TINYINT.createBlockBuilder(null, nextBatchSize);
-        if (presentStream == null) {
-            if (dataStream == null) {
-                throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
+        Block block;
+        if (dataStream == null) {
+            if (presentStream == null) {
+                throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is null but present stream is missing");
             }
-            dataStream.nextVector(TINYINT, nextBatchSize, builder);
+            presentStream.skip(nextBatchSize);
+            block = RunLengthEncodedBlock.create(TINYINT, null, nextBatchSize);
+        }
+        else if (presentStream == null) {
+            block = readNonNullBlock();
         }
         else {
-            for (int i = 0; i < nextBatchSize; i++) {
-                if (presentStream.nextBit()) {
-                    TINYINT.writeLong(builder, dataStream.next());
-                }
-                else {
-                    builder.appendNull();
-                }
+            boolean[] isNull = new boolean[nextBatchSize];
+            int nullCount = presentStream.getUnsetBits(nextBatchSize, isNull);
+            if (nullCount == 0) {
+                block = readNonNullBlock();
+            }
+            else if (nullCount != nextBatchSize) {
+                block = readNullBlock(isNull, nextBatchSize - nullCount);
+            }
+            else {
+                block = RunLengthEncodedBlock.create(TINYINT, null, nextBatchSize);
             }
         }
 
         readOffset = 0;
         nextBatchSize = 0;
 
-        return builder.build();
+        return block;
+    }
+
+    private Block readNonNullBlock()
+            throws IOException
+    {
+        verify(dataStream != null);
+        byte[] values = dataStream.next(nextBatchSize);
+        return new ByteArrayBlock(nextBatchSize, Optional.empty(), values);
+    }
+
+    private Block readNullBlock(boolean[] isNull, int nonNullCount)
+            throws IOException
+    {
+        verify(dataStream != null);
+        int minNonNullValueSize = minNonNullValueSize(nonNullCount);
+        if (nonNullValueTemp.length < minNonNullValueSize) {
+            nonNullValueTemp = new byte[minNonNullValueSize];
+        }
+
+        dataStream.next(nonNullValueTemp, nonNullCount);
+
+        byte[] result = ReaderUtils.unpackByteNulls(nonNullValueTemp, isNull);
+
+        return new ByteArrayBlock(nextBatchSize, Optional.of(isNull), result);
     }
 
     private void openRowGroup()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DecimalBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DecimalBatchStreamReader.java
@@ -238,6 +238,11 @@ public class DecimalBatchStreamReader
     }
 
     @Override
+    public void close()
+    {
+    }
+
+    @Override
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleBatchStreamReader.java
@@ -177,6 +177,11 @@ public class DoubleBatchStreamReader
     }
 
     @Override
+    public void close()
+    {
+    }
+
+    @Override
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleBatchStreamReader.java
@@ -23,6 +23,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -33,7 +34,9 @@ import java.util.List;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
@@ -57,8 +60,11 @@ public class DoubleBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public DoubleBatchStreamReader(StreamDescriptor streamDescriptor)
+    public DoubleBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, DoubleType.class::isInstance);
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
     }
 
@@ -70,7 +76,7 @@ public class DoubleBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
@@ -93,23 +99,23 @@ public class DoubleBatchStreamReader
 
         if (dataStream == null && presentStream != null) {
             presentStream.skip(nextBatchSize);
-            Block nullValueBlock = RunLengthEncodedBlock.create(type, null, nextBatchSize);
+            Block nullValueBlock = RunLengthEncodedBlock.create(DOUBLE, null, nextBatchSize);
             readOffset = 0;
             nextBatchSize = 0;
             return nullValueBlock;
         }
 
-        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
+        BlockBuilder builder = DOUBLE.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
             }
-            dataStream.nextVector(type, nextBatchSize, builder);
+            dataStream.nextVector(DOUBLE, nextBatchSize, builder);
         }
         else {
             for (int i = 0; i < nextBatchSize; i++) {
                 if (presentStream.nextBit()) {
-                    type.writeDouble(builder, dataStream.next());
+                    DOUBLE.writeDouble(builder, dataStream.next());
                 }
                 else {
                     builder.appendNull();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatBatchStreamReader.java
@@ -178,6 +178,11 @@ public class FloatBatchStreamReader
     }
 
     @Override
+    public void close()
+    {
+    }
+
+    @Override
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatBatchStreamReader.java
@@ -23,6 +23,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.RealType;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -33,7 +34,9 @@ import java.util.List;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.lang.Float.floatToRawIntBits;
 import static java.util.Objects.requireNonNull;
@@ -58,8 +61,11 @@ public class FloatBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public FloatBatchStreamReader(StreamDescriptor streamDescriptor)
+    public FloatBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, RealType.class::isInstance);
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
     }
 
@@ -71,7 +77,7 @@ public class FloatBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
@@ -94,23 +100,23 @@ public class FloatBatchStreamReader
 
         if (dataStream == null && presentStream != null) {
             presentStream.skip(nextBatchSize);
-            Block nullValueBlock = RunLengthEncodedBlock.create(type, null, nextBatchSize);
+            Block nullValueBlock = RunLengthEncodedBlock.create(REAL, null, nextBatchSize);
             readOffset = 0;
             nextBatchSize = 0;
             return nullValueBlock;
         }
 
-        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
+        BlockBuilder builder = REAL.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
             }
-            dataStream.nextVector(type, nextBatchSize, builder);
+            dataStream.nextVector(REAL, nextBatchSize, builder);
         }
         else {
             for (int i = 0; i < nextBatchSize; i++) {
                 if (presentStream.nextBit()) {
-                    type.writeLong(builder, floatToRawIntBits(dataStream.next()));
+                    REAL.writeLong(builder, floatToRawIntBits(dataStream.next()));
                 }
                 else {
                     builder.appendNull();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListBatchStreamReader.java
@@ -36,6 +36,8 @@ import java.util.Optional;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.BatchStreamReaders.createStreamReader;
+import static com.facebook.presto.orc.reader.ReaderUtils.convertLengthVectorToOffsetVector;
+import static com.facebook.presto.orc.reader.ReaderUtils.unpackLengthNulls;
 import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -122,18 +124,12 @@ public class ListBatchStreamReader
                 if (lengthStream == null) {
                     throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
                 }
-                lengthStream.nextIntVector(nextBatchSize, offsetVector, 0, nullVector);
+                lengthStream.nextIntVector(nextBatchSize - nullValues, offsetVector, 0, nullVector);
+                unpackLengthNulls(offsetVector, nullVector, nextBatchSize - nullValues);
             }
         }
 
-        // Convert the length values in the offsetVector to offset values in place
-        int currentLength = offsetVector[0];
-        offsetVector[0] = 0;
-        for (int i = 1; i < offsetVector.length; i++) {
-            int nextLength = offsetVector[i];
-            offsetVector[i] = offsetVector[i - 1] + currentLength;
-            currentLength = nextLength;
-        }
+        convertLengthVectorToOffsetVector(offsetVector);
 
         int elementCount = offsetVector[offsetVector.length - 1];
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListBatchStreamReader.java
@@ -22,6 +22,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.block.ArrayBlock;
 import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
@@ -35,6 +36,7 @@ import java.util.Optional;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.BatchStreamReaders.createStreamReader;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.lang.Math.toIntExact;
@@ -45,6 +47,7 @@ public class ListBatchStreamReader
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ListBatchStreamReader.class).instanceSize();
 
+    private final Type elementType;
     private final StreamDescriptor streamDescriptor;
 
     private final BatchStreamReader elementStreamReader;
@@ -62,10 +65,14 @@ public class ListBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public ListBatchStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+    public ListBatchStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, ArrayType.class::isInstance);
+        elementType = ((ArrayType) type).getElementType();
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        this.elementStreamReader = createStreamReader(streamDescriptor.getNestedStreams().get(0), hiveStorageTimeZone);
+        this.elementStreamReader = createStreamReader(elementType, streamDescriptor.getNestedStreams().get(0), hiveStorageTimeZone);
     }
 
     @Override
@@ -76,7 +83,7 @@ public class ListBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
@@ -128,13 +135,12 @@ public class ListBatchStreamReader
             currentLength = nextLength;
         }
 
-        Type elementType = type.getTypeParameters().get(0);
         int elementCount = offsetVector[offsetVector.length - 1];
 
         Block elements;
         if (elementCount > 0) {
             elementStreamReader.prepareNextRead(elementCount);
-            elements = elementStreamReader.readBlock(elementType);
+            elements = elementStreamReader.readBlock();
         }
         else {
             elements = elementType.createBlockBuilder(null, 0).build();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListBatchStreamReader.java
@@ -115,7 +115,7 @@ public class ListBatchStreamReader
             if (lengthStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
             }
-            lengthStream.nextIntVector(nextBatchSize, offsetVector, 0);
+            lengthStream.next(offsetVector, nextBatchSize);
         }
         else {
             nullVector = new boolean[nextBatchSize];
@@ -124,7 +124,7 @@ public class ListBatchStreamReader
                 if (lengthStream == null) {
                     throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
                 }
-                lengthStream.nextIntVector(nextBatchSize - nullValues, offsetVector, 0, nullVector);
+                lengthStream.next(offsetVector, nextBatchSize - nullValues);
                 unpackLengthNulls(offsetVector, nullVector, nextBatchSize - nullValues);
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongBatchStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
@@ -41,11 +42,12 @@ public class LongBatchStreamReader
     private final LongDictionaryBatchStreamReader dictionaryReader;
     private BatchStreamReader currentReader;
 
-    public LongBatchStreamReader(StreamDescriptor streamDescriptor)
+    public LongBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
+            throws OrcCorruptionException
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        directReader = new LongDirectBatchStreamReader(streamDescriptor);
-        dictionaryReader = new LongDictionaryBatchStreamReader(streamDescriptor);
+        directReader = new LongDirectBatchStreamReader(type, streamDescriptor);
+        dictionaryReader = new LongDictionaryBatchStreamReader(type, streamDescriptor);
     }
 
     @Override
@@ -55,10 +57,10 @@ public class LongBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
-        return currentReader.readBlock(type);
+        return currentReader.readBlock();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryBatchStreamReader.java
@@ -22,6 +22,10 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.DateType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.SmallintType;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -34,6 +38,7 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.IN_DICTIONARY;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -44,6 +49,7 @@ public class LongDictionaryBatchStreamReader
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongDictionaryBatchStreamReader.class).instanceSize();
 
+    private final Type type;
     private final StreamDescriptor streamDescriptor;
 
     private int readOffset;
@@ -68,8 +74,12 @@ public class LongDictionaryBatchStreamReader
     private boolean dictionaryOpen;
     private boolean rowGroupOpen;
 
-    public LongDictionaryBatchStreamReader(StreamDescriptor streamDescriptor)
+    public LongDictionaryBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, t -> t instanceof BigintType || t instanceof IntegerType || t instanceof SmallintType || t instanceof DateType);
+        this.type = type;
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
     }
 
@@ -81,7 +91,7 @@ public class LongDictionaryBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryBatchStreamReader.java
@@ -188,7 +188,7 @@ public class LongDictionaryBatchStreamReader
             if (dictionaryStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Dictionary is not empty but data stream is not present");
             }
-            dictionaryStream.nextLongVector(dictionarySize, dictionary);
+            dictionaryStream.next(dictionary, dictionarySize);
         }
         dictionaryOpen = true;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectBatchStreamReader.java
@@ -21,8 +21,10 @@ import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.IntArrayBlock;
+import com.facebook.presto.spi.block.LongArrayBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.block.ShortArrayBlock;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.DateType;
 import com.facebook.presto.spi.type.IntegerType;
@@ -34,12 +36,18 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.minNonNullValueSize;
+import static com.facebook.presto.orc.reader.ReaderUtils.unpackIntNulls;
+import static com.facebook.presto.orc.reader.ReaderUtils.unpackLongNulls;
+import static com.facebook.presto.orc.reader.ReaderUtils.unpackShortNulls;
 import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public class LongDirectBatchStreamReader
@@ -62,6 +70,11 @@ public class LongDirectBatchStreamReader
     private LongInputStream dataStream;
 
     private boolean rowGroupOpen;
+
+    // only one of the three arrays will be used
+    private short[] shortNonNullValueTemp = new short[0];
+    private int[] intNonNullValueTemp = new int[0];
+    private long[] longNonNullValueTemp = new long[0];
 
     public LongDirectBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
             throws OrcCorruptionException
@@ -95,42 +108,125 @@ public class LongDirectBatchStreamReader
             }
             if (readOffset > 0) {
                 if (dataStream == null) {
-                    throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
+                    throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is missing");
                 }
                 dataStream.skip(readOffset);
             }
         }
 
-        if (dataStream == null && presentStream != null) {
-            presentStream.skip(nextBatchSize);
-            Block nullValueBlock = RunLengthEncodedBlock.create(type, null, nextBatchSize);
-            readOffset = 0;
-            nextBatchSize = 0;
-            return nullValueBlock;
-        }
-
-        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
-        if (presentStream == null) {
-            if (dataStream == null) {
-                throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
+        Block block;
+        if (dataStream == null) {
+            if (presentStream == null) {
+                throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is null but present stream is missing");
             }
-            dataStream.nextLongVector(type, nextBatchSize, builder);
+            presentStream.skip(nextBatchSize);
+            block = RunLengthEncodedBlock.create(type, null, nextBatchSize);
+        }
+        else if (presentStream == null) {
+            block = readNonNullBlock();
         }
         else {
-            for (int i = 0; i < nextBatchSize; i++) {
-                if (presentStream.nextBit()) {
-                    type.writeLong(builder, dataStream.next());
-                }
-                else {
-                    builder.appendNull();
-                }
+            boolean[] isNull = new boolean[nextBatchSize];
+            int nullCount = presentStream.getUnsetBits(nextBatchSize, isNull);
+            if (nullCount == 0) {
+                block = readNonNullBlock();
+            }
+            else if (nullCount != nextBatchSize) {
+                block = readNullBlock(isNull, nextBatchSize - nullCount);
+            }
+            else {
+                block = RunLengthEncodedBlock.create(type, null, nextBatchSize);
             }
         }
-
         readOffset = 0;
         nextBatchSize = 0;
 
-        return builder.build();
+        return block;
+    }
+
+    private Block readNonNullBlock()
+            throws IOException
+    {
+        verify(dataStream != null);
+        if (type instanceof BigintType) {
+            long[] values = new long[nextBatchSize];
+            dataStream.next(values, nextBatchSize);
+            return new LongArrayBlock(nextBatchSize, Optional.empty(), values);
+        }
+        if (type instanceof IntegerType || type instanceof DateType) {
+            int[] values = new int[nextBatchSize];
+            dataStream.next(values, nextBatchSize);
+            return new IntArrayBlock(nextBatchSize, Optional.empty(), values);
+        }
+        if (type instanceof SmallintType) {
+            short[] values = new short[nextBatchSize];
+            dataStream.next(values, nextBatchSize);
+            return new ShortArrayBlock(nextBatchSize, Optional.empty(), values);
+        }
+        throw new VerifyError("Unsupported type " + type);
+    }
+
+    private Block readNullBlock(boolean[] isNull, int nonNullCount)
+            throws IOException
+    {
+        if (type instanceof BigintType) {
+            return longReadNullBlock(isNull, nonNullCount);
+        }
+        if (type instanceof IntegerType || type instanceof DateType) {
+            return intReadNullBlock(isNull, nonNullCount);
+        }
+        if (type instanceof SmallintType) {
+            return shortReadNullBlock(isNull, nonNullCount);
+        }
+        throw new VerifyError("Unsupported type " + type);
+    }
+
+    private Block longReadNullBlock(boolean[] isNull, int nonNullCount)
+            throws IOException
+    {
+        verify(dataStream != null);
+        int minNonNullValueSize = minNonNullValueSize(nonNullCount);
+        if (longNonNullValueTemp.length < minNonNullValueSize) {
+            longNonNullValueTemp = new long[minNonNullValueSize];
+        }
+
+        dataStream.next(longNonNullValueTemp, nonNullCount);
+
+        long[] result = unpackLongNulls(longNonNullValueTemp, isNull);
+
+        return new LongArrayBlock(nextBatchSize, Optional.of(isNull), result);
+    }
+
+    private Block intReadNullBlock(boolean[] isNull, int nonNullCount)
+            throws IOException
+    {
+        verify(dataStream != null);
+        int minNonNullValueSize = minNonNullValueSize(nonNullCount);
+        if (intNonNullValueTemp.length < minNonNullValueSize) {
+            intNonNullValueTemp = new int[minNonNullValueSize];
+        }
+
+        dataStream.next(intNonNullValueTemp, nonNullCount);
+
+        int[] result = unpackIntNulls(intNonNullValueTemp, isNull);
+
+        return new IntArrayBlock(nextBatchSize, Optional.of(isNull), result);
+    }
+
+    private Block shortReadNullBlock(boolean[] isNull, int nonNullCount)
+            throws IOException
+    {
+        verify(dataStream != null);
+        int minNonNullValueSize = minNonNullValueSize(nonNullCount);
+        if (shortNonNullValueTemp.length < minNonNullValueSize) {
+            shortNonNullValueTemp = new short[minNonNullValueSize];
+        }
+
+        dataStream.next(shortNonNullValueTemp, nonNullCount);
+
+        short[] result = unpackShortNulls(shortNonNullValueTemp, isNull);
+
+        return new ShortArrayBlock(nextBatchSize, Optional.of(isNull), result);
     }
 
     private void openRowGroup()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectBatchStreamReader.java
@@ -23,6 +23,10 @@ import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.DateType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.SmallintType;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -33,6 +37,7 @@ import java.util.List;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -42,6 +47,7 @@ public class LongDirectBatchStreamReader
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongDirectBatchStreamReader.class).instanceSize();
 
+    private final Type type;
     private final StreamDescriptor streamDescriptor;
 
     private int readOffset;
@@ -57,8 +63,12 @@ public class LongDirectBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public LongDirectBatchStreamReader(StreamDescriptor streamDescriptor)
+    public LongDirectBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, t -> t instanceof BigintType || t instanceof IntegerType || t instanceof SmallintType || t instanceof DateType);
+        this.type = type;
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
     }
 
@@ -70,7 +80,7 @@ public class LongDirectBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapBatchStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
@@ -42,11 +43,12 @@ public class MapBatchStreamReader
     private final MapFlatBatchStreamReader flatReader;
     private BatchStreamReader currentReader;
 
-    public MapBatchStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+    public MapBatchStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+            throws OrcCorruptionException
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        directReader = new MapDirectBatchStreamReader(streamDescriptor, hiveStorageTimeZone);
-        flatReader = new MapFlatBatchStreamReader(streamDescriptor, hiveStorageTimeZone);
+        this.directReader = new MapDirectBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
+        this.flatReader = new MapFlatBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
     }
 
     @Override
@@ -56,10 +58,10 @@ public class MapBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
-        return currentReader.readBlock(type);
+        return currentReader.readBlock();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapBatchStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
@@ -20,10 +21,12 @@ import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.io.Closer;
 import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
@@ -43,12 +46,12 @@ public class MapBatchStreamReader
     private final MapFlatBatchStreamReader flatReader;
     private BatchStreamReader currentReader;
 
-    public MapBatchStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+    public MapBatchStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone, AggregatedMemoryContext systemMemoryContext)
             throws OrcCorruptionException
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        this.directReader = new MapDirectBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
-        this.flatReader = new MapFlatBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
+        this.directReader = new MapDirectBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
+        this.flatReader = new MapFlatBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone, systemMemoryContext);
     }
 
     @Override
@@ -97,6 +100,18 @@ public class MapBatchStreamReader
         return toStringHelper(this)
                 .addValue(streamDescriptor)
                 .toString();
+    }
+
+    @Override
+    public void close()
+    {
+        try (Closer closer = Closer.create()) {
+            closer.register(directReader::close);
+            closer.register(flatReader::close);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectBatchStreamReader.java
@@ -119,7 +119,7 @@ public class MapDirectBatchStreamReader
             if (lengthStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
             }
-            lengthStream.nextIntVector(nextBatchSize, offsetVector, 0);
+            lengthStream.next(offsetVector, nextBatchSize);
         }
         else {
             nullVector = new boolean[nextBatchSize];
@@ -128,7 +128,7 @@ public class MapDirectBatchStreamReader
                 if (lengthStream == null) {
                     throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
                 }
-                lengthStream.nextIntVector(nextBatchSize - nullValues, offsetVector, 0, nullVector);
+                lengthStream.next(offsetVector, nextBatchSize - nullValues);
                 unpackLengthNulls(offsetVector, nullVector, nextBatchSize - nullValues);
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatBatchStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.DwrfSequenceEncoding;
@@ -47,6 +48,7 @@ import java.util.SortedMap;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.IN_MAP;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -68,6 +70,7 @@ public class MapFlatBatchStreamReader
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapFlatBatchStreamReader.class).instanceSize();
 
+    private final MapType type;
     private final StreamDescriptor streamDescriptor;
     private final DateTimeZone hiveStorageTimeZone;
 
@@ -91,8 +94,12 @@ public class MapFlatBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public MapFlatBatchStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+    public MapFlatBatchStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, MapType.class::isInstance);
+        this.type = (MapType) type;
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
         this.hiveStorageTimeZone = requireNonNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
         this.keyOrcType = streamDescriptor.getNestedStreams().get(0).getOrcTypeKind();
@@ -107,7 +114,7 @@ public class MapFlatBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
@@ -172,7 +179,7 @@ public class MapFlatBatchStreamReader
             if (mapsContainingKey > 0) {
                 BatchStreamReader streamReader = valueStreamReaders.get(keyIndex);
                 streamReader.prepareNextRead(mapsContainingKey);
-                valueBlocks[keyIndex] = streamReader.readBlock(valueType);
+                valueBlocks[keyIndex] = streamReader.readBlock();
             }
             else {
                 valueBlocks[keyIndex] = valueType.createBlockBuilder(null, 0).build();
@@ -241,7 +248,7 @@ public class MapFlatBatchStreamReader
             StreamDescriptor valueStreamDescriptor = copyStreamDescriptorWithSequence(baseValueStreamDescriptor, sequence);
             valueStreamDescriptors.add(valueStreamDescriptor);
 
-            BatchStreamReader valueStreamReader = BatchStreamReaders.createStreamReader(valueStreamDescriptor, hiveStorageTimeZone);
+            BatchStreamReader valueStreamReader = BatchStreamReaders.createStreamReader(type.getValueType(), valueStreamDescriptor, hiveStorageTimeZone);
             valueStreamReader.startStripe(dictionaryStreamSources, encodings);
             valueStreamReaders.add(valueStreamReader);
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.function.Predicate;
+
+final class ReaderUtils
+{
+    private ReaderUtils() {}
+
+    public static void verifyStreamType(StreamDescriptor streamDescriptor, Type actual, Predicate<Type> validTypes)
+            throws OrcCorruptionException
+    {
+        if (validTypes.test(actual)) {
+            return;
+        }
+
+        throw new OrcCorruptionException(
+                streamDescriptor.getOrcDataSourceId(),
+                "Can not read SQL type %s from ORC stream %s of type %s",
+                actual,
+                streamDescriptor.getStreamName(),
+                streamDescriptor.getOrcTypeKind());
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
@@ -19,6 +19,8 @@ import com.facebook.presto.spi.type.Type;
 
 import java.util.function.Predicate;
 
+import static java.lang.Math.max;
+
 final class ReaderUtils
 {
     private ReaderUtils() {}
@@ -36,5 +38,24 @@ final class ReaderUtils
                 actual,
                 streamDescriptor.getStreamName(),
                 streamDescriptor.getOrcTypeKind());
+    }
+
+    public static int minNonNullValueSize(int nonNullCount)
+    {
+        return max(nonNullCount + 1, 1025);
+    }
+
+    public static byte[] unpackByteNulls(byte[] values, boolean[] isNull)
+    {
+        byte[] result = new byte[isNull.length];
+
+        int position = 0;
+        for (int i = 0; i < isNull.length; i++) {
+            result[i] = values[position];
+            if (!isNull[i]) {
+                position++;
+            }
+        }
+        return result;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
@@ -59,6 +59,48 @@ final class ReaderUtils
         return result;
     }
 
+    public static short[] unpackShortNulls(short[] values, boolean[] isNull)
+    {
+        short[] result = new short[isNull.length];
+
+        int position = 0;
+        for (int i = 0; i < isNull.length; i++) {
+            result[i] = values[position];
+            if (!isNull[i]) {
+                position++;
+            }
+        }
+        return result;
+    }
+
+    public static int[] unpackIntNulls(int[] values, boolean[] isNull)
+    {
+        int[] result = new int[isNull.length];
+
+        int position = 0;
+        for (int i = 0; i < isNull.length; i++) {
+            result[i] = values[position];
+            if (!isNull[i]) {
+                position++;
+            }
+        }
+        return result;
+    }
+
+    public static long[] unpackLongNulls(long[] values, boolean[] isNull)
+    {
+        long[] result = new long[isNull.length];
+
+        int position = 0;
+        for (int i = 0; i < isNull.length; i++) {
+            result[i] = values[position];
+            if (!isNull[i]) {
+                position++;
+            }
+        }
+        return result;
+    }
+
     public static void unpackLengthNulls(int[] values, boolean[] isNull, int nonNullCount)
     {
         int nullSuppressedPosition = nonNullCount - 1;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
@@ -58,4 +58,29 @@ final class ReaderUtils
         }
         return result;
     }
+
+    public static void unpackLengthNulls(int[] values, boolean[] isNull, int nonNullCount)
+    {
+        int nullSuppressedPosition = nonNullCount - 1;
+        for (int outputPosition = isNull.length - 1; outputPosition >= 0; outputPosition--) {
+            if (isNull[outputPosition]) {
+                values[outputPosition] = 0;
+            }
+            else {
+                values[outputPosition] = values[nullSuppressedPosition];
+                nullSuppressedPosition--;
+            }
+        }
+    }
+
+    public static void convertLengthVectorToOffsetVector(int[] vector)
+    {
+        int currentLength = vector[0];
+        vector[0] = 0;
+        for (int i = 1; i < vector.length; i++) {
+            int nextLength = vector[i];
+            vector[i] = vector[i - 1] + currentLength;
+            currentLength = nextLength;
+        }
+    }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReader.java
@@ -70,6 +70,4 @@ public interface SelectiveStreamReader
      * Used by list and map readers to raise "subscript out of bounds" error.
      */
     void throwAnyError(int[] positions, int positionCount);
-
-    void close();
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceBatchStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
@@ -20,6 +21,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarbinaryType;
 import com.facebook.presto.spi.type.VarcharType;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
@@ -32,6 +34,7 @@ import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DWRF_DIRECT;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.spi.type.Chars.byteCountWithoutTrailingSpace;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.VarbinaryType.isVarbinaryType;
@@ -50,18 +53,21 @@ public class SliceBatchStreamReader
     private final SliceDictionaryBatchStreamReader dictionaryReader;
     private BatchStreamReader currentReader;
 
-    public SliceBatchStreamReader(StreamDescriptor streamDescriptor)
+    public SliceBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, t -> t instanceof VarcharType || t instanceof CharType || t instanceof VarbinaryType);
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        directReader = new SliceDirectBatchStreamReader(streamDescriptor);
-        dictionaryReader = new SliceDictionaryBatchStreamReader(streamDescriptor);
+        this.directReader = new SliceDirectBatchStreamReader(streamDescriptor, getMaxCodePointCount(type), isCharType(type));
+        this.dictionaryReader = new SliceDictionaryBatchStreamReader(streamDescriptor, getMaxCodePointCount(type), isCharType(type));
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
-        return currentReader.readBlock(type);
+        return currentReader.readBlock();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryBatchStreamReader.java
@@ -143,7 +143,7 @@ public class SliceDictionaryBatchStreamReader
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
             }
             if (inDictionaryStream == null) {
-                dataStream.nextIntVector(nextBatchSize, idsVector, 0);
+                dataStream.next(idsVector, nextBatchSize);
             }
             else {
                 for (int i = 0; i < nextBatchSize; i++) {
@@ -219,7 +219,7 @@ public class SliceDictionaryBatchStreamReader
                 if (lengthStream == null) {
                     throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Dictionary is not empty but dictionary length stream is not present");
                 }
-                lengthStream.nextIntVector(stripeDictionarySize, stripeDictionaryLength, 0);
+                lengthStream.next(stripeDictionaryLength, stripeDictionarySize);
 
                 long dataLength = 0;
                 for (int i = 0; i < stripeDictionarySize; i++) {
@@ -253,7 +253,7 @@ public class SliceDictionaryBatchStreamReader
             }
 
             // read the lengths
-            dictionaryLengthStream.nextIntVector(rowGroupDictionarySize, rowGroupDictionaryLength, 0);
+            dictionaryLengthStream.next(rowGroupDictionaryLength, rowGroupDictionarySize);
             long dataLength = 0;
             for (int i = 0; i < rowGroupDictionarySize; i++) {
                 dataLength += rowGroupDictionaryLength[i];

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectBatchStreamReader.java
@@ -23,6 +23,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.block.VariableWidthBlock;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -38,6 +39,8 @@ import java.util.Optional;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.convertLengthVectorToOffsetVector;
+import static com.facebook.presto.orc.reader.ReaderUtils.unpackLengthNulls;
 import static com.facebook.presto.orc.reader.SliceBatchStreamReader.computeTruncatedLength;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -119,6 +122,17 @@ public class SliceDirectBatchStreamReader
             }
         }
 
+        if (lengthStream == null) {
+            if (presentStream == null) {
+                throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is null but present stream is missing");
+            }
+            presentStream.skip(nextBatchSize);
+            Block nullValueBlock = readAllNullsBlock();
+            readOffset = 0;
+            nextBatchSize = 0;
+            return nullValueBlock;
+        }
+
         // create new isNullVector and offsetVector for VariableWidthBlock
         boolean[] isNullVector = null;
 
@@ -127,35 +141,33 @@ public class SliceDirectBatchStreamReader
         int[] offsetVector = new int[nextBatchSize + 1];
 
         if (presentStream == null) {
-            if (lengthStream == null) {
-                throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but length stream is not present");
-            }
             lengthStream.nextIntVector(nextBatchSize, offsetVector, 0);
         }
         else {
             isNullVector = new boolean[nextBatchSize];
-            int nullValues = presentStream.getUnsetBits(nextBatchSize, isNullVector);
-            if (nullValues != nextBatchSize) {
-                if (lengthStream == null) {
-                    throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but length stream is not present");
-                }
+            int nullCount = presentStream.getUnsetBits(nextBatchSize, isNullVector);
+            if (nullCount == nextBatchSize) {
+                // all nulls
+                Block nullValueBlock = readAllNullsBlock();
+                readOffset = 0;
+                nextBatchSize = 0;
+                return nullValueBlock;
+            }
 
-                if (nullValues == 0) {
-                    isNullVector = null;
-                    lengthStream.nextIntVector(nextBatchSize, offsetVector, 0);
-                }
-                else {
-                    lengthStream.nextIntVector(nextBatchSize, offsetVector, 0, isNullVector);
-                }
+            if (nullCount == 0) {
+                isNullVector = null;
+                lengthStream.nextIntVector(nextBatchSize, offsetVector, 0);
+            }
+            else {
+                lengthStream.nextIntVector(nextBatchSize - nullCount, offsetVector, 0);
+                unpackLengthNulls(offsetVector, isNullVector, nextBatchSize - nullCount);
             }
         }
 
         // Calculate the total length for all entries. Note that the values in the offsetVector are still length values now.
         long totalLength = 0;
         for (int i = 0; i < nextBatchSize; i++) {
-            if (isNullVector == null || !isNullVector[i]) {
-                totalLength += offsetVector[i];
-            }
+            totalLength += offsetVector[i];
         }
 
         int currentBatchSize = nextBatchSize;
@@ -169,41 +181,53 @@ public class SliceDirectBatchStreamReader
                     format("Values in column \"%s\" are too large to process for Presto. %s column values are larger than 1GB [%s]", streamDescriptor.getFieldName(), nextBatchSize, streamDescriptor.getOrcDataSourceId()));
         }
         if (dataStream == null) {
-            throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
+            throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is missing");
         }
 
         // allocate enough space to read
         byte[] data = new byte[toIntExact(totalLength)];
         Slice slice = Slices.wrappedBuffer(data);
 
-        // We do the following operations together in the for loop:
-        // * truncate strings
-        // * convert original length values in offsetVector into truncated offset values
-        int currentLength = offsetVector[0];
-        offsetVector[0] = 0;
-        for (int i = 1; i <= currentBatchSize; i++) {
-            int nextLength = offsetVector[i];
-            if (isNullVector != null && isNullVector[i - 1]) {
-                checkState(currentLength == 0, "Corruption in slice direct stream: length is non-zero for null entry");
-                offsetVector[i] = offsetVector[i - 1];
+        if (maxCodePointCount < 0) {
+            // unbounded, simply read all data in on shot
+            dataStream.next(data, 0, data.length);
+            convertLengthVectorToOffsetVector(offsetVector);
+        }
+        else {
+            // We do the following operations together in the for loop:
+            // * truncate strings
+            // * convert original length values in offsetVector into truncated offset values
+            int currentLength = offsetVector[0];
+            offsetVector[0] = 0;
+            for (int i = 1; i <= currentBatchSize; i++) {
+                int nextLength = offsetVector[i];
+                if (isNullVector != null && isNullVector[i - 1]) {
+                    checkState(currentLength == 0, "Corruption in slice direct stream: length is non-zero for null entry");
+                    offsetVector[i] = offsetVector[i - 1];
+                    currentLength = nextLength;
+                    continue;
+                }
+                int offset = offsetVector[i - 1];
+
+                // read data without truncation
+                dataStream.next(data, offset, offset + currentLength);
+
+                // adjust offsetVector with truncated length
+                int truncatedLength = computeTruncatedLength(slice, offset, currentLength, maxCodePointCount, isCharType);
+                verify(truncatedLength >= 0);
+                offsetVector[i] = offset + truncatedLength;
+
                 currentLength = nextLength;
-                continue;
             }
-            int offset = offsetVector[i - 1];
-
-            // read data without truncation
-            dataStream.next(data, offset, offset + currentLength);
-
-            // adjust offsetVector with truncated length
-            int truncatedLength = computeTruncatedLength(slice, offset, currentLength, maxCodePointCount, isCharType);
-            verify(truncatedLength >= 0);
-            offsetVector[i] = offset + truncatedLength;
-
-            currentLength = nextLength;
         }
 
         // this can lead to over-retention but unlikely to happen given truncation rarely happens
         return new VariableWidthBlock(currentBatchSize, slice, offsetVector, Optional.ofNullable(isNullVector));
+    }
+
+    private RunLengthEncodedBlock readAllNullsBlock()
+    {
+        return new RunLengthEncodedBlock(new VariableWidthBlock(1, EMPTY_SLICE, new int[2], Optional.of(new boolean[] {true})), nextBatchSize);
     }
 
     private void openRowGroup()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectBatchStreamReader.java
@@ -283,6 +283,11 @@ public class SliceDirectBatchStreamReader
     }
 
     @Override
+    public void close()
+    {
+    }
+
+    @Override
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectBatchStreamReader.java
@@ -141,7 +141,7 @@ public class SliceDirectBatchStreamReader
         int[] offsetVector = new int[nextBatchSize + 1];
 
         if (presentStream == null) {
-            lengthStream.nextIntVector(nextBatchSize, offsetVector, 0);
+            lengthStream.next(offsetVector, nextBatchSize);
         }
         else {
             isNullVector = new boolean[nextBatchSize];
@@ -156,10 +156,10 @@ public class SliceDirectBatchStreamReader
 
             if (nullCount == 0) {
                 isNullVector = null;
-                lengthStream.nextIntVector(nextBatchSize, offsetVector, 0);
+                lengthStream.next(offsetVector, nextBatchSize);
             }
             else {
-                lengthStream.nextIntVector(nextBatchSize - nullCount, offsetVector, 0);
+                lengthStream.next(offsetVector, nextBatchSize - nullCount);
                 unpackLengthNulls(offsetVector, isNullVector, nextBatchSize - nullCount);
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectBatchStreamReader.java
@@ -24,7 +24,6 @@ import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.VariableWidthBlock;
-import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
@@ -40,10 +39,8 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.SliceBatchStreamReader.computeTruncatedLength;
-import static com.facebook.presto.orc.reader.SliceBatchStreamReader.getMaxCodePointCount;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -60,6 +57,8 @@ public class SliceDirectBatchStreamReader
     private static final int ONE_GIGABYTE = toIntExact(new DataSize(1, GIGABYTE).toBytes());
 
     private final StreamDescriptor streamDescriptor;
+    private final int maxCodePointCount;
+    private final boolean isCharType;
 
     private int readOffset;
     private int nextBatchSize;
@@ -78,8 +77,10 @@ public class SliceDirectBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public SliceDirectBatchStreamReader(StreamDescriptor streamDescriptor)
+    public SliceDirectBatchStreamReader(StreamDescriptor streamDescriptor, int maxCodePointCount, boolean isCharType)
     {
+        this.maxCodePointCount = maxCodePointCount;
+        this.isCharType = isCharType;
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
     }
 
@@ -91,7 +92,7 @@ public class SliceDirectBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
@@ -180,8 +181,6 @@ public class SliceDirectBatchStreamReader
         // * convert original length values in offsetVector into truncated offset values
         int currentLength = offsetVector[0];
         offsetVector[0] = 0;
-        int maxCodePointCount = getMaxCodePointCount(type);
-        boolean isCharType = isCharType(type);
         for (int i = 1; i <= currentBatchSize; i++) {
             int nextLength = offsetVector[i];
             if (isNullVector != null && isNullVector[i - 1]) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StreamReader.java
@@ -27,5 +27,7 @@ public interface StreamReader
     void startRowGroup(InputStreamSources dataStreamSources)
             throws IOException;
 
+    void close();
+
     long getRetainedSizeInBytes();
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructBatchStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.BooleanInputStream;
@@ -22,7 +23,11 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.RowBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.RowType;
+import com.facebook.presto.spi.type.RowType.Field;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -37,10 +42,10 @@ import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.BatchStreamReaders.createStreamReader;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verify;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
 public class StructBatchStreamReader
@@ -51,6 +56,8 @@ public class StructBatchStreamReader
     private final StreamDescriptor streamDescriptor;
 
     private final Map<String, BatchStreamReader> structFields;
+    private final RowType type;
+    private final List<String> fieldNames;
 
     private int readOffset;
     private int nextBatchSize;
@@ -61,11 +68,31 @@ public class StructBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    StructBatchStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+    StructBatchStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, RowType.class::isInstance);
+        this.type = (RowType) type;
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        this.structFields = streamDescriptor.getNestedStreams().stream()
-                .collect(toImmutableMap(stream -> stream.getFieldName().toLowerCase(Locale.ENGLISH), stream -> createStreamReader(stream, hiveStorageTimeZone)));
+
+        Map<String, StreamDescriptor> nestedStreams = Maps.uniqueIndex(
+                streamDescriptor.getNestedStreams(), stream -> stream.getFieldName().toLowerCase(Locale.ENGLISH));
+        ImmutableList.Builder<String> fieldNames = ImmutableList.builder();
+        ImmutableMap.Builder<String, BatchStreamReader> structFields = ImmutableMap.builder();
+        for (Field field : this.type.getFields()) {
+            String fieldName = field.getName()
+                    .orElseThrow(() -> new IllegalArgumentException("ROW type does not have field names declared: " + type))
+                    .toLowerCase(Locale.ENGLISH);
+            fieldNames.add(fieldName);
+
+            StreamDescriptor fieldStream = nestedStreams.get(fieldName);
+            if (fieldStream != null) {
+                structFields.put(fieldName, createStreamReader(field.getType(), fieldStream, hiveStorageTimeZone));
+            }
+        }
+        this.fieldNames = fieldNames.build();
+        this.structFields = structFields.build();
     }
 
     @Override
@@ -76,7 +103,7 @@ public class StructBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
@@ -98,13 +125,13 @@ public class StructBatchStreamReader
         Block[] blocks;
 
         if (presentStream == null) {
-            blocks = getBlocksForType(type, nextBatchSize);
+            blocks = getBlocksForType(nextBatchSize);
         }
         else {
             nullVector = new boolean[nextBatchSize];
             int nullValues = presentStream.getUnsetBits(nextBatchSize, nullVector);
             if (nullValues != nextBatchSize) {
-                blocks = getBlocksForType(type, nextBatchSize - nullValues);
+                blocks = getBlocksForType(nextBatchSize - nullValues);
             }
             else {
                 List<Type> typeParameters = type.getTypeParameters();
@@ -181,40 +208,23 @@ public class StructBatchStreamReader
                 .toString();
     }
 
-    private Block[] getBlocksForType(Type type, int positionCount)
+    private Block[] getBlocksForType(int positionCount)
             throws IOException
     {
-        RowType rowType = (RowType) type;
+        Block[] blocks = new Block[fieldNames.size()];
 
-        Block[] blocks = new Block[rowType.getFields().size()];
-
-        for (int i = 0; i < rowType.getFields().size(); i++) {
-            Optional<String> fieldName = rowType.getFields().get(i).getName();
-            Type fieldType = rowType.getFields().get(i).getType();
-
-            if (!fieldName.isPresent()) {
-                throw new IllegalArgumentException("Missing struct field name in type " + rowType);
-            }
-
-            String lowerCaseFieldName = fieldName.get().toLowerCase(Locale.ENGLISH);
-            BatchStreamReader streamReader = structFields.get(lowerCaseFieldName);
+        for (int i = 0; i < fieldNames.size(); i++) {
+            String fieldName = fieldNames.get(i);
+            BatchStreamReader streamReader = structFields.get(fieldName);
             if (streamReader != null) {
                 streamReader.prepareNextRead(positionCount);
-                blocks[i] = streamReader.readBlock(fieldType);
+                blocks[i] = streamReader.readBlock();
             }
             else {
-                blocks[i] = getNullBlock(fieldType, positionCount);
+                blocks[i] = RunLengthEncodedBlock.create(type.getFields().get(i).getType(), null, positionCount);
             }
         }
         return blocks;
-    }
-
-    private static Block getNullBlock(Type type, int positionCount)
-    {
-        Block nullValueBlock = type.createBlockBuilder(null, 1)
-                .appendNull()
-                .build();
-        return new RunLengthEncodedBlock(nullValueBlock, positionCount);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampBatchStreamReader.java
@@ -21,7 +21,7 @@ import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.LongArrayBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
@@ -42,7 +43,6 @@ import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public class TimestampBatchStreamReader
@@ -104,10 +104,10 @@ public class TimestampBatchStreamReader
             }
             if (readOffset > 0) {
                 if (secondsStream == null) {
-                    throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but seconds stream is not present");
+                    throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but seconds stream is missing");
                 }
                 if (nanosStream == null) {
-                    throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but nanos stream is not present");
+                    throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but nanos stream is missing");
                 }
 
                 secondsStream.skip(readOffset);
@@ -115,44 +115,70 @@ public class TimestampBatchStreamReader
             }
         }
 
-        if (secondsStream == null && nanosStream == null && presentStream != null) {
+        Block block;
+        if (secondsStream == null && nanosStream == null) {
+            if (presentStream == null) {
+                throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is null but present stream is missing");
+            }
             presentStream.skip(nextBatchSize);
-            Block nullValueBlock = RunLengthEncodedBlock.create(TIMESTAMP, null, nextBatchSize);
-            readOffset = 0;
-            nextBatchSize = 0;
-            return nullValueBlock;
+            block = RunLengthEncodedBlock.create(TIMESTAMP, null, nextBatchSize);
         }
-
-        BlockBuilder builder = TIMESTAMP.createBlockBuilder(null, nextBatchSize);
-
-        if (presentStream == null) {
-            if (secondsStream == null) {
-                throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but seconds stream is not present");
-            }
-            if (nanosStream == null) {
-                throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but nanos stream is not present");
-            }
-
-            for (int i = 0; i < nextBatchSize; i++) {
-                TIMESTAMP.writeLong(builder, decodeTimestamp(secondsStream.next(), nanosStream.next(), baseTimestampInSeconds));
-            }
+        else if (presentStream == null) {
+            block = readNonNullBlock();
         }
         else {
-            verify(secondsStream != null, "Value is not null but seconds stream is not present");
-            verify(nanosStream != null, "Value is not null but nanos stream is not present");
-            for (int i = 0; i < nextBatchSize; i++) {
-                if (presentStream.nextBit()) {
-                    TIMESTAMP.writeLong(builder, decodeTimestamp(secondsStream.next(), nanosStream.next(), baseTimestampInSeconds));
-                }
-                else {
-                    builder.appendNull();
-                }
+            boolean[] isNull = new boolean[nextBatchSize];
+            int nullCount = presentStream.getUnsetBits(nextBatchSize, isNull);
+            if (nullCount == 0) {
+                block = readNonNullBlock();
+            }
+            else if (nullCount != nextBatchSize) {
+                block = readNullBlock(isNull);
+            }
+            else {
+                block = RunLengthEncodedBlock.create(TIMESTAMP, null, nextBatchSize);
             }
         }
 
         readOffset = 0;
         nextBatchSize = 0;
-        return builder.build();
+        return block;
+    }
+
+    private Block readNonNullBlock()
+            throws IOException
+    {
+        if (secondsStream == null) {
+            throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but seconds stream is missing");
+        }
+        if (nanosStream == null) {
+            throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but nanos stream is missing");
+        }
+
+        long[] values = new long[nextBatchSize];
+        for (int i = 0; i < nextBatchSize; i++) {
+            values[i] = decodeTimestamp(secondsStream.next(), nanosStream.next(), baseTimestampInSeconds);
+        }
+        return new LongArrayBlock(nextBatchSize, Optional.empty(), values);
+    }
+
+    private Block readNullBlock(boolean[] isNull)
+            throws IOException
+    {
+        if (secondsStream == null) {
+            throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but seconds stream is missing");
+        }
+        if (nanosStream == null) {
+            throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but nanos stream is missing");
+        }
+
+        long[] values = new long[isNull.length];
+        for (int i = 0; i < isNull.length; i++) {
+            if (!isNull[i]) {
+                values[i] = decodeTimestamp(secondsStream.next(), nanosStream.next(), baseTimestampInSeconds);
+            }
+        }
+        return new LongArrayBlock(isNull.length, Optional.of(isNull), values);
     }
 
     private void openRowGroup()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampBatchStreamReader.java
@@ -234,6 +234,11 @@ public class TimestampBatchStreamReader
     }
 
     @Override
+    public void close()
+    {
+    }
+
+    @Override
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampBatchStreamReader.java
@@ -23,6 +23,7 @@ import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -37,7 +38,9 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.SECONDARY;
 import static com.facebook.presto.orc.reader.ApacheHiveTimestampDecoder.decodeTimestamp;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
@@ -69,8 +72,11 @@ public class TimestampBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public TimestampBatchStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+    public TimestampBatchStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, TimestampType.class::isInstance);
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
         this.baseTimestampInSeconds = new DateTime(2015, 1, 1, 0, 0, requireNonNull(hiveStorageTimeZone, "hiveStorageTimeZone is null")).getMillis() / MILLIS_PER_SECOND;
     }
@@ -83,7 +89,7 @@ public class TimestampBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
@@ -111,13 +117,13 @@ public class TimestampBatchStreamReader
 
         if (secondsStream == null && nanosStream == null && presentStream != null) {
             presentStream.skip(nextBatchSize);
-            Block nullValueBlock = RunLengthEncodedBlock.create(type, null, nextBatchSize);
+            Block nullValueBlock = RunLengthEncodedBlock.create(TIMESTAMP, null, nextBatchSize);
             readOffset = 0;
             nextBatchSize = 0;
             return nullValueBlock;
         }
 
-        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
+        BlockBuilder builder = TIMESTAMP.createBlockBuilder(null, nextBatchSize);
 
         if (presentStream == null) {
             if (secondsStream == null) {
@@ -128,7 +134,7 @@ public class TimestampBatchStreamReader
             }
 
             for (int i = 0; i < nextBatchSize; i++) {
-                type.writeLong(builder, decodeTimestamp(secondsStream.next(), nanosStream.next(), baseTimestampInSeconds));
+                TIMESTAMP.writeLong(builder, decodeTimestamp(secondsStream.next(), nanosStream.next(), baseTimestampInSeconds));
             }
         }
         else {
@@ -136,7 +142,7 @@ public class TimestampBatchStreamReader
             verify(nanosStream != null, "Value is not null but nanos stream is not present");
             for (int i = 0; i < nextBatchSize; i++) {
                 if (presentStream.nextBit()) {
-                    type.writeLong(builder, decodeTimestamp(secondsStream.next(), nanosStream.next(), baseTimestampInSeconds));
+                    TIMESTAMP.writeLong(builder, decodeTimestamp(secondsStream.next(), nanosStream.next(), baseTimestampInSeconds));
                 }
                 else {
                     builder.appendNull();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanInputStream.java
@@ -14,8 +14,6 @@
 package com.facebook.presto.orc.stream;
 
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
-import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.type.Type;
 
 import java.io.IOException;
 
@@ -126,17 +124,171 @@ public class BooleanInputStream
     }
 
     /**
+     * Gets a vector of bytes set to 1 if the bit is set.
+     */
+    public byte[] getSetBits(int batchSize)
+            throws IOException
+    {
+        byte[] vector = new byte[batchSize];
+        getSetBits(batchSize, vector);
+        return vector;
+    }
+
+    /**
+     * Sets the vector element to 1 if the bit is set.
+     */
+    @SuppressWarnings({"PointlessBitwiseExpression", "PointlessArithmeticExpression", "UnusedAssignment"})
+    public void getSetBits(int batchSize, byte[] vector)
+            throws IOException
+    {
+        int offset = 0;
+        // handle the head
+        int count = Math.min(batchSize, bitsInData);
+        if (count != 0) {
+            int value = data >>> (8 - count);
+            switch (count) {
+                case 7:
+                    vector[offset++] = (byte) ((value & 64) >>> 6);
+                case 6:
+                    vector[offset++] = (byte) ((value & 32) >>> 5);
+                case 5:
+                    vector[offset++] = (byte) ((value & 16) >>> 4);
+                case 4:
+                    vector[offset++] = (byte) ((value & 8) >>> 3);
+                case 3:
+                    vector[offset++] = (byte) ((value & 4) >>> 2);
+                case 2:
+                    vector[offset++] = (byte) ((value & 2) >>> 1);
+                case 1:
+                    vector[offset++] = (byte) ((value & 1) >>> 0);
+            }
+            data <<= count;
+            bitsInData -= count;
+
+            if (count == batchSize) {
+                return;
+            }
+        }
+
+        // the middle part
+        while (offset < batchSize - 7) {
+            byte value = byteStream.next();
+            vector[offset + 0] = (byte) ((value & 128) >>> 7);
+            vector[offset + 1] = (byte) ((value & 64) >>> 6);
+            vector[offset + 2] = (byte) ((value & 32) >>> 5);
+            vector[offset + 3] = (byte) ((value & 16) >>> 4);
+            vector[offset + 4] = (byte) ((value & 8) >>> 3);
+            vector[offset + 5] = (byte) ((value & 4) >>> 2);
+            vector[offset + 6] = (byte) ((value & 2) >>> 1);
+            vector[offset + 7] = (byte) ((value & 1));
+            offset += 8;
+        }
+
+        // the tail
+        int remaining = batchSize - offset;
+        if (remaining > 0) {
+            byte data = byteStream.next();
+            int value = data >>> (8 - remaining);
+            switch (remaining) {
+                case 7:
+                    vector[offset++] = (byte) ((value & 64) >>> 6);
+                case 6:
+                    vector[offset++] = (byte) ((value & 32) >>> 5);
+                case 5:
+                    vector[offset++] = (byte) ((value & 16) >>> 4);
+                case 4:
+                    vector[offset++] = (byte) ((value & 8) >>> 3);
+                case 3:
+                    vector[offset++] = (byte) ((value & 4) >>> 2);
+                case 2:
+                    vector[offset++] = (byte) ((value & 2) >>> 1);
+                case 1:
+                    vector[offset++] = (byte) ((value & 1) >>> 0);
+            }
+            this.data = (byte) (data << remaining);
+            bitsInData = 8 - remaining;
+        }
+    }
+
+    /**
      * Sets the vector element to true if the bit is set.
      */
+    @SuppressWarnings({"PointlessBitwiseExpression", "PointlessArithmeticExpression", "UnusedAssignment"})
     public int getSetBits(int batchSize, boolean[] vector)
             throws IOException
     {
-        int count = 0;
-        for (int i = 0; i < batchSize; i++) {
-            vector[i] = nextBit();
-            count += vector[i] ? 1 : 0;
+        int offset = 0;
+        int countBitsSet = 0;
+        // handle the head
+        int count = Math.min(batchSize, bitsInData);
+        if (count != 0) {
+            int value = (data >>> (8 - count)) & 0x7f;
+            countBitsSet += Integer.bitCount(value);
+            switch (count) {
+                case 7:
+                    vector[offset++] = ((value & 64) >>> 6) == 1;
+                case 6:
+                    vector[offset++] = ((value & 32) >>> 5) == 1;
+                case 5:
+                    vector[offset++] = ((value & 16) >>> 4) == 1;
+                case 4:
+                    vector[offset++] = ((value & 8) >>> 3) == 1;
+                case 3:
+                    vector[offset++] = ((value & 4) >>> 2) == 1;
+                case 2:
+                    vector[offset++] = ((value & 2) >>> 1) == 1;
+                case 1:
+                    vector[offset++] = ((value & 1) >>> 0) == 1;
+            }
+            data <<= count;
+            bitsInData -= count;
+
+            if (count == batchSize) {
+                return countBitsSet;
+            }
         }
-        return count;
+
+        // the middle part
+        while (offset < batchSize - 7) {
+            int value = byteStream.next() & 0xff;
+            countBitsSet += Integer.bitCount(value);
+            vector[offset + 0] = ((value & 128) >>> 7) == 1;
+            vector[offset + 1] = ((value & 64) >>> 6) == 1;
+            vector[offset + 2] = ((value & 32) >>> 5) == 1;
+            vector[offset + 3] = ((value & 16) >>> 4) == 1;
+            vector[offset + 4] = ((value & 8) >>> 3) == 1;
+            vector[offset + 5] = ((value & 4) >>> 2) == 1;
+            vector[offset + 6] = ((value & 2) >>> 1) == 1;
+            vector[offset + 7] = ((value & 1)) == 1;
+            offset += 8;
+        }
+
+        // the tail
+        int remaining = batchSize - offset;
+        if (remaining > 0) {
+            int data = byteStream.next() & 0xff;
+            int value = (data >>> (8 - remaining)) & 0x7f;
+            countBitsSet += Integer.bitCount(value);
+            switch (remaining) {
+                case 7:
+                    vector[offset++] = ((value & 64) >>> 6) == 1;
+                case 6:
+                    vector[offset++] = ((value & 32) >>> 5) == 1;
+                case 5:
+                    vector[offset++] = ((value & 16) >>> 4) == 1;
+                case 4:
+                    vector[offset++] = ((value & 8) >>> 3) == 1;
+                case 3:
+                    vector[offset++] = ((value & 4) >>> 2) == 1;
+                case 2:
+                    vector[offset++] = ((value & 2) >>> 1) == 1;
+                case 1:
+                    vector[offset++] = ((value & 1) >>> 0) == 1;
+            }
+            this.data = (byte) (data << remaining);
+            bitsInData = 8 - remaining;
+        }
+        return countBitsSet;
     }
 
     /**
@@ -156,38 +308,86 @@ public class BooleanInputStream
     }
 
     /**
-     * Sets the vector element to true if the bit is set.
-     */
-    public void getSetBits(Type type, int batchSize, BlockBuilder builder)
-            throws IOException
-    {
-        for (int i = 0; i < batchSize; i++) {
-            type.writeBoolean(builder, nextBit());
-        }
-    }
-
-    /**
      * Sets the vector element to true if the bit is not set.
      */
+    @SuppressWarnings({"PointlessArithmeticExpression", "UnusedAssignment"})
     public int getUnsetBits(int batchSize, boolean[] vector)
             throws IOException
     {
-        return getUnsetBits(batchSize, vector, 0);
-    }
+        int unsetCount = 0;
+        int offset = 0;
 
-    /**
-     * Sets the vector element to true for the batchSize number of elements starting at offset
-     * if the bit is not set.
-     */
-    public int getUnsetBits(int batchSize, boolean[] vector, int offset)
-            throws IOException
-    {
-        int count = 0;
-        for (int i = offset; i < batchSize + offset; i++) {
-            vector[i] = !nextBit();
-            count += vector[i] ? 1 : 0;
+        // handle the head
+        int count = Math.min(batchSize, bitsInData);
+        if (count != 0) {
+            int value = (data & 0xFF) >>> (8 - count);
+            unsetCount += (count - Integer.bitCount(value));
+            switch (count) {
+                case 7:
+                    vector[offset++] = (value & 64) == 0;
+                case 6:
+                    vector[offset++] = (value & 32) == 0;
+                case 5:
+                    vector[offset++] = (value & 16) == 0;
+                case 4:
+                    vector[offset++] = (value & 8) == 0;
+                case 3:
+                    vector[offset++] = (value & 4) == 0;
+                case 2:
+                    vector[offset++] = (value & 2) == 0;
+                case 1:
+                    vector[offset++] = (value & 1) == 0;
+            }
+            data <<= count;
+            bitsInData -= count;
+
+            if (count == batchSize) {
+                return unsetCount;
+            }
         }
-        return count;
+
+        // the middle part
+        while (offset < batchSize - 7) {
+            byte value = byteStream.next();
+            unsetCount += (8 - Integer.bitCount(value & 0xFF));
+            vector[offset + 0] = (value & 128) == 0;
+            vector[offset + 1] = (value & 64) == 0;
+            vector[offset + 2] = (value & 32) == 0;
+            vector[offset + 3] = (value & 16) == 0;
+            vector[offset + 4] = (value & 8) == 0;
+            vector[offset + 5] = (value & 4) == 0;
+            vector[offset + 6] = (value & 2) == 0;
+            vector[offset + 7] = (value & 1) == 0;
+            offset += 8;
+        }
+
+        // the tail
+        int remaining = batchSize - offset;
+        if (remaining > 0) {
+            byte data = byteStream.next();
+            int value = (data & 0xff) >> (8 - remaining);
+            unsetCount += (remaining - Integer.bitCount(value));
+            switch (remaining) {
+                case 7:
+                    vector[offset++] = (value & 64) == 0;
+                case 6:
+                    vector[offset++] = (value & 32) == 0;
+                case 5:
+                    vector[offset++] = (value & 16) == 0;
+                case 4:
+                    vector[offset++] = (value & 8) == 0;
+                case 3:
+                    vector[offset++] = (value & 4) == 0;
+                case 2:
+                    vector[offset++] = (value & 2) == 0;
+                case 1:
+                    vector[offset++] = (value & 1) == 0;
+            }
+            this.data = (byte) (data << remaining);
+            bitsInData = 8 - remaining;
+        }
+
+        return unsetCount;
     }
 
     /**

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStream.java
@@ -14,8 +14,6 @@
 package com.facebook.presto.orc.stream;
 
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
-import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.type.Type;
 
 import java.io.IOException;
 
@@ -28,6 +26,15 @@ public interface LongInputStream
     long next()
             throws IOException;
 
+    void next(long[] values, int items)
+            throws IOException;
+
+    void next(int[] values, int items)
+            throws IOException;
+
+    void next(short[] values, int items)
+            throws IOException;
+
     default void nextIntVector(int items, int[] vector, int offset)
             throws IOException
     {
@@ -38,19 +45,6 @@ public interface LongInputStream
         }
     }
 
-    default void nextIntVector(int items, int[] vector, int vectorOffset, boolean[] isNull)
-            throws IOException
-    {
-        checkPositionIndex(items + vectorOffset, vector.length);
-        checkPositionIndex(items, isNull.length);
-
-        for (int i = 0; i < items; i++) {
-            if (!isNull[i]) {
-                vector[i + vectorOffset] = toIntExact(next());
-            }
-        }
-    }
-
     default void nextLongVector(int items, long[] vector)
             throws IOException
     {
@@ -58,14 +52,6 @@ public interface LongInputStream
 
         for (int i = 0; i < items; i++) {
             vector[i] = next();
-        }
-    }
-
-    default void nextLongVector(Type type, int items, BlockBuilder builder)
-            throws IOException
-    {
-        for (int i = 0; i < items; i++) {
-            type.writeLong(builder, next());
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStreamDwrf.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongInputStreamDwrf.java
@@ -70,4 +70,31 @@ public class LongInputStreamDwrf
         }
         return input.readDwrfLong(orcTypeKind);
     }
+
+    @Override
+    public void next(long[] values, int items)
+            throws IOException
+    {
+        for (int i = 0; i < items; i++) {
+            values[i] = next();
+        }
+    }
+
+    @Override
+    public void next(int[] values, int items)
+            throws IOException
+    {
+        for (int i = 0; i < items; i++) {
+            values[i] = (int) next();
+        }
+    }
+
+    @Override
+    public void next(short[] values, int items)
+            throws IOException
+    {
+        for (int i = 0; i < items; i++) {
+            values[i] = (short) next();
+        }
+    }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
@@ -234,7 +234,7 @@ public abstract class AbstractTestOrcReader
             assertEquals(stripeFootercache.stats().hitCount(), 1);
             assertEquals(stripeStreamCache.stats().missCount(), 2);
             assertEquals(stripeStreamCache.stats().hitCount(), 2);
-            assertEquals(storageReader.readBlock(BIGINT, 0).getInt(0), cacheReader.readBlock(BIGINT, 0).getInt(0));
+            assertEquals(storageReader.readBlock(0).getInt(0), cacheReader.readBlock(0).getInt(0));
         }
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
@@ -90,7 +90,7 @@ public class BenchmarkBatchStreamReaders
         OrcBatchRecordReader recordReader = data.createRecordReader();
         List<Block> blocks = new ArrayList<>();
         while (recordReader.nextBatch() > 0) {
-            Block block = recordReader.readBlock(data.type, 0);
+            Block block = recordReader.readBlock(0);
             blocks.add(block);
         }
         return blocks;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
@@ -40,6 +40,7 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
+import org.openjdk.jmh.runner.options.WarmupMode;
 
 import java.io.File;
 import java.io.IOException;
@@ -70,7 +71,7 @@ import static org.joda.time.DateTimeZone.UTC;
 
 @SuppressWarnings("MethodMayBeStatic")
 @State(Scope.Thread)
-@OutputTimeUnit(TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(3)
 @Warmup(iterations = 20, time = 500, timeUnit = MILLISECONDS)
 @Measurement(iterations = 20, time = 500, timeUnit = MILLISECONDS)
@@ -118,7 +119,7 @@ public class BenchmarkBatchStreamReaders
                 "real",
                 "double",
                 "varchar_direct",
-                "varchar_dictionary",
+                "varchar_dictionary"
         })
         private String typeSignature;
 
@@ -238,6 +239,7 @@ public class BenchmarkBatchStreamReaders
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
                 .include(".*" + BenchmarkBatchStreamReaders.class.getSimpleName() + ".*")
+                .warmupMode(WarmupMode.BULK)
                 .build();
 
         new Runner(options).run();

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -891,7 +891,7 @@ public class OrcTester
                 else {
                     for (int i = 0; i < types.size(); i++) {
                         Type type = types.get(i);
-                        Block block = recordReader.readBlock(type, i);
+                        Block block = recordReader.readBlock(i);
                         assertEquals(block.getPositionCount(), batchSize);
 
                         List<Object> data = new ArrayList<>(block.getPositionCount());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
@@ -221,7 +221,7 @@ public class TestCachingOrcDataSource
             if (batchSize <= 0) {
                 break;
             }
-            Block block = orcRecordReader.readBlock(VARCHAR, 0);
+            Block block = orcRecordReader.readBlock(0);
             positionCount += block.getPositionCount();
         }
         assertEquals(positionCount, POSITION_COUNT);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
@@ -421,7 +421,7 @@ public class TestMapFlatBatchStreamReader
                     isFirst = false;
                 }
                 else {
-                    Block block = recordReader.readBlock(mapType, 0);
+                    Block block = recordReader.readBlock(0);
 
                     for (int position = 0; position < block.getPositionCount(); position++) {
                         assertEquals(mapType.getObjectValue(SESSION, block, position), expectedValuesIterator.next());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
@@ -73,9 +73,9 @@ public class TestOrcLz4
             }
             rows += batchSize;
 
-            Block xBlock = reader.readBlock(BIGINT, 0);
-            Block yBlock = reader.readBlock(INTEGER, 1);
-            Block zBlock = reader.readBlock(BIGINT, 2);
+            Block xBlock = reader.readBlock(0);
+            Block yBlock = reader.readBlock(1);
+            Block zBlock = reader.readBlock(2);
 
             for (int position = 0; position < batchSize; position++) {
                 BIGINT.getLong(xBlock, position);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
@@ -83,7 +83,7 @@ public class TestOrcReaderMemoryUsage
                     break;
                 }
 
-                Block block = reader.readBlock(VARCHAR, 0);
+                Block block = reader.readBlock(0);
                 assertEquals(block.getPositionCount(), batchSize);
 
                 // We only verify the memory usage when the batchSize reaches MAX_BATCH_SIZE as batchSize may be
@@ -130,7 +130,7 @@ public class TestOrcReaderMemoryUsage
                     break;
                 }
 
-                Block block = reader.readBlock(BIGINT, 0);
+                Block block = reader.readBlock(0);
                 assertEquals(block.getPositionCount(), batchSize);
 
                 // We only verify the memory usage when the batchSize reaches MAX_BATCH_SIZE as batchSize may be
@@ -194,7 +194,7 @@ public class TestOrcReaderMemoryUsage
                     break;
                 }
 
-                Block block = reader.readBlock(mapType, 0);
+                Block block = reader.readBlock(0);
                 assertEquals(block.getPositionCount(), batchSize);
 
                 // We only verify the memory usage when the batchSize reaches MAX_BATCH_SIZE as batchSize may be

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
@@ -94,8 +94,8 @@ public class TestOrcReaderMemoryUsage
 
                 // StripeReader memory should increase after reading a block.
                 assertGreaterThan(reader.getCurrentStripeRetainedSizeInBytes(), stripeReaderRetainedSize);
-                // There are no local buffers needed.
-                assertEquals(reader.getStreamReaderRetainedSizeInBytes() - streamReaderRetainedSize, 0L);
+                // SliceDictionaryBatchStreamReader uses stripeDictionaryLength local buffer.
+                assertEquals(reader.getStreamReaderRetainedSizeInBytes() - streamReaderRetainedSize, 4L);
                 // The total retained size and system memory usage should be greater than 0 byte because of the instance sizes.
                 assertGreaterThan(reader.getRetainedSizeInBytes() - readerRetainedSize, 0L);
                 assertGreaterThan(reader.getSystemMemoryUsage() - readerSystemMemoryUsage, 0L);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
@@ -164,7 +164,7 @@ public class TestOrcReaderPositions
                         break;
                     }
 
-                    Block block = reader.readBlock(BIGINT, 0);
+                    Block block = reader.readBlock(0);
                     for (int i = 0; i < batchSize; i++) {
                         assertEquals(BIGINT.getLong(block, i), position + i);
                     }
@@ -217,7 +217,7 @@ public class TestOrcReaderPositions
 
                     rowCountsInCurrentRowGroup += batchSize;
 
-                    Block block = reader.readBlock(VARCHAR, 0);
+                    Block block = reader.readBlock(0);
                     if (MAX_BATCH_SIZE * currentStringBytes <= MAX_BLOCK_SIZE.toBytes()) {
                         // Either we are bounded by 1024 rows per batch, or it is the last batch in the row group
                         // For the first 3 row groups, the strings are of length 300, 600, and 900 respectively
@@ -271,7 +271,7 @@ public class TestOrcReaderPositions
                     }
                     rowCountsInCurrentRowGroup += batchSize;
 
-                    Block block = reader.readBlock(BIGINT, 0);
+                    Block block = reader.readBlock(0);
                     // 8 bytes per row; 1024 row at most given 1024 X 8B < 1MB
                     assertTrue(block.getPositionCount() == MAX_BATCH_SIZE || rowCountsInCurrentRowGroup == rowsInRowGroup);
 
@@ -371,7 +371,7 @@ public class TestOrcReaderPositions
     private static void assertCurrentBatch(OrcBatchRecordReader reader, int rowIndex, int batchSize)
             throws IOException
     {
-        Block block = reader.readBlock(BIGINT, 0);
+        Block block = reader.readBlock(0);
         for (int i = 0; i < batchSize; i++) {
             assertEquals(BIGINT.getLong(block, i), (rowIndex + i) * 3);
         }
@@ -380,7 +380,7 @@ public class TestOrcReaderPositions
     private static void assertCurrentBatch(OrcBatchRecordReader reader, int stripe)
             throws IOException
     {
-        Block block = reader.readBlock(BIGINT, 0);
+        Block block = reader.readBlock(0);
         for (int i = 0; i < 20; i++) {
             assertEquals(BIGINT.getLong(block, i), ((stripe * 20L) + i) * 3);
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
@@ -154,7 +154,7 @@ public class TestStructBatchStreamReader
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp =
-            "Missing struct field name in type row\\(varchar,varchar,varchar\\)")
+            "ROW type does not have field names declared: row\\(varchar,varchar,varchar\\)")
     public void testThrowsExceptionWhenFieldNameMissing()
             throws IOException
     {
@@ -272,7 +272,7 @@ public class TestStructBatchStreamReader
         OrcBatchRecordReader recordReader = orcReader.createBatchRecordReader(includedColumns, OrcPredicate.TRUE, UTC, newSimpleAggregatedMemoryContext(), OrcReader.INITIAL_BATCH_SIZE);
 
         recordReader.nextBatch();
-        RowBlock block = (RowBlock) recordReader.readBlock(readerType, 0);
+        RowBlock block = (RowBlock) recordReader.readBlock(0);
         recordReader.close();
         return block;
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcPageSource.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcPageSource.java
@@ -166,7 +166,6 @@ public class OrcPageSource
 
             Block[] blocks = new Block[columnIndexes.length];
             for (int fieldId = 0; fieldId < blocks.length; fieldId++) {
-                Type type = types.get(fieldId);
                 if (constantBlocks[fieldId] != null) {
                     blocks[fieldId] = constantBlocks[fieldId].getRegion(0, batchSize);
                 }
@@ -174,7 +173,7 @@ public class OrcPageSource
                     blocks[fieldId] = buildSequenceBlock(filePosition, batchSize);
                 }
                 else {
-                    blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(columnIndexes[fieldId], type));
+                    blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(columnIndexes[fieldId]));
                 }
             }
 
@@ -264,13 +263,11 @@ public class OrcPageSource
     {
         private final int expectedBatchId = batchId;
         private final int columnIndex;
-        private final Type type;
         private boolean loaded;
 
-        public OrcBlockLoader(int columnIndex, Type type)
+        public OrcBlockLoader(int columnIndex)
         {
             this.columnIndex = columnIndex;
-            this.type = requireNonNull(type, "type is null");
         }
 
         @Override
@@ -283,7 +280,7 @@ public class OrcPageSource
             checkState(batchId == expectedBatchId);
 
             try {
-                Block block = recordReader.readBlock(type, columnIndex);
+                Block block = recordReader.readBlock(columnIndex);
                 lazyBlock.setBlock(block);
             }
             catch (IOException e) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardStats.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardStats.java
@@ -20,12 +20,11 @@ import com.facebook.presto.raptor.metadata.ColumnStats;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.BigintType;
-import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.DateType;
-import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.TimeType;
 import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
@@ -37,6 +36,9 @@ import java.util.Optional;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_ERROR;
+import static com.facebook.presto.raptor.storage.OrcStorageManager.toOrcFileType;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
 import static org.joda.time.DateTimeZone.UTC;
@@ -58,20 +60,27 @@ public final class ShardStats
         return slice;
     }
 
-    public static Optional<ColumnStats> computeColumnStats(OrcReader orcReader, long columnId, Type type)
+    public static Optional<ColumnStats> computeColumnStats(OrcReader orcReader, long columnId, Type type, TypeManager typeManager)
             throws IOException
     {
-        return Optional.ofNullable(doComputeColumnStats(orcReader, columnId, type));
+        return Optional.ofNullable(doComputeColumnStats(orcReader, columnId, type, typeManager));
     }
 
-    private static ColumnStats doComputeColumnStats(OrcReader orcReader, long columnId, Type type)
+    private static ColumnStats doComputeColumnStats(OrcReader orcReader, long columnId, Type type, TypeManager typeManager)
             throws IOException
     {
-        int columnIndex = columnIndex(orcReader.getColumnNames(), columnId);
-        OrcBatchRecordReader reader = orcReader.createBatchRecordReader(ImmutableMap.of(columnIndex, type), OrcPredicate.TRUE, UTC, newSimpleAggregatedMemoryContext(), INITIAL_BATCH_SIZE);
+        StorageTypeConverter storageTypeConverter = new StorageTypeConverter(typeManager);
 
-        if (type.equals(BooleanType.BOOLEAN)) {
-            return indexBoolean(type, reader, columnIndex, columnId);
+        int columnIndex = columnIndex(orcReader.getColumnNames(), columnId);
+        OrcBatchRecordReader reader = orcReader.createBatchRecordReader(
+                storageTypeConverter.toStorageTypes(ImmutableMap.of(columnIndex, toOrcFileType(type, typeManager))),
+                OrcPredicate.TRUE,
+                UTC,
+                newSimpleAggregatedMemoryContext(),
+                INITIAL_BATCH_SIZE);
+
+        if (type.equals(BOOLEAN)) {
+            return indexBoolean(reader, columnIndex, columnId);
         }
         if (type.equals(BigintType.BIGINT) ||
                 type.equals(DateType.DATE) ||
@@ -79,8 +88,8 @@ public final class ShardStats
                 type.equals(TimestampType.TIMESTAMP)) {
             return indexLong(type, reader, columnIndex, columnId);
         }
-        if (type.equals(DoubleType.DOUBLE)) {
-            return indexDouble(type, reader, columnIndex, columnId);
+        if (type.equals(DOUBLE)) {
+            return indexDouble(reader, columnIndex, columnId);
         }
         if (type instanceof VarcharType) {
             return indexString(type, reader, columnIndex, columnId);
@@ -97,7 +106,7 @@ public final class ShardStats
         return index;
     }
 
-    private static ColumnStats indexBoolean(Type type, OrcBatchRecordReader reader, int columnIndex, long columnId)
+    private static ColumnStats indexBoolean(OrcBatchRecordReader reader, int columnIndex, long columnId)
             throws IOException
     {
         boolean minSet = false;
@@ -110,13 +119,13 @@ public final class ShardStats
             if (batchSize <= 0) {
                 break;
             }
-            Block block = reader.readBlock(type, columnIndex);
+            Block block = reader.readBlock(columnIndex);
 
             for (int i = 0; i < batchSize; i++) {
                 if (block.isNull(i)) {
                     continue;
                 }
-                boolean value = type.getBoolean(block, i);
+                boolean value = BOOLEAN.getBoolean(block, i);
                 if (!minSet || Boolean.compare(value, min) < 0) {
                     minSet = true;
                     min = value;
@@ -146,7 +155,7 @@ public final class ShardStats
             if (batchSize <= 0) {
                 break;
             }
-            Block block = reader.readBlock(type, columnIndex);
+            Block block = reader.readBlock(columnIndex);
 
             for (int i = 0; i < batchSize; i++) {
                 if (block.isNull(i)) {
@@ -169,7 +178,7 @@ public final class ShardStats
                 maxSet ? max : null);
     }
 
-    private static ColumnStats indexDouble(Type type, OrcBatchRecordReader reader, int columnIndex, long columnId)
+    private static ColumnStats indexDouble(OrcBatchRecordReader reader, int columnIndex, long columnId)
             throws IOException
     {
         boolean minSet = false;
@@ -182,13 +191,13 @@ public final class ShardStats
             if (batchSize <= 0) {
                 break;
             }
-            Block block = reader.readBlock(type, columnIndex);
+            Block block = reader.readBlock(columnIndex);
 
             for (int i = 0; i < batchSize; i++) {
                 if (block.isNull(i)) {
                     continue;
                 }
-                double value = type.getDouble(block, i);
+                double value = DOUBLE.getDouble(block, i);
                 if (isNaN(value)) {
                     continue;
                 }
@@ -231,7 +240,7 @@ public final class ShardStats
             if (batchSize <= 0) {
                 break;
             }
-            Block block = reader.readBlock(type, columnIndex);
+            Block block = reader.readBlock(columnIndex);
 
             for (int i = 0; i < batchSize; i++) {
                 if (block.isNull(i)) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageTypeConverter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageTypeConverter.java
@@ -22,6 +22,8 @@ import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
 import com.google.common.collect.ImmutableList;
 
+import java.util.Map;
+
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -39,6 +41,7 @@ import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
 public class StorageTypeConverter
@@ -88,6 +91,11 @@ public class StorageTypeConverter
         // Need to make sure min/max are compliant with both storage and column types.
         checkState(storageType.getJavaType().equals(type.getJavaType()));
         return storageType;
+    }
+
+    public Map<Integer, Type> toStorageTypes(Map<Integer, Type> includedColumns)
+    {
+        return includedColumns.entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, entry -> toStorageType(entry.getValue())));
     }
 
     private Type mapType(Type keyType, Type valueType)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
@@ -15,8 +15,11 @@ package com.facebook.presto.raptor.storage;
 
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.metadata.FunctionManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.orc.FileOrcDataSource;
 import com.facebook.presto.orc.OrcBatchRecordReader;
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcPredicate;
 import com.facebook.presto.orc.OrcReader;
@@ -83,8 +86,14 @@ final class OrcTestingUtil
     }
 
     public static OrcBatchRecordReader createRecordReader(OrcReader orcReader, Map<Integer, Type> includedColumns)
+            throws OrcCorruptionException
     {
-        return orcReader.createBatchRecordReader(includedColumns, OrcPredicate.TRUE, DateTimeZone.UTC, newSimpleAggregatedMemoryContext(), MAX_BATCH_SIZE);
+        Metadata metadata = MetadataManager.createTestMetadataManager();
+        FunctionManager functionManager = metadata.getFunctionManager();
+        TypeRegistry typeRegistry = new TypeRegistry();
+        typeRegistry.setFunctionManager(functionManager);
+        StorageTypeConverter storageTypeConverter = new StorageTypeConverter(typeRegistry);
+        return orcReader.createBatchRecordReader(storageTypeConverter.toStorageTypes(includedColumns), OrcPredicate.TRUE, DateTimeZone.UTC, newSimpleAggregatedMemoryContext(), MAX_BATCH_SIZE);
     }
 
     public static byte[] octets(int... values)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
@@ -154,7 +154,7 @@ public class TestOrcFileRewriter
 
             assertEquals(reader.nextBatch(), 5);
 
-            Block column0 = reader.readBlock(BIGINT, 0);
+            Block column0 = reader.readBlock(0);
             assertEquals(column0.getPositionCount(), 5);
             for (int i = 0; i < 5; i++) {
                 assertEquals(column0.isNull(i), false);
@@ -165,7 +165,7 @@ public class TestOrcFileRewriter
             assertEquals(BIGINT.getLong(column0, 3), 888L);
             assertEquals(BIGINT.getLong(column0, 4), 999L);
 
-            Block column1 = reader.readBlock(createVarcharType(20), 1);
+            Block column1 = reader.readBlock(1);
             assertEquals(column1.getPositionCount(), 5);
             for (int i = 0; i < 5; i++) {
                 assertEquals(column1.isNull(i), false);
@@ -176,7 +176,7 @@ public class TestOrcFileRewriter
             assertEquals(createVarcharType(20).getSlice(column1, 3), utf8Slice("world"));
             assertEquals(createVarcharType(20).getSlice(column1, 4), utf8Slice("done"));
 
-            Block column2 = reader.readBlock(arrayType, 2);
+            Block column2 = reader.readBlock(2);
             assertEquals(column2.getPositionCount(), 5);
             for (int i = 0; i < 5; i++) {
                 assertEquals(column2.isNull(i), false);
@@ -187,7 +187,7 @@ public class TestOrcFileRewriter
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column2, 3), arrayBlockOf(BIGINT, 7, 8)));
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column2, 4), arrayBlockOf(BIGINT, 9, 10)));
 
-            Block column3 = reader.readBlock(mapType, 3);
+            Block column3 = reader.readBlock(3);
             assertEquals(column3.getPositionCount(), 5);
             for (int i = 0; i < 5; i++) {
                 assertEquals(column3.isNull(i), false);
@@ -198,7 +198,7 @@ public class TestOrcFileRewriter
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, arrayType.getObject(column3, 3), mapBlockOf(createVarcharType(5), BOOLEAN, "k4", true)));
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, arrayType.getObject(column3, 4), mapBlockOf(createVarcharType(5), BOOLEAN, "k5", true)));
 
-            Block column4 = reader.readBlock(arrayOfArrayType, 4);
+            Block column4 = reader.readBlock(4);
             assertEquals(column4.getPositionCount(), 5);
             for (int i = 0; i < 5; i++) {
                 assertEquals(column4.isNull(i), false);
@@ -242,7 +242,7 @@ public class TestOrcFileRewriter
 
             assertEquals(reader.nextBatch(), 2);
 
-            Block column0 = reader.readBlock(BIGINT, 0);
+            Block column0 = reader.readBlock(0);
             assertEquals(column0.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column0.isNull(i), false);
@@ -250,7 +250,7 @@ public class TestOrcFileRewriter
             assertEquals(BIGINT.getLong(column0, 0), 123L);
             assertEquals(BIGINT.getLong(column0, 1), 456L);
 
-            Block column1 = reader.readBlock(createVarcharType(20), 1);
+            Block column1 = reader.readBlock(1);
             assertEquals(column1.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column1.isNull(i), false);
@@ -258,7 +258,7 @@ public class TestOrcFileRewriter
             assertEquals(createVarcharType(20).getSlice(column1, 0), utf8Slice("hello"));
             assertEquals(createVarcharType(20).getSlice(column1, 1), utf8Slice("bye"));
 
-            Block column2 = reader.readBlock(arrayType, 2);
+            Block column2 = reader.readBlock(2);
             assertEquals(column2.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column2.isNull(i), false);
@@ -266,7 +266,7 @@ public class TestOrcFileRewriter
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column2, 0), arrayBlockOf(BIGINT, 1, 2)));
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column2, 1), arrayBlockOf(BIGINT, 5, 6)));
 
-            Block column3 = reader.readBlock(mapType, 3);
+            Block column3 = reader.readBlock(3);
             assertEquals(column3.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column3.isNull(i), false);
@@ -274,7 +274,7 @@ public class TestOrcFileRewriter
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, arrayType.getObject(column3, 0), mapBlockOf(createVarcharType(5), BOOLEAN, "k1", true)));
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, arrayType.getObject(column3, 1), mapBlockOf(createVarcharType(5), BOOLEAN, "k3", true)));
 
-            Block column4 = reader.readBlock(arrayOfArrayType, 4);
+            Block column4 = reader.readBlock(4);
             assertEquals(column4.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column4.isNull(i), false);
@@ -321,7 +321,7 @@ public class TestOrcFileRewriter
 
             assertEquals(reader.nextBatch(), 2);
 
-            Block column0 = reader.readBlock(BIGINT, 0);
+            Block column0 = reader.readBlock(0);
             assertEquals(column0.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column0.isNull(i), false);
@@ -329,7 +329,7 @@ public class TestOrcFileRewriter
             assertEquals(BIGINT.getLong(column0, 0), 123L);
             assertEquals(BIGINT.getLong(column0, 1), 777L);
 
-            Block column1 = reader.readBlock(createVarcharType(20), 1);
+            Block column1 = reader.readBlock(1);
             assertEquals(column1.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column1.isNull(i), false);
@@ -358,12 +358,12 @@ public class TestOrcFileRewriter
 
             assertEquals(reader.nextBatch(), 1);
 
-            Block column0 = reader.readBlock(BIGINT, 0);
+            Block column0 = reader.readBlock(0);
             assertEquals(column0.getPositionCount(), 1);
             assertEquals(column0.isNull(0), false);
             assertEquals(BIGINT.getLong(column0, 0), 123L);
 
-            Block column1 = reader.readBlock(createVarcharType(20), 1);
+            Block column1 = reader.readBlock(1);
             assertEquals(column1.getPositionCount(), 1);
             assertEquals(column1.isNull(0), false);
             assertEquals(createVarcharType(20).getSlice(column1, 0), utf8Slice("hello"));

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
@@ -241,13 +241,13 @@ public class TestOrcStorageManager
 
             assertEquals(reader.nextBatch(), 2);
 
-            Block column0 = reader.readBlock(BIGINT, 0);
+            Block column0 = reader.readBlock(0);
             assertEquals(column0.isNull(0), false);
             assertEquals(column0.isNull(1), false);
             assertEquals(BIGINT.getLong(column0, 0), 123L);
             assertEquals(BIGINT.getLong(column0, 1), 456L);
 
-            Block column1 = reader.readBlock(createVarcharType(10), 1);
+            Block column1 = reader.readBlock(1);
             assertEquals(createVarcharType(10).getSlice(column1, 0), utf8Slice("hello"));
             assertEquals(createVarcharType(10).getSlice(column1, 1), utf8Slice("bye"));
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardWriter.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardWriter.java
@@ -150,24 +150,24 @@ public class TestShardWriter
             assertEquals(reader.getReaderPosition(), 0);
             assertEquals(reader.getFilePosition(), reader.getFilePosition());
 
-            Block column0 = reader.readBlock(BIGINT, 0);
+            Block column0 = reader.readBlock(0);
             assertEquals(column0.isNull(0), false);
             assertEquals(column0.isNull(1), true);
             assertEquals(column0.isNull(2), false);
             assertEquals(BIGINT.getLong(column0, 0), 123L);
             assertEquals(BIGINT.getLong(column0, 2), 456L);
 
-            Block column1 = reader.readBlock(createVarcharType(10), 1);
+            Block column1 = reader.readBlock(1);
             assertEquals(createVarcharType(10).getSlice(column1, 0), utf8Slice("hello"));
             assertEquals(createVarcharType(10).getSlice(column1, 1), utf8Slice("world"));
             assertEquals(createVarcharType(10).getSlice(column1, 2), utf8Slice("bye \u2603"));
 
-            Block column2 = reader.readBlock(VARBINARY, 2);
+            Block column2 = reader.readBlock(2);
             assertEquals(VARBINARY.getSlice(column2, 0), wrappedBuffer(bytes1));
             assertEquals(column2.isNull(1), true);
             assertEquals(VARBINARY.getSlice(column2, 2), wrappedBuffer(bytes3));
 
-            Block column3 = reader.readBlock(DOUBLE, 3);
+            Block column3 = reader.readBlock(3);
             assertEquals(column3.isNull(0), false);
             assertEquals(column3.isNull(1), false);
             assertEquals(column3.isNull(2), false);
@@ -175,21 +175,21 @@ public class TestShardWriter
             assertEquals(DOUBLE.getDouble(column3, 1), Double.POSITIVE_INFINITY);
             assertEquals(DOUBLE.getDouble(column3, 2), Double.NaN);
 
-            Block column4 = reader.readBlock(BOOLEAN, 4);
+            Block column4 = reader.readBlock(4);
             assertEquals(column4.isNull(0), false);
             assertEquals(column4.isNull(1), true);
             assertEquals(column4.isNull(2), false);
             assertEquals(BOOLEAN.getBoolean(column4, 0), true);
             assertEquals(BOOLEAN.getBoolean(column4, 2), false);
 
-            Block column5 = reader.readBlock(arrayType, 5);
+            Block column5 = reader.readBlock(5);
             assertEquals(column5.getPositionCount(), 3);
 
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column5, 0), arrayBlockOf(BIGINT, 1, 2)));
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column5, 1), arrayBlockOf(BIGINT, 3, null)));
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column5, 2), arrayBlockOf(BIGINT)));
 
-            Block column6 = reader.readBlock(mapType, 6);
+            Block column6 = reader.readBlock(6);
             assertEquals(column6.getPositionCount(), 3);
 
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, arrayType.getObject(column6, 0), mapBlockOf(createVarcharType(5), BOOLEAN, "k1", true)));
@@ -198,24 +198,24 @@ public class TestShardWriter
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, object, k2));
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, arrayType.getObject(column6, 2), mapBlockOf(createVarcharType(5), BOOLEAN, "k3", false)));
 
-            Block column7 = reader.readBlock(arrayOfArrayType, 7);
+            Block column7 = reader.readBlock(7);
             assertEquals(column7.getPositionCount(), 3);
 
             assertTrue(arrayBlocksEqual(arrayType, arrayOfArrayType.getObject(column7, 0), arrayBlockOf(arrayType, arrayBlockOf(BIGINT, 5))));
             assertTrue(arrayBlocksEqual(arrayType, arrayOfArrayType.getObject(column7, 1), arrayBlockOf(arrayType, null, arrayBlockOf(BIGINT, 6, 7))));
             assertTrue(arrayBlocksEqual(arrayType, arrayOfArrayType.getObject(column7, 2), arrayBlockOf(arrayType, arrayBlockOf(BIGINT))));
 
-            Block column8 = reader.readBlock(TIMESTAMP, 8);
+            Block column8 = reader.readBlock(8);
             assertEquals(TIMESTAMP.getLong(column8, 0), timestampValue);
             assertEquals(TIMESTAMP.getLong(column8, 1), timestampValue);
             assertEquals(TIMESTAMP.getLong(column8, 2), timestampValue);
 
-            Block column9 = reader.readBlock(TIME, 9);
+            Block column9 = reader.readBlock(9);
             assertEquals(TIME.getLong(column9, 0), timeValue);
             assertEquals(TIME.getLong(column9, 1), timeValue);
             assertEquals(TIME.getLong(column9, 2), timeValue);
 
-            Block column10 = reader.readBlock(DATE, 10);
+            Block column10 = reader.readBlock(10);
             assertEquals(DATE.getLong(column10, 0), dateValue);
             assertEquals(DATE.getLong(column10, 1), dateValue);
             assertEquals(DATE.getLong(column10, 2), dateValue);


### PR DESCRIPTION
Cherry-pick of https://github.com/prestosql/presto/pull/555

The memory tracking for StreamReader was firstly introduced in 97552478c9 Add memory tracking for StreamReader local buffers and then removed in
303cecacf7 Remove unnecessary StreamReader.close method
47423bbb2c Remove unused systemMemoryContext from OrcBatchRecordReader
be749f6197 Remove unused systemMemoryContext variable from XxxBatchStreamReader

BenchmarkBatchStreamReaders results:

Before
Benchmark                                  (typeSignature)  (withNulls)  Mode  Cnt    Score   Error  Units
BenchmarkBatchStreamReaders.readBlocks             boolean      PARTIAL  avgt   60   45.432 ± 0.720  ms/op
BenchmarkBatchStreamReaders.readBlocks             boolean         NONE  avgt   60   34.396 ± 0.629  ms/op
BenchmarkBatchStreamReaders.readBlocks             boolean          ALL  avgt   60    7.894 ± 0.166  ms/op
BenchmarkBatchStreamReaders.readBlocks             tinyint      PARTIAL  avgt   60   47.784 ± 1.106  ms/op
BenchmarkBatchStreamReaders.readBlocks             tinyint         NONE  avgt   60   39.331 ± 0.747  ms/op
BenchmarkBatchStreamReaders.readBlocks             tinyint          ALL  avgt   60    8.269 ± 0.217  ms/op
BenchmarkBatchStreamReaders.readBlocks            smallint      PARTIAL  avgt   60   87.624 ± 3.163  ms/op
BenchmarkBatchStreamReaders.readBlocks            smallint         NONE  avgt   60   93.390 ± 2.122  ms/op
BenchmarkBatchStreamReaders.readBlocks            smallint          ALL  avgt   60    8.886 ± 0.289  ms/op
BenchmarkBatchStreamReaders.readBlocks             integer      PARTIAL  avgt   60   97.352 ± 2.974  ms/op
BenchmarkBatchStreamReaders.readBlocks             integer         NONE  avgt   60  106.238 ± 2.092  ms/op
BenchmarkBatchStreamReaders.readBlocks             integer          ALL  avgt   60    9.017 ± 0.301  ms/op
BenchmarkBatchStreamReaders.readBlocks              bigint      PARTIAL  avgt   60  111.976 ± 3.586  ms/op
BenchmarkBatchStreamReaders.readBlocks              bigint         NONE  avgt   60  133.045 ± 4.189  ms/op
BenchmarkBatchStreamReaders.readBlocks              bigint          ALL  avgt   60    8.871 ± 0.322  ms/op
BenchmarkBatchStreamReaders.readBlocks           timestamp      PARTIAL  avgt   60  165.562 ± 5.700  ms/op
BenchmarkBatchStreamReaders.readBlocks           timestamp         NONE  avgt   60  238.276 ± 7.139  ms/op
BenchmarkBatchStreamReaders.readBlocks           timestamp          ALL  avgt   60    9.239 ± 0.506  ms/op
BenchmarkBatchStreamReaders.readBlocks      varchar_direct      PARTIAL  avgt   60  208.502 ± 3.426  ms/op
BenchmarkBatchStreamReaders.readBlocks      varchar_direct         NONE  avgt   60  279.045 ± 6.075  ms/op
BenchmarkBatchStreamReaders.readBlocks      varchar_direct          ALL  avgt   60   32.427 ± 0.826  ms/op
BenchmarkBatchStreamReaders.readBlocks  varchar_dictionary      PARTIAL  avgt   60   52.460 ± 1.217  ms/op
BenchmarkBatchStreamReaders.readBlocks  varchar_dictionary         NONE  avgt   60   38.757 ± 0.596  ms/op
BenchmarkBatchStreamReaders.readBlocks  varchar_dictionary          ALL  avgt   60   32.064 ± 0.518  ms/op

After
Benchmark                                  (typeSignature)  (withNulls)  Mode  Cnt    Score   Error  Units
BenchmarkBatchStreamReaders.readBlocks             boolean      PARTIAL  avgt   60   26.017 ± 0.436  ms/op
BenchmarkBatchStreamReaders.readBlocks             boolean         NONE  avgt   60   14.980 ± 0.255  ms/op
BenchmarkBatchStreamReaders.readBlocks             boolean          ALL  avgt   60    8.180 ± 0.195  ms/op
BenchmarkBatchStreamReaders.readBlocks             tinyint      PARTIAL  avgt   60   27.405 ± 0.604  ms/op
BenchmarkBatchStreamReaders.readBlocks             tinyint         NONE  avgt   60   16.941 ± 2.228  ms/op
BenchmarkBatchStreamReaders.readBlocks             tinyint          ALL  avgt   60    7.880 ± 0.181  ms/op
BenchmarkBatchStreamReaders.readBlocks            smallint      PARTIAL  avgt   60   43.038 ± 1.083  ms/op
BenchmarkBatchStreamReaders.readBlocks            smallint         NONE  avgt   60   49.573 ± 2.417  ms/op
BenchmarkBatchStreamReaders.readBlocks            smallint          ALL  avgt   60    8.062 ± 0.105  ms/op
BenchmarkBatchStreamReaders.readBlocks             integer      PARTIAL  avgt   60   49.302 ± 0.955  ms/op
BenchmarkBatchStreamReaders.readBlocks             integer         NONE  avgt   60   56.010 ± 1.357  ms/op
BenchmarkBatchStreamReaders.readBlocks             integer          ALL  avgt   60    8.114 ± 0.265  ms/op
BenchmarkBatchStreamReaders.readBlocks              bigint      PARTIAL  avgt   60   60.625 ± 1.964  ms/op
BenchmarkBatchStreamReaders.readBlocks              bigint         NONE  avgt   60   82.082 ± 4.071  ms/op
BenchmarkBatchStreamReaders.readBlocks              bigint          ALL  avgt   60    8.117 ± 0.136  ms/op
BenchmarkBatchStreamReaders.readBlocks           timestamp      PARTIAL  avgt   60  131.245 ± 3.605  ms/op
BenchmarkBatchStreamReaders.readBlocks           timestamp         NONE  avgt   60  199.041 ± 4.008  ms/op
BenchmarkBatchStreamReaders.readBlocks           timestamp          ALL  avgt   60    8.134 ± 0.155  ms/op
BenchmarkBatchStreamReaders.readBlocks      varchar_direct      PARTIAL  avgt   60   61.129 ± 1.331  ms/op
BenchmarkBatchStreamReaders.readBlocks      varchar_direct         NONE  avgt   60   71.723 ± 2.255  ms/op
BenchmarkBatchStreamReaders.readBlocks      varchar_direct          ALL  avgt   60   21.339 ± 0.940  ms/op
BenchmarkBatchStreamReaders.readBlocks  varchar_dictionary      PARTIAL  avgt   60   55.705 ± 1.959  ms/op
BenchmarkBatchStreamReaders.readBlocks  varchar_dictionary         NONE  avgt   60   29.450 ± 0.479  ms/op
BenchmarkBatchStreamReaders.readBlocks  varchar_dictionary          ALL  avgt   60   20.122 ± 0.396  ms/op


```
== RELEASE NOTES ==

Hive Changes
* Improve BatchStreamReader performance
```
