### PR TITLE
Fail creation of table with unsupported bucket count

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
@@ -170,6 +170,9 @@ public class HiveTableProperties
         if (bucketCount < 0) {
             throw new PrestoException(INVALID_TABLE_PROPERTY, format("%s must be greater than zero", BUCKET_COUNT_PROPERTY));
         }
+        if (bucketCount > 1_000_000) {
+            throw new PrestoException(INVALID_TABLE_PROPERTY, format("%s should be no more than 1000000", BUCKET_COUNT_PROPERTY));
+        }
         if (bucketedBy.isEmpty() || bucketCount == 0) {
             throw new PrestoException(INVALID_TABLE_PROPERTY, format("%s and %s must be specified together", BUCKETED_BY_PROPERTY, BUCKET_COUNT_PROPERTY));
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -4254,6 +4254,16 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testBucketedTablesFailWithTooManyBuckets()
+            throws Exception
+    {
+        @Language("SQL") String createSql = "CREATE TABLE t (dummy VARCHAR)\n" +
+                "WITH (bucket_count = 1000001, bucketed_by=ARRAY['dummy'])";
+
+        assertQueryFails(createSql, "bucket_count should be no more than 1000000");
+    }
+
+    @Test
     public void testBucketedTablesFailWithAvroSchemaUrl()
             throws Exception
     {


### PR DESCRIPTION
This commit moves bucket_count check from scheduling stage to query analyzer and throw user error.
Here is stack trace of current error https://gist.github.com/viczhang861/95f02041f595637450c4035098ccd841

```
== NO RELEASE NOTE ==
```
