### PR TITLE
Fix materialized exchange planning with filter pushdown

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownIntegrationSmokeTest.java
@@ -16,7 +16,6 @@ package com.facebook.presto.hive;
 import com.facebook.presto.spi.security.SelectedRole;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.Test;
 
 import java.util.Optional;
 
@@ -40,11 +39,5 @@ public class TestHivePushdownIntegrationSmokeTest
                 createMaterializeExchangesSession(Optional.of(new SelectedRole(ROLE, Optional.of("admin")))),
                 HIVE_CATALOG,
                 new HiveTypeTranslator());
-    }
-
-    // TODO Enable this test after we fix the query plan to retain information about the pushed down filter on the Join column so that we need not perform an exchange for it.
-    @Test
-    public void testMaterializedPartitioning()
-    {
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
@@ -59,7 +59,7 @@ public final class Partitioning
         this.arguments = ImmutableList.copyOf(requireNonNull(arguments, "arguments is null"));
     }
 
-    public static Partitioning create(PartitioningHandle handle, List<VariableReferenceExpression> columns)
+    public static <T extends RowExpression> Partitioning create(PartitioningHandle handle, List<T> columns)
     {
         return new Partitioning(handle, columns.stream()
                 .map(RowExpression.class::cast)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ActualProperties.java
@@ -403,10 +403,10 @@ public class ActualProperties
             return new Global(Optional.empty(), Optional.empty(), false);
         }
 
-        public static Global partitionedOn(
+        public static <T extends RowExpression, U extends RowExpression> Global partitionedOn(
                 PartitioningHandle nodePartitioningHandle,
-                List<VariableReferenceExpression> nodePartitioning,
-                Optional<List<VariableReferenceExpression>> streamPartitioning)
+                List<T> nodePartitioning,
+                Optional<List<U>> streamPartitioning)
         {
             return new Global(
                     Optional.of(Partitioning.create(nodePartitioningHandle, nodePartitioning)),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PropertyDerivations.java
@@ -774,9 +774,14 @@ public class PropertyDerivations
 
             if (planWithTableNodePartitioning(session) && layout.getTablePartitioning().isPresent()) {
                 TablePartitioning tablePartitioning = layout.getTablePartitioning().get();
-                if (assignments.keySet().containsAll(tablePartitioning.getPartitioningColumns())) {
-                    List<VariableReferenceExpression> arguments = tablePartitioning.getPartitioningColumns().stream()
-                            .map(assignments::get)
+
+                Set<ColumnHandle> assignmentsAndConstants = ImmutableSet.<ColumnHandle>builder()
+                        .addAll(assignments.keySet())
+                        .addAll(constants.keySet())
+                        .build();
+                if (assignmentsAndConstants.containsAll(tablePartitioning.getPartitioningColumns())) {
+                    List<RowExpression> arguments = tablePartitioning.getPartitioningColumns().stream()
+                            .map(column -> assignments.containsKey(column) ? assignments.get(column) : constants.get(column))
                             .collect(toImmutableList());
 
                     return partitionedOn(tablePartitioning.getPartitioningHandle(), arguments, streamPartitioning);


### PR DESCRIPTION
- Make sure to include pushed down range filters in ConnectorTableLayout#predicate.
- Populate constant values for Partitioning#arguments if corresponding column is not
projected out of table scan and has fixed value (due to pushed down x = 5 filter)

```
== NO RELEASE NOTE ==
```
