### PR TITLE
Allow range filter on subfields of structs with coercion

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercer.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercer.java
@@ -489,7 +489,14 @@ public interface HiveCoercer
                 String fieldName = ((Subfield.NestedField) subfield.getPath().get(0)).getName();
                 for (int i = 0; i < toFieldNames.size(); i++) {
                     if (fieldName.equals(toFieldNames.get(i))) {
-                        return coercers[i].toCoercingFilter(filter, subfield.tail(fieldName));
+                        HiveCoercer coercer = coercers[i];
+                        if (coercer == null) {
+                            // the column value will be null
+                            //  -> only isNull method will be called
+                            //   -> the original filter will work just fine
+                            return filter;
+                        }
+                        return coercer.toCoercingFilter(filter, subfield.tail(fieldName));
                     }
                 }
                 throw new IllegalArgumentException("Struct field not found: " + fieldName);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -892,6 +892,11 @@ public final class HiveUtil
                 .collect(toImmutableList());
     }
 
+    public static List<String> extractStructFieldNames(HiveType hiveType)
+    {
+        return ((StructTypeInfo) hiveType.getTypeInfo()).getAllStructFieldNames();
+    }
+
     public static int getHeaderCount(Properties schema)
     {
         return getPositiveIntegerValue(schema, "skip.header.line.count", "0");

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -542,7 +542,7 @@ public class OrcSelectivePageSourceFactory
             int columnIndex = columnIndices.get(subfield.getRootName());
             TupleDomainFilter filter = entry.getValue();
             if (coercers.containsKey(columnIndex)) {
-                filter = coercers.get(columnIndex).toCoercingFilter(filter);
+                filter = coercers.get(columnIndex).toCoercingFilter(filter, subfield);
             }
             filtersByColumn.computeIfAbsent(columnIndex, k -> new HashMap<>()).put(subfield, filter);
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -489,7 +489,10 @@ public abstract class AbstractTestHiveClient
             TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("tinyint_append", TINYINT), Domain.notNull(TINYINT))),
             // struct_to_struct
             TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("struct_to_struct.f_integer_to_varchar", MISMATCH_SCHEMA_ROW_TYPE_APPEND), Domain.singleValue(VARCHAR, Slices.utf8Slice("-27")))),
-            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("struct_to_struct.f_varchar_to_integer", MISMATCH_SCHEMA_ROW_TYPE_APPEND), Domain.singleValue(INTEGER, 2147483647L))));
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("struct_to_struct.f_varchar_to_integer", MISMATCH_SCHEMA_ROW_TYPE_APPEND), Domain.singleValue(INTEGER, 2147483647L))),
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("struct_to_struct.f_tinyint_to_smallint_append", MISMATCH_SCHEMA_ROW_TYPE_APPEND), Domain.singleValue(TINYINT, 1L))),
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("struct_to_struct.f_tinyint_to_smallint_append", MISMATCH_SCHEMA_ROW_TYPE_APPEND), Domain.onlyNull(TINYINT))),
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("struct_to_struct.f_tinyint_to_smallint_append", MISMATCH_SCHEMA_ROW_TYPE_APPEND), Domain.notNull(TINYINT))));
 
     private static final List<Predicate<MaterializedRow>> MISMATCH_SCHEMA_TABLE_AFTER_RESULT_PREDICATES = ImmutableList.of(
             // integer_to_varchar
@@ -506,7 +509,10 @@ public abstract class AbstractTestHiveClient
             row -> false,
             // struct_to_struct
             row -> Objects.equals(row.getField(6), "-27"),
-            row -> Objects.equals(row.getField(7), 2147483647));
+            row -> Objects.equals(row.getField(7), 2147483647),
+            row -> false,
+            row -> true,
+            row -> false);
 
     protected Set<HiveStorageFormat> createTableFormats = difference(ImmutableSet.copyOf(HiveStorageFormat.values()), ImmutableSet.of(AVRO));
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -444,6 +444,7 @@ public abstract class AbstractTestHiveClient
             .add(new ColumnMetadata("struct_to_struct", MISMATCH_SCHEMA_ROW_TYPE_APPEND))
             .add(new ColumnMetadata("list_to_list", arrayType(MISMATCH_SCHEMA_ROW_TYPE_APPEND)))
             .add(new ColumnMetadata("map_to_map", mapType(MISMATCH_SCHEMA_PRIMITIVE_COLUMN_AFTER.get(1).getType(), MISMATCH_SCHEMA_ROW_TYPE_DROP)))
+            .add(new ColumnMetadata("tinyint_append", TINYINT))
             .add(new ColumnMetadata("ds", createUnboundedVarcharType()))
             .build();
 
@@ -467,6 +468,7 @@ public abstract class AbstractTestHiveClient
                                 result.add(appendFieldRowResult);
                                 result.add(Arrays.asList(appendFieldRowResult, null, appendFieldRowResult));
                                 result.add(ImmutableMap.of(result.get(1), dropFieldRowResult));
+                                result.add(null);
                                 result.add(result.get(9));
                                 return new MaterializedRow(materializedRow.getPrecision(), result);
                             }).collect(toList()))
@@ -481,17 +483,28 @@ public abstract class AbstractTestHiveClient
             TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("varchar_to_integer", INTEGER), Domain.singleValue(INTEGER, -923L))),
             TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("varchar_to_integer", INTEGER), Domain.notNull(INTEGER))),
             TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("varchar_to_integer", INTEGER), Domain.onlyNull(INTEGER))),
+            // tinyint_append
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("tinyint_append", TINYINT), Domain.singleValue(TINYINT, 1L))),
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("tinyint_append", TINYINT), Domain.onlyNull(TINYINT))),
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("tinyint_append", TINYINT), Domain.notNull(TINYINT))),
             // struct_to_struct
             TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("struct_to_struct.f_integer_to_varchar", MISMATCH_SCHEMA_ROW_TYPE_APPEND), Domain.singleValue(VARCHAR, Slices.utf8Slice("-27")))),
             TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("struct_to_struct.f_varchar_to_integer", MISMATCH_SCHEMA_ROW_TYPE_APPEND), Domain.singleValue(INTEGER, 2147483647L))));
 
     private static final List<Predicate<MaterializedRow>> MISMATCH_SCHEMA_TABLE_AFTER_RESULT_PREDICATES = ImmutableList.of(
+            // integer_to_varchar
             row -> Objects.equals(row.getField(6), "17"),
             row -> row.getField(6) != null,
             row -> row.getField(6) == null,
+            // varchar_to_integer
             row -> Objects.equals(row.getField(7), -923),
             row -> row.getField(7) != null,
             row -> row.getField(7) == null,
+            // tinyint_append
+            row -> false,
+            row -> true,
+            row -> false,
+            // struct_to_struct
             row -> Objects.equals(row.getField(6), "-27"),
             row -> Objects.equals(row.getField(7), 2147483647));
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -472,15 +472,18 @@ public abstract class AbstractTestHiveClient
                             }).collect(toList()))
                     .build();
 
-    private static final List<TupleDomain<ColumnMetadata>> MISMATCH_SCHEMA_TABLE_AFTER_FILTERS = ImmutableList.of(
+    private static final List<TupleDomain<SubfieldWithType>> MISMATCH_SCHEMA_TABLE_AFTER_FILTERS = ImmutableList.of(
             // integer_to_varchar
-            TupleDomain.withColumnDomains(ImmutableMap.of(MISMATCH_SCHEMA_TABLE_AFTER.get(6), Domain.singleValue(VARCHAR, Slices.utf8Slice("17")))),
-            TupleDomain.withColumnDomains(ImmutableMap.of(MISMATCH_SCHEMA_TABLE_AFTER.get(6), Domain.notNull(VARCHAR))),
-            TupleDomain.withColumnDomains(ImmutableMap.of(MISMATCH_SCHEMA_TABLE_AFTER.get(6), Domain.onlyNull(VARCHAR))),
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("integer_to_varchar", VARCHAR), Domain.singleValue(VARCHAR, Slices.utf8Slice("17")))),
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("integer_to_varchar", VARCHAR), Domain.notNull(VARCHAR))),
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("integer_to_varchar", VARCHAR), Domain.onlyNull(VARCHAR))),
             // varchar_to_integer
-            TupleDomain.withColumnDomains(ImmutableMap.of(MISMATCH_SCHEMA_TABLE_AFTER.get(7), Domain.singleValue(INTEGER, -923L))),
-            TupleDomain.withColumnDomains(ImmutableMap.of(MISMATCH_SCHEMA_TABLE_AFTER.get(7), Domain.notNull(INTEGER))),
-            TupleDomain.withColumnDomains(ImmutableMap.of(MISMATCH_SCHEMA_TABLE_AFTER.get(7), Domain.onlyNull(INTEGER))));
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("varchar_to_integer", INTEGER), Domain.singleValue(INTEGER, -923L))),
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("varchar_to_integer", INTEGER), Domain.notNull(INTEGER))),
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("varchar_to_integer", INTEGER), Domain.onlyNull(INTEGER))),
+            // struct_to_struct
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("struct_to_struct.f_integer_to_varchar", MISMATCH_SCHEMA_ROW_TYPE_APPEND), Domain.singleValue(VARCHAR, Slices.utf8Slice("-27")))),
+            TupleDomain.withColumnDomains(ImmutableMap.of(SubfieldWithType.of("struct_to_struct.f_varchar_to_integer", MISMATCH_SCHEMA_ROW_TYPE_APPEND), Domain.singleValue(INTEGER, 2147483647L))));
 
     private static final List<Predicate<MaterializedRow>> MISMATCH_SCHEMA_TABLE_AFTER_RESULT_PREDICATES = ImmutableList.of(
             row -> Objects.equals(row.getField(6), "17"),
@@ -488,7 +491,9 @@ public abstract class AbstractTestHiveClient
             row -> row.getField(6) == null,
             row -> Objects.equals(row.getField(7), -923),
             row -> row.getField(7) != null,
-            row -> row.getField(7) == null);
+            row -> row.getField(7) == null,
+            row -> Objects.equals(row.getField(6), "-27"),
+            row -> Objects.equals(row.getField(7), 2147483647));
 
     protected Set<HiveStorageFormat> createTableFormats = difference(ImmutableSet.copyOf(HiveStorageFormat.values()), ImmutableSet.of(AVRO));
 
@@ -1248,7 +1253,7 @@ public abstract class AbstractTestHiveClient
             MaterializedResult dataBefore,
             List<ColumnMetadata> tableAfter,
             MaterializedResult dataAfter,
-            List<TupleDomain<ColumnMetadata>> afterFilters,
+            List<TupleDomain<SubfieldWithType>> afterFilters,
             List<Predicate<MaterializedRow>> afterResultPredicates)
             throws Exception
     {
@@ -1320,9 +1325,9 @@ public abstract class AbstractTestHiveClient
 
             int filterCount = afterFilters.size();
             for (int i = 0; i < filterCount; i++) {
-                TupleDomain<ColumnMetadata> tupleDomain = afterFilters.get(i);
+                TupleDomain<SubfieldWithType> tupleDomain = afterFilters.get(i);
 
-                RowExpression predicate = ROW_EXPRESSION_SERVICE.getDomainTranslator().toPredicate(tupleDomain.transform(AbstractTestHiveClient::toVariable));
+                RowExpression predicate = ROW_EXPRESSION_SERVICE.getDomainTranslator().toPredicate(tupleDomain.transform(column -> toVariable(column, session)));
                 ConnectorTableLayoutHandle layoutHandle = metadata.pushdownFilter(session, tableHandle, predicate, Optional.empty()).getLayout().getHandle();
 
                 // Read all columns with a filter
@@ -1335,7 +1340,8 @@ public abstract class AbstractTestHiveClient
 
                 // Read all columns except the ones used in the filter
                 Set<String> filterColumnNames = tupleDomain.getDomains().get().keySet().stream()
-                        .map(ColumnMetadata::getName)
+                        .map(SubfieldWithType::getSubfield)
+                        .map(Subfield::getRootName)
                         .collect(toImmutableSet());
 
                 List<ColumnHandle> nonFilterColumns = columnHandles.stream()
@@ -1372,9 +1378,10 @@ public abstract class AbstractTestHiveClient
         }
     }
 
-    private static VariableReferenceExpression toVariable(ColumnMetadata column)
+    private static RowExpression toVariable(SubfieldWithType column, ConnectorSession session)
     {
-        return new VariableReferenceExpression(column.getName(), column.getType());
+        SubfieldExtractor subfieldExtractor = new SubfieldExtractor(FUNCTION_RESOLUTION, ROW_EXPRESSION_SERVICE.getExpressionOptimizer(), session);
+        return subfieldExtractor.toRowExpression(column.getSubfield(), column.getType());
     }
 
     protected void assertExpectedTableLayout(ConnectorTableLayout actualTableLayout, ConnectorTableLayout expectedTableLayout)
@@ -5467,6 +5474,33 @@ public abstract class AbstractTestHiveClient
             // The file we added to trigger a conflict was cleaned up because it matches the query prefix.
             // Consider this the same as a network failure that caused the successful creation of file not reported to the caller.
             assertFalse(hdfsEnvironment.getFileSystem(context, path).exists(path));
+        }
+    }
+
+    private static final class SubfieldWithType
+    {
+        private final Subfield subfield;
+        private final Type type;
+
+        private SubfieldWithType(Subfield subfield, Type type)
+        {
+            this.subfield = subfield;
+            this.type = type;
+        }
+
+        public static SubfieldWithType of(String subfield, Type type)
+        {
+            return new SubfieldWithType(new Subfield(subfield), type);
+        }
+
+        public Subfield getSubfield()
+        {
+            return subfield;
+        }
+
+        public Type getType()
+        {
+            return type;
         }
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestCoercingFilters.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestCoercingFilters.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.HiveCoercer.VarcharToIntegerNumberCoercer;
 import com.facebook.presto.orc.TupleDomainFilter;
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
 import com.facebook.presto.orc.TupleDomainFilter.BytesRange;
+import com.facebook.presto.spi.Subfield;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
@@ -34,7 +35,7 @@ public class TestCoercingFilters
 
         HiveCoercer coercer = new IntegerNumberToVarcharCoercer(INTEGER, VARCHAR);
 
-        TupleDomainFilter coercingFilter = coercer.toCoercingFilter(filter);
+        TupleDomainFilter coercingFilter = coercer.toCoercingFilter(filter, new Subfield("c"));
 
         assertTrue(coercingFilter.testLong(10));
         assertFalse(coercingFilter.testLong(25));
@@ -48,7 +49,7 @@ public class TestCoercingFilters
 
         HiveCoercer coercer = new VarcharToIntegerNumberCoercer(VARCHAR, INTEGER);
 
-        TupleDomainFilter coercingFilter = coercer.toCoercingFilter(filter);
+        TupleDomainFilter coercingFilter = coercer.toCoercingFilter(filter, new Subfield("c"));
 
         assertTrue(coercingFilter.testLength(1));
         assertTrue(coercingFilter.testLength(2));


### PR DESCRIPTION
Fixes `UnsupportedOperationException` for queries with range filters on struct subfields when applied to tables with updated schema.

```
Caused by: java.lang.UnsupportedOperationException: Range filers on array types are not supported
	at com.facebook.presto.hive.HiveCoercer$StructCoercer.toCoercingFilter(HiveCoercer.java:479)
	at com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory.toTupleDomainFilters(OrcSelectivePageSourceFactory.java:545)
```

```
== NO RELEASE NOTE ==
```
