### PR TITLE
Add support for column names with hyphen to SubfieldTokenizer

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/SubfieldTokenizer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SubfieldTokenizer.java
@@ -148,7 +148,7 @@ class SubfieldTokenizer
 
     private static boolean isUnquotedPathCharacter(char c)
     {
-        return c == ':' || c == '$' || isUnquotedSubscriptCharacter(c);
+        return c == ':' || c == '$' || c == '-' || isUnquotedSubscriptCharacter(c);
     }
 
     private Subfield.PathElement matchUnquotedSubscript()

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestSubfieldTokenizer.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestSubfieldTokenizer.java
@@ -33,7 +33,6 @@ public class TestSubfieldTokenizer
     {
         List<PathElement> elements = ImmutableList.of(
                 new NestedField("b"),
-                new NestedField("$bucket"),
                 new Subfield.LongSubscript(2),
                 new Subfield.StringSubscript("z"),
                 Subfield.allSubscripts(),
@@ -68,6 +67,13 @@ public class TestSubfieldTokenizer
         SubfieldTokenizer tokenizer = new SubfieldTokenizer(path.serialize());
         assertTrue(tokenizer.hasNext());
         assertEquals(new Subfield(((NestedField) tokenizer.next()).getName(), Streams.stream(tokenizer).collect(toImmutableList())), path);
+    }
+
+    @Test
+    public void testColumnNames()
+    {
+        assertPath(new Subfield("$bucket", ImmutableList.of()));
+        assertPath(new Subfield("apollo-11", ImmutableList.of()));
     }
 
     @Test


### PR DESCRIPTION
Fixes #13759

```
== NO RELEASE NOTE ==
```
