### PR TITLE
Fix interactions between filter pushdown and CBO

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -252,7 +252,7 @@ public class JdbcMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> tableLayoutHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
     {
         JdbcTableHandle handle = (JdbcTableHandle) tableHandle;
         List<JdbcColumnHandle> columns = columnHandles.stream().map(JdbcColumnHandle.class::cast).collect(Collectors.toList());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
@@ -43,6 +43,7 @@ import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPag
 import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorSplitManager;
 import com.facebook.presto.spi.connector.classloader.ClassLoaderSafeNodePartitioningProvider;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.procedure.Procedure;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.facebook.presto.spi.type.TypeManager;
@@ -118,6 +119,7 @@ public class HiveConnectorFactory
                         binder.bind(PageSorter.class).toInstance(context.getPageSorter());
                         binder.bind(StandardFunctionResolution.class).toInstance(context.getStandardFunctionResolution());
                         binder.bind(RowExpressionService.class).toInstance(context.getRowExpressionService());
+                        binder.bind(FilterStatsCalculatorService.class).toInstance(context.getFilterStatsCalculatorService());
                     });
 
             Injector injector = app

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -598,7 +598,7 @@ public class HiveMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> tableLayoutHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
     {
         if (!isStatisticsEnabled(session)) {
             return TableStatistics.empty();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -65,12 +65,14 @@ import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorPartitioningMetadata;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.predicate.Domain;
 import com.facebook.presto.spi.predicate.NullableValue;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.relation.DomainTranslator.ExtractionResult;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionService;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrestoPrincipal;
@@ -92,6 +94,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.base.VerifyException;
+import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
@@ -127,6 +130,7 @@ import java.util.stream.IntStream;
 
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.expressions.LogicalRowExpressions.and;
+import static com.facebook.presto.expressions.LogicalRowExpressions.binaryExpression;
 import static com.facebook.presto.hive.HiveAnalyzeProperties.getPartitionList;
 import static com.facebook.presto.hive.HiveBasicStatistics.createEmptyStatistics;
 import static com.facebook.presto.hive.HiveBasicStatistics.createZeroStatistics;
@@ -264,6 +268,7 @@ public class HiveMetadata
     private final LocationService locationService;
     private final StandardFunctionResolution functionResolution;
     private final RowExpressionService rowExpressionService;
+    private final FilterStatsCalculatorService filterStatsCalculatorService;
     private final TableParameterCodec tableParameterCodec;
     private final JsonCodec<PartitionUpdate> partitionUpdateCodec;
     private final boolean writesToNonManagedTablesEnabled;
@@ -287,6 +292,7 @@ public class HiveMetadata
             LocationService locationService,
             StandardFunctionResolution functionResolution,
             RowExpressionService rowExpressionService,
+            FilterStatsCalculatorService filterStatsCalculatorService,
             TableParameterCodec tableParameterCodec,
             JsonCodec<PartitionUpdate> partitionUpdateCodec,
             TypeTranslator typeTranslator,
@@ -306,6 +312,7 @@ public class HiveMetadata
         this.locationService = requireNonNull(locationService, "locationService is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
         this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
+        this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
         this.tableParameterCodec = requireNonNull(tableParameterCodec, "tableParameterCodec is null");
         this.partitionUpdateCodec = requireNonNull(partitionUpdateCodec, "partitionUpdateCodec is null");
         this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
@@ -606,15 +613,52 @@ public class HiveMetadata
 
         // TODO Adjust statistics to take into account required subfields
 
-        Map<String, ColumnHandle> columns = columnHandles.stream()
+        if (!tableLayoutHandle.isPresent() || !((HiveTableLayoutHandle) tableLayoutHandle.get()).isPushdownFilterEnabled()) {
+            Map<String, ColumnHandle> columns = columnHandles.stream()
+                    .map(HiveColumnHandle.class::cast)
+                    .filter(not(HiveColumnHandle::isHidden))
+                    .collect(toImmutableMap(HiveColumnHandle::getName, Function.identity()));
+
+            Map<String, Type> columnTypes = columns.entrySet().stream()
+                    .collect(toImmutableMap(Map.Entry::getKey, entry -> getColumnMetadata(session, tableHandle, entry.getValue()).getType()));
+            List<HivePartition> partitions = partitionManager.getPartitions(metastore, tableHandle, constraint, session).getPartitions();
+            return hiveStatisticsProvider.getTableStatistics(session, ((HiveTableHandle) tableHandle).getSchemaTableName(), columns, columnTypes, partitions);
+        }
+
+        verify(!constraint.predicate().isPresent());
+
+        HiveTableLayoutHandle hiveLayoutHandle = (HiveTableLayoutHandle) tableLayoutHandle.get();
+
+        Set<ColumnHandle> allColumnHandles = ImmutableSet.<ColumnHandle>builder()
+                .addAll(columnHandles)
+                .addAll(hiveLayoutHandle.getPredicateColumns().values())
+                .build();
+
+        Map<String, ColumnHandle> columns = allColumnHandles.stream()
                 .map(HiveColumnHandle.class::cast)
-                .filter(not(HiveColumnHandle::isHidden))
                 .collect(toImmutableMap(HiveColumnHandle::getName, Function.identity()));
 
-        Map<String, Type> columnTypes = columns.entrySet().stream()
+        Map<String, Type> columnTypesByName = columns.entrySet().stream()
                 .collect(toImmutableMap(Map.Entry::getKey, entry -> getColumnMetadata(session, tableHandle, entry.getValue()).getType()));
-        List<HivePartition> partitions = partitionManager.getPartitions(metastore, tableHandle, constraint, session).getPartitions();
-        return hiveStatisticsProvider.getTableStatistics(session, ((HiveTableHandle) tableHandle).getSchemaTableName(), columns, columnTypes, partitions);
+
+        Constraint<ColumnHandle> combinedConstraint = new Constraint<>(constraint.getSummary().intersect(hiveLayoutHandle.getDomainPredicate()
+                .transform(subfield -> isEntireColumn(subfield) ? subfield.getRootName() : null)
+                .transform(columns::get)));
+
+        SubfieldExtractor subfieldExtractor = new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(), session);
+
+        RowExpression domainPredicate = rowExpressionService.getDomainTranslator().toPredicate(
+                hiveLayoutHandle.getDomainPredicate()
+                        .transform(subfield -> subfieldExtractor.toRowExpression(subfield, columnTypesByName.get(subfield.getRootName()))));
+        RowExpression combinedPredicate = binaryExpression(SpecialFormExpression.Form.AND, ImmutableList.of(hiveLayoutHandle.getRemainingPredicate(), domainPredicate));
+
+        List<HivePartition> partitions = partitionManager.getPartitions(metastore, tableHandle, combinedConstraint, session).getPartitions();
+        TableStatistics tableStatistics = hiveStatisticsProvider.getTableStatistics(session, ((HiveTableHandle) tableHandle).getSchemaTableName(), columns, columnTypesByName, partitions);
+
+        Map<ColumnHandle, Type> columnTypes = columns.entrySet().stream()
+                .collect(toImmutableMap(Map.Entry::getValue, entry -> columnTypesByName.get(entry.getKey())));
+
+        return filterStatsCalculatorService.filterStats(tableStatistics, combinedPredicate, session, ImmutableBiMap.copyOf(columns).inverse(), columnTypes);
     }
 
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -20,6 +20,7 @@ import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
 import com.facebook.presto.hive.statistics.MetastoreHiveStatisticsProvider;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.facebook.presto.spi.type.TypeManager;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -50,6 +51,7 @@ public class HiveMetadataFactory
     private final LocationService locationService;
     private final StandardFunctionResolution functionResolution;
     private final RowExpressionService rowExpressionService;
+    private final FilterStatsCalculatorService filterStatsCalculatorService;
     private final TableParameterCodec tableParameterCodec;
     private final JsonCodec<PartitionUpdate> partitionUpdateCodec;
     private final ListeningExecutorService fileRenameExecutor;
@@ -71,6 +73,7 @@ public class HiveMetadataFactory
             LocationService locationService,
             StandardFunctionResolution functionResolution,
             RowExpressionService rowExpressionService,
+            FilterStatsCalculatorService filterStatsCalculatorService,
             TableParameterCodec tableParameterCodec,
             JsonCodec<PartitionUpdate> partitionUpdateCodec,
             TypeTranslator typeTranslator,
@@ -94,6 +97,7 @@ public class HiveMetadataFactory
                 locationService,
                 functionResolution,
                 rowExpressionService,
+                filterStatsCalculatorService,
                 tableParameterCodec,
                 partitionUpdateCodec,
                 fileRenameExecutor,
@@ -119,6 +123,7 @@ public class HiveMetadataFactory
             LocationService locationService,
             StandardFunctionResolution functionResolution,
             RowExpressionService rowExpressionService,
+            FilterStatsCalculatorService filterStatsCalculatorService,
             TableParameterCodec tableParameterCodec,
             JsonCodec<PartitionUpdate> partitionUpdateCodec,
             ListeningExecutorService fileRenameExecutor,
@@ -143,6 +148,7 @@ public class HiveMetadataFactory
         this.locationService = requireNonNull(locationService, "locationService is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
         this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
+        this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
         this.tableParameterCodec = requireNonNull(tableParameterCodec, "tableParameterCodec is null");
         this.partitionUpdateCodec = requireNonNull(partitionUpdateCodec, "partitionUpdateCodec is null");
         this.fileRenameExecutor = requireNonNull(fileRenameExecutor, "fileRenameExecutor is null");
@@ -182,6 +188,7 @@ public class HiveMetadataFactory
                 locationService,
                 functionResolution,
                 rowExpressionService,
+                filterStatsCalculatorService,
                 tableParameterCodec,
                 partitionUpdateCodec,
                 typeTranslator,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Subfield;
+import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
@@ -27,7 +28,9 @@ import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,8 +38,12 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.hive.HiveSessionProperties.isNestedColumnsFilterEnabled;
+import static com.facebook.presto.spi.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.DEREFERENCE;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.Varchars.isVarcharType;
+import static com.google.common.base.Verify.verify;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
@@ -157,5 +164,91 @@ public final class SubfieldExtractor
 
             return Optional.empty();
         }
+    }
+
+    public RowExpression toRowExpression(Subfield subfield, Type columnType)
+    {
+        List<Subfield.PathElement> path = subfield.getPath();
+        ImmutableList.Builder<Type> types = ImmutableList.builder();
+        types.add(columnType);
+        Type type = columnType;
+        for (int i = 0; i < path.size(); i++) {
+            if (type instanceof RowType) {
+                type = getFieldType((RowType) type, ((Subfield.NestedField) path.get(i)).getName());
+                types.add(type);
+            }
+            else if (type instanceof ArrayType) {
+                type = ((ArrayType) type).getElementType();
+                types.add(type);
+            }
+            else if (type instanceof MapType) {
+                type = ((MapType) type).getValueType();
+                types.add(type);
+            }
+            else {
+                verify(false, "Unexpected type: " + type);
+            }
+        }
+
+        return toRowExpression(subfield, types.build());
+    }
+
+    private RowExpression toRowExpression(Subfield subfield, List<Type> types)
+    {
+        List<Subfield.PathElement> path = subfield.getPath();
+        if (path.isEmpty()) {
+            return new VariableReferenceExpression(subfield.getRootName(), types.get(0));
+        }
+
+        RowExpression base = toRowExpression(new Subfield(subfield.getRootName(), path.subList(0, path.size() - 1)), types.subList(0, types.size() - 1));
+        Type baseType = types.get(types.size() - 2);
+        Subfield.PathElement pathElement = path.get(path.size() - 1);
+        if (pathElement instanceof Subfield.LongSubscript) {
+            Type indexType = baseType instanceof MapType ? ((MapType) baseType).getKeyType() : BIGINT;
+            FunctionHandle functionHandle = functionResolution.subscriptFunction(baseType, indexType);
+            ConstantExpression index = new ConstantExpression(((Subfield.LongSubscript) pathElement).getIndex(), indexType);
+            return new CallExpression(SUBSCRIPT.name(), functionHandle, types.get(types.size() - 1), ImmutableList.of(base, index));
+        }
+
+        if (pathElement instanceof Subfield.StringSubscript) {
+            Type indexType = ((MapType) baseType).getKeyType();
+            FunctionHandle functionHandle = functionResolution.subscriptFunction(baseType, indexType);
+            ConstantExpression index = new ConstantExpression(Slices.utf8Slice(((Subfield.StringSubscript) pathElement).getIndex()), indexType);
+            return new CallExpression(SUBSCRIPT.name(), functionHandle, types.get(types.size() - 1), ImmutableList.of(base, index));
+        }
+
+        if (pathElement instanceof Subfield.NestedField) {
+            Subfield.NestedField nestedField = (Subfield.NestedField) pathElement;
+            return new SpecialFormExpression(DEREFERENCE, types.get(types.size() - 1), base, new ConstantExpression(getFieldIndex((RowType) baseType, nestedField.getName()), INTEGER));
+        }
+
+        verify(false, "Unexpected path element: " + pathElement);
+        return null;
+    }
+
+    private static Type getFieldType(RowType rowType, String fieldName)
+    {
+        for (RowType.Field field : rowType.getFields()) {
+            verify(field.getName().isPresent());
+            if (field.getName().get().equals(fieldName)) {
+                return field.getType();
+            }
+        }
+        verify(false, "Unexpected field name: " + fieldName);
+        return null;
+    }
+
+    private static long getFieldIndex(RowType rowType, String fieldName)
+    {
+        List<RowType.Field> fields = rowType.getFields();
+        for (int i = 0; i < fields.size(); i++) {
+            RowType.Field field = fields.get(i);
+            verify(field.getName().isPresent());
+            if (field.getName().get().equals(fieldName)) {
+                return i;
+            }
+        }
+        verify(false, "Unexpected field name: " + fieldName);
+        return -1;
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1484,7 +1484,7 @@ public abstract class AbstractTestHiveClient
             ConnectorSession session = newSession();
             ConnectorTableHandle tableHandle = getTableHandle(metadata, tableName);
             List<ColumnHandle> allColumnHandles = ImmutableList.copyOf(metadata.getColumnHandles(session, tableHandle).values());
-            TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, allColumnHandles, Constraint.alwaysTrue());
+            TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, Optional.empty(), allColumnHandles, Constraint.alwaysTrue());
 
             assertFalse(tableStatistics.getRowCount().isUnknown(), "row count is unknown");
 
@@ -3418,8 +3418,8 @@ public abstract class AbstractTestHiveClient
 
                 ConnectorTableHandle tableHandle = metadata.getTableHandle(session, tableName);
                 List<ColumnHandle> allColumnHandles = ImmutableList.copyOf(metadata.getColumnHandles(session, tableHandle).values());
-                TableStatistics unsampledStatistics = metadata.getTableStatistics(sampleSize(2), tableHandle, allColumnHandles, Constraint.alwaysTrue());
-                TableStatistics sampledStatistics = metadata.getTableStatistics(sampleSize(1), tableHandle, allColumnHandles, Constraint.alwaysTrue());
+                TableStatistics unsampledStatistics = metadata.getTableStatistics(sampleSize(2), tableHandle, Optional.empty(), allColumnHandles, Constraint.alwaysTrue());
+                TableStatistics sampledStatistics = metadata.getTableStatistics(sampleSize(1), tableHandle, Optional.empty(), allColumnHandles, Constraint.alwaysTrue());
                 assertEquals(sampledStatistics, unsampledStatistics);
             }
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -190,6 +190,7 @@ import static com.facebook.presto.hive.HiveTableProperties.BUCKET_COUNT_PROPERTY
 import static com.facebook.presto.hive.HiveTableProperties.PARTITIONED_BY_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.SORTED_BY_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.STORAGE_FORMAT_PROPERTY;
+import static com.facebook.presto.hive.HiveTestUtils.FILTER_STATS_CALCULATOR_SERVICE;
 import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_RESOLUTION;
 import static com.facebook.presto.hive.HiveTestUtils.PAGE_SORTER;
 import static com.facebook.presto.hive.HiveTestUtils.ROW_EXPRESSION_SERVICE;
@@ -837,6 +838,7 @@ public abstract class AbstractTestHiveClient
                 locationService,
                 FUNCTION_RESOLUTION,
                 ROW_EXPRESSION_SERVICE,
+                FILTER_STATS_CALCULATOR_SERVICE,
                 new TableParameterCodec(),
                 PARTITION_UPDATE_CODEC,
                 listeningDecorator(executor),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -89,6 +89,7 @@ import static com.facebook.presto.hive.AbstractTestHiveClient.createTablePropert
 import static com.facebook.presto.hive.AbstractTestHiveClient.filterNonHiddenColumnHandles;
 import static com.facebook.presto.hive.AbstractTestHiveClient.filterNonHiddenColumnMetadata;
 import static com.facebook.presto.hive.AbstractTestHiveClient.getAllSplits;
+import static com.facebook.presto.hive.HiveTestUtils.FILTER_STATS_CALCULATOR_SERVICE;
 import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_RESOLUTION;
 import static com.facebook.presto.hive.HiveTestUtils.PAGE_SORTER;
 import static com.facebook.presto.hive.HiveTestUtils.ROW_EXPRESSION_SERVICE;
@@ -189,6 +190,7 @@ public abstract class AbstractTestHiveFileSystem
                 locationService,
                 FUNCTION_RESOLUTION,
                 ROW_EXPRESSION_SERVICE,
+                FILTER_STATS_CALCULATOR_SERVICE,
                 new TableParameterCodec(),
                 partitionUpdateCodec,
                 new HiveTypeTranslator(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -15,6 +15,10 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.PagesIndexPageSorter;
 import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.cost.ConnectorFilterStatsCalculatorService;
+import com.facebook.presto.cost.FilterStatsCalculator;
+import com.facebook.presto.cost.ScalarStatsCalculator;
+import com.facebook.presto.cost.StatsNormalizer;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.gcs.HiveGcsConfig;
 import com.facebook.presto.hive.gcs.HiveGcsConfigurationInitializer;
@@ -33,6 +37,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PageSorter;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
@@ -112,6 +117,9 @@ public final class HiveTestUtils
             return new RowExpressionFormatter(METADATA.getFunctionManager()).formatRowExpression(session, expression);
         }
     };
+
+    public static final FilterStatsCalculatorService FILTER_STATS_CALCULATOR_SERVICE = new ConnectorFilterStatsCalculatorService(
+            new FilterStatsCalculator(METADATA, new ScalarStatsCalculator(METADATA), new StatsNormalizer()));
 
     static {
         // associate TYPE_MANAGER with a function manager

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -568,6 +568,18 @@ public class TestHiveLogicalPlanner
                     anyTree(join(INNER, ImmutableList.of(equiJoinClause("l_orderkey", "o_orderkey")),
                             anyTree(PlanMatchPattern.tableScan("lineitem", ImmutableMap.of("l_orderkey", "orderkey"))),
                             anyTree(PlanMatchPattern.tableScan("orders_ex", ImmutableMap.of("o_orderkey", "orderkey"))))));
+
+            assertPlan(joinReorderingOff, "SELECT l.discount, l.orderkey, o.totalprice FROM lineitem l, orders o WHERE l.orderkey = o.orderkey AND l.quantity < 2 AND o.totalprice BETWEEN 0 AND 200000",
+                    anyTree(
+                            node(JoinNode.class,
+                                    anyTree(tableScan("lineitem", ImmutableMap.of())),
+                                    anyTree(tableScan("orders", ImmutableMap.of())))));
+
+            assertPlan(joinReorderingOn, "SELECT l.discount, l.orderkey, o.totalprice FROM lineitem l, orders o WHERE l.orderkey = o.orderkey AND l.quantity < 2 AND o.totalprice BETWEEN 0 AND 200000",
+                    anyTree(
+                            node(JoinNode.class,
+                                    anyTree(tableScan("orders", ImmutableMap.of())),
+                                    anyTree(tableScan("lineitem", ImmutableMap.of())))));
         }
         finally {
             assertUpdate("DROP TABLE orders_ex");

--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorContextInstance.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorContextInstance.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.PageSorter;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.facebook.presto.spi.type.TypeManager;
 
@@ -34,6 +35,7 @@ public class ConnectorContextInstance
     private final PageSorter pageSorter;
     private final PageIndexerFactory pageIndexerFactory;
     private final RowExpressionService rowExpressionService;
+    private final FilterStatsCalculatorService filterStatsCalculatorService;
 
     public ConnectorContextInstance(
             NodeManager nodeManager,
@@ -42,7 +44,8 @@ public class ConnectorContextInstance
             StandardFunctionResolution functionResolution,
             PageSorter pageSorter,
             PageIndexerFactory pageIndexerFactory,
-            RowExpressionService rowExpressionService)
+            RowExpressionService rowExpressionService,
+            FilterStatsCalculatorService filterStatsCalculatorService)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -51,6 +54,7 @@ public class ConnectorContextInstance
         this.pageSorter = requireNonNull(pageSorter, "pageSorter is null");
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
         this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
+        this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
     }
 
     @Override
@@ -93,5 +97,11 @@ public class ConnectorContextInstance
     public RowExpressionService getRowExpressionService()
     {
         return rowExpressionService;
+    }
+
+    @Override
+    public FilterStatsCalculatorService getFilterStatsCalculatorService()
+    {
+        return filterStatsCalculatorService;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -144,26 +144,26 @@ public class ConnectorManager
             DeterminismEvaluator determinismEvaluator,
             FilterStatsCalculator filterStatsCalculator)
     {
-        this.metadataManager = metadataManager;
-        this.catalogManager = catalogManager;
-        this.accessControlManager = accessControlManager;
-        this.splitManager = splitManager;
-        this.pageSourceManager = pageSourceManager;
-        this.indexManager = indexManager;
-        this.partitioningProviderManager = partitioningProviderManager;
-        this.connectorPlanOptimizerManager = connectorPlanOptimizerManager;
-        this.pageSinkManager = pageSinkManager;
-        this.handleResolver = handleResolver;
-        this.nodeManager = nodeManager;
-        this.typeManager = typeManager;
-        this.pageSorter = pageSorter;
-        this.pageIndexerFactory = pageIndexerFactory;
-        this.nodeInfo = nodeInfo;
-        this.transactionManager = transactionManager;
-        this.domainTranslator = domainTranslator;
-        this.predicateCompiler = predicateCompiler;
-        this.determinismEvaluator = determinismEvaluator;
-        this.filterStatsCalculator = filterStatsCalculator;
+        this.metadataManager = requireNonNull(metadataManager, "metadataManager is null");
+        this.catalogManager = requireNonNull(catalogManager, "catalogManager is null");
+        this.accessControlManager = requireNonNull(accessControlManager, "accessControlManager is null");
+        this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.pageSourceManager = requireNonNull(pageSourceManager, "pageSourceManager is null");
+        this.indexManager = requireNonNull(indexManager, "indexManager is null");
+        this.partitioningProviderManager = requireNonNull(partitioningProviderManager, "partitioningProviderManager is null");
+        this.connectorPlanOptimizerManager = requireNonNull(connectorPlanOptimizerManager, "connectorPlanOptimizerManager is null");
+        this.pageSinkManager = requireNonNull(pageSinkManager, "pageSinkManager is null");
+        this.handleResolver = requireNonNull(handleResolver, "handleResolver is null");
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.pageSorter = requireNonNull(pageSorter, "pageSorter is null");
+        this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
+        this.nodeInfo = requireNonNull(nodeInfo, "nodeInfo is null");
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.domainTranslator = requireNonNull(domainTranslator, "domainTranslator is null");
+        this.predicateCompiler = requireNonNull(predicateCompiler, "predicateCompiler is null");
+        this.determinismEvaluator = requireNonNull(determinismEvaluator, "determinismEvaluator is null");
+        this.filterStatsCalculator = requireNonNull(filterStatsCalculator, "filterStatsCalculator is null");
     }
 
     @PreDestroy

--- a/presto-main/src/main/java/com/facebook/presto/cost/ConnectorFilterStatsCalculatorService.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ConnectorFilterStatsCalculatorService.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.statistics.ColumnStatistics;
+import com.facebook.presto.spi.statistics.ColumnStatistics.Builder;
+import com.facebook.presto.spi.statistics.DoubleRange;
+import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableBiMap;
+
+import java.util.Map;
+
+import static com.facebook.presto.cost.StatsUtil.toVariableStatsEstimate;
+import static java.util.Objects.requireNonNull;
+
+public class ConnectorFilterStatsCalculatorService
+        implements FilterStatsCalculatorService
+{
+    private final FilterStatsCalculator filterStatsCalculator;
+
+    public ConnectorFilterStatsCalculatorService(FilterStatsCalculator filterStatsCalculator)
+    {
+        this.filterStatsCalculator = requireNonNull(filterStatsCalculator, "filterStatsCalculator is null");
+    }
+
+    @Override
+    public TableStatistics filterStats(
+            TableStatistics tableStatistics,
+            RowExpression predicate,
+            ConnectorSession session,
+            Map<ColumnHandle, String> columnNames,
+            Map<ColumnHandle, Type> columnTypes)
+    {
+        PlanNodeStatsEstimate tableStats = toPlanNodeStats(tableStatistics, columnNames, columnTypes);
+        PlanNodeStatsEstimate filteredStats = filterStatsCalculator.filterStats(tableStats, predicate, session);
+        return toTableStatistics(filteredStats, ImmutableBiMap.copyOf(columnNames).inverse());
+    }
+
+    private static PlanNodeStatsEstimate toPlanNodeStats(
+            TableStatistics tableStatistics,
+            Map<ColumnHandle, String> columnNames,
+            Map<ColumnHandle, Type> columnTypes)
+    {
+        PlanNodeStatsEstimate.Builder builder = PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(tableStatistics.getRowCount().getValue());
+
+        for (Map.Entry<ColumnHandle, ColumnStatistics> entry : tableStatistics.getColumnStatistics().entrySet()) {
+            String columnName = columnNames.get(entry.getKey());
+            Type type = columnTypes.get(entry.getKey());
+            builder.addVariableStatistics(new VariableReferenceExpression(columnName, type), toVariableStatsEstimate(tableStatistics, entry.getValue()));
+        }
+        return builder.build();
+    }
+
+    private static TableStatistics toTableStatistics(PlanNodeStatsEstimate planNodeStats, Map<String, ColumnHandle> columnByName)
+    {
+        TableStatistics.Builder builder = TableStatistics.builder();
+        if (planNodeStats.isOutputRowCountUnknown()) {
+            builder.setRowCount(Estimate.unknown());
+            return builder.build();
+        }
+
+        double rowCount = planNodeStats.getOutputRowCount();
+        builder.setRowCount(Estimate.of(rowCount));
+        for (Map.Entry<VariableReferenceExpression, VariableStatsEstimate> entry : planNodeStats.getVariableStatistics().entrySet()) {
+            builder.setColumnStatistics(columnByName.get(entry.getKey().getName()), toColumnStatistics(entry.getValue(), rowCount));
+        }
+        return builder.build();
+    }
+
+    private static ColumnStatistics toColumnStatistics(VariableStatsEstimate variableStatsEstimate, double rowCount)
+    {
+        if (variableStatsEstimate.isUnknown()) {
+            return ColumnStatistics.empty();
+        }
+
+        double nullsFractionDouble = variableStatsEstimate.getNullsFraction();
+        double nonNullRowsCount = rowCount * (1.0 - nullsFractionDouble);
+
+        Builder builder = ColumnStatistics.builder();
+        if (!Double.isNaN(nullsFractionDouble)) {
+            builder.setNullsFraction(Estimate.of(nullsFractionDouble));
+        }
+
+        if (!Double.isNaN(variableStatsEstimate.getDistinctValuesCount())) {
+            builder.setDistinctValuesCount(Estimate.of(variableStatsEstimate.getDistinctValuesCount()));
+        }
+
+        if (!Double.isNaN(variableStatsEstimate.getAverageRowSize())) {
+            builder.setDataSize(Estimate.of(variableStatsEstimate.getAverageRowSize() * nonNullRowsCount));
+        }
+
+        if (!Double.isNaN(variableStatsEstimate.getLowValue()) && !Double.isNaN(variableStatsEstimate.getHighValue())) {
+            builder.setRange(new DoubleRange(variableStatsEstimate.getLowValue(), variableStatsEstimate.getHighValue()));
+        }
+        return builder.build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
+import com.google.inject.Scopes;
 
 import javax.inject.Singleton;
 
@@ -27,16 +28,19 @@ public class StatsCalculatorModule
     @Override
     public void configure(Binder binder)
     {
+        binder.bind(ScalarStatsCalculator.class).in(Scopes.SINGLETON);
+        binder.bind(StatsNormalizer.class).in(Scopes.SINGLETON);
+        binder.bind(FilterStatsCalculator.class).in(Scopes.SINGLETON);
     }
 
     @Provides
     @Singleton
-    public static StatsCalculator createNewStatsCalculator(Metadata metadata)
+    public static StatsCalculator createNewStatsCalculator(
+            Metadata metadata,
+            ScalarStatsCalculator scalarStatsCalculator,
+            StatsNormalizer normalizer,
+            FilterStatsCalculator filterStatsCalculator)
     {
-        StatsNormalizer normalizer = new StatsNormalizer();
-        ScalarStatsCalculator scalarStatsCalculator = new ScalarStatsCalculator(metadata);
-        FilterStatsCalculator filterStatsCalculator = new FilterStatsCalculator(metadata, scalarStatsCalculator, normalizer);
-
         ImmutableList.Builder<ComposableStatsCalculator.Rule<?>> rules = ImmutableList.builder();
         rules.add(new OutputStatsRule());
         rules.add(new TableScanStatsRule(metadata, normalizer));

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsUtil.java
@@ -77,7 +77,7 @@ final class StatsUtil
                 || BooleanType.BOOLEAN.equals(type);
     }
 
-    public static VariableStatsEstimate toSymbolStatistics(TableStatistics tableStatistics, ColumnStatistics columnStatistics)
+    public static VariableStatsEstimate toVariableStatsEstimate(TableStatistics tableStatistics, ColumnStatistics columnStatistics)
     {
         double nullsFraction = columnStatistics.getNullsFraction().getValue();
         double nonNullRowsCount = tableStatistics.getRowCount().getValue() * (1.0 - nullsFraction);

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsUtil.java
@@ -18,6 +18,8 @@ import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.statistics.ColumnStatistics;
+import com.facebook.presto.spi.statistics.TableStatistics;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.DateType;
@@ -73,5 +75,21 @@ final class StatsUtil
                 || SmallintType.SMALLINT.equals(type)
                 || TinyintType.TINYINT.equals(type)
                 || BooleanType.BOOLEAN.equals(type);
+    }
+
+    public static VariableStatsEstimate toSymbolStatistics(TableStatistics tableStatistics, ColumnStatistics columnStatistics)
+    {
+        double nullsFraction = columnStatistics.getNullsFraction().getValue();
+        double nonNullRowsCount = tableStatistics.getRowCount().getValue() * (1.0 - nullsFraction);
+        double averageRowSize = nonNullRowsCount == 0 ? 0 : columnStatistics.getDataSize().getValue() / nonNullRowsCount;
+        VariableStatsEstimate.Builder result = VariableStatsEstimate.builder();
+        result.setNullsFraction(nullsFraction);
+        result.setDistinctValuesCount(columnStatistics.getDistinctValuesCount().getValue());
+        result.setAverageRowSize(averageRowSize);
+        columnStatistics.getRange().ifPresent(range -> {
+            result.setLowValue(range.getMin());
+            result.setHighValue(range.getMax());
+        });
+        return result.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/TableScanStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/TableScanStatsRule.java
@@ -63,7 +63,7 @@ public class TableScanStatsRule
 
         for (Map.Entry<VariableReferenceExpression, ColumnHandle> entry : node.getAssignments().entrySet()) {
             Optional<ColumnStatistics> columnStatistics = Optional.ofNullable(tableStatistics.getColumnStatistics().get(entry.getValue()));
-            outputVariableStats.put(entry.getKey(), columnStatistics.map(statistics -> StatsUtil.toSymbolStatistics(tableStatistics, statistics)).orElse(VariableStatsEstimate.unknown()));
+            outputVariableStats.put(entry.getKey(), columnStatistics.map(statistics -> StatsUtil.toVariableStatsEstimate(tableStatistics, statistics)).orElse(VariableStatsEstimate.unknown()));
         }
 
         return Optional.of(PlanNodeStatsEstimate.builder()

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -520,7 +520,7 @@ public class MetadataManager
     {
         ConnectorId connectorId = tableHandle.getConnectorId();
         ConnectorMetadata metadata = getMetadata(session, connectorId);
-        return metadata.getTableStatistics(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), columnHandles, constraint);
+        return metadata.getTableStatistics(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), tableHandle.getLayout(), columnHandles, constraint);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -27,6 +27,9 @@ import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.connector.ConnectorManager;
 import com.facebook.presto.connector.system.SystemConnectorModule;
+import com.facebook.presto.cost.FilterStatsCalculator;
+import com.facebook.presto.cost.ScalarStatsCalculator;
+import com.facebook.presto.cost.StatsNormalizer;
 import com.facebook.presto.event.SplitMonitor;
 import com.facebook.presto.execution.ExecutionFailureInfo;
 import com.facebook.presto.execution.ExplainAnalyzeContext;
@@ -409,6 +412,9 @@ public class ServerMainModule
         binder.install(new HandleJsonModule());
 
         // connector
+        binder.bind(ScalarStatsCalculator.class).in(Scopes.SINGLETON);
+        binder.bind(StatsNormalizer.class).in(Scopes.SINGLETON);
+        binder.bind(FilterStatsCalculator.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorManager.class).in(Scopes.SINGLETON);
 
         // system connector

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
@@ -17,6 +17,10 @@ import com.facebook.presto.GroupByHashPageIndexerFactory;
 import com.facebook.presto.PagesIndexPageSorter;
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.connector.ConnectorAwareNodeManager;
+import com.facebook.presto.cost.ConnectorFilterStatsCalculatorService;
+import com.facebook.presto.cost.FilterStatsCalculator;
+import com.facebook.presto.cost.ScalarStatsCalculator;
+import com.facebook.presto.cost.StatsNormalizer;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.Metadata;
@@ -30,6 +34,7 @@ import com.facebook.presto.spi.PageSorter;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.DomainTranslator;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
@@ -60,6 +65,7 @@ public class TestingConnectorContext
     private final DomainTranslator domainTranslator = new RowExpressionDomainTranslator(metadata);
     private final PredicateCompiler predicateCompiler = new RowExpressionPredicateCompiler(metadata);
     private final DeterminismEvaluator determinismEvaluator = new RowExpressionDeterminismEvaluator(functionManager);
+    private final FilterStatsCalculatorService filterStatsCalculatorService = new ConnectorFilterStatsCalculatorService(new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata), new StatsNormalizer()));
 
     @Override
     public NodeManager getNodeManager()
@@ -132,5 +138,11 @@ public class TestingConnectorContext
                 return new RowExpressionFormatter(functionManager).formatRowExpression(session, expression);
             }
         };
+    }
+
+    @Override
+    public FilterStatsCalculatorService getFilterStatsCalculatorService()
+    {
+        return filterStatsCalculatorService;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
@@ -928,8 +928,8 @@ public class TestRowExpressionDomainTranslator
         assertEquals(
                 toPredicate(fromPredicate(expression).getTupleDomain()),
                 and(
-                        greaterThan(C_BIGINT, bigintLiteral(0)),
-                        greaterThan(C_DOUBLE, doubleLiteral(0))));
+                        greaterThan(C_DOUBLE, doubleLiteral(0)),
+                        greaterThan(C_BIGINT, bigintLiteral(0))));
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorContext.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.facebook.presto.spi.type.TypeManager;
 
@@ -54,6 +55,11 @@ public interface ConnectorContext
     }
 
     default RowExpressionService getRowExpressionService()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default FilterStatsCalculatorService getFilterStatsCalculatorService()
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -259,7 +259,7 @@ public interface ConnectorMetadata
     /**
      * Get statistics for table for given columns and filtering constraint.
      */
-    default TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
+    default TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> tableLayoutHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
     {
         return TableStatistics.empty();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -282,10 +282,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> tableLayoutHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getTableStatistics(session, tableHandle, columnHandles, constraint);
+            return delegate.getTableStatistics(session, tableHandle, tableLayoutHandle, columnHandles, constraint);
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/FilterStatsCalculatorService.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/FilterStatsCalculatorService.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.plan;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.Map;
+
+/**
+ * Estimates the size of the data after applying a predicate using calculations compatible with Cost-Based Optimizer.
+ */
+public interface FilterStatsCalculatorService
+{
+    TableStatistics filterStats(TableStatistics tableStatistics, RowExpression predicate, ConnectorSession session, Map<ColumnHandle, String> columnNames, Map<ColumnHandle, Type> columnTypes);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/DomainTranslator.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/DomainTranslator.java
@@ -34,7 +34,7 @@ public interface DomainTranslator
         Optional<T> extract(RowExpression expression, Domain domain);
     }
 
-    RowExpression toPredicate(TupleDomain<VariableReferenceExpression> tupleDomain);
+    <T extends RowExpression> RowExpression toPredicate(TupleDomain<T> tupleDomain);
 
     /**
      * Convert a RowExpression predicate into an ExtractionResult consisting of:

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsMetadata.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsMetadata.java
@@ -148,7 +148,7 @@ public class TpcdsMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> tableLayoutHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
     {
         TpcdsTableHandle tpcdsTableHandle = (TpcdsTableHandle) tableHandle;
 

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsMetadataStatistics.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsMetadataStatistics.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.spi.Constraint.alwaysTrue;
@@ -55,7 +56,7 @@ public class TestTpcdsMetadataStatistics
                             SchemaTableName schemaTableName = new SchemaTableName(schemaName, table.getName());
                             ConnectorTableHandle tableHandle = metadata.getTableHandle(session, schemaTableName);
                             List<ColumnHandle> columnHandles = ImmutableList.copyOf(metadata.getColumnHandles(session, tableHandle).values());
-                            TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, columnHandles, alwaysTrue());
+                            TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, Optional.empty(), columnHandles, alwaysTrue());
                             assertTrue(tableStatistics.getRowCount().isUnknown());
                             assertTrue(tableStatistics.getColumnStatistics().isEmpty());
                         }));
@@ -70,7 +71,7 @@ public class TestTpcdsMetadataStatistics
                             SchemaTableName schemaTableName = new SchemaTableName(schemaName, table.getName());
                             ConnectorTableHandle tableHandle = metadata.getTableHandle(session, schemaTableName);
                             List<ColumnHandle> columnHandles = ImmutableList.copyOf(metadata.getColumnHandles(session, tableHandle).values());
-                            TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, columnHandles, alwaysTrue());
+                            TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, Optional.empty(), columnHandles, alwaysTrue());
                             assertFalse(tableStatistics.getRowCount().isUnknown());
                             for (ColumnHandle column : metadata.getColumnHandles(session, tableHandle).values()) {
                                 assertTrue(tableStatistics.getColumnStatistics().containsKey(column));
@@ -85,7 +86,7 @@ public class TestTpcdsMetadataStatistics
         SchemaTableName schemaTableName = new SchemaTableName("sf1", Table.CALL_CENTER.getName());
         ConnectorTableHandle tableHandle = metadata.getTableHandle(session, schemaTableName);
         Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandle);
-        TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, ImmutableList.copyOf(columnHandles.values()), alwaysTrue());
+        TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, Optional.empty(), ImmutableList.copyOf(columnHandles.values()), alwaysTrue());
 
         estimateAssertion.assertClose(tableStatistics.getRowCount(), Estimate.of(6), "Row count does not match");
 
@@ -155,7 +156,7 @@ public class TestTpcdsMetadataStatistics
         SchemaTableName schemaTableName = new SchemaTableName("sf1", Table.WEB_SITE.getName());
         ConnectorTableHandle tableHandle = metadata.getTableHandle(session, schemaTableName);
         Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandle);
-        TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, ImmutableList.copyOf(columnHandles.values()), alwaysTrue());
+        TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, Optional.empty(), ImmutableList.copyOf(columnHandles.values()), alwaysTrue());
 
         // some null values
         assertColumnStatistics(
@@ -173,7 +174,7 @@ public class TestTpcdsMetadataStatistics
         SchemaTableName schemaTableName = new SchemaTableName("sf1", Table.WEB_SITE.getName());
         ConnectorTableHandle tableHandle = metadata.getTableHandle(session, schemaTableName);
         List<ColumnHandle> columnHandles = ImmutableList.copyOf(metadata.getColumnHandles(session, tableHandle).values());
-        TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, columnHandles, alwaysTrue());
+        TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle, Optional.empty(), columnHandles, alwaysTrue());
 
         Entry<ColumnHandle, ColumnStatistics> entry = tableStatistics.getColumnStatistics().entrySet().iterator().next();
 

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchMetadata.java
@@ -322,7 +322,7 @@ public class TpchMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> tableLayoutHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
     {
         TpchTableHandle tpchTableHandle = (TpchTableHandle) tableHandle;
         String tableName = tpchTableHandle.getTableName();

--- a/presto-tpch/src/test/java/com/facebook/presto/tpch/TestTpchMetadata.java
+++ b/presto-tpch/src/test/java/com/facebook/presto/tpch/TestTpchMetadata.java
@@ -137,7 +137,7 @@ public class TestTpchMetadata
     {
         TpchTableHandle tableHandle = tpchMetadata.getTableHandle(session, new SchemaTableName(schema, table.getTableName()));
         List<ColumnHandle> columnHandles = ImmutableList.copyOf(tpchMetadata.getColumnHandles(session, tableHandle).values());
-        TableStatistics tableStatistics = tpchMetadata.getTableStatistics(session, tableHandle, columnHandles, constraint);
+        TableStatistics tableStatistics = tpchMetadata.getTableStatistics(session, tableHandle, Optional.empty(), columnHandles, constraint);
 
         double actualRowCountValue = tableStatistics.getRowCount().getValue();
         assertEquals(tableStatistics.getRowCount(), Estimate.of(actualRowCountValue));
@@ -148,7 +148,7 @@ public class TestTpchMetadata
     {
         TpchTableHandle tableHandle = tpchMetadata.getTableHandle(session, new SchemaTableName(schema, table.getTableName()));
         List<ColumnHandle> columnHandles = ImmutableList.copyOf(tpchMetadata.getColumnHandles(session, tableHandle).values());
-        TableStatistics tableStatistics = tpchMetadata.getTableStatistics(session, tableHandle, columnHandles, alwaysTrue());
+        TableStatistics tableStatistics = tpchMetadata.getTableStatistics(session, tableHandle, Optional.empty(), columnHandles, alwaysTrue());
         assertTrue(tableStatistics.getRowCount().isUnknown());
     }
 
@@ -240,7 +240,7 @@ public class TestTpchMetadata
     {
         TpchTableHandle tableHandle = tpchMetadata.getTableHandle(session, new SchemaTableName(schema, table.getTableName()));
         List<ColumnHandle> columnHandles = ImmutableList.copyOf(tpchMetadata.getColumnHandles(session, tableHandle).values());
-        TableStatistics tableStatistics = tpchMetadata.getTableStatistics(session, tableHandle, columnHandles, constraint);
+        TableStatistics tableStatistics = tpchMetadata.getTableStatistics(session, tableHandle, Optional.empty(), columnHandles, constraint);
         ColumnHandle columnHandle = tpchMetadata.getColumnHandles(session, tableHandle).get(column.getSimplifiedColumnName());
 
         ColumnStatistics actual = tableStatistics.getColumnStatistics().get(columnHandle);


### PR DESCRIPTION
Update Hive connector to have statistics returned from the `ConnectorMetadata.getTableStatistics` API reflect the pushed down filter.

```
== NO RELEASE NOTE ==
```
