### PR TITLE
Make restProxyServiceForQuery nullable for Pinot connector

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
@@ -121,7 +121,7 @@ public class PinotConfig
         return this;
     }
 
-    @NotNull
+    @Nullable
     public String getControllerRestService()
     {
         return controllerRestService;


### PR DESCRIPTION
Summary: I think we missed making it nullable in the first version of
this code. Indeed it should be nullable, because its only call is
inside of Optional.ofNullable(...). This setting is kind of Uber
internal because of the way Pinot is deployed there and its not
publicized in https://prestodb.io/docs/current/connector/pinot.html.

Make it nullable as intended.

Test Plan: Start the presto server locally with a pinot property file
not having this setting and paired with a locally (docker) running pinot
installation.

Would fix https://github.com/prestodb/presto/issues/13724
```
== NO RELEASE NOTE ==
```
