### PR TITLE
Fix position count of prefilled Blocks

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -375,7 +375,7 @@ public class OrcSelectiveRecordReader
         for (int i = 0; i < outputColumns.size(); i++) {
             int columnIndex = outputColumns.get(i);
             if (constantValues[columnIndex] != null) {
-                blocks[i] = RunLengthEncodedBlock.create(columnTypes.get(columnIndex), constantValues[columnIndex] == NULL_MARKER ? null : constantValues[columnIndex], batchSize);
+                blocks[i] = RunLengthEncodedBlock.create(columnTypes.get(columnIndex), constantValues[columnIndex] == NULL_MARKER ? null : constantValues[columnIndex], positionCount);
             }
             else {
                 Block block = getStreamReader(columnIndex).getBlock(positionsToRead, positionCount);


### PR DESCRIPTION
Downstream operators, e.g. table writer, expect Blocks on a Page to
have the same position count.