### PR TITLE
Enable bucket pruning for IN predicates

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
@@ -37,11 +37,9 @@ import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -49,6 +47,8 @@ import static com.facebook.presto.hive.HiveColumnHandle.BUCKET_COLUMN_NAME;
 import static com.facebook.presto.hive.HiveUtil.getRegularColumnHandles;
 import static com.facebook.presto.hive.MetastoreErrorCode.HIVE_INVALID_METADATA;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Math.toIntExact;
@@ -291,13 +291,14 @@ public final class HiveBucketing
             return Optional.empty();
         }
 
-        Optional<Map<ColumnHandle, NullableValue>> bindings = TupleDomain.extractFixedValues(effectivePredicate);
+        Optional<Map<ColumnHandle, Set<NullableValue>>> bindings = TupleDomain.extractFixedValueSets(effectivePredicate);
         if (!bindings.isPresent()) {
             return Optional.empty();
         }
-        OptionalInt singleBucket = getHiveBucket(table, bindings.get());
-        if (singleBucket.isPresent()) {
-            return Optional.of(new HiveBucketFilter(ImmutableSet.of(singleBucket.getAsInt())));
+
+        Optional<Set<Integer>> buckets = getHiveBuckets(table, bindings.get());
+        if (buckets.isPresent()) {
+            return Optional.of(new HiveBucketFilter(buckets.get()));
         }
 
         if (!effectivePredicate.getDomains().isPresent()) {
@@ -321,49 +322,62 @@ public final class HiveBucketing
         return Optional.of(new HiveBucketFilter(builder.build()));
     }
 
-    private static OptionalInt getHiveBucket(Table table, Map<ColumnHandle, NullableValue> bindings)
+    private static Optional<Set<Integer>> getHiveBuckets(Table table, Map<ColumnHandle, Set<NullableValue>> bindings)
     {
-        if (bindings.isEmpty()) {
-            return OptionalInt.empty();
+        List<String> bucketColumns = table.getStorage().getBucketProperty().get().getBucketedBy();
+        if (bucketColumns.isEmpty()) {
+            return Optional.empty();
         }
 
-        List<String> bucketColumns = table.getStorage().getBucketProperty().get().getBucketedBy();
-        Map<String, HiveType> hiveTypes = new HashMap<>();
-        for (Column column : table.getDataColumns()) {
-            hiveTypes.put(column.getName(), column.getType());
-        }
+        Map<String, HiveType> hiveTypes = table.getDataColumns().stream()
+                .collect(toImmutableMap(Column::getName, Column::getType));
 
         // Verify the bucket column types are supported
         for (String column : bucketColumns) {
             if (!SUPPORTED_TYPES_FOR_BUCKET_FILTER.contains(hiveTypes.get(column))) {
-                return OptionalInt.empty();
+                return Optional.empty();
             }
         }
 
-        // Get bindings for bucket columns
-        Map<String, Object> bucketBindings = new HashMap<>();
-        for (Entry<ColumnHandle, NullableValue> entry : bindings.entrySet()) {
-            HiveColumnHandle colHandle = (HiveColumnHandle) entry.getKey();
-            if (!entry.getValue().isNull() && bucketColumns.contains(colHandle.getName())) {
-                bucketBindings.put(colHandle.getName(), entry.getValue().getValue());
+        Map<String, Set<NullableValue>> nameToBindings = bindings.entrySet().stream()
+                .collect(toImmutableMap(entry -> ((HiveColumnHandle) entry.getKey()).getName(), Entry::getValue));
+
+        ImmutableList.Builder<Set<NullableValue>> orderedBindingsBuilder = ImmutableList.builder();
+        for (String columnName : bucketColumns) {
+            if (!nameToBindings.containsKey(columnName)) {
+                return Optional.empty();
             }
+            orderedBindingsBuilder.add(nameToBindings.get(columnName));
         }
 
-        // Check that we have bindings for all bucket columns
-        if (bucketBindings.size() != bucketColumns.size()) {
-            return OptionalInt.empty();
+        List<Set<NullableValue>> orderedBindings = orderedBindingsBuilder.build();
+        int bucketCount = table.getStorage().getBucketProperty().get().getBucketCount();
+        List<TypeInfo> types = bucketColumns.stream()
+                .map(hiveTypes::get)
+                .map(HiveType::getTypeInfo)
+                .collect(toImmutableList());
+        ImmutableSet.Builder<Integer> buckets = ImmutableSet.builder();
+        getHiveBuckets(new Object[types.size()], 0, orderedBindings, bucketCount, types, buckets);
+        return Optional.of(buckets.build());
+    }
+
+    private static void getHiveBuckets(
+            Object[] values,
+            int valuesCount,
+            List<Set<NullableValue>> bindings,
+            int bucketCount,
+            List<TypeInfo> typeInfos,
+            ImmutableSet.Builder<Integer> buckets)
+    {
+        if (valuesCount == typeInfos.size()) {
+            buckets.add(getHiveBucket(bucketCount, typeInfos, values));
+            return;
         }
 
-        // Get bindings of bucket columns
-        ImmutableList.Builder<TypeInfo> typeInfos = ImmutableList.builder();
-        Object[] values = new Object[bucketColumns.size()];
-        for (int i = 0; i < bucketColumns.size(); i++) {
-            String column = bucketColumns.get(i);
-            typeInfos.add(hiveTypes.get(column).getTypeInfo());
-            values[i] = bucketBindings.get(column);
+        for (NullableValue value : bindings.get(valuesCount)) {
+            values[valuesCount] = value.getValue();
+            getHiveBuckets(values, valuesCount + 1, bindings, bucketCount, typeInfos, buckets);
         }
-
-        return OptionalInt.of(getHiveBucket(table.getStorage().getBucketProperty().get().getBucketCount(), typeInfos.build(), values));
     }
 
     public static class HiveBucketFilter

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -47,6 +47,7 @@ import com.facebook.presto.sql.planner.planPrinter.IOPlanPrinter.IOPlan;
 import com.facebook.presto.sql.planner.planPrinter.IOPlanPrinter.IOPlan.TableColumnInfo;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableList;
@@ -1948,6 +1949,54 @@ public class TestHiveIntegrationSmokeTest
         assertQuery(
                 Session.builder(session).setSystemProperty("task_writer_count", "4").build(),
                 "SELECT custkey, COUNT(*) FROM orders GROUP BY custkey");
+    }
+
+    @Test
+    public void testBucketPruning()
+    {
+        Session session = getSession();
+        QueryRunner queryRunner = getQueryRunner();
+        queryRunner.execute("CREATE TABLE orders_bucketed WITH (bucket_count = 11, bucketed_by = ARRAY['orderkey']) AS " +
+                "SELECT * FROM orders");
+
+        try {
+            assertQuery(session, "SELECT * FROM orders_bucketed WHERE orderkey = 100", "SELECT * FROM orders WHERE orderkey = 100");
+
+            assertQuery(session, "SELECT * FROM orders_bucketed WHERE orderkey = 100 OR orderkey = 101", "SELECT * FROM orders WHERE orderkey = 100 OR orderkey = 101");
+
+            assertQuery(session, "SELECT * FROM orders_bucketed WHERE orderkey IN (100, 101, 133)", "SELECT * FROM orders WHERE orderkey IN (100, 101, 133)");
+
+            assertQuery(session, "SELECT * FROM orders_bucketed", "SELECT * FROM orders");
+
+            assertQuery(session, "SELECT * FROM orders_bucketed WHERE orderkey > 100", "SELECT * FROM orders WHERE orderkey > 100");
+
+            assertQuery(session, "SELECT * FROM orders_bucketed WHERE orderkey != 100", "SELECT * FROM orders WHERE orderkey != 100");
+        }
+        finally {
+            queryRunner.execute("DROP TABLE orders_bucketed");
+        }
+
+        queryRunner.execute("CREATE TABLE orders_bucketed WITH (bucket_count = 11, bucketed_by = ARRAY['orderkey', 'custkey']) AS " +
+                "SELECT * FROM orders");
+
+        try {
+            assertQuery(session, "SELECT * FROM orders_bucketed WHERE orderkey = 101 AND custkey = 280", "SELECT * FROM orders WHERE orderkey = 101 AND custkey = 280");
+
+            assertQuery(session, "SELECT * FROM orders_bucketed WHERE orderkey IN (101, 71) AND custkey = 280", "SELECT * FROM orders WHERE orderkey IN (101, 71) AND custkey = 280");
+
+            assertQuery(session, "SELECT * FROM orders_bucketed WHERE orderkey IN (101, 71) AND custkey IN (280, 34)", "SELECT * FROM orders WHERE orderkey IN (101, 71) AND custkey IN (280, 34)");
+
+            assertQuery(session, "SELECT * FROM orders_bucketed WHERE orderkey = 101 AND custkey = 280 AND orderstatus <> '0'", "SELECT * FROM orders WHERE orderkey = 101 AND custkey = 280 AND orderstatus <> '0'");
+
+            assertQuery(session, "SELECT * FROM orders_bucketed WHERE orderkey = 101", "SELECT * FROM orders WHERE orderkey = 101");
+
+            assertQuery(session, "SELECT * FROM orders_bucketed WHERE custkey = 280", "SELECT * FROM orders WHERE custkey = 280");
+
+            assertQuery(session, "SELECT * FROM orders_bucketed WHERE orderkey = 101 AND custkey > 280", "SELECT * FROM orders WHERE orderkey = 101 AND custkey > 280");
+        }
+        finally {
+            queryRunner.execute("DROP TABLE orders_bucketed");
+        }
     }
 
     @Test

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -97,6 +97,7 @@ import static io.airlift.tpch.TpchTable.ORDERS;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class TestHiveLogicalPlanner
@@ -731,6 +732,79 @@ public class TestHiveLogicalPlanner
         }
     }
 
+    @Test
+    public void testBucketPruning()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        queryRunner.execute("CREATE TABLE orders_bucketed WITH (bucket_count = 11, bucketed_by = ARRAY['orderkey']) AS " +
+                "SELECT * FROM orders");
+
+        try {
+            assertPlan(getSession(), "SELECT * FROM orders_bucketed WHERE orderkey = 100",
+                    anyTree(PlanMatchPattern.tableScan("orders_bucketed")),
+                    plan -> assertBucketFilter(plan, "orders_bucketed", 11, ImmutableSet.of(1)));
+
+            assertPlan(getSession(), "SELECT * FROM orders_bucketed WHERE orderkey = 100 OR orderkey = 101",
+                    anyTree(PlanMatchPattern.tableScan("orders_bucketed")),
+                    plan -> assertBucketFilter(plan, "orders_bucketed", 11, ImmutableSet.of(1, 2)));
+
+            assertPlan(getSession(), "SELECT * FROM orders_bucketed WHERE orderkey IN (100, 101, 133)",
+                    anyTree(PlanMatchPattern.tableScan("orders_bucketed")),
+                    plan -> assertBucketFilter(plan, "orders_bucketed", 11, ImmutableSet.of(1, 2)));
+
+            assertPlan(getSession(), "SELECT * FROM orders_bucketed",
+                    anyTree(PlanMatchPattern.tableScan("orders_bucketed")),
+                    plan -> assertNoBucketFilter(plan, "orders_bucketed", 11));
+
+            assertPlan(getSession(), "SELECT * FROM orders_bucketed WHERE orderkey > 100",
+                    anyTree(PlanMatchPattern.tableScan("orders_bucketed")),
+                    plan -> assertNoBucketFilter(plan, "orders_bucketed", 11));
+
+            assertPlan(getSession(), "SELECT * FROM orders_bucketed WHERE orderkey != 100",
+                    anyTree(PlanMatchPattern.tableScan("orders_bucketed")),
+                    plan -> assertNoBucketFilter(plan, "orders_bucketed", 11));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE orders_bucketed");
+        }
+
+        queryRunner.execute("CREATE TABLE orders_bucketed WITH (bucket_count = 11, bucketed_by = ARRAY['orderkey', 'custkey']) AS " +
+                "SELECT * FROM orders");
+
+        try {
+            assertPlan(getSession(), "SELECT * FROM orders_bucketed WHERE orderkey = 101 AND custkey = 280",
+                    anyTree(PlanMatchPattern.tableScan("orders_bucketed")),
+                    plan -> assertBucketFilter(plan, "orders_bucketed", 11, ImmutableSet.of(1)));
+
+            assertPlan(getSession(), "SELECT * FROM orders_bucketed WHERE orderkey IN (101, 71) AND custkey = 280",
+                    anyTree(PlanMatchPattern.tableScan("orders_bucketed")),
+                    plan -> assertBucketFilter(plan, "orders_bucketed", 11, ImmutableSet.of(1, 6)));
+
+            assertPlan(getSession(), "SELECT * FROM orders_bucketed WHERE orderkey IN (101, 71) AND custkey IN (280, 34)",
+                    anyTree(PlanMatchPattern.tableScan("orders_bucketed")),
+                    plan -> assertBucketFilter(plan, "orders_bucketed", 11, ImmutableSet.of(1, 2, 6, 8)));
+
+            assertPlan(getSession(), "SELECT * FROM orders_bucketed WHERE orderkey = 101 AND custkey = 280 AND orderstatus <> '0'",
+                    anyTree(PlanMatchPattern.tableScan("orders_bucketed")),
+                    plan -> assertBucketFilter(plan, "orders_bucketed", 11, ImmutableSet.of(1)));
+
+            assertPlan(getSession(), "SELECT * FROM orders_bucketed WHERE orderkey = 101",
+                    anyTree(PlanMatchPattern.tableScan("orders_bucketed")),
+                    plan -> assertNoBucketFilter(plan, "orders_bucketed", 11));
+
+            assertPlan(getSession(), "SELECT * FROM orders_bucketed WHERE custkey = 280",
+                    anyTree(PlanMatchPattern.tableScan("orders_bucketed")),
+                    plan -> assertNoBucketFilter(plan, "orders_bucketed", 11));
+
+            assertPlan(getSession(), "SELECT * FROM orders_bucketed WHERE orderkey = 101 AND custkey > 280",
+                    anyTree(PlanMatchPattern.tableScan("orders_bucketed")),
+                    plan -> assertNoBucketFilter(plan, "orders_bucketed", 11));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE orders_bucketed");
+        }
+    }
+
     private static Set<Subfield> toSubfields(String... subfieldPaths)
     {
         return Arrays.stream(subfieldPaths)
@@ -808,6 +882,35 @@ public class TestHiveLogicalPlanner
         assertEquals(layoutHandle.getPredicateColumns().keySet(), predicateColumnNames);
         assertEquals(layoutHandle.getDomainPredicate(), domainPredicate);
         assertEquals(layoutHandle.getRemainingPredicate(), remainingPredicate);
+        assertEquals(layoutHandle.getRemainingPredicate(), remainingPredicate);
+    }
+
+    private void assertBucketFilter(Plan plan, String tableName, int readBucketCount, Set<Integer> bucketsToKeep)
+    {
+        TableScanNode tableScan = searchFrom(plan.getRoot())
+                .where(node -> isTableScanNode(node, tableName))
+                .findOnlyElement();
+
+        assertTrue(tableScan.getTable().getLayout().isPresent());
+        HiveTableLayoutHandle layoutHandle = (HiveTableLayoutHandle) tableScan.getTable().getLayout().get();
+
+        assertTrue(layoutHandle.getBucketHandle().isPresent());
+        assertTrue(layoutHandle.getBucketFilter().isPresent());
+        assertEquals(layoutHandle.getBucketHandle().get().getReadBucketCount(), readBucketCount);
+        assertEquals(layoutHandle.getBucketFilter().get().getBucketsToKeep(), bucketsToKeep);
+    }
+
+    private void assertNoBucketFilter(Plan plan, String tableName, int readBucketCount)
+    {
+        TableScanNode tableScan = searchFrom(plan.getRoot())
+                .where(node -> isTableScanNode(node, tableName))
+                .findOnlyElement();
+
+        assertTrue(tableScan.getTable().getLayout().isPresent());
+        HiveTableLayoutHandle layoutHandle = (HiveTableLayoutHandle) tableScan.getTable().getLayout().get();
+
+        assertEquals(layoutHandle.getBucketHandle().get().getReadBucketCount(), readBucketCount);
+        assertFalse(layoutHandle.getBucketFilter().isPresent());
     }
 
     private static PlanMatchPattern tableScan(String tableName, TupleDomain<String> domainPredicate, RowExpression remainingPredicate, Set<String> predicateColumnNames)


### PR DESCRIPTION
Given table `t` bucketed by column `x` and a query `SELECT * FROM t WHERE x = 5`, Presto compute bucket ID for x = 5 and reduces table scan to just that bucket. This technique is called bucket pruning.

This change extends bucket pruning to predicates where multiple values match. For queries with predicates like `x IN (5, 7)` and `x = 5 OR x = 7`, Presto will compute bucket IDs for values 5 and 7 and reduce table scan to just these buckets. 

This logic doesn't apply to predicates like `x BETWEEN 5 AND 7` or `x > 5 AND x < 10`.

CC: @prestodb/aria 

== NO RELEASE NOTE ==
