### PR TITLE
WIP - Remove type from OrcRecordReader.readBlock

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
@@ -144,12 +144,11 @@ public class OrcBatchPageSource
 
             Block[] blocks = new Block[hiveColumnIndexes.length];
             for (int fieldId = 0; fieldId < blocks.length; fieldId++) {
-                Type type = types.get(fieldId);
                 if (constantBlocks[fieldId] != null) {
                     blocks[fieldId] = constantBlocks[fieldId].getRegion(0, batchSize);
                 }
                 else {
-                    blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(hiveColumnIndexes[fieldId], type));
+                    blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(hiveColumnIndexes[fieldId]));
                 }
             }
             return new Page(batchSize, blocks);
@@ -220,13 +219,11 @@ public class OrcBatchPageSource
     {
         private final int expectedBatchId = batchId;
         private final int columnIndex;
-        private final Type type;
         private boolean loaded;
 
-        public OrcBlockLoader(int columnIndex, Type type)
+        public OrcBlockLoader(int columnIndex)
         {
             this.columnIndex = columnIndex;
-            this.type = requireNonNull(type, "type is null");
         }
 
         @Override
@@ -239,7 +236,7 @@ public class OrcBatchPageSource
             checkState(batchId == expectedBatchId);
 
             try {
-                Block block = recordReader.readBlock(type, columnIndex);
+                Block block = recordReader.readBlock(columnIndex);
                 lazyBlock.setBlock(block);
             }
             catch (OrcCorruptionException e) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.AbstractIterator;
-import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 
 import java.io.IOException;
@@ -44,12 +43,13 @@ import static org.joda.time.DateTimeZone.UTC;
 public class TempFileReader
         extends AbstractIterator<Page>
 {
-    private final List<Type> types;
+    private final int columnCount;
     private final OrcBatchRecordReader reader;
 
     public TempFileReader(List<Type> types, OrcDataSource dataSource)
     {
-        this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+        requireNonNull(types, "types is null");
+        this.columnCount = types.size();
 
         try {
             OrcReader orcReader = new OrcReader(
@@ -91,9 +91,9 @@ public class TempFileReader
                 return endOfData();
             }
 
-            Block[] blocks = new Block[types.size()];
-            for (int i = 0; i < types.size(); i++) {
-                blocks[i] = reader.readBlock(types.get(i), i).getLoadedBlock();
+            Block[] blocks = new Block[columnCount];
+            for (int i = 0; i < columnCount; i++) {
+                blocks[i] = reader.readBlock(i).getLoadedBlock();
             }
             return new Page(batchSize, blocks);
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
@@ -67,6 +67,8 @@ public class OrcBatchRecordReader
             Optional<OrcWriteValidation> writeValidation,
             int initialBatchSize,
             StripeMetadataSource stripeMetadataSource)
+            throws OrcCorruptionException
+
     {
         super(includedColumns,
                 // The streamReadersSystemMemoryContext covers the StreamReader local buffer sizes, plus leaf node StreamReaders'
@@ -120,10 +122,10 @@ public class OrcBatchRecordReader
         return batchSize;
     }
 
-    public Block readBlock(Type type, int columnIndex)
+    public Block readBlock(int columnIndex)
             throws IOException
     {
-        Block block = getStreamReaders()[columnIndex].readBlock(type);
+        Block block = getStreamReaders()[columnIndex].readBlock();
         updateMaxCombinedBytesPerRow(columnIndex, block);
         return block;
     }
@@ -144,7 +146,7 @@ public class OrcBatchRecordReader
         if (shouldValidateWritePageChecksum()) {
             Block[] blocks = new Block[getStreamReaders().length];
             for (int columnIndex = 0; columnIndex < getStreamReaders().length; columnIndex++) {
-                blocks[columnIndex] = readBlock(includedColumns.get(columnIndex), columnIndex);
+                blocks[columnIndex] = readBlock(columnIndex);
             }
             Page page = new Page(batchSize, blocks);
             validateWritePageChecksum(page);
@@ -156,6 +158,7 @@ public class OrcBatchRecordReader
             List<OrcType> types,
             DateTimeZone hiveStorageTimeZone,
             Map<Integer, Type> includedColumns)
+            throws OrcCorruptionException
     {
         List<StreamDescriptor> streamDescriptors = createStreamDescriptor("", "", 0, types, orcDataSource).getNestedStreams();
 
@@ -163,8 +166,11 @@ public class OrcBatchRecordReader
         BatchStreamReader[] streamReaders = new BatchStreamReader[rowType.getFieldCount()];
         for (int columnId = 0; columnId < rowType.getFieldCount(); columnId++) {
             if (includedColumns.containsKey(columnId)) {
-                StreamDescriptor streamDescriptor = streamDescriptors.get(columnId);
-                streamReaders[columnId] = BatchStreamReaders.createStreamReader(streamDescriptor, hiveStorageTimeZone);
+                Type type = includedColumns.get(columnId);
+                if (type != null) {
+                    StreamDescriptor streamDescriptor = streamDescriptors.get(columnId);
+                    streamReaders[columnId] = BatchStreamReaders.createStreamReader(type, streamDescriptor, hiveStorageTimeZone);
+                }
             }
         }
         return streamReaders;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -153,6 +153,7 @@ public class OrcReader
     }
 
     public OrcBatchRecordReader createBatchRecordReader(Map<Integer, Type> includedColumns, OrcPredicate predicate, DateTimeZone hiveStorageTimeZone, AggregatedMemoryContext systemMemoryUsage, int initialBatchSize)
+            throws OrcCorruptionException
     {
         return createBatchRecordReader(includedColumns, predicate, 0, orcDataSource.getSize(), hiveStorageTimeZone, systemMemoryUsage, initialBatchSize);
     }
@@ -165,6 +166,7 @@ public class OrcReader
             DateTimeZone hiveStorageTimeZone,
             AggregatedMemoryContext systemMemoryUsage,
             int initialBatchSize)
+            throws OrcCorruptionException
     {
         return new OrcBatchRecordReader(
                 requireNonNull(includedColumns, "includedColumns is null"),

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReader.java
@@ -14,14 +14,13 @@
 package com.facebook.presto.orc.reader;
 
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.type.Type;
 
 import java.io.IOException;
 
 public interface BatchStreamReader
         extends StreamReader
 {
-    Block readBlock(Type type)
+    Block readBlock()
             throws IOException;
 
     void prepareNextRead(int batchSize);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
@@ -13,7 +13,9 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.spi.type.Type;
 import org.joda.time.DateTimeZone;
 
 public final class BatchStreamReaders
@@ -22,39 +24,38 @@ public final class BatchStreamReaders
     {
     }
 
-    public static BatchStreamReader createStreamReader(
-            StreamDescriptor streamDescriptor,
-            DateTimeZone hiveStorageTimeZone)
+    public static BatchStreamReader createStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+            throws OrcCorruptionException
     {
         switch (streamDescriptor.getOrcTypeKind()) {
             case BOOLEAN:
-                return new BooleanBatchStreamReader(streamDescriptor);
+                return new BooleanBatchStreamReader(type, streamDescriptor);
             case BYTE:
-                return new ByteBatchStreamReader(streamDescriptor);
+                return new ByteBatchStreamReader(type, streamDescriptor);
             case SHORT:
             case INT:
             case LONG:
             case DATE:
-                return new LongBatchStreamReader(streamDescriptor);
+                return new LongBatchStreamReader(type, streamDescriptor);
             case FLOAT:
-                return new FloatBatchStreamReader(streamDescriptor);
+                return new FloatBatchStreamReader(type, streamDescriptor);
             case DOUBLE:
-                return new DoubleBatchStreamReader(streamDescriptor);
+                return new DoubleBatchStreamReader(type, streamDescriptor);
             case BINARY:
             case STRING:
             case VARCHAR:
             case CHAR:
-                return new SliceBatchStreamReader(streamDescriptor);
+                return new SliceBatchStreamReader(type, streamDescriptor);
             case TIMESTAMP:
-                return new TimestampBatchStreamReader(streamDescriptor, hiveStorageTimeZone);
+                return new TimestampBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
             case LIST:
-                return new ListBatchStreamReader(streamDescriptor, hiveStorageTimeZone);
+                return new ListBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
             case STRUCT:
-                return new StructBatchStreamReader(streamDescriptor, hiveStorageTimeZone);
+                return new StructBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
             case MAP:
-                return new MapBatchStreamReader(streamDescriptor, hiveStorageTimeZone);
+                return new MapBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
             case DECIMAL:
-                return new DecimalBatchStreamReader(streamDescriptor);
+                return new DecimalBatchStreamReader(type, streamDescriptor);
             case UNION:
             default:
                 throw new IllegalArgumentException("Unsupported type: " + streamDescriptor.getOrcTypeKind());

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanBatchStreamReader.java
@@ -22,6 +22,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -32,7 +33,9 @@ import java.util.List;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
@@ -56,8 +59,12 @@ public class BooleanBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public BooleanBatchStreamReader(StreamDescriptor streamDescriptor)
+    public BooleanBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, BooleanType.class::isInstance);
+
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
     }
 
@@ -69,7 +76,7 @@ public class BooleanBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
@@ -92,23 +99,23 @@ public class BooleanBatchStreamReader
 
         if (dataStream == null && presentStream != null) {
             presentStream.skip(nextBatchSize);
-            Block nullValueBlock = RunLengthEncodedBlock.create(type, null, nextBatchSize);
+            Block nullValueBlock = RunLengthEncodedBlock.create(BOOLEAN, null, nextBatchSize);
             readOffset = 0;
             nextBatchSize = 0;
             return nullValueBlock;
         }
 
-        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
+        BlockBuilder builder = BOOLEAN.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
             }
-            dataStream.getSetBits(type, nextBatchSize, builder);
+            dataStream.getSetBits(BOOLEAN, nextBatchSize, builder);
         }
         else {
             for (int i = 0; i < nextBatchSize; i++) {
                 if (presentStream.nextBit()) {
-                    type.writeBoolean(builder, dataStream.nextBit());
+                    BOOLEAN.writeBoolean(builder, dataStream.nextBit());
                 }
                 else {
                     builder.appendNull();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteBatchStreamReader.java
@@ -23,6 +23,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.TinyintType;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -33,7 +34,9 @@ import java.util.List;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
@@ -57,8 +60,12 @@ public class ByteBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public ByteBatchStreamReader(StreamDescriptor streamDescriptor)
+    public ByteBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, TinyintType.class::isInstance);
+
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
     }
 
@@ -70,7 +77,7 @@ public class ByteBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
@@ -93,23 +100,23 @@ public class ByteBatchStreamReader
 
         if (dataStream == null && presentStream != null) {
             presentStream.skip(nextBatchSize);
-            Block nullValueBlock = RunLengthEncodedBlock.create(type, null, nextBatchSize);
+            Block nullValueBlock = RunLengthEncodedBlock.create(TINYINT, null, nextBatchSize);
             readOffset = 0;
             nextBatchSize = 0;
             return nullValueBlock;
         }
 
-        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
+        BlockBuilder builder = TINYINT.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
             }
-            dataStream.nextVector(type, nextBatchSize, builder);
+            dataStream.nextVector(TINYINT, nextBatchSize, builder);
         }
         else {
             for (int i = 0; i < nextBatchSize; i++) {
                 if (presentStream.nextBit()) {
-                    type.writeLong(builder, dataStream.next());
+                    TINYINT.writeLong(builder, dataStream.next());
                 }
                 else {
                     builder.appendNull();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleBatchStreamReader.java
@@ -23,6 +23,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -33,7 +34,9 @@ import java.util.List;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
@@ -57,8 +60,11 @@ public class DoubleBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public DoubleBatchStreamReader(StreamDescriptor streamDescriptor)
+    public DoubleBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, DoubleType.class::isInstance);
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
     }
 
@@ -70,7 +76,7 @@ public class DoubleBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
@@ -93,23 +99,23 @@ public class DoubleBatchStreamReader
 
         if (dataStream == null && presentStream != null) {
             presentStream.skip(nextBatchSize);
-            Block nullValueBlock = RunLengthEncodedBlock.create(type, null, nextBatchSize);
+            Block nullValueBlock = RunLengthEncodedBlock.create(DOUBLE, null, nextBatchSize);
             readOffset = 0;
             nextBatchSize = 0;
             return nullValueBlock;
         }
 
-        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
+        BlockBuilder builder = DOUBLE.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
             }
-            dataStream.nextVector(type, nextBatchSize, builder);
+            dataStream.nextVector(DOUBLE, nextBatchSize, builder);
         }
         else {
             for (int i = 0; i < nextBatchSize; i++) {
                 if (presentStream.nextBit()) {
-                    type.writeDouble(builder, dataStream.next());
+                    DOUBLE.writeDouble(builder, dataStream.next());
                 }
                 else {
                     builder.appendNull();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatBatchStreamReader.java
@@ -23,6 +23,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
+import com.facebook.presto.spi.type.RealType;
 import com.facebook.presto.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -33,7 +34,9 @@ import java.util.List;
 
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
+import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.lang.Float.floatToRawIntBits;
 import static java.util.Objects.requireNonNull;
@@ -58,8 +61,11 @@ public class FloatBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public FloatBatchStreamReader(StreamDescriptor streamDescriptor)
+    public FloatBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, RealType.class::isInstance);
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
     }
 
@@ -71,7 +77,7 @@ public class FloatBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
@@ -94,23 +100,23 @@ public class FloatBatchStreamReader
 
         if (dataStream == null && presentStream != null) {
             presentStream.skip(nextBatchSize);
-            Block nullValueBlock = RunLengthEncodedBlock.create(type, null, nextBatchSize);
+            Block nullValueBlock = RunLengthEncodedBlock.create(REAL, null, nextBatchSize);
             readOffset = 0;
             nextBatchSize = 0;
             return nullValueBlock;
         }
 
-        BlockBuilder builder = type.createBlockBuilder(null, nextBatchSize);
+        BlockBuilder builder = REAL.createBlockBuilder(null, nextBatchSize);
         if (presentStream == null) {
             if (dataStream == null) {
                 throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Value is not null but data stream is not present");
             }
-            dataStream.nextVector(type, nextBatchSize, builder);
+            dataStream.nextVector(REAL, nextBatchSize, builder);
         }
         else {
             for (int i = 0; i < nextBatchSize; i++) {
                 if (presentStream.nextBit()) {
-                    type.writeLong(builder, floatToRawIntBits(dataStream.next()));
+                    REAL.writeLong(builder, floatToRawIntBits(dataStream.next()));
                 }
                 else {
                     builder.appendNull();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongBatchStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
@@ -41,11 +42,12 @@ public class LongBatchStreamReader
     private final LongDictionaryBatchStreamReader dictionaryReader;
     private BatchStreamReader currentReader;
 
-    public LongBatchStreamReader(StreamDescriptor streamDescriptor)
+    public LongBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
+            throws OrcCorruptionException
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        directReader = new LongDirectBatchStreamReader(streamDescriptor);
-        dictionaryReader = new LongDictionaryBatchStreamReader(streamDescriptor);
+        directReader = new LongDirectBatchStreamReader(type, streamDescriptor);
+        dictionaryReader = new LongDictionaryBatchStreamReader(type, streamDescriptor);
     }
 
     @Override
@@ -55,10 +57,10 @@ public class LongBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
-        return currentReader.readBlock(type);
+        return currentReader.readBlock();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapBatchStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
@@ -42,11 +43,12 @@ public class MapBatchStreamReader
     private final MapFlatBatchStreamReader flatReader;
     private BatchStreamReader currentReader;
 
-    public MapBatchStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+    public MapBatchStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+            throws OrcCorruptionException
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        directReader = new MapDirectBatchStreamReader(streamDescriptor, hiveStorageTimeZone);
-        flatReader = new MapFlatBatchStreamReader(streamDescriptor, hiveStorageTimeZone);
+        directReader = new MapDirectBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
+        flatReader = new MapFlatBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
     }
 
     @Override
@@ -56,10 +58,10 @@ public class MapBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
-        return currentReader.readBlock(type);
+        return currentReader.readBlock();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectBatchStreamReader.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.BatchStreamReaders.createStreamReader;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.lang.Math.toIntExact;
@@ -46,6 +47,7 @@ public class MapDirectBatchStreamReader
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapDirectBatchStreamReader.class).instanceSize();
 
+    private final MapType type;
     private final StreamDescriptor streamDescriptor;
 
     private final BatchStreamReader keyStreamReader;
@@ -64,11 +66,16 @@ public class MapDirectBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public MapDirectBatchStreamReader(StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+    public MapDirectBatchStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, MapType.class::isInstance);
+        this.type = (MapType) type;
+
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        this.keyStreamReader = createStreamReader(streamDescriptor.getNestedStreams().get(0), hiveStorageTimeZone);
-        this.valueStreamReader = createStreamReader(streamDescriptor.getNestedStreams().get(1), hiveStorageTimeZone);
+        this.keyStreamReader = createStreamReader(this.type.getKeyType(), streamDescriptor.getNestedStreams().get(0), hiveStorageTimeZone);
+        this.valueStreamReader = createStreamReader(this.type.getValueType(), streamDescriptor.getNestedStreams().get(1), hiveStorageTimeZone);
     }
 
     @Override
@@ -79,7 +86,7 @@ public class MapDirectBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
@@ -139,8 +146,8 @@ public class MapDirectBatchStreamReader
         if (entryCount > 0) {
             keyStreamReader.prepareNextRead(entryCount);
             valueStreamReader.prepareNextRead(entryCount);
-            keys = keyStreamReader.readBlock(keyType);
-            values = valueStreamReader.readBlock(valueType);
+            keys = keyStreamReader.readBlock();
+            values = valueStreamReader.readBlock();
         }
         else {
             keys = keyType.createBlockBuilder(null, 0).build();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.spi.type.Type;
+
+import java.util.function.Predicate;
+
+import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
+import static java.lang.Math.max;
+
+final class ReaderUtils
+{
+    private ReaderUtils() {}
+
+    public static void verifyStreamType(StreamDescriptor streamDescriptor, Type actual, Predicate<Type> validTypes)
+            throws OrcCorruptionException
+    {
+        if (validTypes.test(actual)) {
+            return;
+        }
+
+        throw new OrcCorruptionException(
+                streamDescriptor.getOrcDataSourceId(),
+                "Can not read SQL type %s from ORC stream %s of type %s",
+                actual,
+                streamDescriptor.getStreamName(),
+                streamDescriptor.getOrcTypeKind());
+    }
+
+    public static int minNonNullValueSize(int nonNullCount)
+    {
+        return max(nonNullCount, MAX_BATCH_SIZE) + 1;
+    }
+
+    public static byte[] unpackByteNulls(byte[] values, boolean[] isNull)
+    {
+        byte[] result = new byte[isNull.length];
+
+        int position = 0;
+        for (int i = 0; i < isNull.length; i++) {
+            result[i] = values[position];
+            if (!isNull[i]) {
+                position++;
+            }
+        }
+        return result;
+    }
+
+    public static short[] unpackShortNulls(short[] values, boolean[] isNull)
+    {
+        short[] result = new short[isNull.length];
+
+        int position = 0;
+        for (int i = 0; i < isNull.length; i++) {
+            result[i] = values[position];
+            if (!isNull[i]) {
+                position++;
+            }
+        }
+        return result;
+    }
+
+    public static int[] unpackIntNulls(int[] values, boolean[] isNull)
+    {
+        int[] result = new int[isNull.length];
+
+        int position = 0;
+        for (int i = 0; i < isNull.length; i++) {
+            result[i] = values[position];
+            if (!isNull[i]) {
+                position++;
+            }
+        }
+        return result;
+    }
+
+    public static long[] unpackLongNulls(long[] values, boolean[] isNull)
+    {
+        long[] result = new long[isNull.length];
+
+        int position = 0;
+        for (int i = 0; i < isNull.length; i++) {
+            result[i] = values[position];
+            if (!isNull[i]) {
+                position++;
+            }
+        }
+        return result;
+    }
+
+    public static long[] unpackInt128Nulls(long[] values, boolean[] isNull)
+    {
+        long[] result = new long[isNull.length * 2];
+
+        int position = 0;
+        int outputPosition = 0;
+        for (int i = 0; i < isNull.length; i++) {
+            result[outputPosition] = values[position];
+            result[outputPosition + 1] = values[position + 1];
+            if (!isNull[i]) {
+                position += 2;
+            }
+            outputPosition += 2;
+        }
+        return result;
+    }
+
+    public static void unpackLengthNulls(int[] values, boolean[] isNull, int nonNullCount)
+    {
+        int nullSuppressedPosition = nonNullCount - 1;
+        for (int outputPosition = isNull.length - 1; outputPosition >= 0; outputPosition--) {
+            if (isNull[outputPosition]) {
+                values[outputPosition] = 0;
+            }
+            else {
+                values[outputPosition] = values[nullSuppressedPosition];
+                nullSuppressedPosition--;
+            }
+        }
+    }
+
+    public static void convertLengthVectorToOffsetVector(int[] vector)
+    {
+        int currentLength = vector[0];
+        vector[0] = 0;
+        for (int i = 1; i < vector.length; i++) {
+            int nextLength = vector[i];
+            vector[i] = vector[i - 1] + currentLength;
+            currentLength = nextLength;
+        }
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceBatchStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.reader;
 
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
@@ -20,6 +21,7 @@ import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarbinaryType;
 import com.facebook.presto.spi.type.VarcharType;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
@@ -32,6 +34,7 @@ import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DWRF_DIRECT;
+import static com.facebook.presto.orc.reader.ReaderUtils.verifyStreamType;
 import static com.facebook.presto.spi.type.Chars.byteCountWithoutTrailingSpace;
 import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.facebook.presto.spi.type.VarbinaryType.isVarbinaryType;
@@ -50,18 +53,26 @@ public class SliceBatchStreamReader
     private final SliceDictionaryBatchStreamReader dictionaryReader;
     private BatchStreamReader currentReader;
 
-    public SliceBatchStreamReader(StreamDescriptor streamDescriptor)
+    public SliceBatchStreamReader(Type type, StreamDescriptor streamDescriptor)
+            throws OrcCorruptionException
     {
+        requireNonNull(type, "type is null");
+        verifyStreamType(streamDescriptor, type, t -> t instanceof VarcharType || t instanceof CharType || t instanceof VarbinaryType);
+
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        directReader = new SliceDirectBatchStreamReader(streamDescriptor);
-        dictionaryReader = new SliceDictionaryBatchStreamReader(streamDescriptor);
+
+        int maxCodePointCount = getMaxCodePointCount(type);
+        boolean charType = isCharType(type);
+
+        directReader = new SliceDirectBatchStreamReader(streamDescriptor, maxCodePointCount, charType);
+        dictionaryReader = new SliceDictionaryBatchStreamReader(streamDescriptor, maxCodePointCount, charType);
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
-        return currentReader.readBlock(type);
+        return currentReader.readBlock();
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryBatchStreamReader.java
@@ -25,7 +25,6 @@ import com.facebook.presto.orc.stream.RowGroupDictionaryLengthInputStream;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.block.VariableWidthBlock;
-import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -44,9 +43,7 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.ROW_GROUP_DICTIONARY;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.ROW_GROUP_DICTIONARY_LENGTH;
 import static com.facebook.presto.orc.reader.SliceBatchStreamReader.computeTruncatedLength;
-import static com.facebook.presto.orc.reader.SliceBatchStreamReader.getMaxCodePointCount;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
-import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.Slices.wrappedBuffer;
@@ -63,6 +60,8 @@ public class SliceDictionaryBatchStreamReader
     private static final int[] EMPTY_DICTIONARY_OFFSETS = new int[2];
 
     private final StreamDescriptor streamDescriptor;
+    private final int maxCodePointCount;
+    private final boolean isCharType;
 
     private int readOffset;
     private int nextBatchSize;
@@ -98,8 +97,11 @@ public class SliceDictionaryBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public SliceDictionaryBatchStreamReader(StreamDescriptor streamDescriptor)
+    public SliceDictionaryBatchStreamReader(StreamDescriptor streamDescriptor, int maxCodePointCount, boolean isCharType)
     {
+        this.maxCodePointCount = maxCodePointCount;
+        this.isCharType = isCharType;
+
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
     }
 
@@ -111,11 +113,11 @@ public class SliceDictionaryBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
-            openRowGroup(type);
+            openRowGroup();
         }
 
         if (readOffset > 0) {
@@ -202,7 +204,7 @@ public class SliceDictionaryBatchStreamReader
         }
     }
 
-    private void openRowGroup(Type type)
+    private void openRowGroup()
             throws IOException
     {
         // read the dictionary
@@ -232,7 +234,7 @@ public class SliceDictionaryBatchStreamReader
 
                 // read dictionary values
                 ByteArrayInputStream dictionaryDataStream = stripeDictionaryDataStreamSource.openStream();
-                readDictionary(dictionaryDataStream, stripeDictionarySize, stripeDictionaryLength, 0, stripeDictionaryData, stripeDictionaryOffsetVector, type);
+                readDictionary(dictionaryDataStream, stripeDictionarySize, stripeDictionaryLength, 0, stripeDictionaryData, stripeDictionaryOffsetVector, maxCodePointCount, isCharType);
             }
             else {
                 stripeDictionaryData = EMPTY_DICTIONARY_DATA;
@@ -265,7 +267,7 @@ public class SliceDictionaryBatchStreamReader
 
             // read dictionary values
             ByteArrayInputStream dictionaryDataStream = rowGroupDictionaryDataStreamSource.openStream();
-            readDictionary(dictionaryDataStream, rowGroupDictionarySize, rowGroupDictionaryLength, stripeDictionarySize, rowGroupDictionaryData, rowGroupDictionaryOffsetVector, type);
+            readDictionary(dictionaryDataStream, rowGroupDictionarySize, rowGroupDictionaryLength, stripeDictionarySize, rowGroupDictionaryData, rowGroupDictionaryOffsetVector, maxCodePointCount, isCharType);
             setDictionaryBlockData(rowGroupDictionaryData, rowGroupDictionaryOffsetVector, stripeDictionarySize + rowGroupDictionarySize + 1);
         }
         else {
@@ -288,7 +290,8 @@ public class SliceDictionaryBatchStreamReader
             int offsetVectorOffset,
             byte[] data,
             int[] offsetVector,
-            Type type)
+            int maxCodePointCount,
+            boolean isCharType)
             throws IOException
     {
         Slice slice = wrappedBuffer(data);
@@ -306,8 +309,6 @@ public class SliceDictionaryBatchStreamReader
             int length = dictionaryLengthVector[i];
 
             int truncatedLength;
-            int maxCodePointCount = getMaxCodePointCount(type);
-            boolean isCharType = isCharType(type);
             if (length > 0) {
                 // read data without truncation
                 dictionaryDataStream.next(data, offset, offset + length);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectBatchStreamReader.java
@@ -24,7 +24,6 @@ import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.VariableWidthBlock;
-import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
@@ -40,10 +39,8 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.SliceBatchStreamReader.computeTruncatedLength;
-import static com.facebook.presto.orc.reader.SliceBatchStreamReader.getMaxCodePointCount;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static com.facebook.presto.spi.type.Chars.isCharType;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -60,6 +57,8 @@ public class SliceDirectBatchStreamReader
     private static final int ONE_GIGABYTE = toIntExact(new DataSize(1, GIGABYTE).toBytes());
 
     private final StreamDescriptor streamDescriptor;
+    private final int maxCodePointCount;
+    private final boolean isCharType;
 
     private int readOffset;
     private int nextBatchSize;
@@ -78,8 +77,11 @@ public class SliceDirectBatchStreamReader
 
     private boolean rowGroupOpen;
 
-    public SliceDirectBatchStreamReader(StreamDescriptor streamDescriptor)
+    public SliceDirectBatchStreamReader(StreamDescriptor streamDescriptor, int maxCodePointCount, boolean isCharType)
     {
+        this.maxCodePointCount = maxCodePointCount;
+        this.isCharType = isCharType;
+
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
     }
 
@@ -91,7 +93,7 @@ public class SliceDirectBatchStreamReader
     }
 
     @Override
-    public Block readBlock(Type type)
+    public Block readBlock()
             throws IOException
     {
         if (!rowGroupOpen) {
@@ -180,8 +182,6 @@ public class SliceDirectBatchStreamReader
         // * convert original length values in offsetVector into truncated offset values
         int currentLength = offsetVector[0];
         offsetVector[0] = 0;
-        int maxCodePointCount = getMaxCodePointCount(type);
-        boolean isCharType = isCharType(type);
         for (int i = 1; i <= currentBatchSize; i++) {
             int nextLength = offsetVector[i];
             if (isNullVector != null && isNullVector[i - 1]) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestOrcReader.java
@@ -234,7 +234,7 @@ public abstract class AbstractTestOrcReader
             assertEquals(stripeFootercache.stats().hitCount(), 1);
             assertEquals(stripeStreamCache.stats().missCount(), 2);
             assertEquals(stripeStreamCache.stats().hitCount(), 2);
-            assertEquals(storageReader.readBlock(BIGINT, 0).getInt(0), cacheReader.readBlock(BIGINT, 0).getInt(0));
+            assertEquals(storageReader.readBlock(0).getInt(0), cacheReader.readBlock(0).getInt(0));
         }
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
@@ -90,7 +90,7 @@ public class BenchmarkBatchStreamReaders
         OrcBatchRecordReader recordReader = data.createRecordReader();
         List<Block> blocks = new ArrayList<>();
         while (recordReader.nextBatch() > 0) {
-            Block block = recordReader.readBlock(data.type, 0);
+            Block block = recordReader.readBlock(0);
             blocks.add(block);
         }
         return blocks;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -891,7 +891,7 @@ public class OrcTester
                 else {
                     for (int i = 0; i < types.size(); i++) {
                         Type type = types.get(i);
-                        Block block = recordReader.readBlock(type, i);
+                        Block block = recordReader.readBlock(i);
                         assertEquals(block.getPositionCount(), batchSize);
 
                         List<Object> data = new ArrayList<>(block.getPositionCount());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
@@ -221,7 +221,7 @@ public class TestCachingOrcDataSource
             if (batchSize <= 0) {
                 break;
             }
-            Block block = orcRecordReader.readBlock(VARCHAR, 0);
+            Block block = orcRecordReader.readBlock(0);
             positionCount += block.getPositionCount();
         }
         assertEquals(positionCount, POSITION_COUNT);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
@@ -421,7 +421,7 @@ public class TestMapFlatBatchStreamReader
                     isFirst = false;
                 }
                 else {
-                    Block block = recordReader.readBlock(mapType, 0);
+                    Block block = recordReader.readBlock(0);
 
                     for (int position = 0; position < block.getPositionCount(); position++) {
                         assertEquals(mapType.getObjectValue(SESSION, block, position), expectedValuesIterator.next());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
@@ -73,9 +73,9 @@ public class TestOrcLz4
             }
             rows += batchSize;
 
-            Block xBlock = reader.readBlock(BIGINT, 0);
-            Block yBlock = reader.readBlock(INTEGER, 1);
-            Block zBlock = reader.readBlock(BIGINT, 2);
+            Block xBlock = reader.readBlock(0);
+            Block yBlock = reader.readBlock(1);
+            Block zBlock = reader.readBlock(2);
 
             for (int position = 0; position < batchSize; position++) {
                 BIGINT.getLong(xBlock, position);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
@@ -83,7 +83,7 @@ public class TestOrcReaderMemoryUsage
                     break;
                 }
 
-                Block block = reader.readBlock(VARCHAR, 0);
+                Block block = reader.readBlock(0);
                 assertEquals(block.getPositionCount(), batchSize);
 
                 // We only verify the memory usage when the batchSize reaches MAX_BATCH_SIZE as batchSize may be
@@ -130,7 +130,7 @@ public class TestOrcReaderMemoryUsage
                     break;
                 }
 
-                Block block = reader.readBlock(BIGINT, 0);
+                Block block = reader.readBlock(0);
                 assertEquals(block.getPositionCount(), batchSize);
 
                 // We only verify the memory usage when the batchSize reaches MAX_BATCH_SIZE as batchSize may be
@@ -194,7 +194,7 @@ public class TestOrcReaderMemoryUsage
                     break;
                 }
 
-                Block block = reader.readBlock(mapType, 0);
+                Block block = reader.readBlock(0);
                 assertEquals(block.getPositionCount(), batchSize);
 
                 // We only verify the memory usage when the batchSize reaches MAX_BATCH_SIZE as batchSize may be

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
@@ -164,7 +164,7 @@ public class TestOrcReaderPositions
                         break;
                     }
 
-                    Block block = reader.readBlock(BIGINT, 0);
+                    Block block = reader.readBlock(0);
                     for (int i = 0; i < batchSize; i++) {
                         assertEquals(BIGINT.getLong(block, i), position + i);
                     }
@@ -217,7 +217,7 @@ public class TestOrcReaderPositions
 
                     rowCountsInCurrentRowGroup += batchSize;
 
-                    Block block = reader.readBlock(VARCHAR, 0);
+                    Block block = reader.readBlock(0);
                     if (MAX_BATCH_SIZE * currentStringBytes <= MAX_BLOCK_SIZE.toBytes()) {
                         // Either we are bounded by 1024 rows per batch, or it is the last batch in the row group
                         // For the first 3 row groups, the strings are of length 300, 600, and 900 respectively
@@ -271,7 +271,7 @@ public class TestOrcReaderPositions
                     }
                     rowCountsInCurrentRowGroup += batchSize;
 
-                    Block block = reader.readBlock(BIGINT, 0);
+                    Block block = reader.readBlock(0);
                     // 8 bytes per row; 1024 row at most given 1024 X 8B < 1MB
                     assertTrue(block.getPositionCount() == MAX_BATCH_SIZE || rowCountsInCurrentRowGroup == rowsInRowGroup);
 
@@ -371,7 +371,7 @@ public class TestOrcReaderPositions
     private static void assertCurrentBatch(OrcBatchRecordReader reader, int rowIndex, int batchSize)
             throws IOException
     {
-        Block block = reader.readBlock(BIGINT, 0);
+        Block block = reader.readBlock(0);
         for (int i = 0; i < batchSize; i++) {
             assertEquals(BIGINT.getLong(block, i), (rowIndex + i) * 3);
         }
@@ -380,7 +380,7 @@ public class TestOrcReaderPositions
     private static void assertCurrentBatch(OrcBatchRecordReader reader, int stripe)
             throws IOException
     {
-        Block block = reader.readBlock(BIGINT, 0);
+        Block block = reader.readBlock(0);
         for (int i = 0; i < 20; i++) {
             assertEquals(BIGINT.getLong(block, i), ((stripe * 20L) + i) * 3);
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
@@ -154,7 +154,7 @@ public class TestStructBatchStreamReader
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp =
-            "Missing struct field name in type row\\(varchar,varchar,varchar\\)")
+            "ROW type does not have field names declared: row\\(varchar,varchar,varchar\\)")
     public void testThrowsExceptionWhenFieldNameMissing()
             throws IOException
     {
@@ -272,7 +272,7 @@ public class TestStructBatchStreamReader
         OrcBatchRecordReader recordReader = orcReader.createBatchRecordReader(includedColumns, OrcPredicate.TRUE, UTC, newSimpleAggregatedMemoryContext(), OrcReader.INITIAL_BATCH_SIZE);
 
         recordReader.nextBatch();
-        RowBlock block = (RowBlock) recordReader.readBlock(readerType, 0);
+        RowBlock block = (RowBlock) recordReader.readBlock(0);
         recordReader.close();
         return block;
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
@@ -215,7 +215,7 @@ public final class OrcFileRewriter
             Block[] blocks = new Block[types.size()];
             for (int i = 0; i < types.size(); i++) {
                 // read from existing columns
-                blocks[i] = reader.readBlock(types.get(i), readerColumnIndex.get(i));
+                blocks[i] = reader.readBlock(readerColumnIndex.get(i));
             }
 
             row = toIntExact(reader.getFilePosition());

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcPageSource.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcPageSource.java
@@ -166,7 +166,6 @@ public class OrcPageSource
 
             Block[] blocks = new Block[columnIndexes.length];
             for (int fieldId = 0; fieldId < blocks.length; fieldId++) {
-                Type type = types.get(fieldId);
                 if (constantBlocks[fieldId] != null) {
                     blocks[fieldId] = constantBlocks[fieldId].getRegion(0, batchSize);
                 }
@@ -174,7 +173,7 @@ public class OrcPageSource
                     blocks[fieldId] = buildSequenceBlock(filePosition, batchSize);
                 }
                 else {
-                    blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(columnIndexes[fieldId], type));
+                    blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(columnIndexes[fieldId]));
                 }
             }
 
@@ -264,13 +263,11 @@ public class OrcPageSource
     {
         private final int expectedBatchId = batchId;
         private final int columnIndex;
-        private final Type type;
         private boolean loaded;
 
-        public OrcBlockLoader(int columnIndex, Type type)
+        public OrcBlockLoader(int columnIndex)
         {
             this.columnIndex = columnIndex;
-            this.type = requireNonNull(type, "type is null");
         }
 
         @Override
@@ -283,7 +280,7 @@ public class OrcPageSource
             checkState(batchId == expectedBatchId);
 
             try {
-                Block block = recordReader.readBlock(type, columnIndex);
+                Block block = recordReader.readBlock(columnIndex);
                 lazyBlock.setBlock(block);
             }
             catch (IOException e) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -43,10 +43,14 @@ import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.predicate.TupleDomain;
+import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.NamedTypeSignature;
 import com.facebook.presto.spi.type.RowFieldName;
+import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
@@ -117,6 +121,7 @@ import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.units.DataSize.Unit.PETABYTE;
 import static java.lang.Math.min;
 import static java.lang.String.format;
@@ -307,7 +312,7 @@ public class OrcStorageManager
                 }
                 else {
                     columnIndexes.add(index);
-                    includedColumns.put(index, columnTypes.get(i));
+                    includedColumns.put(index, toOrcFileType(columnTypes.get(i), typeManager));
                 }
             }
 
@@ -446,7 +451,7 @@ public class OrcStorageManager
 
             ImmutableList.Builder<ColumnStats> list = ImmutableList.builder();
             for (ColumnInfo info : getColumnInfo(reader)) {
-                computeColumnStats(reader, info.getColumnId(), info.getType()).ifPresent(list::add);
+                computeColumnStats(reader, info.getColumnId(), info.getType(), typeManager).ifPresent(list::add);
             }
             return list.build();
         }
@@ -583,6 +588,30 @@ public class OrcStorageManager
                 return typeManager.getParameterizedType(StandardTypes.ROW, fieldTypes.build());
         }
         throw new PrestoException(RAPTOR_ERROR, "Unhandled ORC type: " + type);
+    }
+
+    static Type toOrcFileType(Type raptorType, TypeManager typeManager)
+    {
+        // TIMESTAMPS are stored as BIGINT to void the poor encoding in ORC
+        if (raptorType == TimestampType.TIMESTAMP) {
+            return BIGINT;
+        }
+        if (raptorType instanceof ArrayType) {
+            Type elementType = toOrcFileType(((ArrayType) raptorType).getElementType(), typeManager);
+            return new ArrayType(elementType);
+        }
+        if (raptorType instanceof MapType) {
+            TypeSignature keyType = toOrcFileType(((MapType) raptorType).getKeyType(), typeManager).getTypeSignature();
+            TypeSignature valueType = toOrcFileType(((MapType) raptorType).getValueType(), typeManager).getTypeSignature();
+            return typeManager.getParameterizedType(StandardTypes.MAP, ImmutableList.of(TypeSignatureParameter.of(keyType), TypeSignatureParameter.of(valueType)));
+        }
+        if (raptorType instanceof RowType) {
+            List<RowType.Field> fields = ((RowType) raptorType).getFields().stream()
+                    .map(field -> new RowType.Field(field.getName(), toOrcFileType(field.getType(), typeManager)))
+                    .collect(toImmutableList());
+            return RowType.from(fields);
+        }
+        return raptorType;
     }
 
     private static OrcPredicate getPredicate(TupleDomain<RaptorColumnHandle> effectivePredicate, Map<Long, Integer> indexMap)

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardStats.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardStats.java
@@ -20,12 +20,11 @@ import com.facebook.presto.raptor.metadata.ColumnStats;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.BigintType;
-import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.DateType;
-import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.TimeType;
 import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
@@ -37,6 +36,9 @@ import java.util.Optional;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_ERROR;
+import static com.facebook.presto.raptor.storage.OrcStorageManager.toOrcFileType;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
 import static org.joda.time.DateTimeZone.UTC;
@@ -58,20 +60,20 @@ public final class ShardStats
         return slice;
     }
 
-    public static Optional<ColumnStats> computeColumnStats(OrcReader orcReader, long columnId, Type type)
+    public static Optional<ColumnStats> computeColumnStats(OrcReader orcReader, long columnId, Type type, TypeManager typeManager)
             throws IOException
     {
-        return Optional.ofNullable(doComputeColumnStats(orcReader, columnId, type));
+        return Optional.ofNullable(doComputeColumnStats(orcReader, columnId, type, typeManager));
     }
 
-    private static ColumnStats doComputeColumnStats(OrcReader orcReader, long columnId, Type type)
+    private static ColumnStats doComputeColumnStats(OrcReader orcReader, long columnId, Type type, TypeManager typeManager)
             throws IOException
     {
         int columnIndex = columnIndex(orcReader.getColumnNames(), columnId);
-        OrcBatchRecordReader reader = orcReader.createBatchRecordReader(ImmutableMap.of(columnIndex, type), OrcPredicate.TRUE, UTC, newSimpleAggregatedMemoryContext(), INITIAL_BATCH_SIZE);
+        OrcBatchRecordReader reader = orcReader.createBatchRecordReader(ImmutableMap.of(columnIndex, toOrcFileType(type, typeManager)), OrcPredicate.TRUE, UTC, newSimpleAggregatedMemoryContext(), INITIAL_BATCH_SIZE);
 
-        if (type.equals(BooleanType.BOOLEAN)) {
-            return indexBoolean(type, reader, columnIndex, columnId);
+        if (type.equals(BOOLEAN)) {
+            return indexBoolean(reader, columnIndex, columnId);
         }
         if (type.equals(BigintType.BIGINT) ||
                 type.equals(DateType.DATE) ||
@@ -79,8 +81,8 @@ public final class ShardStats
                 type.equals(TimestampType.TIMESTAMP)) {
             return indexLong(type, reader, columnIndex, columnId);
         }
-        if (type.equals(DoubleType.DOUBLE)) {
-            return indexDouble(type, reader, columnIndex, columnId);
+        if (type.equals(DOUBLE)) {
+            return indexDouble(reader, columnIndex, columnId);
         }
         if (type instanceof VarcharType) {
             return indexString(type, reader, columnIndex, columnId);
@@ -97,7 +99,7 @@ public final class ShardStats
         return index;
     }
 
-    private static ColumnStats indexBoolean(Type type, OrcBatchRecordReader reader, int columnIndex, long columnId)
+    private static ColumnStats indexBoolean(OrcBatchRecordReader reader, int columnIndex, long columnId)
             throws IOException
     {
         boolean minSet = false;
@@ -110,13 +112,13 @@ public final class ShardStats
             if (batchSize <= 0) {
                 break;
             }
-            Block block = reader.readBlock(type, columnIndex);
+            Block block = reader.readBlock(columnIndex);
 
             for (int i = 0; i < batchSize; i++) {
                 if (block.isNull(i)) {
                     continue;
                 }
-                boolean value = type.getBoolean(block, i);
+                boolean value = BOOLEAN.getBoolean(block, i);
                 if (!minSet || Boolean.compare(value, min) < 0) {
                     minSet = true;
                     min = value;
@@ -146,7 +148,7 @@ public final class ShardStats
             if (batchSize <= 0) {
                 break;
             }
-            Block block = reader.readBlock(type, columnIndex);
+            Block block = reader.readBlock(columnIndex);
 
             for (int i = 0; i < batchSize; i++) {
                 if (block.isNull(i)) {
@@ -169,7 +171,7 @@ public final class ShardStats
                 maxSet ? max : null);
     }
 
-    private static ColumnStats indexDouble(Type type, OrcBatchRecordReader reader, int columnIndex, long columnId)
+    private static ColumnStats indexDouble(OrcBatchRecordReader reader, int columnIndex, long columnId)
             throws IOException
     {
         boolean minSet = false;
@@ -182,13 +184,13 @@ public final class ShardStats
             if (batchSize <= 0) {
                 break;
             }
-            Block block = reader.readBlock(type, columnIndex);
+            Block block = reader.readBlock(columnIndex);
 
             for (int i = 0; i < batchSize; i++) {
                 if (block.isNull(i)) {
                     continue;
                 }
-                double value = type.getDouble(block, i);
+                double value = DOUBLE.getDouble(block, i);
                 if (isNaN(value)) {
                     continue;
                 }
@@ -231,7 +233,7 @@ public final class ShardStats
             if (batchSize <= 0) {
                 break;
             }
-            Block block = reader.readBlock(type, columnIndex);
+            Block block = reader.readBlock(columnIndex);
 
             for (int i = 0; i < batchSize; i++) {
                 if (block.isNull(i)) {

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
@@ -17,6 +17,7 @@ import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.orc.FileOrcDataSource;
 import com.facebook.presto.orc.OrcBatchRecordReader;
+import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcPredicate;
 import com.facebook.presto.orc.OrcReader;
@@ -83,6 +84,7 @@ final class OrcTestingUtil
     }
 
     public static OrcBatchRecordReader createRecordReader(OrcReader orcReader, Map<Integer, Type> includedColumns)
+            throws OrcCorruptionException
     {
         return orcReader.createBatchRecordReader(includedColumns, OrcPredicate.TRUE, DateTimeZone.UTC, newSimpleAggregatedMemoryContext(), MAX_BATCH_SIZE);
     }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
@@ -154,7 +154,7 @@ public class TestOrcFileRewriter
 
             assertEquals(reader.nextBatch(), 5);
 
-            Block column0 = reader.readBlock(BIGINT, 0);
+            Block column0 = reader.readBlock(0);
             assertEquals(column0.getPositionCount(), 5);
             for (int i = 0; i < 5; i++) {
                 assertEquals(column0.isNull(i), false);
@@ -165,7 +165,7 @@ public class TestOrcFileRewriter
             assertEquals(BIGINT.getLong(column0, 3), 888L);
             assertEquals(BIGINT.getLong(column0, 4), 999L);
 
-            Block column1 = reader.readBlock(createVarcharType(20), 1);
+            Block column1 = reader.readBlock(1);
             assertEquals(column1.getPositionCount(), 5);
             for (int i = 0; i < 5; i++) {
                 assertEquals(column1.isNull(i), false);
@@ -176,7 +176,7 @@ public class TestOrcFileRewriter
             assertEquals(createVarcharType(20).getSlice(column1, 3), utf8Slice("world"));
             assertEquals(createVarcharType(20).getSlice(column1, 4), utf8Slice("done"));
 
-            Block column2 = reader.readBlock(arrayType, 2);
+            Block column2 = reader.readBlock(2);
             assertEquals(column2.getPositionCount(), 5);
             for (int i = 0; i < 5; i++) {
                 assertEquals(column2.isNull(i), false);
@@ -187,7 +187,7 @@ public class TestOrcFileRewriter
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column2, 3), arrayBlockOf(BIGINT, 7, 8)));
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column2, 4), arrayBlockOf(BIGINT, 9, 10)));
 
-            Block column3 = reader.readBlock(mapType, 3);
+            Block column3 = reader.readBlock(3);
             assertEquals(column3.getPositionCount(), 5);
             for (int i = 0; i < 5; i++) {
                 assertEquals(column3.isNull(i), false);
@@ -198,7 +198,7 @@ public class TestOrcFileRewriter
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, arrayType.getObject(column3, 3), mapBlockOf(createVarcharType(5), BOOLEAN, "k4", true)));
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, arrayType.getObject(column3, 4), mapBlockOf(createVarcharType(5), BOOLEAN, "k5", true)));
 
-            Block column4 = reader.readBlock(arrayOfArrayType, 4);
+            Block column4 = reader.readBlock(4);
             assertEquals(column4.getPositionCount(), 5);
             for (int i = 0; i < 5; i++) {
                 assertEquals(column4.isNull(i), false);
@@ -242,7 +242,7 @@ public class TestOrcFileRewriter
 
             assertEquals(reader.nextBatch(), 2);
 
-            Block column0 = reader.readBlock(BIGINT, 0);
+            Block column0 = reader.readBlock(0);
             assertEquals(column0.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column0.isNull(i), false);
@@ -250,7 +250,7 @@ public class TestOrcFileRewriter
             assertEquals(BIGINT.getLong(column0, 0), 123L);
             assertEquals(BIGINT.getLong(column0, 1), 456L);
 
-            Block column1 = reader.readBlock(createVarcharType(20), 1);
+            Block column1 = reader.readBlock(1);
             assertEquals(column1.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column1.isNull(i), false);
@@ -258,7 +258,7 @@ public class TestOrcFileRewriter
             assertEquals(createVarcharType(20).getSlice(column1, 0), utf8Slice("hello"));
             assertEquals(createVarcharType(20).getSlice(column1, 1), utf8Slice("bye"));
 
-            Block column2 = reader.readBlock(arrayType, 2);
+            Block column2 = reader.readBlock(2);
             assertEquals(column2.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column2.isNull(i), false);
@@ -266,7 +266,7 @@ public class TestOrcFileRewriter
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column2, 0), arrayBlockOf(BIGINT, 1, 2)));
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column2, 1), arrayBlockOf(BIGINT, 5, 6)));
 
-            Block column3 = reader.readBlock(mapType, 3);
+            Block column3 = reader.readBlock(3);
             assertEquals(column3.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column3.isNull(i), false);
@@ -274,7 +274,7 @@ public class TestOrcFileRewriter
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, arrayType.getObject(column3, 0), mapBlockOf(createVarcharType(5), BOOLEAN, "k1", true)));
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, arrayType.getObject(column3, 1), mapBlockOf(createVarcharType(5), BOOLEAN, "k3", true)));
 
-            Block column4 = reader.readBlock(arrayOfArrayType, 4);
+            Block column4 = reader.readBlock(4);
             assertEquals(column4.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column4.isNull(i), false);
@@ -321,7 +321,7 @@ public class TestOrcFileRewriter
 
             assertEquals(reader.nextBatch(), 2);
 
-            Block column0 = reader.readBlock(BIGINT, 0);
+            Block column0 = reader.readBlock(0);
             assertEquals(column0.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column0.isNull(i), false);
@@ -329,7 +329,7 @@ public class TestOrcFileRewriter
             assertEquals(BIGINT.getLong(column0, 0), 123L);
             assertEquals(BIGINT.getLong(column0, 1), 777L);
 
-            Block column1 = reader.readBlock(createVarcharType(20), 1);
+            Block column1 = reader.readBlock(1);
             assertEquals(column1.getPositionCount(), 2);
             for (int i = 0; i < 2; i++) {
                 assertEquals(column1.isNull(i), false);
@@ -358,12 +358,12 @@ public class TestOrcFileRewriter
 
             assertEquals(reader.nextBatch(), 1);
 
-            Block column0 = reader.readBlock(BIGINT, 0);
+            Block column0 = reader.readBlock(0);
             assertEquals(column0.getPositionCount(), 1);
             assertEquals(column0.isNull(0), false);
             assertEquals(BIGINT.getLong(column0, 0), 123L);
 
-            Block column1 = reader.readBlock(createVarcharType(20), 1);
+            Block column1 = reader.readBlock(1);
             assertEquals(column1.getPositionCount(), 1);
             assertEquals(column1.isNull(0), false);
             assertEquals(createVarcharType(20).getSlice(column1, 0), utf8Slice("hello"));

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
@@ -241,13 +241,13 @@ public class TestOrcStorageManager
 
             assertEquals(reader.nextBatch(), 2);
 
-            Block column0 = reader.readBlock(BIGINT, 0);
+            Block column0 = reader.readBlock(0);
             assertEquals(column0.isNull(0), false);
             assertEquals(column0.isNull(1), false);
             assertEquals(BIGINT.getLong(column0, 0), 123L);
             assertEquals(BIGINT.getLong(column0, 1), 456L);
 
-            Block column1 = reader.readBlock(createVarcharType(10), 1);
+            Block column1 = reader.readBlock(1);
             assertEquals(createVarcharType(10).getSlice(column1, 0), utf8Slice("hello"));
             assertEquals(createVarcharType(10).getSlice(column1, 1), utf8Slice("bye"));
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardWriter.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardWriter.java
@@ -150,24 +150,24 @@ public class TestShardWriter
             assertEquals(reader.getReaderPosition(), 0);
             assertEquals(reader.getFilePosition(), reader.getFilePosition());
 
-            Block column0 = reader.readBlock(BIGINT, 0);
+            Block column0 = reader.readBlock(0);
             assertEquals(column0.isNull(0), false);
             assertEquals(column0.isNull(1), true);
             assertEquals(column0.isNull(2), false);
             assertEquals(BIGINT.getLong(column0, 0), 123L);
             assertEquals(BIGINT.getLong(column0, 2), 456L);
 
-            Block column1 = reader.readBlock(createVarcharType(10), 1);
+            Block column1 = reader.readBlock(1);
             assertEquals(createVarcharType(10).getSlice(column1, 0), utf8Slice("hello"));
             assertEquals(createVarcharType(10).getSlice(column1, 1), utf8Slice("world"));
             assertEquals(createVarcharType(10).getSlice(column1, 2), utf8Slice("bye \u2603"));
 
-            Block column2 = reader.readBlock(VARBINARY, 2);
+            Block column2 = reader.readBlock(2);
             assertEquals(VARBINARY.getSlice(column2, 0), wrappedBuffer(bytes1));
             assertEquals(column2.isNull(1), true);
             assertEquals(VARBINARY.getSlice(column2, 2), wrappedBuffer(bytes3));
 
-            Block column3 = reader.readBlock(DOUBLE, 3);
+            Block column3 = reader.readBlock(3);
             assertEquals(column3.isNull(0), false);
             assertEquals(column3.isNull(1), false);
             assertEquals(column3.isNull(2), false);
@@ -175,21 +175,21 @@ public class TestShardWriter
             assertEquals(DOUBLE.getDouble(column3, 1), Double.POSITIVE_INFINITY);
             assertEquals(DOUBLE.getDouble(column3, 2), Double.NaN);
 
-            Block column4 = reader.readBlock(BOOLEAN, 4);
+            Block column4 = reader.readBlock(4);
             assertEquals(column4.isNull(0), false);
             assertEquals(column4.isNull(1), true);
             assertEquals(column4.isNull(2), false);
             assertEquals(BOOLEAN.getBoolean(column4, 0), true);
             assertEquals(BOOLEAN.getBoolean(column4, 2), false);
 
-            Block column5 = reader.readBlock(arrayType, 5);
+            Block column5 = reader.readBlock(5);
             assertEquals(column5.getPositionCount(), 3);
 
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column5, 0), arrayBlockOf(BIGINT, 1, 2)));
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column5, 1), arrayBlockOf(BIGINT, 3, null)));
             assertTrue(arrayBlocksEqual(BIGINT, arrayType.getObject(column5, 2), arrayBlockOf(BIGINT)));
 
-            Block column6 = reader.readBlock(mapType, 6);
+            Block column6 = reader.readBlock(6);
             assertEquals(column6.getPositionCount(), 3);
 
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, arrayType.getObject(column6, 0), mapBlockOf(createVarcharType(5), BOOLEAN, "k1", true)));
@@ -198,24 +198,24 @@ public class TestShardWriter
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, object, k2));
             assertTrue(mapBlocksEqual(createVarcharType(5), BOOLEAN, arrayType.getObject(column6, 2), mapBlockOf(createVarcharType(5), BOOLEAN, "k3", false)));
 
-            Block column7 = reader.readBlock(arrayOfArrayType, 7);
+            Block column7 = reader.readBlock(7);
             assertEquals(column7.getPositionCount(), 3);
 
             assertTrue(arrayBlocksEqual(arrayType, arrayOfArrayType.getObject(column7, 0), arrayBlockOf(arrayType, arrayBlockOf(BIGINT, 5))));
             assertTrue(arrayBlocksEqual(arrayType, arrayOfArrayType.getObject(column7, 1), arrayBlockOf(arrayType, null, arrayBlockOf(BIGINT, 6, 7))));
             assertTrue(arrayBlocksEqual(arrayType, arrayOfArrayType.getObject(column7, 2), arrayBlockOf(arrayType, arrayBlockOf(BIGINT))));
 
-            Block column8 = reader.readBlock(TIMESTAMP, 8);
+            Block column8 = reader.readBlock(8);
             assertEquals(TIMESTAMP.getLong(column8, 0), timestampValue);
             assertEquals(TIMESTAMP.getLong(column8, 1), timestampValue);
             assertEquals(TIMESTAMP.getLong(column8, 2), timestampValue);
 
-            Block column9 = reader.readBlock(TIME, 9);
+            Block column9 = reader.readBlock(9);
             assertEquals(TIME.getLong(column9, 0), timeValue);
             assertEquals(TIME.getLong(column9, 1), timeValue);
             assertEquals(TIME.getLong(column9, 2), timeValue);
 
-            Block column10 = reader.readBlock(DATE, 10);
+            Block column10 = reader.readBlock(10);
             assertEquals(DATE.getLong(column10, 0), dateValue);
             assertEquals(DATE.getLong(column10, 1), dateValue);
             assertEquals(DATE.getLong(column10, 2), dateValue);


### PR DESCRIPTION
This is a test PR for the CLA enforcement

Pass SQL type to ORC stream reader constructor and use that instead
of passing to each readBlock call.

Cherry-pick of https://github.com/prestosql/presto/pull/555

The difference from the original commit include:
1) Removed systemMemoryContext because the BatchStreamReaders don't
have local arrays;
2) Other Nits changes

Co-authored-by: Dain Sundstrom <dain@iq80.com>

```
== NO RELEASE NOTE ==
```
