### PR TITLE
Add query integrity check in AccessControlManager

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -335,6 +335,7 @@ public class SqlQueryManager
 
             // decode session
             session = sessionSupplier.createSession(queryId, sessionContext);
+            accessControl.checkQueryIntegrity(session.getIdentity(), query);
 
             WarningCollector warningCollector = warningCollectorFactory.create();
 

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -35,6 +35,12 @@ public interface AccessControl
     void checkCanSetUser(Optional<Principal> principal, String userName);
 
     /**
+     * Check if the query is unexpectedly modified compared to the token passed in identity.
+     * @throws com.facebook.presto.spi.security.AccessDeniedException if query is modified.
+     */
+    void checkQueryIntegrity(Identity identity, String query);
+
+    /**
      * Filter the list of catalogs to those visible to the identity.
      */
     Set<String> filterCatalogs(Identity identity, Set<String> catalogs);

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -151,6 +151,15 @@ public class AccessControlManager
     }
 
     @Override
+    public void checkQueryIntegrity(Identity identity, String query)
+    {
+        requireNonNull(identity, "extraCredentials is null");
+        requireNonNull(query, "query is null");
+
+        authenticationCheck(() -> systemAccessControl.get().checkQueryIntegrity(identity, query));
+    }
+
+    @Override
     public Set<String> filterCatalogs(Identity identity, Set<String> catalogs)
     {
         requireNonNull(identity, "identity is null");
@@ -753,6 +762,12 @@ public class AccessControlManager
     private static class InitializingSystemAccessControl
             implements SystemAccessControl
     {
+        @Override
+        public void checkQueryIntegrity(Identity identity, String query)
+        {
+            throw new PrestoException(SERVER_STARTING_UP, "Presto server is still initializing");
+        }
+
         @Override
         public void checkCanSetUser(Optional<Principal> principal, String userName)
         {

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
@@ -34,6 +34,11 @@ public class AllowAllAccessControl
     }
 
     @Override
+    public void checkQueryIntegrity(Identity identity, String query)
+    {
+    }
+
+    @Override
     public Set<String> filterCatalogs(Identity identity, Set<String> catalogs)
     {
         return catalogs;

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
@@ -56,6 +56,11 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
+    public void checkQueryIntegrity(Identity identity, String query)
+    {
+    }
+
+    @Override
     public void checkCanSetUser(Optional<Principal> principal, String userName)
     {
     }

--- a/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
@@ -42,6 +42,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyDropVie
 import static com.facebook.presto.spi.security.AccessDeniedException.denyGrantRoles;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyGrantTablePrivilege;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyInsertTable;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyQueryIntegrityCheck;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameColumn;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameSchema;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameTable;
@@ -65,6 +66,12 @@ public class DenyAllAccessControl
     public void checkCanSetUser(Optional<Principal> principal, String userName)
     {
         denySetUser(principal, userName);
+    }
+
+    @Override
+    public void checkQueryIntegrity(Identity identity, String query)
+    {
+        denyQueryIntegrityCheck();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
@@ -158,6 +158,11 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
+    public void checkQueryIntegrity(Identity identity, String query)
+    {
+    }
+
+    @Override
     public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
     {
     }

--- a/presto-main/src/main/java/com/facebook/presto/security/ReadOnlySystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/ReadOnlySystemAccessControl.java
@@ -59,6 +59,11 @@ public class ReadOnlySystemAccessControl
     }
 
     @Override
+    public void checkQueryIntegrity(Identity identity, String query)
+    {
+    }
+
+    @Override
     public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
     {
     }

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -51,18 +51,21 @@ import java.util.Set;
 
 import static com.facebook.presto.spi.ConnectorId.createInformationSchemaConnectorId;
 import static com.facebook.presto.spi.ConnectorId.createSystemTablesConnectorId;
+import static com.facebook.presto.spi.security.AccessDeniedException.denyQueryIntegrityCheck;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectColumns;
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectTable;
 import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.fail;
 
 public class TestAccessControlManager
 {
     private static final Principal PRINCIPAL = new BasicPrincipal("principal");
     private static final String USER_NAME = "user_name";
+    private static final String QUERY_TOKEN_FIELD = "query_token";
 
     @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Presto server is still initializing")
     public void testInitializing()
@@ -129,6 +132,27 @@ public class TestAccessControlManager
         accessControlManager.checkCanSetUser(Optional.of(PRINCIPAL), USER_NAME);
         assertEquals(accessControlFactory.getCheckedUserName(), USER_NAME);
         assertEquals(accessControlFactory.getCheckedPrincipal(), Optional.of(PRINCIPAL));
+    }
+
+    @Test
+    public void testCheckQueryIntegrity()
+    {
+        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager());
+
+        TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
+        accessControlManager.addSystemAccessControlFactory(accessControlFactory);
+        accessControlManager.setSystemAccessControl("test", ImmutableMap.of());
+        String testQuery = "test_query";
+
+        accessControlManager.checkQueryIntegrity(new Identity(USER_NAME, Optional.of(PRINCIPAL), ImmutableMap.of(), ImmutableMap.of(QUERY_TOKEN_FIELD, testQuery)), testQuery);
+        assertEquals(accessControlFactory.getCheckedUserName(), USER_NAME);
+        assertEquals(accessControlFactory.getCheckedPrincipal(), Optional.of(PRINCIPAL));
+        assertEquals(accessControlFactory.getCheckedQuery(), testQuery);
+
+        assertThrows(AccessDeniedException.class,
+                () -> accessControlManager.checkQueryIntegrity(
+                        new Identity(USER_NAME, Optional.of(PRINCIPAL), ImmutableMap.of(), ImmutableMap.of(QUERY_TOKEN_FIELD, testQuery + " modified")),
+                        testQuery));
     }
 
     @Test
@@ -219,6 +243,7 @@ public class TestAccessControlManager
 
         private Optional<Principal> checkedPrincipal;
         private String checkedUserName;
+        private String checkedQuery;
 
         public TestSystemAccessControlFactory(String name)
         {
@@ -240,6 +265,11 @@ public class TestAccessControlManager
             return checkedUserName;
         }
 
+        public String getCheckedQuery()
+        {
+            return checkedQuery;
+        }
+
         @Override
         public String getName()
         {
@@ -257,6 +287,17 @@ public class TestAccessControlManager
                 {
                     checkedPrincipal = principal;
                     checkedUserName = userName;
+                }
+
+                @Override
+                public void checkQueryIntegrity(Identity identity, String query)
+                {
+                    if (!query.equals(identity.getExtraCredentials().get(QUERY_TOKEN_FIELD))) {
+                        denyQueryIntegrityCheck();
+                    }
+                    checkedUserName = identity.getUser();
+                    checkedPrincipal = identity.getPrincipal();
+                    checkedQuery = query;
                 }
 
                 @Override

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ForwardingSystemAccessControl.java
@@ -53,6 +53,12 @@ public abstract class ForwardingSystemAccessControl
     }
 
     @Override
+    public void checkQueryIntegrity(Identity identity, String query)
+    {
+        delegate().checkQueryIntegrity(identity, query);
+    }
+
+    @Override
     public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
     {
         delegate().checkCanSetSystemSessionProperty(identity, propertyName);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessDeniedException.java
@@ -36,6 +36,11 @@ public class AccessDeniedException
         denySetUser(principal, userName, null);
     }
 
+    public static void denyQueryIntegrityCheck()
+    {
+        throw new AccessDeniedException("Query integrity check failed.");
+    }
+
     public static void denySetUser(Optional<Principal> principal, String userName, String extraInfo)
     {
         throw new AccessDeniedException(format("Principal %s cannot become user %s%s", principal.orElse(null), userName, formatExtraInfo(extraInfo)));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -54,6 +54,12 @@ public interface SystemAccessControl
     void checkCanSetUser(Optional<Principal> principal, String userName);
 
     /**
+     * Check if the query is unexpectedly modified compared to token provided in Identity.
+     * @throws AccessDeniedException if query is modified.
+     */
+    void checkQueryIntegrity(Identity identity, String query);
+
+    /**
      * Check if identity is allowed to set the specified system property.
      *
      * @throws AccessDeniedException if not allowed


### PR DESCRIPTION
This PR adds support to validate query integrity before we execute it. Client will provide certain token in `Identity` (most likely in `extraCredentials`). 

```
== RELEASE NOTES ==

General Changes
*  Added support in `AccessControlManager` to check query integrity.
```

