### PR TITLE
Support supplying benchmark queries through MySQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
         <module>presto-elasticsearch</module>
         <module>presto-sql-function</module>
         <module>presto-expressions</module>
+        <module>presto-benchmark-runner</module>
     </modules>
 
     <dependencyManagement>

--- a/presto-benchmark-runner/pom.xml
+++ b/presto-benchmark-runner/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>presto-root</artifactId>
+        <groupId>com.facebook.presto</groupId>
+        <version>0.230-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-benchmark-runner</artifactId>
+    <name>presto-benchmark-runner</name>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-sqlobject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>testing-mysql-server-5</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>testing-mysql-server-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkQuery.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkQuery.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class BenchmarkQuery
+{
+    private final String querySet;
+    private final String name;
+    private final String query;
+    private final String catalog;
+    private final String schema;
+
+    @JdbiConstructor
+    public BenchmarkQuery(
+            @ColumnName("query_set") String querySet,
+            @ColumnName("name") String name,
+            @ColumnName("query") String query,
+            @ColumnName("catalog") String catalog,
+            @ColumnName("schema") String schema)
+    {
+        this.querySet = requireNonNull(querySet, "querySet is null");
+        this.name = requireNonNull(name, "name is null");
+        this.query = clean(query);
+        this.catalog = requireNonNull(catalog, "catalog is null");
+        this.schema = requireNonNull(schema, "schema is null");
+    }
+
+    public String getQuerySet()
+    {
+        return querySet;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public String getQuery()
+    {
+        return query;
+    }
+
+    public String getCatalog()
+    {
+        return catalog;
+    }
+
+    public String getSchema()
+    {
+        return schema;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        BenchmarkQuery o = (BenchmarkQuery) obj;
+        return Objects.equals(querySet, o.querySet) &&
+                Objects.equals(name, o.name) &&
+                Objects.equals(query, o.query) &&
+                Objects.equals(catalog, o.catalog) &&
+                Objects.equals(schema, o.schema);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(querySet, name, query, catalog, schema);
+    }
+
+    private static String clean(String sql)
+    {
+        sql = sql.replaceAll("\t", "  ");
+        sql = sql.replaceAll("\n+", "\n");
+        sql = sql.trim();
+        while (sql.endsWith(";")) {
+            sql = sql.substring(0, sql.length() - 1).trim();
+        }
+        return sql;
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkRunnerConfig.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkRunnerConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+import static com.facebook.presto.benchmark.source.DbBenchmarkSuiteSupplier.BENCHMARK_SUITE_SUPPLIER;
+
+public class BenchmarkRunnerConfig
+{
+    private String testId;
+    private String benchmarkSuiteSupplier = BENCHMARK_SUITE_SUPPLIER;
+
+    @NotNull
+    public String getTestId()
+    {
+        return testId;
+    }
+
+    @Config("test-id")
+    public BenchmarkRunnerConfig setTestId(String testId)
+    {
+        this.testId = testId;
+        return this;
+    }
+
+    @NotNull
+    public String getBenchmarkSuiteSupplier()
+    {
+        return benchmarkSuiteSupplier;
+    }
+
+    @Config("benchmark-suite-supplier")
+    public BenchmarkRunnerConfig setBenchmarkSuiteSupplier(String benchmarkSuiteSupplier)
+    {
+        this.benchmarkSuiteSupplier = benchmarkSuiteSupplier;
+        return this;
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkSuite.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkSuite.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.UnaryOperator.identity;
+
+public class BenchmarkSuite
+{
+    private final BenchmarkSuiteInfo suiteInfo;
+    private final Map<String, BenchmarkQuery> queries;
+
+    public BenchmarkSuite(
+            BenchmarkSuiteInfo suiteInfo,
+            List<BenchmarkQuery> queries)
+    {
+        this.suiteInfo = requireNonNull(suiteInfo, "SuiteInfo is null");
+        this.queries = queries.stream()
+                .collect(toImmutableMap(BenchmarkQuery::getName, identity()));
+    }
+
+    public BenchmarkSuiteInfo getSuiteInfo()
+    {
+        return suiteInfo;
+    }
+
+    public Map<String, BenchmarkQuery> getQueryMap()
+    {
+        return queries;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        BenchmarkSuite o = (BenchmarkSuite) obj;
+        return Objects.equals(suiteInfo, o.suiteInfo) &&
+                Objects.equals(queries, o.queries);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(suiteInfo, queries);
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkSuiteInfo.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkSuiteInfo.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import com.google.common.collect.ImmutableMap;
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class BenchmarkSuiteInfo
+{
+    private final String suite;
+    private final String querySet;
+    private final List<PhaseSpecification> phases;
+    private final Map<String, String> sessionProperties;
+
+    @JdbiConstructor
+    public BenchmarkSuiteInfo(
+            @ColumnName("suite") String suite,
+            @ColumnName("query_set") String querySet,
+            @ColumnName("phases") List<PhaseSpecification> phases,
+            @ColumnName("session_properties") Map<String, String> sessionProperties)
+    {
+        this.suite = requireNonNull(suite, "suite is null");
+        this.querySet = requireNonNull(querySet, "querySet is null");
+        this.phases = requireNonNull(phases, "phases is null");
+        this.sessionProperties = ImmutableMap.copyOf(sessionProperties);
+    }
+
+    public String getSuite()
+    {
+        return suite;
+    }
+
+    public String getQuerySet()
+    {
+        return querySet;
+    }
+
+    public List<PhaseSpecification> getPhases()
+    {
+        return phases;
+    }
+
+    public Map<String, String> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        BenchmarkSuiteInfo o = (BenchmarkSuiteInfo) obj;
+        return Objects.equals(suite, o.getSuite()) &&
+                Objects.equals(querySet, o.querySet) &&
+                Objects.equals(phases, o.phases) &&
+                Objects.equals(sessionProperties, o.sessionProperties);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(suite, querySet, phases, sessionProperties);
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/ConcurrentExecutionPhase.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/ConcurrentExecutionPhase.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class ConcurrentExecutionPhase
+        extends PhaseSpecification
+{
+    private final ExecutionStrategy executionStrategy;
+    private final List<String> queries;
+
+    @JsonCreator
+    public ConcurrentExecutionPhase(String name, ExecutionStrategy executionStrategy, List<String> queries)
+    {
+        super(name);
+        this.executionStrategy = requireNonNull(executionStrategy, "executionStrategy is null");
+        this.queries = requireNonNull(ImmutableList.copyOf(queries), "queries is null");
+    }
+
+    @JsonProperty
+    @Override
+    public ExecutionStrategy getExecutionStrategy()
+    {
+        return executionStrategy;
+    }
+
+    @JsonProperty
+    public List<String> getQueries()
+    {
+        return queries;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ConcurrentExecutionPhase o = (ConcurrentExecutionPhase) obj;
+        return Objects.equals(getExecutionStrategy(), o.getExecutionStrategy()) &&
+                Objects.equals(getName(), o.getName()) &&
+                Objects.equals(queries, o.queries);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getExecutionStrategy(), getName(), queries);
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/MySqlBenchmarkSuiteConfig.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/MySqlBenchmarkSuiteConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+public class MySqlBenchmarkSuiteConfig
+{
+    private String databaseUrl;
+
+    @NotNull
+    public String getDatabaseUrl()
+    {
+        return databaseUrl;
+    }
+
+    @Config("database-url")
+    public MySqlBenchmarkSuiteConfig setDatabaseUrl(String databaseUrl)
+    {
+        this.databaseUrl = databaseUrl;
+        return this;
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/PhaseSpecification.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/PhaseSpecification.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import static java.util.Objects.requireNonNull;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "@type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = StreamExecutionPhase.class, name = "stream"),
+        @JsonSubTypes.Type(value = ConcurrentExecutionPhase.class, name = "concurrent")})
+public abstract class PhaseSpecification
+{
+    public enum ExecutionStrategy
+    {
+        STREAM,
+        CONCURRENT
+    }
+
+    private final String name;
+
+    public abstract ExecutionStrategy getExecutionStrategy();
+
+    public PhaseSpecification(String name)
+    {
+        this.name = requireNonNull(name, "name is null");
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/StreamExecutionPhase.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/StreamExecutionPhase.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class StreamExecutionPhase
+        extends PhaseSpecification
+{
+    private final ExecutionStrategy executionStrategy;
+    private final List<List<String>> streams;
+
+    @JsonCreator
+    public StreamExecutionPhase(String name, ExecutionStrategy executionStrategy, List<List<String>> streams)
+    {
+        super(name);
+        this.executionStrategy = requireNonNull(executionStrategy, "executionStrategy is null");
+        this.streams = streams.stream()
+                .map(ImmutableList::copyOf)
+                .collect(toImmutableList());
+    }
+
+    @JsonProperty
+    @Override
+    public ExecutionStrategy getExecutionStrategy()
+    {
+        return executionStrategy;
+    }
+
+    @JsonProperty
+    public List<List<String>> getStreams()
+    {
+        return streams;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        StreamExecutionPhase o = (StreamExecutionPhase) obj;
+        return Objects.equals(getExecutionStrategy(), o.getExecutionStrategy()) &&
+                Objects.equals(getName(), o.getName()) &&
+                Objects.equals(streams, o.streams);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getExecutionStrategy(), getName(), streams);
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/BenchmarkSuiteConfig.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/BenchmarkSuiteConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.source;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+public class BenchmarkSuiteConfig
+{
+    private String suite;
+    private String suitesTableName = "benchmark_suites";
+    private String queriesTableName = "benchmark_queries";
+
+    @NotNull
+    public String getSuite()
+    {
+        return suite;
+    }
+
+    @Config("suite")
+    public BenchmarkSuiteConfig setSuite(String suite)
+    {
+        this.suite = suite;
+        return this;
+    }
+
+    @NotNull
+    public String getSuitesTableName()
+    {
+        return suitesTableName;
+    }
+
+    @Config("suites-table-name")
+    public BenchmarkSuiteConfig setSuitesTableName(String suitesTableName)
+    {
+        this.suitesTableName = suitesTableName;
+        return this;
+    }
+
+    @NotNull
+    public String getQueriesTableName()
+    {
+        return queriesTableName;
+    }
+
+    @Config("queries-table-name")
+    public BenchmarkSuiteConfig setQueriesTableName(String queriesTableName)
+    {
+        this.queriesTableName = queriesTableName;
+        return this;
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/BenchmarkSuiteDao.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/BenchmarkSuiteDao.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.source;
+
+import com.facebook.presto.benchmark.framework.BenchmarkQuery;
+import com.facebook.presto.benchmark.framework.BenchmarkSuiteInfo;
+import org.jdbi.v3.sqlobject.config.RegisterColumnMapper;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.Define;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+import java.util.List;
+
+@RegisterColumnMapper(StringToStringMapColumnMapper.class)
+@RegisterColumnMapper(PhaseSpecificationsColumnMapper.class)
+public interface BenchmarkSuiteDao
+{
+    @SqlUpdate("CREATE TABLE <table_name> (\n" +
+            "  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n" +
+            "  `suite` varchar(256) NOT NULL,\n" +
+            "  `query_set` varchar(256) NOT NULL,\n" +
+            "  `phases` mediumtext NOT NULL,\n" +
+            "  `session_properties` mediumtext NOT NULL,\n" +
+            "  `created_by` varchar(256) NOT NULL,\n" +
+            "  `create_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,\n" +
+            "  `update_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,\n" +
+            "  PRIMARY KEY (`id`),\n" +
+            "  UNIQUE KEY suite (`suite`))")
+    void createBenchmarkSuitesTable(
+            @Define("table_name") String tableName);
+
+    @SqlUpdate("CREATE TABLE <table_name> (\n" +
+            "  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n" +
+            "  `query_set` varchar(256) NOT NULL,\n" +
+            "  `name` varchar(256) NOT NULL,\n" +
+            "  `catalog` varchar(256) NOT NULL,\n" +
+            "  `schema` varchar(256) NOT NULL,\n" +
+            "  `query` mediumtext NOT NULL,\n" +
+            "  `create_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,\n" +
+            "  `update_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,\n" +
+            "  PRIMARY KEY (`id`),\n" +
+            "  UNIQUE KEY `query_set_name` (`query_set`,`name`))")
+    void createBenchmarkQueriesTable(
+            @Define("table_name") String tableName);
+
+    @SqlQuery("SELECT\n" +
+            "  `suite`,\n" +
+            "  `query_set`,\n" +
+            "  `phases`,\n" +
+            "  `session_properties`\n" +
+            "FROM\n" +
+            "  <table_name>\n" +
+            "WHERE\n" +
+            "  `suite`  = :suite\n")
+    @RegisterConstructorMapper(BenchmarkSuiteInfo.class)
+    BenchmarkSuiteInfo getBenchmarkSuiteInfo(
+            @Define("table_name") String tableName,
+            @Bind("suite") String suite);
+
+    @SqlQuery("SELECT\n" +
+            "  `name`,\n" +
+            "  `query_set`,\n" +
+            "  `catalog`,\n" +
+            "  `schema`,\n" +
+            "  `query`\n" +
+            "FROM\n" +
+            "  <table_name>\n" +
+            "WHERE\n" +
+            "  `query_set`  = :query_set\n")
+    @RegisterConstructorMapper(BenchmarkQuery.class)
+    List<BenchmarkQuery> getBenchmarkQueries(
+            @Define("table_name") String tableName,
+            @Bind("query_set") String querySet);
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/BenchmarkSuiteModule.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/BenchmarkSuiteModule.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.source;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.benchmark.framework.BenchmarkRunnerConfig;
+import com.facebook.presto.benchmark.framework.MySqlBenchmarkSuiteConfig;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Binder;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+
+import java.sql.DriverManager;
+import java.util.Set;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.presto.benchmark.source.DbBenchmarkSuiteSupplier.BENCHMARK_SUITE_SUPPLIER;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.inject.Scopes.SINGLETON;
+
+public class BenchmarkSuiteModule
+        extends AbstractConfigurationAwareModule
+{
+    private final Set<String> supportedBenchmarkSuiteSuppliers;
+
+    public BenchmarkSuiteModule(Set<String> customBenchmarkSuiteSuppliers)
+    {
+        this.supportedBenchmarkSuiteSuppliers = ImmutableSet.<String>builder()
+                .add(BENCHMARK_SUITE_SUPPLIER)
+                .addAll(customBenchmarkSuiteSuppliers)
+                .build();
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        String benchmarkSuiteSupplier = buildConfigObject(BenchmarkRunnerConfig.class).getBenchmarkSuiteSupplier();
+        checkArgument(supportedBenchmarkSuiteSuppliers.contains(benchmarkSuiteSupplier), "Unsupported BenchmarkSuiteSupplier: %s", benchmarkSuiteSupplier);
+
+        if (BENCHMARK_SUITE_SUPPLIER.equals(benchmarkSuiteSupplier)) {
+            configBinder(binder).bindConfig(BenchmarkSuiteConfig.class);
+            binder.bind(BenchmarkSuiteSupplier.class).to(DbBenchmarkSuiteSupplier.class).in(SINGLETON);
+            String database = buildConfigObject(MySqlBenchmarkSuiteConfig.class).getDatabaseUrl();
+            binder.bind(Jdbi.class).toInstance(Jdbi.create(() -> DriverManager.getConnection(database)).installPlugin(new SqlObjectPlugin()));
+        }
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/BenchmarkSuiteSupplier.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/BenchmarkSuiteSupplier.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.source;
+
+import com.facebook.presto.benchmark.framework.BenchmarkSuite;
+
+import java.util.function.Supplier;
+
+public interface BenchmarkSuiteSupplier
+        extends Supplier<BenchmarkSuite>
+{
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/DbBenchmarkSuiteSupplier.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/DbBenchmarkSuiteSupplier.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.source;
+
+import com.facebook.presto.benchmark.framework.BenchmarkSuite;
+import com.facebook.presto.benchmark.framework.BenchmarkSuiteInfo;
+import com.google.inject.Inject;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+
+import static java.util.Objects.requireNonNull;
+
+public class DbBenchmarkSuiteSupplier
+        implements BenchmarkSuiteSupplier
+{
+    public static final String BENCHMARK_SUITE_SUPPLIER = "mysql";
+
+    private final Jdbi jdbi;
+    private final String suitesTableName;
+    private final String queriesTableName;
+    private final String suite;
+
+    @Inject
+    public DbBenchmarkSuiteSupplier(Jdbi jdbi, BenchmarkSuiteConfig config)
+    {
+        this.jdbi = requireNonNull(jdbi, "jdbi is null");
+        this.suitesTableName = requireNonNull(config.getSuitesTableName(), "suites-table-name is null");
+        this.queriesTableName = requireNonNull(config.getQueriesTableName(), "queries-table-name is null");
+        this.suite = requireNonNull(config.getSuite(), "suite name is null");
+    }
+
+    @Override
+    public BenchmarkSuite get()
+    {
+        BenchmarkSuite benchmarkSuite;
+        try (Handle handle = jdbi.open()) {
+            BenchmarkSuiteDao benchmarkDao = handle.attach(BenchmarkSuiteDao.class);
+            BenchmarkSuiteInfo benchmarkSuiteInfo = benchmarkDao.getBenchmarkSuiteInfo(suitesTableName, suite);
+            benchmarkSuite = new BenchmarkSuite(benchmarkSuiteInfo, benchmarkDao.getBenchmarkQueries(queriesTableName, benchmarkSuiteInfo.getQuerySet()));
+        }
+        return benchmarkSuite;
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/PhaseSpecificationsColumnMapper.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/PhaseSpecificationsColumnMapper.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.source;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.benchmark.framework.PhaseSpecification;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+
+public class PhaseSpecificationsColumnMapper
+        implements ColumnMapper<List<PhaseSpecification>>
+{
+    protected static final JsonCodec<List<PhaseSpecification>> PHASE_SPECIFICATION_LIST_CODEC = listJsonCodec(PhaseSpecification.class);
+
+    @Override
+    public List<PhaseSpecification> map(ResultSet resultSet, int columnNumber, StatementContext ctx)
+            throws SQLException
+    {
+        String columnValue = resultSet.getString(columnNumber);
+        return columnValue == null ? null : PHASE_SPECIFICATION_LIST_CODEC.fromJson(columnValue);
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/StringToStringMapColumnMapper.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/StringToStringMapColumnMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.source;
+
+import com.facebook.airlift.json.JsonCodec;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+
+import static com.facebook.airlift.json.JsonCodec.mapJsonCodec;
+
+public class StringToStringMapColumnMapper
+        implements ColumnMapper<Map<String, String>>
+{
+    protected static final JsonCodec<Map<String, String>> MAP_CODEC = mapJsonCodec(String.class, String.class);
+
+    @Override
+    public Map<String, String> map(ResultSet resultSet, int columnNumber, StatementContext ctx)
+            throws SQLException
+    {
+        String columnValue = resultSet.getString(columnNumber);
+        return columnValue == null ? null : MAP_CODEC.fromJson(columnValue);
+    }
+}

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/BenchmarkTestUtil.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/BenchmarkTestUtil.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.benchmark.framework.BenchmarkQuery;
+import com.facebook.presto.benchmark.framework.BenchmarkSuite;
+import com.facebook.presto.benchmark.framework.BenchmarkSuiteInfo;
+import com.facebook.presto.benchmark.framework.ConcurrentExecutionPhase;
+import com.facebook.presto.benchmark.framework.PhaseSpecification;
+import com.facebook.presto.benchmark.framework.StreamExecutionPhase;
+import com.facebook.presto.benchmark.source.BenchmarkSuiteDao;
+import com.facebook.presto.testing.mysql.TestingMySqlServer;
+import com.google.common.collect.ImmutableList;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.benchmark.framework.PhaseSpecification.ExecutionStrategy.CONCURRENT;
+import static com.facebook.presto.benchmark.framework.PhaseSpecification.ExecutionStrategy.STREAM;
+
+public class BenchmarkTestUtil
+{
+    public static final String CATALOG = "benchmark";
+    public static final String SCHEMA = "default";
+    public static final String XDB = "presto";
+
+    private BenchmarkTestUtil()
+    {
+    }
+
+    public static TestingMySqlServer setupMySql()
+            throws Exception
+    {
+        TestingMySqlServer mySqlServer = new TestingMySqlServer("testuser", "testpass", ImmutableList.of(XDB));
+        Handle handle = getJdbi(mySqlServer).open();
+        BenchmarkSuiteDao benchmarkDao = handle.attach(BenchmarkSuiteDao.class);
+        benchmarkDao.createBenchmarkSuitesTable("benchmark_suites");
+        benchmarkDao.createBenchmarkQueriesTable("benchmark_queries");
+        return mySqlServer;
+    }
+
+    public static Jdbi getJdbi(TestingMySqlServer mySqlServer)
+    {
+        return Jdbi.create(mySqlServer.getJdbcUrl(XDB)).installPlugin(new SqlObjectPlugin());
+    }
+
+    public static void insertBenchmarkQuery(Handle handle, String querySet, String name, String query)
+    {
+        handle.execute(
+                "INSERT INTO benchmark_queries(\n" +
+                        "    `query_set`, `name`, `catalog`, `schema`, `query`)\n" +
+                        "SELECT\n" +
+                        "    ?,\n" +
+                        "    ?,\n" +
+                        "    'benchmark',\n" +
+                        "    'default',\n" +
+                        "    ?\n",
+                querySet,
+                name,
+                query);
+    }
+
+    public static void insertBenchmarkSuite(Handle handle, String suite, String querySet, String phases, String sessionProperties)
+    {
+        handle.execute(
+                "INSERT INTO benchmark_suites(\n" +
+                        "    `suite`, `query_set`, `phases`, `session_properties`, `created_by`)\n" +
+                        "SELECT\n" +
+                        "    ?,\n" +
+                        "    ?,\n" +
+                        "    ?,\n" +
+                        "    ?,\n" +
+                        "    'benchmark'\n",
+                suite,
+                querySet,
+                phases,
+                sessionProperties);
+    }
+
+    public static List<PhaseSpecification> getBenchmarkSuitePhases()
+    {
+        List<List<String>> streams = ImmutableList.of(ImmutableList.of("Q1", "Q2"), ImmutableList.of("Q2", "Q3"));
+        PhaseSpecification streamExecutionPhase = new StreamExecutionPhase("Phase-1", STREAM, streams);
+
+        List<String> queries = ImmutableList.of("Q1", "Q2", "Q3");
+        PhaseSpecification concurrentExecutionPhase = new ConcurrentExecutionPhase("Phase-2", CONCURRENT, queries);
+
+        return ImmutableList.of(streamExecutionPhase, concurrentExecutionPhase);
+    }
+
+    public static Map<String, String> getBenchmarkSuiteSessionProperties()
+    {
+        Map<String, String> sessionProperties = new HashMap();
+        sessionProperties.put("max", "5");
+        return sessionProperties;
+    }
+
+    public static BenchmarkSuite getBenchmarkSuiteObject(String suite, String querySet)
+    {
+        BenchmarkQuery benchmarkQuery1 = new BenchmarkQuery(querySet, "Q1", "SELECT 1", CATALOG, SCHEMA);
+        BenchmarkQuery benchmarkQuery2 = new BenchmarkQuery(querySet, "Q2", "SELECT 2", CATALOG, SCHEMA);
+        BenchmarkQuery benchmarkQuery3 = new BenchmarkQuery(querySet, "Q3", "SELECT 3", CATALOG, SCHEMA);
+
+        return new BenchmarkSuite(new BenchmarkSuiteInfo(suite, querySet, getBenchmarkSuitePhases(), getBenchmarkSuiteSessionProperties()),
+                ImmutableList.of(benchmarkQuery1, benchmarkQuery2, benchmarkQuery3));
+    }
+}

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/framework/TestBenchmarkRunnerConfig.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/framework/TestBenchmarkRunnerConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestBenchmarkRunnerConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(BenchmarkRunnerConfig.class)
+                .setTestId(null)
+                .setBenchmarkSuiteSupplier("mysql"));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("test-id", "12345")
+                .put("benchmark-suite-supplier", "custom-supplier")
+                .build();
+        BenchmarkRunnerConfig expected = new BenchmarkRunnerConfig()
+                .setTestId("12345")
+                .setBenchmarkSuiteSupplier("custom-supplier");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/source/TestBenchmarkSuiteConfig.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/source/TestBenchmarkSuiteConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.source;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestBenchmarkSuiteConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(BenchmarkSuiteConfig.class)
+                .setSuite(null)
+                .setSuitesTableName("benchmark_suites")
+                .setQueriesTableName("benchmark_queries"));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("suite", "test1")
+                .put("suites-table-name", "suite_source")
+                .put("queries-table-name", "query_source")
+                .build();
+        BenchmarkSuiteConfig expected = new BenchmarkSuiteConfig()
+                .setSuite("test1")
+                .setSuitesTableName("suite_source")
+                .setQueriesTableName("query_source");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/source/TestBenchmarkSuiteModule.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/source/TestBenchmarkSuiteModule.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.source;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.bootstrap.LifeCycleManager;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.CreationException;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertTrue;
+
+public class TestBenchmarkSuiteModule
+{
+    private static final Map<String, String> DEFAULT_CONFIGURATION_PROPERTIES = ImmutableMap.<String, String>builder()
+            .put("test-id", "test")
+            .build();
+
+    @Test
+    public void testDbBenchmarkSuiteSupplier()
+    {
+        Bootstrap app = new Bootstrap(ImmutableList.<Module>builder()
+                .add(new BenchmarkSuiteModule(ImmutableSet.of()))
+                .build());
+        Injector injector = null;
+        try {
+            injector = app.strictConfig()
+                    .setRequiredConfigurationProperties(ImmutableMap.<String, String>builder()
+                            .putAll(DEFAULT_CONFIGURATION_PROPERTIES)
+                            .put("database-url", "jdbc://localhost:1080")
+                            .put("suite", "test")
+                            .build())
+                    .initialize();
+            assertTrue(injector.getInstance(BenchmarkSuiteSupplier.class) instanceof DbBenchmarkSuiteSupplier);
+        }
+        finally {
+            if (injector != null) {
+                injector.getInstance(LifeCycleManager.class).stop();
+            }
+        }
+    }
+
+    @Test
+    public void testCustomBenchmarkSuiteSupplier()
+    {
+        Bootstrap app = new Bootstrap(ImmutableList.<Module>builder()
+                .add(new BenchmarkSuiteModule(ImmutableSet.of("test-supplier")))
+                .build());
+        Injector injector = null;
+        try {
+            injector = app.strictConfig()
+                    .setRequiredConfigurationProperties(ImmutableMap.<String, String>builder()
+                            .putAll(DEFAULT_CONFIGURATION_PROPERTIES)
+                            .put("benchmark-suite-supplier", "test-supplier")
+                            .build())
+                    .initialize();
+        }
+        finally {
+            if (injector != null) {
+                injector.getInstance(LifeCycleManager.class).stop();
+            }
+        }
+    }
+
+    @Test(expectedExceptions = CreationException.class, expectedExceptionsMessageRegExp = "Unable to create injector.*")
+    public void testInvalidBenchmarkSuiteSupplier()
+    {
+        Bootstrap app = new Bootstrap(ImmutableList.<Module>builder()
+                .add(new BenchmarkSuiteModule(ImmutableSet.of("test-supplier")))
+                .build());
+        Injector injector = null;
+        try {
+            injector = app.strictConfig()
+                    .setRequiredConfigurationProperties(ImmutableMap.<String, String>builder()
+                            .putAll(DEFAULT_CONFIGURATION_PROPERTIES)
+                            .put("benchmark-query-supplier", "unknown-supplier")
+                            .build())
+                    .initialize();
+        }
+        finally {
+            if (injector != null) {
+                injector.getInstance(LifeCycleManager.class).stop();
+            }
+        }
+    }
+}

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/source/TestDbBenchmarkSuiteSupplier.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/source/TestDbBenchmarkSuiteSupplier.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.source;
+
+import com.facebook.presto.testing.mysql.TestingMySqlServer;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.airlift.testing.Closeables.closeQuietly;
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.getBenchmarkSuiteObject;
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.getBenchmarkSuitePhases;
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.getBenchmarkSuiteSessionProperties;
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.getJdbi;
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.insertBenchmarkQuery;
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.insertBenchmarkSuite;
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.setupMySql;
+import static com.facebook.presto.benchmark.source.PhaseSpecificationsColumnMapper.PHASE_SPECIFICATION_LIST_CODEC;
+import static com.facebook.presto.benchmark.source.StringToStringMapColumnMapper.MAP_CODEC;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestDbBenchmarkSuiteSupplier
+{
+    private static final String SUITE = "test_suite";
+    private static final String QUERY_SET = "test_set";
+    private static TestingMySqlServer mySqlServer;
+    private static Handle handle;
+    private static Jdbi jdbi;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        mySqlServer = setupMySql();
+        jdbi = getJdbi(mySqlServer);
+        handle = jdbi.open();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+    {
+        closeQuietly(mySqlServer, handle);
+    }
+
+    @AfterMethod
+    public void cleanup()
+    {
+        handle.execute("DELETE FROM benchmark_suites");
+        handle.execute("DELETE FROM benchmark_queries");
+    }
+
+    @Test
+    public void testSupplySuite()
+    {
+        insertBenchmarkQuery(handle, QUERY_SET, "Q1", "SELECT 1");
+        insertBenchmarkQuery(handle, QUERY_SET, "Q2", "SELECT 2");
+        insertBenchmarkQuery(handle, QUERY_SET, "Q3", "SELECT 3");
+
+        insertBenchmarkSuite(handle, SUITE, QUERY_SET, PHASE_SPECIFICATION_LIST_CODEC.toJson(getBenchmarkSuitePhases()), MAP_CODEC.toJson(getBenchmarkSuiteSessionProperties()));
+
+        assertEquals(new DbBenchmarkSuiteSupplier(jdbi, new BenchmarkSuiteConfig().setSuite(SUITE)).get(), getBenchmarkSuiteObject(SUITE, QUERY_SET));
+    }
+}


### PR DESCRIPTION
- Create a new module presto-benchmark-runner to enable running benchmark queries on Presto.
- Add code changes to able to connect and retrieve the Benchmark suite information from MySql.
- QuerySet is a set of queries. All the queries of a Benchmark suite belong to a single query set. 
- Each benchmark might have multiple phases. And each phase will have queries and an execution strategy that describes as to how to execute them. 
- If the execution strategy is CONCURRENT , then all the queries in the phase will be executed at the same time. If the execution strategy is STREAM, then one query from each stream will be executed at once.

```
== NO RELEASE NOTE ==
```
