### PR TITLE
Support running benchmark queries concurrently

### DIFF
--- a/presto-benchmark-runner/pom.xml
+++ b/presto-benchmark-runner/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <main-class>com.facebook.presto.benchmark.PrestoBenchmarkRunner</main-class>
     </properties>
 
     <dependencies>
@@ -152,6 +153,11 @@
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>airline</artifactId>
         </dependency>
 
         <!-- for testing -->

--- a/presto-benchmark-runner/pom.xml
+++ b/presto-benchmark-runner/pom.xml
@@ -149,6 +149,11 @@
             <artifactId>jackson-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-benchmark-runner/pom.xml
+++ b/presto-benchmark-runner/pom.xml
@@ -139,6 +139,16 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-benchmark-runner/pom.xml
+++ b/presto-benchmark-runner/pom.xml
@@ -68,7 +68,34 @@
             <artifactId>validation-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-parser</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+        </dependency>
+
         <!-- for testing -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/presto-benchmark-runner/pom.xml
+++ b/presto-benchmark-runner/pom.xml
@@ -83,6 +83,53 @@
             <artifactId>presto-main</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-thrift-connector</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-hive</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.facebook.presto.hive</groupId>
+                    <artifactId>hive-apache</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-hive-metastore</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.facebook.presto.hive</groupId>
+                    <artifactId>hive-apache</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-base-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-benchmark-runner/pom.xml
+++ b/presto-benchmark-runner/pom.xml
@@ -54,13 +54,11 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -128,6 +126,17 @@
         <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>log-manager</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>event</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- for testing -->

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/PrestoBenchmarkCommand.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/PrestoBenchmarkCommand.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.bootstrap.LifeCycleManager;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.benchmark.event.EventClientModule;
+import com.facebook.presto.benchmark.framework.BenchmarkModule;
+import com.facebook.presto.benchmark.prestoaction.PrestoExceptionClassifier;
+import com.facebook.presto.benchmark.source.BenchmarkSuiteModule;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import io.airlift.airline.Command;
+
+import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+
+@Command(name = "benchmark", description = "benchmark")
+public class PrestoBenchmarkCommand
+        implements Runnable
+{
+    private static final Logger log = Logger.get(PrestoBenchmarkCommand.class);
+
+    @Override
+    public void run()
+    {
+        Bootstrap app = new Bootstrap(ImmutableList.<Module>builder()
+                .add(new BenchmarkSuiteModule(ImmutableSet.of()))
+                .add(new BenchmarkModule(
+                        new SqlParserOptions(),
+                        ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build(),
+                        new PrestoExceptionClassifier(ImmutableSet.of())))
+                .add(new EventClientModule(ImmutableSet.of()))
+                .build());
+        Injector injector = null;
+        try {
+            injector = app.strictConfig().initialize();
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+        finally {
+            if (injector != null) {
+                try {
+                    injector.getInstance(LifeCycleManager.class).stop();
+                }
+                catch (Exception e) {
+                    log.error(e);
+                }
+            }
+        }
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/PrestoBenchmarkRunner.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/PrestoBenchmarkRunner.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import io.airlift.airline.Cli;
+import io.airlift.airline.Help;
+
+public class PrestoBenchmarkRunner
+{
+    private PrestoBenchmarkRunner()
+    {
+    }
+
+    public static void main(String[] args)
+    {
+        Cli<Runnable> benchmarkParser = Cli.<Runnable>builder("benchmark")
+                .withDescription("Presto Benchmark")
+                .withDefaultCommand(Help.class)
+                .withCommand(Help.class)
+                .withCommand(PrestoBenchmarkCommand.class)
+                .build();
+        benchmarkParser.parse(args).run();
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/BenchmarkPhaseEvent.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/BenchmarkPhaseEvent.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.event;
+
+import com.facebook.airlift.event.client.EventField;
+import com.facebook.airlift.event.client.EventType;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Optional;
+
+import static com.facebook.presto.benchmark.event.BenchmarkPhaseEvent.Status.FAILED;
+import static com.facebook.presto.benchmark.event.BenchmarkPhaseEvent.Status.SUCCEEDED;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+@EventType("BenchmarkPhase")
+public class BenchmarkPhaseEvent
+{
+    public enum Status
+    {
+        SUCCEEDED,
+        FAILED
+    }
+
+    private final String name;
+    private final String status;
+    private final String errorMessage;
+
+    public BenchmarkPhaseEvent(
+            String name,
+            Status status,
+            Optional<String> errorMessage)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.status = requireNonNull(status, "status is null").name();
+        this.errorMessage = requireNonNull(errorMessage, "errorMessage is null").orElse(null);
+    }
+
+    public static BenchmarkPhaseEvent succeeded(String name)
+    {
+        return new BenchmarkPhaseEvent(name, SUCCEEDED, Optional.empty());
+    }
+
+    public static BenchmarkPhaseEvent failed(String name, String errorMessage)
+    {
+        return new BenchmarkPhaseEvent(name, FAILED, Optional.of(errorMessage));
+    }
+
+    @EventField
+    public String getName()
+    {
+        return name;
+    }
+
+    @EventField
+    public String getStatus()
+    {
+        return status;
+    }
+
+    @EventField
+    public String getErrorMessage()
+    {
+        return errorMessage;
+    }
+
+    public Status getEventStatus()
+    {
+        return Status.valueOf(status);
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/BenchmarkPhaseEvent.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/BenchmarkPhaseEvent.java
@@ -20,6 +20,7 @@ import javax.annotation.concurrent.Immutable;
 
 import java.util.Optional;
 
+import static com.facebook.presto.benchmark.event.BenchmarkPhaseEvent.Status.COMPLETED_WITH_FAILURES;
 import static com.facebook.presto.benchmark.event.BenchmarkPhaseEvent.Status.FAILED;
 import static com.facebook.presto.benchmark.event.BenchmarkPhaseEvent.Status.SUCCEEDED;
 import static java.util.Objects.requireNonNull;
@@ -31,6 +32,7 @@ public class BenchmarkPhaseEvent
     public enum Status
     {
         SUCCEEDED,
+        COMPLETED_WITH_FAILURES,
         FAILED
     }
 
@@ -56,6 +58,11 @@ public class BenchmarkPhaseEvent
     public static BenchmarkPhaseEvent failed(String name, String errorMessage)
     {
         return new BenchmarkPhaseEvent(name, FAILED, Optional.of(errorMessage));
+    }
+
+    public static BenchmarkPhaseEvent completedWithFailures(String name, String errorMessage)
+    {
+        return new BenchmarkPhaseEvent(name, COMPLETED_WITH_FAILURES, Optional.of(errorMessage));
     }
 
     @EventField

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/BenchmarkQueryEvent.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/BenchmarkQueryEvent.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.event;
+
+import com.facebook.airlift.event.client.EventField;
+import com.facebook.airlift.event.client.EventType;
+import com.facebook.presto.jdbc.QueryStats;
+import io.airlift.units.Duration;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@Immutable
+@EventType("BenchmarkQuery")
+public class BenchmarkQueryEvent
+{
+    public enum Status
+    {
+        SUCCEEDED,
+        FAILED
+    }
+
+    private final String testId;
+    private final String name;
+    private final String status;
+    private final String catalog;
+    private final String schema;
+    private final String query;
+    private final String queryId;
+    private final Double cpuTimeSecs;
+    private final Double wallTimeSecs;
+    private final String errorCode;
+    private final String errorMessage;
+    private final String stackTrace;
+
+    public BenchmarkQueryEvent(
+            String testId,
+            String name,
+            Status status,
+            String catalog,
+            String schema,
+            String query,
+            Optional<QueryStats> queryStats,
+            Optional<String> errorCode,
+            Optional<String> errorMessage,
+            Optional<String> stackTrace)
+    {
+        this.testId = requireNonNull(testId, "testId is null");
+        this.name = requireNonNull(name, "name is null");
+        this.status = requireNonNull(status, "status is null").name();
+        this.catalog = requireNonNull(catalog, "catalog is null");
+        this.schema = requireNonNull(schema, "schema is null");
+        this.query = requireNonNull(query, "query is null");
+        this.queryId = requireNonNull(queryStats, "queryStats is null").map(QueryStats::getQueryId).orElse(null);
+        this.cpuTimeSecs = millisToSeconds(queryStats.map(QueryStats::getCpuTimeMillis)).orElse(null);
+        this.wallTimeSecs = millisToSeconds(queryStats.map(QueryStats::getWallTimeMillis)).orElse(null);
+        this.errorCode = requireNonNull(errorCode, "errorCode is null").orElse(null);
+        this.errorMessage = requireNonNull(errorMessage, "errorMessage is null").orElse("");
+        this.stackTrace = requireNonNull(stackTrace, "stackTrace is null").orElse(null);
+    }
+
+    @EventField
+    public String getTestId()
+    {
+        return testId;
+    }
+
+    @EventField
+    public String getName()
+    {
+        return name;
+    }
+
+    @EventField
+    public String getStatus()
+    {
+        return status;
+    }
+
+    @EventField
+    public String getCatalog()
+    {
+        return catalog;
+    }
+
+    @EventField
+    public String getSchema()
+    {
+        return schema;
+    }
+
+    @EventField
+    public String getQuery()
+    {
+        return query;
+    }
+
+    @EventField
+    public String getQueryId()
+    {
+        return queryId;
+    }
+
+    @EventField
+    public Double getCpuTime()
+    {
+        return cpuTimeSecs;
+    }
+
+    @EventField
+    public Double getWallTime()
+    {
+        return wallTimeSecs;
+    }
+
+    @EventField
+    public String getErrorCode()
+    {
+        return errorCode;
+    }
+
+    @EventField
+    public String getErrorMessage()
+    {
+        return errorMessage;
+    }
+
+    @EventField
+    public String getStackTrace()
+    {
+        return stackTrace;
+    }
+
+    public Status getEventStatus()
+    {
+        return Status.valueOf(status);
+    }
+
+    private static Optional<Double> millisToSeconds(Optional<Long> millis)
+    {
+        return millis.map(value -> new Duration(value, MILLISECONDS).getValue(SECONDS));
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/BenchmarkSuiteEvent.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/BenchmarkSuiteEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.event;
+
+import com.facebook.airlift.event.client.EventField;
+import com.facebook.airlift.event.client.EventType;
+
+import javax.annotation.concurrent.Immutable;
+
+import static com.facebook.presto.benchmark.event.BenchmarkSuiteEvent.Status.FAILED;
+import static com.facebook.presto.benchmark.event.BenchmarkSuiteEvent.Status.SUCCEEDED;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+@EventType("BenchmarkSuite")
+public class BenchmarkSuiteEvent
+{
+    public enum Status
+    {
+        SUCCEEDED,
+        FAILED
+    }
+
+    private final String name;
+    private final String status;
+
+    public BenchmarkSuiteEvent(
+            String name,
+            Status status)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.status = requireNonNull(status, "status is null").name();
+    }
+
+    public static BenchmarkSuiteEvent succeeded(String name)
+    {
+        return new BenchmarkSuiteEvent(name, SUCCEEDED);
+    }
+
+    public static BenchmarkSuiteEvent failed(String name)
+    {
+        return new BenchmarkSuiteEvent(name, FAILED);
+    }
+
+    @EventField
+    public String getName()
+    {
+        return name;
+    }
+
+    @EventField
+    public String getStatus()
+    {
+        return status;
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/BenchmarkSuiteEvent.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/BenchmarkSuiteEvent.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.event.client.EventType;
 
 import javax.annotation.concurrent.Immutable;
 
+import static com.facebook.presto.benchmark.event.BenchmarkSuiteEvent.Status.COMPLETED_WITH_FAILURES;
 import static com.facebook.presto.benchmark.event.BenchmarkSuiteEvent.Status.FAILED;
 import static com.facebook.presto.benchmark.event.BenchmarkSuiteEvent.Status.SUCCEEDED;
 import static java.util.Objects.requireNonNull;
@@ -29,6 +30,7 @@ public class BenchmarkSuiteEvent
     public enum Status
     {
         SUCCEEDED,
+        COMPLETED_WITH_FAILURES,
         FAILED
     }
 
@@ -51,6 +53,11 @@ public class BenchmarkSuiteEvent
     public static BenchmarkSuiteEvent failed(String name)
     {
         return new BenchmarkSuiteEvent(name, FAILED);
+    }
+
+    public static BenchmarkSuiteEvent completedWithFailures(String name)
+    {
+        return new BenchmarkSuiteEvent(name, COMPLETED_WITH_FAILURES);
     }
 
     @EventField

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/EventClientModule.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/EventClientModule.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.event;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.airlift.event.client.EventClient;
+import com.facebook.presto.benchmark.framework.BenchmarkRunnerConfig;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.inject.Binder;
+import com.google.inject.multibindings.Multibinder;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Sets.difference;
+import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+
+public class EventClientModule
+        extends AbstractConfigurationAwareModule
+{
+    private static final Map<String, Class<? extends EventClient>> DEFAULT_EVENT_CLIENTS = ImmutableMap.<String, Class<? extends EventClient>>builder()
+            .put("json", JsonEventClient.class)
+            .build();
+
+    private final Set<String> supportedEventClientTypes;
+
+    public EventClientModule(Set<String> customEventClientType)
+    {
+        this.supportedEventClientTypes = ImmutableSet.<String>builder()
+                .addAll(DEFAULT_EVENT_CLIENTS.keySet())
+                .addAll(customEventClientType)
+                .build();
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        Set<String> eventClientTypes = buildConfigObject(BenchmarkRunnerConfig.class).getEventClients();
+        Sets.SetView<String> unsupportedEventClients = difference(eventClientTypes, supportedEventClientTypes);
+        checkArgument(unsupportedEventClients.isEmpty(), "Unsupported EventClient: %s", unsupportedEventClients);
+
+        Multibinder<EventClient> eventClientBinder = newSetBinder(binder, EventClient.class);
+        for (Entry<String, Class<? extends EventClient>> entry : DEFAULT_EVENT_CLIENTS.entrySet()) {
+            if (eventClientTypes.contains(entry.getKey())) {
+                eventClientBinder.addBinding().to(entry.getValue()).in(SINGLETON);
+            }
+        }
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/JsonEventClient.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/event/JsonEventClient.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.event;
+
+import com.facebook.airlift.event.client.AbstractEventClient;
+import com.facebook.airlift.event.client.JsonEventSerializer;
+import com.facebook.presto.benchmark.framework.BenchmarkRunnerConfig;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+
+import javax.inject.Inject;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import static com.fasterxml.jackson.core.JsonEncoding.UTF8;
+import static java.util.Objects.requireNonNull;
+
+public class JsonEventClient
+        extends AbstractEventClient
+{
+    private static final JsonEventSerializer serializer = new JsonEventSerializer(BenchmarkQueryEvent.class);
+    private static final JsonFactory factory = new JsonFactory();
+
+    private final PrintStream out;
+
+    @Inject
+    public JsonEventClient(BenchmarkRunnerConfig config)
+            throws FileNotFoundException
+    {
+        requireNonNull(config.getJsonEventLogFile(), "jsonEventLogFile is null");
+        this.out = config.getJsonEventLogFile().isPresent() ? new PrintStream(config.getJsonEventLogFile().get()) : System.out;
+    }
+
+    @Override
+    public <T> void postEvent(T event)
+            throws IOException
+    {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(buffer, UTF8);
+        serializer.serialize(event, generator);
+        out.println(buffer.toString().trim());
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/BenchmarkQueryExecutor.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/BenchmarkQueryExecutor.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.executor;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.benchmark.event.BenchmarkQueryEvent;
+import com.facebook.presto.benchmark.framework.BenchmarkQuery;
+import com.facebook.presto.benchmark.framework.BenchmarkRunnerConfig;
+import com.facebook.presto.benchmark.framework.QueryException;
+import com.facebook.presto.benchmark.prestoaction.PrestoAction;
+import com.facebook.presto.benchmark.prestoaction.PrestoActionFactory;
+import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.spi.ErrorCode;
+import com.facebook.presto.spi.ErrorCodeSupplier;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Statement;
+import com.google.inject.Inject;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.benchmark.event.BenchmarkQueryEvent.Status;
+import static com.facebook.presto.benchmark.event.BenchmarkQueryEvent.Status.FAILED;
+import static com.facebook.presto.benchmark.event.BenchmarkQueryEvent.Status.SUCCEEDED;
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static java.util.Objects.requireNonNull;
+
+public class BenchmarkQueryExecutor
+        implements QueryExecutor
+{
+    private static final Logger log = Logger.get(BenchmarkQueryExecutor.class);
+
+    private final PrestoActionFactory prestoActionFactory;
+    private final SqlParser sqlParser;
+    private final ParsingOptions parsingOptions;
+    private final String testId;
+
+    @Inject
+    public BenchmarkQueryExecutor(
+            PrestoActionFactory prestoActionFactory,
+            SqlParser sqlParser,
+            ParsingOptions parsingOptions,
+            BenchmarkRunnerConfig benchmarkRunnerConfig)
+    {
+        this.prestoActionFactory = requireNonNull(prestoActionFactory, "prestoAction is null");
+        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+        this.parsingOptions = requireNonNull(parsingOptions, "parsingOptions is null");
+        this.testId = requireNonNull(benchmarkRunnerConfig, "testId is null").getTestId();
+    }
+
+    @Override
+    public BenchmarkQueryEvent run(BenchmarkQuery benchmarkQuery, Map<String, String> sessionProperties)
+    {
+        QueryStats queryStats = null;
+        Statement statement = sqlParser.createStatement(benchmarkQuery.getQuery(), parsingOptions);
+        PrestoAction prestoAction = prestoActionFactory.get(benchmarkQuery, sessionProperties);
+
+        try {
+            queryStats = prestoAction.execute(statement);
+            return buildEvent(benchmarkQuery, Optional.ofNullable(queryStats), Optional.empty());
+        }
+        catch (QueryException e) {
+            return buildEvent(benchmarkQuery, Optional.ofNullable(queryStats), Optional.of(e));
+        }
+        catch (Throwable t) {
+            log.error(t);
+            return buildEvent(benchmarkQuery, Optional.ofNullable(queryStats), Optional.empty());
+        }
+    }
+
+    private BenchmarkQueryEvent buildEvent(
+            BenchmarkQuery benchmarkQuery,
+            Optional<QueryStats> queryStats,
+            Optional<QueryException> queryException)
+    {
+        boolean succeeded = queryStats.isPresent();
+        Status status = succeeded ? SUCCEEDED : FAILED;
+        Optional<String> errorCode = Optional.empty();
+        String errorMessage = null;
+        String stackTrace = null;
+
+        if (!succeeded && queryException.isPresent()) {
+            queryStats = queryException.get().getQueryStats();
+            errorCode = queryException.get().getPrestoErrorCode().map(ErrorCodeSupplier::toErrorCode).map(ErrorCode::getName);
+            errorMessage = queryException.get().getMessage();
+            stackTrace = getStackTraceAsString(queryException.get().getCause());
+        }
+
+        return new BenchmarkQueryEvent(
+                testId,
+                benchmarkQuery.getName(),
+                status,
+                benchmarkQuery.getCatalog(),
+                benchmarkQuery.getSchema(),
+                benchmarkQuery.getQuery(),
+                queryStats,
+                errorCode,
+                Optional.ofNullable(errorMessage),
+                Optional.ofNullable(stackTrace));
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/ConcurrentPhaseExecutor.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/ConcurrentPhaseExecutor.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.executor;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.benchmark.event.BenchmarkPhaseEvent;
+import com.facebook.presto.benchmark.event.BenchmarkQueryEvent;
+import com.facebook.presto.benchmark.framework.BenchmarkQuery;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+
+import static com.facebook.presto.benchmark.event.BenchmarkQueryEvent.Status;
+import static com.facebook.presto.benchmark.event.BenchmarkQueryEvent.Status.FAILED;
+import static com.facebook.presto.benchmark.event.BenchmarkQueryEvent.Status.SUCCEEDED;
+import static java.lang.Thread.currentThread;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+
+public class ConcurrentPhaseExecutor
+        implements PhaseExecutor
+{
+    private static final Logger log = Logger.get(ConcurrentPhaseExecutor.class);
+
+    private final String phaseName;
+    private final QueryExecutor queryExecutor;
+    private final List<BenchmarkQuery> queries;
+    private final Map<String, String> sessionProperties;
+    private final int maxConcurrency;
+
+    private ExecutorService executor;
+    private CompletionService<BenchmarkQueryEvent> completionService;
+
+    public ConcurrentPhaseExecutor(
+            String phaseName,
+            QueryExecutor queryExecutor,
+            List<BenchmarkQuery> queries,
+            Map<String, String> sessionProperties,
+            int maxConcurrency)
+    {
+        this.phaseName = requireNonNull(phaseName, "phaseName is null");
+        this.queryExecutor = requireNonNull(queryExecutor, "benchmarkQueryExecutor is null");
+        this.queries = ImmutableList.copyOf(requireNonNull(queries, "queries is null"));
+        this.sessionProperties = ImmutableMap.copyOf(requireNonNull(sessionProperties, "sessionProperties is null"));
+        this.maxConcurrency = maxConcurrency;
+    }
+
+    @Override
+    public BenchmarkPhaseEvent run()
+    {
+        this.executor = newFixedThreadPool(maxConcurrency);
+        this.completionService = new ExecutorCompletionService<>(executor);
+
+        for (BenchmarkQuery query : queries) {
+            completionService.submit(() -> queryExecutor.run(query, sessionProperties));
+        }
+
+        return reportProgressUntilFinished(queries.size());
+    }
+
+    private BenchmarkPhaseEvent reportProgressUntilFinished(int queriesSubmitted)
+    {
+        int completed = 0;
+        double lastProgress = 0;
+        Map<Status, Integer> statusCount = new EnumMap<>(Status.class);
+
+        while (completed < queriesSubmitted) {
+            try {
+                BenchmarkQueryEvent event = completionService.take().get();
+                completed++;
+                statusCount.compute(event.getEventStatus(), (status, count) -> count == null ? 1 : count + 1);
+                if (event.getEventStatus() == FAILED) {
+                    executor.shutdownNow();
+                    return BenchmarkPhaseEvent.failed(phaseName, event.getErrorMessage());
+                }
+
+                double progress = ((double) completed) / queriesSubmitted * 100;
+                if (progress - lastProgress > 0.5 || completed == queriesSubmitted) {
+                    log.info("Progress: %s succeeded, %s submitted, %.2f%% done",
+                            statusCount.getOrDefault(SUCCEEDED, 0),
+                            queriesSubmitted,
+                            progress);
+                    lastProgress = progress;
+                }
+            }
+            catch (InterruptedException e) {
+                currentThread().interrupt();
+                executor.shutdownNow();
+                return BenchmarkPhaseEvent.failed(phaseName, e.toString());
+            }
+            catch (ExecutionException e) {
+                executor.shutdownNow();
+                return BenchmarkPhaseEvent.failed(phaseName, e.toString());
+            }
+        }
+        return BenchmarkPhaseEvent.succeeded(phaseName);
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/PhaseExecutor.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/PhaseExecutor.java
@@ -17,5 +17,5 @@ import com.facebook.presto.benchmark.event.BenchmarkPhaseEvent;
 
 public interface PhaseExecutor
 {
-    BenchmarkPhaseEvent run();
+    BenchmarkPhaseEvent run(boolean continueOnFailure);
 }

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/PhaseExecutor.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/PhaseExecutor.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.executor;
+
+import com.facebook.presto.benchmark.event.BenchmarkPhaseEvent;
+
+public interface PhaseExecutor
+{
+    BenchmarkPhaseEvent run();
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/PhaseExecutorFactory.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/PhaseExecutorFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.executor;
+
+import com.facebook.presto.benchmark.framework.BenchmarkQuery;
+import com.facebook.presto.benchmark.framework.BenchmarkSuite;
+import com.facebook.presto.benchmark.framework.ConcurrentExecutionPhase;
+import com.facebook.presto.benchmark.framework.PhaseSpecification;
+import com.google.inject.Inject;
+
+import java.util.List;
+
+import static com.facebook.presto.benchmark.framework.PhaseSpecification.ExecutionStrategy;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class PhaseExecutorFactory
+{
+    private BenchmarkQueryExecutor benchmarkQueryExecutor;
+
+    @Inject
+    public PhaseExecutorFactory(BenchmarkQueryExecutor benchmarkQueryExecutor)
+    {
+        this.benchmarkQueryExecutor = requireNonNull(benchmarkQueryExecutor, "benchmarkQueryExecutor is null");
+    }
+
+    public PhaseExecutor get(PhaseSpecification phaseSpecification, BenchmarkSuite benchmarkSuite)
+    {
+        ExecutionStrategy executionStrategy = phaseSpecification.getExecutionStrategy();
+        switch (executionStrategy) {
+            case CONCURRENT:
+                ConcurrentExecutionPhase phase = (ConcurrentExecutionPhase) phaseSpecification;
+                List<BenchmarkQuery> queryList = phase.getQueries().stream()
+                        .map(query -> benchmarkSuite.getQueryMap().get(query))
+                        .collect(toImmutableList());
+
+                return new ConcurrentPhaseExecutor(
+                        phase.getName(),
+                        benchmarkQueryExecutor,
+                        queryList,
+                        benchmarkSuite.getSuiteInfo().getSessionProperties(),
+                        phase.getMaxConcurrency());
+
+            default:
+                throw new IllegalStateException(format("Unsupported execution strategy type: %s", executionStrategy));
+        }
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/PhaseExecutorFactory.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/PhaseExecutorFactory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.benchmark.executor;
 
+import com.facebook.airlift.event.client.EventClient;
 import com.facebook.presto.benchmark.framework.BenchmarkQuery;
 import com.facebook.presto.benchmark.framework.BenchmarkSuite;
 import com.facebook.presto.benchmark.framework.ConcurrentExecutionPhase;
@@ -20,6 +21,7 @@ import com.facebook.presto.benchmark.framework.PhaseSpecification;
 import com.google.inject.Inject;
 
 import java.util.List;
+import java.util.Set;
 
 import static com.facebook.presto.benchmark.framework.PhaseSpecification.ExecutionStrategy;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -29,11 +31,13 @@ import static java.util.Objects.requireNonNull;
 public class PhaseExecutorFactory
 {
     private BenchmarkQueryExecutor benchmarkQueryExecutor;
+    private Set<EventClient> eventClients;
 
     @Inject
-    public PhaseExecutorFactory(BenchmarkQueryExecutor benchmarkQueryExecutor)
+    public PhaseExecutorFactory(BenchmarkQueryExecutor benchmarkQueryExecutor, Set<EventClient> eventClients)
     {
         this.benchmarkQueryExecutor = requireNonNull(benchmarkQueryExecutor, "benchmarkQueryExecutor is null");
+        this.eventClients = requireNonNull(eventClients, "eventClients is null");
     }
 
     public PhaseExecutor get(PhaseSpecification phaseSpecification, BenchmarkSuite benchmarkSuite)
@@ -50,6 +54,7 @@ public class PhaseExecutorFactory
                         phase.getName(),
                         benchmarkQueryExecutor,
                         queryList,
+                        eventClients,
                         benchmarkSuite.getSuiteInfo().getSessionProperties(),
                         phase.getMaxConcurrency());
 

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/QueryExecutor.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/executor/QueryExecutor.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.executor;
+
+import com.facebook.presto.benchmark.event.BenchmarkQueryEvent;
+import com.facebook.presto.benchmark.framework.BenchmarkQuery;
+
+import java.util.Map;
+
+public interface QueryExecutor
+{
+    BenchmarkQueryEvent run(BenchmarkQuery benchmarkQuery, Map<String, String> sessionProperties);
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkModule.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkModule.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.benchmark.executor.BenchmarkQueryExecutor;
+import com.facebook.presto.benchmark.executor.PhaseExecutorFactory;
+import com.facebook.presto.benchmark.prestoaction.BenchmarkPrestoActionFactory;
+import com.facebook.presto.benchmark.prestoaction.PrestoActionFactory;
+import com.facebook.presto.benchmark.prestoaction.PrestoClusterConfig;
+import com.facebook.presto.benchmark.prestoaction.SqlExceptionClassifier;
+import com.facebook.presto.benchmark.retry.RetryConfig;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.google.inject.Binder;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.google.inject.Scopes.SINGLETON;
+import static java.util.Objects.requireNonNull;
+
+public class BenchmarkModule
+        extends AbstractConfigurationAwareModule
+{
+    private final SqlParserOptions sqlParserOptions;
+    private final ParsingOptions parsingOptions;
+    private final SqlExceptionClassifier exceptionClassifier;
+
+    public BenchmarkModule(SqlParserOptions sqlParserOptions, ParsingOptions parsingOptions, SqlExceptionClassifier exceptionClassifier)
+    {
+        this.sqlParserOptions = requireNonNull(sqlParserOptions, "sqlParserOptions is null");
+        this.parsingOptions = requireNonNull(parsingOptions, "parsingOptions is null");
+        this.exceptionClassifier = requireNonNull(exceptionClassifier, "exceptionClassifier is null");
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(BenchmarkRunnerConfig.class);
+        configBinder(binder).bindConfig(PrestoClusterConfig.class);
+        configBinder(binder).bindConfig(RetryConfig.class);
+
+        binder.bind(SqlExceptionClassifier.class).toInstance(exceptionClassifier);
+        binder.bind(SqlParserOptions.class).toInstance(sqlParserOptions);
+        binder.bind(ParsingOptions.class).toInstance(parsingOptions);
+        binder.bind(SqlParser.class).in(SINGLETON);
+
+        binder.bind(PrestoActionFactory.class).to(BenchmarkPrestoActionFactory.class).in(SINGLETON);
+        binder.bind(PhaseExecutorFactory.class).in(SINGLETON);
+        binder.bind(BenchmarkQueryExecutor.class).in(SINGLETON);
+
+        binder.bind(BenchmarkRunner.class).in(SINGLETON);
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkQuery.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkQuery.java
@@ -22,7 +22,6 @@ import static java.util.Objects.requireNonNull;
 
 public class BenchmarkQuery
 {
-    private final String querySet;
     private final String name;
     private final String query;
     private final String catalog;
@@ -30,22 +29,15 @@ public class BenchmarkQuery
 
     @JdbiConstructor
     public BenchmarkQuery(
-            @ColumnName("query_set") String querySet,
             @ColumnName("name") String name,
             @ColumnName("query") String query,
             @ColumnName("catalog") String catalog,
             @ColumnName("schema") String schema)
     {
-        this.querySet = requireNonNull(querySet, "querySet is null");
         this.name = requireNonNull(name, "name is null");
         this.query = clean(query);
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
-    }
-
-    public String getQuerySet()
-    {
-        return querySet;
     }
 
     public String getName()
@@ -78,8 +70,7 @@ public class BenchmarkQuery
             return false;
         }
         BenchmarkQuery o = (BenchmarkQuery) obj;
-        return Objects.equals(querySet, o.querySet) &&
-                Objects.equals(name, o.name) &&
+        return Objects.equals(name, o.name) &&
                 Objects.equals(query, o.query) &&
                 Objects.equals(catalog, o.catalog) &&
                 Objects.equals(schema, o.schema);
@@ -88,7 +79,7 @@ public class BenchmarkQuery
     @Override
     public int hashCode()
     {
-        return Objects.hash(querySet, name, query, catalog, schema);
+        return Objects.hash(name, query, catalog, schema);
     }
 
     private static String clean(String sql)

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkRunner.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkRunner.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import com.facebook.airlift.event.client.EventClient;
+import com.facebook.presto.benchmark.event.BenchmarkPhaseEvent;
+import com.facebook.presto.benchmark.event.BenchmarkSuiteEvent;
+import com.facebook.presto.benchmark.executor.PhaseExecutor;
+import com.facebook.presto.benchmark.executor.PhaseExecutorFactory;
+import com.facebook.presto.benchmark.source.BenchmarkSuiteSupplier;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+
+import javax.annotation.PostConstruct;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.benchmark.event.BenchmarkPhaseEvent.Status.FAILED;
+import static java.util.Objects.requireNonNull;
+
+public class BenchmarkRunner
+{
+    private final BenchmarkSuiteSupplier benchmarkSuiteSupplier;
+    private final PhaseExecutorFactory phaseExecutorFactory;
+    private final Set<EventClient> eventClients;
+
+    @Inject
+    public BenchmarkRunner(
+            BenchmarkSuiteSupplier benchmarkSuiteSupplier,
+            PhaseExecutorFactory phaseExecutorFactory,
+            Set<EventClient> eventClients)
+    {
+        this.benchmarkSuiteSupplier = requireNonNull(benchmarkSuiteSupplier, "benchmarkSuiteSupplier is null");
+        this.phaseExecutorFactory = requireNonNull(phaseExecutorFactory, "phaseExecutorFactory is null");
+        this.eventClients = ImmutableSet.copyOf(requireNonNull(eventClients, "eventClients is null"));
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        BenchmarkSuite benchmarkSuite = benchmarkSuiteSupplier.get();
+        BenchmarkSuiteInfo benchmarkSuiteInfo = benchmarkSuite.getSuiteInfo();
+        List<PhaseSpecification> phases = benchmarkSuiteInfo.getPhases();
+
+        for (PhaseSpecification phase : phases) {
+            PhaseExecutor phaseExecutor = phaseExecutorFactory.get(phase, benchmarkSuite);
+            BenchmarkPhaseEvent phaseEvent = phaseExecutor.run();
+            if (phaseEvent.getEventStatus() == FAILED) {
+                postEvent(BenchmarkSuiteEvent.failed(benchmarkSuite.getName()));
+                break;
+            }
+        }
+        postEvent(BenchmarkSuiteEvent.succeeded(benchmarkSuite.getName()));
+    }
+
+    private void postEvent(BenchmarkSuiteEvent event)
+    {
+        for (EventClient eventClient : eventClients) {
+            eventClient.post(event);
+        }
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkRunnerConfig.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkRunnerConfig.java
@@ -14,8 +14,14 @@
 package com.facebook.presto.benchmark.framework;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 
 import javax.validation.constraints.NotNull;
+
+import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.benchmark.source.DbBenchmarkSuiteSupplier.BENCHMARK_SUITE_SUPPLIER;
 
@@ -23,6 +29,8 @@ public class BenchmarkRunnerConfig
 {
     private String testId;
     private String benchmarkSuiteSupplier = BENCHMARK_SUITE_SUPPLIER;
+    private Set<String> eventClients = ImmutableSet.of("json");
+    private Optional<String> jsonEventLogFile = Optional.empty();
 
     @NotNull
     public String getTestId()
@@ -47,6 +55,34 @@ public class BenchmarkRunnerConfig
     public BenchmarkRunnerConfig setBenchmarkSuiteSupplier(String benchmarkSuiteSupplier)
     {
         this.benchmarkSuiteSupplier = benchmarkSuiteSupplier;
+        return this;
+    }
+
+    @NotNull
+    public Set<String> getEventClients()
+    {
+        return eventClients;
+    }
+
+    @ConfigDescription("The event client(s) to log the results to")
+    @Config("event-clients")
+    public BenchmarkRunnerConfig setEventClients(String eventClients)
+    {
+        this.eventClients = ImmutableSet.copyOf(Splitter.on(',').trimResults().omitEmptyStrings().splitToList(eventClients));
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getJsonEventLogFile()
+    {
+        return jsonEventLogFile;
+    }
+
+    @ConfigDescription("The file to log json events. Used with event-clients=json. Print to standard output stream if not specified.")
+    @Config("json.log-file")
+    public BenchmarkRunnerConfig setJsonEventLogFile(String jsonEventLogFile)
+    {
+        this.jsonEventLogFile = Optional.ofNullable(jsonEventLogFile);
         return this;
     }
 }

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkRunnerConfig.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkRunnerConfig.java
@@ -31,6 +31,7 @@ public class BenchmarkRunnerConfig
     private String benchmarkSuiteSupplier = BENCHMARK_SUITE_SUPPLIER;
     private Set<String> eventClients = ImmutableSet.of("json");
     private Optional<String> jsonEventLogFile = Optional.empty();
+    private boolean continueOnFailure;
 
     @NotNull
     public String getTestId()
@@ -83,6 +84,18 @@ public class BenchmarkRunnerConfig
     public BenchmarkRunnerConfig setJsonEventLogFile(String jsonEventLogFile)
     {
         this.jsonEventLogFile = Optional.ofNullable(jsonEventLogFile);
+        return this;
+    }
+
+    public boolean isContinueOnFailure()
+    {
+        return continueOnFailure;
+    }
+
+    @Config("continue-on-failure")
+    public BenchmarkRunnerConfig setContinueOnFailure(boolean continueOnFailure)
+    {
+        this.continueOnFailure = continueOnFailure;
         return this;
     }
 }

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkSuite.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/BenchmarkSuite.java
@@ -23,16 +23,24 @@ import static java.util.function.UnaryOperator.identity;
 
 public class BenchmarkSuite
 {
+    private final String name;
     private final BenchmarkSuiteInfo suiteInfo;
     private final Map<String, BenchmarkQuery> queries;
 
     public BenchmarkSuite(
+            String name,
             BenchmarkSuiteInfo suiteInfo,
             List<BenchmarkQuery> queries)
     {
+        this.name = requireNonNull(name, "name is null");
         this.suiteInfo = requireNonNull(suiteInfo, "SuiteInfo is null");
         this.queries = queries.stream()
                 .collect(toImmutableMap(BenchmarkQuery::getName, identity()));
+    }
+
+    public String getName()
+    {
+        return name;
     }
 
     public BenchmarkSuiteInfo getSuiteInfo()

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/ConcurrentExecutionPhase.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/ConcurrentExecutionPhase.java
@@ -27,13 +27,15 @@ public class ConcurrentExecutionPhase
 {
     private final ExecutionStrategy executionStrategy;
     private final List<String> queries;
+    private int maxConcurrency = 50;
 
     @JsonCreator
-    public ConcurrentExecutionPhase(String name, ExecutionStrategy executionStrategy, List<String> queries)
+    public ConcurrentExecutionPhase(String name, ExecutionStrategy executionStrategy, List<String> queries, int maxConcurrency)
     {
         super(name);
         this.executionStrategy = requireNonNull(executionStrategy, "executionStrategy is null");
         this.queries = requireNonNull(ImmutableList.copyOf(queries), "queries is null");
+        this.maxConcurrency = maxConcurrency;
     }
 
     @JsonProperty
@@ -47,6 +49,12 @@ public class ConcurrentExecutionPhase
     public List<String> getQueries()
     {
         return queries;
+    }
+
+    @JsonProperty
+    public int getMaxConcurrency()
+    {
+        return maxConcurrency;
     }
 
     @Override

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/QueryException.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/QueryException.java
@@ -14,20 +14,57 @@
 package com.facebook.presto.benchmark.framework;
 
 import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.spi.ErrorCodeSupplier;
 
 import java.util.Optional;
 
+import static com.facebook.presto.benchmark.framework.QueryException.Type.CLUSTER_CONNECTION;
+import static com.facebook.presto.benchmark.framework.QueryException.Type.PRESTO;
 import static java.util.Objects.requireNonNull;
 
 public class QueryException
         extends RuntimeException
 {
+    public enum Type
+    {
+        CLUSTER_CONNECTION,
+        PRESTO
+    }
+
+    private final Type type;
+    private final Optional<ErrorCodeSupplier> prestoErrorCode;
     private final Optional<QueryStats> queryStats;
 
-    public QueryException(Throwable cause, Optional<QueryStats> queryStats)
+    public QueryException(
+            Throwable cause,
+            Type type,
+            Optional<ErrorCodeSupplier> prestoErrorCode,
+            Optional<QueryStats> queryStats)
     {
         super(cause);
+        this.type = requireNonNull(type, "type is null");
+        this.prestoErrorCode = requireNonNull(prestoErrorCode, "errorCode is null");
         this.queryStats = requireNonNull(queryStats, "queryStats is null");
+    }
+
+    public static QueryException forClusterConnection(Throwable cause)
+    {
+        return new QueryException(cause, CLUSTER_CONNECTION, Optional.empty(), Optional.empty());
+    }
+
+    public static QueryException forPresto(Throwable cause, Optional<ErrorCodeSupplier> prestoErrorCode, Optional<QueryStats> queryStats)
+    {
+        return new QueryException(cause, PRESTO, prestoErrorCode, queryStats);
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+    public Optional<ErrorCodeSupplier> getPrestoErrorCode()
+    {
+        return prestoErrorCode;
     }
 
     public Optional<QueryStats> getQueryStats()

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/QueryException.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/QueryException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import com.facebook.presto.jdbc.QueryStats;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class QueryException
+        extends RuntimeException
+{
+    private final Optional<QueryStats> queryStats;
+
+    public QueryException(Throwable cause, Optional<QueryStats> queryStats)
+    {
+        super(cause);
+        this.queryStats = requireNonNull(queryStats, "queryStats is null");
+    }
+
+    public Optional<QueryStats> getQueryStats()
+    {
+        return queryStats;
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/QueryResult.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/framework/QueryResult.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import com.facebook.presto.jdbc.QueryStats;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class QueryResult<R>
+{
+    private final List<R> results;
+    private final QueryStats queryStats;
+
+    public QueryResult(List<R> results, QueryStats queryStats)
+    {
+        this.results = ImmutableList.copyOf(results);
+        this.queryStats = requireNonNull(queryStats, "queryStats is null");
+    }
+
+    public List<R> getResults()
+    {
+        return results;
+    }
+
+    public QueryStats getQueryStats()
+    {
+        return queryStats;
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/BenchmarkPrestoActionFactory.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/BenchmarkPrestoActionFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.prestoaction;
+
+import com.facebook.presto.benchmark.framework.BenchmarkQuery;
+import com.facebook.presto.benchmark.retry.RetryConfig;
+import com.google.inject.Inject;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class BenchmarkPrestoActionFactory
+        implements PrestoActionFactory
+{
+    private final SqlExceptionClassifier exceptionClassifier;
+    private final PrestoClusterConfig clusterConfig;
+    private final RetryConfig networkRetryConfig;
+
+    @Inject
+    public BenchmarkPrestoActionFactory(
+            SqlExceptionClassifier exceptionClassifier,
+            PrestoClusterConfig clusterConfig,
+            RetryConfig networkRetryConfig)
+    {
+        this.exceptionClassifier = requireNonNull(exceptionClassifier, "exceptionClassifier is null");
+        this.clusterConfig = requireNonNull(clusterConfig, "clusterConfig is null");
+        this.networkRetryConfig = requireNonNull(networkRetryConfig, "networkRetryConfig is null");
+    }
+
+    @Override
+    public PrestoAction get(
+            BenchmarkQuery benchmarkQuery,
+            Map<String, String> sessionProperties)
+    {
+        return new JdbcPrestoAction(
+                exceptionClassifier,
+                benchmarkQuery,
+                clusterConfig,
+                sessionProperties,
+                networkRetryConfig);
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/JdbcPrestoAction.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/JdbcPrestoAction.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.prestoaction;
+
+import com.facebook.presto.benchmark.framework.BenchmarkQuery;
+import com.facebook.presto.benchmark.framework.QueryException;
+import com.facebook.presto.benchmark.framework.QueryResult;
+import com.facebook.presto.jdbc.PrestoConnection;
+import com.facebook.presto.jdbc.PrestoStatement;
+import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.sql.tree.Statement;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static com.facebook.presto.sql.SqlFormatter.formatSql;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class JdbcPrestoAction
+        implements PrestoAction
+{
+    private static final String QUERY_MAX_EXECUTION_TIME = "query_max_execution_time";
+
+    private final BenchmarkQuery benchmarkQuery;
+    private final String jdbcUrl;
+    private final Duration queryTimeout;
+    private final Map<String, String> sessionProperties;
+
+    public JdbcPrestoAction(
+            BenchmarkQuery benchmarkQuery,
+            PrestoClusterConfig prestoClusterConfig,
+            Map<String, String> sessionProperties)
+    {
+        this.benchmarkQuery = requireNonNull(benchmarkQuery, "benchmarkQuery is null");
+        this.jdbcUrl = requireNonNull(prestoClusterConfig.getJdbcUrl(), "jdbcUrl is null");
+        this.queryTimeout = requireNonNull(prestoClusterConfig.getQueryTimeout(), "queryTimeout is null");
+        this.sessionProperties = ImmutableMap.copyOf(sessionProperties);
+    }
+
+    @Override
+    public QueryStats execute(Statement statement)
+    {
+        return execute(statement, Optional.empty()).getQueryStats();
+    }
+
+    @Override
+    public <R> QueryResult<R> execute(Statement statement, ResultSetConverter<R> converter)
+    {
+        return execute(statement, Optional.of(converter));
+    }
+
+    private <R> QueryResult<R> execute(Statement statement, Optional<ResultSetConverter<R>> converter)
+    {
+        String query = formatSql(statement, Optional.empty());
+        ProgressMonitor progressMonitor = new ProgressMonitor();
+
+        try (PrestoConnection connection = getConnection()) {
+            try (java.sql.Statement jdbcStatement = connection.createStatement()) {
+                PrestoStatement prestoStatement = jdbcStatement.unwrap(PrestoStatement.class);
+                prestoStatement.setProgressMonitor(progressMonitor);
+
+                ImmutableList.Builder<R> rows = ImmutableList.builder();
+                if (converter.isPresent()) {
+                    try (ResultSet resultSet = jdbcStatement.executeQuery(query)) {
+                        while (resultSet.next()) {
+                            rows.add(converter.get().apply(resultSet));
+                        }
+                    }
+                }
+                else {
+                    boolean moreResults = jdbcStatement.execute(query);
+                    if (moreResults) {
+                        consumeResultSet(jdbcStatement.getResultSet());
+                    }
+                    do {
+                        moreResults = jdbcStatement.getMoreResults();
+                        if (moreResults) {
+                            consumeResultSet(jdbcStatement.getResultSet());
+                        }
+                    }
+                    while (moreResults || jdbcStatement.getUpdateCount() != -1);
+                }
+
+                checkState(progressMonitor.getLastQueryStats().isPresent(), "lastQueryStats is missing");
+                return new QueryResult<>(rows.build(), progressMonitor.getLastQueryStats().get());
+            }
+        }
+        catch (SQLException e) {
+            throw new QueryException(e, progressMonitor.getLastQueryStats());
+        }
+    }
+
+    private void consumeResultSet(ResultSet resultSet)
+            throws SQLException
+    {
+        while (resultSet.next()) {
+            // Do nothing
+        }
+    }
+
+    private PrestoConnection getConnection()
+            throws SQLException
+    {
+        PrestoConnection connection = DriverManager.getConnection(jdbcUrl, "user", null)
+                .unwrap(PrestoConnection.class);
+
+        try {
+            connection.setClientInfo("ApplicationName", "benchmark-test");
+            connection.setCatalog(benchmarkQuery.getCatalog());
+            connection.setSchema(benchmarkQuery.getSchema());
+        }
+        catch (SQLClientInfoException ignored) {
+            // Do nothing
+        }
+
+        Map<String, String> sessionProperties = ImmutableMap.<String, String>builder()
+                .putAll(this.sessionProperties)
+                .put(QUERY_MAX_EXECUTION_TIME, queryTimeout.toString())
+                .build();
+        for (Map.Entry<String, String> entry : sessionProperties.entrySet()) {
+            connection.setSessionProperty(entry.getKey(), entry.getValue());
+        }
+        return connection;
+    }
+
+    static class ProgressMonitor
+            implements Consumer<QueryStats>
+    {
+        private Optional<QueryStats> queryStats = Optional.empty();
+
+        @Override
+        public synchronized void accept(QueryStats queryStats)
+        {
+            this.queryStats = Optional.of(requireNonNull(queryStats, "queryStats is null"));
+        }
+
+        public synchronized Optional<QueryStats> getLastQueryStats()
+        {
+            return queryStats;
+        }
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/PrestoAction.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/PrestoAction.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.prestoaction;
+
+import com.facebook.presto.benchmark.framework.QueryResult;
+import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.sql.tree.Statement;
+import com.google.common.collect.ImmutableList;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public interface PrestoAction
+{
+    @FunctionalInterface
+    interface ResultSetConverter<R>
+    {
+        R apply(ResultSet resultSet)
+                throws SQLException;
+
+        ResultSetConverter<List<Object>> DEFAULT = resultSet -> {
+            ImmutableList.Builder<Object> row = ImmutableList.builder();
+            for (int i = 0; i < resultSet.getMetaData().getColumnCount(); i++) {
+                row.add(resultSet.getObject(i));
+            }
+            return row.build();
+        };
+    }
+
+    QueryStats execute(Statement statement);
+
+    <R> QueryResult<R> execute(Statement statement, ResultSetConverter<R> converter);
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/PrestoActionFactory.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/PrestoActionFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.prestoaction;
+
+import com.facebook.presto.benchmark.framework.BenchmarkQuery;
+
+import java.util.Map;
+
+public interface PrestoActionFactory
+{
+    PrestoAction get(BenchmarkQuery benchmarkQuery, Map<String, String> sessionProperties);
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/PrestoClusterConfig.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/PrestoClusterConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.prestoaction;
+
+import com.facebook.airlift.configuration.Config;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import javax.validation.constraints.NotNull;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class PrestoClusterConfig
+{
+    private String jdbcUrl;
+    private Duration queryTimeout = new Duration(60, MINUTES);
+
+    @NotNull
+    public String getJdbcUrl()
+    {
+        return jdbcUrl;
+    }
+
+    @Config("jdbc-url")
+    public PrestoClusterConfig setJdbcUrl(String jdbcUrl)
+    {
+        this.jdbcUrl = jdbcUrl;
+        return this;
+    }
+
+    @MinDuration("1s")
+    public Duration getQueryTimeout()
+    {
+        return queryTimeout;
+    }
+
+    @Config("query-timeout")
+    public PrestoClusterConfig setQueryTimeout(Duration queryTimeout)
+    {
+        this.queryTimeout = queryTimeout;
+        return this;
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/PrestoExceptionClassifier.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/PrestoExceptionClassifier.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.prestoaction;
+
+import com.facebook.presto.benchmark.framework.QueryException;
+import com.facebook.presto.connector.thrift.ThriftErrorCode;
+import com.facebook.presto.hive.HiveErrorCode;
+import com.facebook.presto.hive.MetastoreErrorCode;
+import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.plugin.jdbc.JdbcErrorCode;
+import com.facebook.presto.spi.ErrorCodeSupplier;
+import com.facebook.presto.spi.StandardErrorCode;
+import com.google.common.collect.ImmutableSet;
+
+import java.io.EOFException;
+import java.io.UncheckedIOException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Arrays.asList;
+import static java.util.function.Function.identity;
+
+public class PrestoExceptionClassifier
+        implements SqlExceptionClassifier
+{
+    private static final Set<ErrorCodeSupplier> DEFAULT_ERRORS = ImmutableSet.<ErrorCodeSupplier>builder()
+            .addAll(asList(StandardErrorCode.values()))
+            .addAll(asList(MetastoreErrorCode.values()))
+            .addAll(asList(HiveErrorCode.values()))
+            .addAll(asList(JdbcErrorCode.values()))
+            .addAll(asList(ThriftErrorCode.values()))
+            .build();
+
+    private final Map<Integer, ErrorCodeSupplier> errorByCode;
+
+    public PrestoExceptionClassifier(Set<ErrorCodeSupplier> additionalErrors)
+    {
+        this.errorByCode = ImmutableSet.<ErrorCodeSupplier>builder()
+                .addAll(DEFAULT_ERRORS)
+                .addAll(additionalErrors)
+                .build()
+                .stream()
+                .collect(toImmutableMap(errorCode -> errorCode.toErrorCode().getCode(), identity()));
+    }
+
+    @Override
+    public QueryException createException(Optional<QueryStats> queryStats, SQLException cause)
+    {
+        Optional<Throwable> clusterConnectionExceptionCause = getClusterConnectionExceptionCause(cause);
+        if (clusterConnectionExceptionCause.isPresent()) {
+            return QueryException.forClusterConnection(clusterConnectionExceptionCause.get());
+        }
+
+        Optional<ErrorCodeSupplier> errorCode = Optional.ofNullable(errorByCode.get(cause.getErrorCode()));
+        return QueryException.forPresto(cause, errorCode, queryStats);
+    }
+
+    public static boolean isClusterConnectionException(Throwable t)
+    {
+        return getClusterConnectionExceptionCause(t).isPresent();
+    }
+
+    private static Optional<Throwable> getClusterConnectionExceptionCause(Throwable t)
+    {
+        while (t != null) {
+            if (t instanceof SocketTimeoutException ||
+                    t instanceof SocketException ||
+                    t instanceof EOFException ||
+                    t instanceof UncheckedIOException ||
+                    t instanceof TimeoutException ||
+                    (t.getClass().equals(RuntimeException.class) && t.getMessage() != null && t.getMessage().contains("Error fetching next at"))) {
+                return Optional.of(t);
+            }
+            t = t.getCause();
+        }
+        return Optional.empty();
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/SqlExceptionClassifier.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/prestoaction/SqlExceptionClassifier.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.prestoaction;
+
+import com.facebook.presto.benchmark.framework.QueryException;
+import com.facebook.presto.jdbc.QueryStats;
+
+import java.sql.SQLException;
+import java.util.Optional;
+
+public interface SqlExceptionClassifier
+{
+    QueryException createException(Optional<QueryStats> queryStats, SQLException cause);
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/retry/RetryConfig.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/retry/RetryConfig.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.retry;
+
+import com.facebook.airlift.configuration.Config;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import javax.validation.constraints.Min;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class RetryConfig
+{
+    private int maxAttempts = 1;
+    private Duration minBackoffDelay = new Duration(0, NANOSECONDS);
+    private Duration maxBackoffDelay = new Duration(1, MINUTES);
+    private double scaleFactor = 1.0;
+
+    @Min(1)
+    public int getMaxAttempts()
+    {
+        return maxAttempts;
+    }
+
+    @Config("max-attempts")
+    public RetryConfig setMaxAttempts(int maxAttempts)
+    {
+        this.maxAttempts = maxAttempts;
+        return this;
+    }
+
+    @MinDuration("0ns")
+    public Duration getMinBackoffDelay()
+    {
+        return minBackoffDelay;
+    }
+
+    @Config("min-backoff-delay")
+    public RetryConfig setMinBackoffDelay(Duration minBackoffDelay)
+    {
+        this.minBackoffDelay = minBackoffDelay;
+        return this;
+    }
+
+    @MinDuration("0ns")
+    public Duration getMaxBackoffDelay()
+    {
+        return maxBackoffDelay;
+    }
+
+    @Config("max-backoff-delay")
+    public RetryConfig setMaxBackoffDelay(Duration maxBackoffDelay)
+    {
+        this.maxBackoffDelay = maxBackoffDelay;
+        return this;
+    }
+
+    @Min(1)
+    public double getScaleFactor()
+    {
+        return scaleFactor;
+    }
+
+    @Config("backoff-scale-factor")
+    public RetryConfig setScaleFactor(double scaleFactor)
+    {
+        this.scaleFactor = scaleFactor;
+        return this;
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/retry/RetryDriver.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/retry/RetryDriver.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.retry;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.benchmark.framework.QueryException;
+import io.airlift.units.Duration;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Predicate;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.lang.Math.pow;
+import static java.lang.Thread.currentThread;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class RetryDriver
+{
+    private static final Logger log = Logger.get(RetryDriver.class);
+
+    private final int maxAttempts;
+    private final Duration minBackoffDelay;
+    private final Duration maxBackoffDelay;
+    private final double scaleFactor;
+    private final Predicate<Exception> retryPredicate;
+
+    public RetryDriver(
+            RetryConfig config,
+            Predicate<Exception> retryPredicate)
+    {
+        this.maxAttempts = config.getMaxAttempts();
+        this.minBackoffDelay = requireNonNull(config.getMinBackoffDelay(), "minBackoffDelay is null");
+        this.maxBackoffDelay = requireNonNull(config.getMaxBackoffDelay(), "maxBackoffDelay is null");
+        this.scaleFactor = config.getScaleFactor();
+        this.retryPredicate = requireNonNull(retryPredicate, "retryPredicate is null");
+    }
+
+    @SuppressWarnings("unchecked")
+    public <V> V run(String callableName, RetryOperation<V> operation)
+    {
+        int attempt = 1;
+        while (true) {
+            try {
+                return operation.run();
+            }
+            catch (Exception e) {
+                if (attempt >= maxAttempts || !retryPredicate.test(e)) {
+                    throwIfUnchecked(e);
+                    throw new RuntimeException(e);
+                }
+
+                QueryException qe = (QueryException) e;
+                attempt++;
+                int delayMillis = (int) min(minBackoffDelay.toMillis() * pow(scaleFactor, attempt - 1), maxBackoffDelay.toMillis());
+                int jitterMillis = ThreadLocalRandom.current().nextInt(max(1, (int) (delayMillis * 0.1)));
+                log.debug(
+                        "Failed on executing %s with attempt %d. Retry after %sms. Cause: %s",
+                        callableName,
+                        attempt - 1,
+                        delayMillis,
+                        qe.getMessage());
+
+                try {
+                    MILLISECONDS.sleep(delayMillis + jitterMillis);
+                }
+                catch (InterruptedException ie) {
+                    currentThread().interrupt();
+                    throw new RuntimeException(ie);
+                }
+            }
+        }
+    }
+
+    public interface RetryOperation<V>
+    {
+        V run()
+                throws QueryException;
+    }
+}

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/BenchmarkSuiteDao.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/BenchmarkSuiteDao.java
@@ -72,7 +72,6 @@ public interface BenchmarkSuiteDao
 
     @SqlQuery("SELECT\n" +
             "  `name`,\n" +
-            "  `query_set`,\n" +
             "  `catalog`,\n" +
             "  `schema`,\n" +
             "  `query`\n" +

--- a/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/DbBenchmarkSuiteSupplier.java
+++ b/presto-benchmark-runner/src/main/java/com/facebook/presto/benchmark/source/DbBenchmarkSuiteSupplier.java
@@ -47,7 +47,7 @@ public class DbBenchmarkSuiteSupplier
         try (Handle handle = jdbi.open()) {
             BenchmarkSuiteDao benchmarkDao = handle.attach(BenchmarkSuiteDao.class);
             BenchmarkSuiteInfo benchmarkSuiteInfo = benchmarkDao.getBenchmarkSuiteInfo(suitesTableName, suite);
-            benchmarkSuite = new BenchmarkSuite(benchmarkSuiteInfo, benchmarkDao.getBenchmarkQueries(queriesTableName, benchmarkSuiteInfo.getQuerySet()));
+            benchmarkSuite = new BenchmarkSuite(suite, benchmarkSuiteInfo, benchmarkDao.getBenchmarkQueries(queriesTableName, benchmarkSuiteInfo.getQuerySet()));
         }
         return benchmarkSuite;
     }

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/BenchmarkTestUtil.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/BenchmarkTestUtil.java
@@ -115,7 +115,7 @@ public class BenchmarkTestUtil
         PhaseSpecification streamExecutionPhase = new StreamExecutionPhase("Phase-1", STREAM, streams);
 
         List<String> queries = ImmutableList.of("Q1", "Q2", "Q3");
-        PhaseSpecification concurrentExecutionPhase = new ConcurrentExecutionPhase("Phase-2", CONCURRENT, queries);
+        PhaseSpecification concurrentExecutionPhase = new ConcurrentExecutionPhase("Phase-2", CONCURRENT, queries, 50);
 
         return ImmutableList.of(streamExecutionPhase, concurrentExecutionPhase);
     }

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/BenchmarkTestUtil.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/BenchmarkTestUtil.java
@@ -133,7 +133,7 @@ public class BenchmarkTestUtil
         BenchmarkQuery benchmarkQuery2 = new BenchmarkQuery("Q2", "SELECT 2", CATALOG, SCHEMA);
         BenchmarkQuery benchmarkQuery3 = new BenchmarkQuery("Q3", "SELECT 3", CATALOG, SCHEMA);
 
-        return new BenchmarkSuite(new BenchmarkSuiteInfo(suite, querySet, getBenchmarkSuitePhases(), getBenchmarkSuiteSessionProperties()),
+        return new BenchmarkSuite(suite, new BenchmarkSuiteInfo(suite, querySet, getBenchmarkSuitePhases(), getBenchmarkSuiteSessionProperties()),
                 ImmutableList.of(benchmarkQuery1, benchmarkQuery2, benchmarkQuery3));
     }
 }

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/BenchmarkTestUtil.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/BenchmarkTestUtil.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.benchmark;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.benchmark.framework.BenchmarkQuery;
 import com.facebook.presto.benchmark.framework.BenchmarkSuite;
 import com.facebook.presto.benchmark.framework.BenchmarkSuiteInfo;
@@ -20,7 +21,9 @@ import com.facebook.presto.benchmark.framework.ConcurrentExecutionPhase;
 import com.facebook.presto.benchmark.framework.PhaseSpecification;
 import com.facebook.presto.benchmark.framework.StreamExecutionPhase;
 import com.facebook.presto.benchmark.source.BenchmarkSuiteDao;
+import com.facebook.presto.plugin.memory.MemoryPlugin;
 import com.facebook.presto.testing.mysql.TestingMySqlServer;
+import com.facebook.presto.tests.StandaloneQueryRunner;
 import com.google.common.collect.ImmutableList;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
@@ -32,6 +35,7 @@ import java.util.Map;
 
 import static com.facebook.presto.benchmark.framework.PhaseSpecification.ExecutionStrategy.CONCURRENT;
 import static com.facebook.presto.benchmark.framework.PhaseSpecification.ExecutionStrategy.STREAM;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 
 public class BenchmarkTestUtil
 {
@@ -41,6 +45,19 @@ public class BenchmarkTestUtil
 
     private BenchmarkTestUtil()
     {
+    }
+
+    public static StandaloneQueryRunner setupPresto()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(CATALOG)
+                .setSchema(SCHEMA)
+                .build();
+        StandaloneQueryRunner queryRunner = new StandaloneQueryRunner(session);
+        queryRunner.installPlugin(new MemoryPlugin());
+        queryRunner.createCatalog(CATALOG, "memory");
+        return queryRunner;
     }
 
     public static TestingMySqlServer setupMySql()
@@ -112,9 +129,9 @@ public class BenchmarkTestUtil
 
     public static BenchmarkSuite getBenchmarkSuiteObject(String suite, String querySet)
     {
-        BenchmarkQuery benchmarkQuery1 = new BenchmarkQuery(querySet, "Q1", "SELECT 1", CATALOG, SCHEMA);
-        BenchmarkQuery benchmarkQuery2 = new BenchmarkQuery(querySet, "Q2", "SELECT 2", CATALOG, SCHEMA);
-        BenchmarkQuery benchmarkQuery3 = new BenchmarkQuery(querySet, "Q3", "SELECT 3", CATALOG, SCHEMA);
+        BenchmarkQuery benchmarkQuery1 = new BenchmarkQuery("Q1", "SELECT 1", CATALOG, SCHEMA);
+        BenchmarkQuery benchmarkQuery2 = new BenchmarkQuery("Q2", "SELECT 2", CATALOG, SCHEMA);
+        BenchmarkQuery benchmarkQuery3 = new BenchmarkQuery("Q3", "SELECT 3", CATALOG, SCHEMA);
 
         return new BenchmarkSuite(new BenchmarkSuiteInfo(suite, querySet, getBenchmarkSuitePhases(), getBenchmarkSuiteSessionProperties()),
                 ImmutableList.of(benchmarkQuery1, benchmarkQuery2, benchmarkQuery3));

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/executor/TestBenchmarkQueryExecutor.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/executor/TestBenchmarkQueryExecutor.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.executor;
+
+import com.facebook.presto.benchmark.event.BenchmarkQueryEvent;
+import com.facebook.presto.benchmark.event.BenchmarkQueryEvent.Status;
+import com.facebook.presto.benchmark.framework.BenchmarkQuery;
+import com.facebook.presto.benchmark.framework.BenchmarkRunnerConfig;
+import com.facebook.presto.benchmark.framework.QueryException;
+import com.facebook.presto.benchmark.framework.QueryResult;
+import com.facebook.presto.benchmark.prestoaction.JdbcPrestoAction;
+import com.facebook.presto.benchmark.prestoaction.PrestoAction;
+import com.facebook.presto.benchmark.prestoaction.PrestoClusterConfig;
+import com.facebook.presto.benchmark.prestoaction.PrestoExceptionClassifier;
+import com.facebook.presto.benchmark.retry.RetryConfig;
+import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.spi.ErrorCodeSupplier;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.tests.StandaloneQueryRunner;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.CATALOG;
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.SCHEMA;
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.setupPresto;
+import static com.facebook.presto.benchmark.event.BenchmarkQueryEvent.Status.FAILED;
+import static com.facebook.presto.benchmark.event.BenchmarkQueryEvent.Status.SUCCEEDED;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.sql.parser.IdentifierSymbol.AT_SIGN;
+import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
+import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestBenchmarkQueryExecutor
+{
+    private static final String NAME = "test-query";
+    private static final String TEST_ID = "test-id";
+    private final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
+    private final ParsingOptions parsingOptions = ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build();
+    private StandaloneQueryRunner queryRunner;
+
+    private static class MockPrestoAction
+            implements PrestoAction
+    {
+        private final ErrorCodeSupplier errorCode;
+
+        public MockPrestoAction(ErrorCodeSupplier errorCode)
+        {
+            this.errorCode = requireNonNull(errorCode, "errorCode is null");
+        }
+
+        @Override
+        public QueryStats execute(Statement statement)
+        {
+            throw QueryException.forPresto(new RuntimeException(), Optional.of(errorCode), Optional.empty());
+        }
+
+        @Override
+        public <R> QueryResult<R> execute(
+                Statement statement,
+                ResultSetConverter<R> converter)
+        {
+            throw QueryException.forPresto(new RuntimeException(), Optional.of(errorCode), Optional.empty());
+        }
+    }
+
+    @BeforeClass
+    public void setupClass()
+            throws Exception
+    {
+        queryRunner = setupPresto();
+    }
+
+    private BenchmarkQueryExecutor createBenchmarkQueryExecutor(boolean useMockPrestoAction)
+    {
+        BenchmarkRunnerConfig benchmarkRunnerConfig = new BenchmarkRunnerConfig().setTestId(TEST_ID);
+
+        if (useMockPrestoAction) {
+            return new BenchmarkQueryExecutor((query, sessionProperties) -> new MockPrestoAction(GENERIC_INTERNAL_ERROR), sqlParser, parsingOptions, benchmarkRunnerConfig);
+        }
+        else {
+            JdbcPrestoAction jdbcPrestoAction = new JdbcPrestoAction(
+                    new PrestoExceptionClassifier(ImmutableSet.of()),
+                    new BenchmarkQuery("Test-Query", "SELECT 1", CATALOG, SCHEMA),
+                    new PrestoClusterConfig()
+                            .setJdbcUrl(queryRunner.getServer().getBaseUrl().toString().replace("http", "jdbc:presto")),
+                    new HashMap<>(),
+                    new RetryConfig());
+
+            return new BenchmarkQueryExecutor((query, sessionProperties) -> jdbcPrestoAction, sqlParser, parsingOptions, benchmarkRunnerConfig);
+        }
+    }
+
+    @Test
+    public void testSuccess()
+    {
+        BenchmarkQueryEvent event = createBenchmarkQueryExecutor(false)
+                .run(new BenchmarkQuery(NAME, "SELECT 1", CATALOG, SCHEMA), new HashMap<>());
+        assertNotNull(event);
+        assertQueryEvent(event, SUCCEEDED, Optional.empty());
+    }
+
+    @Test
+    public void testFailure()
+    {
+        BenchmarkQueryEvent event = createBenchmarkQueryExecutor(true)
+                .run(new BenchmarkQuery(NAME, "SELECT 1", CATALOG, SCHEMA), new HashMap<>());
+        assertNotNull(event);
+        assertQueryEvent(event, FAILED, Optional.of(GENERIC_INTERNAL_ERROR.toString()));
+    }
+
+    private void assertQueryEvent(
+            BenchmarkQueryEvent event,
+            Status expectedStatus,
+            Optional<String> expectedErrorCode)
+    {
+        assertEquals(event.getTestId(), TEST_ID);
+        assertEquals(event.getName(), NAME);
+        assertEquals(event.getEventStatus(), expectedStatus);
+        assertEquals(event.getErrorCode(), expectedErrorCode.orElse(null));
+    }
+}

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/executor/TestConcurrentPhaseExecutor.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/executor/TestConcurrentPhaseExecutor.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.executor;
+
+import com.facebook.presto.benchmark.event.BenchmarkPhaseEvent;
+import com.facebook.presto.benchmark.event.BenchmarkPhaseEvent.Status;
+import com.facebook.presto.benchmark.event.BenchmarkQueryEvent;
+import com.facebook.presto.benchmark.framework.BenchmarkQuery;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.CATALOG;
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.SCHEMA;
+import static com.facebook.presto.benchmark.event.BenchmarkPhaseEvent.Status.FAILED;
+import static com.facebook.presto.benchmark.event.BenchmarkPhaseEvent.Status.SUCCEEDED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestConcurrentPhaseExecutor
+{
+    private static final String TEST_ID = "test-id";
+    private static final String PHASE_NAME = "test=phase";
+    private static final List<BenchmarkQuery> ALL_QUERIES = ImmutableList.of(
+            new BenchmarkQuery("Q1", "SELECT 1", CATALOG, SCHEMA),
+            new BenchmarkQuery("Q2", "SELECT 2", CATALOG, SCHEMA),
+            new BenchmarkQuery("Q3", "SELECT 3", CATALOG, SCHEMA));
+
+    private static class MockQueryExecutor
+            implements QueryExecutor
+    {
+        private final boolean failQueries;
+
+        public MockQueryExecutor(boolean failQueries)
+        {
+            this.failQueries = failQueries;
+        }
+
+        @Override
+        public BenchmarkQueryEvent run(BenchmarkQuery benchmarkQuery, Map<String, String> sessionProperties)
+        {
+            if (failQueries) {
+                return new BenchmarkQueryEvent(
+                        TEST_ID,
+                        benchmarkQuery.getName(),
+                        BenchmarkQueryEvent.Status.FAILED,
+                        benchmarkQuery.getCatalog(),
+                        benchmarkQuery.getSchema(),
+                        benchmarkQuery.getQuery(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty());
+            }
+            else {
+                return new BenchmarkQueryEvent(
+                        TEST_ID,
+                        benchmarkQuery.getName(),
+                        BenchmarkQueryEvent.Status.SUCCEEDED,
+                        benchmarkQuery.getCatalog(),
+                        benchmarkQuery.getSchema(),
+                        benchmarkQuery.getQuery(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty());
+            }
+        }
+    }
+
+    private ConcurrentPhaseExecutor createConcurrentPhaseExecutor(boolean failQueries)
+    {
+        return new ConcurrentPhaseExecutor(PHASE_NAME, new MockQueryExecutor(failQueries), ALL_QUERIES, new HashMap<>(), 50);
+    }
+
+    private void assertBenchmarkPhaseEvent(BenchmarkPhaseEvent event, Status expectedStatus)
+    {
+        assertEquals(event.getName(), PHASE_NAME);
+        assertEquals(event.getStatus(), expectedStatus.name());
+    }
+
+    @Test
+    public void testSuccess()
+    {
+        BenchmarkPhaseEvent phaseEvent = createConcurrentPhaseExecutor(false).run();
+        assertNotNull(phaseEvent);
+        assertBenchmarkPhaseEvent(phaseEvent, SUCCEEDED);
+    }
+
+    @Test
+    public void testFailure()
+    {
+        BenchmarkPhaseEvent phaseEvent = createConcurrentPhaseExecutor(true).run();
+        assertNotNull(phaseEvent);
+        assertBenchmarkPhaseEvent(phaseEvent, FAILED);
+    }
+}

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/framework/TestBenchmarkRunnerConfig.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/framework/TestBenchmarkRunnerConfig.java
@@ -29,7 +29,9 @@ public class TestBenchmarkRunnerConfig
     {
         assertRecordedDefaults(recordDefaults(BenchmarkRunnerConfig.class)
                 .setTestId(null)
-                .setBenchmarkSuiteSupplier("mysql"));
+                .setBenchmarkSuiteSupplier("mysql")
+                .setEventClients("json")
+                .setJsonEventLogFile(null));
     }
 
     @Test
@@ -38,10 +40,15 @@ public class TestBenchmarkRunnerConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("test-id", "12345")
                 .put("benchmark-suite-supplier", "custom-supplier")
+                .put("event-clients", "human-readable")
+                .put("json.log-file", "verifier-json.log")
                 .build();
+
         BenchmarkRunnerConfig expected = new BenchmarkRunnerConfig()
                 .setTestId("12345")
-                .setBenchmarkSuiteSupplier("custom-supplier");
+                .setBenchmarkSuiteSupplier("custom-supplier")
+                .setEventClients("human-readable")
+                .setJsonEventLogFile("verifier-json.log");
 
         assertFullMapping(properties, expected);
     }

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/framework/TestBenchmarkRunnerConfig.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/framework/TestBenchmarkRunnerConfig.java
@@ -31,7 +31,8 @@ public class TestBenchmarkRunnerConfig
                 .setTestId(null)
                 .setBenchmarkSuiteSupplier("mysql")
                 .setEventClients("json")
-                .setJsonEventLogFile(null));
+                .setJsonEventLogFile(null)
+                .setContinueOnFailure(false));
     }
 
     @Test
@@ -42,13 +43,15 @@ public class TestBenchmarkRunnerConfig
                 .put("benchmark-suite-supplier", "custom-supplier")
                 .put("event-clients", "human-readable")
                 .put("json.log-file", "verifier-json.log")
+                .put("continue-on-failure", "true")
                 .build();
 
         BenchmarkRunnerConfig expected = new BenchmarkRunnerConfig()
                 .setTestId("12345")
                 .setBenchmarkSuiteSupplier("custom-supplier")
                 .setEventClients("human-readable")
-                .setJsonEventLogFile("verifier-json.log");
+                .setJsonEventLogFile("verifier-json.log")
+                .setContinueOnFailure(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/framework/TestQueryException.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/framework/TestQueryException.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.framework;
+
+import org.testng.annotations.Test;
+
+import java.net.SocketTimeoutException;
+import java.sql.SQLException;
+import java.util.Optional;
+
+import static com.facebook.presto.benchmark.framework.QueryException.Type.CLUSTER_CONNECTION;
+import static com.facebook.presto.benchmark.framework.QueryException.Type.PRESTO;
+import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_ERROR;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestQueryException
+{
+    @Test
+    public void testClusterConnectionTypeException()
+    {
+        QueryException qe = QueryException.forClusterConnection(new SocketTimeoutException());
+        assertEquals(qe.getType(), CLUSTER_CONNECTION);
+    }
+
+    @Test
+    public void testPrestoTypeException()
+    {
+        QueryException qe = QueryException.forPresto(new SQLException(), Optional.of(REMOTE_TASK_ERROR), Optional.empty());
+        assertEquals(qe.getType(), PRESTO);
+        assertTrue(qe.getPrestoErrorCode().isPresent());
+    }
+}

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/prestoaction/TestJdbcPrestoAction.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/prestoaction/TestJdbcPrestoAction.java
@@ -15,11 +15,13 @@ package com.facebook.presto.benchmark.prestoaction;
 
 import com.facebook.presto.benchmark.framework.BenchmarkQuery;
 import com.facebook.presto.benchmark.framework.QueryResult;
+import com.facebook.presto.benchmark.retry.RetryConfig;
 import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.tests.StandaloneQueryRunner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -56,10 +58,12 @@ public class TestJdbcPrestoAction
     public void setup()
     {
         prestoAction = new JdbcPrestoAction(
+                new PrestoExceptionClassifier(ImmutableSet.of()),
                 new BenchmarkQuery("Test-Query", "SELECT 1", CATALOG, SCHEMA),
                 new PrestoClusterConfig()
                         .setJdbcUrl(queryRunner.getServer().getBaseUrl().toString().replace("http", "jdbc:presto")),
-                new HashMap<>());
+                new HashMap<>(),
+                new RetryConfig());
     }
 
     @Test

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/prestoaction/TestJdbcPrestoAction.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/prestoaction/TestJdbcPrestoAction.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.prestoaction;
+
+import com.facebook.presto.benchmark.framework.BenchmarkQuery;
+import com.facebook.presto.benchmark.framework.QueryResult;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.facebook.presto.tests.StandaloneQueryRunner;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.CATALOG;
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.SCHEMA;
+import static com.facebook.presto.benchmark.BenchmarkTestUtil.setupPresto;
+import static com.facebook.presto.execution.QueryState.FINISHED;
+import static com.facebook.presto.sql.parser.IdentifierSymbol.AT_SIGN;
+import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
+import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestJdbcPrestoAction
+{
+    private static final SqlParser SQL_PARSER = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
+    private static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().setDecimalLiteralTreatment(AS_DECIMAL).build();
+
+    private static StandaloneQueryRunner queryRunner;
+
+    private PrestoAction prestoAction;
+
+    @BeforeClass
+    public void setupQueryRunner()
+            throws Exception
+    {
+        queryRunner = setupPresto();
+    }
+
+    @BeforeMethod
+    public void setup()
+    {
+        prestoAction = new JdbcPrestoAction(
+                new BenchmarkQuery("Test-Query", "SELECT 1", CATALOG, SCHEMA),
+                new PrestoClusterConfig()
+                        .setJdbcUrl(queryRunner.getServer().getBaseUrl().toString().replace("http", "jdbc:presto")),
+                new HashMap<>());
+    }
+
+    @Test
+    public void testQuerySucceeded()
+    {
+        assertEquals(
+                prestoAction.execute(
+                        SQL_PARSER.createStatement("SELECT 1", PARSING_OPTIONS)).getState(),
+                FINISHED.name());
+    }
+
+    @Test
+    public void testQuerySucceededWithConverter()
+    {
+        QueryResult<Integer> result = prestoAction.execute(
+                SQL_PARSER.createStatement("SELECT x FROM (VALUES (1), (2), (3)) t(x)", PARSING_OPTIONS),
+                resultSet -> resultSet.getInt("x") * resultSet.getInt("x"));
+        assertEquals(result.getQueryStats().getState(), FINISHED.name());
+        assertEquals(result.getResults(), ImmutableList.of(1, 4, 9));
+    }
+}

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/prestoaction/TestPrestoClusterConfig.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/prestoaction/TestPrestoClusterConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.prestoaction;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class TestPrestoClusterConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(PrestoClusterConfig.class)
+                .setJdbcUrl(null)
+                .setQueryTimeout(new Duration(60, MINUTES)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("jdbc-url", "jdbc:presto://proxy.presto.fbinfra.net:7778?SSL=true&SSLTrustStorePath=trust-store&SSLKeyStorePath=key-store")
+                .put("query-timeout", "2h")
+                .build();
+        PrestoClusterConfig expected = new PrestoClusterConfig()
+                .setJdbcUrl("jdbc:presto://proxy.presto.fbinfra.net:7778?SSL=true&SSLTrustStorePath=trust-store&SSLKeyStorePath=key-store")
+                .setQueryTimeout(new Duration(2, HOURS));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/prestoaction/TestPrestoExceptionClassifier.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/prestoaction/TestPrestoExceptionClassifier.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.prestoaction;
+
+import com.facebook.presto.benchmark.framework.QueryException;
+import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.spi.ErrorCodeSupplier;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.sql.SQLException;
+import java.util.Optional;
+
+import static com.facebook.presto.benchmark.framework.QueryException.Type.CLUSTER_CONNECTION;
+import static com.facebook.presto.benchmark.framework.QueryException.Type.PRESTO;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
+import static com.facebook.presto.hive.MetastoreErrorCode.HIVE_CORRUPTED_COLUMN_STATISTICS;
+import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_TIME_LIMIT;
+import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
+import static com.facebook.presto.spi.StandardErrorCode.SERVER_STARTING_UP;
+import static com.facebook.presto.spi.StandardErrorCode.SUBQUERY_MULTIPLE_ROWS;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+
+public class TestPrestoExceptionClassifier
+{
+    private static final QueryStats QUERY_STATS = new QueryStats("id", "", false, false, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, Optional.empty());
+
+    private final SqlExceptionClassifier classifier = new PrestoExceptionClassifier(ImmutableSet.of());
+
+    @Test
+    public void testNetworkException()
+    {
+        testNetworkException(new SQLException(new SocketTimeoutException()));
+        testNetworkException(new SQLException(new SocketException()));
+        testNetworkException(new SQLException(new ConnectException()));
+        testNetworkException(new SQLException(new EOFException()));
+        testNetworkException(new SQLException(new UncheckedIOException(new IOException())));
+        testNetworkException(new SQLException(new RuntimeException("Error fetching next at")));
+    }
+
+    private void testNetworkException(SQLException sqlException)
+    {
+        assertQueryException(
+                classifier.createException(Optional.empty(), sqlException),
+                CLUSTER_CONNECTION,
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    @Test
+    public void assertPrestoException()
+    {
+        assertPrestoException(NO_NODES_AVAILABLE);
+        assertPrestoException(SERVER_STARTING_UP);
+        assertPrestoException(HIVE_CANNOT_OPEN_SPLIT);
+
+        assertPrestoException(SUBQUERY_MULTIPLE_ROWS);
+        assertPrestoException(FUNCTION_IMPLEMENTATION_ERROR);
+        assertPrestoException(EXCEEDED_TIME_LIMIT);
+        assertPrestoException(HIVE_CORRUPTED_COLUMN_STATISTICS);
+    }
+
+    private void assertPrestoException(ErrorCodeSupplier errorCode)
+    {
+        SQLException sqlException = new SQLException("", "", errorCode.toErrorCode().getCode(), new PrestoException(errorCode, errorCode.toErrorCode().getName()));
+        assertQueryException(
+                classifier.createException(Optional.of(QUERY_STATS), sqlException),
+                PRESTO,
+                Optional.of(errorCode),
+                Optional.of(QUERY_STATS));
+    }
+
+    @Test
+    public void testUnknownPrestoException()
+    {
+        SQLException sqlException = new SQLException("", "", 0xabcd_1234, new RuntimeException());
+        assertQueryException(
+                classifier.createException(Optional.of(QUERY_STATS), sqlException),
+                PRESTO,
+                Optional.empty(),
+                Optional.of(QUERY_STATS));
+    }
+
+    private void assertQueryException(
+            QueryException queryException,
+            QueryException.Type type,
+            Optional<ErrorCodeSupplier> prestoErrorCode,
+            Optional<QueryStats> queryStats)
+    {
+        assertEquals(queryException.getType(), type);
+        assertEquals(queryException.getPrestoErrorCode(), prestoErrorCode);
+        assertEquals(queryException.getQueryStats(), queryStats);
+    }
+}

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/retry/TestRetryConfig.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/retry/TestRetryConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.retry;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestRetryConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(RetryConfig.class)
+                .setMaxAttempts(1)
+                .setMinBackoffDelay(new Duration(0, NANOSECONDS))
+                .setMaxBackoffDelay(new Duration(1, MINUTES))
+                .setScaleFactor(1.0));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("max-attempts", "10")
+                .put("min-backoff-delay", "500ms")
+                .put("max-backoff-delay", "10s")
+                .put("backoff-scale-factor", "2.0")
+                .build();
+        RetryConfig expected = new RetryConfig()
+                .setMaxAttempts(10)
+                .setMinBackoffDelay(new Duration(500, MILLISECONDS))
+                .setMaxBackoffDelay(new Duration(10, SECONDS))
+                .setScaleFactor(2.0);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/retry/TestRetryDriver.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/retry/TestRetryDriver.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark.retry;
+
+import com.facebook.airlift.log.Logging;
+import com.facebook.presto.benchmark.framework.QueryException;
+import io.airlift.units.Duration;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.SocketTimeoutException;
+import java.util.Optional;
+
+import static com.facebook.airlift.log.Level.DEBUG;
+import static com.facebook.presto.benchmark.framework.QueryException.Type.CLUSTER_CONNECTION;
+import static com.facebook.presto.spi.StandardErrorCode.REMOTE_HOST_GONE;
+import static java.lang.Boolean.FALSE;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.testng.Assert.assertEquals;
+
+public class TestRetryDriver
+{
+    private static class MockOperation
+            implements RetryDriver.RetryOperation<Integer>
+    {
+        private final int succeedWithNumCalls;
+        private final QueryException exception;
+        private int callCount;
+
+        public MockOperation(int succeedWithNumCalls, QueryException exception)
+        {
+            this.succeedWithNumCalls = succeedWithNumCalls;
+            this.exception = requireNonNull(exception, "exception is null");
+        }
+
+        @Override
+        public Integer run()
+                throws QueryException
+        {
+            callCount++;
+            if (callCount >= succeedWithNumCalls) {
+                return callCount;
+            }
+            throw exception;
+        }
+    }
+
+    static {
+        Logging.initialize().setLevel(RetryDriver.class.getName(), DEBUG);
+    }
+
+    private static final QueryException RETRYABLE_EXCEPTION = QueryException.forClusterConnection(new SocketTimeoutException());
+    private static final QueryException NON_RETRYABLE_EXCEPTION = QueryException.forPresto(new RuntimeException(), Optional.of(REMOTE_HOST_GONE), Optional.empty());
+
+    private RetryDriver retryDriver;
+
+    @BeforeMethod
+    public void setup()
+    {
+        retryDriver = new RetryDriver(
+                new RetryConfig()
+                        .setMaxAttempts(5)
+                        .setMinBackoffDelay(new Duration(10, MILLISECONDS))
+                        .setMaxBackoffDelay(new Duration(100, MILLISECONDS))
+                        .setScaleFactor(2),
+                exception -> (exception instanceof QueryException) ? (((QueryException) exception).getType() == CLUSTER_CONNECTION) : FALSE);
+    }
+
+    @Test
+    public void testSuccess()
+    {
+        assertEquals(
+                retryDriver.run("test", new MockOperation(5, RETRYABLE_EXCEPTION)),
+                Integer.valueOf(5));
+    }
+
+    @Test(expectedExceptions = QueryException.class)
+    public void testMaxAttemptsExceeded()
+    {
+        retryDriver.run("test", new MockOperation(6, RETRYABLE_EXCEPTION));
+    }
+
+    @Test(expectedExceptions = QueryException.class)
+    public void testNonRetryableFailure()
+    {
+        retryDriver.run("test", new MockOperation(3, NON_RETRYABLE_EXCEPTION));
+    }
+
+    @Test(timeOut = 5000)
+    public void testBackoffTimeCapped()
+    {
+        RetryDriver retryDriver = new RetryDriver(
+                new RetryConfig()
+                        .setMaxAttempts(5)
+                        .setMinBackoffDelay(new Duration(10, MILLISECONDS))
+                        .setMaxBackoffDelay(new Duration(100, MILLISECONDS))
+                        .setScaleFactor(1000),
+                exception -> (exception instanceof QueryException) ? (((QueryException) exception).getType() == CLUSTER_CONNECTION) : FALSE);
+        retryDriver.run("test", new MockOperation(5, RETRYABLE_EXCEPTION));
+    }
+}


### PR DESCRIPTION
- Support running benchmarks having CONCURRENT as query executing strategy for all its phases.
- Add ability to retry queries if they failed initially with cluster connection errors.
- Add event clients to export the benchmark results

```
== NO RELEASE NOTE ==
```
