### PR TITLE
Remove unused types from CostCalculator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CachingCostProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CachingCostProvider.java
@@ -16,7 +16,6 @@ package com.facebook.presto.cost;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
 import com.facebook.presto.spi.plan.PlanNode;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
 import com.facebook.presto.sql.planner.iterative.Memo;
 
@@ -38,22 +37,20 @@ public class CachingCostProvider
     private final StatsProvider statsProvider;
     private final Optional<Memo> memo;
     private final Session session;
-    private final TypeProvider types;
 
     private final Map<PlanNode, PlanCostEstimate> cache = new IdentityHashMap<>();
 
-    public CachingCostProvider(CostCalculator costCalculator, StatsProvider statsProvider, Session session, TypeProvider types)
+    public CachingCostProvider(CostCalculator costCalculator, StatsProvider statsProvider, Session session)
     {
-        this(costCalculator, statsProvider, Optional.empty(), session, types);
+        this(costCalculator, statsProvider, Optional.empty(), session);
     }
 
-    public CachingCostProvider(CostCalculator costCalculator, StatsProvider statsProvider, Optional<Memo> memo, Session session, TypeProvider types)
+    public CachingCostProvider(CostCalculator costCalculator, StatsProvider statsProvider, Optional<Memo> memo, Session session)
     {
         this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
         this.statsProvider = requireNonNull(statsProvider, "statsProvider is null");
         this.memo = requireNonNull(memo, "memo is null");
         this.session = requireNonNull(session, "session is null");
-        this.types = requireNonNull(types, "types is null");
     }
 
     @Override
@@ -106,6 +103,6 @@ public class CachingCostProvider
 
     private PlanCostEstimate calculateCost(PlanNode node)
     {
-        return costCalculator.calculateCost(node, statsProvider, this, session, types);
+        return costCalculator.calculateCost(node, statsProvider, this, session);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculator.java
@@ -16,7 +16,6 @@ package com.facebook.presto.cost;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.spi.plan.PlanNode;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.google.inject.BindingAnnotation;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -32,7 +31,6 @@ public interface CostCalculator
 {
     /**
      * Calculates cumulative cost of a node.
-     *
      * @param node The node to compute cost for.
      * @param stats The stats provider for node's stats and child nodes' stats, to be used if stats are needed to compute cost for the {@code node}
      */
@@ -40,8 +38,7 @@ public interface CostCalculator
             PlanNode node,
             StatsProvider stats,
             CostProvider sourcesCosts,
-            Session session,
-            TypeProvider types);
+            Session session);
 
     @BindingAnnotation
     @Target(PARAMETER)

--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.UnionNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
 import com.facebook.presto.sql.planner.plan.AssignUniqueId;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
@@ -75,9 +74,9 @@ public class CostCalculatorUsingExchanges
     }
 
     @Override
-    public PlanCostEstimate calculateCost(PlanNode node, StatsProvider stats, CostProvider sourcesCosts, Session session, TypeProvider types)
+    public PlanCostEstimate calculateCost(PlanNode node, StatsProvider stats, CostProvider sourcesCosts, Session session)
     {
-        CostEstimator costEstimator = new CostEstimator(stats, sourcesCosts, types, taskCountEstimator);
+        CostEstimator costEstimator = new CostEstimator(stats, sourcesCosts, taskCountEstimator);
         return node.accept(costEstimator, null);
     }
 
@@ -86,14 +85,12 @@ public class CostCalculatorUsingExchanges
     {
         private final StatsProvider stats;
         private final CostProvider sourcesCosts;
-        private final TypeProvider types;
         private final TaskCountEstimator taskCountEstimator;
 
-        CostEstimator(StatsProvider stats, CostProvider sourcesCosts, TypeProvider types, TaskCountEstimator taskCountEstimator)
+        CostEstimator(StatsProvider stats, CostProvider sourcesCosts, TaskCountEstimator taskCountEstimator)
         {
             this.stats = requireNonNull(stats, "stats is null");
             this.sourcesCosts = requireNonNull(sourcesCosts, "sourcesCosts is null");
-            this.types = requireNonNull(types, "types is null");
             this.taskCountEstimator = requireNonNull(taskCountEstimator, "taskCountEstimator is null");
         }
 
@@ -195,7 +192,6 @@ public class CostCalculatorUsingExchanges
                     probe,
                     build,
                     stats,
-                    types,
                     replicated,
                     taskCountEstimator.estimateSourceDistributedTaskCount());
             LocalCostEstimate joinOutputCost = calculateJoinOutputCost(join);

--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorWithEstimatedExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorWithEstimatedExchanges.java
@@ -18,7 +18,6 @@ import com.facebook.presto.Session;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.UnionNode;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
 import com.facebook.presto.sql.planner.iterative.rule.DetermineJoinDistributionType;
 import com.facebook.presto.sql.planner.iterative.rule.ReorderJoins;
@@ -58,10 +57,10 @@ public class CostCalculatorWithEstimatedExchanges
     }
 
     @Override
-    public PlanCostEstimate calculateCost(PlanNode node, StatsProvider stats, CostProvider sourcesCosts, Session session, TypeProvider types)
+    public PlanCostEstimate calculateCost(PlanNode node, StatsProvider stats, CostProvider sourcesCosts, Session session)
     {
-        ExchangeCostEstimator exchangeCostEstimator = new ExchangeCostEstimator(stats, types, taskCountEstimator);
-        PlanCostEstimate costEstimate = costCalculator.calculateCost(node, stats, sourcesCosts, session, types);
+        ExchangeCostEstimator exchangeCostEstimator = new ExchangeCostEstimator(stats, taskCountEstimator);
+        PlanCostEstimate costEstimate = costCalculator.calculateCost(node, stats, sourcesCosts, session);
         LocalCostEstimate estimatedExchangeCost = node.accept(exchangeCostEstimator, null);
         return addExchangeCost(costEstimate, estimatedExchangeCost);
     }
@@ -87,13 +86,11 @@ public class CostCalculatorWithEstimatedExchanges
             extends InternalPlanVisitor<LocalCostEstimate, Void>
     {
         private final StatsProvider stats;
-        private final TypeProvider types;
         private final TaskCountEstimator taskCountEstimator;
 
-        ExchangeCostEstimator(StatsProvider stats, TypeProvider types, TaskCountEstimator taskCountEstimator)
+        ExchangeCostEstimator(StatsProvider stats, TaskCountEstimator taskCountEstimator)
         {
             this.stats = requireNonNull(stats, "stats is null");
-            this.types = requireNonNull(types, "types is null");
             this.taskCountEstimator = requireNonNull(taskCountEstimator, "taskCountEstimator is null");
         }
 
@@ -130,7 +127,6 @@ public class CostCalculatorWithEstimatedExchanges
                     node.getLeft(),
                     node.getRight(),
                     stats,
-                    types,
                     Objects.equals(node.getDistributionType(), Optional.of(JoinNode.DistributionType.REPLICATED)),
                     taskCountEstimator.estimateSourceDistributedTaskCount());
         }
@@ -142,7 +138,6 @@ public class CostCalculatorWithEstimatedExchanges
                     node.getSource(),
                     node.getFilteringSource(),
                     stats,
-                    types,
                     Objects.equals(node.getDistributionType(), Optional.of(SemiJoinNode.DistributionType.REPLICATED)),
                     taskCountEstimator.estimateSourceDistributedTaskCount());
         }
@@ -154,7 +149,6 @@ public class CostCalculatorWithEstimatedExchanges
                     node.getLeft(),
                     node.getRight(),
                     stats,
-                    types,
                     node.getDistributionType() == SpatialJoinNode.DistributionType.REPLICATED,
                     taskCountEstimator.estimateSourceDistributedTaskCount());
         }
@@ -200,7 +194,6 @@ public class CostCalculatorWithEstimatedExchanges
             PlanNode probe,
             PlanNode build,
             StatsProvider stats,
-            TypeProvider types,
             boolean replicated,
             int estimatedSourceDistributedTaskCount)
     {
@@ -208,14 +201,12 @@ public class CostCalculatorWithEstimatedExchanges
                 probe,
                 build,
                 stats,
-                types,
                 replicated,
                 estimatedSourceDistributedTaskCount);
         LocalCostEstimate inputCost = calculateJoinInputCost(
                 probe,
                 build,
                 stats,
-                types,
                 replicated,
                 estimatedSourceDistributedTaskCount);
         return addPartialComponents(exchangesCost, inputCost);
@@ -225,7 +216,6 @@ public class CostCalculatorWithEstimatedExchanges
             PlanNode probe,
             PlanNode build,
             StatsProvider stats,
-            TypeProvider types,
             boolean replicated,
             int estimatedSourceDistributedTaskCount)
     {
@@ -250,7 +240,6 @@ public class CostCalculatorWithEstimatedExchanges
             PlanNode probe,
             PlanNode build,
             StatsProvider stats,
-            TypeProvider types,
             boolean replicated,
             int estimatedSourceDistributedTaskCount)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -204,7 +204,7 @@ public class LogicalPlanner
                 PlanNodeSearcher.searchFrom(root).where(node ->
                     (node instanceof JoinNode) || (node instanceof SemiJoinNode)).matches()) {
             StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types);
-            CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.empty(), session, types);
+            CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.empty(), session);
             return StatsAndCosts.create(root, statsProvider, costProvider);
         }
         return StatsAndCosts.empty();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
@@ -194,7 +194,7 @@ public class IterativeOptimizer
     private Rule.Context ruleContext(Context context)
     {
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, Optional.of(context.memo), context.lookup, context.session, context.variableAllocator.getTypes());
-        CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.of(context.memo), context.session, context.variableAllocator.getTypes());
+        CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.of(context.memo), context.session);
 
         return new Rule.Context()
         {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -23,7 +23,6 @@ import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.google.common.collect.Ordering;
@@ -142,7 +141,6 @@ public class DetermineJoinDistributionType
 
     private PlanNodeWithCost getJoinNodeWithCost(Context context, JoinNode possibleJoinNode)
     {
-        TypeProvider types = context.getVariableAllocator().getTypes();
         StatsProvider stats = context.getStatsProvider();
         boolean replicated = possibleJoinNode.getDistributionType().get().equals(REPLICATED);
         /*
@@ -173,7 +171,6 @@ public class DetermineJoinDistributionType
                 possibleJoinNode.getLeft(),
                 possibleJoinNode.getRight(),
                 stats,
-                types,
                 replicated,
                 estimatedSourceDistributedTaskCount);
         return new PlanNodeWithCost(cost.toPlanCost(), possibleJoinNode);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
@@ -36,7 +36,6 @@ import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.google.common.collect.Ordering;
@@ -129,7 +128,6 @@ public class DetermineSemiJoinDistributionType
 
     private PlanNodeWithCost getSemiJoinNodeWithCost(SemiJoinNode possibleJoinNode, Context context)
     {
-        TypeProvider types = context.getVariableAllocator().getTypes();
         StatsProvider stats = context.getStatsProvider();
         boolean replicated = possibleJoinNode.getDistributionType().get().equals(REPLICATED);
         /*
@@ -156,7 +154,6 @@ public class DetermineSemiJoinDistributionType
                 possibleJoinNode.getSource(),
                 possibleJoinNode.getFilteringSource(),
                 stats,
-                types,
                 replicated,
                 estimatedSourceDistributedTaskCount);
         return new PlanNodeWithCost(cost.toPlanCost(), possibleJoinNode);

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -160,12 +160,12 @@ public class TestCostCalculator
         TableScanNode tableScan = tableScan("ts", "orderkey");
         Map<String, Type> types = ImmutableMap.of("orderkey", BIGINT);
 
-        assertCost(tableScan, ImmutableMap.of(), ImmutableMap.of("ts", statsEstimate(tableScan, 1000)), types)
+        assertCost(tableScan, ImmutableMap.of(), ImmutableMap.of("ts", statsEstimate(tableScan, 1000)))
                 .cpu(1000 * IS_NULL_OVERHEAD)
                 .memory(0)
                 .network(0);
 
-        assertCostEstimatedExchanges(tableScan, ImmutableMap.of(), ImmutableMap.of("ts", statsEstimate(tableScan, 1000)), types)
+        assertCostEstimatedExchanges(tableScan, ImmutableMap.of(), ImmutableMap.of("ts", statsEstimate(tableScan, 1000)))
                 .cpu(1000 * IS_NULL_OVERHEAD)
                 .memory(0)
                 .network(0);
@@ -175,7 +175,7 @@ public class TestCostCalculator
                 .memory(0)
                 .network(0);
 
-        assertCostHasUnknownComponentsForUnknownStats(tableScan, types);
+        assertCostHasUnknownComponentsForUnknownStats(tableScan);
     }
 
     @Test
@@ -191,12 +191,12 @@ public class TestCostCalculator
                 "orderkey", BIGINT,
                 "string", VARCHAR);
 
-        assertCost(project, costs, stats, types)
+        assertCost(project, costs, stats)
                 .cpu(1000 + 4000 * OFFSET_AND_IS_NULL_OVERHEAD)
                 .memory(0)
                 .network(0);
 
-        assertCostEstimatedExchanges(project, costs, stats, types)
+        assertCostEstimatedExchanges(project, costs, stats)
                 .cpu(1000 + 4000 * OFFSET_AND_IS_NULL_OVERHEAD)
                 .memory(0)
                 .network(0);
@@ -206,7 +206,7 @@ public class TestCostCalculator
                 .memory(0)
                 .network(0);
 
-        assertCostHasUnknownComponentsForUnknownStats(project, types);
+        assertCostHasUnknownComponentsForUnknownStats(project);
     }
 
     @Test
@@ -233,12 +233,12 @@ public class TestCostCalculator
                 "orderkey", BIGINT,
                 "orderkey_0", BIGINT);
 
-        assertCost(join, costs, stats, types)
+        assertCost(join, costs, stats)
                 .cpu(6000 + 1000 + (12000 + 6000 + 1000) * IS_NULL_OVERHEAD)
                 .memory(1000 * IS_NULL_OVERHEAD)
                 .network(0);
 
-        assertCostEstimatedExchanges(join, costs, stats, types)
+        assertCostEstimatedExchanges(join, costs, stats)
                 .cpu(6000 + 1000 + (12000 + 6000 + 1000 + 6000 + 1000 + 1000) * IS_NULL_OVERHEAD)
                 .memory(1000 * IS_NULL_OVERHEAD)
                 .network((6000 + 1000) * IS_NULL_OVERHEAD);
@@ -248,7 +248,7 @@ public class TestCostCalculator
                 .memory(1000 * IS_NULL_OVERHEAD)
                 .network(0);
 
-        assertCostHasUnknownComponentsForUnknownStats(join, types);
+        assertCostHasUnknownComponentsForUnknownStats(join);
     }
 
     @Test
@@ -276,12 +276,12 @@ public class TestCostCalculator
                 "orderkey", BIGINT,
                 "orderkey_0", BIGINT);
 
-        assertCost(join, costs, stats, types)
+        assertCost(join, costs, stats)
                 .cpu(1000 + 6000 + (12000 + 6000 + 10000 + 1000 * (NUMBER_OF_NODES - 1)) * IS_NULL_OVERHEAD)
                 .memory(1000 * NUMBER_OF_NODES * IS_NULL_OVERHEAD)
                 .network(0);
 
-        assertCostEstimatedExchanges(join, costs, stats, types)
+        assertCostEstimatedExchanges(join, costs, stats)
                 .cpu(1000 + 6000 + (12000 + 6000 + 10000 + 1000 * NUMBER_OF_NODES) * IS_NULL_OVERHEAD)
                 .memory(1000 * NUMBER_OF_NODES * IS_NULL_OVERHEAD)
                 .network(1000 * NUMBER_OF_NODES * IS_NULL_OVERHEAD);
@@ -291,7 +291,7 @@ public class TestCostCalculator
                 .memory(1000 * NUMBER_OF_NODES * IS_NULL_OVERHEAD)
                 .network(0);
 
-        assertCostHasUnknownComponentsForUnknownStats(join, types);
+        assertCostHasUnknownComponentsForUnknownStats(join);
     }
 
     @Test
@@ -335,7 +335,7 @@ public class TestCostCalculator
 
         Map<String, Type> types = ImmutableMap.of("key1", BIGINT, "key2", BIGINT, "key3", BIGINT);
 
-        assertCost(join23, costs, stats, types)
+        assertCost(join23, costs, stats)
                 .memory(
                         100 * IS_NULL_OVERHEAD // join23 memory footprint
                                 + 64 + 32) // ts2, ts3 memory footprint
@@ -343,7 +343,7 @@ public class TestCostCalculator
                         100 * IS_NULL_OVERHEAD // join23 memory footprint
                                 + 64); // ts2 memory footprint
 
-        assertCost(join, costs, stats, types)
+        assertCost(join, costs, stats)
                 .memory(
                         2000 * IS_NULL_OVERHEAD // join memory footprint
                                 + 100 * IS_NULL_OVERHEAD + 64 // join23 total memory when outputting
@@ -352,7 +352,7 @@ public class TestCostCalculator
                         2000 * IS_NULL_OVERHEAD // join memory footprint
                                 + 128); // ts1 memory footprint
 
-        assertCostEstimatedExchanges(join23, costs, stats, types)
+        assertCostEstimatedExchanges(join23, costs, stats)
                 .memory(
                         100 * IS_NULL_OVERHEAD // join23 memory footprint
                                 + 64 + 32) // ts2, ts3 memory footprint
@@ -360,7 +360,7 @@ public class TestCostCalculator
                         100 * IS_NULL_OVERHEAD // join23 memory footprint
                                 + 64); // ts2 memory footprint
 
-        assertCostEstimatedExchanges(join, costs, stats, types)
+        assertCostEstimatedExchanges(join, costs, stats)
                 .memory(
                         2000 * IS_NULL_OVERHEAD // join memory footprint
                                 + 100 * IS_NULL_OVERHEAD + 64 // join23 total memory when outputting
@@ -401,12 +401,12 @@ public class TestCostCalculator
                 "orderkey", BIGINT,
                 "count", BIGINT);
 
-        assertCost(aggregation, costs, stats, types)
+        assertCost(aggregation, costs, stats)
                 .cpu(6000 * IS_NULL_OVERHEAD + 6000)
                 .memory(13 * IS_NULL_OVERHEAD)
                 .network(0);
 
-        assertCostEstimatedExchanges(aggregation, costs, stats, types)
+        assertCostEstimatedExchanges(aggregation, costs, stats)
                 .cpu((6000 + 6000 + 6000) * IS_NULL_OVERHEAD + 6000)
                 .memory(13 * IS_NULL_OVERHEAD)
                 .network(6000 * IS_NULL_OVERHEAD);
@@ -416,7 +416,7 @@ public class TestCostCalculator
                 .memory(13 * IS_NULL_OVERHEAD)
                 .network(0 * IS_NULL_OVERHEAD);
 
-        assertCostHasUnknownComponentsForUnknownStats(aggregation, types);
+        assertCostHasUnknownComponentsForUnknownStats(aggregation);
     }
 
     @Test
@@ -525,11 +525,11 @@ public class TestCostCalculator
                 "orderkey", BIGINT,
                 "orderkey_0", BIGINT,
                 "orderkey_1", BIGINT);
-        assertCost(union, costs, stats, types)
+        assertCost(union, costs, stats)
                 .cpu(2000)
                 .memory(0)
                 .network(0);
-        assertCostEstimatedExchanges(union, costs, stats, types)
+        assertCostEstimatedExchanges(union, costs, stats)
                 .cpu(2000)
                 .memory(0)
                 .network(5000 * IS_NULL_OVERHEAD);
@@ -538,19 +538,17 @@ public class TestCostCalculator
     private CostAssertionBuilder assertCost(
             PlanNode node,
             Map<String, PlanCostEstimate> costs,
-            Map<String, PlanNodeStatsEstimate> stats,
-            Map<String, Type> types)
+            Map<String, PlanNodeStatsEstimate> stats)
     {
-        return assertCost(costCalculatorUsingExchanges, node, costs, stats, types);
+        return assertCost(costCalculatorUsingExchanges, node, costs, stats);
     }
 
     private CostAssertionBuilder assertCostEstimatedExchanges(
             PlanNode node,
             Map<String, PlanCostEstimate> costs,
-            Map<String, PlanNodeStatsEstimate> stats,
-            Map<String, Type> types)
+            Map<String, PlanNodeStatsEstimate> stats)
     {
-        return assertCost(costCalculatorWithEstimatedExchanges, node, costs, stats, types);
+        return assertCost(costCalculatorWithEstimatedExchanges, node, costs, stats);
     }
 
     private CostAssertionBuilder assertCostFragmentedPlan(
@@ -561,7 +559,7 @@ public class TestCostCalculator
     {
         TypeProvider typeProvider = TypeProvider.copyOf(types);
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator(stats), session, typeProvider);
-        CostProvider costProvider = new TestingCostProvider(costs, costCalculatorUsingExchanges, statsProvider, session, typeProvider);
+        CostProvider costProvider = new TestingCostProvider(costs, costCalculatorUsingExchanges, statsProvider, session);
         PlanNode plan = translateExpression(node, statsCalculator(stats), typeProvider);
         SubPlan subPlan = fragment(new Plan(plan, typeProvider, StatsAndCosts.create(node, statsProvider, costProvider)));
         return new CostAssertionBuilder(subPlan.getFragment().getStatsAndCosts().orElse(StatsAndCosts.empty()).getCosts().getOrDefault(node.getId(), PlanCostEstimate.unknown()));
@@ -580,15 +578,13 @@ public class TestCostCalculator
         private final CostCalculator costCalculator;
         private final StatsProvider statsProvider;
         private final Session session;
-        private final TypeProvider types;
 
-        private TestingCostProvider(Map<String, PlanCostEstimate> costs, CostCalculator costCalculator, StatsProvider statsProvider, Session session, TypeProvider types)
+        private TestingCostProvider(Map<String, PlanCostEstimate> costs, CostCalculator costCalculator, StatsProvider statsProvider, Session session)
         {
             this.costs = ImmutableMap.copyOf(requireNonNull(costs, "costs is null"));
             this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
             this.statsProvider = requireNonNull(statsProvider, "statsProvider is null");
             this.session = requireNonNull(session, "session is null");
-            this.types = requireNonNull(types, "types is null");
         }
 
         @Override
@@ -597,7 +593,7 @@ public class TestCostCalculator
             if (costs.containsKey(node.getId().toString())) {
                 return costs.get(node.getId().toString());
             }
-            return costCalculator.calculateCost(node, statsProvider, this, session, types);
+            return costCalculator.calculateCost(node, statsProvider, this, session);
         }
     }
 
@@ -605,24 +601,21 @@ public class TestCostCalculator
             CostCalculator costCalculator,
             PlanNode node,
             Map<String, PlanCostEstimate> costs,
-            Map<String, PlanNodeStatsEstimate> stats,
-            Map<String, Type> types)
+            Map<String, PlanNodeStatsEstimate> stats)
     {
         Function<PlanNode, PlanNodeStatsEstimate> statsProvider = planNode -> stats.get(planNode.getId().toString());
         PlanCostEstimate cost = calculateCost(
                 costCalculator,
                 node,
-                sourceCostProvider(costCalculator, costs, statsProvider, types),
-                statsProvider,
-                types);
+                sourceCostProvider(costCalculator, costs, statsProvider),
+                statsProvider);
         return new CostAssertionBuilder(cost);
     }
 
     private Function<PlanNode, PlanCostEstimate> sourceCostProvider(
             CostCalculator costCalculator,
             Map<String, PlanCostEstimate> costs,
-            Function<PlanNode, PlanNodeStatsEstimate> statsProvider,
-            Map<String, Type> types)
+            Function<PlanNode, PlanNodeStatsEstimate> statsProvider)
     {
         return node -> {
             PlanCostEstimate providedCost = costs.get(node.getId().toString());
@@ -632,27 +625,24 @@ public class TestCostCalculator
             return calculateCost(
                     costCalculator,
                     node,
-                    sourceCostProvider(costCalculator, costs, statsProvider, types),
-                    statsProvider,
-                    types);
+                    sourceCostProvider(costCalculator, costs, statsProvider),
+                    statsProvider);
         };
     }
 
-    private void assertCostHasUnknownComponentsForUnknownStats(PlanNode node, Map<String, Type> types)
+    private void assertCostHasUnknownComponentsForUnknownStats(PlanNode node)
     {
         new CostAssertionBuilder(calculateCost(
                 costCalculatorUsingExchanges,
                 node,
                 planNode -> PlanCostEstimate.unknown(),
-                planNode -> PlanNodeStatsEstimate.unknown(),
-                types))
+                planNode -> PlanNodeStatsEstimate.unknown()))
                 .hasUnknownComponents();
         new CostAssertionBuilder(calculateCost(
                 costCalculatorWithEstimatedExchanges,
                 node,
                 planNode -> PlanCostEstimate.unknown(),
-                planNode -> PlanNodeStatsEstimate.unknown(),
-                types))
+                planNode -> PlanNodeStatsEstimate.unknown()))
                 .hasUnknownComponents();
     }
 
@@ -674,22 +664,20 @@ public class TestCostCalculator
             CostCalculator costCalculator,
             PlanNode node,
             Function<PlanNode, PlanCostEstimate> costs,
-            Function<PlanNode, PlanNodeStatsEstimate> stats,
-            Map<String, Type> types)
+            Function<PlanNode, PlanNodeStatsEstimate> stats)
     {
         return costCalculator.calculateCost(
                 node,
                 planNode -> requireNonNull(stats.apply(planNode), "no stats for node"),
                 source -> requireNonNull(costs.apply(source), format("no cost for source: %s", source.getId())),
-                session,
-                TypeProvider.copyOf(types));
+                session);
     }
 
     private PlanCostEstimate calculateCost(PlanNode node, CostCalculator costCalculator, StatsCalculator statsCalculator, Map<String, Type> types)
     {
         TypeProvider typeProvider = TypeProvider.copyOf(types);
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, typeProvider);
-        CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.empty(), session, typeProvider);
+        CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.empty(), session);
         return costProvider.getCost(node);
     }
 
@@ -697,7 +685,7 @@ public class TestCostCalculator
     {
         TypeProvider typeProvider = TypeProvider.copyOf(types);
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, typeProvider);
-        CostProvider costProvider = new CachingCostProvider(costCalculatorUsingExchanges, statsProvider, Optional.empty(), session, typeProvider);
+        CostProvider costProvider = new CachingCostProvider(costCalculatorUsingExchanges, statsProvider, Optional.empty(), session);
         node = translateExpression(node, statsCalculator, typeProvider);
         SubPlan subPlan = fragment(new Plan(node, typeProvider, StatsAndCosts.create(node, statsProvider, costProvider)));
         return subPlan.getFragment().getStatsAndCosts().orElse(StatsAndCosts.empty()).getCosts().getOrDefault(node.getId(), PlanCostEstimate.unknown());

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinEnumerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestJoinEnumerator.java
@@ -121,8 +121,7 @@ public class TestJoinEnumerator
                 queryRunner.getCostCalculator(),
                 statsProvider,
                 Optional.empty(),
-                queryRunner.getDefaultSession(),
-                variableAllocator.getTypes());
+                queryRunner.getDefaultSession());
 
         return new Rule.Context()
         {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -205,7 +205,7 @@ public class RuleAssert
     private String formatPlan(PlanNode plan, TypeProvider types)
     {
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types);
-        CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, session, types);
+        CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, session);
         return inTransaction(session -> textLogicalPlan(translateExpressions(plan, types), types, metadata.getFunctionManager(), StatsAndCosts.create(plan, statsProvider, costProvider), session, 2, false));
     }
 
@@ -229,7 +229,7 @@ public class RuleAssert
     private Rule.Context ruleContext(StatsCalculator statsCalculator, CostCalculator costCalculator, PlanVariableAllocator variableAllocator, Memo memo, Lookup lookup, Session session)
     {
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, Optional.of(memo), lookup, session, variableAllocator.getTypes());
-        CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.of(memo), session, variableAllocator.getTypes());
+        CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, Optional.of(memo), session);
 
         return new Rule.Context()
         {


### PR DESCRIPTION
CostCalculator now only deals with RowExpression. TypeProvider is no
longer needed.

```
== NO RELEASE NOTE ==
```
