### PR TITLE
Fix hive columnIndex with default partition

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -627,6 +627,10 @@ public class TestHivePushdownFilterQueries
 
         assertQueryReturnsEmptyResult("SELECT * FROM test_partition_columns WHERE p = 'abc' and p='def'");
 
+        assertUpdate("INSERT into test_partition_columns values (3, 'abc', NULL)", 1);
+
+        assertQuerySucceeds(getSession(), "select * from test_partition_columns");
+
         assertUpdate("DROP TABLE test_partition_columns");
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -180,7 +180,7 @@ public class OrcSelectiveRecordReader
                 // fails the whole split. Filters on prefilled columns
                 // are already evaluated, hence we only check filters
                 // for missing columns here.
-                if (containsNonNullFilter(filters.get(columnIndex))) {
+                if (columnIndex >= 0 && containsNonNullFilter(filters.get(columnIndex))) {
                     constantFilterIsFalse = true;
                     // No further initialization needed.
                     return;
@@ -190,7 +190,10 @@ public class OrcSelectiveRecordReader
         }
 
         for (Map.Entry<Integer, Object> entry : constantValues.entrySet()) {
-            this.constantValues[zeroBasedIndices.get(entry.getKey())] = entry.getValue();
+            // all included columns will be null, the constant columns should have a valid predicate or null marker so that there is no streamReader created below
+            if (entry.getValue() != null) {
+                this.constantValues[zeroBasedIndices.get(entry.getKey())] = entry.getValue();
+            }
         }
 
         // Initial order of stream readers is:


### PR DESCRIPTION
Fix invalid partition column index lookup. Incase of a null partition we are creating a unnecessary streamReader which results in a negative index.
```
== NO RELEASE NOTE ==
```
