### PR TITLE
Add non-linear transformation for structural hash

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayHashCodeOperator.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.function.TypeParameterSpecialization;
+import com.facebook.presto.spi.type.HashUtil;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
@@ -47,7 +48,8 @@ public final class ArrayHashCodeOperator
             for (int i = 0; i < block.getPositionCount(); i++) {
                 hash = CombineHashFunction.getHash(hash, block.isNull(i) ? NULL_HASH_CODE : (long) hashFunction.invoke(readNativeValue(type, block, i)));
             }
-            return hash;
+
+            return HashUtil.shuffle(hash);
         }
         catch (Throwable t) {
             throw internalError(t);
@@ -67,7 +69,8 @@ public final class ArrayHashCodeOperator
             for (int i = 0; i < block.getPositionCount(); i++) {
                 hash = CombineHashFunction.getHash(hash, block.isNull(i) ? NULL_HASH_CODE : (long) hashFunction.invokeExact(type.getLong(block, i)));
             }
-            return hash;
+
+            return HashUtil.shuffle(hash);
         }
         catch (Throwable t) {
             throw internalError(t);
@@ -87,7 +90,8 @@ public final class ArrayHashCodeOperator
             for (int i = 0; i < block.getPositionCount(); i++) {
                 hash = CombineHashFunction.getHash(hash, block.isNull(i) ? NULL_HASH_CODE : (long) hashFunction.invokeExact(type.getBoolean(block, i)));
             }
-            return hash;
+
+            return HashUtil.shuffle(hash);
         }
         catch (Throwable t) {
             throw internalError(t);
@@ -107,7 +111,8 @@ public final class ArrayHashCodeOperator
             for (int i = 0; i < block.getPositionCount(); i++) {
                 hash = CombineHashFunction.getHash(hash, block.isNull(i) ? NULL_HASH_CODE : (long) hashFunction.invokeExact(type.getSlice(block, i)));
             }
-            return hash;
+
+            return HashUtil.shuffle(hash);
         }
         catch (Throwable t) {
             throw internalError(t);
@@ -127,7 +132,8 @@ public final class ArrayHashCodeOperator
             for (int i = 0; i < block.getPositionCount(); i++) {
                 hash = CombineHashFunction.getHash(hash, block.isNull(i) ? NULL_HASH_CODE : (long) hashFunction.invokeExact(type.getDouble(block, i)));
             }
-            return hash;
+
+            return HashUtil.shuffle(hash);
         }
         catch (Throwable t) {
             throw internalError(t);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapHashCodeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapHashCodeOperator.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.BoundVariables;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.SqlOperator;
 import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.type.HashUtil;
 import com.facebook.presto.spi.type.StandardTypes;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
@@ -72,6 +73,7 @@ public class MapHashCodeOperator
         for (int position = 0; position < block.getPositionCount(); position += 2) {
             result += hashPosition(keyHashCodeFunction, keyType, block, position) ^ hashPosition(valueHashCodeFunction, valueType, block, position + 1);
         }
-        return result;
+
+        return HashUtil.shuffle(result);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -60,6 +60,7 @@ import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
 import static com.facebook.presto.util.StructuralTestUtil.appendToBlockBuilder;
+import static com.facebook.presto.util.StructuralTestUtil.mapType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.Float.floatToRawIntBits;
@@ -552,6 +553,72 @@ public final class BlockAssertions
             }
             else {
                 arrayType.writeObject(builder, createLongsBlock(value));
+            }
+        }
+
+        return builder.build();
+    }
+
+    public static Block createMapVarcharBigintBlock(Iterable<Map<String, Long>> values)
+    {
+        MapType mapType = mapType(VARCHAR, BIGINT);
+        BlockBuilder builder = mapType.createBlockBuilder(null, 100);
+
+        for (Map<String, Long> value : values) {
+            if (value == null) {
+                builder.appendNull();
+            }
+            else {
+                BlockBuilder entryWriter = builder.beginBlockEntry();
+                for (Map.Entry<String, Long> entry : value.entrySet()) {
+                    if (entry.getKey() == null) {
+                        entryWriter.appendNull();
+                    }
+                    else {
+                        VARCHAR.writeString(entryWriter, entry.getKey());
+                    }
+                    if (entry.getValue() == null) {
+                        entryWriter.appendNull();
+                    }
+                    else {
+                        BIGINT.writeLong(entryWriter, entry.getValue());
+                    }
+                }
+
+                builder.closeEntry();
+            }
+        }
+
+        return builder.build();
+    }
+
+    public static Block createRowVarcharBigintBlock(Iterable<List<Object>> values)
+    {
+        RowType rowType = RowType.anonymous(ImmutableList.of(VARCHAR, BIGINT));
+        BlockBuilder builder = rowType.createBlockBuilder(null, 100);
+
+        for (List<Object> value : values) {
+            if (value == null) {
+                builder.appendNull();
+            }
+            else {
+                checkArgument(value.size() == 2);
+                BlockBuilder entryWriter = builder.beginBlockEntry();
+
+                if (value.get(0) == null) {
+                    entryWriter.appendNull();
+                }
+                else {
+                    VARCHAR.writeString(entryWriter, (String) value.get(0));
+                }
+                if (value.get(1) == null) {
+                    entryWriter.appendNull();
+                }
+                else {
+                    BIGINT.writeLong(entryWriter, (Long) value.get(1));
+                }
+
+                builder.closeEntry();
             }
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestChecksumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestChecksumAggregation.java
@@ -17,16 +17,26 @@ import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.MapType;
+import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.SqlVarbinary;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
 
 import static com.facebook.presto.block.BlockAssertions.createArrayBigintBlock;
 import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
 import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
 import static com.facebook.presto.block.BlockAssertions.createLongDecimalsBlock;
 import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createMapVarcharBigintBlock;
+import static com.facebook.presto.block.BlockAssertions.createRowVarcharBigintBlock;
 import static com.facebook.presto.block.BlockAssertions.createShortDecimalsBlock;
 import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
 import static com.facebook.presto.operator.aggregation.AggregationTestUtils.assertAggregation;
@@ -37,8 +47,10 @@ import static com.facebook.presto.spi.type.DecimalType.createDecimalType;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.util.StructuralTestUtil.mapType;
 import static io.airlift.slice.Slices.wrappedLongArray;
 import static java.util.Arrays.asList;
+import static org.testng.Assert.assertNotEquals;
 
 public class TestChecksumAggregation
 {
@@ -108,6 +120,62 @@ public class TestChecksumAggregation
         InternalAggregationFunction stringAgg = getAggregation(arrayType);
         Block block = createArrayBigintBlock(asList(null, asList(1L, 2L), asList(3L, 4L), asList(5L, 6L)));
         assertAggregation(stringAgg, expectedChecksum(arrayType, block), block);
+    }
+
+    @Test
+    public void testStructuralChecksumCollision()
+    {
+        ArrayType arrayType = new ArrayType(BigintType.BIGINT);
+        for (int i = 0; i < 100; i++) {
+            long a1 = ThreadLocalRandom.current().nextLong();
+            long b1 = ThreadLocalRandom.current().nextLong();
+            long a2 = ThreadLocalRandom.current().nextLong();
+            long b2 = ThreadLocalRandom.current().nextLong();
+
+            Block arrayBlock1 = createArrayBigintBlock(ImmutableList.of(
+                    ImmutableList.of(a1, b1),
+                    ImmutableList.of(a2, b2)));
+            Block arrayBlock2 = createArrayBigintBlock(ImmutableList.of(
+                    ImmutableList.of(a1, b2),
+                    ImmutableList.of(a2, b1)));
+            assertNotEquals(expectedChecksum(arrayType, arrayBlock1), expectedChecksum(arrayType, arrayBlock2), "unexpected checksum collision");
+        }
+
+        MapType mapType = mapType(VarcharType.VARCHAR, BigintType.BIGINT);
+        for (int i = 0; i < 100; i++) {
+            String k1 = Long.valueOf(ThreadLocalRandom.current().nextLong()).toString();
+            long v1 = ThreadLocalRandom.current().nextLong();
+            String k2 = Long.valueOf(ThreadLocalRandom.current().nextLong()).toString();
+            long v2 = ThreadLocalRandom.current().nextLong();
+            String k3 = Long.valueOf(ThreadLocalRandom.current().nextLong()).toString();
+            long v3 = ThreadLocalRandom.current().nextLong();
+            String k4 = Long.valueOf(ThreadLocalRandom.current().nextLong()).toString();
+            long v4 = ThreadLocalRandom.current().nextLong();
+
+            Block mapBlock1 = createMapVarcharBigintBlock(ImmutableList.of(
+                    ImmutableMap.of(k1, v1, k2, v2),
+                    ImmutableMap.of(k3, v3, k4, v4)));
+            Block mapBlock2 = createMapVarcharBigintBlock(ImmutableList.of(
+                    ImmutableMap.of(k1, v1, k4, v4),
+                    ImmutableMap.of(k3, v3, k2, v2)));
+            assertNotEquals(expectedChecksum(mapType, mapBlock1), expectedChecksum(mapType, mapBlock2), "unexpected checksum collision");
+        }
+
+        RowType rowType = RowType.anonymous(ImmutableList.of(VarcharType.VARCHAR, BigintType.BIGINT));
+        for (int i = 0; i < 100; i++) {
+            String a1 = Long.valueOf(ThreadLocalRandom.current().nextLong()).toString();
+            long b1 = ThreadLocalRandom.current().nextLong();
+            String a2 = Long.valueOf(ThreadLocalRandom.current().nextLong()).toString();
+            long b2 = ThreadLocalRandom.current().nextLong();
+
+            Block rowBlock1 = createRowVarcharBigintBlock(ImmutableList.of(
+                    ImmutableList.of(a1, b1),
+                    ImmutableList.of(a2, b2)));
+            Block rowBlock2 = createRowVarcharBigintBlock(ImmutableList.of(
+                    ImmutableList.of(a1, b2),
+                    ImmutableList.of(a2, b1)));
+            assertNotEquals(expectedChecksum(rowType, rowBlock1), expectedChecksum(rowType, rowBlock2), "unexpected checksum collision");
+        }
     }
 
     private static SqlVarbinary expectedChecksum(Type type, Block block)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/ArrayType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/ArrayType.java
@@ -89,7 +89,8 @@ public class ArrayType
         for (int i = 0; i < array.getPositionCount(); i++) {
             hash = 31 * hash + hashPosition(elementType, array, i);
         }
-        return hash;
+
+        return HashUtil.shuffle(hash);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/HashUtil.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/HashUtil.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.type;
+
+public class HashUtil
+{
+    private static final long XXHASH64_PRIME64_2 = 0xC2B2AE3D27D4EB4FL;
+    private static final long XXHASH64_PRIME64_3 = 0x165667B19E3779F9L;
+
+    private HashUtil() {}
+
+    /**
+     * <p>
+     * This method is copied from {@code finalShuffle} from XxHash64 to provide non-linear transformation to
+     * avoid hash collisions when computing checksum over structural types.
+     *
+     * <p>
+     * When both structural hash and checksum are linear functions to input elements,
+     * it's vulnerable to hash collision attack by exchanging some input values
+     * (e.g. values in the same nested column).
+     *
+     * <p>
+     * Example for checksum collision:
+     *
+     * <pre>
+     * SELECT checksum(value)
+     * FROM (VALUES
+     *     ARRAY['a', '1'],
+     *     ARRAY['b', '2']
+     * ) AS t(value)
+     * </pre>
+     *
+     * vs.
+     *
+     * <pre>
+     * SELECT checksum(value)
+     * FROM (VALUES
+     *     ARRAY['a', '2'],
+     *     ARRAY['b', '1']
+     * ) AS t(value)
+     * </pre>
+
+     *
+     * @see io.airlift.slice.XxHash64
+     */
+    public static long shuffle(long hash)
+    {
+        hash ^= hash >>> 33;
+        hash *= XXHASH64_PRIME64_2;
+        hash ^= hash >>> 29;
+        hash *= XXHASH64_PRIME64_3;
+        hash ^= hash >>> 32;
+        return hash;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/MapType.java
@@ -120,7 +120,8 @@ public class MapType
         for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
             result += hashPosition(keyType, mapBlock, i) ^ hashPosition(valueType, mapBlock, i + 1);
         }
-        return result;
+
+        return HashUtil.shuffle(result);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/RowType.java
@@ -275,7 +275,8 @@ public class RowType
             Type elementType = fields.get(i).getType();
             result = 31 * result + TypeUtils.hashPosition(elementType, arrayBlock, i);
         }
-        return result;
+
+        return HashUtil.shuffle(result);
     }
 
     private static void checkElementNotNull(boolean isNull)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestRepartitionQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestRepartitionQueries.java
@@ -190,7 +190,7 @@ public abstract class AbstractTestRepartitionQueries
                         "    l.partkey = p.partkey\n" +
                         "    AND l.suppkey = p.suppkey\n" +
                         "    AND p.availqty < 1000",
-                new byte[] {10, -59, 46, 87, 22, -93, 58, -16});
+                new byte[] {-32, 9, 126, -65, -36, -86, -92, 22});
     }
 
     @Test
@@ -211,7 +211,7 @@ public abstract class AbstractTestRepartitionQueries
                         "    l.partkey = p.partkey\n" +
                         "    AND l.suppkey = p.suppkey\n" +
                         "    AND p.availqty < 1000",
-                new byte[] {10, -59, 46, 87, 22, -93, 58, -16});
+                new byte[] {-75, -83, 96, 40, 5, -56, 9, -45});
     }
 
     @Test
@@ -251,7 +251,7 @@ public abstract class AbstractTestRepartitionQueries
                         "    orders o\n" +
                         "WHERE\n" +
                         "    l.orderkey = o.orderkey",
-                new byte[] {-56, 110, 18, -107, -123, 121, 87, 79});
+                new byte[] {122, 28, -89, 51, -102, -91, 56, 51});
     }
 
     @Test
@@ -282,7 +282,7 @@ public abstract class AbstractTestRepartitionQueries
                         "    orders o\n" +
                         "WHERE\n" +
                         "    l.orderkey = o.orderkey",
-                new byte[] {67, 108, 83, 92, 16, -5, 66, 65});
+                new byte[] {121, -89, 11, 88, -40, 115, 109, 125});
     }
 
     @Test
@@ -303,7 +303,7 @@ public abstract class AbstractTestRepartitionQueries
                         "    l.partkey = p.partkey\n" +
                         "    AND l.suppkey = p.suppkey\n" +
                         "    AND p.availqty < 1000",
-                new byte[] {-28, 76, -12, -42, 116, -118, -9, 46});
+                new byte[] {58, -52, -125, -4, -19, 15, -122, -39});
 
         assertQuery("WITH lineitem_ex AS (\n" +
                         "    SELECT\n" +

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -244,7 +244,7 @@ public class TestDataVerification
                         "COLUMN MISMATCH\n" +
                         "Control 1 rows, Test 1 rows\n" +
                         "Mismatched Columns:\n" +
-                        "  _col0 \\(array\\(row\\(integer, varchar\\(1\\)\\)\\)\\): control\\(checksum: 71 b5 2f 7f 1e 9b a6 a4\\) test\\(checksum: b4 3c 7d 02 2b 14 77 12\\)\n"));
+                        "  _col0 \\(array\\(row\\(integer, varchar\\(1\\)\\)\\)\\): control\\(checksum: 73 91 a4 46 3b 0b 7e 2a\\) test\\(checksum: cd 1e ff 0f be 70 a6 94\\)\n"));
     }
 
     private void assertEvent(


### PR DESCRIPTION
Both structural hash and checksum are linear functions to the hash
values of input elements. This makes vulnerable to hash collision
attack by exchanging exchanging some input values .
(e.g. values in the same nested column)

This commit avoids such checksum collision by adding non-linear
transformation at the end of structural hash computation.

Example for checksum collision:

```SQL
SELECT checksum(value)
FROM (VALUES
    ARRAY['a', '1'],
    ARRAY['b', '2']
) AS t(value)
```

vs.

```SQL
SELECT checksum(value)
FROM (VALUES
    ARRAY['a', '2'],
    ARRAY['b', '1']
) AS t(value)
```

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* Improve hash value computation for structrual types to avoid collision.
