### PR TITLE
Populate basic query info for skipped events in Verifier

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/event/QueryInfo.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/event/QueryInfo.java
@@ -42,6 +42,14 @@ public class QueryInfo
     public QueryInfo(
             String catalog,
             String schema,
+            String originalQuery)
+    {
+        this(catalog, schema, originalQuery, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    public QueryInfo(
+            String catalog,
+            String schema,
             String originalQuery,
             Optional<String> queryId,
             Optional<String> checksumQueryId,

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/event/VerifierQueryEvent.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/event/VerifierQueryEvent.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.event.client.EventField;
 import com.facebook.airlift.event.client.EventType;
 import com.facebook.presto.verifier.framework.DeterminismAnalysis;
 import com.facebook.presto.verifier.framework.SkippedReason;
+import com.facebook.presto.verifier.framework.SourceQuery;
 import com.google.common.collect.ImmutableList;
 
 import javax.annotation.concurrent.Immutable;
@@ -69,8 +70,8 @@ public class VerifierQueryEvent
             Optional<DeterminismAnalysis> determinismAnalysis,
             Optional<DeterminismAnalysisDetails> determinismAnalysisDetails,
             Optional<String> resolveMessage,
-            Optional<QueryInfo> controlQueryInfo,
-            Optional<QueryInfo> testQueryInfo,
+            QueryInfo controlQueryInfo,
+            QueryInfo testQueryInfo,
             Optional<String> errorCode,
             Optional<String> errorMessage,
             Optional<QueryFailure> finalQueryFailure,
@@ -85,8 +86,8 @@ public class VerifierQueryEvent
         this.determinismAnalysis = determinismAnalysis.map(DeterminismAnalysis::name).orElse(null);
         this.determinismAnalysisDetails = determinismAnalysisDetails.orElse(null);
         this.resolveMessage = resolveMessage.orElse(null);
-        this.controlQueryInfo = controlQueryInfo.orElse(null);
-        this.testQueryInfo = testQueryInfo.orElse(null);
+        this.controlQueryInfo = requireNonNull(controlQueryInfo, "controlQueryInfo is null");
+        this.testQueryInfo = requireNonNull(testQueryInfo, "testQueryInfo is null");
         this.errorCode = errorCode.orElse(null);
         this.errorMessage = errorMessage.orElse(null);
         this.finalQueryFailure = finalQueryFailure.orElse(null);
@@ -96,20 +97,26 @@ public class VerifierQueryEvent
     public static VerifierQueryEvent skipped(
             String suite,
             String testId,
-            String name,
+            SourceQuery sourceQuery,
             SkippedReason skippedReason)
     {
         return new VerifierQueryEvent(
                 suite,
                 testId,
-                name,
+                sourceQuery.getName(),
                 SKIPPED,
                 Optional.of(skippedReason),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
+                new QueryInfo(
+                        sourceQuery.getControlConfiguration().getCatalog(),
+                        sourceQuery.getControlConfiguration().getSchema(),
+                        sourceQuery.getControlQuery()),
+                new QueryInfo(
+                        sourceQuery.getTestConfiguration().getCatalog(),
+                        sourceQuery.getTestConfiguration().getSchema(),
+                        sourceQuery.getTestQuery()),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
@@ -282,20 +282,20 @@ public abstract class AbstractVerification
                                 verificationContext.getLimitQueryAnalysisQueryId())) :
                         Optional.empty(),
                 resolveMessage,
-                Optional.of(buildQueryInfo(
+                buildQueryInfo(
                         sourceQuery.getControlConfiguration(),
                         sourceQuery.getControlQuery(),
                         verificationContext.getControlChecksumQueryId(),
                         verificationContext.getControlChecksumQuery(),
                         control,
-                        controlStats)),
-                Optional.of(buildQueryInfo(
+                        controlStats),
+                buildQueryInfo(
                         sourceQuery.getTestConfiguration(),
                         sourceQuery.getTestQuery(),
                         verificationContext.getTestChecksumQueryId(),
                         verificationContext.getTestChecksumQuery(),
                         test,
-                        testStats)),
+                        testStats),
                 errorCode,
                 Optional.ofNullable(errorMessage),
                 queryException.map(QueryException::toQueryFailure),

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationManager.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationManager.java
@@ -231,10 +231,10 @@ public class VerificationManager
                 QueryType testQueryType = QueryType.of(sqlParser.createStatement(sourceQuery.getTestQuery(), PARSING_OPTIONS));
 
                 if (controlQueryType != testQueryType) {
-                    postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery.getName(), MISMATCHED_QUERY_TYPE));
+                    postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery, MISMATCHED_QUERY_TYPE));
                 }
                 else if (controlQueryType.getCategory() != DATA_PRODUCING) {
-                    postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery.getName(), UNSUPPORTED_QUERY_TYPE));
+                    postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery, UNSUPPORTED_QUERY_TYPE));
                 }
                 else {
                     selected.add(sourceQuery);
@@ -242,10 +242,10 @@ public class VerificationManager
             }
             catch (ParsingException e) {
                 log.warn("Failed to parse query: %s", sourceQuery.getName());
-                postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery.getName(), SYNTAX_ERROR));
+                postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery, SYNTAX_ERROR));
             }
             catch (UnsupportedQueryTypeException ignored) {
-                postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery.getName(), UNSUPPORTED_QUERY_TYPE));
+                postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery, UNSUPPORTED_QUERY_TYPE));
             }
         }
         List<SourceQuery> selectQueries = selected.build();
@@ -267,7 +267,7 @@ public class VerificationManager
                 SourceQuery sourceQuery = iterator.next();
                 if (!filter.test(sourceQuery)) {
                     iterator.remove();
-                    postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery.getName(), CUSTOM_FILTER));
+                    postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery, CUSTOM_FILTER));
                 }
             }
             log.info("Applying custom filter %s... Remaining queries: %s", filter.getClass().getSimpleName(), sourceQueries.size());


### PR DESCRIPTION
When a verification is skipped, we can still populate the control/test catalog, schema, and original query.

```
== NO RELEASE NOTE ==
```
