### PR TITLE
[WIP] Bypass http call if the node is local

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -77,6 +77,7 @@ public class TaskManagerConfig
     private int taskYieldThreads = 3;
 
     private BigDecimal levelTimeMultiplier = new BigDecimal(2.0);
+    private boolean bypassHttpForLocal;
 
     private boolean legacyLifespanCompletionCondition;
 
@@ -493,6 +494,18 @@ public class TaskManagerConfig
     public TaskManagerConfig setLegacyLifespanCompletionCondition(boolean legacyLifespanCompletionCondition)
     {
         this.legacyLifespanCompletionCondition = legacyLifespanCompletionCondition;
+        return this;
+    }
+
+    public boolean isBypassHttpForLocal()
+    {
+        return bypassHttpForLocal;
+    }
+
+    @Config("task.bypass-http-for-local")
+    public TaskManagerConfig setBypassHttpForLocal(boolean bypassHttpForLocal)
+    {
+        this.bypassHttpForLocal = bypassHttpForLocal;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -141,6 +141,7 @@ import io.airlift.units.Duration;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import java.util.List;
@@ -344,9 +345,9 @@ public class CoordinatorModule
 
     @Provides
     @Singleton
-    public static QueryPerformanceFetcher createQueryPerformanceFetcher(QueryManager queryManager)
+    public static QueryPerformanceFetcher createQueryPerformanceFetcher(Provider<QueryManager> queryManager)
     {
-        return queryManager::getFullQueryInfo;
+        return queryId -> queryManager.get().getFullQueryInfo(queryId);
     }
 
     @Provides

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/Backoff.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/Backoff.java
@@ -41,7 +41,7 @@ public class Backoff
             .add(new Duration(500, MILLISECONDS))
             .build();
 
-    private final int minTries;
+    private final long minTries;
     private final long maxFailureIntervalNanos;
     private final Ticker ticker;
     private final long[] backoffDelayIntervalsNanos;
@@ -64,7 +64,7 @@ public class Backoff
     }
 
     @VisibleForTesting
-    public Backoff(int minTries, Duration maxFailureInterval, Ticker ticker, List<Duration> backoffDelayIntervals)
+    public Backoff(long minTries, Duration maxFailureInterval, Ticker ticker, List<Duration> backoffDelayIntervals)
     {
         checkArgument(minTries > 0, "minTries must be at least 1");
         requireNonNull(maxFailureInterval, "maxFailureInterval is null");
@@ -83,6 +83,11 @@ public class Backoff
     public synchronized long getFailureCount()
     {
         return failureCount;
+    }
+
+    public static Backoff createNeverBackingOff()
+    {
+        return new Backoff(Long.MAX_VALUE, new Duration(Long.MAX_VALUE, NANOSECONDS), Ticker.systemTicker(), ImmutableList.of(new Duration(0, NANOSECONDS)));
     }
 
     public synchronized Duration getFailureDuration()

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/RequestErrorTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/RequestErrorTracker.java
@@ -61,10 +61,15 @@ class RequestErrorTracker
 
     public RequestErrorTracker(TaskId taskId, URI taskUri, Duration maxErrorDuration, ScheduledExecutorService scheduledExecutor, String jobDescription)
     {
+        this(taskId, taskUri, new Backoff(requireNonNull(maxErrorDuration, "maxErrorDuration is null")), scheduledExecutor, jobDescription);
+    }
+
+    public RequestErrorTracker(TaskId taskId, URI taskUri, Backoff backoff, ScheduledExecutorService scheduledExecutor, String jobDescription)
+    {
         this.taskId = requireNonNull(taskId, "taskId is null");
         this.taskUri = requireNonNull(taskUri, "taskUri is null");
         this.scheduledExecutor = requireNonNull(scheduledExecutor, "scheduledExecutor is null");
-        this.backoff = new Backoff(requireNonNull(maxErrorDuration, "maxErrorDuration is null"));
+        this.backoff = requireNonNull(backoff, "backoff is null");
         this.jobDescription = requireNonNull(jobDescription, "jobDescription is null");
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -62,7 +62,8 @@ public class TestTaskManagerConfig
                 .setTaskYieldThreads(3)
                 .setLevelTimeMultiplier(new BigDecimal("2"))
                 .setStatisticsCpuTimerEnabled(true)
-                .setLegacyLifespanCompletionCondition(false));
+                .setLegacyLifespanCompletionCondition(false)
+                .setBypassHttpForLocal(false));
     }
 
     @Test
@@ -97,6 +98,7 @@ public class TestTaskManagerConfig
                 .put("task.task-notification-threads", "13")
                 .put("task.task-yield-threads", "8")
                 .put("task.level-time-multiplier", "2.1")
+                .put("task.bypass-http-for-local", "true")
                 .put("task.statistics-cpu-timer-enabled", "false")
                 .put("task.legacy-lifespan-completion-condition", "true")
                 .build();
@@ -131,7 +133,8 @@ public class TestTaskManagerConfig
                 .setTaskYieldThreads(8)
                 .setLevelTimeMultiplier(new BigDecimal("2.1"))
                 .setStatisticsCpuTimerEnabled(false)
-                .setLegacyLifespanCompletionCondition(true);
+                .setLegacyLifespanCompletionCondition(true)
+                .setBypassHttpForLocal(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMergeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMergeOperator.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator;
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.client.testing.TestingHttpClient;
 import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.execution.buffer.PagesSerdeFactory;
 import com.facebook.presto.execution.buffer.TestingPagesSerdeFactory;
 import com.facebook.presto.metadata.RemoteTransactionHandle;
@@ -83,7 +84,7 @@ public class TestMergeOperator
 
         taskBuffers = CacheBuilder.newBuilder().build(CacheLoader.from(TestingTaskBuffer::new));
         httpClient = new TestingHttpClient(new TestingExchangeHttpClientHandler(taskBuffers), executor);
-        exchangeClientFactory = new ExchangeClientFactory(new ExchangeClientConfig(), httpClient, executor);
+        exchangeClientFactory = new ExchangeClientFactory(new ExchangeClientConfig(), new TaskManagerConfig(), httpClient, executor);
         orderingCompiler = new OrderingCompiler();
     }
 

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueriesIndexed.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueriesIndexed.java
@@ -23,7 +23,7 @@ public class TestThriftDistributedQueriesIndexed
 {
     public TestThriftDistributedQueriesIndexed()
     {
-        super(() -> createThriftQueryRunner(2, 2, true, ImmutableMap.of()));
+        super(() -> createThriftQueryRunner(2, 2, true, ImmutableMap.of("task.bypass-http-for-local", "false")));
     }
 
     @Override


### PR DESCRIPTION
#13937 
If a global config is set and the node-uri matches the current
node, then use the task manager directly for fetching exchange data and
doing task calls. That is bypass the taskResource if these conditions
are satisfied.

In addition, the backoff changed  such that the local mode
never undergoes a backoff. It's a bit hacky but does the job.

Can be enabled (default is disabled) by setting
task.bypass-http-for-local=true

In the low latency one-node setup (designed by @agrawaldevesh ), large sum of latency stemmed from http calls on the local host, this change helps shave of that latency piece 
```
== RELEASE NOTES ==

General Changes
* Bypass http call if the node is local with global config