### PR TITLE
Fix subfield pruning for legacy unnest

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -506,6 +506,17 @@ public class TestHiveLogicalPlanner
         assertPushdownSubfields("SELECT id, x.a FROM test_pushdown_struct_subfields CROSS JOIN UNNEST(y) as t(a, b, c, d)", "test_pushdown_struct_subfields",
                 ImmutableMap.of("x", toSubfields("x.a")));
 
+        // Legacy unnest
+        Session legacyUnnest = Session.builder(getSession()).setSystemProperty("legacy_unnest", "true").build();
+        assertPushdownSubfields(legacyUnnest, "SELECT t.y.a, t.y.d.d1, x.a FROM test_pushdown_struct_subfields CROSS JOIN UNNEST(y) as t(y)", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a"), "y", toSubfields("y[*].a", "y[*].d.d1")));
+
+        assertPushdownSubfields(legacyUnnest, "SELECT t.*, x.a FROM test_pushdown_struct_subfields CROSS JOIN UNNEST(y) as t(y)", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a")));
+
+        assertPushdownSubfields(legacyUnnest, "SELECT id, x.a FROM test_pushdown_struct_subfields CROSS JOIN UNNEST(y) as t(y)", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a")));
+
         assertUpdate("DROP TABLE test_pushdown_struct_subfields");
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -124,6 +124,17 @@ public class TestHivePushdownFilterQueries
     }
 
     @Test
+    public void testLegacyUnnest()
+    {
+        Session legacyUnnest = Session.builder(getSession()).setSystemProperty("legacy_unnest", "true").build();
+
+        assertQuery(legacyUnnest, "SELECT orderkey, date.day FROM lineitem_ex CROSS JOIN UNNEST(dates) t(date)",
+                "SELECT orderkey, day(shipdate) FROM lineitem WHERE orderkey % 31 <> 0 UNION ALL " +
+                "SELECT orderkey, day(commitdate) FROM lineitem WHERE orderkey % 31 <> 0 UNION ALL " +
+                "SELECT orderkey, day(receiptdate) FROM lineitem WHERE orderkey % 31 <> 0");
+    }
+
+    @Test
     public void testPushdownWithDisjointFilters()
     {
         assertQueryUsingH2Cte("SELECT * FROM lineitem_ex where orderkey = 1 and orderkey = 2");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -75,6 +75,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.SystemSessionProperties.isLegacyUnnest;
 import static com.facebook.presto.SystemSessionProperties.isPushdownSubfieldsEnabled;
 import static com.facebook.presto.spi.Subfield.allSubscripts;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -361,7 +362,7 @@ public class PushdownSubfields
                 VariableReferenceExpression container = entry.getKey();
                 boolean found = false;
 
-                if (isRowType(container)) {
+                if (isRowType(container) && !isLegacyUnnest(session)) {
                     for (VariableReferenceExpression field : entry.getValue()) {
                         if (context.get().variables.contains(field)) {
                             found = true;


### PR DESCRIPTION
With `legacy_unnest=true` we used to generate subfield paths with extra `.field`, e.g. `array_of_structs[*].field.linenumber` instead of `array_of_structs[*].linenumber`. These paths would cause struct reader to prune *all* the fields and return null.

```
== NO RELEASE NOTE ==
```
