### PR TITLE
Rename session variable to be more specific

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -151,7 +151,7 @@ public class HiveClientConfig
     private HiveCompressionCodec temporaryTableCompressionCodec = HiveCompressionCodec.SNAPPY;
 
     private boolean pushdownFilterEnabled;
-    private boolean nestedColumnsFilterEnabled;
+    private boolean rangeFiltersOnSubscriptsEnabled;
     private boolean zstdJniDecompressionEnabled;
 
     public int getMaxInitialSplits()
@@ -1240,16 +1240,16 @@ public class HiveClientConfig
         return this;
     }
 
-    public boolean isNestedColumnsFilterEnabled()
+    public boolean isRangeFiltersOnSubscriptsEnabled()
     {
-        return nestedColumnsFilterEnabled;
+        return rangeFiltersOnSubscriptsEnabled;
     }
 
-    @Config("hive.nested-columns-filter-enabled")
-    @ConfigDescription("Experimental: enable filters on nested columns")
-    public HiveClientConfig setNestedColumnsFilterEnabled(boolean nestedColumnsFilterEnabled)
+    @Config("hive.range-filters-on-subscripts-enabled")
+    @ConfigDescription("Experimental: enable pushdown of range filters on subscripts (a[2] = 5) into ORC column readers")
+    public HiveClientConfig setRangeFiltersOnSubscriptsEnabled(boolean rangeFiltersOnSubscriptsEnabled)
     {
-        this.nestedColumnsFilterEnabled = nestedColumnsFilterEnabled;
+        this.rangeFiltersOnSubscriptsEnabled = rangeFiltersOnSubscriptsEnabled;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -88,7 +88,7 @@ public final class HiveSessionProperties
     private static final String TEMPORARY_TABLE_STORAGE_FORMAT = "temporary_table_storage_format";
     private static final String TEMPORARY_TABLE_COMPRESSION_CODEC = "temporary_table_compression_codec";
     public static final String PUSHDOWN_FILTER_ENABLED = "pushdown_filter_enabled";
-    public static final String NESTED_COLUMNS_FILTER_ENABLED = "nested_columns_filter_enabled";
+    public static final String RANGE_FILTERS_ON_SUBSCRIPTS_ENABLED = "range_filters_on_subscripts_enabled";
     public static final String VIRTUAL_BUCKET_COUNT = "virtual_bucket_count";
     public static final String MAX_BUCKETS_FOR_GROUPED_EXECUTION = "max_buckets_for_grouped_execution";
     public static final String OFFLINE_DATA_DEBUG_MODE_ENABLED = "offline_data_debug_mode_enabled";
@@ -381,9 +381,9 @@ public final class HiveSessionProperties
                         hiveClientConfig.isPushdownFilterEnabled(),
                         false),
                 booleanProperty(
-                        NESTED_COLUMNS_FILTER_ENABLED,
-                        "Experimental: enable filters on nested columns",
-                        hiveClientConfig.isNestedColumnsFilterEnabled(),
+                        RANGE_FILTERS_ON_SUBSCRIPTS_ENABLED,
+                        "Experimental: enable pushdown of range filters on subscripts (a[2] = 5) into ORC column readers",
+                        hiveClientConfig.isRangeFiltersOnSubscriptsEnabled(),
                         false),
                 integerProperty(
                         VIRTUAL_BUCKET_COUNT,
@@ -669,9 +669,9 @@ public final class HiveSessionProperties
         return session.getProperty(PUSHDOWN_FILTER_ENABLED, Boolean.class);
     }
 
-    public static boolean isNestedColumnsFilterEnabled(ConnectorSession session)
+    public static boolean isRangeFiltersOnSubscriptsEnabled(ConnectorSession session)
     {
-        return session.getProperty(NESTED_COLUMNS_FILTER_ENABLED, Boolean.class);
+        return session.getProperty(RANGE_FILTERS_ON_SUBSCRIPTS_ENABLED, Boolean.class);
     }
 
     public static int getVirtualBucketCount(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
@@ -37,7 +37,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.hive.HiveSessionProperties.isNestedColumnsFilterEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isRangeFiltersOnSubscriptsEnabled;
 import static com.facebook.presto.spi.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.DEREFERENCE;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -76,7 +76,7 @@ public final class SubfieldExtractor
             Optional<Subfield> subfield = extract(expression);
             // If the expression involves array or map subscripts, it is considered only if allowed by nested_columns_filter_enabled.
             if (hasSubscripts(subfield)) {
-                if (isNestedColumnsFilterEnabled(connectorSession)) {
+                if (isRangeFiltersOnSubscriptsEnabled(connectorSession)) {
                     return subfield;
                 }
                 return Optional.empty();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
@@ -111,7 +111,7 @@ public class TestDomainTranslator
                 TEST_EXPRESSION_OPTIMIZER,
                 new TestingConnectorSession(
                         new HiveSessionProperties(
-                                new HiveClientConfig().setNestedColumnsFilterEnabled(true),
+                                new HiveClientConfig().setRangeFiltersOnSubscriptsEnabled(true),
                                 new OrcFileWriterConfig(),
                                 new ParquetFileWriterConfig()).getSessionProperties())).toColumnExtractor();
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -122,7 +122,7 @@ public class TestHiveClientConfig
                 .setTemporaryTableCompressionCodec(SNAPPY)
                 .setPushdownFilterEnabled(false)
                 .setZstdJniDecompressionEnabled(false)
-                .setNestedColumnsFilterEnabled(false));
+                .setRangeFiltersOnSubscriptsEnabled(false));
     }
 
     @Test
@@ -208,7 +208,7 @@ public class TestHiveClientConfig
                 .put("hive.temporary-table-storage-format", "DWRF")
                 .put("hive.temporary-table-compression-codec", "NONE")
                 .put("hive.pushdown-filter-enabled", "true")
-                .put("hive.nested-columns-filter-enabled", "true")
+                .put("hive.range-filters-on-subscripts-enabled", "true")
                 .put("hive.zstd-jni-decompression-enabled", "true")
                 .build();
 
@@ -294,7 +294,7 @@ public class TestHiveClientConfig
                 .setTemporaryTableCompressionCodec(NONE)
                 .setPushdownFilterEnabled(true)
                 .setZstdJniDecompressionEnabled(true)
-                .setNestedColumnsFilterEnabled(true);
+                .setRangeFiltersOnSubscriptsEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -60,8 +60,8 @@ import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTAN
 import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
 import static com.facebook.presto.hive.HiveQueryRunner.createQueryRunner;
 import static com.facebook.presto.hive.HiveSessionProperties.COLLECT_COLUMN_STATISTICS_ON_WRITE;
-import static com.facebook.presto.hive.HiveSessionProperties.NESTED_COLUMNS_FILTER_ENABLED;
 import static com.facebook.presto.hive.HiveSessionProperties.PUSHDOWN_FILTER_ENABLED;
+import static com.facebook.presto.hive.HiveSessionProperties.RANGE_FILTERS_ON_SUBSCRIPTS_ENABLED;
 import static com.facebook.presto.hive.TestHiveIntegrationSmokeTest.assertRemoteExchangesCount;
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
 import static com.facebook.presto.spi.predicate.Domain.multipleValues;
@@ -778,7 +778,7 @@ public class TestHiveLogicalPlanner
     {
         return Session.builder(getQueryRunner().getDefaultSession())
                 .setCatalogSessionProperty(HIVE_CATALOG, PUSHDOWN_FILTER_ENABLED, "true")
-                .setCatalogSessionProperty(HIVE_CATALOG, NESTED_COLUMNS_FILTER_ENABLED, "true")
+                .setCatalogSessionProperty(HIVE_CATALOG, RANGE_FILTERS_ON_SUBSCRIPTS_ENABLED, "true")
                 .build();
     }
 


### PR DESCRIPTION
The implementation of the session variable allows range filter on nested fields with out subscripts.
Changed the variable name to be more appropriate.

```
== NO RELEASE NOTE ==
```
