### PR TITLE
Fix double and float NaN comparisons

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
@@ -621,6 +621,8 @@ public interface TupleDomainFilter
         protected DoubleRange(double lower, boolean lowerUnbounded, boolean lowerExclusive, double upper, boolean upperUnbounded, boolean upperExclusive, boolean nullAllowed)
         {
             super(lowerUnbounded, lowerExclusive, upperUnbounded, upperExclusive, nullAllowed);
+            checkArgument(lowerUnbounded || !Double.isNaN(lower));
+            checkArgument(upperUnbounded || !Double.isNaN(upper));
             this.lower = lower;
             this.upper = upper;
         }
@@ -643,6 +645,9 @@ public interface TupleDomainFilter
         @Override
         public boolean testDouble(double value)
         {
+            if (Double.isNaN(value)) {
+                return false;
+            }
             if (!lowerUnbounded) {
                 if (value < lower) {
                     return false;
@@ -713,6 +718,8 @@ public interface TupleDomainFilter
         private FloatRange(float lower, boolean lowerUnbounded, boolean lowerExclusive, float upper, boolean upperUnbounded, boolean upperExclusive, boolean nullAllowed)
         {
             super(lowerUnbounded, lowerExclusive, upperUnbounded, upperExclusive, nullAllowed);
+            checkArgument(lowerUnbounded || !Float.isNaN(lower));
+            checkArgument(upperUnbounded || !Float.isNaN(upper));
             this.lower = lower;
             this.upper = upper;
         }
@@ -725,6 +732,9 @@ public interface TupleDomainFilter
         @Override
         public boolean testFloat(float value)
         {
+            if (Float.isNaN(value)) {
+                return false;
+            }
             if (!lowerUnbounded) {
                 if (value < lower) {
                     return false;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilterUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilterUtils.java
@@ -208,6 +208,12 @@ public class TupleDomainFilterUtils
         Marker high = range.getHigh();
         double lowerDouble = low.isLowerUnbounded() ? Double.MIN_VALUE : (double) low.getValue();
         double upperDouble = high.isUpperUnbounded() ? Double.MAX_VALUE : (double) high.getValue();
+        if (!low.isLowerUnbounded() && Double.isNaN(lowerDouble)) {
+            return ALWAYS_FALSE;
+        }
+        if (!high.isUpperUnbounded() && Double.isNaN(upperDouble)) {
+            return ALWAYS_FALSE;
+        }
         return DoubleRange.of(
                 lowerDouble,
                 low.isLowerUnbounded(),
@@ -224,6 +230,12 @@ public class TupleDomainFilterUtils
         Marker high = range.getHigh();
         float lowerFloat = low.isLowerUnbounded() ? Float.MIN_VALUE : intBitsToFloat(toIntExact((long) low.getValue()));
         float upperFloat = high.isUpperUnbounded() ? Float.MAX_VALUE : intBitsToFloat(toIntExact((long) high.getValue()));
+        if (!low.isLowerUnbounded() && Float.isNaN(lowerFloat)) {
+            return ALWAYS_FALSE;
+        }
+        if (!high.isUpperUnbounded() && Float.isNaN(upperFloat)) {
+            return ALWAYS_FALSE;
+        }
         return FloatRange.of(
                 lowerFloat,
                 low.isLowerUnbounded(),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilter.java
@@ -35,6 +35,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 public class TestTupleDomainFilter
 {
@@ -144,6 +145,15 @@ public class TestTupleDomainFilter
         assertFalse(filter.testNull());
         assertFalse(filter.testDouble(-0.3));
         assertFalse(filter.testDouble(55.6));
+        assertFalse(filter.testDouble(Double.NaN));
+
+        try {
+            DoubleRange.of(Double.NaN, false, false, Double.NaN, false, false, false);
+            fail("able to create a DoubleRange with NaN");
+        }
+        catch (IllegalArgumentException e) {
+            //expected
+        }
     }
 
     @Test
@@ -170,6 +180,15 @@ public class TestTupleDomainFilter
         assertFalse(filter.testNull());
         assertFalse(filter.testFloat(1.1f));
         assertFalse(filter.testFloat(15.632f));
+        assertFalse(filter.testFloat(Float.NaN));
+
+        try {
+            FloatRange.of(Float.NaN, false, false, Float.NaN, false, false, false);
+            fail("able to create a FloatRange with NaN");
+        }
+        catch (IllegalArgumentException e) {
+            //expected
+        }
     }
 
     @Test

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilterUtils.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilterUtils.java
@@ -71,6 +71,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.orc.TupleDomainFilter.ALWAYS_FALSE;
 import static com.facebook.presto.orc.TupleDomainFilter.IS_NOT_NULL;
 import static com.facebook.presto.orc.TupleDomainFilter.IS_NULL;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -279,6 +280,12 @@ public class TestTupleDomainFilterUtils
                 DoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), true));
 
         assertEquals(toFilter(between(C_DOUBLE, doubleLiteral(1.2), doubleLiteral(3.4))), DoubleRange.of(1.2, false, false, 3.4, false, false, false));
+
+        assertEquals(toFilter(lessThan(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
+        assertEquals(toFilter(lessThanOrEqual(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
+        assertEquals(toFilter(greaterThanOrEqual(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
+        assertEquals(toFilter(greaterThan(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
+        assertEquals(toFilter(notEqual(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
     }
 
     @Test
@@ -294,6 +301,13 @@ public class TestTupleDomainFilterUtils
         assertEquals(toFilter(or(isNull(C_REAL), notEqual(C_REAL, realLiteral))), MultiRange.of(ImmutableList.of(
                 FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
                 FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), true));
+
+        Expression floatNaNLiteral = toExpression(realValue(Float.NaN), TYPES.get(C_REAL.toSymbolReference()));
+        assertEquals(toFilter(lessThan(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
+        assertEquals(toFilter(lessThanOrEqual(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
+        assertEquals(toFilter(greaterThanOrEqual(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
+        assertEquals(toFilter(greaterThan(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
+        assertEquals(toFilter(notEqual(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
     }
 
     @Test


### PR DESCRIPTION
Fix comparison for NaNs in double and floats
```
== NO RELEASE NOTE ==
```
