### PR TITLE
Fix filter pushdown for always-true range filter on a boolean column

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
@@ -1130,6 +1130,15 @@ public class TestRowExpressionDomainTranslator
         assertUnsupportedPredicate(equal(cast(C_CHAR, charType), cast(stringLiteral("abc12345678"), charType)));
     }
 
+    @Test
+    public void testBooleanAll()
+    {
+        RowExpression rowExpression = or(or(equal(C_BOOLEAN, constant(true, BOOLEAN)), equal(C_BOOLEAN, constant(false, BOOLEAN))), isNull(C_BOOLEAN));
+        ExtractionResult result = fromPredicate(rowExpression);
+        TupleDomain tupleDomain = result.getTupleDomain();
+        assertTrue(tupleDomain.isAll());
+    }
+
     private void assertPredicateTranslates(RowExpression expression, TupleDomain<VariableReferenceExpression> tupleDomain)
     {
         ExtractionResult result = fromPredicate(expression);


### PR DESCRIPTION
Fixes filter pushdown for an always-true range filter on a boolean column. The following query fails without the fix:

`select * from t where b = true or b = false or b is null`

```
Caused by: java.lang.IllegalArgumentException: Unexpected range of ALL values
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:141)
	at com.facebook.presto.orc.TupleDomainFilterUtils.createBooleanFilter(TupleDomainFilterUtils.java:148)
	at com.facebook.presto.orc.TupleDomainFilterUtils.toFilter(TupleDomainFilterUtils.java:91)
	at com.google.common.collect.Maps$9.transformEntry(Maps.java:1950)
	at com.google.common.collect.Maps$12.getValue(Maps.java:1991)
	at com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory.toTupleDomainFilters(OrcSelectivePageSourceFactory.java:552)
	at com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory.createOrcPageSource(OrcSelectivePageSourceFactory.java:328)
```

```
== NO RELEASE NOTE ==
```
