### PR TITLE
Reset allNulls flag in SliceDictionaryXxx#read

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
@@ -143,11 +143,13 @@ public class SliceDictionarySelectiveReader
     public int read(int offset, int[] positions, int positionCount)
             throws IOException
     {
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
         if (!rowGroupOpen) {
             openRowGroup();
         }
 
-        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+        allNulls = false;
 
         if (outputRequired) {
             values = ensureCapacity(values, positionCount);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
@@ -114,11 +114,13 @@ public class SliceDirectSelectiveStreamReader
     public int read(int offset, int[] positions, int positionCount)
             throws IOException
     {
+        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+
         if (!rowGroupOpen) {
             openRowGroup();
         }
 
-        checkState(!valuesInUse, "BlockLease hasn't been closed yet");
+        allNulls = false;
 
         outputPositions = initializeOutputPositions(outputPositions, positions, positionCount);
 
@@ -150,8 +152,6 @@ public class SliceDirectSelectiveStreamReader
             throws IOException
     {
         int streamPosition = 0;
-        allNulls = false;
-
         for (int i = 0; i < positionCount; i++) {
             int position = positions[i];
             if (position > streamPosition) {
@@ -188,7 +188,6 @@ public class SliceDirectSelectiveStreamReader
     private int readWithFilter(int[] positions, int positionCount)
             throws IOException
     {
-        allNulls = false;
         int streamPosition = 0;
         int dataToSkip = 0;
 


### PR DESCRIPTION
allNulls flag was not being reset in SliceDictionarySelectiveReader#read() causing the reader to return nulls for all batches after the first all-null batch.

SliceDictionarySelectiveReader didn't have this problem, but reset logic there was confusing and different from other readers. Hence, updates that reader to be consistent with the rest.

```
== NO RELEASE NOTE ==
```
