### PR TITLE
Fix NaN comparison

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
@@ -1202,24 +1202,30 @@ public interface TupleDomainFilter
             extends AbstractTupleDomainFilter
     {
         private final TupleDomainFilter[] filters;
+        private final boolean nanAllowed;
 
-        private MultiRange(List<TupleDomainFilter> filters, boolean nullAllowed)
+        private MultiRange(List<TupleDomainFilter> filters, boolean nullAllowed, boolean nanAllowed)
         {
             super(true, nullAllowed);
             requireNonNull(filters, "filters is null");
             checkArgument(filters.size() > 1, "filters must contain at least 2 entries");
 
             this.filters = filters.toArray(new TupleDomainFilter[0]);
+            this.nanAllowed = nanAllowed;
         }
 
-        public static MultiRange of(List<TupleDomainFilter> filters, boolean nullAllowed)
+        public static MultiRange of(List<TupleDomainFilter> filters, boolean nullAllowed, boolean nanAllowed)
         {
-            return new MultiRange(filters, nullAllowed);
+            return new MultiRange(filters, nullAllowed, nanAllowed);
         }
 
         @Override
         public boolean testDouble(double value)
         {
+            if (Double.isNaN(value)) {
+                return nanAllowed;
+            }
+
             for (TupleDomainFilter filter : filters) {
                 if (filter.testDouble(value)) {
                     return true;
@@ -1231,6 +1237,10 @@ public interface TupleDomainFilter
         @Override
         public boolean testFloat(float value)
         {
+            if (Float.isNaN(value)) {
+                return nanAllowed;
+            }
+
             for (TupleDomainFilter filter : filters) {
                 if (filter.testFloat(value)) {
                     return true;
@@ -1285,13 +1295,14 @@ public interface TupleDomainFilter
 
             MultiRange that = (MultiRange) o;
             return Arrays.equals(filters, that.filters) &&
-                    nullAllowed == that.nullAllowed;
+                    nullAllowed == that.nullAllowed &&
+                    nanAllowed == that.nanAllowed;
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(filters, nullAllowed);
+            return Objects.hash(filters, nullAllowed, nanAllowed);
         }
 
         @Override
@@ -1300,6 +1311,7 @@ public interface TupleDomainFilter
             return toStringHelper(this)
                     .add("filters", filters)
                     .add("nullAllowed", nullAllowed)
+                    .add("nanAllowed", nanAllowed)
                     .toString();
         }
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilterUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilterUtils.java
@@ -99,7 +99,8 @@ public class TupleDomainFilterUtils
             return nullAllowed ? IS_NULL : ALWAYS_FALSE;
         }
 
-        if (rangeFilters.get(0) instanceof BigintRange) {
+        TupleDomainFilter firstRangeFilter = rangeFilters.get(0);
+        if (firstRangeFilter instanceof BigintRange) {
             List<BigintRange> bigintRanges = rangeFilters.stream()
                     .map(BigintRange.class::cast)
                     .collect(toImmutableList());
@@ -115,7 +116,7 @@ public class TupleDomainFilterUtils
             return BigintMultiRange.of(bigintRanges, nullAllowed);
         }
 
-        if (rangeFilters.get(0) instanceof BytesRange) {
+        if (firstRangeFilter instanceof BytesRange) {
             List<BytesRange> bytesRanges = rangeFilters.stream()
                     .map(BytesRange.class::cast)
                     .collect(toImmutableList());
@@ -128,7 +129,50 @@ public class TupleDomainFilterUtils
                         nullAllowed);
             }
         }
-        return MultiRange.of(rangeFilters, nullAllowed);
+
+        return MultiRange.of(rangeFilters, nullAllowed, isNanAllowed(ranges));
+    }
+
+    /**
+     * Returns true is ranges represent != or NOT IN filter. These types of filters should
+     * return true when applied to NaN.
+     *
+     * E.g. NaN != 1.0 as well as NaN NOT IN (1.0, 2.5, 3.6) should return true; otherwise false.
+     *
+     * The logic is to return true if ranges are next to each other, but don't include the touch value.
+     */
+    private static boolean isNanAllowed(List<Range> ranges)
+    {
+        if (ranges.size() <= 1) {
+            return false;
+        }
+
+        Range firstRange = ranges.get(0);
+        Marker previousHigh = firstRange.getHigh();
+
+        Type type = previousHigh.getType();
+        if (type != DOUBLE && type != REAL) {
+            return false;
+        }
+
+        Range lastRange = ranges.get(ranges.size() - 1);
+        if (!firstRange.getLow().isLowerUnbounded() || !lastRange.getHigh().isUpperUnbounded()) {
+            return false;
+        }
+
+        for (int i = 1; i < ranges.size(); i++) {
+            Range current = ranges.get(i);
+
+            if (previousHigh.getBound() != Marker.Bound.BELOW ||
+                    current.getLow().getBound() != Marker.Bound.ABOVE ||
+                    type.compareTo(previousHigh.getValueBlock().get(), 0, current.getLow().getValueBlock().get(), 0) != 0) {
+                return false;
+            }
+
+            previousHigh = current.getHigh();
+        }
+
+        return true;
     }
 
     private static TupleDomainFilter createBooleanFilter(List<Range> ranges, boolean nullAllowed)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -964,7 +964,7 @@ public class TestSelectiveOrcReader
     {
         return TupleDomainFilter.MultiRange.of(ImmutableList.of(
                 BytesRange.of(null, false, value.getBytes(), true, nullAllowed),
-                BytesRange.of(value.getBytes(), true, null, false, nullAllowed)), nullAllowed);
+                BytesRange.of(value.getBytes(), true, null, false, nullAllowed)), nullAllowed, false);
     }
 
     private static TupleDomainFilter stringIn(boolean nullAllowed, String... values)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilterUtils.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilterUtils.java
@@ -268,16 +268,16 @@ public class TestTupleDomainFilterUtils
         assertEquals(toFilter(equal(C_DOUBLE, doubleLiteral(1.2))), DoubleRange.of(1.2, false, false, 1.2, false, false, false));
         assertEquals(toFilter(notEqual(C_DOUBLE, doubleLiteral(1.2))), MultiRange.of(ImmutableList.of(
                 DoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
-                DoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), false));
+                DoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), false, true));
 
         assertEquals(toFilter(in(C_DOUBLE, ImmutableList.of(1.2, 3.4, 5.6))), MultiRange.of(ImmutableList.of(
                 DoubleRange.of(1.2, false, false, 1.2, false, false, false),
                 DoubleRange.of(3.4, false, false, 3.4, false, false, false),
-                DoubleRange.of(5.6, false, false, 5.6, false, false, false)), false));
+                DoubleRange.of(5.6, false, false, 5.6, false, false, false)), false, false));
 
         assertEquals(toFilter(isDistinctFrom(C_DOUBLE, doubleLiteral(1.2))), MultiRange.of(ImmutableList.of(
                 DoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
-                DoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), true));
+                DoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), true, true));
 
         assertEquals(toFilter(between(C_DOUBLE, doubleLiteral(1.2), doubleLiteral(3.4))), DoubleRange.of(1.2, false, false, 3.4, false, false, false));
 
@@ -286,21 +286,32 @@ public class TestTupleDomainFilterUtils
         assertEquals(toFilter(greaterThanOrEqual(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
         assertEquals(toFilter(greaterThan(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
         assertEquals(toFilter(notEqual(C_DOUBLE, doubleLiteral(Double.NaN))), ALWAYS_FALSE);
+
+        assertEquals(toFilter(not(in(C_DOUBLE, ImmutableList.of(doubleLiteral(1.2))))), MultiRange.of(ImmutableList.of(
+                DoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
+                DoubleRange.of(1.2, false, true, Double.MAX_VALUE, true, true, false)), false, true));
+
+        assertEquals(toFilter(not(in(C_DOUBLE, ImmutableList.of(doubleLiteral(2.4), doubleLiteral(1.2))))), MultiRange.of(ImmutableList.of(
+                DoubleRange.of(Double.MIN_VALUE, true, true, 1.2, false, true, false),
+                DoubleRange.of(1.2, false, true, 2.4, false, true, false),
+                DoubleRange.of(2.4, false, true, Double.MAX_VALUE, true, true, false)), false, true));
+
+        assertEquals(toFilter((in(C_DOUBLE, ImmutableList.of(doubleLiteral(2.4), doubleLiteral(1.2))))), MultiRange.of(ImmutableList.of(
+                DoubleRange.of(1.2, false, false, 1.2, false, false, false),
+                DoubleRange.of(2.4, false, false, 2.4, false, false, false)), false, false));
     }
 
     @Test
     public void testFloat()
     {
         Expression realLiteral = toExpression(realValue(1.2f), TYPES.get(C_REAL.toSymbolReference()));
+        Expression realLiteralHigh = toExpression(realValue(2.4f), TYPES.get(C_REAL.toSymbolReference()));
         assertEquals(toFilter(equal(C_REAL, realLiteral)), FloatRange.of(1.2f, false, false, 1.2f, false, false, false));
         assertEquals(toFilter(not(equal(C_REAL, realLiteral))), MultiRange.of(ImmutableList.of(
                 FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
-                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false));
+                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), false, true));
 
         assertEquals(toFilter(or(isNull(C_REAL), equal(C_REAL, realLiteral))), FloatRange.of(1.2f, false, false, 1.2f, false, false, true));
-        assertEquals(toFilter(or(isNull(C_REAL), notEqual(C_REAL, realLiteral))), MultiRange.of(ImmutableList.of(
-                FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
-                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), true));
 
         Expression floatNaNLiteral = toExpression(realValue(Float.NaN), TYPES.get(C_REAL.toSymbolReference()));
         assertEquals(toFilter(lessThan(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
@@ -308,6 +319,23 @@ public class TestTupleDomainFilterUtils
         assertEquals(toFilter(greaterThanOrEqual(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
         assertEquals(toFilter(greaterThan(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
         assertEquals(toFilter(notEqual(C_REAL, floatNaNLiteral)), ALWAYS_FALSE);
+
+        assertEquals(toFilter(isDistinctFrom(C_REAL, realLiteral)), MultiRange.of(ImmutableList.of(
+                FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), true, true));
+
+        assertEquals(toFilter(or(isNull(C_REAL), notEqual(C_REAL, realLiteral))), MultiRange.of(ImmutableList.of(
+                FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                FloatRange.of(1.2f, false, true, Float.MAX_VALUE, true, true, false)), true, true));
+
+        assertEquals(toFilter(not(in(C_REAL, ImmutableList.of(realLiteral, realLiteralHigh)))), MultiRange.of(ImmutableList.of(
+                FloatRange.of(Float.MIN_VALUE, true, true, 1.2f, false, true, false),
+                FloatRange.of(1.2f, false, true, 2.4f, false, true, false),
+                FloatRange.of(2.4f, false, true, Float.MAX_VALUE, true, true, false)), false, true));
+
+        assertEquals(toFilter((in(C_REAL, ImmutableList.of(realLiteral, realLiteralHigh)))), MultiRange.of(ImmutableList.of(
+                FloatRange.of(1.2f, false, false, 1.2f, false, false, false),
+                FloatRange.of(2.4f, false, false, 2.4f, false, false, false)), false, false));
     }
 
     @Test
@@ -318,12 +346,12 @@ public class TestTupleDomainFilterUtils
         assertEquals(toFilter(equal(C_DECIMAL_21_3, decimalLiteral)), LongDecimalRange.of(decimal.getLong(0), decimal.getLong(SIZE_OF_LONG), false, false, decimal.getLong(0), decimal.getLong(SIZE_OF_LONG), false, false, false));
         assertEquals(toFilter(not(equal(C_DECIMAL_21_3, decimalLiteral))), MultiRange.of(ImmutableList.of(
                 LongDecimalRange.of(Long.MIN_VALUE, Long.MIN_VALUE, true, true, decimal.getLong(0), decimal.getLong(SIZE_OF_LONG), false, true, false),
-                LongDecimalRange.of(decimal.getLong(0), decimal.getLong(SIZE_OF_LONG), false, true, Long.MAX_VALUE, Long.MAX_VALUE, true, true, false)), false));
+                LongDecimalRange.of(decimal.getLong(0), decimal.getLong(SIZE_OF_LONG), false, true, Long.MAX_VALUE, Long.MAX_VALUE, true, true, false)), false, false));
 
         assertEquals(toFilter(or(isNull(C_DECIMAL_21_3), equal(C_DECIMAL_21_3, decimalLiteral))), LongDecimalRange.of(decimal.getLong(0), decimal.getLong(SIZE_OF_LONG), false, false, decimal.getLong(0), decimal.getLong(SIZE_OF_LONG), false, false, true));
         assertEquals(toFilter(or(isNull(C_DECIMAL_21_3), not(equal(C_DECIMAL_21_3, decimalLiteral)))), MultiRange.of(ImmutableList.of(
                 LongDecimalRange.of(Long.MIN_VALUE, Long.MIN_VALUE, true, true, decimal.getLong(0), decimal.getLong(SIZE_OF_LONG), false, true, false),
-                LongDecimalRange.of(decimal.getLong(0), decimal.getLong(SIZE_OF_LONG), false, true, Long.MAX_VALUE, Long.MAX_VALUE, true, true, false)), true));
+                LongDecimalRange.of(decimal.getLong(0), decimal.getLong(SIZE_OF_LONG), false, true, Long.MAX_VALUE, Long.MAX_VALUE, true, true, false)), true, false));
     }
 
     @Test
@@ -332,7 +360,7 @@ public class TestTupleDomainFilterUtils
         assertEquals(toFilter(equal(C_VARCHAR, stringLiteral("abc", VARCHAR))), BytesRange.of(toBytes("abc"), false, toBytes("abc"), false, false));
         assertEquals(toFilter(not(equal(C_VARCHAR, stringLiteral("abc", VARCHAR)))), MultiRange.of(ImmutableList.of(
                 BytesRange.of(null, true, toBytes("abc"), true, false),
-                BytesRange.of(toBytes("abc"), true, null, true, false)), false));
+                BytesRange.of(toBytes("abc"), true, null, true, false)), false, false));
 
         assertEquals(toFilter(lessThan(C_VARCHAR, stringLiteral("abc", VARCHAR))), BytesRange.of(null, true, toBytes("abc"), true, false));
         assertEquals(toFilter(lessThanOrEqual(C_VARCHAR, stringLiteral("abc", VARCHAR))), BytesRange.of(null, true, toBytes("abc"), false, false));


### PR DESCRIPTION
Any floating point comparison with NaN should return false, but `!=` and `<>` operators should return true:

```
NaN  != 1 -> true
NaN != NaN -> true

select * from t where value = 1  -> doesn't return NaNs
select * from  t where value <> 1 -> returns NaNs
```

```
== NO RELEASE NOTE ==
```
