### PR TITLE
Fix NPE in SimpleNodeSelector

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -36,7 +36,6 @@ import javax.inject.Inject;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -202,12 +201,14 @@ public class NodeScheduler
     {
         checkArgument(limit > 0, "limit must be at least 1");
 
-        List<InternalNode> selected = new ArrayList<>(min(limit, candidates.size()));
-        while (selected.size() < limit && candidates.hasNext()) {
-            selected.add(candidates.next());
+        ImmutableList.Builder<InternalNode> selectedNodes = ImmutableList.builderWithExpectedSize(min(limit, candidates.size()));
+        int selectedCount = 0;
+        while (selectedCount < limit && candidates.hasNext()) {
+            selectedNodes.add(candidates.next());
+            selectedCount++;
         }
 
-        return selected;
+        return selectedNodes.build();
     }
 
     public static ResettableRandomizedIterator<InternalNode> randomizedNodes(NodeMap nodeMap, boolean includeCoordinator, Set<InternalNode> excludedNodes)


### PR DESCRIPTION
When node disappears (for example due to a slow heartbeat or due to the
failure) the NPE can happen in SimpleNodeSelector, as the node mapping
for the existing task won't be found in the node map.

Example stacktrace:
```
Caused by: java.lang.NullPointerException
	at java.base/java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:946)
	at com.facebook.presto.execution.NodeTaskMap.createOrGetNodeTasks(NodeTaskMap.java:62)
	at com.facebook.presto.execution.NodeTaskMap.getPartitionedSplitsOnNode(NodeTaskMap.java:52)
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1138)
	at com.facebook.presto.execution.scheduler.NodeAssignmentStats.getTotalSplitCount(NodeAssignmentStats.java:50)
	at com.facebook.presto.execution.scheduler.SimpleNodeSelector.computeAssignments(SimpleNodeSelector.java:134)
	at com.facebook.presto.execution.scheduler.DynamicSplitPlacementPolicy.computeAssignments(DynamicSplitPlacementPolicy.java:41)
	at com.facebook.presto.execution.scheduler.SourcePartitionedScheduler.schedule(SourcePartitionedScheduler.java:271)
	at com.facebook.presto.execution.scheduler.SourcePartitionedScheduler$1.schedule(SourcePartitionedScheduler.java:146)
	at com.facebook.presto.execution.scheduler.SqlQueryScheduler.schedule(SqlQueryScheduler.java:747)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:514)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1135)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:844)
```


```
== NO RELEASE NOTE ==
```
