### PR TITLE
Add geospatial function line_interpolate_point

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -409,6 +409,14 @@ Accessors
 
     Returns ``null`` if a LineString or a Point is empty or ``null``.
 
+.. function:: line_interpolate_point(LineString, double) -> Geometry
+
+    Returns the Point on the LineString at a fractional distance given by the
+    double argument.  Throws an exception if the distance is not between 0 and 1.
+
+    Returns an empty Point if the LineString is empty.  Returns ``null`` if
+    either the LineString or double is null.
+
 .. function:: geometry_invalid_reason(Geometry) -> varchar
 
     Returns the reason for why the input geometry is not valid.

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
@@ -23,12 +23,19 @@ import com.esri.core.geometry.Polygon;
 import com.esri.core.geometry.ogc.OGCGeometry;
 import com.esri.core.geometry.ogc.OGCPoint;
 import com.esri.core.geometry.ogc.OGCPolygon;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequenceFactory;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 
 import java.util.HashSet;
 import java.util.Set;
 
 public final class GeometryUtils
 {
+    private static final CoordinateSequenceFactory COORDINATE_SEQUENCE_FACTORY = new PackedCoordinateSequenceFactory();
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(COORDINATE_SEQUENCE_FACTORY);
+
     private GeometryUtils() {}
 
     /**
@@ -211,5 +218,15 @@ public final class GeometryUtils
         }
 
         return true;
+    }
+
+    public static org.locationtech.jts.geom.Point makeJtsEmptyPoint()
+    {
+        return GEOMETRY_FACTORY.createPoint();
+    }
+
+    public static org.locationtech.jts.geom.Point makeJtsPoint(Coordinate coordinate)
+    {
+        return GEOMETRY_FACTORY.createPoint(coordinate);
     }
 }

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -470,6 +470,30 @@ public class TestGeoFunctions
     }
 
     @Test
+    public void testLineInterpolatePoint()
+    {
+        assertLineInterpolatePoint("LINESTRING EMPTY", 0.5, "POINT EMPTY");
+        assertLineInterpolatePoint("LINESTRING (0 0, 0 1)", 0.2, "POINT (0 0.2)");
+        assertLineInterpolatePoint("LINESTRING (0 0, 0 1)", 0.0, "POINT (0 0)");
+        assertLineInterpolatePoint("LINESTRING (0 0, 0 1)", 1.0, "POINT (0 1)");
+        assertLineInterpolatePoint("LINESTRING (0 0, 0 1, 3 1)", 0.0625, "POINT (0 0.25)");
+        assertLineInterpolatePoint("LINESTRING (0 0, 0 1, 3 1)", 0.75, "POINT (2 1)");
+        assertLineInterpolatePoint("LINESTRING (1 3, 5 4)", 0.0, "POINT (1 3)");
+        assertLineInterpolatePoint("LINESTRING (1 3, 5 4)", 0.25, "POINT (2 3.25)");
+        assertLineInterpolatePoint("LINESTRING (1 3, 5 4)", 1.0, "POINT (5 4)");
+
+        assertInvalidFunction("line_interpolate_point(ST_GeometryFromText('POLYGON ((1 1, 1 4, 4 4, 4 1, 1 1))'), 0.5)", "line_interpolate_point only applies to LINE_STRING. Input type is: POLYGON");
+        assertInvalidFunction("line_interpolate_point(ST_GeometryFromText('MULTILINESTRING ((0 0, 0 1), (2 2, 4 2))'), 0.0)", "line_interpolate_point only applies to LINE_STRING. Input type is: MULTI_LINE_STRING");
+        assertInvalidFunction("line_interpolate_point(ST_GeometryFromText('LINESTRING (0 0, 0 1, 2 1)'), -1)", "line_interpolate_point: Fraction must be between 0 and 1, but is -1.0");
+        assertInvalidFunction("line_interpolate_point(ST_GeometryFromText('LINESTRING (0 0, 0 1, 2 1)'), 1.5)", "line_interpolate_point: Fraction must be between 0 and 1, but is 1.5");
+    }
+
+    private void assertLineInterpolatePoint(String sourceWkt, double distance, String expectedWkt)
+    {
+        assertFunction(format("ST_AsText(line_interpolate_point(ST_GeometryFromText('%s'), %s))", sourceWkt, distance), VARCHAR, expectedWkt);
+    }
+
+    @Test
     public void testSTMax()
     {
         assertFunction("ST_XMax(ST_GeometryFromText('POINT (1.5 2.5)'))", DOUBLE, 1.5);


### PR DESCRIPTION
One of our most requested functions.  Given a linestring and a double
between 0 and 1, give the point at that fractional distance along the
line.


```
== RELEASE NOTES ==

General Changes
-----------------
* Add geospatial function line_interpolate_point
```
