### PR TITLE
Allow reading non-ORC tables when pushdown filter is enabled 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
     - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-materialized"
     - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-recoverable-grouped-execution"
     - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-pushdown-filter-queries"
+    - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-repartitioning"
     - TEST_SPECIFIC_MODULES=presto-hive TEST_FLAGS="-P test-hive-parquet"
     - TEST_SPECIFIC_MODULES=presto-main
     - TEST_SPECIFIC_MODULES=presto-mongodb

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -408,6 +408,7 @@
                                 <exclude>**/TestHiveDistributedQueriesWithExchangeMaterialization.java</exclude>
                                 <exclude>**/TestHiveRecoverableGroupedExecution.java</exclude>
                                 <exclude>**/TestHivePushdownFilterQueries.java</exclude>
+                                <exclude>**/TestHivePushdownIntegrationSmokeTest.java</exclude>
                                 <exclude>**/TestParquetDistributedQueries.java</exclude>
                             </excludes>
                         </configuration>
@@ -474,6 +475,7 @@
                         <configuration>
                             <includes>
                                 <include>**/TestHivePushdownFilterQueries.java</include>
+                                <include>**/TestHivePushdownIntegrationSmokeTest.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -406,6 +406,7 @@
                                 <exclude>**/TestHiveClientGlueMetastore.java</exclude>
                                 <exclude>**/TestHiveDistributedAggregationsWithExchangeMaterialization.java</exclude>
                                 <exclude>**/TestHiveDistributedQueriesWithExchangeMaterialization.java</exclude>
+                                <exclude>**/TestHiveDistributedQueriesWithOptimizedRepartitioning.java</exclude>
                                 <exclude>**/TestHiveRecoverableGroupedExecution.java</exclude>
                                 <exclude>**/TestHivePushdownFilterQueries.java</exclude>
                                 <exclude>**/TestHivePushdownIntegrationSmokeTest.java</exclude>
@@ -427,6 +428,22 @@
                             <includes>
                                 <include>**/TestHiveDistributedAggregationsWithExchangeMaterialization.java</include>
                                 <include>**/TestHiveDistributedQueriesWithExchangeMaterialization.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-hive-repartitioning</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/TestHiveDistributedQueriesWithOptimizedRepartitioning.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1784,6 +1784,7 @@ public class HiveMetadata
                                 hivePartitionResult.getEnforcedConstraint(),
                                 hivePartitionResult.getBucketHandle(),
                                 hivePartitionResult.getBucketFilter(),
+                                true,
                                 createTableLayoutString(session, tableName, hivePartitionResult.getBucketHandle(), decomposedFilter.getRemainingExpression(), domainPredicate))),
                 TRUE_CONSTANT);
     }
@@ -1876,6 +1877,7 @@ public class HiveMetadata
                                 hivePartitionResult.getEnforcedConstraint(),
                                 hiveBucketHandle,
                                 hivePartitionResult.getBucketFilter(),
+                                false,
                                 createTableLayoutString(session, handle.getSchemaTableName(), hivePartitionResult.getBucketHandle(), TRUE_CONSTANT, domainPredicate))),
                 hivePartitionResult.getUnenforcedConstraint()));
     }
@@ -2058,6 +2060,7 @@ public class HiveMetadata
                 hiveLayoutHandle.getPartitionColumnPredicate(),
                 Optional.of(new HiveBucketHandle(bucketHandle.getColumns(), bucketHandle.getTableBucketCount(), hivePartitioningHandle.getBucketCount())),
                 hiveLayoutHandle.getBucketFilter(),
+                hiveLayoutHandle.isPushdownFilterEnabled(),
                 hiveLayoutHandle.getLayoutString());
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -53,7 +53,6 @@ import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.PARTITION_KEY
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
 import static com.facebook.presto.hive.HivePageSourceProvider.ColumnMapping.toColumnHandles;
-import static com.facebook.presto.hive.HiveSessionProperties.isPushdownFilterEnabled;
 import static com.facebook.presto.hive.HiveUtil.getPrefilledColumnValue;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveSchema;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.reconstructPartitionSchema;
@@ -112,7 +111,7 @@ public class HivePageSourceProvider
 
         Configuration configuration = hdfsEnvironment.getConfiguration(new HdfsContext(session, hiveSplit.getDatabase(), hiveSplit.getTable()), path);
 
-        if (isPushdownFilterEnabled(session)) {
+        if (hiveLayout.isPushdownFilterEnabled()) {
             return createSelectivePageSource(selectivePageSourceFactories, configuration, session, hiveSplit, hiveLayout, selectedColumns, hiveStorageTimeZone, rowExpressionService);
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
@@ -48,6 +48,7 @@ public final class HiveTableLayoutHandle
     private final TupleDomain<ColumnHandle> partitionColumnPredicate;
     private final Optional<HiveBucketHandle> bucketHandle;
     private final Optional<HiveBucketFilter> bucketFilter;
+    private final boolean pushdownFilterEnabled;
     private final String layoutString;
 
     // coordinator-only properties
@@ -66,6 +67,7 @@ public final class HiveTableLayoutHandle
             @JsonProperty("partitionColumnPredicate") TupleDomain<ColumnHandle> partitionColumnPredicate,
             @JsonProperty("bucketHandle") Optional<HiveBucketHandle> bucketHandle,
             @JsonProperty("bucketFilter") Optional<HiveBucketFilter> bucketFilter,
+            @JsonProperty("pushdownFilterEnabled") boolean pushdownFilterEnabled,
             @JsonProperty("layoutString") String layoutString)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "table is null");
@@ -79,6 +81,7 @@ public final class HiveTableLayoutHandle
         this.partitions = null;
         this.bucketHandle = requireNonNull(bucketHandle, "bucketHandle is null");
         this.bucketFilter = requireNonNull(bucketFilter, "bucketFilter is null");
+        this.pushdownFilterEnabled = pushdownFilterEnabled;
         this.layoutString = requireNonNull(layoutString, "layoutString is null");
     }
 
@@ -94,6 +97,7 @@ public final class HiveTableLayoutHandle
             TupleDomain<ColumnHandle> partitionColumnPredicate,
             Optional<HiveBucketHandle> bucketHandle,
             Optional<HiveBucketFilter> bucketFilter,
+            boolean pushdownFilterEnabled,
             String layoutString)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "table is null");
@@ -107,6 +111,7 @@ public final class HiveTableLayoutHandle
         this.partitionColumnPredicate = requireNonNull(partitionColumnPredicate, "partitionColumnPredicate is null");
         this.bucketHandle = requireNonNull(bucketHandle, "bucketHandle is null");
         this.bucketFilter = requireNonNull(bucketFilter, "bucketFilter is null");
+        this.pushdownFilterEnabled = pushdownFilterEnabled;
         this.layoutString = requireNonNull(layoutString, "layoutString is null");
     }
 
@@ -179,6 +184,12 @@ public final class HiveTableLayoutHandle
     public Optional<HiveBucketFilter> getBucketFilter()
     {
         return bucketFilter;
+    }
+
+    @JsonProperty
+    public boolean isPushdownFilterEnabled()
+    {
+        return pushdownFilterEnabled;
     }
 
     @JsonProperty

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -679,6 +679,7 @@ public abstract class AbstractTestHiveClient
                 TupleDomain.all(),
                 Optional.empty(),
                 Optional.empty(),
+                false,
                 "layout");
 
         int partitionColumnIndex = MAX_PARTITION_KEY_COLUMN_INDEX;
@@ -744,6 +745,7 @@ public abstract class AbstractTestHiveClient
                         tupleDomain,
                         Optional.empty(),
                         Optional.empty(),
+                        false,
                         "layout"),
                 Optional.empty(),
                 TupleDomain.withColumnDomains(ImmutableMap.of(
@@ -785,6 +787,7 @@ public abstract class AbstractTestHiveClient
                 TupleDomain.all(),
                 Optional.empty(),
                 Optional.empty(),
+                false,
                 "layout"));
         timeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(timeZoneId));
     }
@@ -1834,6 +1837,7 @@ public abstract class AbstractTestHiveClient
                     layoutHandle.getPartitionColumnPredicate(),
                     Optional.of(new HiveBucketHandle(bucketHandle.getColumns(), bucketHandle.getTableBucketCount(), 2)),
                     layoutHandle.getBucketFilter(),
+                    false,
                     "layout");
 
             List<ConnectorSplit> splits = getAllSplits(session, transaction, modifiedReadBucketCountLayoutHandle);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -257,6 +257,7 @@ public class TestHivePageSink
                         TupleDomain.all(),
                         Optional.empty(),
                         Optional.empty(),
+                        false,
                         "layout")));
         HivePageSourceProvider provider = new HivePageSourceProvider(config, createTestHdfsEnvironment(config), getDefaultHiveRecordCursorProvider(config), getDefaultHiveDataStreamFactories(config), ImmutableSet.of(), TYPE_MANAGER, ROW_EXPRESSION_SERVICE);
         return provider.createPageSource(transaction, getSession(config), split, tableHandle.getLayout().get(), ImmutableList.copyOf(getColumnHandles()));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -600,11 +600,11 @@ public class TestHivePushdownFilterQueries
         // Tests composing two pushdowns each with a range filter and filter function.
         assertQuery(
                 "WITH data AS (" +
-                "    SELECT l.suppkey, l.linenumber, l.shipmode, MAX(o.orderdate)" +
-                "    FROM lineitem l,  orders o WHERE" +
-                "        o.orderkey = l.orderkey AND linenumber IN (2, 3, 4, 6) AND shipmode LIKE '%AIR%'" +
-                "        GROUP BY l.suppkey, l.linenumber, l.shipmode)" +
-                "SELECT COUNT(*) FROM data WHERE suppkey BETWEEN 10 AND 30 AND shipmode LIKE '%REG%'");
+                    "    SELECT l.suppkey, l.linenumber, l.shipmode, MAX(o.orderdate)" +
+                    "    FROM lineitem l,  orders o WHERE" +
+                    "        o.orderkey = l.orderkey AND linenumber IN (2, 3, 4, 6) AND shipmode LIKE '%AIR%'" +
+                    "        GROUP BY l.suppkey, l.linenumber, l.shipmode)" +
+                    "SELECT COUNT(*) FROM data WHERE suppkey BETWEEN 10 AND 30 AND shipmode LIKE '%REG%'");
     }
 
     @Test
@@ -652,6 +652,16 @@ public class TestHivePushdownFilterQueries
         Session session = getQueryRunner().getDefaultSession();
         assertQuerySucceeds(session, "SELECT linenumber, \"$path\" FROM lineitem");
         assertQuerySucceeds(session, "SELECT linenumber, \"$path\" FROM lineitem WHERE length(\"$path\") % 2 = linenumber % 2");
+    }
+
+    @Test
+    public void testTextfileFormatWithPushdown()
+    {
+        assertUpdate("CREATE TABLE textfile (id BIGINT) WITH (format = 'TEXTFILE')");
+        assertUpdate("INSERT INTO textfile VALUES (1), (2), (3)", 3);
+        assertQuery("SELECT id FROM textfile WHERE id = 1", "SELECT 1");
+        assertQuery("SELECT id FROM textfile", "SELECT 1 UNION SELECT 2 UNION SELECT 3 ");
+        assertUpdate("DROP TABLE textfile");
     }
 
     @Test

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownIntegrationSmokeTest.java
@@ -1,0 +1,56 @@
+package com.facebook.presto.hive;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.facebook.presto.spi.security.SelectedRole;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
+import static com.facebook.presto.hive.HiveQueryRunner.createBucketedSession;
+import static com.facebook.presto.hive.HiveQueryRunner.createMaterializeExchangesSession;
+import static com.facebook.presto.hive.HiveQueryRunner.createQueryRunner;
+import static com.facebook.presto.spi.security.SelectedRole.Type.ROLE;
+import static io.airlift.tpch.TpchTable.CUSTOMER;
+import static io.airlift.tpch.TpchTable.LINE_ITEM;
+import static io.airlift.tpch.TpchTable.ORDERS;
+import static io.airlift.tpch.TpchTable.PART_SUPPLIER;
+
+public class TestHivePushdownIntegrationSmokeTest
+        extends TestHiveIntegrationSmokeTest
+{
+    public TestHivePushdownIntegrationSmokeTest()
+    {
+        super(() -> createQueryRunner(ImmutableList.of(ORDERS, CUSTOMER, LINE_ITEM, PART_SUPPLIER), ImmutableMap.of("experimental.pushdown-subfields-enabled", "true"), "sql-standard", ImmutableMap.of("hive.pushdown-filter-enabled", "true"), Optional.empty()),
+                createBucketedSession(Optional.of(new SelectedRole(ROLE, Optional.of("admin")))),
+                createMaterializeExchangesSession(Optional.of(new SelectedRole(ROLE, Optional.of("admin")))),
+                HIVE_CATALOG,
+                new HiveTypeTranslator());
+    }
+
+    // TODO Enable this test after we fix the query plan to retain information about the pushed down filter on the Join column so that we need not perform an exchange for it.
+    @Test
+    public void testMaterializedPartitioning()
+    {
+    }
+
+    // TODO Enable this test after we fix the query plan to retain information to indicate that a column filter is pushed down and the "DELETE" operation is not on entire partition.
+    @Test
+    public void testMetadataDelete()
+    {
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
@@ -188,7 +188,8 @@ public class MapFlatSelectiveStreamReader
                     requiredLongKeys = null;
                     return;
                 default:
-                    throw new IllegalArgumentException("Unsupported flat map key type: " + keyOrcTypeKind);
+                    requiredStringKeys = null;
+                    requiredLongKeys = null;
             }
         }
     }


### PR DESCRIPTION
capture whether pushdown is enabled at query plan time and pass it into tableLayout to use it during execution

```
== NO RELEASE NOTE ==
```
