### PR TITLE
Supporting split JdbcSplit according to column which is auto-discovered using statistics

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/ColumnInfo.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/ColumnInfo.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+public class ColumnInfo
+{
+    private String name;
+    private String type;
+    private boolean isAutoIncrement;
+    private boolean isNullable;
+
+    public ColumnInfo(String name, String type, boolean isAutoIncrement)
+    {
+        this(name, type, isAutoIncrement, true);
+    }
+
+    public ColumnInfo(String name, String type, boolean isAutoIncrement, boolean isNullable)
+    {
+        this.name = name;
+        this.type = type;
+        this.isAutoIncrement = isAutoIncrement;
+        this.isNullable = isNullable;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public boolean isAutoIncrement()
+    {
+        return isAutoIncrement;
+    }
+
+    public boolean isNullable()
+    {
+        return isNullable;
+    }
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplit.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplit.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import javax.annotation.Nullable;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -39,6 +40,8 @@ public class JdbcSplit
     private final TupleDomain<ColumnHandle> tupleDomain;
     private final Optional<JdbcExpression> additionalPredicate;
 
+    private final RangeInfo rangeInfo;
+
     @JsonCreator
     public JdbcSplit(
             @JsonProperty("connectorId") String connectorId,
@@ -46,7 +49,8 @@ public class JdbcSplit
             @JsonProperty("schemaName") @Nullable String schemaName,
             @JsonProperty("tableName") String tableName,
             @JsonProperty("tupleDomain") TupleDomain<ColumnHandle> tupleDomain,
-            @JsonProperty("additionalProperty") Optional<JdbcExpression> additionalPredicate)
+            @JsonProperty("additionalProperty") Optional<JdbcExpression> additionalPredicate,
+            @JsonProperty("rangeInfo") RangeInfo rangeInfo)
     {
         this.connectorId = requireNonNull(connectorId, "connector id is null");
         this.catalogName = catalogName;
@@ -54,6 +58,7 @@ public class JdbcSplit
         this.tableName = requireNonNull(tableName, "table name is null");
         this.tupleDomain = requireNonNull(tupleDomain, "tupleDomain is null");
         this.additionalPredicate = requireNonNull(additionalPredicate, "additionalPredicate is null");
+        this.rangeInfo = rangeInfo;
     }
 
     @JsonProperty
@@ -110,5 +115,69 @@ public class JdbcSplit
     public Object getInfo()
     {
         return this;
+    }
+
+    @JsonProperty
+    public RangeInfo getRangeInfo()
+    {
+        return rangeInfo;
+    }
+
+    public static class RangeInfo
+    {
+        private String columnName;
+        private Long inclusiveMinValue;
+        private Long inclusiveMaxValue;
+
+        @JsonCreator
+        public RangeInfo(@JsonProperty("columnName") String columnName,
+                @JsonProperty("inclusiveMinValue") Long inclusiveMinValue,
+                @JsonProperty("inclusiveMaxValue") Long inclusiveMaxValue)
+        {
+            this.columnName = columnName;
+            this.inclusiveMinValue = inclusiveMinValue;
+            this.inclusiveMaxValue = inclusiveMaxValue;
+        }
+
+        @JsonProperty("columnName")
+        public String getColumnName()
+        {
+            return columnName;
+        }
+
+        @JsonProperty("inclusiveMinValue")
+        public Long getInclusiveMinValue()
+        {
+            return inclusiveMinValue;
+        }
+
+        @JsonProperty("inclusiveMaxValue")
+        public Long getInclusiveMaxValue()
+        {
+            return inclusiveMaxValue;
+        }
+
+        public boolean isNullRange()
+        {
+            return inclusiveMinValue == null && inclusiveMaxValue == null;
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (obj == null || !(obj instanceof RangeInfo)) {
+                return false;
+            }
+            RangeInfo other = (RangeInfo) obj;
+            return Objects.equals(this.columnName, other.columnName) &&
+                    Objects.equals(this.inclusiveMinValue, other.inclusiveMinValue) &&
+                    Objects.equals(this.inclusiveMaxValue, other.inclusiveMaxValue);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(columnName, inclusiveMinValue, inclusiveMaxValue);
+        }
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcSplit.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcSplit.java
@@ -25,7 +25,7 @@ import static org.testng.Assert.assertEquals;
 
 public class TestJdbcSplit
 {
-    private final JdbcSplit split = new JdbcSplit("connectorId", "catalog", "schemaName", "tableName", TupleDomain.all(), Optional.empty());
+    private final JdbcSplit split = new JdbcSplit("connectorId", "catalog", "schemaName", "tableName", TupleDomain.all(), Optional.empty(), null);
 
     @Test
     public void testAddresses()
@@ -34,7 +34,7 @@ public class TestJdbcSplit
         assertEquals(split.getAddresses(), ImmutableList.of());
         assertEquals(split.isRemotelyAccessible(), true);
 
-        JdbcSplit jdbcSplit = new JdbcSplit("connectorId", "catalog", "schemaName", "tableName", TupleDomain.all(), Optional.empty());
+        JdbcSplit jdbcSplit = new JdbcSplit("connectorId", "catalog", "schemaName", "tableName", TupleDomain.all(), Optional.empty(), null);
         assertEquals(jdbcSplit.getAddresses(), ImmutableList.of());
     }
 


### PR DESCRIPTION
Currently for JDBC Connector there is only 1 split, this PR provides the capability to have multiple splits when scanning jdbc tables, it use sqls to collect statistics from the underlying database tables to determine use which column to use, and how many splits will be used, currently at most 100 splits will be produced.


== RELEASE NOTES ==

JDBC Changes
* Supporting split JdbcSplit according to column which is auto-discovered using statistics

