### PR TITLE
Fix outputPositions in List- and MapFlatSelectiveStreamReader in case of all null values

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -51,6 +51,7 @@ import java.util.stream.IntStream;
 
 import static com.facebook.presto.orc.reader.SelectiveStreamReaders.createStreamReader;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -354,6 +355,7 @@ public class OrcSelectiveRecordReader
             }
 
             positionsToRead = streamReader.getReadPositions();
+            verify(positionCount == 1 || positionsToRead[positionCount - 1] - positionsToRead[0] >= positionCount - 1, "positions must monotonically increase");
         }
 
         if (positionCount > 0 && !filterFunctionsApplied) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
@@ -293,11 +293,12 @@ public class ListSelectiveStreamReader
             throws IOException
     {
         presentStream.skip(positions[positionCount - 1]);
-
         if (nullsAllowed) {
             if (nullsFilter != null) {
+                outputPositionCount = 0;
                 for (int i = 0; i < positionCount; i++) {
                     if (nullsFilter.testNull()) {
+                        outputPositions[outputPositionCount] = positions[i];
                         outputPositionCount++;
                     }
                     else {
@@ -308,6 +309,8 @@ public class ListSelectiveStreamReader
             }
             else {
                 outputPositionCount = positionCount;
+                outputPositions = positions;
+                outputPositionsReadOnly = true;
             }
         }
         else {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
@@ -254,6 +254,8 @@ public class MapFlatSelectiveStreamReader
         }
         else {
             outputPositionCount = positionCount;
+            outputPositions = positions;
+            outputPositionsReadOnly = true;
         }
     }
 
@@ -263,7 +265,9 @@ public class MapFlatSelectiveStreamReader
         int streamPosition = 0;
 
         int[] nonNullPositions = new int[positionCount];
+        int[] nullPositions = new int[positionCount];
         int nonNullPositionCount = 0;
+        int nullPositionCount = 0;
         int nonNullSkipped = 0;
 
         if (presentStream == null) {
@@ -313,6 +317,8 @@ public class MapFlatSelectiveStreamReader
                 else {
                     if (nullsAllowed) {
                         nulls[i] = true;
+                        nullPositions[nullPositionCount] = positions[i];
+                        nullPositionCount++;
                     }
                 }
             }
@@ -321,8 +327,10 @@ public class MapFlatSelectiveStreamReader
         readOffset = offset + streamPosition;
 
         if (!nonNullsAllowed) {
-            outputPositionCount = positionCount - nonNullPositionCount;
+            checkState(nullPositionCount == (positionCount - nonNullPositionCount), "nullPositionCount should be equal to postitionCount - nonNullPositionCount");
+            outputPositionCount = nullPositionCount;
             allNulls = true;
+            System.arraycopy(nullPositions, 0, outputPositions, 0, nullPositionCount);
         }
         else {
             nestedLengths = ensureCapacity(nestedLengths, nonNullPositionCount);


### PR DESCRIPTION
List- and MapFlatSelectiveStreamReader returned junk values from `getReadPositions` when all values are null.  This PR is fixing that ands a sanity check for the return value of `getReadPositions` to the caller.

```
== NO RELEASE NOTE ==
```
