### PR TITLE
Add config to disable backup read back verification

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/BackupConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/backup/BackupConfig.java
@@ -31,6 +31,7 @@ public class BackupConfig
     private int timeoutThreads = 1000;
     private String provider;
     private int backupThreads = 5;
+    private boolean enableVerification = true;
 
     @NotNull
     @MinDuration("1s")
@@ -87,6 +88,19 @@ public class BackupConfig
     public BackupConfig setBackupThreads(int backupThreads)
     {
         this.backupThreads = backupThreads;
+        return this;
+    }
+
+    public boolean isEnableVerification()
+    {
+        return enableVerification;
+    }
+
+    @Config("backup.enable-verification")
+    @ConfigDescription("Enable backup verification which immediately reads back from backup after write")
+    public BackupConfig setEnableVerification(boolean enableVerification)
+    {
+        this.enableVerification = enableVerification;
         return this;
     }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestBackupConfig.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestBackupConfig.java
@@ -34,6 +34,7 @@ public class TestBackupConfig
                 .setProvider(null)
                 .setTimeoutThreads(1000)
                 .setTimeout(new Duration(1, MINUTES))
+                .setEnableVerification(true)
                 .setBackupThreads(5));
     }
 
@@ -45,13 +46,15 @@ public class TestBackupConfig
                 .put("backup.timeout", "42s")
                 .put("backup.timeout-threads", "13")
                 .put("backup.threads", "3")
+                .put("backup.enable-verification", "false")
                 .build();
 
         BackupConfig expected = new BackupConfig()
                 .setProvider("file")
                 .setTimeout(new Duration(42, SECONDS))
                 .setTimeoutThreads(13)
-                .setBackupThreads(3);
+                .setBackupThreads(3)
+                .setEnableVerification(false);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestBackupManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/backup/TestBackupManager.java
@@ -71,7 +71,7 @@ public class TestBackupManager
         storageService = new LocalFileStorageService(new LocalOrcDataEnvironment(), new File(temporary, "data").toURI());
         storageService.start();
 
-        backupManager = new BackupManager(Optional.of(backupStore), storageService, new LocalOrcDataEnvironment(), 5);
+        backupManager = new BackupManager(Optional.of(backupStore), storageService, new LocalOrcDataEnvironment(), 5, true);
     }
 
     @AfterMethod(alwaysRun = true)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
@@ -641,7 +641,7 @@ public class TestOrcStorageManager
                 storageService,
                 backupStore,
                 READER_ATTRIBUTES,
-                new BackupManager(backupStore, storageService, new LocalOrcDataEnvironment(), 1),
+                new BackupManager(backupStore, storageService, new LocalOrcDataEnvironment(), 1, true),
                 recoveryManager,
                 shardRecorder,
                 new TypeRegistry(),


### PR DESCRIPTION

```
== RELEASE NOTES ==
Raptor Changes
- Add config option "backup.enable-verification" to control the read back verification behavior. Default value is "true". 
```