### PR TITLE
Fix PRESTO_EXTRA_CREDENTIAL parsing

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
@@ -190,7 +190,7 @@ public final class HttpRequestSessionContext
 
     private static Map<String, String> parseExtraCredentials(HttpServletRequest servletRequest)
     {
-        return parseProperty(servletRequest, PRESTO_EXTRA_CREDENTIAL);
+        return parseCredentialProperty(servletRequest, PRESTO_EXTRA_CREDENTIAL);
     }
 
     private static Map<String, String> parseProperty(HttpServletRequest servletRequest, String headerName)
@@ -200,6 +200,17 @@ public final class HttpRequestSessionContext
             List<String> nameValue = Splitter.on('=').trimResults().splitToList(header);
             assertRequest(nameValue.size() == 2, "Invalid %s header", headerName);
             properties.put(nameValue.get(0), nameValue.get(1));
+        }
+        return properties;
+    }
+
+    private static Map<String, String> parseCredentialProperty(HttpServletRequest servletRequest, String headerName)
+    {
+        Map<String, String> properties = new HashMap<>();
+        for (String header : splitSessionHeader(servletRequest.getHeaders(headerName))) {
+            List<String> nameValue = Splitter.on('=').limit(2).trimResults().splitToList(header);
+            assertRequest(nameValue.size() == 2, "Invalid %s header", headerName);
+            properties.put(nameValue.get(0), urlDecode(nameValue.get(1)));
         }
         return properties;
     }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestHttpRequestSessionContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestHttpRequestSessionContext.java
@@ -22,6 +22,8 @@ import org.testng.annotations.Test;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.WebApplicationException;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.HASH_PARTITION_COUNT;
@@ -98,5 +100,52 @@ public class TestHttpRequestSessionContext
                         .build(),
                 "testRemote");
         new HttpRequestSessionContext(request);
+    }
+
+    @Test
+    public void testExtraCredentials()
+    {
+        HttpServletRequest request = new MockHttpServletRequest(
+                ImmutableListMultimap.<String, String>builder()
+                        .put(PRESTO_USER, "testUser")
+                        .put(PRESTO_SOURCE, "testSource")
+                        .put(PRESTO_CATALOG, "testCatalog")
+                        .put(PRESTO_SCHEMA, "testSchema")
+                        .put(PRESTO_LANGUAGE, "zh-TW")
+                        .put(PRESTO_TIME_ZONE, "Asia/Taipei")
+                        .put(PRESTO_CLIENT_INFO, "client-info")
+                        .put(PRESTO_SESSION, QUERY_MAX_MEMORY + "=1GB")
+                        .put(PRESTO_SESSION, JOIN_DISTRIBUTION_TYPE + "=partitioned," + HASH_PARTITION_COUNT + " = 43")
+                        .put(PRESTO_PREPARED_STATEMENT, "query1=select * from foo,query2=select * from bar")
+                        .put(PRESTO_ROLE, "foo_connector=ALL")
+                        .put(PRESTO_ROLE, "bar_connector=NONE")
+                        .put(PRESTO_ROLE, "foobar_connector=ROLE{role}")
+                        .put(PRESTO_EXTRA_CREDENTIAL, "test.token.key1=" + urlEncode("bar=ab===,d"))
+                        .put(PRESTO_EXTRA_CREDENTIAL, "test.token.key2=bar=ab===")
+                        .put(PRESTO_EXTRA_CREDENTIAL, "test.json=" + urlEncode("{\"a\" : \"b\", \"c\" : \"d=\"}") + ", test.token.key3 = abc=cd")
+                        .put(PRESTO_EXTRA_CREDENTIAL, "test.token.abc=xyz")
+                        .build(),
+                "testRemote");
+
+        HttpRequestSessionContext context = new HttpRequestSessionContext(request);
+        assertEquals(
+                context.getIdentity().getExtraCredentials(),
+                ImmutableMap.builder()
+                        .put("test.token.key1", "bar=ab===,d")
+                        .put("test.token.key2", "bar=ab===")
+                        .put("test.token.key3", "abc=cd")
+                        .put("test.json", "{\"a\" : \"b\", \"c\" : \"d=\"}")
+                        .put("test.token.abc", "xyz")
+                        .build());
+    }
+
+    private static String urlEncode(String value)
+    {
+        try {
+            return URLEncoder.encode(value, "UTF-8");
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new AssertionError(e);
+        }
     }
 }


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Improved PRESTO_EXTRA_CREDENTIAL header parsing to allow value contain multiple '=' and urlEncode characters.


```

