### PR TITLE
Fix pushdown for filters on multiple subfields of a struct

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -2169,7 +2169,7 @@ public class HiveMetadata
         Map<ColumnHandle, ConstantExpression> constants;
         if (hiveLayoutHandle.isPushdownFilterEnabled()) {
             predicate = hiveLayoutHandle.getDomainPredicate()
-                    .transform(Subfield::getRootName)
+                    .transform(subfield -> isEntireColumn(subfield) ? subfield.getRootName() : null)
                     .transform(hiveLayoutHandle.getPredicateColumns()::get)
                     .transform(ColumnHandle.class::cast)
                     .intersect(createPredicate(partitionColumns, partitions));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -28,6 +28,7 @@ import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.ArrayType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.assertions.MatchResult;
@@ -65,6 +66,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.RANGE_FILTERS_ON_SU
 import static com.facebook.presto.hive.TestHiveIntegrationSmokeTest.assertRemoteExchangesCount;
 import static com.facebook.presto.spi.function.OperatorType.EQUAL;
 import static com.facebook.presto.spi.predicate.Domain.multipleValues;
+import static com.facebook.presto.spi.predicate.Domain.notNull;
 import static com.facebook.presto.spi.predicate.Domain.singleValue;
 import static com.facebook.presto.spi.predicate.TupleDomain.withColumnDomains;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -326,6 +328,9 @@ public class TestHiveLogicalPlanner
 
         assertPushdownFilterOnSubfields("SELECT * FROM test_pushdown_filter_on_subfields WHERE c.e['foo'] = 1",
                         ImmutableMap.of(new Subfield("c.e[\"foo\"]"), singleValue(BIGINT, 1L)));
+
+        assertPushdownFilterOnSubfields("SELECT * FROM test_pushdown_filter_on_subfields WHERE c.a IS NOT NULL AND c.c IS NOT NULL",
+                ImmutableMap.of(new Subfield("c.a"), notNull(BIGINT), new Subfield("c.c"), notNull(new ArrayType(BIGINT))));
 
         assertUpdate("DROP TABLE test_pushdown_filter_on_subfields");
     }


### PR DESCRIPTION
A filter on multiple subfields of a struct would fail with an error:

`SELECT count(*) FROM t WHERE a.x IS NOT NULL AND a.y IS NOT NULL`

```
java.lang.IllegalArgumentException: Every argument must have a unique mapping. c.c maps to com.facebook.presto.spi.predicate.Domain@8c1adaec and com.facebook.presto.spi.predicate.Domain@99b87377

	at com.facebook.presto.spi.predicate.TupleDomain.transform(TupleDomain.java:395)
	at com.facebook.presto.hive.HiveMetadata.getTableLayout(HiveMetadata.java:2173)
	at com.facebook.presto.hive.HiveMetadata.pushdownFilter(HiveMetadata.java:1924)
	at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.pushdownFilter(ClassLoaderSafeConnectorMetadata.java:105)
	at com.facebook.presto.metadata.MetadataManager.pushdownFilter(MetadataManager.java:446)
	at com.facebook.presto.sql.planner.iterative.rule.PickTableLayout.pushPredicateIntoTableScan(PickTableLayout.java:336)
```

```
== NO RELEASE NOTE ==
```
