### PR TITLE
Enable creating table with table_supports_delta_delete property for raptor

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorOutputTableHandle.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorOutputTableHandle.java
@@ -45,6 +45,7 @@ public class RaptorOutputTableHandle
     private final OptionalInt bucketCount;
     private final List<RaptorColumnHandle> bucketColumnHandles;
     private final boolean organized;
+    private final boolean tableSupportsDeltaDelete;
 
     @JsonCreator
     public RaptorOutputTableHandle(
@@ -59,8 +60,9 @@ public class RaptorOutputTableHandle
             @JsonProperty("temporalColumnHandle") Optional<RaptorColumnHandle> temporalColumnHandle,
             @JsonProperty("distributionId") OptionalLong distributionId,
             @JsonProperty("bucketCount") OptionalInt bucketCount,
+            @JsonProperty("bucketColumnHandles") List<RaptorColumnHandle> bucketColumnHandles,
             @JsonProperty("organized") boolean organized,
-            @JsonProperty("bucketColumnHandles") List<RaptorColumnHandle> bucketColumnHandles)
+            @JsonProperty("tableSupportsDeltaDelete") boolean tableSupportsDeltaDelete)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.transactionId = transactionId;
@@ -75,6 +77,7 @@ public class RaptorOutputTableHandle
         this.bucketCount = requireNonNull(bucketCount, "bucketCount is null");
         this.bucketColumnHandles = ImmutableList.copyOf(requireNonNull(bucketColumnHandles, "bucketColumnHandles is null"));
         this.organized = organized;
+        this.tableSupportsDeltaDelete = tableSupportsDeltaDelete;
     }
 
     @JsonProperty
@@ -153,6 +156,12 @@ public class RaptorOutputTableHandle
     public boolean isOrganized()
     {
         return organized;
+    }
+
+    @JsonProperty
+    public boolean isTableSupportsDeltaDelete()
+    {
+        return tableSupportsDeltaDelete;
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorTableHandle.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorTableHandle.java
@@ -43,6 +43,7 @@ public final class RaptorTableHandle
     private final OptionalLong transactionId;
     private final Optional<Map<String, Type>> columnTypes;
     private final boolean delete;
+    private final boolean tableSupportsDeltaDelete;
 
     @JsonCreator
     public RaptorTableHandle(
@@ -56,7 +57,8 @@ public final class RaptorTableHandle
             @JsonProperty("organized") boolean organized,
             @JsonProperty("transactionId") OptionalLong transactionId,
             @JsonProperty("columnTypes") Optional<Map<String, Type>> columnTypes,
-            @JsonProperty("delete") boolean delete)
+            @JsonProperty("delete") boolean delete,
+            @JsonProperty("tableSupportsDeltaDelete") boolean tableSupportsDeltaDelete)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.schemaName = checkSchemaName(schemaName);
@@ -73,6 +75,7 @@ public final class RaptorTableHandle
         this.columnTypes = requireNonNull(columnTypes, "columnTypes is null");
 
         this.delete = delete;
+        this.tableSupportsDeltaDelete = tableSupportsDeltaDelete;
     }
 
     public boolean isBucketed()
@@ -144,6 +147,12 @@ public final class RaptorTableHandle
     public boolean isDelete()
     {
         return delete;
+    }
+
+    @JsonProperty
+    public boolean isTableSupportsDeltaDelete()
+    {
+        return tableSupportsDeltaDelete;
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorTableProperties.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorTableProperties.java
@@ -39,6 +39,7 @@ public class RaptorTableProperties
     public static final String BUCKETED_ON_PROPERTY = "bucketed_on";
     public static final String DISTRIBUTION_NAME_PROPERTY = "distribution_name";
     public static final String ORGANIZED_PROPERTY = "organized";
+    public static final String TABLE_SUPPORTS_DELTA_DELETE = "table_supports_delta_delete";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -68,6 +69,11 @@ public class RaptorTableProperties
                 .add(booleanProperty(
                         ORGANIZED_PROPERTY,
                         "Keep the table organized using the sort order",
+                        null,
+                        false))
+                .add(booleanProperty(
+                        TABLE_SUPPORTS_DELTA_DELETE,
+                        "Support delta delete on the table",
                         null,
                         false))
                 .build();
@@ -107,6 +113,12 @@ public class RaptorTableProperties
     public static boolean isOrganized(Map<String, Object> tableProperties)
     {
         Boolean value = (Boolean) tableProperties.get(ORGANIZED_PROPERTY);
+        return (value == null) ? false : value;
+    }
+
+    public static boolean isTableSupportsDeltaDelete(Map<String, Object> tableProperties)
+    {
+        Boolean value = (Boolean) tableProperties.get(TABLE_SUPPORTS_DELTA_DELETE);
         return (value == null) ? false : value;
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/MetadataDao.java
@@ -27,7 +27,7 @@ import java.util.Set;
 public interface MetadataDao
 {
     String TABLE_INFORMATION_SELECT = "" +
-            "SELECT t.table_id, t.distribution_id, d.distribution_name, d.bucket_count, t.temporal_column_id, t.organization_enabled\n" +
+            "SELECT t.table_id, t.distribution_id, d.distribution_name, d.bucket_count, t.temporal_column_id, t.organization_enabled, t.table_supports_delta_delete\n" +
             "FROM tables t\n" +
             "LEFT JOIN distributions d ON (t.distribution_id = d.distribution_id)\n";
 
@@ -115,11 +115,11 @@ public interface MetadataDao
     @SqlUpdate("INSERT INTO tables (\n" +
             "  schema_name, table_name, compaction_enabled, organization_enabled, distribution_id,\n" +
             "  create_time, update_time, table_version,\n" +
-            "  shard_count, row_count, compressed_size, uncompressed_size)\n" +
+            "  shard_count, row_count, compressed_size, uncompressed_size, table_supports_delta_delete)\n" +
             "VALUES (\n" +
             "  :schemaName, :tableName, :compactionEnabled, :organizationEnabled, :distributionId,\n" +
             "  :createTime, :createTime, 0,\n" +
-            "  0, 0, 0, 0)\n")
+            "  0, 0, 0, 0, :tableSupportsDeltaDelete)\n")
     @GetGeneratedKeys
     long insertTable(
             @Bind("schemaName") String schemaName,
@@ -127,7 +127,8 @@ public interface MetadataDao
             @Bind("compactionEnabled") boolean compactionEnabled,
             @Bind("organizationEnabled") boolean organizationEnabled,
             @Bind("distributionId") Long distributionId,
-            @Bind("createTime") long createTime);
+            @Bind("createTime") long createTime,
+            @Bind("tableSupportsDeltaDelete") boolean tableSupportsDeltaDelete);
 
     @SqlUpdate("UPDATE tables SET\n" +
             "  update_time = :updateTime\n" +
@@ -246,7 +247,7 @@ public interface MetadataDao
             @Bind("columnTypes") String columnTypes,
             @Bind("bucketCount") int bucketCount);
 
-    @SqlQuery("SELECT table_id, schema_name, table_name, temporal_column_id, distribution_name, bucket_count, organization_enabled\n" +
+    @SqlQuery("SELECT table_id, schema_name, table_name, temporal_column_id, distribution_name, bucket_count, organization_enabled, table_supports_delta_delete\n" +
             "FROM tables\n" +
             "LEFT JOIN distributions\n" +
             "ON tables.distribution_id = distributions.distribution_id\n" +

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/SchemaDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/SchemaDao.java
@@ -42,6 +42,7 @@ public interface SchemaDao
             "  compressed_size BIGINT NOT NULL,\n" +
             "  uncompressed_size BIGINT NOT NULL,\n" +
             "  maintenance_blocked DATETIME,\n" +
+            "  table_supports_delta_delete BOOLEAN NOT NULL DEFAULT false,\n" +
             "  UNIQUE (schema_name, table_name),\n" +
             "  UNIQUE (distribution_id, table_id),\n" +
             "  UNIQUE (maintenance_blocked, table_id),\n" +

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
@@ -30,7 +30,7 @@ public interface ShardManager
     /**
      * Create a table.
      */
-    void createTable(long tableId, List<ColumnInfo> columns, boolean bucketed, OptionalLong temporalColumnId);
+    void createTable(long tableId, List<ColumnInfo> columns, boolean bucketed, OptionalLong temporalColumnId, boolean tableSupportsDeltaDelete);
 
     /**
      * Drop a table.

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/Table.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/Table.java
@@ -35,6 +35,7 @@ public final class Table
     private final OptionalInt bucketCount;
     private final OptionalLong temporalColumnId;
     private final boolean organized;
+    private final boolean tableSupportsDeltaDelete;
 
     public Table(
             long tableId,
@@ -42,7 +43,8 @@ public final class Table
             Optional<String> distributionName,
             OptionalInt bucketCount,
             OptionalLong temporalColumnId,
-            boolean organized)
+            boolean organized,
+            boolean tableSupportsDeltaDelete)
     {
         this.tableId = tableId;
         this.distributionId = requireNonNull(distributionId, "distributionId is null");
@@ -50,6 +52,7 @@ public final class Table
         this.bucketCount = requireNonNull(bucketCount, "bucketCount is null");
         this.temporalColumnId = requireNonNull(temporalColumnId, "temporalColumnId is null");
         this.organized = organized;
+        this.tableSupportsDeltaDelete = tableSupportsDeltaDelete;
     }
 
     public long getTableId()
@@ -82,6 +85,11 @@ public final class Table
         return organized;
     }
 
+    public boolean isTableSupportsDeltaDelete()
+    {
+        return tableSupportsDeltaDelete;
+    }
+
     @Override
     public String toString()
     {
@@ -91,6 +99,7 @@ public final class Table
                 .add("bucketCount", bucketCount.isPresent() ? bucketCount.getAsInt() : null)
                 .add("temporalColumnId", temporalColumnId.isPresent() ? temporalColumnId.getAsLong() : null)
                 .add("organized", organized)
+                .add("tableSupportsDeltaDelete", tableSupportsDeltaDelete)
                 .omitNullValues()
                 .toString();
     }
@@ -108,7 +117,8 @@ public final class Table
                     Optional.ofNullable(r.getString("distribution_name")),
                     getOptionalInt(r, "bucket_count"),
                     getOptionalLong(r, "temporal_column_id"),
-                    r.getBoolean("organization_enabled"));
+                    r.getBoolean("organization_enabled"),
+                    r.getBoolean("table_supports_delta_delete"));
         }
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/TableMetadataRow.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/TableMetadataRow.java
@@ -35,6 +35,7 @@ public class TableMetadataRow
     private final Optional<String> distributionName;
     private final OptionalInt bucketCount;
     private final boolean organized;
+    private final boolean tableSupportsDeltaDelete;
 
     public TableMetadataRow(
             long tableId,
@@ -43,7 +44,8 @@ public class TableMetadataRow
             OptionalLong temporalColumnId,
             Optional<String> distributionName,
             OptionalInt bucketCount,
-            boolean organized)
+            boolean organized,
+            boolean tableSupportsDeltaDelete)
     {
         this.tableId = tableId;
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
@@ -52,6 +54,7 @@ public class TableMetadataRow
         this.distributionName = requireNonNull(distributionName, "distributionName is null");
         this.bucketCount = requireNonNull(bucketCount, "bucketCount is null");
         this.organized = organized;
+        this.tableSupportsDeltaDelete = tableSupportsDeltaDelete;
     }
 
     public long getTableId()
@@ -89,6 +92,11 @@ public class TableMetadataRow
         return organized;
     }
 
+    public boolean isTableSupportsDeltaDelete()
+    {
+        return tableSupportsDeltaDelete;
+    }
+
     public static class Mapper
             implements ResultSetMapper<TableMetadataRow>
     {
@@ -103,7 +111,8 @@ public class TableMetadataRow
                     getOptionalLong(rs, "temporal_column_id"),
                     Optional.ofNullable(rs.getString("distribution_name")),
                     getOptionalInt(rs, "bucket_count"),
-                    rs.getBoolean("organization_enabled"));
+                    rs.getBoolean("organization_enabled"),
+                    rs.getBoolean("table_supports_delta_delete"));
         }
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/systemtables/TableMetadataSystemTable.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/systemtables/TableMetadataSystemTable.java
@@ -89,7 +89,8 @@ public class TableMetadataSystemTable
                         new ColumnMetadata("distribution_name", VARCHAR),
                         new ColumnMetadata("bucket_count", BIGINT),
                         new ColumnMetadata("bucketing_columns", arrayOfVarchar),
-                        new ColumnMetadata("organized", BOOLEAN)));
+                        new ColumnMetadata("organized", BOOLEAN),
+                        new ColumnMetadata("table_supports_delta_delete", BOOLEAN)));
     }
 
     @Override
@@ -190,6 +191,9 @@ public class TableMetadataSystemTable
 
             // organized
             BOOLEAN.writeBoolean(pageBuilder.nextBlockBuilder(), tableRow.isOrganized());
+
+            // delta delete enabled
+            BOOLEAN.writeBoolean(pageBuilder.nextBlockBuilder(), tableRow.isTableSupportsDeltaDelete());
         }
 
         return pageBuilder.build();

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
@@ -58,6 +58,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Optional;
 
+import static com.facebook.presto.raptor.RaptorTableProperties.TABLE_SUPPORTS_DELTA_DELETE;
 import static com.facebook.presto.raptor.RaptorTableProperties.TEMPORAL_COLUMN_PROPERTY;
 import static com.facebook.presto.raptor.metadata.SchemaDaoUtil.createTablesWithRetry;
 import static com.facebook.presto.raptor.metadata.TestDatabaseShardManager.createShardManager;
@@ -234,7 +235,7 @@ public class TestRaptorConnector
                 new ConnectorTableMetadata(
                         new SchemaTableName("test", "test"),
                         ImmutableList.of(new ColumnMetadata("id", BIGINT), new ColumnMetadata("time", temporalType)),
-                        ImmutableMap.of(TEMPORAL_COLUMN_PROPERTY, "time")),
+                        ImmutableMap.of(TEMPORAL_COLUMN_PROPERTY, "time", TABLE_SUPPORTS_DELTA_DELETE, false)),
                 false);
         connector.commit(transaction);
 
@@ -275,7 +276,8 @@ public class TestRaptorConnector
                 SESSION,
                 new ConnectorTableMetadata(
                         new SchemaTableName("test", name),
-                        ImmutableList.of(new ColumnMetadata("id", BIGINT))),
+                        ImmutableList.of(new ColumnMetadata("id", BIGINT)),
+                        ImmutableMap.of(TABLE_SUPPORTS_DELTA_DELETE, false)),
                 false);
         connector.commit(transaction);
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTest.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTest.java
@@ -374,6 +374,8 @@ public class TestRaptorIntegrationSmokeTest
     {
         computeActual("CREATE TABLE test_table_properties_1 (foo BIGINT, bar BIGINT, ds DATE) WITH (ordering=array['foo','bar'], temporal_column='ds')");
         computeActual("CREATE TABLE test_table_properties_2 (foo BIGINT, bar BIGINT, ds DATE) WITH (ORDERING=array['foo','bar'], TEMPORAL_COLUMN='ds')");
+        computeActual("CREATE TABLE test_table_properties_3 (foo BIGINT, bar BIGINT, ds DATE) WITH (TABLE_SUPPORTS_DELTA_DELETE=false)");
+        computeActual("CREATE TABLE test_table_properties_4 (foo BIGINT, bar BIGINT, ds DATE) WITH (table_supports_delta_delete=true)");
     }
 
     @Test
@@ -589,6 +591,7 @@ public class TestRaptorIntegrationSmokeTest
                         "   bucket_count = 32,\n" +
                         "   bucketed_on = ARRAY['c1','c6'],\n" +
                         "   ordering = ARRAY['c6','c1'],\n" +
+                        "   table_supports_delta_delete = true,\n" +
                         "   temporal_column = 'c7'\n" +
                         ")",
                 getSession().getCatalog().get(), getSession().getSchema().get(), "test_show_create_table");
@@ -618,7 +621,8 @@ public class TestRaptorIntegrationSmokeTest
                         "   bucket_count = 32,\n" +
                         "   bucketed_on = ARRAY['c1','c6'],\n" +
                         "   ordering = ARRAY['c6','c1'],\n" +
-                        "   organized = true\n" +
+                        "   organized = true,\n" +
+                        "   table_supports_delta_delete = true\n" +
                         ")",
                 getSession().getCatalog().get(), getSession().getSchema().get(), "test_show_create_table_organized");
         assertUpdate(createTableSql);
@@ -640,10 +644,10 @@ public class TestRaptorIntegrationSmokeTest
                         "   \"c'4\" array(bigint),\n" +
                         "   c5 map(bigint, varchar)\n" +
                         ")",
-                getSession().getCatalog().get(), getSession().getSchema().get(), "\"test_show_create_table\"\"2\"");
+                getSession().getCatalog().get(), getSession().getSchema().get(), "test_show_create_table_default");
         assertUpdate(createTableSql);
 
-        actualResult = computeActual("SHOW CREATE TABLE \"test_show_create_table\"\"2\"");
+        actualResult = computeActual("SHOW CREATE TABLE \"test_show_create_table_default\"");
         assertEquals(getOnlyElement(actualResult.getOnlyColumnAsSet()), createTableSql);
     }
 
@@ -667,6 +671,9 @@ public class TestRaptorIntegrationSmokeTest
         assertUpdate("" +
                 "CREATE TABLE system_tables_test5 (c50 timestamp, c51 varchar, c52 double, c53 bigint, c54 bigint) " +
                 "WITH (ordering = ARRAY['c51', 'c52'], distribution_name = 'test_distribution', bucket_count = 50, bucketed_on = ARRAY ['c53', 'c54'], organized = true)");
+        assertUpdate("" +
+                "CREATE TABLE system_tables_test6 (c60 timestamp, c61 varchar, c62 double, c63 bigint, c64 bigint) " +
+                "WITH (ordering = ARRAY['c61', 'c62'], distribution_name = 'test_distribution', bucket_count = 50, bucketed_on = ARRAY ['c63', 'c64'], organized = true, table_supports_delta_delete = true)");
 
         MaterializedResult actualResults = computeActual("SELECT * FROM system.tables");
         assertEquals(
@@ -680,35 +687,39 @@ public class TestRaptorIntegrationSmokeTest
                         .add(BIGINT) // bucket_count
                         .add(new ArrayType(VARCHAR)) // bucket_columns
                         .add(BOOLEAN) // organized
+                        .add(BOOLEAN) // table_supports_delta_delete
                         .build());
         Map<String, MaterializedRow> map = actualResults.getMaterializedRows().stream()
                 .filter(row -> ((String) row.getField(1)).startsWith("system_tables_test"))
                 .collect(toImmutableMap(row -> ((String) row.getField(1)), identity()));
-        assertEquals(map.size(), 6);
+        assertEquals(map.size(), 7);
         assertEquals(
                 map.get("system_tables_test0").getFields(),
-                asList("tpch", "system_tables_test0", null, null, null, null, null, Boolean.FALSE));
+                asList("tpch", "system_tables_test0", null, null, null, null, null, Boolean.FALSE, Boolean.FALSE));
         assertEquals(
                 map.get("system_tables_test1").getFields(),
-                asList("tpch", "system_tables_test1", "c10", null, null, null, null, Boolean.FALSE));
+                asList("tpch", "system_tables_test1", "c10", null, null, null, null, Boolean.FALSE, Boolean.FALSE));
         assertEquals(
                 map.get("system_tables_test2").getFields(),
-                asList("tpch", "system_tables_test2", "c20", ImmutableList.of("c22", "c21"), null, null, null, Boolean.FALSE));
+                asList("tpch", "system_tables_test2", "c20", ImmutableList.of("c22", "c21"), null, null, null, Boolean.FALSE, Boolean.FALSE));
         assertEquals(
                 map.get("system_tables_test3").getFields(),
-                asList("tpch", "system_tables_test3", "c30", null, null, 40L, ImmutableList.of("c34", "c33"), Boolean.FALSE));
+                asList("tpch", "system_tables_test3", "c30", null, null, 40L, ImmutableList.of("c34", "c33"), Boolean.FALSE, Boolean.FALSE));
         assertEquals(
                 map.get("system_tables_test4").getFields(),
-                asList("tpch", "system_tables_test4", "c40", ImmutableList.of("c41", "c42"), "test_distribution", 50L, ImmutableList.of("c43", "c44"), Boolean.FALSE));
+                asList("tpch", "system_tables_test4", "c40", ImmutableList.of("c41", "c42"), "test_distribution", 50L, ImmutableList.of("c43", "c44"), Boolean.FALSE, Boolean.FALSE));
         assertEquals(
                 map.get("system_tables_test5").getFields(),
-                asList("tpch", "system_tables_test5", null, ImmutableList.of("c51", "c52"), "test_distribution", 50L, ImmutableList.of("c53", "c54"), Boolean.TRUE));
+                asList("tpch", "system_tables_test5", null, ImmutableList.of("c51", "c52"), "test_distribution", 50L, ImmutableList.of("c53", "c54"), Boolean.TRUE, Boolean.FALSE));
+        assertEquals(
+                map.get("system_tables_test6").getFields(),
+                asList("tpch", "system_tables_test6", null, ImmutableList.of("c61", "c62"), "test_distribution", 50L, ImmutableList.of("c63", "c64"), Boolean.TRUE, Boolean.TRUE));
 
         actualResults = computeActual("SELECT * FROM system.tables WHERE table_schema = 'tpch'");
         long actualRowCount = actualResults.getMaterializedRows().stream()
                 .filter(row -> ((String) row.getField(1)).startsWith("system_tables_test"))
                 .count();
-        assertEquals(actualRowCount, 6);
+        assertEquals(actualRowCount, 7);
 
         actualResults = computeActual("SELECT * FROM system.tables WHERE table_name = 'system_tables_test3'");
         assertEquals(actualResults.getMaterializedRows().size(), 1);
@@ -729,6 +740,7 @@ public class TestRaptorIntegrationSmokeTest
         assertUpdate("DROP TABLE system_tables_test3");
         assertUpdate("DROP TABLE system_tables_test4");
         assertUpdate("DROP TABLE system_tables_test5");
+        assertUpdate("DROP TABLE system_tables_test6");
 
         assertEquals(computeActual("SELECT * FROM system.tables WHERE table_schema IN ('foo', 'bar')").getRowCount(), 0);
     }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestMetadataDao.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestMetadataDao.java
@@ -54,7 +54,7 @@ public class TestMetadataDao
     public void testTemporalColumn()
     {
         Long columnId = 1L;
-        long tableId = dao.insertTable("schema1", "table1", true, false, null, 0);
+        long tableId = dao.insertTable("schema1", "table1", true, false, null, 0, false);
         dao.insertColumn(tableId, columnId, "col1", 1, "bigint", null, null);
         Long temporalColumnId = dao.getTemporalColumnId(tableId);
         assertNull(temporalColumnId);
@@ -64,7 +64,7 @@ public class TestMetadataDao
         assertNotNull(temporalColumnId);
         assertEquals(temporalColumnId, columnId);
 
-        long tableId2 = dao.insertTable("schema1", "table2", true, false, null, 0);
+        long tableId2 = dao.insertTable("schema1", "table2", true, false, null, 0, false);
         Long columnId2 = dao.getTemporalColumnId(tableId2);
         assertNull(columnId2);
     }
@@ -73,7 +73,7 @@ public class TestMetadataDao
     public void testGetTableInformation()
     {
         Long columnId = 1L;
-        long tableId = dao.insertTable("schema1", "table1", true, false, null, 0);
+        long tableId = dao.insertTable("schema1", "table1", true, false, null, 0, false);
         dao.insertColumn(tableId, columnId, "col1", 1, "bigint", null, null);
 
         Table info = dao.getTableInformation(tableId);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorMetadata.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorMetadata.java
@@ -66,6 +66,7 @@ import static com.facebook.presto.raptor.RaptorTableProperties.BUCKET_COUNT_PROP
 import static com.facebook.presto.raptor.RaptorTableProperties.DISTRIBUTION_NAME_PROPERTY;
 import static com.facebook.presto.raptor.RaptorTableProperties.ORDERING_PROPERTY;
 import static com.facebook.presto.raptor.RaptorTableProperties.ORGANIZED_PROPERTY;
+import static com.facebook.presto.raptor.RaptorTableProperties.TABLE_SUPPORTS_DELTA_DELETE;
 import static com.facebook.presto.raptor.RaptorTableProperties.TEMPORAL_COLUMN_PROPERTY;
 import static com.facebook.presto.raptor.metadata.SchemaDaoUtil.createTablesWithRetry;
 import static com.facebook.presto.raptor.metadata.TestDatabaseShardManager.createShardManager;
@@ -139,7 +140,7 @@ public class TestRaptorMetadata
     public void testAddColumn()
     {
         assertNull(metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS));
-        metadata.createTable(SESSION, buildTable(ImmutableMap.of(), tableMetadataBuilder(DEFAULT_TEST_ORDERS)
+        metadata.createTable(SESSION, buildTable(ImmutableMap.of(TABLE_SUPPORTS_DELTA_DELETE, false), tableMetadataBuilder(DEFAULT_TEST_ORDERS)
                         .column("orderkey", BIGINT)
                         .column("price", BIGINT)),
                 false);
@@ -156,7 +157,7 @@ public class TestRaptorMetadata
     public void testDropColumn()
     {
         assertNull(metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS));
-        metadata.createTable(SESSION, buildTable(ImmutableMap.of(), tableMetadataBuilder(DEFAULT_TEST_ORDERS)
+        metadata.createTable(SESSION, buildTable(ImmutableMap.of(TABLE_SUPPORTS_DELTA_DELETE, false), tableMetadataBuilder(DEFAULT_TEST_ORDERS)
                         .column("orderkey", BIGINT)
                         .column("price", BIGINT)),
                 false);
@@ -174,7 +175,7 @@ public class TestRaptorMetadata
     public void testAddColumnAfterDropColumn()
     {
         assertNull(metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS));
-        metadata.createTable(SESSION, buildTable(ImmutableMap.of(), tableMetadataBuilder(DEFAULT_TEST_ORDERS)
+        metadata.createTable(SESSION, buildTable(ImmutableMap.of(TABLE_SUPPORTS_DELTA_DELETE, false), tableMetadataBuilder(DEFAULT_TEST_ORDERS)
                         .column("orderkey", BIGINT)
                         .column("price", BIGINT)),
                 false);
@@ -198,7 +199,8 @@ public class TestRaptorMetadata
                 BUCKET_COUNT_PROPERTY, 16,
                 BUCKETED_ON_PROPERTY, ImmutableList.of("orderkey"),
                 ORDERING_PROPERTY, ImmutableList.of("totalprice"),
-                TEMPORAL_COLUMN_PROPERTY, "orderdate");
+                TEMPORAL_COLUMN_PROPERTY, "orderdate",
+                TABLE_SUPPORTS_DELTA_DELETE, false);
         ConnectorTableMetadata ordersTable = buildTable(properties, tableMetadataBuilder(DEFAULT_TEST_ORDERS)
                 .column("orderkey", BIGINT)
                 .column("totalprice", DOUBLE)
@@ -298,7 +300,8 @@ public class TestRaptorMetadata
 
         ConnectorTableMetadata ordersTable = getOrdersTable(ImmutableMap.of(
                 ORDERING_PROPERTY, ImmutableList.of("orderdate", "custkey"),
-                TEMPORAL_COLUMN_PROPERTY, "orderdate"));
+                TEMPORAL_COLUMN_PROPERTY, "orderdate",
+                TABLE_SUPPORTS_DELTA_DELETE, false));
         metadata.createTable(SESSION, ordersTable, false);
 
         ConnectorTableHandle tableHandle = metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS);
@@ -325,13 +328,36 @@ public class TestRaptorMetadata
     }
 
     @Test
+    public void testTablePropertiesDeltaDelete()
+    {
+        assertNull(metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS));
+        ConnectorTableMetadata ordersTable = getOrdersTable(ImmutableMap.of(
+                TABLE_SUPPORTS_DELTA_DELETE, true));
+        metadata.createTable(SESSION, ordersTable, false);
+
+        ConnectorTableHandle tableHandle = metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS);
+        assertInstanceOf(tableHandle, RaptorTableHandle.class);
+        RaptorTableHandle raptorTableHandle = (RaptorTableHandle) tableHandle;
+        assertEquals(raptorTableHandle.getTableId(), 1);
+
+        long tableId = raptorTableHandle.getTableId();
+        MetadataDao metadataDao = dbi.onDemand(MetadataDao.class);
+
+        // verify delta delete enabled property
+        assertTrue(metadataDao.getTableInformation(tableId).isTableSupportsDeltaDelete());
+
+        metadata.dropTable(SESSION, tableHandle);
+    }
+
+    @Test
     public void testTablePropertiesWithOrganization()
     {
         assertNull(metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS));
 
         ConnectorTableMetadata ordersTable = getOrdersTable(ImmutableMap.of(
                 ORDERING_PROPERTY, ImmutableList.of("orderdate", "custkey"),
-                ORGANIZED_PROPERTY, true));
+                ORGANIZED_PROPERTY, true,
+                TABLE_SUPPORTS_DELTA_DELETE, false));
         metadata.createTable(SESSION, ordersTable, false);
 
         ConnectorTableHandle tableHandle = metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS);
@@ -361,7 +387,8 @@ public class TestRaptorMetadata
 
         ConnectorTableMetadata ordersTable = getOrdersTable(ImmutableMap.of(
                 BUCKET_COUNT_PROPERTY, 16,
-                BUCKETED_ON_PROPERTY, ImmutableList.of("custkey", "orderkey")));
+                BUCKETED_ON_PROPERTY, ImmutableList.of("custkey", "orderkey"),
+                TABLE_SUPPORTS_DELTA_DELETE, false));
         metadata.createTable(SESSION, ordersTable, false);
 
         ConnectorTableHandle tableHandle = metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS);
@@ -396,7 +423,8 @@ public class TestRaptorMetadata
 
         ConnectorTableMetadata ordersTable = getOrdersTable(ImmutableMap.of(
                 BUCKET_COUNT_PROPERTY, 32,
-                BUCKETED_ON_PROPERTY, ImmutableList.of("orderkey", "custkey")));
+                BUCKETED_ON_PROPERTY, ImmutableList.of("orderkey", "custkey"),
+                TABLE_SUPPORTS_DELTA_DELETE, false));
 
         ConnectorNewTableLayout layout = metadata.getNewTableLayout(SESSION, ordersTable).get();
         assertEquals(layout.getPartitionColumns(), ImmutableList.of("orderkey", "custkey"));
@@ -437,7 +465,8 @@ public class TestRaptorMetadata
         ConnectorTableMetadata table = getOrdersTable(ImmutableMap.of(
                 BUCKET_COUNT_PROPERTY, 16,
                 BUCKETED_ON_PROPERTY, ImmutableList.of("orderkey"),
-                DISTRIBUTION_NAME_PROPERTY, "orders"));
+                DISTRIBUTION_NAME_PROPERTY, "orders",
+                TABLE_SUPPORTS_DELTA_DELETE, false));
         metadata.createTable(SESSION, table, false);
 
         ConnectorTableHandle tableHandle = metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS);
@@ -460,7 +489,8 @@ public class TestRaptorMetadata
         table = getLineItemsTable(ImmutableMap.of(
                 BUCKET_COUNT_PROPERTY, 16,
                 BUCKETED_ON_PROPERTY, ImmutableList.of("orderkey"),
-                DISTRIBUTION_NAME_PROPERTY, "orders"));
+                DISTRIBUTION_NAME_PROPERTY, "orders",
+                TABLE_SUPPORTS_DELTA_DELETE, false));
         metadata.createTable(SESSION, table, false);
 
         tableHandle = metadata.getTableHandle(SESSION, DEFAULT_TEST_LINEITEMS);
@@ -511,7 +541,8 @@ public class TestRaptorMetadata
         assertNull(metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS));
         metadata.createTable(SESSION, getOrdersTable(ImmutableMap.of(
                 TEMPORAL_COLUMN_PROPERTY, "orderdate",
-                ORGANIZED_PROPERTY, true)),
+                ORGANIZED_PROPERTY, true,
+                TABLE_SUPPORTS_DELTA_DELETE, false)),
                 false);
     }
 
@@ -519,7 +550,7 @@ public class TestRaptorMetadata
     public void testInvalidOrderingOrganization()
     {
         assertNull(metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS));
-        metadata.createTable(SESSION, getOrdersTable(ImmutableMap.of(ORGANIZED_PROPERTY, true)), false);
+        metadata.createTable(SESSION, getOrdersTable(ImmutableMap.of(ORGANIZED_PROPERTY, true, TABLE_SUPPORTS_DELTA_DELETE, false)), false);
     }
 
     @Test
@@ -527,7 +558,8 @@ public class TestRaptorMetadata
     {
         assertNull(metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS));
 
-        ConnectorTableMetadata ordersTable = getOrdersTable(ImmutableMap.of(ORDERING_PROPERTY, ImmutableList.of("orderdate", "custkey")));
+        ConnectorTableMetadata ordersTable = getOrdersTable(ImmutableMap.of(ORDERING_PROPERTY,
+                ImmutableList.of("orderdate", "custkey"), TABLE_SUPPORTS_DELTA_DELETE, false));
         metadata.createTable(SESSION, ordersTable, false);
 
         ConnectorTableHandle tableHandle = metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS);
@@ -554,7 +586,8 @@ public class TestRaptorMetadata
     {
         assertNull(metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS));
 
-        ConnectorTableMetadata ordersTable = getOrdersTable(ImmutableMap.of(TEMPORAL_COLUMN_PROPERTY, "orderdate"));
+        ConnectorTableMetadata ordersTable = getOrdersTable(ImmutableMap.of(TEMPORAL_COLUMN_PROPERTY, "orderdate",
+                TABLE_SUPPORTS_DELTA_DELETE, false));
         metadata.createTable(SESSION, ordersTable, false);
 
         ConnectorTableHandle tableHandle = metadata.getTableHandle(SESSION, DEFAULT_TEST_ORDERS);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorSplitManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorSplitManager.java
@@ -56,6 +56,7 @@ import java.util.UUID;
 
 import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
 import static com.facebook.airlift.testing.Assertions.assertInstanceOf;
+import static com.facebook.presto.raptor.RaptorTableProperties.TABLE_SUPPORTS_DELTA_DELETE;
 import static com.facebook.presto.raptor.metadata.DatabaseShardManager.shardIndexTable;
 import static com.facebook.presto.raptor.metadata.SchemaDaoUtil.createTablesWithRetry;
 import static com.facebook.presto.raptor.metadata.TestDatabaseShardManager.shardInfo;
@@ -80,6 +81,7 @@ public class TestRaptorSplitManager
             .column("ds", createVarcharType(10))
             .column("foo", createVarcharType(10))
             .column("bar", BigintType.BIGINT)
+            .property(TABLE_SUPPORTS_DELTA_DELETE, false)
             .build();
 
     private Handle dummyHandle;

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardCleaner.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardCleaner.java
@@ -197,7 +197,7 @@ public class TestShardCleaner
         TestingShardDao shardDao = dbi.onDemand(TestingShardDao.class);
         MetadataDao metadataDao = dbi.onDemand(MetadataDao.class);
 
-        long tableId = metadataDao.insertTable("test", "test", false, false, null, 0);
+        long tableId = metadataDao.insertTable("test", "test", false, false, null, 0, false);
 
         UUID shard1 = randomUUID();
         UUID shard2 = randomUUID();
@@ -243,7 +243,7 @@ public class TestShardCleaner
         TestingShardDao shardDao = dbi.onDemand(TestingShardDao.class);
         MetadataDao metadataDao = dbi.onDemand(MetadataDao.class);
 
-        long tableId = metadataDao.insertTable("test", "test", false, false, null, 0);
+        long tableId = metadataDao.insertTable("test", "test", false, false, null, 0, false);
 
         UUID shard1 = randomUUID();
         UUID shard2 = randomUUID();

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardDao.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardDao.java
@@ -167,8 +167,8 @@ public class TestShardDao
             dao.insertBuckets(distributionId, ImmutableList.of(i), ImmutableList.of(nodeId));
         }
 
-        long plainTableId = metadataDao.insertTable("test", "plain", false, false, null, 0);
-        long bucketedTableId = metadataDao.insertTable("test", "bucketed", false, false, distributionId, 0);
+        long plainTableId = metadataDao.insertTable("test", "plain", false, false, null, 0, false);
+        long bucketedTableId = metadataDao.insertTable("test", "bucketed", false, false, distributionId, 0, false);
 
         long shardId1 = dao.insertShard(shardUuid1, plainTableId, null, 1, 11, 111, 888_111);
         long shardId2 = dao.insertShard(shardUuid2, plainTableId, null, 2, 22, 222, 888_222);
@@ -278,7 +278,7 @@ public class TestShardDao
 
     private long createTable(String name)
     {
-        return dbi.onDemand(MetadataDao.class).insertTable("test", name, false, false, null, 0);
+        return dbi.onDemand(MetadataDao.class).insertTable("test", name, false, false, null, 0, false);
     }
 
     private static void assertContainsShardNode(Set<ShardNode> nodes, String nodeName, UUID shardUuid)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestBucketBalancer.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestBucketBalancer.java
@@ -275,9 +275,9 @@ public class TestBucketBalancer
     private long createBucketedTable(String tableName, long distributionId, DataSize compressedSize)
     {
         MetadataDao dao = dbi.onDemand(MetadataDao.class);
-        long tableId = dao.insertTable("test", tableName, false, false, distributionId, 0);
+        long tableId = dao.insertTable("test", tableName, false, false, distributionId, 0, false);
         List<ColumnInfo> columnsA = ImmutableList.of(new ColumnInfo(1, BIGINT));
-        shardManager.createTable(tableId, columnsA, false, OptionalLong.empty());
+        shardManager.createTable(tableId, columnsA, false, OptionalLong.empty(), false);
 
         metadataDao.updateTableStats(tableId, 1024, 1024 * 1024 * 1024, compressedSize.toBytes(), compressedSize.toBytes() * 2);
         return tableId;

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardEjector.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardEjector.java
@@ -130,7 +130,7 @@ public class TestShardEjector
         long tableId = createTable("test");
         List<ColumnInfo> columns = ImmutableList.of(new ColumnInfo(1, BIGINT));
 
-        shardManager.createTable(tableId, columns, false, OptionalLong.empty());
+        shardManager.createTable(tableId, columns, false, OptionalLong.empty(), false);
 
         long transactionId = shardManager.beginTransaction();
         shardManager.commitShards(transactionId, tableId, columns, shards, Optional.empty(), 0);
@@ -176,7 +176,7 @@ public class TestShardEjector
 
     private long createTable(String name)
     {
-        return dbi.onDemand(MetadataDao.class).insertTable("test", name, false, false, null, 0);
+        return dbi.onDemand(MetadataDao.class).insertTable("test", name, false, false, null, 0, false);
     }
 
     private static Set<UUID> uuids(Set<ShardMetadata> metadata)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestCompactionSetCreator.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestCompactionSetCreator.java
@@ -40,10 +40,10 @@ public class TestCompactionSetCreator
 {
     private static final long MAX_SHARD_ROWS = 100;
     private static final DataSize MAX_SHARD_SIZE = new DataSize(100, DataSize.Unit.BYTE);
-    private static final Table tableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.empty(), false);
-    private static final Table temporalTableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.of(1), false);
-    private static final Table bucketedTableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.of(3), OptionalLong.empty(), false);
-    private static final Table bucketedTemporalTableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.of(3), OptionalLong.of(1), false);
+    private static final Table tableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.empty(), false, false);
+    private static final Table temporalTableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.of(1), false, false);
+    private static final Table bucketedTableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.of(3), OptionalLong.empty(), false, false);
+    private static final Table bucketedTemporalTableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.of(3), OptionalLong.of(1), false, false);
 
     private final CompactionSetCreator compactionSetCreator = new CompactionSetCreator(new TemporalFunction(UTC), MAX_SHARD_SIZE, MAX_SHARD_ROWS);
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizationManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizationManager.java
@@ -58,8 +58,8 @@ public class TestShardOrganizationManager
     private MetadataDao metadataDao;
     private ShardOrganizerDao organizerDao;
 
-    private static final Table tableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.empty(), true);
-    private static final Table temporalTableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.of(1), true);
+    private static final Table tableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.empty(), true, false);
+    private static final Table temporalTableInfo = new Table(1L, OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), OptionalLong.of(1), true, false);
 
     private static final List<Type> types = ImmutableList.of(BIGINT, VARCHAR, DATE, TIMESTAMP);
     private static final TemporalFunction TEMPORAL_FUNCTION = new TemporalFunction(UTC);
@@ -84,11 +84,11 @@ public class TestShardOrganizationManager
     @Test
     public void testOrganizationEligibleTables()
     {
-        long table1 = metadataDao.insertTable("schema", "table1", false, true, null, 0);
+        long table1 = metadataDao.insertTable("schema", "table1", false, true, null, 0, false);
         metadataDao.insertColumn(table1, 1, "foo", 1, "bigint", 1, null);
 
-        metadataDao.insertTable("schema", "table2", false, true, null, 0);
-        metadataDao.insertTable("schema", "table3", false, false, null, 0);
+        metadataDao.insertTable("schema", "table2", false, true, null, 0, false);
+        metadataDao.insertTable("schema", "table3", false, false, null, 0, false);
         assertEquals(metadataDao.getOrganizationEligibleTables(), ImmutableSet.of(table1));
     }
 
@@ -96,13 +96,13 @@ public class TestShardOrganizationManager
     public void testTableDiscovery()
             throws Exception
     {
-        long table1 = metadataDao.insertTable("schema", "table1", false, true, null, 0);
+        long table1 = metadataDao.insertTable("schema", "table1", false, true, null, 0, false);
         metadataDao.insertColumn(table1, 1, "foo", 1, "bigint", 1, null);
 
-        long table2 = metadataDao.insertTable("schema", "table2", false, true, null, 0);
+        long table2 = metadataDao.insertTable("schema", "table2", false, true, null, 0, false);
         metadataDao.insertColumn(table2, 1, "foo", 1, "bigint", 1, null);
 
-        metadataDao.insertTable("schema", "table3", false, false, null, 0);
+        metadataDao.insertTable("schema", "table3", false, false, null, 0, false);
 
         long intervalMillis = 100;
         ShardOrganizationManager organizationManager = createShardOrganizationManager(intervalMillis);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizerUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizerUtil.java
@@ -110,6 +110,7 @@ public class TestShardOrganizerUtil
                         .column("orderstatus", createVarcharType(3))
                         .property("ordering", ImmutableList.of("orderstatus", "orderkey"))
                         .property("temporal_column", "orderdate")
+                        .property("table_supports_delta_delete", false)
                         .build(),
                 false);
         Table tableInfo = metadataDao.getTableInformation(tableName.getSchemaName(), tableName.getTableName());

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/systemtables/TestShardMetadataRecordCursor.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/systemtables/TestShardMetadataRecordCursor.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
+import static com.facebook.presto.raptor.RaptorTableProperties.TABLE_SUPPORTS_DELTA_DELETE;
 import static com.facebook.presto.raptor.metadata.SchemaDaoUtil.createTablesWithRetry;
 import static com.facebook.presto.raptor.metadata.TestDatabaseShardManager.createShardManager;
 import static com.facebook.presto.raptor.systemtables.ShardMetadataRecordCursor.SHARD_METADATA;
@@ -86,6 +87,7 @@ public class TestShardMetadataRecordCursor
                 .column("orderkey", BIGINT)
                 .column("orderdate", DATE)
                 .property("temporal_column", "orderdate")
+                .property(TABLE_SUPPORTS_DELTA_DELETE, false)
                 .build();
         createTable(table);
     }
@@ -157,11 +159,13 @@ public class TestShardMetadataRecordCursor
         // Create "orders" table in a different schema
         createTable(tableMetadataBuilder(new SchemaTableName("other", "orders"))
                 .column("orderkey", BIGINT)
+                .property(TABLE_SUPPORTS_DELTA_DELETE, false)
                 .build());
 
         // Create another table that should not be selected
         createTable(tableMetadataBuilder(new SchemaTableName("schema1", "foo"))
                 .column("orderkey", BIGINT)
+                .property(TABLE_SUPPORTS_DELTA_DELETE, false)
                 .build());
 
         TupleDomain<Integer> tupleDomain = TupleDomain.withColumnDomains(
@@ -183,11 +187,13 @@ public class TestShardMetadataRecordCursor
         // Create "orders" table in a different schema
         createTable(tableMetadataBuilder(new SchemaTableName("test", "orders2"))
                 .column("orderkey", BIGINT)
+                .property(TABLE_SUPPORTS_DELTA_DELETE, false)
                 .build());
 
         // Create another table that should not be selected
         createTable(tableMetadataBuilder(new SchemaTableName("schema1", "foo"))
                 .column("orderkey", BIGINT)
+                .property(TABLE_SUPPORTS_DELTA_DELETE, false)
                 .build());
 
         TupleDomain<Integer> tupleDomain = TupleDomain.withColumnDomains(


### PR DESCRIPTION
```
== RELEASE NOTES ==

Raptor Changes
* Add table_supports_delta_delete property in Raptor to allow deletion happening in background. DELETE queries in Raptor can now delete data logically but relying on compactors to delete physical data.
```
