### PR TITLE
[WIP]Support other file formats with pushdown filter

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBatchPageSourceFactory.java
@@ -17,6 +17,7 @@ import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.relation.RowExpression;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.joda.time.DateTimeZone;
@@ -38,6 +39,7 @@ public interface HiveBatchPageSourceFactory
             Map<String, String> tableParameters,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
+            RowExpression remainingPredicate,
             DateTimeZone hiveStorageTimeZone,
             Optional<byte[]> extraFileInfo);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -166,6 +166,7 @@ public class HiveClientConfig
 
     private boolean pushdownFilterEnabled;
     private boolean nestedColumnsFilterEnabled;
+    private boolean supportOnlyOrcDwrfFiles;
 
     public int getMaxInitialSplits()
     {
@@ -1392,6 +1393,19 @@ public class HiveClientConfig
     public HiveClientConfig setNestedColumnsFilterEnabled(boolean nestedColumnsFilterEnabled)
     {
         this.nestedColumnsFilterEnabled = nestedColumnsFilterEnabled;
+        return this;
+    }
+
+    public boolean isSupportOnlyOrcDwrfFiles()
+    {
+        return supportOnlyOrcDwrfFiles;
+    }
+
+    @Config("hive.support-only-orc-dwrf-files")
+    @ConfigDescription("Experimental: support only orc/dwrf file formats")
+    public HiveClientConfig setSupportOnlyOrcDwrfFiles(boolean supportOnlyOrcDwrfFiles)
+    {
+        this.supportOnlyOrcDwrfFiles = supportOnlyOrcDwrfFiles;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1895,7 +1895,7 @@ public class HiveMetadata
         boolean pushdownFilterEnabled = HiveSessionProperties.isPushdownFilterEnabled(session);
         if (pushdownFilterEnabled) {
             HiveStorageFormat hiveStorageFormat = getHiveStorageFormat(getTableMetadata(session, tableHandle).getProperties());
-            if (hiveStorageFormat == HiveStorageFormat.ORC || hiveStorageFormat == HiveStorageFormat.DWRF) {
+            if (hiveStorageFormat == HiveStorageFormat.RCTEXT || hiveStorageFormat == HiveStorageFormat.DWRF) {
                 return true;
             }
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -91,6 +91,7 @@ public final class HiveSessionProperties
     public static final String VIRTUAL_BUCKET_COUNT = "virtual_bucket_count";
     public static final String MAX_BUCKETS_FOR_GROUPED_EXECUTION = "max_buckets_for_grouped_execution";
     public static final String OFFLINE_DATA_DEBUG_MODE_ENABLED = "offline_data_debug_mode_enabled";
+    public static final String SUPPORT_ONLY_ORC_DWRF_FILES = "support_only_orc_dwrf_files";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -398,7 +399,12 @@ public final class HiveSessionProperties
                         OFFLINE_DATA_DEBUG_MODE_ENABLED,
                         "allow reading from tables or partitions that are marked as offline or not readable",
                         false,
-                        true));
+                        true),
+                booleanProperty(
+                        SUPPORT_ONLY_ORC_DWRF_FILES,
+                        "Experimental: support only orc,dwrf files",
+                        hiveClientConfig.isSupportOnlyOrcDwrfFiles(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfBatchPageSourceFactory.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.type.TypeManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -86,6 +87,7 @@ public class DwrfBatchPageSourceFactory
             Map<String, String> tableParameters,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
+            RowExpression remainingPredicate,
             DateTimeZone hiveStorageTimeZone,
             Optional<byte[]> extraFileInfo)
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.collect.ImmutableList;
@@ -127,6 +128,7 @@ public class OrcBatchPageSourceFactory
             Map<String, String> tableParameters,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
+            RowExpression remainingPredicate,
             DateTimeZone hiveStorageTimeZone,
             Optional<byte[]> extraFileInfo)
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.Subfield;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -133,6 +134,7 @@ public class ParquetPageSourceFactory
             Map<String, String> tableParameters,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
+            RowExpression remainingPredicate,
             DateTimeZone hiveStorageTimeZone,
             Optional<byte[]> extraFileInfo)
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSource.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.rcfile.RcFileCorruptionException;
 import com.facebook.presto.rcfile.RcFileReader;
 import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
@@ -54,6 +55,7 @@ public class RcFilePageSource
 
     private final Block[] constantBlocks;
     private final int[] hiveColumnIndexes;
+    private final ConnectorSession session;
 
     private int pageId;
     private long completedPositions;
@@ -64,7 +66,8 @@ public class RcFilePageSource
             RcFileReader rcFileReader,
             List<HiveColumnHandle> columns,
             DateTimeZone hiveStorageTimeZone,
-            TypeManager typeManager)
+            TypeManager typeManager,
+            ConnectorSession session)
     {
         requireNonNull(rcFileReader, "rcReader is null");
         requireNonNull(columns, "columns is null");
@@ -77,6 +80,7 @@ public class RcFilePageSource
 
         this.constantBlocks = new Block[size];
         this.hiveColumnIndexes = new int[size];
+        this.session = session;
 
         ImmutableList.Builder<String> namesBuilder = ImmutableList.builder();
         ImmutableList.Builder<Type> typesBuilder = ImmutableList.builder();
@@ -155,7 +159,7 @@ public class RcFilePageSource
                 }
             }
 
-            return new Page(currentPageSize, blocks);
+            return  new Page(currentPageSize, blocks);
         }
         catch (PrestoException e) {
             closeWithSuppression(e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSourceFactory.java
@@ -13,12 +13,16 @@
  */
 package com.facebook.presto.hive.rcfile;
 
+import com.facebook.presto.expressions.DefaultRowExpressionTraversalVisitor;
 import com.facebook.presto.hive.FileFormatDataSourceStats;
 import com.facebook.presto.hive.FileOpener;
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.HiveBatchPageSourceFactory;
 import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HiveSessionProperties;
 import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory;
+import com.facebook.presto.orc.FilterFunction;
 import com.facebook.presto.rcfile.AircompressorCodecFactory;
 import com.facebook.presto.rcfile.HadoopCodecFactory;
 import com.facebook.presto.rcfile.RcFileCorruptionException;
@@ -29,10 +33,19 @@ import com.facebook.presto.rcfile.text.TextRcFileEncoding;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.relation.DeterminismEvaluator;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.PredicateCompiler;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionService;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
@@ -49,19 +62,29 @@ import javax.inject.Inject;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
+import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
+import static com.facebook.presto.expressions.LogicalRowExpressions.binaryExpression;
+import static com.facebook.presto.expressions.LogicalRowExpressions.extractConjuncts;
+import static com.facebook.presto.expressions.RowExpressionNodeInliner.replaceExpression;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_MISSING_DATA;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveSchema;
 import static com.facebook.presto.rcfile.text.TextRcFileEncoding.DEFAULT_NULL_SEQUENCE;
 import static com.facebook.presto.rcfile.text.TextRcFileEncoding.DEFAULT_SEPARATORS;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
 import static com.google.common.base.Strings.nullToEmpty;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.hive.serde.serdeConstants.COLLECTION_DELIM;
@@ -84,14 +107,16 @@ public class RcFilePageSourceFactory
     private final HdfsEnvironment hdfsEnvironment;
     private final FileFormatDataSourceStats stats;
     private final FileOpener fileOpener;
+    private final RowExpressionService rowExpressionService;
 
     @Inject
-    public RcFilePageSourceFactory(TypeManager typeManager, HdfsEnvironment hdfsEnvironment, FileFormatDataSourceStats stats, FileOpener fileOpener)
+    public RcFilePageSourceFactory(TypeManager typeManager, HdfsEnvironment hdfsEnvironment, FileFormatDataSourceStats stats, FileOpener fileOpener, RowExpressionService service)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.stats = requireNonNull(stats, "stats is null");
         this.fileOpener = requireNonNull(fileOpener, "fileOpener is null");
+        this.rowExpressionService = service;
     }
 
     @Override
@@ -106,6 +131,7 @@ public class RcFilePageSourceFactory
             Map<String, String> tableParameters,
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
+            RowExpression remainingPredicate,
             DateTimeZone hiveStorageTimeZone,
             Optional<byte[]> extraFileInfo)
     {
@@ -152,11 +178,29 @@ public class RcFilePageSourceFactory
                     length,
                     new DataSize(8, Unit.MEGABYTE));
 
+            if (HiveSessionProperties.isPushdownFilterEnabled(session)) {
+                Map<VariableReferenceExpression, InputReferenceExpression> variableToInput = columns.stream()
+                        .collect(toImmutableMap(
+                                hiveColumnIndex -> new VariableReferenceExpression(hiveColumnIndex.getName(), hiveColumnIndex.getHiveType().getType(typeManager)),
+                                hiveColumnIndex -> new InputReferenceExpression(hiveColumnIndex.getHiveColumnIndex(), hiveColumnIndex.getHiveType().getType(typeManager))));
+
+                List<FilterFunction> filterFunctions = toFilterFunctions(replaceExpression(remainingPredicate, variableToInput), session, rowExpressionService.getDeterminismEvaluator(), rowExpressionService.getPredicateCompiler());
+                return Optional.of(new RcFileSelectivePageSource(
+                        rcFileReader,
+                        columns,
+                        hiveStorageTimeZone,
+                        typeManager,
+                        session,
+                        effectivePredicate,
+                        filterFunctions));
+            }
+
             return Optional.of(new RcFilePageSource(
                     rcFileReader,
                     columns,
                     hiveStorageTimeZone,
-                    typeManager));
+                    typeManager,
+                    session));
         }
         catch (Throwable e) {
             try {
@@ -227,5 +271,50 @@ public class RcFilePageSourceFactory
                 separators,
                 escapeByte,
                 lastColumnTakesRest);
+    }
+
+    /**
+     * Split filter expression into groups of conjuncts that depend on the same set of inputs,
+     * then compile each group into FilterFunction.
+     */
+    private static List<FilterFunction> toFilterFunctions(RowExpression filter, ConnectorSession session, DeterminismEvaluator determinismEvaluator, PredicateCompiler predicateCompiler)
+    {
+        if (TRUE_CONSTANT.equals(filter)) {
+            return ImmutableList.of();
+        }
+
+        List<RowExpression> conjuncts = extractConjuncts(filter);
+        if (conjuncts.size() == 1) {
+            return ImmutableList.of(new FilterFunction(session, determinismEvaluator.isDeterministic(filter), predicateCompiler.compilePredicate(filter).get()));
+        }
+
+        // Use LinkedHashMap to preserve user-specified order of conjuncts. This will be the initial order in which filters are applied.
+        Map<Set<Integer>, List<RowExpression>> inputsToConjuncts = new LinkedHashMap<>();
+        for (RowExpression conjunct : conjuncts) {
+            inputsToConjuncts.computeIfAbsent(extractInputs(conjunct), k -> new ArrayList<>()).add(conjunct);
+        }
+
+        return inputsToConjuncts.values().stream()
+                .map(expressions -> binaryExpression(AND, expressions))
+                .map(predicate -> new FilterFunction(session, determinismEvaluator.isDeterministic(predicate), predicateCompiler.compilePredicate(predicate).get()))
+                .collect(toImmutableList());
+    }
+
+    private static Set<Integer> extractInputs(RowExpression expression)
+    {
+        ImmutableSet.Builder<Integer> inputs = ImmutableSet.builder();
+        expression.accept(new InputReferenceBuilderVisitor(), inputs);
+        return inputs.build();
+    }
+
+    private static class InputReferenceBuilderVisitor
+            extends DefaultRowExpressionTraversalVisitor<ImmutableSet.Builder<Integer>>
+    {
+        @Override
+        public Void visitInputReference(InputReferenceExpression input, ImmutableSet.Builder<Integer> builder)
+        {
+            builder.add(input.getField());
+            return null;
+        }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFileSelectivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFileSelectivePageSource.java
@@ -1,0 +1,174 @@
+package com.facebook.presto.hive.rcfile;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.orc.FilterFunction;
+import com.facebook.presto.orc.TupleDomainFilter;
+import com.facebook.presto.orc.TupleDomainFilterUtils;
+import com.facebook.presto.rcfile.RcFileReader;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.predicate.Domain;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.spi.type.VarcharType;
+import io.airlift.slice.Slice;
+import org.joda.time.DateTimeZone;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
+import static java.lang.Double.longBitsToDouble;
+import static java.lang.Float.intBitsToFloat;
+import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+
+public class RcFileSelectivePageSource
+        extends RcFilePageSource
+{
+    private final List<HiveColumnHandle> columns;
+    private TupleDomain<HiveColumnHandle> predicate;
+    private TypeManager typeManager;
+    private List<FilterFunction> filterFunctions;
+
+    public RcFileSelectivePageSource(
+            RcFileReader rcFileReader,
+            List<HiveColumnHandle> columns,
+            DateTimeZone hiveStorageTimeZone,
+            TypeManager typeManager,
+            ConnectorSession session,
+            TupleDomain<HiveColumnHandle> predicate,
+            List<FilterFunction> remainingPredicate)
+    {
+        super(rcFileReader, columns, hiveStorageTimeZone, typeManager, session);
+        this.columns = columns;
+        this.predicate = predicate;
+        this.typeManager = typeManager;
+        this.filterFunctions = remainingPredicate;
+    }
+
+    public Page getNextPage()
+    {
+        Page page = super.getNextPage();
+        if (page == null || page.getPositionCount() == 0 || this.predicate == null) {
+            return page;
+        }
+        int[] positions = new int[page.getPositionCount()];
+        RuntimeException[] errors = new RuntimeException[page.getPositionCount()];
+        Map<HiveColumnHandle, Domain> columnDomains = this.predicate.getDomains().get();
+        Collection<HiveColumnHandle> columnIndices = columnDomains.keySet();
+        int positionCount = positions.length;
+
+        for (HiveColumnHandle col : columnIndices) {
+            positionCount = filterBlock(page.getBlock(col.getHiveColumnIndex()), col.getHiveType().getType(typeManager), TupleDomainFilterUtils.toFilter(columnDomains.get(col)), positions, positionCount);
+        }
+
+        for (FilterFunction function : filterFunctions) {
+            Block[] inputBlocks = new Block[page.getChannelCount()];
+
+            for (int i = 0; i < page.getChannelCount(); i++) {
+                inputBlocks[i] = page.getBlock(i);
+            }
+
+            page = new Page(positionCount, inputBlocks);
+            positionCount = function.filter(page, positions, positionCount, errors);
+            if (positionCount == 0) {
+                break;
+            }
+        }
+
+        for (int i = 0; i < positionCount; i++) {
+            if (errors[i] != null) {
+                throw errors[i];
+            }
+        }
+
+        return page.getPositions(positions, 0, positionCount);
+    }
+
+    public static int filterBlock(Block block, Type type, TupleDomainFilter filter, int[] positions, int positionCount)
+    {
+
+        int livePositionCount = 0;
+        if (type == BIGINT || type == INTEGER || type == SMALLINT || type == TINYINT) {
+            for (int i = 0; i < positionCount; i++) {
+                int position = positions[i];
+                if (block.isNull(position)) {
+                    if (filter.testNull()) {
+                        positions[i] = position;
+                        livePositionCount++;
+                    }
+                }
+                else if (filter.testLong(type.getLong(block, position))) {
+                    positions[i] = position;
+                    livePositionCount++;
+                }
+            }
+        }
+        else if (type == DoubleType.DOUBLE) {
+            for (int i = 0; i < positionCount; i++) {
+                int position = positions[i];
+                if (block.isNull(position)) {
+                    if (filter.testNull()) {
+                        positions[i] = position;
+                        livePositionCount++;
+                    }
+                }
+                else if (filter.testDouble(longBitsToDouble(block.getLong(position)))) {
+                    positions[i] = position;
+                    livePositionCount++;
+                }
+            }
+        }
+        else if (type == REAL) {
+            for (int i = 0; i < positionCount; i++) {
+                int position = positions[i];
+                if (block.isNull(position)) {
+                    if (filter.testNull()) {
+                        positions[i] = position;
+                        livePositionCount++;
+                    }
+                }
+                else if (filter.testFloat(intBitsToFloat(block.getInt(position)))) {
+                    positions[i] = position;
+                    livePositionCount++;
+                }
+            }
+        }
+        else if (isVarcharType(type)) {
+            for (int i = 0; i < positionCount; i++) {
+                int position = positions[i];
+                if (block.isNull(position)) {
+                    if (filter.testNull()) {
+                        positions[i] = position;
+                        livePositionCount++;
+                    }
+                }
+                else {
+                    Slice slice = block.getSlice(position, 0, block.getSliceLength(position));
+                    if (filter.testBytes((byte[]) slice.getBase(), (int) slice.getAddress() - ARRAY_BYTE_BASE_OFFSET, slice.length())) {
+                        positions[i] = position;
+                        livePositionCount++;
+                    }
+                }
+            }
+        }
+        else {
+            throw new UnsupportedOperationException("BlockStreamReadre of " + type.toString() + " not supported");
+        }
+
+        return livePositionCount;
+    }
+
+    public static boolean isVarcharType(Type type)
+    {
+        return type instanceof VarcharType;
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -128,7 +128,7 @@ public final class HiveTestUtils
         FileFormatDataSourceStats stats = new FileFormatDataSourceStats();
         HdfsEnvironment testHdfsEnvironment = createTestHdfsEnvironment(hiveClientConfig);
         return ImmutableSet.<HiveBatchPageSourceFactory>builder()
-                .add(new RcFilePageSourceFactory(TYPE_MANAGER, testHdfsEnvironment, stats, new HadoopFileOpener()))
+                .add(new RcFilePageSourceFactory(TYPE_MANAGER, testHdfsEnvironment, stats, new HadoopFileOpener(), ROW_EXPRESSION_SERVICE))
                 .add(new OrcBatchPageSourceFactory(TYPE_MANAGER, hiveClientConfig, testHdfsEnvironment, stats, new StorageOrcFileTailSource(), new HadoopFileOpener()))
                 .add(new DwrfBatchPageSourceFactory(TYPE_MANAGER, hiveClientConfig, testHdfsEnvironment, stats, new StorageOrcFileTailSource(), new HadoopFileOpener()))
                 .add(new ParquetPageSourceFactory(TYPE_MANAGER, testHdfsEnvironment, stats, new HadoopFileOpener()))

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -133,7 +133,8 @@ public class TestHiveClientConfig
                 .setTemporaryTableStorageFormat(ORC)
                 .setTemporaryTableCompressionCodec(SNAPPY)
                 .setPushdownFilterEnabled(false)
-                .setNestedColumnsFilterEnabled(false));
+                .setNestedColumnsFilterEnabled(false)
+                .setSupportOnlyOrcDwrfFiles(false));
     }
 
     @Test
@@ -231,6 +232,7 @@ public class TestHiveClientConfig
                 .put("hive.temporary-table-compression-codec", "NONE")
                 .put("hive.pushdown-filter-enabled", "true")
                 .put("hive.nested-columns-filter-enabled", "true")
+                .put("hive.support-only-rc-dwrf-files", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
@@ -75,6 +75,7 @@ import static com.facebook.presto.hive.HiveStorageFormat.SEQUENCEFILE;
 import static com.facebook.presto.hive.HiveStorageFormat.TEXTFILE;
 import static com.facebook.presto.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static com.facebook.presto.hive.HiveTestUtils.HIVE_CLIENT_CONFIG;
+import static com.facebook.presto.hive.HiveTestUtils.ROW_EXPRESSION_SERVICE;
 import static com.facebook.presto.hive.HiveTestUtils.SESSION;
 import static com.facebook.presto.hive.HiveTestUtils.TYPE_MANAGER;
 import static com.facebook.presto.hive.HiveTestUtils.getTypes;
@@ -197,7 +198,7 @@ public class TestHiveFileFormats
         assertThatFileFormat(RCTEXT)
                 .withColumns(TEST_COLUMNS)
                 .withRowsCount(rowCount)
-                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener()));
+                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener(), ROW_EXPRESSION_SERVICE));
     }
 
     @Test(dataProvider = "rowCount")
@@ -218,7 +219,7 @@ public class TestHiveFileFormats
                 .withSession(session)
                 .withFileWriterFactory(new RcFileFileWriterFactory(HDFS_ENVIRONMENT, TYPE_MANAGER, new NodeVersion("test"), HIVE_STORAGE_TIME_ZONE, STATS))
                 .isReadableByRecordCursor(new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT))
-                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener()));
+                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener(), ROW_EXPRESSION_SERVICE));
     }
 
     @Test(dataProvider = "rowCount")
@@ -249,7 +250,7 @@ public class TestHiveFileFormats
         assertThatFileFormat(RCBINARY)
                 .withColumns(testColumns)
                 .withRowsCount(rowCount)
-                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener()));
+                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener(), ROW_EXPRESSION_SERVICE));
     }
 
     @Test(dataProvider = "rowCount")
@@ -272,7 +273,7 @@ public class TestHiveFileFormats
                 .withSession(session)
                 .withFileWriterFactory(new RcFileFileWriterFactory(HDFS_ENVIRONMENT, TYPE_MANAGER, new NodeVersion("test"), HIVE_STORAGE_TIME_ZONE, STATS))
                 .isReadableByRecordCursor(new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT))
-                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener()));
+                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener(), ROW_EXPRESSION_SERVICE));
     }
 
     @Test(dataProvider = "rowCount")
@@ -454,13 +455,13 @@ public class TestHiveFileFormats
         assertThatFileFormat(RCTEXT)
                 .withWriteColumns(ImmutableList.of(writeColumn))
                 .withReadColumns(ImmutableList.of(readColumn))
-                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener()))
+                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener(), ROW_EXPRESSION_SERVICE))
                 .isReadableByRecordCursor(new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT));
 
         assertThatFileFormat(RCBINARY)
                 .withWriteColumns(ImmutableList.of(writeColumn))
                 .withReadColumns(ImmutableList.of(readColumn))
-                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener()))
+                .isReadableByPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener(), ROW_EXPRESSION_SERVICE))
                 .isReadableByRecordCursor(new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT));
 
         assertThatFileFormat(ORC)
@@ -504,12 +505,12 @@ public class TestHiveFileFormats
 
         assertThatFileFormat(RCTEXT)
                 .withColumns(columns)
-                .isFailingForPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener()), expectedErrorCode, expectedMessage)
+                .isFailingForPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener(), ROW_EXPRESSION_SERVICE), expectedErrorCode, expectedMessage)
                 .isFailingForRecordCursor(new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT), expectedErrorCode, expectedMessage);
 
         assertThatFileFormat(RCBINARY)
                 .withColumns(columns)
-                .isFailingForPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener()), expectedErrorCode, expectedMessage)
+                .isFailingForPageSource(new RcFilePageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener(), ROW_EXPRESSION_SERVICE), expectedErrorCode, expectedMessage)
                 .isFailingForRecordCursor(new GenericHiveRecordCursorProvider(HDFS_ENVIRONMENT), expectedErrorCode, expectedMessage);
 
         assertThatFileFormat(ORC)
@@ -732,6 +733,7 @@ public class TestHiveFileFormats
                         false,
                         ImmutableMap.of()),
                 TupleDomain.all(),
+                null,
                 getColumnHandles(testColumns),
                 partitionKeys,
                 DateTimeZone.getDefault(),
@@ -789,6 +791,7 @@ public class TestHiveFileFormats
                         false,
                         ImmutableMap.of()),
                 TupleDomain.all(),
+                null,
                 columnHandles,
                 partitionKeys,
                 DateTimeZone.getDefault(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
@@ -485,6 +485,7 @@ public class TestOrcBatchPageSourceMemoryTracking
                     fileSplit.getLength(),
                     storage,
                     TupleDomain.all(),
+                    null,
                     columns,
                     partitionKeys,
                     DateTimeZone.UTC,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -69,6 +69,7 @@ import java.util.Properties;
 
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveTestUtils.HIVE_CLIENT_CONFIG;
+import static com.facebook.presto.hive.HiveTestUtils.ROW_EXPRESSION_SERVICE;
 import static com.facebook.presto.hive.HiveTestUtils.TYPE_MANAGER;
 import static com.facebook.presto.hive.HiveType.toHiveType;
 import static com.facebook.presto.hive.metastore.StorageFormat.fromHiveStorageFormat;
@@ -88,7 +89,7 @@ public enum FileFormat
         @Override
         public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
         {
-            HiveBatchPageSourceFactory pageSourceFactory = new RcFilePageSourceFactory(TYPE_MANAGER, hdfsEnvironment, new FileFormatDataSourceStats(), new HadoopFileOpener());
+            HiveBatchPageSourceFactory pageSourceFactory = new RcFilePageSourceFactory(TYPE_MANAGER, hdfsEnvironment, new FileFormatDataSourceStats(), new HadoopFileOpener(), ROW_EXPRESSION_SERVICE);
             return createPageSource(pageSourceFactory, session, targetFile, columnNames, columnTypes, HiveStorageFormat.RCBINARY);
         }
 
@@ -113,7 +114,7 @@ public enum FileFormat
         @Override
         public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
         {
-            HiveBatchPageSourceFactory pageSourceFactory = new RcFilePageSourceFactory(TYPE_MANAGER, hdfsEnvironment, new FileFormatDataSourceStats(), new HadoopFileOpener());
+            HiveBatchPageSourceFactory pageSourceFactory = new RcFilePageSourceFactory(TYPE_MANAGER, hdfsEnvironment, new FileFormatDataSourceStats(), new HadoopFileOpener(), ROW_EXPRESSION_SERVICE);
             return createPageSource(pageSourceFactory, session, targetFile, columnNames, columnTypes, HiveStorageFormat.RCTEXT);
         }
 
@@ -413,6 +414,7 @@ public enum FileFormat
                         ImmutableMap.of(),
                         columnHandles,
                         TupleDomain.all(),
+                        null,
                         DateTimeZone.forID(session.getTimeZoneKey().getId()),
                         Optional.empty())
                 .get();


### PR DESCRIPTION
Currently pushdown filter supports only ORC and DWRF file formats. This results in failures reading the other formats. This change will support those files by falling back to the older implementation. There is a session property that controls whether to throw an exception or not.

```
== NO RELEASE NOTE ==
```
