### PR TITLE
Enable testGroupByKeyPredicatePushdown with filter pushdown

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownDistributedQueries.java
@@ -46,12 +46,6 @@ public class TestHivePushdownDistributedQueries
         // Hive connector currently does not support row-by-row delete
     }
 
-    // TODO Enable this test after the fix in HivePartitionManager enforcedConstraint with empty Partition columns
-    @Override
-    public void testGroupByKeyPredicatePushdown()
-    {
-    }
-
     @Test
     public void testExplainOfCreateTableAs()
     {


### PR DESCRIPTION
The fix for the underlying issue was added in #13675

```
== NO RELEASE NOTE ==
```
