### PR TITLE
Replace Joda-Time libraries with java.time

### DIFF
--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -242,17 +242,6 @@
         </dependency>
 
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
         </dependency>

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/Row.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/Row.java
@@ -22,13 +22,14 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang.StringUtils;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -55,9 +56,9 @@ import static java.util.Objects.requireNonNull;
 
 public class Row
 {
-    private static final DateTimeFormatter DATE_PARSER = ISODateTimeFormat.date();
-    private static final DateTimeFormatter TIME_PARSER = DateTimeFormat.forPattern("HH:mm:ss");
-    private static final DateTimeFormatter TIMESTAMP_PARSER = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS");
+    private static final DateTimeFormatter DATE_PARSER = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final DateTimeFormatter TIME_PARSER = DateTimeFormatter.ISO_LOCAL_TIME;
+    private static final DateTimeFormatter TIMESTAMP_PARSER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
 
     private final List<Field> fields = new ArrayList<>();
 
@@ -201,7 +202,7 @@ public class Row
             return Boolean.parseBoolean(str);
         }
         else if (type.equals(DATE)) {
-            return new Date(DATE_PARSER.parseDateTime(str).getMillis());
+            return Date.valueOf(LocalDate.parse(str, DATE_PARSER));
         }
         else if (type.equals(DOUBLE)) {
             return Double.parseDouble(str);
@@ -216,10 +217,10 @@ public class Row
             return Short.parseShort(str);
         }
         else if (type.equals(TIME)) {
-            return new Time(TIME_PARSER.parseDateTime(str).getMillis());
+            return Time.valueOf(LocalTime.parse(str, TIME_PARSER));
         }
         else if (type.equals(TIMESTAMP)) {
-            return new Timestamp(TIMESTAMP_PARSER.parseDateTime(str).getMillis());
+            return Timestamp.valueOf(LocalDateTime.parse(str, TIMESTAMP_PARSER));
         }
         else if (type.equals(TINYINT)) {
             return Byte.valueOf(str);

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/model/TestRow.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/model/TestRow.java
@@ -108,7 +108,7 @@ public class TestRow
         schema.addColumn("m", Optional.of("m"), Optional.of("m"), VARCHAR);
         schema.addColumn("n", Optional.of("n"), Optional.of("n"), VARCHAR);
 
-        Row actual = Row.fromString(schema, "a,b,c|true|1999-01-01|123.45678|123.45678|12345678|12345678|12345|12:30:00|1999-01-01 12:30:00.0|123|O'Leary|O'Leary|", '|');
+        Row actual = Row.fromString(schema, "a,b,c|true|1999-01-01|123.45678|123.45678|12345678|12345678|12345|12:30:00|1999-01-01 12:30:00.000|123|O'Leary|O'Leary|", '|');
         assertEquals(actual, expected);
     }
 }

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/serializers/AbstractTestAccumuloRowSerializer.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/serializers/AbstractTestAccumuloRowSerializer.java
@@ -27,13 +27,13 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
 import java.util.Map;
@@ -108,7 +108,7 @@ public abstract class AbstractTestAccumuloRowSerializer
     public void testDate()
             throws Exception
     {
-        Date expected = new Date(new DateTime(2001, 2, 3, 4, 5, 6, DateTimeZone.UTC).getMillis());
+        Date expected = new Date(ZonedDateTime.of(2001, 2, 3, 4, 5, 6, 0, ZoneId.of("UTC")).toEpochSecond());
         AccumuloRowSerializer serializer = serializerClass.getConstructor().newInstance();
         byte[] data = serializer.encode(DATE, expected);
 


### PR DESCRIPTION
Since Java 8 we have java.time packages which are equivalent to Joda and
the recommendation from the author of the Joda-Time is to migrate to
java.time(JSR-310) library.

```
== NO RELEASE NOTE ==
```