### PR TITLE
Run filters without inputs first in OrcSelectiveStreamReader

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -215,6 +215,11 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertQuerySucceeds(queryRunner, session, sql);
     }
 
+    protected void assertQuerySucceeds(@Language("SQL") String sql)
+    {
+        QueryAssertions.assertQuerySucceeds(queryRunner, getSession(), sql);
+    }
+
     protected void assertQueryFailsEventually(@Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp, Duration timeout)
     {
         QueryAssertions.assertQueryFailsEventually(queryRunner, getSession(), sql, expectedMessageRegExp, timeout);

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcds.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcds.java
@@ -71,9 +71,4 @@ public class TestTpcds
         assertQuerySucceeds("SELECT i_current_price FROM item WHERE i_current_price IN (i_wholesale_cost, " + longValues + ")");
         assertQuerySucceeds("SELECT i_current_price FROM item WHERE i_current_price NOT IN (i_wholesale_cost, " + longValues + ")");
     }
-
-    private void assertQuerySucceeds(String sql)
-    {
-        computeActual(sql);
-    }
 }


### PR DESCRIPTION
Filters without any inputs are usually less expensive and
more productive than other filters, so it is more efficient
to run them first.

```
== NO RELEASE NOTE ==
```
