### PR TITLE
Invert if condition for better readability

### DIFF
--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/LogicalRowExpressions.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/LogicalRowExpressions.java
@@ -377,12 +377,14 @@ public final class LogicalRowExpressions
 
         List<RowExpression> result = new ArrayList<>();
         for (RowExpression expression : expressions) {
-            if (!determinismEvaluator.isDeterministic(expression)) {
-                result.add(expression);
+            if (determinismEvaluator.isDeterministic(expression)) {
+                if (!seen.contains(expression)) {
+                    result.add(expression);
+                    seen.add(expression);
+                }
             }
-            else if (!seen.contains(expression)) {
+            else {
                 result.add(expression);
-                seen.add(expression);
             }
         }
 


### PR DESCRIPTION
This refactoring inverts the if condition in removeDuplicates() method
for better readability of code and aligns with the intent described in
the javadoc for the method

```
== NO RELEASE NOTE ==
```