### PR TITLE
Create NestedField using lowercase field name

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -586,6 +586,10 @@ public class TestHiveLogicalPlanner
         assertPushdownSubfields(legacyUnnest, "SELECT id, x.a FROM test_pushdown_struct_subfields CROSS JOIN UNNEST(y) as t(y)", "test_pushdown_struct_subfields",
                 ImmutableMap.of("x", toSubfields("x.a")));
 
+        // Case sensitivity
+        assertPushdownSubfields("SELECT x.a, x.b, x.A + 2 FROM test_pushdown_struct_subfields WHERE x.B LIKE 'abc%'", "test_pushdown_struct_subfields",
+                ImmutableMap.of("x", toSubfields("x.a", "x.b")));
+
         assertUpdate("DROP TABLE test_pushdown_struct_subfields");
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -71,6 +71,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -366,7 +367,7 @@ public class PushdownSubfields
                     for (VariableReferenceExpression field : entry.getValue()) {
                         if (context.get().variables.contains(field)) {
                             found = true;
-                            newSubfields.add(new Subfield(container.getName(), ImmutableList.of(allSubscripts(), new NestedField(field.getName()))));
+                            newSubfields.add(new Subfield(container.getName(), ImmutableList.of(allSubscripts(), nestedField(field.getName()))));
                         }
                         else {
                             List<Subfield> matchingSubfields = context.get().findSubfields(field.getName());
@@ -376,7 +377,7 @@ public class PushdownSubfields
                                         .map(Subfield::getPath)
                                         .map(path -> new Subfield(container.getName(), ImmutableList.<Subfield.PathElement>builder()
                                                 .add(allSubscripts())
-                                                .add(new NestedField(field.getName()))
+                                                .add(nestedField(field.getName()))
                                                 .addAll(path)
                                                 .build()))
                                         .forEach(newSubfields::add);
@@ -473,7 +474,7 @@ public class PushdownSubfields
 
                 if (expression instanceof DereferenceExpression) {
                     DereferenceExpression dereference = (DereferenceExpression) expression;
-                    elements.add(new NestedField(dereference.getField().getValue()));
+                    elements.add(nestedField(dereference.getField().getValue()));
                     expression = dereference.getBase();
                 }
                 else if (expression instanceof SubscriptExpression) {
@@ -506,6 +507,11 @@ public class PushdownSubfields
                     return Optional.empty();
                 }
             }
+        }
+
+        private static NestedField nestedField(String name)
+        {
+            return new NestedField(name.toLowerCase(Locale.ENGLISH));
         }
 
         private static final class SubfieldExtractor


### PR DESCRIPTION
Fix subfield pruning for queries that refer to the same subfield using
different word casings:.

`SELECT s.a, s.A FROM t`

Without the fix the query above generated two subfield paths: s.a and s.A.

```
== NO RELEASE NOTE ==
```
