### PR TITLE
Fix size type when calculating retained size.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/DecodedBlockNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/DecodedBlockNode.java
@@ -60,7 +60,7 @@ class DecodedBlockNode
 
     public long getRetainedSizeInBytes()
     {
-        int size = INSTANCE_SIZE;
+        long size = INSTANCE_SIZE;
         if (decodedBlock instanceof Block) {
             size += ((Block) decodedBlock).getRetainedSizeInBytes();
         }


### PR DESCRIPTION
There're some cases where the decodedBlock is ColumnarArray whose elementBlock is large DictionaryBlock. For such cases, the retained size, if in int type, would overflow.

Note that this doesn't fix the problem where the big DictionaryBlock was generated: https://github.com/prestodb/presto/issues/13722

```
== NO RELEASE NOTE ==
```
