### PR TITLE
Fix slice size overflow in DictionaryBlock.getIds()

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockFlattener.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/BlockFlattener.java
@@ -53,7 +53,7 @@ public class BlockFlattener
     {
         Block dictionary = dictionaryBlock.getDictionary();
         int positionCount = dictionaryBlock.getPositionCount();
-        int[] currentRemappedIds = (int[]) dictionaryBlock.getIds().getBase();
+        int[] currentRemappedIds = dictionaryBlock.getRawIds();
         // Initially, the below variable is null.  After the first pass of the loop, it will be a borrowed array from the allocator,
         // and it will have reference equality with currentRemappedIds
         int[] newRemappedIds = null;
@@ -61,7 +61,7 @@ public class BlockFlattener
         while (true) {
             if (dictionary instanceof DictionaryBlock) {
                 dictionaryBlock = (DictionaryBlock) dictionary;
-                int[] ids = (int[]) dictionaryBlock.getIds().getBase();
+                int[] ids = dictionaryBlock.getRawIds();
 
                 if (newRemappedIds == null) {
                     newRemappedIds = allocator.borrowIntArray(positionCount);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/DictionaryBlock.java
@@ -401,6 +401,11 @@ public class DictionaryBlock
         return Slices.wrappedIntArray(ids, idsOffset, positionCount);
     }
 
+    int[] getRawIds()
+    {
+        return ids;
+    }
+
     public int getId(int position)
     {
         checkValidPosition(position, positionCount);


### PR DESCRIPTION
When OptimizedPartitionedOutputOperator receives DictionaryBlock of
DictionaryBlock and the dictionary's ids array is over 500 million rows,
the BlockFlattener would throw an exception in DictionaryBlock.getIds()
because it's trying to wrap the large ids array into a Slice but the
size limit of a Slice is 2GB. This fix introduces ImmutableIntArray
and uses it as the return type of DictionaryBlock.getIds().

Related issue: https://github.com/prestodb/presto/issues/13722

```
== NO RELEASE NOTE ==
```
