### PR TITLE
Optimize lambda body when possible

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -295,6 +295,11 @@ public class RowExpressionInterpreter
             if (optimizationLevel.ordinal() < EVALUATED.ordinal()) {
                 // TODO: enable optimization related to lambda expression
                 // Currently, we are not able to determine if lambda is deterministic.
+                // context is passed down as null here since lambda argument can only be resolved under the evaluation context.
+                RowExpression rewrittenBody = toRowExpression(processWithExceptionHandling(node.getBody(), null), node.getBody());
+                if (!rewrittenBody.equals(node.getBody())) {
+                    return new LambdaDefinitionExpression(node.getArgumentTypes(), node.getArguments(), rewrittenBody);
+                }
                 return node;
             }
             RowExpression body = node.getBody();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -18,6 +18,7 @@ import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.RowBlockBuilder;
 import com.facebook.presto.spi.function.FunctionHandle;
@@ -80,6 +81,7 @@ import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.ROW_CO
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.SWITCH;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.WHEN;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.StandardTypes.ARRAY;
 import static com.facebook.presto.spi.type.StandardTypes.MAP;
 import static com.facebook.presto.spi.type.StandardTypes.ROW;
@@ -96,6 +98,7 @@ import static com.facebook.presto.sql.planner.LiteralEncoder.isSupportedLiteralT
 import static com.facebook.presto.sql.planner.RowExpressionInterpreter.SpecialCallResult.changed;
 import static com.facebook.presto.sql.planner.RowExpressionInterpreter.SpecialCallResult.notChanged;
 import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.SqlFunctionUtils.getSqlFunctionRowExpression;
 import static com.facebook.presto.type.JsonType.JSON;
 import static com.facebook.presto.type.LikeFunctions.isLikePattern;
@@ -681,10 +684,14 @@ public class RowExpressionInterpreter
             String failureInfo = JsonCodec.jsonCodec(FailureInfo.class).toJson(Failures.toFailure(exception).toFailureInfo());
             FunctionHandle jsonParse = metadata.getFunctionManager().lookupFunction("json_parse", fromTypes(VARCHAR));
             Object json = functionInvoker.invoke(jsonParse, session, utf8Slice(failureInfo));
+            FunctionHandle cast = metadata.getFunctionManager().lookupCast(CAST, UNKNOWN.getTypeSignature(), type.getTypeSignature());
+            if (exception instanceof PrestoException) {
+                long errorCode = ((PrestoException) exception).getErrorCode().getCode();
+                FunctionHandle failureFunction = metadata.getFunctionManager().lookupFunction("fail", fromTypes(INTEGER, JSON));
+                return call(CAST.name(), cast, type, call("fail", failureFunction, UNKNOWN, constant(errorCode, INTEGER), LiteralEncoder.toRowExpression(json, JSON)));
+            }
 
             FunctionHandle failureFunction = metadata.getFunctionManager().lookupFunction("fail", fromTypes(JSON));
-            FunctionHandle cast = metadata.getFunctionManager().lookupCast(CAST, UNKNOWN.getTypeSignature(), type.getTypeSignature());
-
             return call(CAST.name(), cast, type, call("fail", failureFunction, UNKNOWN, LiteralEncoder.toRowExpression(json, JSON)));
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestFailureFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestFailureFunction.java
@@ -15,12 +15,16 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.client.FailureInfo;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.util.Failures;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static org.testng.Assert.assertTrue;
 
 public class TestFailureFunction
         extends AbstractTestFunctions
@@ -33,13 +37,20 @@ public class TestFailureFunction
         assertFunction("fail(json_parse('" + FAILURE_INFO + "'))", UNKNOWN, null);
     }
 
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "/ by zero")
+    @Test
     public void testQuery()
     {
         // The other test does not exercise this function during execution (i.e. inside a page processor).
         // It only verifies constant folding works.
         try (LocalQueryRunner runner = new LocalQueryRunner(TEST_SESSION)) {
-            runner.execute("select if(x, 78, 0/0) from (values rand() >= 0, rand() < 0) t(x)");
+            try {
+                runner.execute("select if(x, 78, 0/0) from (values rand() >= 0, rand() < 0) t(x)");
+                throw new RuntimeException("Should throw PrestoException");
+            }
+            catch (PrestoException e) {
+                assertEquals(e.getErrorCode(), DIVISION_BY_ZERO.toErrorCode());
+                assertTrue(e.getMessage().contains("/ by zero"));
+            }
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -1329,6 +1329,14 @@ public class TestExpressionInterpreter
         assertDoNotOptimize("transform(unbound_array, x -> x + x)", OPTIMIZED);
         assertOptimizedEquals("transform(ARRAY[1, 5], x -> x + x)", "transform(ARRAY[1, 5], x -> x + x)");
         assertOptimizedEquals("transform(sequence(1, 5), x -> x + x)", "transform(sequence(1, 5), x -> x + x)");
+        assertRowExpressionOptimizedEquals(
+                OPTIMIZED,
+                "transform(sequence(1, unbound_long), x -> cast(json_parse('[1, 2]') AS ARRAY<INTEGER>)[1] + x)",
+                "transform(sequence(1, unbound_long), x -> 1 + x)");
+        assertRowExpressionOptimizedEquals(
+                OPTIMIZED,
+                "transform(sequence(1, unbound_long), x -> cast(json_parse('[1, 2]') AS ARRAY<INTEGER>)[1] + 1)",
+                "transform(sequence(1, unbound_long), x -> 2)");
         assertEquals(evaluate("reduce(ARRAY[1, 5], 0, (x, y) -> x + y, x -> x)", true), 6L);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -890,9 +890,9 @@ public class TestExpressionInterpreter
                         "end");
 
         assertOptimizedMatches("case when 0 / 0 = 0 then 1 end",
-                "case when cast(fail() as boolean) then 1 end");
+                "case when cast(fail(8, 'ignored failure message') as boolean) then 1 end");
 
-        assertOptimizedMatches("if(false, 1, 0 / 0)", "cast(fail() as integer)");
+        assertOptimizedMatches("if(false, 1, 0 / 0)", "cast(fail(8, 'ignored failure message') as integer)");
 
         assertOptimizedEquals("case " +
                         "when false then 2.2 " +
@@ -1113,7 +1113,7 @@ public class TestExpressionInterpreter
                 "" +
                         "case BIGINT '1' " +
                         "when unbound_long then 1 " +
-                        "when cast(fail() AS integer) then 2 " +
+                        "when cast(fail(8, 'ignored failure message') AS integer) then 2 " +
                         "else 1 " +
                         "end");
 
@@ -1124,8 +1124,8 @@ public class TestExpressionInterpreter
                         "end",
                 "" +
                         "case 1 " +
-                        "when cast(fail() as integer) then 1 " +
-                        "when cast(fail() as integer) then 2 " +
+                        "when cast(fail(8, 'ignored failure message') as integer) then 1 " +
+                        "when cast(fail(8, 'ignored failure message') as integer) then 2 " +
                         "else 1 " +
                         "end");
 
@@ -1164,7 +1164,7 @@ public class TestExpressionInterpreter
         assertOptimizedEquals("coalesce(2 * 3 * unbound_integer, 1.0E0/2.0E0, null)", "coalesce(6 * unbound_integer, 0.5E0)");
         assertOptimizedEquals("coalesce(unbound_integer, 2, 1.0E0/2.0E0, 12.34E0, null)", "coalesce(unbound_integer, 2.0E0, 0.5E0, 12.34E0)");
         assertOptimizedMatches("coalesce(0 / 0 > 1, unbound_boolean, 0 / 0 = 0)",
-                "coalesce(cast(fail() as boolean), unbound_boolean)");
+                "coalesce(cast(fail(8, 'ignored failure message') as boolean), unbound_boolean)");
         assertOptimizedMatches("coalesce(unbound_long, unbound_long)", "unbound_long");
         assertOptimizedMatches("coalesce(2 * unbound_long, 2 * unbound_long)", "BIGINT '2' * unbound_long");
         assertOptimizedMatches("coalesce(unbound_long, unbound_long2, unbound_long)", "coalesce(unbound_long, unbound_long2)");
@@ -1347,22 +1347,22 @@ public class TestExpressionInterpreter
         assertOptimizedEquals("if(unbound_boolean, 0 / 0, 1)", "CASE WHEN unbound_boolean THEN 0 / 0 ELSE 1 END");
 
         assertOptimizedMatches("CASE unbound_long WHEN 1 THEN 1 WHEN 0 / 0 THEN 2 END",
-                "CASE unbound_long WHEN BIGINT '1' THEN 1 WHEN cast(fail() as bigint) THEN 2 END");
+                "CASE unbound_long WHEN BIGINT '1' THEN 1 WHEN cast(fail(8, 'ignored failure message') as bigint) THEN 2 END");
 
         assertOptimizedMatches("CASE unbound_boolean WHEN true THEN 1 ELSE 0 / 0 END",
-                "CASE unbound_boolean WHEN true THEN 1 ELSE cast(fail() as integer) END");
+                "CASE unbound_boolean WHEN true THEN 1 ELSE cast(fail(8, 'ignored failure message') as integer) END");
 
         assertOptimizedMatches("CASE bound_long WHEN unbound_long THEN 1 WHEN 0 / 0 THEN 2 ELSE 1 END",
-                "CASE BIGINT '1234' WHEN unbound_long THEN 1 WHEN cast(fail() as bigint) THEN 2 ELSE 1 END");
+                "CASE BIGINT '1234' WHEN unbound_long THEN 1 WHEN cast(fail(8, 'ignored failure message') as bigint) THEN 2 ELSE 1 END");
 
         assertOptimizedMatches("case when unbound_boolean then 1 when 0 / 0 = 0 then 2 end",
-                "case when unbound_boolean then 1 when cast(fail() as boolean) then 2 end");
+                "case when unbound_boolean then 1 when cast(fail(8, 'ignored failure message') as boolean) then 2 end");
 
         assertOptimizedMatches("case when unbound_boolean then 1 else 0 / 0  end",
-                "case when unbound_boolean then 1 else cast(fail() as integer) end");
+                "case when unbound_boolean then 1 else cast(fail(8, 'ignored failure message') as integer) end");
 
         assertOptimizedMatches("case when unbound_boolean then 0 / 0 else 1 end",
-                "case when unbound_boolean then cast(fail() as integer) else 1 end");
+                "case when unbound_boolean then cast(fail(8, 'ignored failure message') as integer) else 1 end");
     }
 
     @Test(expectedExceptions = PrestoException.class)
@@ -1767,7 +1767,7 @@ public class TestExpressionInterpreter
         public Expression rewriteFunctionCall(FunctionCall node, Object context, ExpressionTreeRewriter<Object> treeRewriter)
         {
             if (node.getName().equals(QualifiedName.of("fail"))) {
-                return new FunctionCall(QualifiedName.of("fail"), ImmutableList.of());
+                return new FunctionCall(QualifiedName.of("fail"), ImmutableList.of(node.getArguments().get(0), new StringLiteral("ignored failure message")));
             }
             return node;
         }


### PR DESCRIPTION
Commit 98f05bf deprecated `ExpressionOptimizer` without porting the
handling of lambda body into `RowExpressionInterpreter`. This commit
added optimization on Lambda definition body so that expensive
operation within lambda can be replaced with constant.

Fixes #13648

```
== RELEASE NOTES ==

General Changes
* Fix regression on lambda evaluation (Issue#13648).
```
