### PR TITLE
 Fix the size of all-null blocks returned from selective readers

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractDecimalSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractDecimalSelectiveStreamReader.java
@@ -249,7 +249,7 @@ public abstract class AbstractDecimalSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return new RunLengthEncodedBlock(nullBlock, outputPositionCount);
+            return new RunLengthEncodedBlock(nullBlock, positionCount);
         }
 
         boolean includeNulls = nullsAllowed && presentStream != null;
@@ -282,7 +282,7 @@ public abstract class AbstractDecimalSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return newLease(new RunLengthEncodedBlock(nullBlock, outputPositionCount));
+            return newLease(new RunLengthEncodedBlock(nullBlock, positionCount));
         }
 
         boolean includeNulls = nullsAllowed && presentStream != null;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
@@ -334,7 +334,7 @@ public class BooleanSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return new RunLengthEncodedBlock(NULL_BLOCK, outputPositionCount);
+            return new RunLengthEncodedBlock(NULL_BLOCK, positionCount);
         }
 
         boolean includeNulls = nullsAllowed && presentStream != null;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
@@ -319,7 +319,7 @@ public class ByteSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return new RunLengthEncodedBlock(NULL_BLOCK, outputPositionCount);
+            return new RunLengthEncodedBlock(NULL_BLOCK, positionCount);
         }
 
         boolean includeNulls = nullsAllowed && presentStream != null;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleSelectiveStreamReader.java
@@ -337,7 +337,7 @@ public class DoubleSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return new RunLengthEncodedBlock(NULL_BLOCK, outputPositionCount);
+            return new RunLengthEncodedBlock(NULL_BLOCK, positionCount);
         }
 
         boolean includeNulls = nullsAllowed && presentStream != null;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatSelectiveStreamReader.java
@@ -312,7 +312,7 @@ public class FloatSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return new RunLengthEncodedBlock(NULL_BLOCK, outputPositionCount);
+            return new RunLengthEncodedBlock(NULL_BLOCK, positionCount);
         }
 
         boolean includeNulls = nullsAllowed && presentStream != null;
@@ -363,7 +363,7 @@ public class FloatSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return newLease(new RunLengthEncodedBlock(NULL_BLOCK, outputPositionCount));
+            return newLease(new RunLengthEncodedBlock(NULL_BLOCK, positionCount));
         }
 
         boolean includeNulls = nullsAllowed && presentStream != null;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
@@ -509,7 +509,7 @@ public class ListSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), outputPositionCount);
+            return new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), positionCount);
         }
 
         boolean mayHaveNulls = nullsAllowed && presentStream != null;
@@ -577,7 +577,7 @@ public class ListSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return newLease(new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), outputPositionCount));
+            return newLease(new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), positionCount));
         }
 
         boolean includeNulls = nullsAllowed && presentStream != null;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
@@ -231,7 +231,7 @@ public class LongDirectSelectiveStreamReader
         checkState(positionCount <= outputPositionCount, "Not enough values");
 
         if (allNulls) {
-            return new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), outputPositionCount);
+            return new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), positionCount);
         }
 
         return buildOutputBlock(positions, positionCount, nullsAllowed && presentStream != null);
@@ -245,7 +245,7 @@ public class LongDirectSelectiveStreamReader
         checkState(positionCount <= outputPositionCount, "Not enough values");
 
         if (allNulls) {
-            return newLease(new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), outputPositionCount));
+            return newLease(new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), positionCount));
         }
 
         return buildOutputBlockView(positions, positionCount, nullsAllowed && presentStream != null);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
@@ -511,7 +511,7 @@ public class MapFlatSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return newLease(createNullBlock(outputType, outputPositionCount));
+            return newLease(createNullBlock(outputType, positionCount));
         }
 
         boolean includeNulls = nullsAllowed && presentStream != null;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
@@ -364,7 +364,7 @@ public class SliceDictionarySelectiveReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), outputPositionCount);
+            return new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), positionCount);
         }
 
         if (positionCount == outputPositionCount) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
@@ -348,7 +348,7 @@ public class SliceDirectSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), outputPositionCount);
+            return new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), positionCount);
         }
 
         boolean includeNulls = nullsAllowed && presentStream != null;
@@ -406,7 +406,7 @@ public class SliceDirectSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return newLease(new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), outputPositionCount));
+            return newLease(new RunLengthEncodedBlock(outputType.createBlockBuilder(null, 1).appendNull().build(), positionCount));
         }
         boolean includeNulls = nullsAllowed && presentStream != null;
         if (positionCount != outputPositionCount) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
@@ -335,7 +335,7 @@ public class TimestampSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return new RunLengthEncodedBlock(NULL_BLOCK, outputPositionCount);
+            return new RunLengthEncodedBlock(NULL_BLOCK, positionCount);
         }
 
         boolean includeNulls = nullsAllowed && presentStream != null;
@@ -386,7 +386,7 @@ public class TimestampSelectiveStreamReader
         checkState(!valuesInUse, "BlockLease hasn't been closed yet");
 
         if (allNulls) {
-            return newLease(new RunLengthEncodedBlock(NULL_BLOCK, outputPositionCount));
+            return newLease(new RunLengthEncodedBlock(NULL_BLOCK, positionCount));
         }
 
         boolean includeNulls = nullsAllowed && presentStream != null;


### PR DESCRIPTION
When all data in a column is null, `SelectiveStreamReader.getBlock()` may return a block with more positions when requested. If this column happens to be inside of a struct and there are other non-null columns, RowBlock constructor will throw an exception: `IllegalArgumentException: length of field blocks differ`

```
@Test
public void testAllNulls()
{
    getQueryRunner().execute("CREATE TABLE test_all_nulls AS SELECT orderkey, cast(row(null, 1) AS ROW(null_boolean BOOLEAN, a INTEGER)) as struct FROM orders");

    try {
        assertQuery("SELECT * FROM test_all_nulls WHERE struct IS NOT NULL AND orderkey % 2 = 0", "SELECT orderkey, (null, 1) FROM orders WHERE orderkey % 2 = 0");
    }
    finally {
        getQueryRunner().execute("DROP TABLE test_all_nulls");
    }
}
```

This test fails with an exception in RowBlock: “length of field blocks differ”
 
```
Caused by: java.lang.IllegalArgumentException: length of field blocks differ: field 0: 2, block 1: 1
         at com.facebook.presto.spi.block.RowBlock.validateConstructorArguments(RowBlock.java:93)
         at com.facebook.presto.spi.block.RowBlock.fromFieldBlocks(RowBlock.java:52)
         at com.facebook.presto.orc.reader.StructSelectiveStreamReader.getBlock(StructSelectiveStreamReader.java:427)
         at com.facebook.presto.orc.OrcSelectiveRecordReader.getNextPage(OrcSelectiveRecordReader.java:393)
         at com.facebook.presto.hive.orc.OrcSelectivePageSource.getNextPage(OrcSelectivePageSource.java:84)
         ... 12 more
```

```
== NO RELEASE NOTE ==
```
