### PR TITLE
Add support for JNI based decompression for zstd files

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcDecompressor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcDecompressor.java
@@ -29,6 +29,12 @@ public interface OrcDecompressor
     static Optional<OrcDecompressor> createOrcDecompressor(OrcDataSourceId orcDataSourceId, CompressionKind compression, int bufferSize)
             throws OrcCorruptionException
     {
+        return createOrcDecompressor(orcDataSourceId, compression, bufferSize, false);
+    }
+
+    static Optional<OrcDecompressor> createOrcDecompressor(OrcDataSourceId orcDataSourceId, CompressionKind compression, int bufferSize, boolean zstdJniDecompressionEnabled)
+            throws OrcCorruptionException
+    {
         if ((compression != NONE) && ((bufferSize <= 0) || (bufferSize > MAX_BUFFER_SIZE))) {
             throw new OrcCorruptionException(orcDataSourceId, "Invalid compression block size: " + bufferSize);
         }
@@ -42,7 +48,7 @@ public interface OrcDecompressor
             case LZ4:
                 return Optional.of(new OrcLz4Decompressor(orcDataSourceId, bufferSize));
             case ZSTD:
-                return Optional.of(new OrcZstdDecompressor(orcDataSourceId, bufferSize));
+                return Optional.of(new OrcZstdDecompressor(orcDataSourceId, bufferSize, zstdJniDecompressionEnabled));
             default:
                 throw new OrcCorruptionException(orcDataSourceId, "Unknown compression type: " + compression);
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -97,7 +97,7 @@ public class OrcReader
         OrcFileTail orcFileTail = orcFileTailSource.getOrcFileTail(orcDataSource, metadataReader, writeValidation);
         this.bufferSize = orcFileTail.getBufferSize();
         this.compressionKind = orcFileTail.getCompressionKind();
-        this.decompressor = createOrcDecompressor(orcDataSource.getId(), compressionKind, bufferSize);
+        this.decompressor = createOrcDecompressor(orcDataSource.getId(), compressionKind, bufferSize, orcReaderOptions.isOrcZstdJniDecompressionEnabled());
         this.hiveWriterVersion = orcFileTail.getHiveWriterVersion();
 
         try (InputStream footerInputStream = new OrcInputStream(orcDataSource.getId(), orcFileTail.getFooterSlice().getInput(), decompressor, newSimpleAggregatedMemoryContext(), orcFileTail.getFooterSize())) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkZstdJniDecompression.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkZstdJniDecompression.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.zstd.ZstdJniCompressor;
+import com.google.common.collect.ImmutableList;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.List;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.testng.Assert.assertEquals;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(MILLISECONDS)
+@Fork(3)
+@Warmup(iterations = 20, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 20, time = 500, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+
+public class BenchmarkZstdJniDecompression
+{
+    private static final ZstdJniCompressor compressor = new ZstdJniCompressor();
+    private static final List<Unit> list = generateWorkload();
+    private static final int sourceLength = 256 * 1024;
+    private static byte[] decompressedBytes = new byte[sourceLength];
+
+    @Benchmark
+    public void decompressJni()
+            throws OrcCorruptionException
+    {
+        decompressList(createOrcDecompressor(true));
+    }
+
+    @Benchmark
+    public void decompressJava()
+            throws OrcCorruptionException
+    {
+        decompressList(createOrcDecompressor(false));
+    }
+
+    private void decompressList(OrcDecompressor decompressor)
+            throws OrcCorruptionException
+    {
+        for (Unit unit : list) {
+            int outputSize = decompressor.decompress(unit.compressedBytes, 0, unit.compressedLength, new OrcDecompressor.OutputBuffer()
+            {
+                @Override
+                public byte[] initialize(int size)
+                {
+                    return decompressedBytes;
+                }
+
+                @Override
+                public byte[] grow(int size)
+                {
+                    throw new RuntimeException();
+                }
+            });
+            assertEquals(outputSize, unit.sourceLength);
+        }
+    }
+
+    private static List<Unit> generateWorkload()
+    {
+        ImmutableList.Builder<Unit> builder = new ImmutableList.Builder<>();
+        for (int i = 0; i < 10; i++) {
+            byte[] sourceBytes = getAlphaNumericString(sourceLength).getBytes();
+            byte[] compressedBytes = new byte[sourceLength * 32];
+            int size = compressor.compress(sourceBytes, 0, sourceBytes.length, compressedBytes, 0, compressedBytes.length);
+            builder.add(new Unit(sourceBytes, sourceLength, compressedBytes, size));
+        }
+        return builder.build();
+    }
+
+    private OrcDecompressor createOrcDecompressor(boolean zstdJniDecompressionEnabled)
+    {
+        return new OrcZstdDecompressor(new OrcDataSourceId("orc"), sourceLength, zstdJniDecompressionEnabled);
+    }
+
+    private static String getAlphaNumericString(int length)
+    {
+        String alphaNumericString = "USINDIA";
+
+        StringBuilder stringBuilder = new StringBuilder(length);
+
+        for (int index = 0; index < length; index++) {
+            int arrayIndex = (int) (alphaNumericString.length() * Math.random());
+
+            stringBuilder.append(alphaNumericString.charAt(arrayIndex));
+        }
+        return stringBuilder.toString();
+    }
+
+    static class Unit
+    {
+        final byte[] sourceBytes;
+        final int sourceLength;
+        final byte[] compressedBytes;
+        final int compressedLength;
+
+        public Unit(byte[] sourceBytes, int sourceLength, byte[] compressedBytes, int compressedLength)
+        {
+            this.sourceBytes = sourceBytes;
+            this.sourceLength = sourceLength;
+            this.compressedBytes = compressedBytes;
+            this.compressedLength = compressedLength;
+        }
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcReaderTestingUtils.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcReaderTestingUtils.java
@@ -23,10 +23,15 @@ public class OrcReaderTestingUtils
 
     public static OrcReaderOptions createDefaultTestConfig()
     {
+        return createTestingReaderOptions(false);
+    }
+
+    public static OrcReaderOptions createTestingReaderOptions(boolean zstdJniDecompressionEnabled)
+    {
         return new OrcReaderOptions(
                 new DataSize(1, MEGABYTE),
                 new DataSize(1, MEGABYTE),
                 new DataSize(1, MEGABYTE),
-                false);
+                zstdJniDecompressionEnabled);
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1313,6 +1313,12 @@ public class OrcTester
         return orcReader.createBatchRecordReader(columnTypes, predicate, HIVE_STORAGE_TIME_ZONE, newSimpleAggregatedMemoryContext(), initialBatchSize);
     }
 
+    public static void writeOrcColumnPresto(File outputFile, Format format, CompressionKind compression, Type type, List<?> values)
+            throws Exception
+    {
+        writeOrcColumnsPresto(outputFile, format, compression, ImmutableList.of(type), ImmutableList.of(values), new OrcWriterStats());
+    }
+
     private static void writeOrcColumnsPresto(File outputFile, Format format, CompressionKind compression, List<Type> types, List<List<?>> values, OrcWriterStats stats)
             throws Exception
     {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestZstdJniDecompression.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestZstdJniDecompression.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.zstd.ZstdJniCompressor;
+import com.facebook.presto.testing.assertions.Assert;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.util.Random;
+
+public class TestZstdJniDecompression
+{
+    private static final DataSize MAX_BUFFER_SIZE = new DataSize(4, DataSize.Unit.MEGABYTE);
+    private final ZstdJniCompressor compressor = new ZstdJniCompressor();
+    private final OrcZstdDecompressor decompressor = new OrcZstdDecompressor(new OrcDataSourceId("test"), (int) MAX_BUFFER_SIZE.toBytes(), true);
+
+    @Test
+    public void testDecompression()
+            throws OrcCorruptionException
+    {
+        byte[] sourceBytes = generateRandomBytes();
+        byte[] compressedBytes = new byte[1024 * 1024];
+        int size = compressor.compress(sourceBytes, 0, sourceBytes.length, compressedBytes, 0, compressedBytes.length);
+        byte[] output = new byte[sourceBytes.length];
+        int outputSize = decompressor.decompress(
+                compressedBytes,
+                0,
+                size,
+                new OrcDecompressor.OutputBuffer()
+                {
+                    @Override
+                    public byte[] initialize(int size)
+                    {
+                        return output;
+                    }
+
+                    @Override
+                    public byte[] grow(int size)
+                    {
+                        throw new RuntimeException();
+                    }
+                });
+        Assert.assertEquals(outputSize, sourceBytes.length);
+        Assert.assertEquals(output, sourceBytes);
+    }
+
+    private byte[] generateRandomBytes()
+    {
+        Random random = new Random();
+        byte[] array = new byte[1024];
+        random.nextBytes(array);
+        return array;
+    }
+}


### PR DESCRIPTION
Initial results and estimates point to 10% improvement in CPU by using JNI.

The feature is controlled by a flag, that is false by default.

I tried to split the pull requests but there is no way to stack them across different forks.