### PR TITLE
Optimize and refactor array_distinct, array_filter and array_sort 

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
@@ -106,7 +106,7 @@ public class TypedSet
         }
     }
 
-    public void add(Block block, int position)
+    public boolean add(Block block, int position)
     {
         requireNonNull(block, "block must not be null");
         checkArgument(position >= 0, "position must be >= 0");
@@ -119,7 +119,24 @@ public class TypedSet
         int hashPosition = getHashPositionOfElement(block, position);
         if (blockPositionByHash.get(hashPosition) == EMPTY_SLOT) {
             addNewElement(hashPosition, block, position);
+            return true;
         }
+
+        return false;
+    }
+
+    public boolean addNonNull(Block block, int position)
+    {
+        requireNonNull(block, "block must not be null");
+        checkArgument(position >= 0, "position must be >= 0");
+
+        int hashPosition = getHashPositionOfElement(block, position);
+        if (blockPositionByHash.get(hashPosition) == EMPTY_SLOT) {
+            addNewElement(hashPosition, block, position);
+            return true;
+        }
+
+        return false;
     }
 
     public int size()

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayExceptFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayExceptFunction.java
@@ -47,8 +47,7 @@ public final class ArrayExceptFunction
             typedSet.add(rightArray, i);
         }
         for (int i = 0; i < leftPositionCount; i++) {
-            if (!typedSet.contains(leftArray, i)) {
-                typedSet.add(leftArray, i);
+            if (typedSet.add(leftArray, i)) {
                 type.appendTo(leftArray, i, distinctElementBlockBuilder);
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
@@ -40,18 +40,56 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") LongToBooleanFunction function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
-        for (int position = 0; position < positionCount; position++) {
-            Long input = null;
-            if (!arrayBlock.isNull(position)) {
-                input = elementType.getLong(arrayBlock, position);
+        int position = 0;
+        BlockBuilder resultBuilder;
+
+        if (arrayBlock.mayHaveNull()) {
+            while (position < positionCount &&
+                    TRUE.equals(function.apply(arrayBlock.isNull(position) ?
+                                               null :
+                                               elementType.getLong(arrayBlock, position)))) {
+                position++;
             }
 
-            Boolean keep = function.apply(input);
-            if (TRUE.equals(keep)) {
-                elementType.appendTo(arrayBlock, position, resultBuilder);
+            if (position == positionCount) {
+                // Nothing fitered out. So just return the original.
+                return arrayBlock;
+            }
+
+            resultBuilder = elementType.createBlockBuilder(null, positionCount);
+            for (int i = 0; i < position; i++) {
+                elementType.appendTo(arrayBlock, i, resultBuilder);
+            }
+
+            for (position++; position < positionCount; position++) {
+                if (TRUE.equals(function.apply(arrayBlock.isNull(position) ?
+                                               null :
+                                               elementType.getLong(arrayBlock, position)))) {
+                    elementType.appendTo(arrayBlock, position, resultBuilder);
+                }
             }
         }
+        else {
+            while (position < positionCount && TRUE.equals(function.apply(elementType.getLong(arrayBlock, position)))) {
+                position++;
+            }
+
+            if (position == positionCount) {
+                // Nothing filtered out. So just return the original.
+                return arrayBlock;
+            }
+
+            resultBuilder = elementType.createBlockBuilder(null, positionCount);
+            for (int i = 0; i < position; i++) {
+                elementType.appendTo(arrayBlock, i, resultBuilder);
+            }
+            for (position++; position < positionCount; position++) {
+                if (TRUE.equals(function.apply(elementType.getLong(arrayBlock, position)))) {
+                    elementType.appendTo(arrayBlock, position, resultBuilder);
+                }
+            }
+        }
+
         return resultBuilder.build();
     }
 
@@ -64,18 +102,55 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") DoubleToBooleanFunction function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
-        for (int position = 0; position < positionCount; position++) {
-            Double input = null;
-            if (!arrayBlock.isNull(position)) {
-                input = elementType.getDouble(arrayBlock, position);
+        int position = 0;
+        BlockBuilder resultBuilder;
+
+        if (arrayBlock.mayHaveNull()) {
+            while (position < positionCount &&
+                    TRUE.equals(function.apply(arrayBlock.isNull(position) ?
+                                               null :
+                                               elementType.getDouble(arrayBlock, position)))) {
+                position++;
             }
 
-            Boolean keep = function.apply(input);
-            if (TRUE.equals(keep)) {
-                elementType.appendTo(arrayBlock, position, resultBuilder);
+            if (position == positionCount) {
+                // Nothing fitered out. So just return the original.
+                return arrayBlock;
+            }
+
+            resultBuilder = elementType.createBlockBuilder(null, positionCount);
+            for (int i = 0; i < position; i++) {
+                elementType.appendTo(arrayBlock, i, resultBuilder);
+            }
+            for (position++; position < positionCount; position++) {
+                if (TRUE.equals(function.apply(arrayBlock.isNull(position) ?
+                                               null :
+                                               elementType.getDouble(arrayBlock, position)))) {
+                    elementType.appendTo(arrayBlock, position, resultBuilder);
+                }
             }
         }
+        else {
+            while (position < positionCount && TRUE.equals(function.apply(elementType.getDouble(arrayBlock, position)))) {
+                position++;
+            }
+
+            if (position == positionCount) {
+                // Nothing filtered out. So just return the original.
+                return arrayBlock;
+            }
+
+            resultBuilder = elementType.createBlockBuilder(null, positionCount);
+            for (int i = 0; i < position; i++) {
+                elementType.appendTo(arrayBlock, i, resultBuilder);
+            }
+            for (position++; position < positionCount; position++) {
+                if (TRUE.equals(function.apply(elementType.getDouble(arrayBlock, position)))) {
+                    elementType.appendTo(arrayBlock, position, resultBuilder);
+                }
+            }
+        }
+
         return resultBuilder.build();
     }
 
@@ -88,18 +163,55 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") BooleanToBooleanFunction function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
-        for (int position = 0; position < positionCount; position++) {
-            Boolean input = null;
-            if (!arrayBlock.isNull(position)) {
-                input = elementType.getBoolean(arrayBlock, position);
+        int position = 0;
+        BlockBuilder resultBuilder;
+
+        if (arrayBlock.mayHaveNull()) {
+            while (position < positionCount &&
+                    TRUE.equals(function.apply(arrayBlock.isNull(position) ?
+                                               null :
+                                               elementType.getBoolean(arrayBlock, position)))) {
+                position++;
             }
 
-            Boolean keep = function.apply(input);
-            if (TRUE.equals(keep)) {
-                elementType.appendTo(arrayBlock, position, resultBuilder);
+            if (position == positionCount) {
+                // Nothing fitered out. So just return the original.
+                return arrayBlock;
+            }
+
+            resultBuilder = elementType.createBlockBuilder(null, positionCount);
+            for (int i = 0; i < position; i++) {
+                elementType.appendTo(arrayBlock, i, resultBuilder);
+            }
+            for (position++; position < positionCount; position++) {
+                if (TRUE.equals(function.apply(arrayBlock.isNull(position) ?
+                                               null :
+                                               elementType.getBoolean(arrayBlock, position)))) {
+                    elementType.appendTo(arrayBlock, position, resultBuilder);
+                }
             }
         }
+        else {
+            while (position < positionCount && TRUE.equals(function.apply(elementType.getBoolean(arrayBlock, position)))) {
+                position++;
+            }
+
+            if (position == positionCount) {
+                // Nothing filtered out. So just return the original.
+                return arrayBlock;
+            }
+
+            resultBuilder = elementType.createBlockBuilder(null, positionCount);
+            for (int i = 0; i < position; i++) {
+                elementType.appendTo(arrayBlock, i, resultBuilder);
+            }
+            for (position++; position < positionCount; position++) {
+                if (TRUE.equals(function.apply(elementType.getBoolean(arrayBlock, position)))) {
+                    elementType.appendTo(arrayBlock, position, resultBuilder);
+                }
+            }
+        }
+
         return resultBuilder.build();
     }
 
@@ -112,18 +224,55 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") SliceToBooleanFunction function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
-        for (int position = 0; position < positionCount; position++) {
-            Slice input = null;
-            if (!arrayBlock.isNull(position)) {
-                input = elementType.getSlice(arrayBlock, position);
+        int position = 0;
+        BlockBuilder resultBuilder;
+
+        if (arrayBlock.mayHaveNull()) {
+            while (position < positionCount &&
+                    TRUE.equals(function.apply(arrayBlock.isNull(position) ?
+                                               null :
+                                               elementType.getSlice(arrayBlock, position)))) {
+                position++;
             }
 
-            Boolean keep = function.apply(input);
-            if (TRUE.equals(keep)) {
-                elementType.appendTo(arrayBlock, position, resultBuilder);
+            if (position == positionCount) {
+                // Nothing fitered out. So just return the original.
+                return arrayBlock;
+            }
+
+            resultBuilder = elementType.createBlockBuilder(null, positionCount);
+            for (int i = 0; i < position; i++) {
+                elementType.appendTo(arrayBlock, i, resultBuilder);
+            }
+            for (position++; position < positionCount; position++) {
+                if (TRUE.equals(function.apply(arrayBlock.isNull(position) ?
+                                               null :
+                                               elementType.getSlice(arrayBlock, position)))) {
+                    elementType.appendTo(arrayBlock, position, resultBuilder);
+                }
             }
         }
+        else {
+            while (position < positionCount && TRUE.equals(function.apply(elementType.getSlice(arrayBlock, position)))) {
+                position++;
+            }
+
+            if (position == positionCount) {
+                // Nothing filtered out. So just return the original.
+                return arrayBlock;
+            }
+
+            resultBuilder = elementType.createBlockBuilder(null, positionCount);
+            for (int i = 0; i < position; i++) {
+                elementType.appendTo(arrayBlock, i, resultBuilder);
+            }
+            for (position++; position < positionCount; position++) {
+                if (TRUE.equals(function.apply(elementType.getSlice(arrayBlock, position)))) {
+                    elementType.appendTo(arrayBlock, position, resultBuilder);
+                }
+            }
+        }
+
         return resultBuilder.build();
     }
 
@@ -136,18 +285,55 @@ public final class ArrayFilterFunction
             @SqlType("function(T, boolean)") BlockToBooleanFunction function)
     {
         int positionCount = arrayBlock.getPositionCount();
-        BlockBuilder resultBuilder = elementType.createBlockBuilder(null, positionCount);
-        for (int position = 0; position < positionCount; position++) {
-            Block input = null;
-            if (!arrayBlock.isNull(position)) {
-                input = (Block) elementType.getObject(arrayBlock, position);
+        int position = 0;
+        BlockBuilder resultBuilder;
+
+        if (arrayBlock.mayHaveNull()) {
+            while (position < positionCount &&
+                    TRUE.equals(function.apply(arrayBlock.isNull(position) ?
+                                               null :
+                                               (Block) elementType.getObject(arrayBlock, position)))) {
+                position++;
             }
 
-            Boolean keep = function.apply(input);
-            if (TRUE.equals(keep)) {
-                elementType.appendTo(arrayBlock, position, resultBuilder);
+            if (position == positionCount) {
+                // Nothing fitered out. So just return the original.
+                return arrayBlock;
+            }
+
+            resultBuilder = elementType.createBlockBuilder(null, positionCount);
+            for (int i = 0; i < position; i++) {
+                elementType.appendTo(arrayBlock, i, resultBuilder);
+            }
+            for (position++; position < positionCount; position++) {
+                if (TRUE.equals(function.apply(arrayBlock.isNull(position) ?
+                                               null :
+                                               (Block) elementType.getObject(arrayBlock, position)))) {
+                    elementType.appendTo(arrayBlock, position, resultBuilder);
+                }
             }
         }
+        else {
+            while (position < positionCount && TRUE.equals(function.apply((Block) elementType.getObject(arrayBlock, position)))) {
+                position++;
+            }
+
+            if (position == positionCount) {
+                // Nothing filtered out. So just return the original.
+                return arrayBlock;
+            }
+
+            resultBuilder = elementType.createBlockBuilder(null, positionCount);
+            for (int i = 0; i < position; i++) {
+                elementType.appendTo(arrayBlock, i, resultBuilder);
+            }
+            for (position++; position < positionCount; position++) {
+                if (TRUE.equals(function.apply((Block) elementType.getObject(arrayBlock, position)))) {
+                    elementType.appendTo(arrayBlock, position, resultBuilder);
+                }
+            }
+        }
+
         return resultBuilder.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayIntersectFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayIntersectFunction.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.operator.aggregation.TypedSet;
-import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.Description;
@@ -22,23 +21,16 @@ import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.collect.ImmutableList;
 
 @ScalarFunction("array_intersect")
 @Description("Intersects elements of the two given arrays")
 public final class ArrayIntersectFunction
 {
-    private final PageBuilder pageBuilder;
-
-    @TypeParameter("E")
-    public ArrayIntersectFunction(@TypeParameter("E") Type elementType)
-    {
-        pageBuilder = new PageBuilder(ImmutableList.of(elementType));
-    }
+    private ArrayIntersectFunction() {}
 
     @TypeParameter("E")
     @SqlType("array(E)")
-    public Block intersect(
+    public static Block intersect(
             @TypeParameter("E") Type type,
             @SqlType("array(E)") Block leftArray,
             @SqlType("array(E)") Block rightArray)
@@ -56,16 +48,12 @@ public final class ArrayIntersectFunction
             return rightArray;
         }
 
-        if (pageBuilder.isFull()) {
-            pageBuilder.reset();
-        }
-
         TypedSet rightTypedSet = new TypedSet(type, rightPositionCount, "array_intersect");
         for (int i = 0; i < rightPositionCount; i++) {
             rightTypedSet.add(rightArray, i);
         }
 
-        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, Math.min(leftPositionCount, rightPositionCount));
 
         // The intersected set can have at most rightPositionCount elements
         TypedSet intersectTypedSet = new TypedSet(type, blockBuilder, rightPositionCount, "array_intersect");
@@ -75,8 +63,6 @@ public final class ArrayIntersectFunction
             }
         }
 
-        pageBuilder.declarePositions(intersectTypedSet.size());
-
-        return blockBuilder.getRegion(blockBuilder.getPositionCount() - intersectTypedSet.size(), intersectTypedSet.size());
+        return blockBuilder.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySortFunction.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
@@ -23,11 +22,10 @@ import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.facebook.presto.spi.type.Type;
-import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 
 import java.lang.invoke.MethodHandle;
-import java.util.Collections;
+import java.util.AbstractList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -39,72 +37,129 @@ import static com.facebook.presto.spi.function.OperatorType.LESS_THAN;
 @Description("Sorts the given array in ascending order according to the natural ordering of its elements.")
 public final class ArraySortFunction
 {
-    private final PageBuilder pageBuilder;
-    private static final int INITIAL_LENGTH = 128;
-    private List<Integer> positions = Ints.asList(new int[INITIAL_LENGTH]);
-
-    @TypeParameter("E")
-    public ArraySortFunction(@TypeParameter("E") Type elementType)
-    {
-        pageBuilder = new PageBuilder(ImmutableList.of(elementType));
-    }
+    private ArraySortFunction() {}
 
     @TypeParameter("E")
     @SqlType("array(E)")
-    public Block sort(
+    public static Block sort(
             @OperatorDependency(operator = LESS_THAN, argumentTypes = {"E", "E"}) MethodHandle lessThanFunction,
             @TypeParameter("E") Type type,
             @SqlType("array(E)") Block block)
     {
         int arrayLength = block.getPositionCount();
-        if (positions.size() < arrayLength) {
-            positions = Ints.asList(new int[arrayLength]);
-        }
-        for (int i = 0; i < arrayLength; i++) {
-            positions.set(i, i);
+
+        if (arrayLength < 2) {
+            return block;
         }
 
-        Collections.sort(positions.subList(0, arrayLength), new Comparator<Integer>()
-        {
-            @Override
-            public int compare(Integer p1, Integer p2)
+        ListOfPositions listOfPositions = new ListOfPositions(block.getPositionCount());
+        if (block.mayHaveNull()) {
+            listOfPositions.sort(new Comparator<Integer>()
             {
-                boolean nullLeft = block.isNull(p1);
-                boolean nullRight = block.isNull(p2);
-                if (nullLeft && nullRight) {
-                    return 0;
-                }
-                if (nullLeft) {
-                    return 1;
-                }
-                if (nullRight) {
-                    return -1;
-                }
-
-                try {
-                    //TODO: This could be quite slow, it should use parametric equals
-                    return type.compareTo(block, p1, block, p2);
-                }
-                catch (PrestoException e) {
-                    if (e.getErrorCode() == NOT_SUPPORTED.toErrorCode()) {
-                        throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Array contains elements not supported for comparison", e);
+                @Override
+                public int compare(Integer p1, Integer p2)
+                {
+                    if (block.isNull(p1)) {
+                        return block.isNull(p2) ? 0 : 1;
                     }
-                    throw e;
-                }
-            }
-        });
+                    else if (block.isNull(p2)) {
+                        return -1;
+                    }
 
-        if (pageBuilder.isFull()) {
-            pageBuilder.reset();
+                    try {
+                        //TODO: This could be quite slow, it should use parametric equals
+                        return type.compareTo(block, p1, block, p2);
+                    }
+                    catch (PrestoException e) {
+                        if (e.getErrorCode() == NOT_SUPPORTED.toErrorCode()) {
+                            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Array contains elements not supported for comparison", e);
+                        }
+                        throw e;
+                    }
+                }
+            });
+        }
+        else {
+            listOfPositions.sort(new Comparator<Integer>()
+            {
+                @Override
+                public int compare(Integer p1, Integer p2)
+                {
+                    try {
+                        //TODO: This could be quite slow, it should use parametric equals
+                        return type.compareTo(block, p1, block, p2);
+                    }
+                    catch (PrestoException e) {
+                        if (e.getErrorCode() == NOT_SUPPORTED.toErrorCode()) {
+                            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Array contains elements not supported for comparison", e);
+                        }
+                        throw e;
+                    }
+                }
+            });
         }
 
-        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
+        List<Integer> sortedListOfPositions = listOfPositions.getSortedListOfPositions();
+        if (sortedListOfPositions == listOfPositions) {
+            // Original array is already sorted.
+            return block;
+        }
+
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, arrayLength);
 
         for (int i = 0; i < arrayLength; i++) {
-            type.appendTo(block, positions.get(i), blockBuilder);
+            type.appendTo(block, sortedListOfPositions.get(i), blockBuilder);
         }
-        pageBuilder.declarePositions(arrayLength);
 
-        return blockBuilder.getRegion(blockBuilder.getPositionCount() - arrayLength, arrayLength);
+        return blockBuilder.build();
+    }
+
+    private static class ListOfPositions
+            extends AbstractList<Integer>
+    {
+        private final int size;
+        private List<Integer> sortedListOfPositions;
+
+        ListOfPositions(int size)
+        {
+            this.size = size;
+        }
+
+        @Override
+        public final int size()
+        {
+            return size;
+        }
+
+        @Override
+        public final Integer get(int i)
+        {
+            return i;
+        }
+
+        @Override
+        public final Integer set(int index, Integer position)
+        {
+            if (index != position) {
+                // The element at position is out of order.
+                if (sortedListOfPositions == null) {
+                    // So we need to store the entire position array in a new list.
+                    sortedListOfPositions = Ints.asList(new int[size()]);
+                    for (int i = 0; i < size(); i++) {
+                        sortedListOfPositions.set(i, i);
+                    }
+                }
+
+                // Set the new position to be used for this index.
+                sortedListOfPositions.set(index, position);
+            }
+
+            return position;
+        }
+
+        List<Integer> getSortedListOfPositions()
+        {
+            return sortedListOfPositions == null ? this : sortedListOfPositions;
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformKeyFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapTransformKeyFunction.java
@@ -278,7 +278,8 @@ public final class MapTransformKeyFunction
                         .append(new IfStatement()
                                 .condition(typedSet.invoke("contains", boolean.class, blockBuilder.cast(Block.class), position))
                                 .ifTrue(throwDuplicatedKeyException)
-                                .ifFalse(typedSet.invoke("add", void.class, blockBuilder.cast(Block.class), position)))));
+                                .ifFalse(typedSet.invoke("add", boolean.class, blockBuilder.cast(Block.class), position)
+                                .pop()))));
 
         body.append(mapBlockBuilder
                 .invoke("closeEntry", BlockBuilder.class)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayIntersectFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayIntersectFunction.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.type.ArrayType;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static java.util.Arrays.asList;
+
+public class TestArrayIntersectFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testBasic()
+    {
+        assertFunction("array_intersect(ARRAY[1, 5, 3], ARRAY[3])", new ArrayType(INTEGER), ImmutableList.of(3));
+        assertFunction("array_intersect(ARRAY[CAST(1 as BIGINT), 5, 3], ARRAY[5])", new ArrayType(BIGINT), ImmutableList.of(5L));
+        assertFunction("array_intersect(ARRAY[CAST('x' as VARCHAR), 'y', 'z'], ARRAY['x', 'y'])", new ArrayType(VARCHAR), ImmutableList.of("x", "y"));
+        assertFunction("array_intersect(ARRAY[true, false, null], ARRAY[true, null])", new ArrayType(BOOLEAN), asList(true, null));
+        assertFunction("array_intersect(ARRAY[1.1E0, 5.4E0, 3.9E0], ARRAY[5, 5.4E0])", new ArrayType(DOUBLE), ImmutableList.of(5.4));
+    }
+
+    @Test
+    public void testEmpty()
+    {
+        assertFunction("array_intersect(ARRAY[], ARRAY[])", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("array_intersect(ARRAY[], ARRAY[1, 3])", new ArrayType(INTEGER), ImmutableList.of());
+        assertFunction("array_intersect(ARRAY[CAST('abc' as VARCHAR)], ARRAY[])", new ArrayType(VARCHAR), ImmutableList.of());
+    }
+
+    @Test
+    public void testNull()
+    {
+        assertFunction("array_intersect(ARRAY[NULL], NULL)", new ArrayType(UNKNOWN), null);
+        assertFunction("array_intersect(NULL, NULL)", new ArrayType(UNKNOWN), null);
+        assertFunction("array_intersect(NULL, ARRAY[NULL])", new ArrayType(UNKNOWN), null);
+        assertFunction("array_intersect(ARRAY[NULL], ARRAY[NULL])", new ArrayType(UNKNOWN), asList(false ? 1 : null));
+        assertFunction("array_intersect(ARRAY[], ARRAY[NULL])", new ArrayType(UNKNOWN), ImmutableList.of());
+        assertFunction("array_intersect(ARRAY[NULL], ARRAY[])", new ArrayType(UNKNOWN), ImmutableList.of());
+    }
+
+    @Test
+    public void testDuplicates()
+    {
+        assertFunction("array_intersect(ARRAY[1, 5, 3, 5, 1], ARRAY[3, 3, 5])", new ArrayType(INTEGER), ImmutableList.of(5, 3));
+        assertFunction("array_intersect(ARRAY[CAST(1 as BIGINT), 5, 5, 3, 3, 3, 1], ARRAY[3, 5])", new ArrayType(BIGINT), ImmutableList.of(5L, 3L));
+        assertFunction("array_intersect(ARRAY[CAST('x' as VARCHAR), 'x', 'y', 'z'], ARRAY['x', 'y', 'x'])", new ArrayType(VARCHAR), ImmutableList.of("x", "y"));
+        assertFunction("array_intersect(ARRAY[true, false, null, true, false, null], ARRAY[true, true, true])", new ArrayType(BOOLEAN), asList(true));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArraySortFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArraySortFunction.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.type.ArrayType;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.VarcharType.createVarcharType;
+import static java.util.Arrays.asList;
+
+public class TestArraySortFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testArraySort()
+    {
+        assertFunction("array_sort(ARRAY [5, 20, null, 5, 3, 50]) ", new ArrayType(INTEGER),
+                asList(3, 5, 5, 20, 50, null));
+        assertFunction("array_sort(array['x', 'a', 'a', 'a', 'a', 'm', 'j', 'p'])",
+                new ArrayType(createVarcharType(1)), ImmutableList.of("a", "a", "a", "a", "j", "m", "p", "x"));
+        assertFunction("array_sort(sequence(-4, 3))", new ArrayType(BIGINT),
+                asList(-4L, -3L, -2L, -1L, 0L, 1L, 2L, 3L));
+        assertFunction("array_sort(reverse(sequence(-4, 3)))", new ArrayType(BIGINT),
+                asList(-4L, -3L, -2L, -1L, 0L, 1L, 2L, 3L));
+        assertFunction("repeat(1,4)", new ArrayType(INTEGER), asList(1, 1, 1, 1));
+        assertFunction("cast(array[] as array<int>)", new ArrayType(INTEGER), asList());
+    }
+}


### PR DESCRIPTION
  * Avoid null checks when mayHaveNulls is false
  * Avoid creating new blocks when not needed
      * when a filter keeps all elements
      * distinct on an already distinct array
      * sort on a sorted array
  * Cleanup the array_sort algorithm to be more efficient
  * Removed page_builder use and made the functions static
  * Added simple tests

Overall all the operations are anywhere 5%-30% faster.

Benchmark results (best numbers for before and after):

BenchmarkArrayFilter.benchmark  avgt   20  26.636 ± 1.571  ns/op
BenchmarkArrayFilter.benchmark  avgt   20  24.918 ± 1.113  ns/op

BenchmarkArraySort.arraySort      avgt   20  78.128 ± 5.007  ns/op
BenchmarkArraySort.arraySort      avgt   20  48.125 ± 3.626  ns/op

BenchmarkArrayDistinct.arrayDistinct avgt 20   35.702 ± 1.024  ns/op
BenchmarkArrayDistinct.arrayDistinct avgt   20  33.535 ± 1.060  ns/op

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== NO RELEASE NOTE ==
```
