### PR TITLE
Allow range filters on columns with coercions

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import static com.facebook.presto.hive.HiveBucketing.getHiveBucket;
-import static com.facebook.presto.hive.HiveCoercers.createCoercer;
+import static com.facebook.presto.hive.HiveCoercer.createCoercer;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_BUCKET_FILES;
 import static com.facebook.presto.hive.HivePageSourceProvider.ColumnMappingKind.PREFILLED;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -26,7 +26,6 @@ import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordPageSource;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.Subfield;
-import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
@@ -49,7 +48,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.Set;
-import java.util.function.Function;
 
 import static com.facebook.presto.hive.HiveCoercer.createCoercer;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
@@ -191,7 +189,7 @@ public class HivePageSourceProvider
                 .filter(mapping -> mapping.getKind() == ColumnMappingKind.PREFILLED)
                 .collect(toImmutableMap(mapping -> mapping.getHiveColumnHandle().getHiveColumnIndex(), ColumnMapping::getPrefilledValue));
 
-        Map<Integer, Function<Block, Block>> coercers = columnMappings.stream()
+        Map<Integer, HiveCoercer> coercers = columnMappings.stream()
                 .filter(mapping -> mapping.getCoercionFrom().isPresent())
                 .collect(toImmutableMap(
                         mapping -> mapping.getHiveColumnHandle().getHiveColumnIndex(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -178,7 +178,7 @@ public class HivePageSourceProvider
                 split.getPartitionKeys(),
                 allColumns,
                 ImmutableList.of(),
-                split.getPartitionSchemaDifference(), // TODO Include predicateColumns
+                split.getPartitionSchemaDifference(),
                 path,
                 split.getTableBucketNumber());
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -51,7 +51,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
 
-import static com.facebook.presto.hive.HiveCoercers.createCoercer;
+import static com.facebook.presto.hive.HiveCoercer.createCoercer;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSelectivePageSourceFactory.java
@@ -17,7 +17,6 @@ import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Subfield;
-import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.relation.RowExpression;
 import org.apache.hadoop.conf.Configuration;
@@ -27,7 +26,6 @@ import org.joda.time.DateTimeZone;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 
 public interface HiveSelectivePageSourceFactory
 {
@@ -41,7 +39,7 @@ public interface HiveSelectivePageSourceFactory
             Storage storage,
             List<HiveColumnHandle> columns,
             Map<Integer, String> prefilledValues,           // key is hiveColumnIndex
-            Map<Integer, Function<Block, Block>> coercers,  // key is hiveColumnIndex
+            Map<Integer, HiveCoercer> coercers,             // key is hiveColumnIndex
             List<Integer> outputColumns,                    // element is hiveColumnIndex
             TupleDomain<Subfield> domainPredicate,
             RowExpression remainingPredicate,               // refers to columns by name; already optimized

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfSelectivePageSourceFactory.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.FileFormatDataSourceStats;
 import com.facebook.presto.hive.FileOpener;
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveCoercer;
 import com.facebook.presto.hive.HiveColumnHandle;
 import com.facebook.presto.hive.HiveSelectivePageSourceFactory;
 import com.facebook.presto.hive.metastore.Storage;
@@ -27,7 +28,6 @@ import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.Subfield;
-import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -42,7 +42,6 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory.createOrcPageSource;
@@ -96,7 +95,7 @@ public class DwrfSelectivePageSourceFactory
             Storage storage,
             List<HiveColumnHandle> columns,
             Map<Integer, String> prefilledValues,
-            Map<Integer, Function<Block, Block>> coercers,
+            Map<Integer, HiveCoercer> coercers,
             List<Integer> outputColumns,
             TupleDomain<Subfield> domainPredicate,
             RowExpression remainingPredicate,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -233,6 +233,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.TRANSACTION_CONFLICT;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
+import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
 import static com.facebook.presto.spi.security.PrincipalType.USER;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
@@ -752,26 +753,26 @@ public abstract class AbstractTestHiveClient
                         false,
                         "layout"),
                 Optional.empty(),
-                TupleDomain.withColumnDomains(ImmutableMap.of(
+                withColumnDomains(ImmutableMap.of(
                         dsColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("2012-12-29"))), false),
                         fileFormatColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("textfile")), Range.equal(createUnboundedVarcharType(), utf8Slice("sequencefile")), Range.equal(createUnboundedVarcharType(), utf8Slice("rctext")), Range.equal(createUnboundedVarcharType(), utf8Slice("rcbinary"))), false),
                         dummyColumn, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 1L), Range.equal(INTEGER, 2L), Range.equal(INTEGER, 3L), Range.equal(INTEGER, 4L)), false))),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(new DiscretePredicates(ImmutableList.copyOf(partitionColumns), ImmutableList.of(
-                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                        withColumnDomains(ImmutableMap.of(
                                 dsColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("2012-12-29"))), false),
                                 fileFormatColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("textfile"))), false),
                                 dummyColumn, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 1L)), false))),
-                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                        withColumnDomains(ImmutableMap.of(
                                 dsColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("2012-12-29"))), false),
                                 fileFormatColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("sequencefile"))), false),
                                 dummyColumn, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 2L)), false))),
-                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                        withColumnDomains(ImmutableMap.of(
                                 dsColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("2012-12-29"))), false),
                                 fileFormatColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("rctext"))), false),
                                 dummyColumn, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 3L)), false))),
-                        TupleDomain.withColumnDomains(ImmutableMap.of(
+                        withColumnDomains(ImmutableMap.of(
                                 dsColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("2012-12-29"))), false),
                                 fileFormatColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("rcbinary"))), false),
                                 dummyColumn, Domain.create(ValueSet.ofRanges(Range.equal(INTEGER, 4L)), false)))))),
@@ -1160,7 +1161,7 @@ public abstract class AbstractTestHiveClient
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
             ConnectorTableHandle tableHandle = getTableHandle(metadata, tablePartitionFormat);
-            ConnectorTableLayout actuaTableLayout = getTableLayout(newSession(), metadata, tableHandle, new Constraint<>(TupleDomain.withColumnDomains(ImmutableMap.of(intColumn, Domain.singleValue(BIGINT, 5L)))));
+            ConnectorTableLayout actuaTableLayout = getTableLayout(newSession(), metadata, tableHandle, new Constraint<>(withColumnDomains(ImmutableMap.of(intColumn, Domain.singleValue(BIGINT, 5L)))));
             assertExpectedTableLayout(actuaTableLayout, tableLayout);
         }
     }
@@ -1601,7 +1602,7 @@ public abstract class AbstractTestHiveClient
             assertNotNull(dsColumn);
 
             Domain domain = Domain.singleValue(createUnboundedVarcharType(), utf8Slice("2012-12-30"));
-            TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(dsColumn, domain));
+            TupleDomain<ColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(dsColumn, domain));
             ConnectorTableLayout tableLayout = getTableLayout(session, metadata, tableHandle, new Constraint<>(tupleDomain));
             try {
                 getSplitCount(splitManager.getSplits(transaction.getTransactionHandle(), session, tableLayout.getHandle(), SPLIT_SCHEDULING_CONTEXT));
@@ -1624,7 +1625,7 @@ public abstract class AbstractTestHiveClient
             assertNotNull(dsColumn);
 
             Domain domain = Domain.singleValue(createUnboundedVarcharType(), utf8Slice("2012-12-30"));
-            TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(dsColumn, domain));
+            TupleDomain<ColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(dsColumn, domain));
             ConnectorTableLayout tableLayout = getTableLayout(session, metadata, tableHandle, new Constraint<>(tupleDomain));
             getSplitCount(splitManager.getSplits(transaction.getTransactionHandle(), session, tableLayout.getHandle(), SPLIT_SCHEDULING_CONTEXT));
         }
@@ -2229,7 +2230,7 @@ public abstract class AbstractTestHiveClient
             ColumnHandle column = metadata.getColumnHandles(session, table).get("t_boolean");
             assertNotNull(column);
 
-            ConnectorTableLayoutHandle layoutHandle = getTableLayout(session, metadata, table, new Constraint<>(TupleDomain.withColumnDomains(ImmutableMap.of(intColumn, Domain.singleValue(BIGINT, 5L))))).getHandle();
+            ConnectorTableLayoutHandle layoutHandle = getTableLayout(session, metadata, table, new Constraint<>(withColumnDomains(ImmutableMap.of(intColumn, Domain.singleValue(BIGINT, 5L))))).getHandle();
             assertEquals(getAllPartitions(layoutHandle).size(), 1);
             assertEquals(getPartitionId(getAllPartitions(layoutHandle).get(0)), "t_boolean=0");
 
@@ -4304,7 +4305,7 @@ public abstract class AbstractTestHiveClient
 
             // delete ds=2015-07-01 and 2015-07-02
             session = newSession();
-            TupleDomain<ColumnHandle> tupleDomain2 = TupleDomain.withColumnDomains(
+            TupleDomain<ColumnHandle> tupleDomain2 = withColumnDomains(
                     ImmutableMap.of(dsColumnHandle, Domain.create(ValueSet.ofRanges(Range.range(createUnboundedVarcharType(), utf8Slice("2015-07-01"), true, utf8Slice("2015-07-02"), true)), false)));
             Constraint<ColumnHandle> constraint2 = new Constraint<>(tupleDomain2, convertToPredicate(tupleDomain2));
             ConnectorTableLayoutHandle tableLayoutHandle2 = getTableLayout(session, metadata, tableHandle, constraint2).getHandle();
@@ -5101,7 +5102,7 @@ public abstract class AbstractTestHiveClient
                 // Query 1: delete
                 session = newSession();
                 HiveColumnHandle dsColumnHandle = (HiveColumnHandle) metadata.getColumnHandles(session, tableHandle).get("pk2");
-                TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                TupleDomain<ColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(
                         dsColumnHandle, domainToDrop));
                 Constraint<ColumnHandle> constraint = new Constraint<>(tupleDomain, convertToPredicate(tupleDomain));
                 ConnectorTableLayoutHandle tableLayoutHandle = getTableLayout(session, metadata, tableHandle, constraint).getHandle();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1321,12 +1321,25 @@ public abstract class AbstractTestHiveClient
                 RowExpression predicate = ROW_EXPRESSION_SERVICE.getDomainTranslator().toPredicate(tupleDomain.transform(AbstractTestHiveClient::toVariable));
                 ConnectorTableLayoutHandle layoutHandle = metadata.pushdownFilter(session, tableHandle, predicate, Optional.empty()).getLayout().getHandle();
 
+                // Read all columns with a filter
                 MaterializedResult filteredResult = readTable(transaction, tableHandle, layoutHandle, columnHandles, session, OptionalInt.empty(), Optional.empty());
 
                 Predicate<MaterializedRow> rowPredicate = afterResultPredicates.get(i);
                 List<MaterializedRow> expectedRows = dataAfter.getMaterializedRows().stream().filter(rowPredicate::apply).collect(toList());
 
                 assertEqualsIgnoreOrder(filteredResult.getMaterializedRows(), expectedRows);
+
+                // Read all columns except the ones used in the filter
+                Set<String> filterColumnNames = tupleDomain.getDomains().get().keySet().stream()
+                        .map(ColumnMetadata::getName)
+                        .collect(toImmutableSet());
+
+                List<ColumnHandle> nonFilterColumns = columnHandles.stream()
+                        .filter(column -> !filterColumnNames.contains(((HiveColumnHandle) column).getName()))
+                        .collect(toList());
+
+                int resultCount = readTable(transaction, tableHandle, layoutHandle, nonFilterColumns, session, OptionalInt.empty(), Optional.empty()).getRowCount();
+                assertEquals(resultCount, expectedRows.size());
             }
 
             transaction.commit();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestCoercingFilters.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestCoercingFilters.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.HiveCoercer.IntegerNumberToVarcharCoercer;
+import com.facebook.presto.hive.HiveCoercer.VarcharToIntegerNumberCoercer;
+import com.facebook.presto.orc.TupleDomainFilter;
+import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
+import com.facebook.presto.orc.TupleDomainFilter.BytesRange;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestCoercingFilters
+{
+    @Test
+    public void testIntegerToVarchar()
+    {
+        TupleDomainFilter filter = BytesRange.of("10".getBytes(), false, "10".getBytes(), false, false);
+
+        HiveCoercer coercer = new IntegerNumberToVarcharCoercer(INTEGER, VARCHAR);
+
+        TupleDomainFilter coercingFilter = coercer.toCoercingFilter(filter);
+
+        assertTrue(coercingFilter.testLong(10));
+        assertFalse(coercingFilter.testLong(25));
+        assertFalse(coercingFilter.testNull());
+    }
+
+    @Test
+    public void testVarcharToInteger()
+    {
+        TupleDomainFilter filter = BigintRange.of(100, Integer.MAX_VALUE, false);
+
+        HiveCoercer coercer = new VarcharToIntegerNumberCoercer(VARCHAR, INTEGER);
+
+        TupleDomainFilter coercingFilter = coercer.toCoercingFilter(filter);
+
+        assertTrue(coercingFilter.testLength(1));
+        assertTrue(coercingFilter.testLength(2));
+        assertTrue(coercingFilter.testLength(3));
+
+        assertTrue(coercingFilter.testBytes("100".getBytes(), 0, 3));
+        assertTrue(coercingFilter.testBytes("145".getBytes(), 0, 3));
+        assertTrue(coercingFilter.testBytes("2147483647".getBytes(), 0, 10));
+
+        assertFalse(coercingFilter.testBytes("50".getBytes(), 0, 2));
+        assertFalse(coercingFilter.testBytes("-50".getBytes(), 0, 3));
+
+        // parsing error
+        assertFalse(coercingFilter.testBytes("abc".getBytes(), 0, 3));
+
+        // out of range
+        assertFalse(coercingFilter.testBytes("2147483648".getBytes(), 0, 10));
+
+        assertFalse(coercingFilter.testNull());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
@@ -419,6 +419,9 @@ public class MaterializedResult
             if (outputPage == null) {
                 break;
             }
+            if (outputPage.getPositionCount() == 0) {
+                continue;
+            }
             builder.page(outputPage);
         }
         return builder.build();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -180,7 +180,6 @@ public class OrcSelectiveRecordReader
         requireNonNull(coercers, "coercers is null");
         this.coercers = new Function[this.hiveColumnIndices.length];
         for (Map.Entry<Integer, Function<Block, Block>> entry : coercers.entrySet()) {
-            checkArgument(!filters.containsKey(entry.getKey()), "Coercions for columns with range filters are not supported yet");
             this.coercers[zeroBasedIndices.get(entry.getKey())] = entry.getValue();
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
@@ -97,7 +97,7 @@ public interface TupleDomainFilter
         protected final boolean nullAllowed;
         private final boolean deterministic;
 
-        private AbstractTupleDomainFilter(boolean deterministic, boolean nullAllowed)
+        protected AbstractTupleDomainFilter(boolean deterministic, boolean nullAllowed)
         {
             this.nullAllowed = nullAllowed;
             this.deterministic = deterministic;


### PR DESCRIPTION
Coercion is now supported for columns with any type of filter and regardless of whether column is filter-only or is being projected out.

```
== NO RELEASE NOTE ==
```
