### PR TITLE
Fix error type for unsupported correlated subquery

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
@@ -16,10 +16,10 @@ package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.warnings.WarningCollector;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.planner.PlanVariableAllocator;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
@@ -27,6 +27,7 @@ import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 
 import java.util.List;
 
+import static com.facebook.presto.spi.StandardErrorCode.UNSUPPORTED_SUBQUERY;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
@@ -41,22 +42,22 @@ public class CheckSubqueryNodesAreRewritten
                 .findFirst()
                 .ifPresent(node -> {
                     ApplyNode applyNode = (ApplyNode) node;
-                    throw error(applyNode.getCorrelation(), applyNode.getOriginSubqueryError());
+                    error(applyNode.getCorrelation(), applyNode.getOriginSubqueryError());
                 });
 
         searchFrom(plan).where(LateralJoinNode.class::isInstance)
                 .findFirst()
                 .ifPresent(node -> {
                     LateralJoinNode lateralJoinNode = (LateralJoinNode) node;
-                    throw error(lateralJoinNode.getCorrelation(), lateralJoinNode.getOriginSubqueryError());
+                    error(lateralJoinNode.getCorrelation(), lateralJoinNode.getOriginSubqueryError());
                 });
 
         return plan;
     }
 
-    private SemanticException error(List<VariableReferenceExpression> correlation, String originSubqueryError)
+    private void error(List<VariableReferenceExpression> correlation, String originSubqueryError)
     {
         checkState(!correlation.isEmpty(), "All the non correlated subqueries should be rewritten at this point");
-        throw new RuntimeException(format(originSubqueryError, "Given correlated subquery is not supported"));
+        throw new PrestoException(UNSUPPORTED_SUBQUERY, format(originSubqueryError, "Given correlated subquery is not supported"));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/QueryAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/QueryAssertions.java
@@ -53,6 +53,11 @@ class QueryAssertions
         runner = new LocalQueryRunner(session);
     }
 
+    public QueryRunner getQueryRunner()
+    {
+        return runner;
+    }
+
     public void assertFails(@Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)
     {
         try {

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestSubqueries.java
@@ -13,12 +13,14 @@
  */
 package com.facebook.presto.sql.query;
 
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.testing.QueryRunner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
@@ -59,6 +61,15 @@ public class TestSubqueries
     {
         assertions.close();
         assertions = null;
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG)
+    public void testCorrelatedSubqueriesWithDistinct()
+    {
+        QueryRunner runner = assertions.getQueryRunner();
+        runner.execute(
+                runner.getDefaultSession(),
+                "select a from (values (1, 10), (2, 20)) t(a,b) where a in (select distinct c from (values 1) t2(c) where b in (10, 11))");
     }
 
     @Test


### PR DESCRIPTION
This reverts previous change of error type in
https://github.com/prestodb/presto/commit/5f72687a4b09abc30648985e5cd5a4db0735bcc5

```
== NO RELEASE NOTE ==
```
