### PR TITLE
Introduce warnings for nonReserved words moving to Reserved

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/SqlParser.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/SqlParser.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static com.facebook.presto.sql.parser.SqlParserOptions.RESERVED_WORDS_WARNING;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -231,9 +232,13 @@ public class SqlParser
             context.getParent().removeLastChild();
 
             Token token = (Token) context.getChild(0).getPayload();
-            if (token.getText().equalsIgnoreCase("CURRENT_ROLE")) {
-                warningConsumer.accept(new ParsingWarning(format("Reserved word used: %s", token.getText()), token.getLine(), token.getCharPositionInLine()));
+            if (RESERVED_WORDS_WARNING.contains(token.getText().toUpperCase())) {
+                warningConsumer.accept(new ParsingWarning(
+                        format("%s should be a reserved word, please use double quote (\"%s\"). This will be made a reserved word in future release.", token.getText(), token.getText()),
+                        token.getLine(),
+                        token.getCharPositionInLine()));
             }
+
             context.getParent().addChild(new CommonToken(
                     new Pair<>(token.getTokenSource(), token.getInputStream()),
                     SqlBaseLexer.IDENTIFIER,

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/SqlParserOptions.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/SqlParserOptions.java
@@ -13,14 +13,19 @@
  */
 package com.facebook.presto.sql.parser;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 import java.util.EnumSet;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
 public class SqlParserOptions
 {
+    protected static final Set<String> RESERVED_WORDS_WARNING = ImmutableSet.of(
+            "CALLED", "CURRENT_ROLE", "DETERMINISTIC", "FUNCTION", "LANGUAGE", "RETURN", "RETURNS", "SQL");
+
     private final EnumSet<IdentifierSymbol> allowedIdentifierSymbols = EnumSet.noneOf(IdentifierSymbol.class);
     private boolean enhancedErrorHandlerEnabled = true;
 


### PR DESCRIPTION
Fix for https://github.com/prestodb/presto/issues/13586 
Open to suggestions for a better way to keep the set of the words. Opted for a static set due to the temporary nature of the warning, and the assumption that this list would not change often. Downside being that this approach is not very extendible. 

```
== NO RELEASE NOTE ==
```
