### PR TITLE
[WIP] Add slug for task output

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -48,5 +48,7 @@ public final class PrestoHeaders
     public static final String PRESTO_PAGE_NEXT_TOKEN = "X-Presto-Page-End-Sequence-Id";
     public static final String PRESTO_BUFFER_COMPLETE = "X-Presto-Buffer-Complete";
 
+    public static final String PRESTO_TASK_COMM_SLUG = "X-Presto-Comm-Slug";
+
     private PrestoHeaders() {}
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -76,6 +76,28 @@ public interface QueryExecution
                 Optional<QueryType> queryType);
     }
 
+    class TaskConnectionInformation
+    {
+        private final TaskId taskId;
+        private final String communicationSlug;
+
+        public TaskConnectionInformation(TaskId taskId, String communicationSlug)
+        {
+            this.taskId = requireNonNull(taskId, "taskId is null");
+            this.communicationSlug = requireNonNull(communicationSlug, "communicationSlug is null");
+        }
+
+        public TaskId getTaskId()
+        {
+            return taskId;
+        }
+
+        public String getCommunicationSlug()
+        {
+            return communicationSlug;
+        }
+    }
+
     /**
      * Output schema and buffer URIs for query.  The info will always contain column names and types.  Buffer locations will always
      * contain the full location set, but may be empty.  Users of this data should keep a private copy of the seen buffers to
@@ -86,10 +108,10 @@ public interface QueryExecution
     {
         private final List<String> columnNames;
         private final List<Type> columnTypes;
-        private final Map<URI, TaskId> bufferLocations;
+        private final Map<URI, TaskConnectionInformation> bufferLocations;
         private final boolean noMoreBufferLocations;
 
-        public QueryOutputInfo(List<String> columnNames, List<Type> columnTypes, Map<URI, TaskId> bufferLocations, boolean noMoreBufferLocations)
+        public QueryOutputInfo(List<String> columnNames, List<Type> columnTypes, Map<URI, TaskConnectionInformation> bufferLocations, boolean noMoreBufferLocations)
         {
             this.columnNames = ImmutableList.copyOf(requireNonNull(columnNames, "columnNames is null"));
             this.columnTypes = ImmutableList.copyOf(requireNonNull(columnTypes, "columnTypes is null"));
@@ -107,7 +129,7 @@ public interface QueryExecution
             return columnTypes;
         }
 
-        public Map<URI, TaskId> getBufferLocations()
+        public Map<URI, TaskConnectionInformation> getBufferLocations()
         {
             return bufferLocations;
         }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -71,6 +71,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import static com.facebook.presto.execution.BasicStageExecutionStats.EMPTY_STAGE_STATS;
+import static com.facebook.presto.execution.QueryExecution.TaskConnectionInformation;
 import static com.facebook.presto.execution.QueryState.FINISHED;
 import static com.facebook.presto.execution.QueryState.FINISHING;
 import static com.facebook.presto.execution.QueryState.PLANNING;
@@ -631,7 +632,7 @@ public class QueryStateMachine
         outputManager.setColumns(columnNames, columnTypes);
     }
 
-    public void updateOutputLocations(Map<URI, TaskId> newExchangeLocations, boolean noMoreExchangeLocations)
+    public void updateOutputLocations(Map<URI, TaskConnectionInformation> newExchangeLocations, boolean noMoreExchangeLocations)
     {
         outputManager.updateOutputLocations(newExchangeLocations, noMoreExchangeLocations);
     }
@@ -1104,7 +1105,7 @@ public class QueryStateMachine
         @GuardedBy("this")
         private List<Type> columnTypes;
         @GuardedBy("this")
-        private final Map<URI, TaskId> exchangeLocations = new LinkedHashMap<>();
+        private final Map<URI, TaskConnectionInformation> exchangeLocations = new LinkedHashMap<>();
         @GuardedBy("this")
         private boolean noMoreExchangeLocations;
 
@@ -1144,7 +1145,7 @@ public class QueryStateMachine
             queryOutputInfo.ifPresent(info -> fireStateChanged(info, outputInfoListeners));
         }
 
-        public void updateOutputLocations(Map<URI, TaskId> newExchangeLocations, boolean noMoreExchangeLocations)
+        public void updateOutputLocations(Map<URI, TaskConnectionInformation> newExchangeLocations, boolean noMoreExchangeLocations)
         {
             requireNonNull(newExchangeLocations, "newExchangeLocations is null");
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
@@ -66,4 +66,6 @@ public interface RemoteTask
     int getPartitionedSplitCount();
 
     int getQueuedPartitionedSplitCount();
+
+    String getCommunicationSlug();
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -356,13 +356,15 @@ public class SqlTaskManager
             List<TaskSource> sources,
             OutputBuffers outputBuffers,
             OptionalInt totalPartitions,
-            Optional<TableWriteInfo> tableWriteInfo)
+            Optional<TableWriteInfo> tableWriteInfo,
+            String communicationSlug)
     {
         requireNonNull(session, "session is null");
         requireNonNull(taskId, "taskId is null");
         requireNonNull(fragment, "fragment is null");
         requireNonNull(sources, "sources is null");
         requireNonNull(outputBuffers, "outputBuffers is null");
+        requireNonNull(communicationSlug, "communicationSlug is null");
 
         if (resourceOvercommit(session)) {
             // TODO: This should have been done when the QueryContext was created. However, the session isn't available at that point.
@@ -371,18 +373,20 @@ public class SqlTaskManager
 
         SqlTask sqlTask = tasks.getUnchecked(taskId);
         sqlTask.recordHeartbeat();
+        sqlTask.updateCommunicationSlug(communicationSlug);
         return sqlTask.updateTask(session, fragment, sources, outputBuffers, totalPartitions, tableWriteInfo);
     }
 
     @Override
-    public ListenableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBufferId bufferId, long startingSequenceId, DataSize maxSize)
+    public ListenableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBufferId bufferId, long startingSequenceId, DataSize maxSize, String communicationSlug)
     {
         requireNonNull(taskId, "taskId is null");
         requireNonNull(bufferId, "bufferId is null");
         checkArgument(startingSequenceId >= 0, "startingSequenceId is negative");
         requireNonNull(maxSize, "maxSize is null");
+        requireNonNull(communicationSlug, "communicationSlug is null");
 
-        return tasks.getUnchecked(taskId).getTaskResults(bufferId, startingSequenceId, maxSize);
+        return tasks.getUnchecked(taskId).getTaskResults(bufferId, startingSequenceId, maxSize, communicationSlug);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
@@ -91,7 +91,8 @@ public interface TaskManager
             List<TaskSource> sources,
             OutputBuffers outputBuffers,
             OptionalInt totalPartitions,
-            Optional<TableWriteInfo> tableWriteInfo);
+            Optional<TableWriteInfo> tableWriteInfo,
+            String communicationSlug);
 
     /**
      * Cancels a task.  If the task does not already exist, is is created and then
@@ -113,7 +114,7 @@ public interface TaskManager
      * NOTE: this design assumes that only tasks and buffers that will
      * eventually exist are queried.
      */
-    ListenableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBufferId bufferId, long startingSequenceId, DataSize maxSize);
+    ListenableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBufferId bufferId, long startingSequenceId, DataSize maxSize, String communicationSlug);
 
     /**
      * Acknowledges previously received results.

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -29,7 +29,6 @@ import com.facebook.presto.execution.StageExecutionInfo;
 import com.facebook.presto.execution.StageExecutionState;
 import com.facebook.presto.execution.StageId;
 import com.facebook.presto.execution.StageInfo;
-import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskStatus;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
@@ -83,6 +82,7 @@ import static com.facebook.presto.SystemSessionProperties.getMaxConcurrentMateri
 import static com.facebook.presto.SystemSessionProperties.getMaxTasksPerStage;
 import static com.facebook.presto.SystemSessionProperties.getWriterMinSize;
 import static com.facebook.presto.execution.BasicStageExecutionStats.aggregateBasicStageStats;
+import static com.facebook.presto.execution.QueryExecution.TaskConnectionInformation;
 import static com.facebook.presto.execution.SqlStageExecution.createSqlStageExecution;
 import static com.facebook.presto.execution.StageExecutionState.ABORTED;
 import static com.facebook.presto.execution.StageExecutionState.CANCELED;
@@ -287,10 +287,10 @@ public class SqlQueryScheduler
 
     private static void updateQueryOutputLocations(QueryStateMachine queryStateMachine, OutputBufferId rootBufferId, Set<RemoteTask> tasks, boolean noMoreExchangeLocations)
     {
-        Map<URI, TaskId> bufferLocations = tasks.stream()
+        Map<URI, TaskConnectionInformation> bufferLocations = tasks.stream()
                 .collect(toImmutableMap(
                         task -> getBufferLocation(task, rootBufferId),
-                        RemoteTask::getTaskId));
+                        task -> new TaskConnectionInformation(task.getTaskId(), task.getCommunicationSlug())));
         queryStateMachine.updateOutputLocations(bufferLocations, noMoreExchangeLocations);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
@@ -163,7 +163,7 @@ public class ExchangeClient
         }
     }
 
-    public synchronized void addLocation(URI location, TaskId remoteSourceTaskId)
+    public synchronized void addLocation(URI location, TaskId remoteSourceTaskId, String communicationSlug)
     {
         requireNonNull(location, "location is null");
 
@@ -192,7 +192,8 @@ public class ExchangeClient
                 location,
                 new ExchangeClientCallback(),
                 scheduler,
-                pageBufferClientCallbackExecutor);
+                pageBufferClientCallbackExecutor,
+                communicationSlug);
         allClients.put(location, client);
         checkState(taskIdToLocationMap.put(remoteSourceTaskId, location) == null, "Duplicate remoteSourceTaskId: " + remoteSourceTaskId);
         queuedClients.add(client);

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeOperator.java
@@ -120,7 +120,7 @@ public class ExchangeOperator
         checkArgument(split.getConnectorId().equals(REMOTE_CONNECTOR_ID), "split is not a remote split");
 
         RemoteSplit remoteSplit = (RemoteSplit) split.getConnectorSplit();
-        exchangeClient.addLocation(remoteSplit.getLocation(), remoteSplit.getRemoteSourceTaskId());
+        exchangeClient.addLocation(remoteSplit.getLocation(), remoteSplit.getRemoteSourceTaskId(), remoteSplit.getCommunicationSlug());
 
         return Optional::empty;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/MergeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MergeOperator.java
@@ -160,7 +160,7 @@ public class MergeOperator
 
         RemoteSplit remoteSplit = (RemoteSplit) split.getConnectorSplit();
         ExchangeClient exchangeClient = closer.register(taskExchangeClientManager.createExchangeClient(operatorContext.localSystemMemoryContext()));
-        exchangeClient.addLocation(remoteSplit.getLocation(), remoteSplit.getRemoteSourceTaskId());
+        exchangeClient.addLocation(remoteSplit.getLocation(), remoteSplit.getRemoteSourceTaskId(), remoteSplit.getCommunicationSlug());
         exchangeClient.noMoreLocations();
         pageProducers.add(exchangeClient.pages()
                 .map(serializedPage -> {

--- a/presto-main/src/main/java/com/facebook/presto/server/TaskUpdateRequest.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskUpdateRequest.java
@@ -40,6 +40,7 @@ public class TaskUpdateRequest
     private final OutputBuffers outputIds;
     private final OptionalInt totalPartitions;
     private final Optional<TableWriteInfo> tableWriteInfo;
+    private final String communicationSlug;
 
     @JsonCreator
     public TaskUpdateRequest(
@@ -49,7 +50,8 @@ public class TaskUpdateRequest
             @JsonProperty("sources") List<TaskSource> sources,
             @JsonProperty("outputIds") OutputBuffers outputIds,
             @JsonProperty("totalPartitions") OptionalInt totalPartitions,
-            @JsonProperty("tableWriteInfo") Optional<TableWriteInfo> tableWriteInfo)
+            @JsonProperty("tableWriteInfo") Optional<TableWriteInfo> tableWriteInfo,
+            @JsonProperty("communicationSlug") String communicationSlug)
     {
         requireNonNull(session, "session is null");
         requireNonNull(extraCredentials, "credentials is null");
@@ -58,6 +60,7 @@ public class TaskUpdateRequest
         requireNonNull(outputIds, "outputIds is null");
         requireNonNull(totalPartitions, "totalPartitions is null");
         requireNonNull(tableWriteInfo, "tableWriteInfo is null");
+        requireNonNull(communicationSlug, "communicationSlug is null");
 
         this.session = session;
         this.extraCredentials = extraCredentials;
@@ -66,6 +69,7 @@ public class TaskUpdateRequest
         this.outputIds = outputIds;
         this.totalPartitions = totalPartitions;
         this.tableWriteInfo = tableWriteInfo;
+        this.communicationSlug = communicationSlug;
     }
 
     @JsonProperty
@@ -110,6 +114,12 @@ public class TaskUpdateRequest
         return tableWriteInfo;
     }
 
+    @JsonProperty
+    public String getCommunicationSlug()
+    {
+        return communicationSlug;
+    }
+
     @Override
     public String toString()
     {
@@ -120,6 +130,7 @@ public class TaskUpdateRequest
                 .add("sources", sources)
                 .add("outputIds", outputIds)
                 .add("totalPartitions", totalPartitions)
+                .add("communicationSlug", "_should_not_be_logged_")
                 .toString();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -552,7 +552,7 @@ class Query
             types = outputInfo.getColumnTypes();
         }
 
-        outputInfo.getBufferLocations().forEach(exchangeClient::addLocation);
+        outputInfo.getBufferLocations().forEach((uri, connectionInfo) -> exchangeClient.addLocation(uri, connectionInfo.getTaskId(), connectionInfo.getCommunicationSlug()));
         if (outputInfo.isNoMoreBufferLocations()) {
             exchangeClient.noMoreLocations();
         }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -111,7 +111,9 @@ import static com.google.common.util.concurrent.Futures.addCallback;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -185,6 +187,8 @@ public final class HttpRemoteTask
     private final int maxTaskUpdateSizeInBytes;
 
     private final TableWriteInfo tableWriteInfo;
+
+    private final String communicationSlug = "x" + randomUUID().toString().toLowerCase(ENGLISH).replace("-", "");
 
     public HttpRemoteTask(
             Session session,
@@ -339,6 +343,12 @@ public final class HttpRemoteTask
     public TaskStatus getTaskStatus()
     {
         return taskStatusFetcher.getTaskStatus();
+    }
+
+    @Override
+    public String getCommunicationSlug()
+    {
+        return communicationSlug;
     }
 
     @Override
@@ -633,7 +643,8 @@ public final class HttpRemoteTask
                 sources,
                 outputBuffers.get(),
                 totalPartitions,
-                writeInfo);
+                writeInfo,
+                communicationSlug);
         byte[] taskUpdateRequestJson = taskUpdateRequestCodec.toBytes(updateRequest);
 
         if (taskUpdateRequestJson.length > maxTaskUpdateSizeInBytes) {

--- a/presto-main/src/main/java/com/facebook/presto/split/RemoteSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/RemoteSplit.java
@@ -31,12 +31,14 @@ public class RemoteSplit
 {
     private final URI location;
     private final TaskId remoteSourceTaskId;
+    private final String communicationSlug;
 
     @JsonCreator
-    public RemoteSplit(@JsonProperty("location") URI location, @JsonProperty("remoteSourceTaskId") TaskId remoteSourceTaskId)
+    public RemoteSplit(@JsonProperty("location") URI location, @JsonProperty("remoteSourceTaskId") TaskId remoteSourceTaskId, @JsonProperty("communicationSlug") String communicationSlug)
     {
         this.location = requireNonNull(location, "location is null");
         this.remoteSourceTaskId = requireNonNull(remoteSourceTaskId, "remoteSourceTaskId is null");
+        this.communicationSlug = requireNonNull(communicationSlug, "communicationSlug is null");
     }
 
     @JsonProperty
@@ -49,6 +51,12 @@ public class RemoteSplit
     public TaskId getRemoteSourceTaskId()
     {
         return remoteSourceTaskId;
+    }
+
+    @JsonProperty
+    public String getCommunicationSlug()
+    {
+        return communicationSlug;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -453,5 +453,11 @@ public class MockRemoteTaskFactory
             }
             return getPartitionedSplitCount() - runningDrivers;
         }
+
+        @Override
+        public String getCommunicationSlug()
+        {
+            return "";
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -117,13 +117,13 @@ public class TestSqlTaskManager
             taskInfo = sqlTaskManager.getTaskInfo(taskId);
             assertEquals(taskInfo.getTaskStatus().getState(), TaskState.RUNNING);
 
-            BufferResult results = sqlTaskManager.getTaskResults(taskId, OUT, 0, new DataSize(1, Unit.MEGABYTE)).get();
+            BufferResult results = sqlTaskManager.getTaskResults(taskId, OUT, 0, new DataSize(1, Unit.MEGABYTE), "").get();
             assertEquals(results.isBufferComplete(), false);
             assertEquals(results.getSerializedPages().size(), 1);
             assertEquals(results.getSerializedPages().get(0).getPositionCount(), 1);
 
             for (boolean moreResults = true; moreResults; moreResults = !results.isBufferComplete()) {
-                results = sqlTaskManager.getTaskResults(taskId, OUT, results.getToken() + results.getSerializedPages().size(), new DataSize(1, Unit.MEGABYTE)).get();
+                results = sqlTaskManager.getTaskResults(taskId, OUT, results.getToken() + results.getSerializedPages().size(), new DataSize(1, Unit.MEGABYTE), "").get();
             }
             assertEquals(results.isBufferComplete(), true);
             assertEquals(results.getSerializedPages().size(), 0);
@@ -258,7 +258,8 @@ public class TestSqlTaskManager
                 ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, splits, true)),
                 outputBuffers,
                 OptionalInt.empty(),
-                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())),
+                "");
     }
 
     private TaskInfo createTask(SqlTaskManager sqlTaskManager, TaskId taskId, OutputBuffers outputBuffers)
@@ -278,7 +279,8 @@ public class TestSqlTaskManager
                 ImmutableList.of(),
                 outputBuffers,
                 OptionalInt.empty(),
-                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())),
+                "");
     }
 
     public static class MockExchangeClientSupplier

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
@@ -126,7 +126,7 @@ public class TestExchangeClient
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor);
 
-        exchangeClient.addLocation(location, TaskId.valueOf("queryid.0.0.0"));
+        exchangeClient.addLocation(location, TaskId.valueOf("queryid.0.0.0"), "");
         exchangeClient.noMoreLocations();
 
         assertFalse(exchangeClient.isClosed());
@@ -171,7 +171,7 @@ public class TestExchangeClient
         processor.addPage(location1, createPage(2));
         processor.addPage(location1, createPage(3));
         processor.setComplete(location1);
-        exchangeClient.addLocation(location1, TaskId.valueOf("foo.0.0.0"));
+        exchangeClient.addLocation(location1, TaskId.valueOf("foo.0.0.0"), "");
 
         assertFalse(exchangeClient.isClosed());
         assertPageEquals(getNextPage(exchangeClient), createPage(1));
@@ -188,7 +188,7 @@ public class TestExchangeClient
         processor.addPage(location2, createPage(5));
         processor.addPage(location2, createPage(6));
         processor.setComplete(location2);
-        exchangeClient.addLocation(location2, TaskId.valueOf("bar.0.0.0"));
+        exchangeClient.addLocation(location2, TaskId.valueOf("bar.0.0.0"), "");
 
         assertFalse(exchangeClient.isClosed());
         assertPageEquals(getNextPage(exchangeClient), createPage(4));
@@ -239,7 +239,7 @@ public class TestExchangeClient
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor);
 
-        exchangeClient.addLocation(location, TaskId.valueOf("taskid.0.0.0"));
+        exchangeClient.addLocation(location, TaskId.valueOf("taskid.0.0.0"), "");
         exchangeClient.noMoreLocations();
         assertFalse(exchangeClient.isClosed());
 
@@ -321,7 +321,7 @@ public class TestExchangeClient
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor);
-        exchangeClient.addLocation(location, TaskId.valueOf("taskid.0.0.0"));
+        exchangeClient.addLocation(location, TaskId.valueOf("taskid.0.0.0"), "");
         exchangeClient.noMoreLocations();
 
         // fetch a page
@@ -387,7 +387,7 @@ public class TestExchangeClient
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor)) {
             for (int i = 0; i < numLocations; i++) {
-                exchangeClient.addLocation(locations.get(i), TaskId.valueOf("taskid.0.0." + i));
+                exchangeClient.addLocation(locations.get(i), TaskId.valueOf("taskid.0.0." + i), "");
             }
             exchangeClient.noMoreLocations();
             assertFalse(exchangeClient.isClosed());
@@ -462,8 +462,8 @@ public class TestExchangeClient
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor);
-        exchangeClient.addLocation(location1, taskId1);
-        exchangeClient.addLocation(location2, taskId2);
+        exchangeClient.addLocation(location1, taskId1, "");
+        exchangeClient.addLocation(location2, taskId2, "");
 
         assertEquals(exchangeClient.isClosed(), false);
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
@@ -144,7 +144,7 @@ public class TestExchangeOperator
 
     private static Split newRemoteSplit(String taskId)
     {
-        return new Split(REMOTE_CONNECTOR_ID, new RemoteTransactionHandle(), new RemoteSplit(URI.create("http://localhost/" + taskId), TaskId.valueOf(taskId)));
+        return new Split(REMOTE_CONNECTOR_ID, new RemoteTransactionHandle(), new RemoteSplit(URI.create("http://localhost/" + taskId), TaskId.valueOf(taskId), taskId + "_slug"));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHttpPageBufferClient.java
@@ -107,7 +107,8 @@ public class TestHttpPageBufferClient
                 location,
                 callback,
                 scheduler,
-                pageBufferClientCallbackExecutor);
+                pageBufferClientCallbackExecutor,
+                "");
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
@@ -192,7 +193,8 @@ public class TestHttpPageBufferClient
                 location,
                 callback,
                 scheduler,
-                pageBufferClientCallbackExecutor);
+                pageBufferClientCallbackExecutor,
+                "");
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
@@ -232,7 +234,8 @@ public class TestHttpPageBufferClient
                 location,
                 callback,
                 scheduler,
-                pageBufferClientCallbackExecutor);
+                pageBufferClientCallbackExecutor,
+                "");
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
@@ -300,7 +303,8 @@ public class TestHttpPageBufferClient
                 location,
                 callback,
                 scheduler,
-                pageBufferClientCallbackExecutor);
+                pageBufferClientCallbackExecutor,
+                "");
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 
@@ -355,7 +359,8 @@ public class TestHttpPageBufferClient
                 callback,
                 scheduler,
                 ticker,
-                pageBufferClientCallbackExecutor);
+                pageBufferClientCallbackExecutor,
+                "");
 
         assertStatus(client, location, "queued", 0, 0, 0, 0, "not scheduled");
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMergeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMergeOperator.java
@@ -351,7 +351,7 @@ public class TestMergeOperator
 
     private static Split createRemoteSplit(String taskId)
     {
-        return new Split(ExchangeOperator.REMOTE_CONNECTOR_ID, new RemoteTransactionHandle(), new RemoteSplit(URI.create("http://localhost/" + taskId), TaskId.valueOf(taskId)));
+        return new Split(ExchangeOperator.REMOTE_CONNECTOR_ID, new RemoteTransactionHandle(), new RemoteSplit(URI.create("http://localhost/" + taskId), TaskId.valueOf(taskId), ""));
     }
 
     private static List<Page> pullAvailablePages(Operator operator)


### PR DESCRIPTION
As of now anyone who can build the task output URL can get the data from workers. This change adds a communication slug per task that the fetching task passes to get the output of the upstream task - this means that even if someone can build a task url, then need to know the communication slug to be able to get the data.

The slug is generated per task and then delivered to the workers running the task using the `TaskResource.createOrUpdateTask` function and to the tasks fetching the data using `RemoteSplit`.

This is WIP, which means that there would be code that doesn't make sense, but the approach is ready for review. Please take a look and let me know if this approach looks fine.

== NO RELEASE NOTE ==
