### PR TITLE
Output verifier events for queries being skipped by pre-filters

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/event/VerifierQueryEvent.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/event/VerifierQueryEvent.java
@@ -24,6 +24,7 @@ import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.SKIPPED;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -66,8 +67,8 @@ public class VerifierQueryEvent
             Optional<SkippedReason> skippedReason,
             Optional<DeterminismAnalysis> determinismAnalysis,
             Optional<String> resolveMessage,
-            QueryInfo controlQueryInfo,
-            QueryInfo testQueryInfo,
+            Optional<QueryInfo> controlQueryInfo,
+            Optional<QueryInfo> testQueryInfo,
             Optional<String> errorCode,
             Optional<String> errorMessage,
             Optional<QueryFailure> finalQueryFailure,
@@ -81,12 +82,34 @@ public class VerifierQueryEvent
         this.deterministic = determinismAnalysis.filter(d -> !d.isUnknown()).map(DeterminismAnalysis::isDeterministic).orElse(null);
         this.determinismAnalysis = determinismAnalysis.map(DeterminismAnalysis::name).orElse(null);
         this.resolveMessage = resolveMessage.orElse(null);
-        this.controlQueryInfo = requireNonNull(controlQueryInfo, "controlQueryInfo is null");
-        this.testQueryInfo = requireNonNull(testQueryInfo, "testQueryInfo is null");
+        this.controlQueryInfo = controlQueryInfo.orElse(null);
+        this.testQueryInfo = testQueryInfo.orElse(null);
         this.errorCode = errorCode.orElse(null);
         this.errorMessage = errorMessage.orElse(null);
         this.finalQueryFailure = finalQueryFailure.orElse(null);
         this.queryFailures = ImmutableList.copyOf(queryFailures);
+    }
+
+    public static VerifierQueryEvent skipped(
+            String suite,
+            String testId,
+            String name,
+            SkippedReason skippedReason)
+    {
+        return new VerifierQueryEvent(
+                suite,
+                testId,
+                name,
+                SKIPPED,
+                Optional.of(skippedReason),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of());
     }
 
     @EventField

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
@@ -270,20 +270,20 @@ public abstract class AbstractVerification
                 skippedReason,
                 determinismAnalysis,
                 resolveMessage,
-                buildQueryInfo(
+                Optional.of(buildQueryInfo(
                         sourceQuery.getControlConfiguration(),
                         sourceQuery.getControlQuery(),
                         verificationResult.map(VerificationResult::getControlChecksumQueryId),
                         verificationResult.map(VerificationResult::getControlChecksumQuery),
                         control,
-                        controlStats),
-                buildQueryInfo(
+                        controlStats)),
+                Optional.of(buildQueryInfo(
                         sourceQuery.getTestConfiguration(),
                         sourceQuery.getTestQuery(),
                         verificationResult.map(VerificationResult::getTestChecksumQueryId),
                         verificationResult.map(VerificationResult::getTestChecksumQuery),
                         test,
-                        testStats),
+                        testStats)),
                 errorCode,
                 Optional.ofNullable(errorMessage),
                 queryException.map(QueryException::toQueryFailure),

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/SkippedReason.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/SkippedReason.java
@@ -15,6 +15,11 @@ package com.facebook.presto.verifier.framework;
 
 public enum SkippedReason
 {
+    SYNTAX_ERROR,
+    UNSUPPORTED_QUERY_TYPE,
+    MISMATCHED_QUERY_TYPE,
+    CUSTOM_FILTER,
+
     CONTROL_QUERY_FAILED,
     CONTROL_SETUP_QUERY_FAILED,
     CONTROL_QUERY_TIMED_OUT,


### PR DESCRIPTION
```
== RELEASE NOTES ==

Verifier Changes
* Add skipped verification results to the output for queries being filtered.
```
