### PR TITLE
Evaluate filter function as soon as all inputs have been read

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -67,6 +67,7 @@ public class OrcSelectiveRecordReader
 {
     // Marks a SQL null when occurring in constantValues.
     private static final byte[] NULL_MARKER = new byte[0];
+    private static final Page EMPTY_PAGE = new Page(0);
 
     private final int[] hiveColumnIndices;                            // elements are hive column indices
     private final List<Integer> outputColumns;                        // elements are hive column indices
@@ -370,7 +371,7 @@ public class OrcSelectiveRecordReader
 
             if (positionCount == 0) {
                 batchRead(batchSize);
-                return new Page(0);
+                return EMPTY_PAGE;
             }
 
             positionsToRead = outputPositions;
@@ -412,7 +413,7 @@ public class OrcSelectiveRecordReader
         batchRead(batchSize);
 
         if (positionCount == 0) {
-            return new Page(0);
+            return EMPTY_PAGE;
         }
 
         if (filterFunctionsWithInputs.isEmpty() && filterFunctionWithoutInput.isPresent()) {


### PR DESCRIPTION
We are seeing a performance regression for filters with multiple conjuncts on different columns and 
the first conjuct being highly selective.

`SELECT * FROM t WHERE f(a) AND g(b)`

In these cases, in baseline, LazyBlocks for the 2nd conjunct are not loaded (or loaded rarely). In Aria, we had all filter functions evaluated together after all inputs for all of them are read. In the query above, we read columns a and b, then evaluated f(a), then f(b). This change is to evaluate each filter function as soon as all the inputs are read. This way, f(a) above will be evaluated before column b is read.

```
== NO RELEASE NOTE ==
```
