### PR TITLE
Fix getTableStatistics with subfield pruning

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -662,10 +662,7 @@ public class HiveMetadata
         List<HivePartition> partitions = partitionManager.getPartitions(metastore, tableHandle, combinedConstraint, session).getPartitions();
         TableStatistics tableStatistics = hiveStatisticsProvider.getTableStatistics(session, ((HiveTableHandle) tableHandle).getSchemaTableName(), columns, columnTypesByName, partitions);
 
-        Map<ColumnHandle, Type> columnTypes = columns.entrySet().stream()
-                .collect(toImmutableMap(Map.Entry::getValue, entry -> columnTypesByName.get(entry.getKey())));
-
-        return filterStatsCalculatorService.filterStats(tableStatistics, combinedPredicate, session, ImmutableBiMap.copyOf(columns).inverse(), columnTypes);
+        return filterStatsCalculatorService.filterStats(tableStatistics, combinedPredicate, session, ImmutableBiMap.copyOf(columns).inverse(), columnTypesByName);
     }
 
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)

--- a/presto-main/src/main/java/com/facebook/presto/cost/ConnectorFilterStatsCalculatorService.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ConnectorFilterStatsCalculatorService.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableBiMap;
 
 import java.util.Map;
 
+import static com.facebook.presto.cost.FilterStatsCalculator.UNKNOWN_FILTER_COEFFICIENT;
 import static com.facebook.presto.cost.StatsUtil.toVariableStatsEstimate;
 import static java.util.Objects.requireNonNull;
 
@@ -52,6 +53,11 @@ public class ConnectorFilterStatsCalculatorService
     {
         PlanNodeStatsEstimate tableStats = toPlanNodeStats(tableStatistics, columnNames, columnTypes);
         PlanNodeStatsEstimate filteredStats = filterStatsCalculator.filterStats(tableStats, predicate, session);
+
+        if (filteredStats.isOutputRowCountUnknown()) {
+            filteredStats = tableStats.mapOutputRowCount(sourceRowCount -> tableStats.getOutputRowCount() * UNKNOWN_FILTER_COEFFICIENT);
+        }
+
         return toTableStatistics(filteredStats, ImmutableBiMap.copyOf(columnNames).inverse());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/cost/ConnectorFilterStatsCalculatorService.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ConnectorFilterStatsCalculatorService.java
@@ -48,7 +48,7 @@ public class ConnectorFilterStatsCalculatorService
             RowExpression predicate,
             ConnectorSession session,
             Map<ColumnHandle, String> columnNames,
-            Map<ColumnHandle, Type> columnTypes)
+            Map<String, Type> columnTypes)
     {
         PlanNodeStatsEstimate tableStats = toPlanNodeStats(tableStatistics, columnNames, columnTypes);
         PlanNodeStatsEstimate filteredStats = filterStatsCalculator.filterStats(tableStats, predicate, session);
@@ -58,15 +58,15 @@ public class ConnectorFilterStatsCalculatorService
     private static PlanNodeStatsEstimate toPlanNodeStats(
             TableStatistics tableStatistics,
             Map<ColumnHandle, String> columnNames,
-            Map<ColumnHandle, Type> columnTypes)
+            Map<String, Type> columnTypes)
     {
         PlanNodeStatsEstimate.Builder builder = PlanNodeStatsEstimate.builder()
                 .setOutputRowCount(tableStatistics.getRowCount().getValue());
 
         for (Map.Entry<ColumnHandle, ColumnStatistics> entry : tableStatistics.getColumnStatistics().entrySet()) {
             String columnName = columnNames.get(entry.getKey());
-            Type type = columnTypes.get(entry.getKey());
-            builder.addVariableStatistics(new VariableReferenceExpression(columnName, type), toVariableStatsEstimate(tableStatistics, entry.getValue()));
+            VariableReferenceExpression variable = new VariableReferenceExpression(columnName, columnTypes.get(columnName));
+            builder.addVariableStatistics(variable, toVariableStatsEstimate(tableStatistics, entry.getValue()));
         }
         return builder.build();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/FilterStatsCalculatorService.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/FilterStatsCalculatorService.java
@@ -27,5 +27,16 @@ import java.util.Map;
  */
 public interface FilterStatsCalculatorService
 {
-    TableStatistics filterStats(TableStatistics tableStatistics, RowExpression predicate, ConnectorSession session, Map<ColumnHandle, String> columnNames, Map<ColumnHandle, Type> columnTypes);
+    /**
+     * @param tableStatistics Table-level and column-level statistics. Columns are identified using ColumnHandles.
+     * @param predicate Filter expression referring to columns by name
+     * @param columnNames Mapping from ColumnHandles used in tableStatistics to column names used in the predicate
+     * @param columnTypes Mapping from column names used in the predicate to column types
+     */
+    TableStatistics filterStats(
+            TableStatistics tableStatistics,
+            RowExpression predicate,
+            ConnectorSession session,
+            Map<ColumnHandle, String> columnNames,
+            Map<String, Type> columnTypes);
 }


### PR DESCRIPTION
Fix `java.lang.IllegalArgumentException: Multiple entries with same key` error in `getTableStatistics` when a complex-type column is used in a filter and is being projected out of scan using only a subset of subfields.

```
== NO RELEASE NOTE ==
```
