### PR TITLE
[WIP] Adding instrumentation framework to log query lifecycle events

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -47,6 +47,7 @@ public final class PrestoHeaders
     public static final String PRESTO_PAGE_TOKEN = "X-Presto-Page-Sequence-Id";
     public static final String PRESTO_PAGE_NEXT_TOKEN = "X-Presto-Page-End-Sequence-Id";
     public static final String PRESTO_BUFFER_COMPLETE = "X-Presto-Buffer-Complete";
+    public static final String PRESTO_QUERY_LOGGING_SIZE = "X-Presto-Query-Logging-Size";
 
     private PrestoHeaders() {}
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -92,6 +92,7 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.facebook.presto.spi.security.PrestoPrincipal;
+import com.facebook.presto.spi.session.SessionLogger;
 import com.facebook.presto.spi.statistics.ColumnStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.facebook.presto.spi.type.ArrayType;
@@ -1037,6 +1038,12 @@ public abstract class AbstractTestHiveClient
             public long getStartTime()
             {
                 return session.getStartTime();
+            }
+
+            @Override
+            public SessionLogger getSessionLogger()
+            {
+                return session.getSessionLogger();
             }
 
             @Override

--- a/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.SqlFunctionProperties;
 import com.facebook.presto.spi.security.ConnectorIdentity;
+import com.facebook.presto.spi.session.SessionLogger;
 import com.facebook.presto.spi.type.TimeZoneKey;
 import com.google.common.collect.ImmutableMap;
 
@@ -143,6 +144,12 @@ public class FullConnectorSession
         }
 
         return sessionPropertyManager.decodeCatalogPropertyValue(connectorId, catalog, propertyName, properties.get(propertyName), type);
+    }
+
+    @Override
+    public SessionLogger getSessionLogger()
+    {
+        return session.getSessionLogger();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
+++ b/presto-main/src/main/java/com/facebook/presto/SessionRepresentation.java
@@ -58,6 +58,7 @@ public final class SessionRepresentation
     private final Map<ConnectorId, Map<String, String>> catalogProperties;
     private final Map<String, Map<String, String>> unprocessedCatalogProperties;
     private final Map<String, SelectedRole> roles;
+    private final int queryLoggingSize;
     private final Map<String, String> preparedStatements;
 
     @JsonCreator
@@ -83,6 +84,7 @@ public final class SessionRepresentation
             @JsonProperty("catalogProperties") Map<ConnectorId, Map<String, String>> catalogProperties,
             @JsonProperty("unprocessedCatalogProperties") Map<String, Map<String, String>> unprocessedCatalogProperties,
             @JsonProperty("roles") Map<String, SelectedRole> roles,
+            @JsonProperty("queryLoggingSize") int queryLoggingSize,
             @JsonProperty("preparedStatements") Map<String, String> preparedStatements)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
@@ -105,6 +107,7 @@ public final class SessionRepresentation
         this.systemProperties = ImmutableMap.copyOf(systemProperties);
         this.roles = ImmutableMap.copyOf(roles);
         this.preparedStatements = ImmutableMap.copyOf(preparedStatements);
+        this.queryLoggingSize = queryLoggingSize;
 
         ImmutableMap.Builder<ConnectorId, Map<String, String>> catalogPropertiesBuilder = ImmutableMap.builder();
         for (Entry<ConnectorId, Map<String, String>> entry : catalogProperties.entrySet()) {
@@ -251,6 +254,12 @@ public final class SessionRepresentation
         return preparedStatements;
     }
 
+    @JsonProperty
+    public int getQueryLoggingSize()
+    {
+        return queryLoggingSize;
+    }
+
     public Session toSession(SessionPropertyManager sessionPropertyManager)
     {
         return toSession(sessionPropertyManager, emptyMap());
@@ -279,6 +288,8 @@ public final class SessionRepresentation
                 catalogProperties,
                 unprocessedCatalogProperties,
                 sessionPropertyManager,
-                preparedStatements);
+                queryLoggingSize,
+                preparedStatements,
+                Optional.empty());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/SizeLimitedSessionLogger.java
+++ b/presto-main/src/main/java/com/facebook/presto/SizeLimitedSessionLogger.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto;
+
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.session.SessionLogger;
+import com.google.common.base.Ticker;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Supplier;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class SizeLimitedSessionLogger
+        implements SessionLogger
+{
+    private final QueryId queryId;
+    private final int maxSize;
+    private final Ticker ticker = Ticker.systemTicker();
+    private final Queue<Entry> entries = new ConcurrentLinkedQueue<>();
+
+    public SizeLimitedSessionLogger(QueryId queryId, int maxSize)
+    {
+        this.queryId = queryId;
+        this.maxSize = maxSize;
+    }
+
+    @Override
+    public Queue<Entry> getEntries()
+    {
+        // Not taking a copy explicitly because this isn't racy
+        // plus then we have to worry about getting the most up to date copy
+        return entries;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("queryId", queryId)
+                .add("numEntries", entries.size())
+                .add("maxSize", maxSize)
+                .toString();
+    }
+
+    @Override
+    public void log(Supplier<String> messageSupplier)
+    {
+        if (entries.size() < maxSize) {
+            String message = messageSupplier.get();
+            if (message != null) {
+                entries.add(new Entry(message,
+                        ticker.read(),
+                        Thread.currentThread().getName()));
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnectorSessionUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemConnectorSessionUtil.java
@@ -44,6 +44,7 @@ public final class SystemConnectorSessionUtil
                 .setTimeZoneKey(session.getTimeZoneKey())
                 .setLocale(session.getLocale())
                 .setStartTime(session.getStartTime())
+                .setSessionLogger(session.getSessionLogger())
                 .build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.resourceGroups.QueryType;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.security.SelectedRole;
+import com.facebook.presto.spi.session.SessionLogger;
 import com.facebook.presto.transaction.TransactionId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,6 +38,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 
 import static com.facebook.presto.execution.QueryState.FAILED;
@@ -81,6 +83,7 @@ public class QueryInfo
     private final Optional<QueryType> queryType;
     // failedTasks is only available for final query info because the construction is expensive.
     private final Optional<List<TaskId>> failedTasks;
+    private Optional<Queue<SessionLogger.Entry>> sessionLogEntries = Optional.empty();
 
     @JsonCreator
     public QueryInfo(
@@ -408,5 +411,16 @@ public class QueryInfo
     public boolean isCompleteInfo()
     {
         return completeInfo;
+    }
+
+    public void setSessionLogEntries(Queue<SessionLogger.Entry> sessionLogEntries)
+    {
+        this.sessionLogEntries = Optional.of(sessionLogEntries);
+    }
+
+    @JsonProperty
+    public Optional<Queue<SessionLogger.Entry>> getSessionLogEntries()
+    {
+        return sessionLogEntries;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -977,6 +977,7 @@ public class QueryStateMachine
     {
         QueryInfo queryInfo = getQueryInfo(stageInfo);
         if (queryInfo.isFinalQueryInfo()) {
+            queryInfo.setSessionLogEntries(session.getSessionLogger().getEntries());
             finalQueryInfo.compareAndSet(Optional.empty(), Optional.of(queryInfo));
         }
         return queryInfo;

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -32,6 +32,7 @@ import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.TaskExchangeClientManager;
 import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.session.SessionLogger;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -47,6 +48,7 @@ import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -341,6 +343,7 @@ public class SqlTask
                 outputBuffer.getInfo(),
                 noMoreSplits,
                 taskStats,
+                taskHolder.getSessionLogEntries(),
                 needsPlan.get());
     }
 
@@ -528,6 +531,19 @@ public class SqlTask
         public TaskInfo getFinalTaskInfo()
         {
             return finalTaskInfo;
+        }
+
+        public Optional<Queue<SessionLogger.Entry>> getSessionLogEntries()
+        {
+            if (finalTaskInfo != null) {
+                return finalTaskInfo.getSessionLogEntries();
+            }
+            else if (taskExecution != null) {
+                return Optional.of(taskExecution.getTaskContext().getSession().getSessionLogger().getEntries());
+            }
+            else {
+                return Optional.empty();
+            }
         }
 
         public SqlTaskIoStats getIoStats()

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -263,6 +263,7 @@ public class SqlTaskExecution
                 outputBuffer::getUtilization,
                 getInitialSplitsPerNode(taskContext.getSession()),
                 getSplitConcurrencyAdjustmentInterval(taskContext.getSession()),
+                taskContext.getSession().getSessionLogger(),
                 getMaxDriversPerTask(taskContext.getSession()));
         taskStateMachine.addStateChangeListener(state -> {
             if (state.isDone()) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
@@ -24,6 +24,7 @@ import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.server.ServerConfig;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.session.SessionLogger;
 import com.facebook.presto.version.EmbedVersion;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ticker;
@@ -253,6 +254,7 @@ public class TaskExecutor
             DoubleSupplier utilizationSupplier,
             int initialSplitConcurrency,
             Duration splitConcurrencyAdjustFrequency,
+            SessionLogger sessionLogger,
             OptionalInt maxDriversPerTask)
     {
         requireNonNull(taskId, "taskId is null");
@@ -262,7 +264,7 @@ public class TaskExecutor
 
         log.debug("Task scheduled " + taskId);
 
-        TaskHandle taskHandle = new TaskHandle(taskId, waitingSplits, utilizationSupplier, initialSplitConcurrency, splitConcurrencyAdjustFrequency, maxDriversPerTask);
+        TaskHandle taskHandle = new TaskHandle(taskId, waitingSplits, utilizationSupplier, initialSplitConcurrency, splitConcurrencyAdjustFrequency, maxDriversPerTask, sessionLogger);
 
         tasks.add(taskHandle);
         return taskHandle;

--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/TaskHandle.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution.executor;
 
 import com.facebook.presto.execution.SplitConcurrencyController;
 import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.spi.session.SessionLogger;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.Duration;
 
@@ -38,6 +39,7 @@ import static java.util.Objects.requireNonNull;
 public class TaskHandle
 {
     private final TaskId taskId;
+    private final SessionLogger sessionLogger;
     protected final DoubleSupplier utilizationSupplier;
 
     @GuardedBy("this")
@@ -65,7 +67,8 @@ public class TaskHandle
             DoubleSupplier utilizationSupplier,
             int initialSplitConcurrency,
             Duration splitConcurrencyAdjustFrequency,
-            OptionalInt maxDriversPerTask)
+            OptionalInt maxDriversPerTask,
+            SessionLogger sessionLogger)
     {
         this.taskId = requireNonNull(taskId, "taskId is null");
         this.splitQueue = requireNonNull(splitQueue, "splitQueue is null");
@@ -74,6 +77,7 @@ public class TaskHandle
         this.concurrencyController = new SplitConcurrencyController(
                 initialSplitConcurrency,
                 requireNonNull(splitConcurrencyAdjustFrequency, "splitConcurrencyAdjustFrequency is null"));
+        this.sessionLogger = sessionLogger;
     }
 
     public synchronized Priority addScheduledNanos(long durationNanos)
@@ -191,5 +195,10 @@ public class TaskHandle
         return toStringHelper(this)
                 .add("taskId", taskId)
                 .toString();
+    }
+
+    public SessionLogger getSessionLogger()
+    {
+        return sessionLogger;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
@@ -74,6 +74,7 @@ public class QuerySessionSupplier
                 .setClientInfo(context.getClientInfo())
                 .setClientTags(context.getClientTags())
                 .setTraceToken(context.getTraceToken())
+                .setQueryLoggingSize(context.getQueryLoggingSize())
                 .setResourceEstimates(context.getResourceEstimates());
 
         if (forcedSessionTimeZone.isPresent()) {

--- a/presto-main/src/main/java/com/facebook/presto/server/SessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SessionContext.java
@@ -65,4 +65,6 @@ public interface SessionContext
     Optional<String> getTraceToken();
 
     boolean supportClientTransaction();
+
+    int getQueryLoggingSize();
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/SessionPropertyDefaults.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SessionPropertyDefaults.java
@@ -106,6 +106,6 @@ public class SessionPropertyDefaults
 
         Map<String, String> systemPropertyOverrides = configurationManager.getSystemSessionProperties(context);
         Map<String, Map<String, String>> catalogPropertyOverrides = configurationManager.getCatalogSessionProperties(context);
-        return session.withDefaultProperties(systemPropertyOverrides, catalogPropertyOverrides);
+        return session.withDefaultProperties(systemPropertyOverrides, catalogPropertyOverrides, session.getSessionLogger());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.client.Request;
 import com.facebook.airlift.http.client.ResponseHandler;
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.Session;
 import com.facebook.presto.execution.StateMachine;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskStatus;
@@ -68,6 +69,7 @@ class ContinuousTaskStatusFetcher
     private final HttpClient httpClient;
     private final RequestErrorTracker errorTracker;
     private final RemoteTaskStats stats;
+    private final Session session;
     private final boolean isBinaryTransportEnabled;
 
     private final AtomicLong currentRequestStartNanos = new AtomicLong();
@@ -88,7 +90,8 @@ class ContinuousTaskStatusFetcher
             Duration maxErrorDuration,
             ScheduledExecutorService errorScheduledExecutor,
             RemoteTaskStats stats,
-            boolean isBinaryTransportEnabled)
+            boolean isBinaryTransportEnabled,
+            Session session)
     {
         requireNonNull(initialTaskStatus, "initialTaskStatus is null");
 
@@ -105,6 +108,7 @@ class ContinuousTaskStatusFetcher
         this.errorTracker = new RequestErrorTracker(taskId, initialTaskStatus.getSelf(), maxErrorDuration, errorScheduledExecutor, "getting task status");
         this.stats = requireNonNull(stats, "stats is null");
         this.isBinaryTransportEnabled = isBinaryTransportEnabled;
+        this.session = requireNonNull(session, "session is null");
     }
 
     public synchronized void start()

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -268,7 +268,7 @@ public final class HttpRemoteTask
                     .map(outputId -> new BufferInfo(outputId, false, 0, 0, PageBufferInfo.empty()))
                     .collect(toImmutableList());
 
-            TaskInfo initialTask = createInitialTask(taskId, location, nodeId, bufferStates, new TaskStats(DateTime.now(), null));
+            TaskInfo initialTask = createInitialTask(session, taskId, location, nodeId, bufferStates, new TaskStats(DateTime.now(), null));
 
             this.taskStatusFetcher = new ContinuousTaskStatusFetcher(
                     this::failTask,
@@ -280,7 +280,8 @@ public final class HttpRemoteTask
                     maxErrorDuration,
                     errorScheduledExecutor,
                     stats,
-                    isBinaryTransportEnabled);
+                    isBinaryTransportEnabled,
+                    session);
 
             this.taskInfoFetcher = new TaskInfoFetcher(
                     this::failTask,

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2005,6 +2005,7 @@ class StatementAnalyzer
                         .setUserAgent(session.getUserAgent().orElse(null))
                         .setClientInfo(session.getClientInfo().orElse(null))
                         .setStartTime(session.getStartTime())
+                        .setSessionLogger(session.getSessionLogger())
                         .build();
 
                 StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, viewAccessControl, viewSession, WarningCollector.NOOP);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -430,7 +430,9 @@ public class LocalQueryRunner
                 defaultSession.getConnectorProperties(),
                 defaultSession.getUnprocessedCatalogProperties(),
                 metadata.getSessionPropertyManager(),
-                defaultSession.getPreparedStatements());
+                defaultSession.getQueryLoggingSize(),
+                defaultSession.getPreparedStatements(),
+                Optional.of(defaultSession.getSessionLogger()));
 
         dataDefinitionTask = ImmutableMap.<Class<? extends Statement>, DataDefinitionTask<?>>builder()
                 .put(CreateTable.class, new CreateTableTask())

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.SqlFunctionProperties;
 import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.facebook.presto.spi.session.PropertyMetadata;
+import com.facebook.presto.spi.session.SessionLogger;
 import com.facebook.presto.spi.type.TimeZoneKey;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.google.common.collect.ImmutableList;
@@ -31,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static com.facebook.presto.spi.session.SessionLogger.NOOP_SESSION_LOGGER;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Locale.ENGLISH;
@@ -119,6 +121,12 @@ public class TestingConnectorSession
     public long getStartTime()
     {
         return startTime;
+    }
+
+    @Override
+    public SessionLogger getSessionLogger()
+    {
+        return NOOP_SESSION_LOGGER;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -154,7 +154,7 @@ public class MockRemoteTaskFactory
             boolean summarizeTaskInfo,
             TableWriteInfo tableWriteInfo)
     {
-        return new MockRemoteTask(taskId, fragment, node.getNodeIdentifier(), executor, scheduledExecutor, initialSplits, partitionedSplitCountTracker);
+        return new MockRemoteTask(taskId, session, fragment, node.getNodeIdentifier(), executor, scheduledExecutor, initialSplits, partitionedSplitCountTracker);
     }
 
     public static final class MockRemoteTask
@@ -183,8 +183,10 @@ public class MockRemoteTaskFactory
         private SettableFuture<?> whenSplitQueueHasSpace = SettableFuture.create();
 
         private final PartitionedSplitCountTracker partitionedSplitCountTracker;
+        private final Session session;
 
         public MockRemoteTask(TaskId taskId,
+                Session session,
                 PlanFragment fragment,
                 String nodeId,
                 Executor executor,
@@ -208,7 +210,7 @@ public class MockRemoteTaskFactory
             this.taskContext = queryContext.addTaskContext(taskStateMachine, TEST_SESSION, true, true, false);
 
             this.location = URI.create("fake://task/" + taskId);
-
+            this.session = session;
             this.outputBuffer = new LazyOutputBuffer(
                     taskId,
                     TASK_INSTANCE_ID,
@@ -267,6 +269,7 @@ public class MockRemoteTaskFactory
                     outputBuffer.getInfo(),
                     ImmutableSet.of(),
                     taskContext.getTaskStats(),
+                    Optional.of(session.getSessionLogger().getEntries()),
                     true);
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/executor/SimulationTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/executor/SimulationTask.java
@@ -23,6 +23,7 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.facebook.presto.spi.session.SessionLogger.NOOP_SESSION_LOGGER;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 abstract class SimulationTask
@@ -40,7 +41,7 @@ abstract class SimulationTask
     {
         this.specification = specification;
         this.taskId = taskId;
-        taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, SECONDS), OptionalInt.empty());
+        taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, SECONDS), NOOP_SESSION_LOGGER, OptionalInt.empty());
     }
 
     public void setKilled()

--- a/presto-main/src/test/java/com/facebook/presto/execution/executor/TestTaskExecutor.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/executor/TestTaskExecutor.java
@@ -35,6 +35,7 @@ import static com.facebook.airlift.testing.Assertions.assertGreaterThan;
 import static com.facebook.airlift.testing.Assertions.assertLessThan;
 import static com.facebook.presto.execution.executor.MultilevelSplitQueue.LEVEL_CONTRIBUTION_CAP;
 import static com.facebook.presto.execution.executor.MultilevelSplitQueue.LEVEL_THRESHOLD_SECONDS;
+import static com.facebook.presto.spi.session.SessionLogger.NOOP_SESSION_LOGGER;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -56,7 +57,7 @@ public class TestTaskExecutor
 
         try {
             TaskId taskId = new TaskId("test", 0, 0, 0);
-            TaskHandle taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TaskHandle taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS), NOOP_SESSION_LOGGER, OptionalInt.empty());
 
             Phaser beginPhase = new Phaser();
             beginPhase.register();
@@ -149,8 +150,8 @@ public class TestTaskExecutor
         ticker.increment(20, MILLISECONDS);
 
         try {
-            TaskHandle shortQuantaTaskHandle = taskExecutor.addTask(new TaskId("short_quanta", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
-            TaskHandle longQuantaTaskHandle = taskExecutor.addTask(new TaskId("long_quanta", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TaskHandle shortQuantaTaskHandle = taskExecutor.addTask(new TaskId("short_quanta", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), NOOP_SESSION_LOGGER, OptionalInt.empty());
+            TaskHandle longQuantaTaskHandle = taskExecutor.addTask(new TaskId("long_quanta", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), NOOP_SESSION_LOGGER, OptionalInt.empty());
 
             Phaser globalPhaser = new Phaser();
 
@@ -183,7 +184,7 @@ public class TestTaskExecutor
         ticker.increment(20, MILLISECONDS);
 
         try {
-            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), NOOP_SESSION_LOGGER, OptionalInt.empty());
 
             Phaser globalPhaser = new Phaser();
             globalPhaser.bulkRegister(3);
@@ -224,9 +225,9 @@ public class TestTaskExecutor
         try {
             for (int i = 0; i < (LEVEL_THRESHOLD_SECONDS.length - 1); i++) {
                 TaskHandle[] taskHandles = {
-                        taskExecutor.addTask(new TaskId("test1", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty()),
-                        taskExecutor.addTask(new TaskId("test2", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty()),
-                        taskExecutor.addTask(new TaskId("test3", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty())
+                        taskExecutor.addTask(new TaskId("test1", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), NOOP_SESSION_LOGGER, OptionalInt.empty()),
+                        taskExecutor.addTask(new TaskId("test2", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), NOOP_SESSION_LOGGER, OptionalInt.empty()),
+                        taskExecutor.addTask(new TaskId("test3", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), NOOP_SESSION_LOGGER, OptionalInt.empty())
                 };
 
                 // move task 0 to next level
@@ -306,7 +307,7 @@ public class TestTaskExecutor
 
         try {
             TaskId taskId = new TaskId("test", 0, 0, 0);
-            TaskHandle taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TaskHandle taskHandle = taskExecutor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS), NOOP_SESSION_LOGGER, OptionalInt.empty());
 
             Phaser beginPhase = new Phaser();
             beginPhase.register();
@@ -337,8 +338,8 @@ public class TestTaskExecutor
     public void testLevelContributionCap()
     {
         MultilevelSplitQueue splitQueue = new MultilevelSplitQueue(2);
-        TaskHandle handle0 = new TaskHandle(new TaskId("test0", 0, 0, 0), splitQueue, () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty());
-        TaskHandle handle1 = new TaskHandle(new TaskId("test1", 0, 0, 0), splitQueue, () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty());
+        TaskHandle handle0 = new TaskHandle(new TaskId("test0", 0, 0, 0), splitQueue, () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty(), NOOP_SESSION_LOGGER);
+        TaskHandle handle1 = new TaskHandle(new TaskId("test1", 0, 0, 0), splitQueue, () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty(), NOOP_SESSION_LOGGER);
 
         for (int i = 0; i < (LEVEL_THRESHOLD_SECONDS.length - 1); i++) {
             long levelAdvanceTime = SECONDS.toNanos(LEVEL_THRESHOLD_SECONDS[i + 1] - LEVEL_THRESHOLD_SECONDS[i]);
@@ -357,7 +358,7 @@ public class TestTaskExecutor
     public void testUpdateLevelWithCap()
     {
         MultilevelSplitQueue splitQueue = new MultilevelSplitQueue(2);
-        TaskHandle handle0 = new TaskHandle(new TaskId("test0", 0, 0, 0), splitQueue, () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty());
+        TaskHandle handle0 = new TaskHandle(new TaskId("test0", 0, 0, 0), splitQueue, () -> 1, 1, new Duration(1, SECONDS), OptionalInt.empty(), NOOP_SESSION_LOGGER);
 
         long quantaNanos = MINUTES.toNanos(10);
         handle0.addScheduledNanos(quantaNanos);
@@ -379,7 +380,7 @@ public class TestTaskExecutor
         TaskExecutor taskExecutor = new TaskExecutor(4, 16, 1, maxDriversPerTask, splitQueue, ticker);
         taskExecutor.start();
         try {
-            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), NOOP_SESSION_LOGGER, OptionalInt.empty());
 
             // enqueue all batches of splits
             int batchCount = 4;
@@ -420,7 +421,7 @@ public class TestTaskExecutor
         taskExecutor.start();
         try {
             // overwrite the max drivers per task to be 1
-            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.of(1));
+            TaskHandle testTaskHandle = taskExecutor.addTask(new TaskId("test", 0, 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), NOOP_SESSION_LOGGER, OptionalInt.of(1));
 
             // enqueue all batches of splits
             int batchCount = 4;

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -460,6 +460,7 @@ public class TestHttpRemoteTask
                     initialTaskInfo.getOutputBuffers(),
                     initialTaskInfo.getNoMoreSplits(),
                     initialTaskInfo.getStats(),
+                    initialTaskInfo.getSessionLogEntries(),
                     initialTaskInfo.isNeedsPlan());
         }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi;
 
 import com.facebook.presto.spi.function.SqlFunctionProperties;
 import com.facebook.presto.spi.security.ConnectorIdentity;
+import com.facebook.presto.spi.session.SessionLogger;
 import com.facebook.presto.spi.type.TimeZoneKey;
 
 import java.util.Locale;
@@ -47,6 +48,8 @@ public interface ConnectorSession
     Optional<String> getClientInfo();
 
     long getStartTime();
+
+    SessionLogger getSessionLogger();
 
     /**
      * @deprecated In favor of {@link com.facebook.presto.spi.function.SqlFunctionProperties#isLegacyTimestamp()}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/session/SessionLogger.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/session/SessionLogger.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.session;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+public interface SessionLogger
+{
+    SessionLogger NOOP_SESSION_LOGGER = new SessionLogger()
+    {
+        private LinkedList<Entry> emptyQ = new LinkedList<>();
+
+        @Override
+        public void log(Supplier<String> message)
+        {
+        }
+
+        @Override
+        public Queue<Entry> getEntries()
+        {
+            return emptyQ;
+        }
+    };
+
+    void log(Supplier<String> message);
+
+    Queue<Entry> getEntries();
+
+    @Immutable
+    public static class Entry
+    {
+        final String message;
+        final long nanos;
+        final String threadName;
+
+        @JsonCreator
+        public Entry(@JsonProperty("message") String message, @JsonProperty("nanos") long nanos, @JsonProperty("threadName") String threadName)
+        {
+            this.message = requireNonNull(message, "messsage is null");
+            this.nanos = nanos;
+            this.threadName = threadName;
+        }
+
+        @JsonProperty
+        public String getThreadName()
+        {
+            return threadName;
+        }
+
+        @JsonProperty
+        public String getMessage()
+        {
+            return message;
+        }
+
+        @JsonProperty
+        public long getNanos()
+        {
+            return nanos;
+        }
+    }
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingSession.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/TestingSession.java
@@ -17,12 +17,14 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.SqlFunctionProperties;
 import com.facebook.presto.spi.security.ConnectorIdentity;
+import com.facebook.presto.spi.session.SessionLogger;
 import com.facebook.presto.spi.type.TimeZoneKey;
 
 import java.util.Locale;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static com.facebook.presto.spi.session.SessionLogger.NOOP_SESSION_LOGGER;
 import static com.facebook.presto.spi.type.TimeZoneKey.UTC_KEY;
 import static java.util.Locale.ENGLISH;
 
@@ -70,6 +72,12 @@ public final class TestingSession
         public long getStartTime()
         {
             return 0;
+        }
+
+        @Override
+        public SessionLogger getSessionLogger()
+        {
+            return NOOP_SESSION_LOGGER;
         }
 
         @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4991,7 +4991,9 @@ public abstract class AbstractTestQueries
                         .put("connector_long", "11")
                         .build()),
                 getQueryRunner().getMetadata().getSessionPropertyManager(),
-                getSession().getPreparedStatements());
+                getSession().getQueryLoggingSize(),
+                getSession().getPreparedStatements(),
+                Optional.empty());
         MaterializedResult result = computeActual(session, "SHOW SESSION");
 
         ImmutableMap<String, MaterializedRow> properties = Maps.uniqueIndex(result.getMaterializedRows(), input -> {

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestingSessionContext.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestingSessionContext.java
@@ -143,4 +143,10 @@ public class TestingSessionContext
     {
         return session.isClientTransactionSupport();
     }
+
+    @Override
+    public int getQueryLoggingSize()
+    {
+        return session.getQueryLoggingSize();
+    }
 }


### PR DESCRIPTION
#13937 
This framework provides ability to log events with timestamp during query's
execution lifecycle. The basic usage is:

```
session.getSessionLogger().log(() -> String.format("some message")).
```

These messages can be logged at the connector
(using the ConnectorSession) or at the coordinator or tasks (that have access
to the Session). The log messages are shipped as a part of the regular
QueryInfo from all the tasks and show up in the final json: there is one
"sessionLogEntries" for the QueryInfo and one per each of the tasks in the
query.

This is disabled by default and can be enabled by using the header
X-Presto-Query-Logging-Size on the query.

Added examples of usage by logging for planning completion and plan
distribution events. The `sessionLogEntries` for a sample query is as following:

```
"sessionLogEntries" : [ {
  "message" : "starting query",
  "nanos" : 659651498121659,
  "threadName" : "Query-20191031_045412_00002_7p8ay-390"
}, {
  "message" : "done planning",
  "nanos" : 659651538419849,
  "threadName" : "Query-20191031_045412_00002_7p8ay-390"
}, {
  "message" : "done plan distribution",
  "nanos" : 659651540308691,
  "threadName" : "Query-20191031_045412_00002_7p8ay-390"
} ]
```

This PR also includes the log entries @agrawaldevesh used to find the latency gaps
```
== RELEASE NOTES ==

General Changes
* Adding Instrumentation for query lifecycle events logging
