### PR TITLE
Fix IS DISTINCT FROM for decimals with precision > 18

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalInequalityOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalInequalityOperators.java
@@ -202,8 +202,8 @@ public class DecimalInequalityOperators
 
         long leftLow = left.getLong(leftPosition, 0);
         long leftHigh = left.getLong(leftPosition, SIZE_OF_LONG);
-        long rightLow = left.getLong(rightPosition, 0);
-        long rightHigh = left.getLong(rightPosition, SIZE_OF_LONG);
+        long rightLow = right.getLong(rightPosition, 0);
+        long rightHigh = right.getLong(rightPosition, SIZE_OF_LONG);
         return UnscaledDecimal128Arithmetic.compare(leftLow, leftHigh, rightLow, rightHigh) != 0;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/block/TestInt128ArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestInt128ArrayBlock.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.block;
 
+import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.Int128ArrayBlock;
 import com.facebook.presto.spi.block.Int128ArrayBlockBuilder;
@@ -23,7 +24,9 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.block.Int128ArrayBlock.INT128_BYTES;
+import static com.facebook.presto.type.DecimalInequalityOperators.distinctBlockPositionLongLong;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class TestInt128ArrayBlock
@@ -80,6 +83,16 @@ public class TestInt128ArrayBlock
         testCompactBlock(new Int128ArrayBlock(0, Optional.empty(), new long[0]));
         testCompactBlock(new Int128ArrayBlock(valueIsNull.length, Optional.of(valueIsNull), longArray));
         testIncompactBlock(new Int128ArrayBlock(valueIsNull.length - 2, Optional.of(valueIsNull), longArray));
+    }
+
+    @Test
+    public void testIsDistinctFrom()
+    {
+        Block left = new Int128ArrayBlock(1, Optional.empty(), new long[]{112L, 0L});
+        Block right = new Int128ArrayBlock(1, Optional.empty(), new long[]{185L, 0L});
+
+        assertFalse(distinctBlockPositionLongLong(left, 0, left, 0));
+        assertTrue(distinctBlockPositionLongLong(left, 0, right, 0));
     }
 
     private void assertFixedWithValues(Slice[] expectedValues)


### PR DESCRIPTION
The current logic in method `distinctBlockPositionLongLong` compares the left value to itself. This PR corrects this by assigning the proper values to `rightLow` and `rightHigh`.

Fixes https://github.com/prestodb/presto/issues/13667.
