### PR TITLE
Fix flaky test TestRetryDriver

### DIFF
--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/retry/TestRetryDriver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/retry/TestRetryDriver.java
@@ -32,6 +32,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.testng.Assert.assertEquals;
 
+@Test(singleThreaded = true)
 public class TestRetryDriver
 {
     private static class MockOperation
@@ -108,7 +109,6 @@ public class TestRetryDriver
     @Test(timeOut = 5000)
     public void testBackoffTimeCapped()
     {
-        verificationContext = new VerificationContext();
         RetryDriver retryDriver = new RetryDriver<>(
                 new RetryConfig()
                         .setMaxAttempts(5)


### PR DESCRIPTION
Fixes intermittent failure:

```
java.lang.IllegalStateException: There already is a start record for test: com.facebook.presto.verifier.retry.TestRetryDriver::setup
```

```
== NO RELEASE NOTE ==
```
