### PR TITLE
Add support for filter functions on columns with coercions

### DIFF
--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -105,6 +105,13 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Filter expressions are referring to columns from the latest table schema, hence, variables in the variableToInput mapping in OrcSelectivePageSourceFactory must use column types from the latest table schema, not from the partition schema.

```
Caused by: com.facebook.presto.spi.PrestoException: Error opening Hive split xxx java.lang.UnsupportedOperationException
	at com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory.createOrcPageSource(OrcSelectivePageSourceFactory.java:395)
	at com.facebook.presto.hive.orc.DwrfSelectivePageSourceFactory.createPageSource(DwrfSelectivePageSourceFactory.java:115)
	at com.facebook.presto.hive.HivePageSourceProvider.createSelectivePageSource(HivePageSourceProvider.java:211)
	at com.facebook.presto.hive.HivePageSourceProvider.createPageSource(HivePageSourceProvider.java:117)
	at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPageSourceProvider.createPageSource(ClassLoaderSafeConnectorPageSourceProvider.java:51)
	at com.facebook.presto.split.PageSourceManager.createPageSource(PageSourceManager.java:58)
	at com.facebook.presto.operator.ScanFilterAndProjectOperator.getOutput(ScanFilterAndProjectOperator.java:226)
Caused by: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.UnsupportedOperationException
	...
	at com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory.toFilterFunctions(OrcSelectivePageSourceFactory.java:606)
	at com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory.createOrcPageSource(OrcSelectivePageSourceFactory.java:357)
	... 17 more
Caused by: java.lang.UnsupportedOperationException
	at com.facebook.presto.sql.gen.InputReferenceCompiler.visitVariableReference(InputReferenceCompiler.java:98)
	at com.facebook.presto.sql.gen.InputReferenceCompiler.visitVariableReference(InputReferenceCompiler.java:43)
	at com.facebook.presto.sql.gen.RowExpressionCompiler$Visitor.visitVariableReference(RowExpressionCompiler.java:237)
	at com.facebook.presto.sql.gen.RowExpressionCompiler$Visitor.visitVariableReference(RowExpressionCompiler.java:98)
	at com.facebook.presto.spi.relation.VariableReferenceExpression.accept(VariableReferenceExpression.java:71)
	...
	at com.facebook.presto.sql.gen.RowExpressionPredicateCompiler.lambda$new$0(RowExpressionPredicateCompiler.java:89)
	at com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:165)
```
```
== NO RELEASE NOTE ==
```
