### PR TITLE
[WIP] Added a way to respond only after query is finished on createQuery

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -47,6 +47,7 @@ public final class PrestoHeaders
     public static final String PRESTO_PAGE_TOKEN = "X-Presto-Page-Sequence-Id";
     public static final String PRESTO_PAGE_NEXT_TOKEN = "X-Presto-Page-End-Sequence-Id";
     public static final String PRESTO_BUFFER_COMPLETE = "X-Presto-Buffer-Complete";
+    public static final String PRESTO_WAIT_FOR_ENTIRE_RESPONSE_MS = "X-Presto-Wait-For-Entire-Response-Ms";
 
     private PrestoHeaders() {}
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -207,6 +207,12 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
+    public ListenableFuture<Optional<QueryInfo>> getFinalQueryInfoChange(Optional<QueryInfo> currentQueryInfo)
+    {
+        return stateMachine.getFinalQueryInfoChange(currentQueryInfo);
+    }
+
+    @Override
     public void addStateChangeListener(StateChangeListener<QueryState> stateChangeListener)
     {
         stateMachine.addStateChangeListener(stateChangeListener);

--- a/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/FailedQueryExecution.java
@@ -176,6 +176,12 @@ public class FailedQueryExecution
     }
 
     @Override
+    public ListenableFuture<Optional<QueryInfo>> getFinalQueryInfoChange(Optional<QueryInfo> currentQueryInfo)
+    {
+        return immediateFuture(Optional.of(queryInfo));
+    }
+
+    @Override
     public void addStateChangeListener(StateChangeListener<QueryState> stateChangeListener)
     {
         executor.execute(() -> stateChangeListener.stateChanged(FAILED));

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -42,6 +42,8 @@ public interface QueryExecution
 
     ListenableFuture<QueryState> getStateChange(QueryState currentState);
 
+    ListenableFuture<Optional<QueryInfo>> getFinalQueryInfoChange(Optional<QueryInfo> currentInfo);
+
     void addOutputInfoListener(Consumer<QueryOutputInfo> listener);
 
     Plan getQueryPlan();

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManager.java
@@ -22,6 +22,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 public interface QueryManager
@@ -53,6 +54,13 @@ public interface QueryManager
      * the future will contain a {@link NoSuchElementException}
      */
     ListenableFuture<QueryState> getStateChange(QueryId queryId, QueryState currentState);
+
+    /**
+     * Gets a future that completes when the final query info changes from the specified current query info
+     * or immediately if the query already has a final query info set.  If the query does not exist,
+     * the future will contain a {@link NoSuchElementException}
+     */
+    ListenableFuture<Optional<QueryInfo>> getFinalQueryInfoChange(QueryId queryId, Optional<QueryInfo> currentQueryInfo);
 
     /**
      * @throws NoSuchElementException if query does not exist

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -914,6 +914,11 @@ public class QueryStateMachine
         return queryState.getStateChange(currentState);
     }
 
+    public ListenableFuture<Optional<QueryInfo>> getFinalQueryInfoChange(Optional<QueryInfo> currentQueryInfo)
+    {
+        return finalQueryInfo.getStateChange(currentQueryInfo);
+    }
+
     public void recordHeartbeat()
     {
         queryStateTimer.recordHeartbeat();

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -569,6 +569,12 @@ public class SqlQueryExecution
     }
 
     @Override
+    public ListenableFuture<Optional<QueryInfo>> getFinalQueryInfoChange(Optional<QueryInfo> currentQueryInfo)
+    {
+        return stateMachine.getFinalQueryInfoChange(currentQueryInfo);
+    }
+
+    @Override
     public void recordHeartbeat()
     {
         stateMachine.recordHeartbeat();

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryManager.java
@@ -247,6 +247,14 @@ public class SqlQueryManager
     }
 
     @Override
+    public ListenableFuture<Optional<QueryInfo>> getFinalQueryInfoChange(QueryId queryId, Optional<QueryInfo> currentQueryInfo)
+    {
+        return queryTracker.tryGetQuery(queryId)
+                .map(query -> query.getFinalQueryInfoChange(currentQueryInfo))
+                .orElseGet(() -> immediateFailedFuture(new NoSuchElementException()));
+    }
+
+    @Override
     public ListenableFuture<QueryState> getStateChange(QueryId queryId, QueryState currentState)
     {
         return queryTracker.tryGetQuery(queryId)

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -188,6 +188,7 @@ public class CoordinatorModule
         jsonCodecBinder(binder).bindJsonCodec(QueryResults.class);
         jsonCodecBinder(binder).bindJsonCodec(SelectedRole.class);
         jaxrsBinder(binder).bind(StatementResource.class);
+        configBinder(binder).bindConfig(StatementResourceConfig.class);
         newExporter(binder).export(StatementResource.class).withGeneratedName();
         binder.bind(StatementHttpExecutionMBean.class).in(Scopes.SINGLETON);
         newExporter(binder).export(StatementHttpExecutionMBean.class).withGeneratedName();

--- a/presto-main/src/main/java/com/facebook/presto/server/StatementResourceConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StatementResourceConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.server;
+
+import com.facebook.airlift.configuration.Config;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import javax.annotation.Nonnull;
+
+import java.util.Optional;
+
+public class StatementResourceConfig
+{
+    private Optional<Duration> defaultWaitForEntireResponseIntervalMs = Optional.empty();
+
+    @Nonnull
+    public Optional<Duration> getDefaultWaitForEntireResponseIntervalMs()
+    {
+        return defaultWaitForEntireResponseIntervalMs;
+    }
+
+    @Config("statement.default-wait-for-entire-response-interval")
+    @MinDuration("0s")
+    public StatementResourceConfig setDefaultWaitForEntireResponseIntervalMs(Duration defaultWaitForEntireResponseIntervalMs)
+    {
+        this.defaultWaitForEntireResponseIntervalMs = Optional.ofNullable(defaultWaitForEntireResponseIntervalMs);
+        return this;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -211,6 +211,12 @@ public class MockQueryExecution
     }
 
     @Override
+    public ListenableFuture<Optional<QueryInfo>> getFinalQueryInfoChange(Optional<QueryInfo> currentQueryInfo)
+    {
+        return immediateFuture(Optional.of(getQueryInfo()));
+    }
+
+    @Override
     public VersionedMemoryPoolId getMemoryPool()
     {
         throw new UnsupportedOperationException();

--- a/presto-main/src/test/java/com/facebook/presto/server/TestStatementResourceConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestStatementResourceConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.server;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestStatementResourceConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(StatementResourceConfig.class)
+                .setDefaultWaitForEntireResponseIntervalMs(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("statement.default-wait-for-entire-response-interval", "1m")
+                .build();
+
+        StatementResourceConfig expected = new StatementResourceConfig()
+                .setDefaultWaitForEntireResponseIntervalMs(new Duration(1, TimeUnit.MINUTES));
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
#13937 
If `X-Presto-Wait-For-Entire-Response-Ms` is set or the config property `statement.default-wait-for-entire-response-interval` is set then either the query returns completely in response to the POST, or it times out and is killed. If this header is absent, then the semantics are unchanged: Post returns with query is created (But not yet submitted). The submission happens on
the first get. The client semantics remain unchanged.

The major change (leading from findings by @agrawaldevesh)  here is to expose the final query info change also as a listenable future (in the same way as the state change) and plumb that all the way through from the Query, through the different QueryExecution implementations. We need this because the QueryState can be done even when the QueryInfo isn't final yet because some task is still running i.e. a task can be running, the stage could be running, and yet the root stage is done and therefore the query state is done.

This isn't a problem when the client keeps polling: the client will keep polling as long as there is a next uri, which will always be send until the final query info is reached. So we are taking the final query info as the indication that the query is done.

```
== RELEASE NOTES ==

General Changes
* Added a way to respond only after query is finished on createQuery
```