### PR TITLE
Make subfield name matching case insensitive

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -649,6 +649,11 @@ public class TestHivePushdownFilterQueries
 
         assertQueryUsingH2Cte("SELECT info.shipdate.ship_day FROM lineitem_ex WHERE info.shipdate.ship_day < 15", rewriter);
         assertQueryUsingH2Cte("SELECT info.linenumber FROM lineitem_ex WHERE info.shipdate.ship_day < 15", rewriter);
+
+        // case sensitivity
+        assertQuery("SELECT INFO.orderkey FROM lineitem_ex", "SELECT CASE WHEN orderkey % 23 = 0 THEN null ELSE orderkey END FROM lineitem");
+        assertQuery("SELECT INFO.ORDERKEY FROM lineitem_ex", "SELECT CASE WHEN orderkey % 23 = 0 THEN null ELSE orderkey END FROM lineitem");
+        assertQuery("SELECT iNfO.oRdErKeY FROM lineitem_ex", "SELECT CASE WHEN orderkey % 23 = 0 THEN null ELSE orderkey END FROM lineitem");
     }
 
     @Test

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
@@ -660,7 +660,7 @@ public class StructSelectiveStreamReader
         Map<String, List<Subfield>> fields = new HashMap<>();
         for (Subfield subfield : requiredSubfields) {
             List<Subfield.PathElement> path = subfield.getPath();
-            String name = ((Subfield.NestedField) path.get(0)).getName();
+            String name = ((Subfield.NestedField) path.get(0)).getName().toLowerCase(Locale.ENGLISH);
             fields.computeIfAbsent(name, k -> new ArrayList<>());
             if (path.size() > 1) {
                 fields.get(name).add(new Subfield("c", path.subList(1, path.size())));


### PR DESCRIPTION
Before this fix, with subfield pruning enabled, the following
query returned NULLs:

`SELECT INFO.ORDERKEY FROM lineitem_ex`

```
== NO RELEASE NOTE ==
```
