### PR TITLE
Construct QualifiedFunctionName with CatalogSchemaName and function name

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateFunctionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateFunctionTask.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.spi.CatalogSchemaName;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.QualifiedFunctionName;
 import com.facebook.presto.spi.function.RoutineCharacteristics;
@@ -76,11 +77,14 @@ public class CreateFunctionTask
 
     private SqlInvokedFunction createSqlInvokedFunction(CreateFunction statement)
     {
-        if (statement.getFunctionName().getParts().size() != 3) {
+        List<String> parts = statement.getFunctionName().getParts();
+        if (parts.size() != 3) {
             throw new PrestoException(GENERIC_USER_ERROR, format("Invalid function name: %s, require exactly 3 parts", statement.getFunctionName()));
         }
 
-        QualifiedFunctionName functionName = QualifiedFunctionName.of(statement.getFunctionName().toString());
+        QualifiedFunctionName functionName = QualifiedFunctionName.of(
+                new CatalogSchemaName(parts.get(0), parts.get(1)),
+                parts.get(2));
         List<SqlParameter> parameters = statement.getParameters().stream()
                 .map(parameter -> new SqlParameter(parameter.getName().toString().toLowerCase(ENGLISH), parseTypeSignature(parameter.getType())))
                 .collect(toImmutableList());

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/OperatorType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/OperatorType.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.spi.function;
 
+import com.facebook.presto.spi.CatalogSchemaName;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -52,7 +54,7 @@ public enum OperatorType
     OperatorType(String operator, boolean calledOnNullInput)
     {
         this.operator = operator;
-        this.functionName = QualifiedFunctionName.of("presto.default.$operator$" + name());
+        this.functionName = QualifiedFunctionName.of(new CatalogSchemaName("presto", "default"), "$operator$" + name());
         this.calledOnNullInput = calledOnNullInput;
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/QualifiedFunctionName.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/QualifiedFunctionName.java
@@ -33,6 +33,7 @@ public class QualifiedFunctionName
         this.functionName = requireNonNull(functionName, "name is null").toLowerCase(ENGLISH);
     }
 
+    // This function should only be used for JSON deserialization. Do not use it directly.
     @JsonCreator
     public static QualifiedFunctionName of(String dottedName)
     {


### PR DESCRIPTION
Do not use dot separated string to create QualifiedFunctionName to lower the chance of throwing runtime error
```
== NO RELEASE NOTE ==
```
