### PR TITLE
Wrap OrcReader parameters into OrcReaderOptions

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -152,6 +152,7 @@ public class HiveClientConfig
 
     private boolean pushdownFilterEnabled;
     private boolean nestedColumnsFilterEnabled;
+    private boolean zstdJniDecompressionEnabled;
 
     public int getMaxInitialSplits()
     {
@@ -857,6 +858,18 @@ public class HiveClientConfig
     public HiveClientConfig setOptimizeMismatchedBucketCount(boolean optimizeMismatchedBucketCount)
     {
         this.optimizeMismatchedBucketCount = optimizeMismatchedBucketCount;
+        return this;
+    }
+
+    public boolean isZstdJniDecompressionEnabled()
+    {
+        return zstdJniDecompressionEnabled;
+    }
+
+    @Config("hive.zstd-jni-decompression-enabled")
+    public HiveClientConfig setZstdJniDecompressionEnabled(boolean zstdJniDecompressionEnabled)
+    {
+        this.zstdJniDecompressionEnabled = zstdJniDecompressionEnabled;
         return this;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -51,6 +51,7 @@ public final class HiveSessionProperties
     private static final String ORC_TINY_STRIPE_THRESHOLD = "orc_tiny_stripe_threshold";
     private static final String ORC_MAX_READ_BLOCK_SIZE = "orc_max_read_block_size";
     private static final String ORC_LAZY_READ_SMALL_RANGES = "orc_lazy_read_small_ranges";
+    private static final String ORC_ZSTD_JNI_DECOMPRESSION_ENABLED = "orc_zstd_jni_decompression_enabled";
     private static final String ORC_STRING_STATISTICS_LIMIT = "orc_string_statistics_limit";
     private static final String ORC_OPTIMIZED_WRITER_ENABLED = "orc_optimized_writer_enabled";
     private static final String ORC_OPTIMIZED_WRITER_VALIDATE = "orc_optimized_writer_validate";
@@ -398,6 +399,11 @@ public final class HiveSessionProperties
                         OFFLINE_DATA_DEBUG_MODE_ENABLED,
                         "allow reading from tables or partitions that are marked as offline or not readable",
                         false,
+                        true),
+                booleanProperty(
+                        ORC_ZSTD_JNI_DECOMPRESSION_ENABLED,
+                        "use JNI based zstd decompression for reading ORC files",
+                        hiveClientConfig.isZstdJniDecompressionEnabled(),
                         true));
     }
 
@@ -464,6 +470,11 @@ public final class HiveSessionProperties
     public static boolean getOrcLazyReadSmallRanges(ConnectorSession session)
     {
         return session.getProperty(ORC_LAZY_READ_SMALL_RANGES, Boolean.class);
+    }
+
+    public static boolean isOrcZstdJniDecompressionEnabled(ConnectorSession session)
+    {
+        return session.getProperty(ORC_ZSTD_JNI_DECOMPRESSION_ENABLED, Boolean.class);
     }
 
     public static DataSize getOrcStringStatisticsLimit(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfBatchPageSourceFactory.java
@@ -21,6 +21,7 @@ import com.facebook.presto.hive.HiveBatchPageSourceFactory;
 import com.facebook.presto.hive.HiveClientConfig;
 import com.facebook.presto.hive.HiveColumnHandle;
 import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.orc.OrcReaderOptions;
 import com.facebook.presto.orc.StripeMetadataSource;
 import com.facebook.presto.orc.cache.OrcFileTailSource;
 import com.facebook.presto.spi.ConnectorPageSource;
@@ -45,6 +46,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxMergeDista
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxReadBlockSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcStreamBufferSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcTinyStripeThreshold;
+import static com.facebook.presto.hive.HiveSessionProperties.isOrcZstdJniDecompressionEnabled;
 import static com.facebook.presto.hive.orc.OrcBatchPageSourceFactory.createOrcPageSource;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
 import static java.util.Objects.requireNonNull;
@@ -115,11 +117,8 @@ public class DwrfBatchPageSourceFactory
                 effectivePredicate,
                 hiveStorageTimeZone,
                 typeManager,
-                getOrcMaxMergeDistance(session),
                 getOrcMaxBufferSize(session),
                 getOrcStreamBufferSize(session),
-                getOrcTinyStripeThreshold(session),
-                getOrcMaxReadBlockSize(session),
                 getOrcLazyReadSmallRanges(session),
                 false,
                 stats,
@@ -127,6 +126,11 @@ public class DwrfBatchPageSourceFactory
                 orcFileTailSource,
                 stripeMetadataSource,
                 extraFileInfo,
-                fileOpener));
+                fileOpener,
+                new OrcReaderOptions(
+                        getOrcMaxMergeDistance(session),
+                        getOrcTinyStripeThreshold(session),
+                        getOrcMaxReadBlockSize(session),
+                        isOrcZstdJniDecompressionEnabled(session))));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -30,6 +30,7 @@ import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.OrcEncoding;
 import com.facebook.presto.orc.OrcPredicate;
 import com.facebook.presto.orc.OrcReader;
+import com.facebook.presto.orc.OrcReaderOptions;
 import com.facebook.presto.orc.OrcSelectiveRecordReader;
 import com.facebook.presto.orc.StripeMetadataSource;
 import com.facebook.presto.orc.TupleDomainFilter;
@@ -98,6 +99,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxReadBlockS
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcStreamBufferSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcTinyStripeThreshold;
 import static com.facebook.presto.hive.HiveSessionProperties.isOrcBloomFiltersEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isOrcZstdJniDecompressionEnabled;
 import static com.facebook.presto.hive.HiveUtil.getPhysicalHiveColumnHandles;
 import static com.facebook.presto.hive.HiveUtil.typedPartitionKey;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
@@ -268,6 +270,7 @@ public class OrcSelectivePageSourceFactory
         DataSize streamBufferSize = getOrcStreamBufferSize(session);
         DataSize tinyStripeThreshold = getOrcTinyStripeThreshold(session);
         DataSize maxReadBlockSize = getOrcMaxReadBlockSize(session);
+        OrcReaderOptions orcReaderOptions = new OrcReaderOptions(maxMergeDistance, tinyStripeThreshold, maxReadBlockSize, isOrcZstdJniDecompressionEnabled(session));
         boolean lazyReadSmallRanges = getOrcLazyReadSmallRanges(session);
 
         OrcDataSource orcDataSource;
@@ -294,7 +297,7 @@ public class OrcSelectivePageSourceFactory
 
         AggregatedMemoryContext systemMemoryUsage = newSimpleAggregatedMemoryContext();
         try {
-            OrcReader reader = new OrcReader(orcDataSource, orcEncoding, maxMergeDistance, tinyStripeThreshold, maxReadBlockSize, orcFileTailSource, stripeMetadataSource);
+            OrcReader reader = new OrcReader(orcDataSource, orcEncoding, orcFileTailSource, stripeMetadataSource, orcReaderOptions);
 
             checkArgument(!domainPredicate.isNone(), "Unexpected NONE domain");
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.OrcBatchRecordReader;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcPredicate;
 import com.facebook.presto.orc.OrcReader;
+import com.facebook.presto.orc.OrcReaderOptions;
 import com.facebook.presto.orc.StorageStripeMetadataSource;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.spi.Page;
@@ -55,11 +56,13 @@ public class TempFileReader
             OrcReader orcReader = new OrcReader(
                     dataSource,
                     ORC,
-                    new DataSize(1, MEGABYTE),
-                    new DataSize(8, MEGABYTE),
-                    new DataSize(16, MEGABYTE),
                     new StorageOrcFileTailSource(),
-                    new StorageStripeMetadataSource());
+                    new StorageStripeMetadataSource(),
+                    new OrcReaderOptions(
+                            new DataSize(1, MEGABYTE),
+                            new DataSize(8, MEGABYTE),
+                            new DataSize(16, MEGABYTE),
+                            false));
 
             Map<Integer, Type> includedColumns = new HashMap<>();
             for (int i = 0; i < types.size(); i++) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -121,6 +121,7 @@ public class TestHiveClientConfig
                 .setTemporaryTableStorageFormat(ORC)
                 .setTemporaryTableCompressionCodec(SNAPPY)
                 .setPushdownFilterEnabled(false)
+                .setZstdJniDecompressionEnabled(false)
                 .setNestedColumnsFilterEnabled(false));
     }
 
@@ -208,6 +209,7 @@ public class TestHiveClientConfig
                 .put("hive.temporary-table-compression-codec", "NONE")
                 .put("hive.pushdown-filter-enabled", "true")
                 .put("hive.nested-columns-filter-enabled", "true")
+                .put("hive.zstd-jni-decompression-enabled", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -291,6 +293,7 @@ public class TestHiveClientConfig
                 .setTemporaryTableStorageFormat(DWRF)
                 .setTemporaryTableCompressionCodec(NONE)
                 .setPushdownFilterEnabled(true)
+                .setZstdJniDecompressionEnabled(true)
                 .setNestedColumnsFilterEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import io.airlift.units.DataSize;
+
+import static java.util.Objects.requireNonNull;
+
+public class OrcReaderOptions
+{
+    private final DataSize maxMergeDistance;
+    private final DataSize tinyStripeThreshold;
+    private final DataSize maxBlockSize;
+    private final boolean zstdJniDecompressionEnabled;
+
+    public OrcReaderOptions(DataSize maxMergeDistance, DataSize tinyStripeThreshold, DataSize maxBlockSize, boolean zstdJniDecompressionEnabled)
+    {
+        this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
+        this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
+        this.tinyStripeThreshold = requireNonNull(tinyStripeThreshold, "tinyStripeThreshold is null");
+        this.zstdJniDecompressionEnabled = zstdJniDecompressionEnabled;
+    }
+
+    public DataSize getMaxMergeDistance()
+    {
+        return maxMergeDistance;
+    }
+
+    public DataSize getMaxBlockSize()
+    {
+        return maxBlockSize;
+    }
+
+    public boolean isOrcZstdJniDecompressionEnabled()
+    {
+        return zstdJniDecompressionEnabled;
+    }
+
+    public DataSize getTinyStripeThreshold()
+    {
+        return tinyStripeThreshold;
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
 import org.joda.time.DateTimeZone;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -68,6 +69,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.Integer.max;
 import static java.lang.Integer.min;
 import static java.lang.Math.toIntExact;
@@ -519,7 +521,8 @@ public class OrcWriter
                 input,
                 types,
                 hiveStorageTimeZone,
-                orcEncoding);
+                orcEncoding,
+                new OrcReaderOptions(new DataSize(1, MEGABYTE), new DataSize(8, MEGABYTE), new DataSize(16, MEGABYTE), false));
     }
 
     private int estimateAverageLogicalSizePerRow(Page page)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
@@ -204,11 +204,9 @@ public class BenchmarkBatchStreamReaders
             OrcReader orcReader = new OrcReader(
                     dataSource,
                     ORC,
-                    new DataSize(1, MEGABYTE),
-                    new DataSize(1, MEGABYTE),
-                    new DataSize(1, MEGABYTE),
                     new StorageOrcFileTailSource(),
-                    new StorageStripeMetadataSource());
+                    new StorageStripeMetadataSource(),
+                    OrcReaderTestingUtils.createDefaultTestConfig());
             return orcReader.createBatchRecordReader(
                     ImmutableMap.of(0, type),
                     OrcPredicate.TRUE,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -193,11 +193,9 @@ public class BenchmarkSelectiveStreamReaders
             OrcReader orcReader = new OrcReader(
                     dataSource,
                     ORC,
-                    new DataSize(1, MEGABYTE),
-                    new DataSize(1, MEGABYTE),
-                    new DataSize(1, MEGABYTE),
                     new StorageOrcFileTailSource(),
-                    new StorageStripeMetadataSource());
+                    new StorageStripeMetadataSource(),
+                    OrcReaderTestingUtils.createDefaultTestConfig());
 
             return orcReader.createSelectiveRecordReader(
                     ImmutableMap.of(0, type),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcReaderTestingUtils.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcReaderTestingUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import io.airlift.units.DataSize;
+
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+
+public class OrcReaderTestingUtils
+{
+    private OrcReaderTestingUtils() {}
+
+    public static OrcReaderOptions createDefaultTestConfig()
+    {
+        return new OrcReaderOptions(
+                new DataSize(1, MEGABYTE),
+                new DataSize(1, MEGABYTE),
+                new DataSize(1, MEGABYTE),
+                false);
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1295,11 +1295,13 @@ public class OrcTester
         OrcReader orcReader = new OrcReader(
                 orcDataSource,
                 orcEncoding,
-                new DataSize(1, MEGABYTE),
-                new DataSize(1, MEGABYTE),
-                MAX_BLOCK_SIZE,
                 orcFileTailSource,
-                stripeMetadataSource);
+                stripeMetadataSource,
+                new OrcReaderOptions(
+                        new DataSize(1, MEGABYTE),
+                        new DataSize(1, MEGABYTE),
+                        MAX_BLOCK_SIZE,
+                        false));
 
         assertEquals(orcReader.getColumnNames(), ImmutableList.of("test"));
         assertEquals(orcReader.getFooter().getRowsInRowGroup(), 10_000);
@@ -1364,11 +1366,13 @@ public class OrcTester
         OrcReader orcReader = new OrcReader(
                 orcDataSource,
                 orcEncoding,
-                new DataSize(1, MEGABYTE),
-                new DataSize(1, MEGABYTE),
-                MAX_BLOCK_SIZE,
                 new StorageOrcFileTailSource(),
-                new StorageStripeMetadataSource());
+                new StorageStripeMetadataSource(),
+                new OrcReaderOptions(
+                        new DataSize(1, MEGABYTE),
+                        new DataSize(1, MEGABYTE),
+                        MAX_BLOCK_SIZE,
+                        false));
 
         assertEquals(orcReader.getColumnNames().subList(0, types.size()), makeColumnNames(types.size()));
         assertEquals(orcReader.getFooter().getRowsInRowGroup(), 10_000);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
@@ -196,11 +196,9 @@ public class TestCachingOrcDataSource
         OrcReader orcReader = new OrcReader(
                 orcDataSource,
                 ORC,
-                maxMergeDistance,
-                tinyStripeThreshold,
-                new DataSize(1, Unit.MEGABYTE),
                 new StorageOrcFileTailSource(),
-                new StorageStripeMetadataSource());
+                new StorageStripeMetadataSource(),
+                new OrcReaderOptions(maxMergeDistance, tinyStripeThreshold, new DataSize(1, Unit.MEGABYTE), false));
         // 1 for reading file footer
         assertEquals(orcDataSource.getReadCount(), 1);
         List<StripeInformation> stripes = orcReader.getFooter().getStripes();

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
@@ -396,11 +396,9 @@ public class TestMapFlatBatchStreamReader
         OrcReader orcReader = new OrcReader(
                 orcDataSource,
                 OrcEncoding.DWRF,
-                new DataSize(1, MEGABYTE),
-                new DataSize(1, MEGABYTE),
-                new DataSize(1, DataSize.Unit.MEGABYTE),
                 new StorageOrcFileTailSource(),
-                new StorageStripeMetadataSource());
+                new StorageStripeMetadataSource(),
+                OrcReaderTestingUtils.createDefaultTestConfig());
         Type mapType = TYPE_MANAGER.getParameterizedType(
                 StandardTypes.MAP,
                 ImmutableList.of(

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
@@ -47,7 +47,16 @@ public class TestOrcLz4
         // TODO: use Apache ORC library in OrcTester
         byte[] data = toByteArray(getResource("apache-lz4.orc"));
 
-        OrcReader orcReader = new OrcReader(new InMemoryOrcDataSource(data), ORC, SIZE, SIZE, SIZE, new StorageOrcFileTailSource(), new StorageStripeMetadataSource());
+        OrcReader orcReader = new OrcReader(
+                new InMemoryOrcDataSource(data),
+                ORC,
+                new StorageOrcFileTailSource(),
+                new StorageStripeMetadataSource(),
+                new OrcReaderOptions(
+                        SIZE,
+                        SIZE,
+                        SIZE,
+                        false));
 
         assertEquals(orcReader.getCompressionKind(), LZ4);
         assertEquals(orcReader.getFooter().getNumberOfRows(), 10_000);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
@@ -301,11 +301,9 @@ public class TestOrcReaderPositions
             OrcReader orcReader = new OrcReader(
                     orcDataSource,
                     ORC,
-                    new DataSize(1, MEGABYTE),
-                    new DataSize(1, MEGABYTE),
-                    new DataSize(1, MEGABYTE),
                     new StorageOrcFileTailSource(),
-                    new StorageStripeMetadataSource());
+                    new StorageStripeMetadataSource(),
+                    OrcReaderTestingUtils.createDefaultTestConfig());
             Footer footer = orcReader.getFooter();
             Map<String, String> readMetadata = Maps.transformValues(footer.getUserMetadata(), Slice::toStringAscii);
             assertEquals(readMetadata, metadata);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -98,7 +98,16 @@ public class TestOrcWriter
             // read the footer and verify the streams are ordered by size
             DataSize dataSize = new DataSize(1, MEGABYTE);
             OrcDataSource orcDataSource = new FileOrcDataSource(tempFile.getFile(), dataSize, dataSize, dataSize, true);
-            Footer footer = new OrcReader(orcDataSource, ORC, dataSize, dataSize, dataSize, new StorageOrcFileTailSource(), new StorageStripeMetadataSource()).getFooter();
+            Footer footer = new OrcReader(
+                    orcDataSource,
+                    ORC,
+                    new StorageOrcFileTailSource(),
+                    new StorageStripeMetadataSource(),
+                    new OrcReaderOptions(
+                            dataSize,
+                            dataSize,
+                            dataSize,
+                            false)).getFooter();
 
             for (StripeInformation stripe : footer.getStripes()) {
                 // read the footer

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestReadBloomFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestReadBloomFilter.java
@@ -116,11 +116,9 @@ public class TestReadBloomFilter
         OrcReader orcReader = new OrcReader(
                 orcDataSource,
                 OrcEncoding.ORC,
-                new DataSize(1, MEGABYTE),
-                new DataSize(1, MEGABYTE),
-                new DataSize(1, MEGABYTE),
                 new StorageOrcFileTailSource(),
-                new StorageStripeMetadataSource());
+                new StorageStripeMetadataSource(),
+                OrcReaderTestingUtils.createDefaultTestConfig());
 
         assertEquals(orcReader.getColumnNames(), ImmutableList.of("test"));
         assertEquals(orcReader.getFooter().getRowsInRowGroup(), 10_000);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
@@ -264,7 +264,16 @@ public class TestStructBatchStreamReader
     {
         DataSize dataSize = new DataSize(1, MEGABYTE);
         OrcDataSource orcDataSource = new FileOrcDataSource(tempFile.getFile(), dataSize, dataSize, dataSize, true);
-        OrcReader orcReader = new OrcReader(orcDataSource, ORC, dataSize, dataSize, dataSize, new StorageOrcFileTailSource(), new StorageStripeMetadataSource());
+        OrcReader orcReader = new OrcReader(
+                orcDataSource,
+                ORC,
+                new StorageOrcFileTailSource(),
+                new StorageStripeMetadataSource(),
+                new OrcReaderOptions(
+                        dataSize,
+                        dataSize,
+                        dataSize,
+                        false));
 
         Map<Integer, Type> includedColumns = new HashMap<>();
         includedColumns.put(0, readerType);

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSessionProperties.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSessionProperties.java
@@ -39,6 +39,7 @@ public class RaptorSessionProperties
     private static final String READER_TINY_STRIPE_THRESHOLD = "reader_tiny_stripe_threshold";
     private static final String READER_LAZY_READ_SMALL_RANGES = "reader_lazy_read_small_ranges";
     private static final String ONE_SPLIT_PER_BUCKET_THRESHOLD = "one_split_per_bucket_threshold";
+    private static final String ORC_ZSTD_JNI_DECOMPRESSION_ENABLED = "orc_ztd_jni_decompression_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -80,7 +81,12 @@ public class RaptorSessionProperties
                         ONE_SPLIT_PER_BUCKET_THRESHOLD,
                         "Experimental: Maximum bucket count at which to produce multiple splits per bucket",
                         config.getOneSplitPerBucketThreshold(),
-                        false));
+                        false),
+                booleanProperty(
+                        ORC_ZSTD_JNI_DECOMPRESSION_ENABLED,
+                        "use JNI based std decompression for reading ORC files",
+                        config.isZstdJniDecompressionEnabled(),
+                        true));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -121,6 +127,11 @@ public class RaptorSessionProperties
     public static int getOneSplitPerBucketThreshold(ConnectorSession session)
     {
         return session.getProperty(ONE_SPLIT_PER_BUCKET_THRESHOLD, Integer.class);
+    }
+
+    public static boolean isZstdJniDecompressionEnabled(ConnectorSession session)
+    {
+        return session.getProperty(ORC_ZSTD_JNI_DECOMPRESSION_ENABLED, Boolean.class);
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.presto.orc.OrcBatchRecordReader;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcReader;
+import com.facebook.presto.orc.OrcReaderOptions;
 import com.facebook.presto.orc.OrcWriter;
 import com.facebook.presto.orc.OrcWriterStats;
 import com.facebook.presto.orc.StripeMetadataSource;
@@ -102,11 +103,9 @@ public final class OrcFileRewriter
             OrcReader reader = new OrcReader(
                     dataSource,
                     ORC,
-                    readerAttributes.getMaxMergeDistance(),
-                    readerAttributes.getTinyStripeThreshold(),
-                    HUGE_MAX_READ_BLOCK_SIZE,
                     orcFileTailSource,
-                    stripeMetadataSource);
+                    stripeMetadataSource,
+                    new OrcReaderOptions(readerAttributes.getMaxMergeDistance(), readerAttributes.getTinyStripeThreshold(), HUGE_MAX_READ_BLOCK_SIZE, readerAttributes.isZstdJniDecompressionEnabled()));
 
             if (reader.getFooter().getNumberOfRows() < rowsToDelete.length()) {
                 throw new IOException("File has fewer rows than deletion vector");

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -20,6 +20,7 @@ import com.facebook.presto.orc.OrcDataSink;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcPredicate;
 import com.facebook.presto.orc.OrcReader;
+import com.facebook.presto.orc.OrcReaderOptions;
 import com.facebook.presto.orc.OrcWriterStats;
 import com.facebook.presto.orc.StripeMetadataSource;
 import com.facebook.presto.orc.TupleDomainOrcPredicate;
@@ -285,11 +286,9 @@ public class OrcStorageManager
             OrcReader reader = new OrcReader(
                     dataSource,
                     ORC,
-                    readerAttributes.getMaxMergeDistance(),
-                    readerAttributes.getTinyStripeThreshold(),
-                    HUGE_MAX_READ_BLOCK_SIZE,
                     orcFileTailSource,
-                    stripeMetadataSource);
+                    stripeMetadataSource,
+                    new OrcReaderOptions(readerAttributes.getMaxMergeDistance(), readerAttributes.getTinyStripeThreshold(), HUGE_MAX_READ_BLOCK_SIZE, readerAttributes.isZstdJniDecompressionEnabled()));
 
             Map<Long, Integer> indexMap = columnIdIndex(reader.getColumnNames());
             ImmutableMap.Builder<Integer, Type> includedColumns = ImmutableMap.builder();
@@ -438,11 +437,9 @@ public class OrcStorageManager
             OrcReader reader = new OrcReader(
                     dataSource,
                     ORC,
-                    defaultReaderAttributes.getMaxMergeDistance(),
-                    defaultReaderAttributes.getTinyStripeThreshold(),
-                    HUGE_MAX_READ_BLOCK_SIZE,
                     orcFileTailSource,
-                    stripeMetadataSource);
+                    stripeMetadataSource,
+                    new OrcReaderOptions(defaultReaderAttributes.getMaxMergeDistance(), defaultReaderAttributes.getTinyStripeThreshold(), HUGE_MAX_READ_BLOCK_SIZE, defaultReaderAttributes.isZstdJniDecompressionEnabled()));
 
             ImmutableList.Builder<ColumnStats> list = ImmutableList.builder();
             for (ColumnInfo info : getColumnInfo(reader)) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ReaderAttributes.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ReaderAttributes.java
@@ -25,23 +25,25 @@ public class ReaderAttributes
 {
     private final DataSize maxMergeDistance;
     private final DataSize maxReadSize;
-    private final DataSize streamBufferSize;
     private final DataSize tinyStripeThreshold;
+    private final DataSize streamBufferSize;
     private final boolean lazyReadSmallRanges;
+    private final boolean zstdJniDecompressionEnabled;
 
     @Inject
     public ReaderAttributes(StorageManagerConfig config)
     {
-        this(config.getOrcMaxMergeDistance(), config.getOrcMaxReadSize(), config.getOrcStreamBufferSize(), config.getOrcTinyStripeThreshold(), config.isOrcLazyReadSmallRanges());
+        this(config.getOrcMaxMergeDistance(), config.getOrcMaxReadSize(), config.getOrcStreamBufferSize(), config.getOrcTinyStripeThreshold(), config.isOrcLazyReadSmallRanges(), config.isZstdJniDecompressionEnabled());
     }
 
-    public ReaderAttributes(DataSize maxMergeDistance, DataSize maxReadSize, DataSize streamBufferSize, DataSize tinyStripeThreshold, boolean lazyReadSmallRanges)
+    public ReaderAttributes(DataSize maxMergeDistance, DataSize maxReadSize, DataSize streamBufferSize, DataSize tinyStripeThreshold, boolean lazyReadSmallRanges, boolean zstdJniDecompressionEnabled)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxReadSize = requireNonNull(maxReadSize, "maxReadSize is null");
-        this.streamBufferSize = requireNonNull(streamBufferSize, "streamBufferSize is null");
         this.tinyStripeThreshold = requireNonNull(tinyStripeThreshold, "tinyStripeThreshold is null");
+        this.streamBufferSize = requireNonNull(streamBufferSize, "streamBufferSize is null");
         this.lazyReadSmallRanges = lazyReadSmallRanges;
+        this.zstdJniDecompressionEnabled = zstdJniDecompressionEnabled;
     }
 
     public DataSize getMaxMergeDistance()
@@ -69,6 +71,11 @@ public class ReaderAttributes
         return lazyReadSmallRanges;
     }
 
+    public boolean isZstdJniDecompressionEnabled()
+    {
+        return zstdJniDecompressionEnabled;
+    }
+
     public static ReaderAttributes from(ConnectorSession session)
     {
         return new ReaderAttributes(
@@ -76,6 +83,7 @@ public class ReaderAttributes
                 RaptorSessionProperties.getReaderMaxReadSize(session),
                 RaptorSessionProperties.getReaderStreamBufferSize(session),
                 RaptorSessionProperties.getReaderTinyStripeThreshold(session),
-                RaptorSessionProperties.isReaderLazyReadSmallRanges(session));
+                RaptorSessionProperties.isReaderLazyReadSmallRanges(session),
+                RaptorSessionProperties.isZstdJniDecompressionEnabled(session));
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
@@ -72,6 +72,7 @@ public class StorageManagerConfig
     private int oneSplitPerBucketThreshold;
     private String shardDayBoundaryTimeZone = TimeZoneKey.UTC_KEY.getId();
     private int maxAllowedFilesPerWriter = Integer.MAX_VALUE;
+    private boolean zstdJniDecompressionEnabled;
 
     @NotNull
     public URI getDataDirectory()
@@ -445,6 +446,18 @@ public class StorageManagerConfig
     public StorageManagerConfig setShardDayBoundaryTimeZone(String timeZone)
     {
         this.shardDayBoundaryTimeZone = timeZone;
+        return this;
+    }
+
+    public boolean isZstdJniDecompressionEnabled()
+    {
+        return zstdJniDecompressionEnabled;
+    }
+
+    @Config("storage.zstd-jni-decompression-enabled")
+    public StorageManagerConfig setZstdJniDecompressionEnabled(boolean zstdJniDecompressionEnabled)
+    {
+        this.zstdJniDecompressionEnabled = zstdJniDecompressionEnabled;
         return this;
     }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
@@ -20,6 +20,7 @@ import com.facebook.presto.orc.OrcBatchRecordReader;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcPredicate;
 import com.facebook.presto.orc.OrcReader;
+import com.facebook.presto.orc.OrcReaderOptions;
 import com.facebook.presto.orc.OrcWriterStats;
 import com.facebook.presto.orc.OutputStreamOrcDataSink;
 import com.facebook.presto.orc.StorageStripeMetadataSource;
@@ -62,11 +63,9 @@ final class OrcTestingUtil
         OrcReader orcReader = new OrcReader(
                 dataSource,
                 ORC,
-                new DataSize(1, MEGABYTE),
-                new DataSize(1, MEGABYTE),
-                new DataSize(1, MEGABYTE),
                 new StorageOrcFileTailSource(),
-                new StorageStripeMetadataSource());
+                new StorageStripeMetadataSource(),
+                createDefaultTestConfig());
 
         List<String> columnNames = orcReader.getColumnNames();
         assertEquals(columnNames.size(), columnIds.size());
@@ -109,5 +108,14 @@ final class OrcTestingUtil
         TypeRegistry typeManager = new TypeRegistry();
         new FunctionManager(typeManager, new BlockEncodingManager(typeManager), new FeaturesConfig());
         return new OrcFileWriter(columnIds, columnTypes, new OutputStreamOrcDataSink(new FileOutputStream(file)), true, true, new OrcWriterStats(), typeManager, ZSTD);
+    }
+
+    public static OrcReaderOptions createDefaultTestConfig()
+    {
+        return new OrcReaderOptions(
+                new DataSize(1, MEGABYTE),
+                new DataSize(1, MEGABYTE),
+                new DataSize(1, MEGABYTE),
+                false);
     }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
@@ -97,7 +97,7 @@ import static org.testng.Assert.fail;
 @Test(singleThreaded = true)
 public class TestOrcFileRewriter
 {
-    private static final ReaderAttributes READER_ATTRIBUTES = new ReaderAttributes(new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+    private static final ReaderAttributes READER_ATTRIBUTES = new ReaderAttributes(new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true, false);
     private static final JsonCodec<OrcFileMetadata> METADATA_CODEC = jsonCodec(OrcFileMetadata.class);
 
     private File temporary;
@@ -495,7 +495,7 @@ public class TestOrcFileRewriter
         assertEquals(info.getRowCount(), 4);
 
         // Optimized writer will keep the only column
-        OrcReader orcReader = new OrcReader(fileOrcDataSource(newFile2), ORC, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new StorageOrcFileTailSource(), new StorageStripeMetadataSource());
+        OrcReader orcReader = new OrcReader(fileOrcDataSource(newFile2), ORC, new StorageOrcFileTailSource(), new StorageStripeMetadataSource(), OrcTestingUtil.createDefaultTestConfig());
         orcReader.getColumnNames().equals(ImmutableList.of("7"));
 
         // Add a column with the different ID with different type

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcStorageManager.java
@@ -136,7 +136,7 @@ public class TestOrcStorageManager
     private static final int MAX_SHARD_ROWS = 100;
     private static final DataSize MAX_FILE_SIZE = new DataSize(1, MEGABYTE);
     private static final Duration MISSING_SHARD_DISCOVERY = new Duration(5, TimeUnit.MINUTES);
-    private static final ReaderAttributes READER_ATTRIBUTES = new ReaderAttributes(new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+    private static final ReaderAttributes READER_ATTRIBUTES = new ReaderAttributes(new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true, false);
 
     private final NodeManager nodeManager = new TestingNodeManager();
     private Handle dummyHandle;

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestStorageManagerConfig.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestStorageManagerConfig.java
@@ -72,6 +72,7 @@ public class TestStorageManagerConfig
                 .setMaxBufferSize(new DataSize(256, MEGABYTE))
                 .setOneSplitPerBucketThreshold(0)
                 .setShardDayBoundaryTimeZone(TimeZoneKey.UTC_KEY.getId())
+                .setZstdJniDecompressionEnabled(false)
                 .setMaxAllowedFilesPerWriter(Integer.MAX_VALUE));
     }
 
@@ -107,6 +108,7 @@ public class TestStorageManagerConfig
                 .put("storage.one-split-per-bucket-threshold", "4")
                 .put("storage.shard-day-boundary-time-zone", "PST")
                 .put("storage.max-allowed-files-per-writer", "50")
+                .put("storage.zstd-jni-decompression-enabled", "true")
                 .build();
 
         StorageManagerConfig expected = new StorageManagerConfig()
@@ -136,7 +138,8 @@ public class TestStorageManagerConfig
                 .setMaxBufferSize(new DataSize(512, MEGABYTE))
                 .setOneSplitPerBucketThreshold(4)
                 .setShardDayBoundaryTimeZone("PST")
-                .setMaxAllowedFilesPerWriter(50);
+                .setMaxAllowedFilesPerWriter(50)
+                .setZstdJniDecompressionEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardCompactor.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardCompactor.java
@@ -73,7 +73,7 @@ public class TestShardCompactor
 {
     private static final int MAX_SHARD_ROWS = 1000;
     private static final PagesIndexPageSorter PAGE_SORTER = new PagesIndexPageSorter(new PagesIndex.TestingFactory(false));
-    private static final ReaderAttributes READER_ATTRIBUTES = new ReaderAttributes(new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+    private static final ReaderAttributes READER_ATTRIBUTES = new ReaderAttributes(new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true, false);
 
     private File temporary;
     private IDBI dbi;


### PR DESCRIPTION
Currently adding any new config param to OrcReader is quite painful. I have created a OrcReaderConfig to serve the purpose of making this easier in the future. The change would need to be made in one place rather than doing it across all layers.

I am trying to add a config param to control whether the zstd decompression should use the JNI version or the Java version.

cc: @highker 