### PR TITLE
Raptor background jobs

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplitManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplitManager.java
@@ -247,7 +247,12 @@ public class RaptorSplitManager
                     throw new PrestoException(NO_NODES_AVAILABLE, "No nodes available to run query");
                 }
                 Node node = selectRandom(availableNodes);
-                shardManager.replaceShardAssignment(tableId, shardUuid, node.getNodeIdentifier(), true);
+                shardManager.replaceShardAssignment(
+                        tableId,
+                        shardUuid,
+                        deltaShardUuid,
+                        node.getNodeIdentifier(),
+                        true);
                 addresses = ImmutableList.of(node.getHostAndPort());
             }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
@@ -958,6 +958,12 @@ public class DatabaseShardManager
     }
 
     @Override
+    public Set<ShardMetadata> getNodeShardsAndDeltas(String nodeIdentifier)
+    {
+        return dao.getNodeShardsAndDeltas(nodeIdentifier, null);
+    }
+
+    @Override
     public Set<ShardMetadata> getNodeShards(String nodeIdentifier)
     {
         return dao.getNodeShards(nodeIdentifier, null);

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
@@ -988,7 +988,7 @@ public class DatabaseShardManager
     }
 
     @Override
-    public void replaceShardAssignment(long tableId, UUID shardUuid, String nodeIdentifier, boolean gracePeriod)
+    public void replaceShardAssignment(long tableId, UUID shardUuid, Optional<UUID> deltaUuid, String nodeIdentifier, boolean gracePeriod)
     {
         if (gracePeriod && (nanosSince(startTime).compareTo(startupGracePeriod) < 0)) {
             throw new PrestoException(SERVER_STARTING_UP, "Cannot reassign shards while server is starting");
@@ -1000,10 +1000,18 @@ public class DatabaseShardManager
             ShardDao dao = shardDaoSupplier.attach(handle);
 
             Set<Integer> oldAssignments = new HashSet<>(fetchLockedNodeIds(handle, tableId, shardUuid));
+
+            // 1. Update index table
             updateNodeIds(handle, tableId, shardUuid, ImmutableSet.of(nodeId));
 
+            // 2. Update shards table
             dao.deleteShardNodes(shardUuid, oldAssignments);
             dao.insertShardNode(shardUuid, nodeId);
+
+            if (deltaUuid.isPresent()) {
+                dao.deleteShardNodes(deltaUuid.get(), oldAssignments);
+                dao.insertShardNode(deltaUuid.get(), nodeId);
+            }
             return null;
         });
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardCleaner.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardCleaner.java
@@ -379,7 +379,7 @@ public class ShardCleaner
             throws IOException
     {
         // get shards assigned to the local node
-        Set<UUID> assigned = dao.getNodeShards(currentNode, null).stream()
+        Set<UUID> assigned = dao.getNodeShardsAndDeltas(currentNode, null).stream()
                 .map(ShardMetadata::getShardUuid)
                 .collect(toSet());
 
@@ -402,7 +402,7 @@ public class ShardCleaner
         Set<UUID> local = getLocalShards();
 
         // get shards assigned to the local node
-        Set<UUID> assigned = dao.getNodeShards(currentNode, null).stream()
+        Set<UUID> assigned = dao.getNodeShardsAndDeltas(currentNode, null).stream()
                 .map(ShardMetadata::getShardUuid)
                 .collect(toSet());
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardDao.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardDao.java
@@ -87,6 +87,32 @@ public interface ShardDao
             "      AND (s.table_id = :tableId OR :tableId IS NULL)\n" +
             ") x")
     @Mapper(ShardMetadata.Mapper.class)
+    Set<ShardMetadata> getNodeShardsAndDeltas(@Bind("nodeIdentifier") String nodeIdentifier, @Bind("tableId") Long tableId);
+
+    @SqlQuery("SELECT " + SHARD_METADATA_COLUMNS + "\n" +
+            "FROM (\n" +
+            "    SELECT s.*\n" +
+            "    FROM shards s\n" +
+            "    JOIN shard_nodes sn ON (s.shard_id = sn.shard_id)\n" +
+            "    JOIN nodes n ON (sn.node_id = n.node_id)\n" +
+            "    WHERE n.node_identifier = :nodeIdentifier\n" +
+            "      AND s.bucket_number IS NULL\n" +
+            "      AND s.is_delta = false\n" +
+            "      AND (s.table_id = :tableId OR :tableId IS NULL)\n" +
+            "  UNION ALL\n" +
+            "    SELECT s.*\n" +
+            "    FROM shards s\n" +
+            "    JOIN tables t ON (s.table_id = t.table_id)\n" +
+            "    JOIN distributions d ON (t.distribution_id = d.distribution_id)\n" +
+            "    JOIN buckets b ON (\n" +
+            "      d.distribution_id = b.distribution_id AND\n" +
+            "      s.bucket_number = b.bucket_number)\n" +
+            "    JOIN nodes n ON (b.node_id = n.node_id)\n" +
+            "    WHERE n.node_identifier = :nodeIdentifier\n" +
+            "      AND s.is_delta  = false\n" +
+            "      AND (s.table_id = :tableId OR :tableId IS NULL)\n" +
+            ") x")
+    @Mapper(ShardMetadata.Mapper.class)
     Set<ShardMetadata> getNodeShards(@Bind("nodeIdentifier") String nodeIdentifier, @Bind("tableId") Long tableId);
 
     @SqlQuery("SELECT n.node_identifier, x.bytes\n" +

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
@@ -102,7 +102,7 @@ public interface ShardManager
     /**
      * Remove all old shard assignments and assign a shard to a node
      */
-    void replaceShardAssignment(long tableId, UUID shardUuid, String nodeIdentifier, boolean gracePeriod);
+    void replaceShardAssignment(long tableId, UUID shardUuid, Optional<UUID> deltaUuid, String nodeIdentifier, boolean gracePeriod);
 
     /**
      * Get the number of bytes used by assigned shards per node.

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/ShardManager.java
@@ -73,12 +73,19 @@ public interface ShardManager
     ShardMetadata getShard(UUID shardUuid);
 
     /**
-     * Get shard metadata for shards on a given node.
+     * Get shard and delta metadata for shards on a given node.
+     */
+    Set<ShardMetadata> getNodeShardsAndDeltas(String nodeIdentifier);
+
+    /**
+     * Get only shard metadata for shards on a given node.
+     * Note: shard metadata will contain its delta
      */
     Set<ShardMetadata> getNodeShards(String nodeIdentifier);
 
     /**
-     * Get shard metadata for shards on a given node.
+     * Get only shard metadata for shards on a given node.
+     * Note: shard metadata will contain its delta
      */
     Set<ShardMetadata> getNodeShards(String nodeIdentifier, long tableId);
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardRecoveryManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardRecoveryManager.java
@@ -188,7 +188,7 @@ public class ShardRecoveryManager
 
     private Set<ShardMetadata> getMissingShards()
     {
-        return shardManager.getNodeShards(nodeIdentifier).stream()
+        return shardManager.getNodeShardsAndDeltas(nodeIdentifier).stream()
                 .filter(shard -> shardNeedsRecovery(shard.getShardUuid(), shard.getCompressedSize()))
                 .collect(toSet());
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/CompactionSetCreator.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/CompactionSetCreator.java
@@ -70,16 +70,21 @@ public class CompactionSetCreator
         ImmutableSet.Builder<ShardIndexInfo> builder = ImmutableSet.builder();
         ImmutableSet.Builder<OrganizationSet> compactionSets = ImmutableSet.builder();
 
+        int priority = 0;
         for (ShardIndexInfo shard : shards) {
             if (((consumedBytes + shard.getUncompressedSize()) > maxShardSize.toBytes()) ||
                     (consumedRows + shard.getRowCount() > maxShardRows)) {
                 // Finalize this compaction set, and start a new one for the rest of the shards
                 Set<ShardIndexInfo> shardsToCompact = builder.build();
-                addToCompactionSets(compactionSets, shardsToCompact, tableId, tableInfo);
+                addToCompactionSets(compactionSets, shardsToCompact, tableId, tableInfo, priority);
 
+                priority = 0;
                 builder = ImmutableSet.builder();
                 consumedBytes = 0;
                 consumedRows = 0;
+            }
+            if (shard.getDeltaUuid().isPresent()) {
+                priority += 1;
             }
             builder.add(shard);
             consumedBytes += shard.getUncompressedSize();
@@ -88,15 +93,15 @@ public class CompactionSetCreator
 
         // create compaction set for the remaining shards of this day
         Set<ShardIndexInfo> shardsToCompact = builder.build();
-        addToCompactionSets(compactionSets, shardsToCompact, tableId, tableInfo);
+        addToCompactionSets(compactionSets, shardsToCompact, tableId, tableInfo, priority);
         return compactionSets.build();
     }
 
-    private void addToCompactionSets(ImmutableSet.Builder<OrganizationSet> compactionSets, Set<ShardIndexInfo> shardsToCompact, long tableId, Table tableInfo)
+    private void addToCompactionSets(ImmutableSet.Builder<OrganizationSet> compactionSets, Set<ShardIndexInfo> shardsToCompact, long tableId, Table tableInfo, int priority)
     {
         // Add special rule for shard which is too big to compact with other shards but have delta to compact
         if (shardsToCompact.size() > 1 || shardsToCompact.stream().anyMatch(shard -> shard.getDeltaUuid().isPresent())) {
-            compactionSets.add(createOrganizationSet(tableId, tableInfo.isTableSupportsDeltaDelete(), shardsToCompact));
+            compactionSets.add(createOrganizationSet(tableId, tableInfo.isTableSupportsDeltaDelete(), shardsToCompact, priority));
         }
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/OrganizationJob.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/OrganizationJob.java
@@ -31,6 +31,7 @@ import java.util.OptionalLong;
 import java.util.UUID;
 
 import static com.facebook.presto.spi.block.SortOrder.ASC_NULLS_FIRST;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -123,5 +124,22 @@ class OrganizationJob
                 tableMetadata.getColumns(),
                 tableMetadata.getSortColumnIds(),
                 nCopies(tableMetadata.getSortColumnIds().size(), ASC_NULLS_FIRST));
+    }
+
+    public int getPriority()
+    {
+        return organizationSet.getPriority();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("metadataDao", metadataDao)
+                .add("shardManager", shardManager)
+                .add("compactor", compactor)
+                .add("organizationSet", organizationSet)
+                .add("priority", organizationSet.getPriority())
+                .toString();
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/OrganizationSet.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/OrganizationSet.java
@@ -13,7 +13,9 @@
  */
 package com.facebook.presto.raptor.storage.organization;
 
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.UUID;
@@ -24,13 +26,15 @@ import static java.util.Objects.requireNonNull;
 public class OrganizationSet
 {
     private final long tableId;
-    private final Set<UUID> shards;
+    private final boolean tableSupportsDeltaDelete;
+    private final Map<UUID, Optional<UUID>> shardsMap;
     private final OptionalInt bucketNumber;
 
-    public OrganizationSet(long tableId, Set<UUID> shards, OptionalInt bucketNumber)
+    public OrganizationSet(long tableId, boolean tableSupportsDeltaDelete, Map<UUID, Optional<UUID>> shardsMap, OptionalInt bucketNumber)
     {
         this.tableId = tableId;
-        this.shards = requireNonNull(shards, "shards is null");
+        this.tableSupportsDeltaDelete = tableSupportsDeltaDelete;
+        this.shardsMap = requireNonNull(shardsMap, "shards is null");
         this.bucketNumber = requireNonNull(bucketNumber, "bucketNumber is null");
     }
 
@@ -39,9 +43,19 @@ public class OrganizationSet
         return tableId;
     }
 
+    public boolean isTableSupportsDeltaDelete()
+    {
+        return tableSupportsDeltaDelete;
+    }
+
+    public Map<UUID, Optional<UUID>> getShardsMap()
+    {
+        return shardsMap;
+    }
+
     public Set<UUID> getShards()
     {
-        return shards;
+        return shardsMap.keySet();
     }
 
     public OptionalInt getBucketNumber()
@@ -60,14 +74,15 @@ public class OrganizationSet
         }
         OrganizationSet that = (OrganizationSet) o;
         return tableId == that.tableId &&
-                Objects.equals(shards, that.shards) &&
+                tableSupportsDeltaDelete == that.tableSupportsDeltaDelete &&
+                Objects.equals(shardsMap, that.shardsMap) &&
                 Objects.equals(bucketNumber, that.bucketNumber);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(tableId, shards, bucketNumber);
+        return Objects.hash(tableId, tableSupportsDeltaDelete, shardsMap, bucketNumber);
     }
 
     @Override
@@ -75,7 +90,8 @@ public class OrganizationSet
     {
         return toStringHelper(this)
                 .add("tableId", tableId)
-                .add("shards", shards)
+                .add("tableSupportsDeltaDelete", tableSupportsDeltaDelete)
+                .add("shards", shardsMap)
                 .add("bucketNumber", bucketNumber.isPresent() ? bucketNumber.getAsInt() : null)
                 .omitNullValues()
                 .toString();

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/OrganizationSet.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/OrganizationSet.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toSet;
 
 public class OrganizationSet
 {
@@ -29,13 +30,15 @@ public class OrganizationSet
     private final boolean tableSupportsDeltaDelete;
     private final Map<UUID, Optional<UUID>> shardsMap;
     private final OptionalInt bucketNumber;
+    private final int priority;
 
-    public OrganizationSet(long tableId, boolean tableSupportsDeltaDelete, Map<UUID, Optional<UUID>> shardsMap, OptionalInt bucketNumber)
+    public OrganizationSet(long tableId, boolean tableSupportsDeltaDelete, Map<UUID, Optional<UUID>> shardsMap, OptionalInt bucketNumber, int priority)
     {
         this.tableId = tableId;
         this.tableSupportsDeltaDelete = tableSupportsDeltaDelete;
         this.shardsMap = requireNonNull(shardsMap, "shards is null");
         this.bucketNumber = requireNonNull(bucketNumber, "bucketNumber is null");
+        this.priority = priority;
     }
 
     public long getTableId()
@@ -61,6 +64,11 @@ public class OrganizationSet
     public OptionalInt getBucketNumber()
     {
         return bucketNumber;
+    }
+
+    public int getPriority()
+    {
+        return priority;
     }
 
     @Override
@@ -91,7 +99,9 @@ public class OrganizationSet
         return toStringHelper(this)
                 .add("tableId", tableId)
                 .add("tableSupportsDeltaDelete", tableSupportsDeltaDelete)
-                .add("shards", shardsMap)
+                .add("shardSize", shardsMap.size())
+                .add("deltaSize", shardsMap.values().stream().filter(Optional::isPresent).collect(toSet()).size())
+                .add("priority", priority)
                 .add("bucketNumber", bucketNumber.isPresent() ? bucketNumber.getAsInt() : null)
                 .omitNullValues()
                 .toString();

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardCompactionManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardCompactionManager.java
@@ -179,7 +179,7 @@ public class ShardCompactionManager
             }
             List<ShardMetadata> shards = entry.getValue();
             Collection<OrganizationSet> organizationSets = filterAndCreateCompactionSets(tableId, shards);
-            log.info("Created %s organization set(s) for table ID %s", organizationSets.size(), tableId);
+            log.info("Created %s compaction set(s) from %s shards for table ID %s", organizationSets.size(), shards.size(), tableId);
 
             for (OrganizationSet set : organizationSets) {
                 organizer.enqueue(set);
@@ -230,6 +230,10 @@ public class ShardCompactionManager
         }
 
         if (shard.getRowCount() < (FILL_FACTOR * maxShardRows)) {
+            return true;
+        }
+
+        if (shard.getDeltaUuid().isPresent()) {
             return true;
         }
         return false;

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardIndexInfo.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardIndexInfo.java
@@ -26,6 +26,8 @@ public class ShardIndexInfo
     private final long tableId;
     private final OptionalInt bucketNumber;
     private final UUID shardUuid;
+    private final boolean isDelta;
+    private final Optional<UUID> deltaUuid;
     private final long rowCount;
     private final long uncompressedSize;
     private final Optional<ShardRange> sortRange;
@@ -35,6 +37,8 @@ public class ShardIndexInfo
             long tableId,
             OptionalInt bucketNumber,
             UUID shardUuid,
+            boolean isDelta,
+            Optional<UUID> deltaUuid,
             long rowCount,
             long uncompressedSize,
             Optional<ShardRange> sortRange,
@@ -43,6 +47,8 @@ public class ShardIndexInfo
         this.tableId = tableId;
         this.bucketNumber = requireNonNull(bucketNumber, "bucketNumber is null");
         this.shardUuid = requireNonNull(shardUuid, "shardUuid is null");
+        this.isDelta = isDelta;
+        this.deltaUuid = requireNonNull(deltaUuid, "Optional<deltaUuid> is null");
         this.rowCount = rowCount;
         this.uncompressedSize = uncompressedSize;
         this.sortRange = requireNonNull(sortRange, "sortRange is null");
@@ -62,6 +68,16 @@ public class ShardIndexInfo
     public UUID getShardUuid()
     {
         return shardUuid;
+    }
+
+    public boolean isDelta()
+    {
+        return isDelta;
+    }
+
+    public Optional<UUID> getDeltaUuid()
+    {
+        return deltaUuid;
     }
 
     public long getRowCount()
@@ -97,6 +113,8 @@ public class ShardIndexInfo
         return tableId == that.tableId &&
                 rowCount == that.rowCount &&
                 uncompressedSize == that.uncompressedSize &&
+                isDelta == that.isDelta &&
+                Objects.equals(deltaUuid, that.deltaUuid) &&
                 Objects.equals(bucketNumber, that.bucketNumber) &&
                 Objects.equals(shardUuid, that.shardUuid) &&
                 Objects.equals(sortRange, that.sortRange) &&
@@ -106,7 +124,7 @@ public class ShardIndexInfo
     @Override
     public int hashCode()
     {
-        return Objects.hash(tableId, bucketNumber, shardUuid, rowCount, uncompressedSize, sortRange, temporalRange);
+        return Objects.hash(tableId, bucketNumber, shardUuid, rowCount, isDelta, deltaUuid, uncompressedSize, sortRange, temporalRange);
     }
 
     @Override
@@ -116,6 +134,8 @@ public class ShardIndexInfo
                 .add("tableId", tableId)
                 .add("bucketNumber", bucketNumber.isPresent() ? bucketNumber.getAsInt() : null)
                 .add("shardUuid", shardUuid)
+                .add("isDelta", isDelta)
+                .add("deltaUuid", deltaUuid.orElse(null))
                 .add("rowCount", rowCount)
                 .add("uncompressedSize", uncompressedSize)
                 .add("sortRange", sortRange.orElse(null))

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardOrganizationManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardOrganizationManager.java
@@ -279,7 +279,7 @@ public class ShardOrganizationManager
             else {
                 Set<ShardIndexInfo> indexInfos = builder.build();
                 if (indexInfos.size() > 1) {
-                    organizationSets.add(createOrganizationSet(tableInfo.getTableId(), indexInfos));
+                    organizationSets.add(createOrganizationSet(tableInfo.getTableId(), tableInfo.isTableSupportsDeltaDelete(), indexInfos));
                 }
                 builder = ImmutableSet.builder();
                 previousRange = nextRange;
@@ -290,7 +290,7 @@ public class ShardOrganizationManager
 
         Set<ShardIndexInfo> indexInfos = builder.build();
         if (indexInfos.size() > 1) {
-            organizationSets.add(createOrganizationSet(tableInfo.getTableId(), indexInfos));
+            organizationSets.add(createOrganizationSet(tableInfo.getTableId(), tableInfo.isTableSupportsDeltaDelete(), indexInfos));
         }
         return organizationSets;
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardOrganizer.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardOrganizer.java
@@ -17,16 +17,22 @@ import com.facebook.airlift.concurrent.ThreadPoolExecutorMBean;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.raptor.storage.StorageManagerConfig;
+import com.facebook.presto.raptor.util.PrioritizedFifoExecutor;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -35,14 +41,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.CompletableFuture.runAsync;
-import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.stream.Collectors.toSet;
 
 public class ShardOrganizer
 {
     private static final Logger log = Logger.get(ShardOrganizer.class);
 
     private final ExecutorService executorService;
+    private final PrioritizedFifoExecutor<Runnable> prioritizedFifoExecutor;
     private final ThreadPoolExecutorMBean executorMBean;
 
     private final AtomicBoolean shutdown = new AtomicBoolean();
@@ -52,6 +59,8 @@ public class ShardOrganizer
     private final JobFactory jobFactory;
     private final CounterStat successCount = new CounterStat();
     private final CounterStat failureCount = new CounterStat();
+
+    private int deltaCountInProgress;
 
     @Inject
     public ShardOrganizer(JobFactory jobFactory, StorageManagerConfig config)
@@ -63,7 +72,8 @@ public class ShardOrganizer
     {
         checkArgument(threads > 0, "threads must be > 0");
         this.jobFactory = requireNonNull(jobFactory, "jobFactory is null");
-        this.executorService = newFixedThreadPool(threads, daemonThreadsNamed("shard-organizer-%s"));
+        this.executorService = newCachedThreadPool(daemonThreadsNamed("shard-organizer-%s"));
+        this.prioritizedFifoExecutor = new PrioritizedFifoExecutor(executorService, threads, new OrganizationJobComparator());
         this.executorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) executorService);
     }
 
@@ -75,27 +85,43 @@ public class ShardOrganizer
         }
     }
 
-    public CompletableFuture<?> enqueue(OrganizationSet organizationSet)
+    public ListenableFuture<?> enqueue(OrganizationSet organizationSet)
     {
+        log.info("enqueue organizationSet: %s", organizationSet);
         shardsInProgress.putAll(organizationSet.getShardsMap());
-        return runAsync(jobFactory.create(organizationSet), executorService)
-                .whenComplete((none, throwable) -> {
+        deltaCountInProgress = shardsInProgress.values().stream().filter(Optional::isPresent).collect(toSet()).size();
+        ListenableFuture<?> listenableFuture = prioritizedFifoExecutor.submit(jobFactory.create(organizationSet));
+        listenableFuture.addListener(
+                () -> {
                     for (UUID uuid : organizationSet.getShardsMap().keySet()) {
                         shardsInProgress.remove(uuid);
+                        deltaCountInProgress = shardsInProgress.values().stream().filter(Optional::isPresent).collect(toSet()).size();
                     }
-                    if (throwable == null) {
+                },
+                MoreExecutors.directExecutor());
+        Futures.addCallback(
+                listenableFuture,
+                new FutureCallback<Object>() {
+                    @Override
+                    public void onSuccess(Object o)
+                    {
                         successCount.update(1);
                     }
-                    else {
+
+                    @Override
+                    public void onFailure(Throwable throwable)
+                    {
                         log.warn(throwable, "Error running organization job");
                         failureCount.update(1);
                     }
-                });
+                },
+                MoreExecutors.directExecutor());
+        return listenableFuture;
     }
 
     public boolean inProgress(UUID shardUuid)
     {
-        return shardsInProgress.keySet().contains(shardUuid);
+        return shardsInProgress.containsKey(shardUuid);
     }
 
     @Managed
@@ -112,6 +138,12 @@ public class ShardOrganizer
     }
 
     @Managed
+    public int getDeltaCountInProgress()
+    {
+        return deltaCountInProgress;
+    }
+
+    @Managed
     @Nested
     public CounterStat getSuccessCount()
     {
@@ -123,5 +155,16 @@ public class ShardOrganizer
     public CounterStat getFailureCount()
     {
         return failureCount;
+    }
+
+    @VisibleForTesting
+    static class OrganizationJobComparator
+            implements Comparator<OrganizationJob>
+    {
+        @Override
+        public int compare(OrganizationJob left, OrganizationJob right)
+        {
+            return right.getPriority() - left.getPriority();
+        }
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardOrganizerUtil.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardOrganizerUtil.java
@@ -42,6 +42,7 @@ import static com.facebook.presto.raptor.metadata.DatabaseShardManager.minColumn
 import static com.facebook.presto.raptor.metadata.DatabaseShardManager.shardIndexTable;
 import static com.facebook.presto.raptor.storage.ColumnIndexStatsUtils.jdbcType;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Iterables.partition;
 import static com.google.common.collect.Maps.uniqueIndex;
@@ -137,6 +138,8 @@ public class ShardOrganizerUtil
                 shardMetadata.getTableId(),
                 shardMetadata.getBucketNumber(),
                 shardMetadata.getShardUuid(),
+                shardMetadata.isDelta(),
+                shardMetadata.getDeltaUuid(),
                 shardMetadata.getRowCount(),
                 shardMetadata.getUncompressedSize(),
                 sortRange,
@@ -238,17 +241,16 @@ public class ShardOrganizerUtil
         throw new IllegalArgumentException("Unhandled type: " + type);
     }
 
-    static OrganizationSet createOrganizationSet(long tableId, Set<ShardIndexInfo> shardsToCompact)
+    static OrganizationSet createOrganizationSet(long tableId, boolean tableSupportsDeltaDelete, Set<ShardIndexInfo> shardsToCompact)
     {
-        Set<UUID> uuids = shardsToCompact.stream()
-                .map(ShardIndexInfo::getShardUuid)
-                .collect(toSet());
+        Map<UUID, Optional<UUID>> uuidsMap = shardsToCompact.stream()
+                .collect(toImmutableMap(ShardIndexInfo::getShardUuid, ShardIndexInfo::getDeltaUuid));
 
         Set<OptionalInt> bucketNumber = shardsToCompact.stream()
                 .map(ShardIndexInfo::getBucketNumber)
                 .collect(toSet());
 
         checkArgument(bucketNumber.size() == 1);
-        return new OrganizationSet(tableId, uuids, getOnlyElement(bucketNumber));
+        return new OrganizationSet(tableId, tableSupportsDeltaDelete, uuidsMap, getOnlyElement(bucketNumber));
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardOrganizerUtil.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/organization/ShardOrganizerUtil.java
@@ -241,7 +241,7 @@ public class ShardOrganizerUtil
         throw new IllegalArgumentException("Unhandled type: " + type);
     }
 
-    static OrganizationSet createOrganizationSet(long tableId, boolean tableSupportsDeltaDelete, Set<ShardIndexInfo> shardsToCompact)
+    static OrganizationSet createOrganizationSet(long tableId, boolean tableSupportsDeltaDelete, Set<ShardIndexInfo> shardsToCompact, int priority)
     {
         Map<UUID, Optional<UUID>> uuidsMap = shardsToCompact.stream()
                 .collect(toImmutableMap(ShardIndexInfo::getShardUuid, ShardIndexInfo::getDeltaUuid));
@@ -251,6 +251,6 @@ public class ShardOrganizerUtil
                 .collect(toSet());
 
         checkArgument(bucketNumber.size() == 1);
-        return new OrganizationSet(tableId, tableSupportsDeltaDelete, uuidsMap, getOnlyElement(bucketNumber));
+        return new OrganizationSet(tableId, tableSupportsDeltaDelete, uuidsMap, getOnlyElement(bucketNumber), priority);
     }
 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
@@ -222,7 +222,7 @@ public class TestDatabaseShardManager
         assertEquals(actual, new ShardNodes(shard, Optional.empty(), ImmutableSet.of("node1")));
 
         try {
-            shardManager.replaceShardAssignment(tableId, shard, "node2", true);
+            shardManager.replaceShardAssignment(tableId, shard, Optional.empty(), "node2", true);
             fail("expected exception");
         }
         catch (PrestoException e) {
@@ -230,13 +230,13 @@ public class TestDatabaseShardManager
         }
 
         // replace shard assignment to another node
-        shardManager.replaceShardAssignment(tableId, shard, "node2", false);
+        shardManager.replaceShardAssignment(tableId, shard, Optional.empty(), "node2", false);
 
         actual = getOnlyElement(getShardNodes(tableId, TupleDomain.all()));
         assertEquals(actual, new ShardNodes(shard, Optional.empty(), ImmutableSet.of("node2")));
 
         // replacing shard assignment should be idempotent
-        shardManager.replaceShardAssignment(tableId, shard, "node2", false);
+        shardManager.replaceShardAssignment(tableId, shard, Optional.empty(), "node2", false);
 
         actual = getOnlyElement(getShardNodes(tableId, TupleDomain.all()));
         assertEquals(actual, new ShardNodes(shard, Optional.empty(), ImmutableSet.of("node2")));
@@ -266,7 +266,7 @@ public class TestDatabaseShardManager
 
         assertEquals(shardManager.getNodeBytes(), ImmutableMap.of("node1", 88L));
 
-        shardManager.replaceShardAssignment(tableId, shard1, "node2", false);
+        shardManager.replaceShardAssignment(tableId, shard1, Optional.empty(), "node2", false);
 
         assertEquals(getShardNodes(tableId, TupleDomain.all()), ImmutableSet.of(
                 new ShardNodes(shard1, Optional.empty(), ImmutableSet.of("node2")),

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestDatabaseShardManager.java
@@ -296,7 +296,7 @@ public class TestDatabaseShardManager
         shardManager.commitShards(transactionId, tableId, columns, inputShards.build(), Optional.empty(), 0);
 
         for (String node : nodes) {
-            Set<ShardMetadata> shardMetadata = shardManager.getNodeShards(node);
+            Set<ShardMetadata> shardMetadata = shardManager.getNodeShardsAndDeltas(node);
             Set<UUID> expectedUuids = ImmutableSet.copyOf(nodeShardMap.get(node));
             Set<UUID> actualUuids = shardMetadata.stream().map(ShardMetadata::getShardUuid).collect(toSet());
             assertEquals(actualUuids, expectedUuids);
@@ -352,7 +352,7 @@ public class TestDatabaseShardManager
         ShardInfo newShardInfo4 = new ShardInfo(newUuid5, OptionalInt.empty(), ImmutableSet.of("node1"), ImmutableList.of(), 5, 5, 5, 5);
 
         // toReplace
-        Set<ShardMetadata> shardMetadata = shardManager.getNodeShards("node1");
+        Set<ShardMetadata> shardMetadata = shardManager.getNodeShardsAndDeltas("node1");
         Set<UUID> replacedUuids = shardMetadata.stream().map(ShardMetadata::getShardUuid).collect(toSet());
         Map<UUID, Optional<UUID>> replaceUuidMap = replacedUuids.stream().collect(Collectors.toMap(uuid -> uuid, uuid -> Optional.empty()));
 
@@ -360,7 +360,7 @@ public class TestDatabaseShardManager
         shardManager.replaceShardUuids(transactionId, tableId, columns, replaceUuidMap, ImmutableList.of(newShardInfo4), OptionalLong.of(0), true);
 
         // check shards on this node1 are correct
-        shardMetadata = shardManager.getNodeShards("node1");
+        shardMetadata = shardManager.getNodeShardsAndDeltas("node1");
         assertEquals(shardMetadata.size(), 1);
         for (ShardMetadata actual : shardMetadata) {
             assertEquals(actual.getShardUuid(), newUuid5);
@@ -422,7 +422,7 @@ public class TestDatabaseShardManager
                 .build();
 
         // toReplace
-        Set<ShardMetadata> shardMetadata = shardManager.getNodeShards(nodes.get(0));
+        Set<ShardMetadata> shardMetadata = shardManager.getNodeShardsAndDeltas(nodes.get(0));
         Set<UUID> replacedUuids = shardMetadata.stream().map(ShardMetadata::getShardUuid).collect(toSet());
         Map<UUID, Optional<UUID>> replaceUuidMap = replacedUuids.stream().collect(Collectors.toMap(uuid -> uuid, uuid -> Optional.empty()));
 
@@ -430,7 +430,7 @@ public class TestDatabaseShardManager
         shardManager.replaceShardUuids(transactionId, tableId, columns, replaceUuidMap, newShards, OptionalLong.of(0), true);
 
         // check that shards are replaced in shards table for node1
-        shardMetadata = shardManager.getNodeShards(nodes.get(0));
+        shardMetadata = shardManager.getNodeShardsAndDeltas(nodes.get(0));
         Set<UUID> actualUuids = shardMetadata.stream().map(ShardMetadata::getShardUuid).collect(toSet());
         assertEquals(actualUuids, ImmutableSet.copyOf(expectedUuids));
 
@@ -518,7 +518,7 @@ public class TestDatabaseShardManager
         shardManager.replaceDeltaUuids(transactionId, tableId, columns, shardMap, OptionalLong.of(0));
 
         // check shards on this node1 are correct
-        Set<ShardMetadata> shardMetadata = shardManager.getNodeShards("node1");
+        Set<ShardMetadata> shardMetadata = shardManager.getNodeShardsAndDeltas("node1");
         assertEquals(shardMetadata.size(), 3);
 
         // check index table as well
@@ -576,13 +576,13 @@ public class TestDatabaseShardManager
         shardManager.replaceDeltaUuids(transactionId, tableId, columns, shardMap, OptionalLong.of(0));
 
         // check that delta shard are added in shards table for node1
-        Set<ShardMetadata> shardMetadata = shardManager.getNodeShards(nodes.get(0));
+        Set<ShardMetadata> shardMetadata = shardManager.getNodeShardsAndDeltas(nodes.get(0));
         Map<UUID, Optional<UUID>> actualUuidsMap = shardMetadata.stream().collect(toImmutableMap(ShardMetadata::getShardUuid, ShardMetadata::getDeltaUuid));
         Map<UUID, Optional<UUID>> expectedUuidsMap = ImmutableMap.of(originalUuids.get(0), Optional.of(newDeltaUuid1), newDeltaUuid1, Optional.empty());
         assertEquals(actualUuidsMap, expectedUuidsMap);
 
         // check that shard are deleted in shards table for node2
-        shardMetadata = shardManager.getNodeShards(nodes.get(1));
+        shardMetadata = shardManager.getNodeShardsAndDeltas(nodes.get(1));
         actualUuidsMap = shardMetadata.stream().collect(toImmutableMap(ShardMetadata::getShardUuid, ShardMetadata::getDeltaUuid));
         expectedUuidsMap = ImmutableMap.of();
         assertEquals(actualUuidsMap, expectedUuidsMap);
@@ -628,7 +628,7 @@ public class TestDatabaseShardManager
         shardManager.replaceDeltaUuids(transactionId, tableId, columns, shardMap, OptionalLong.of(0));
 
         // check that delta shard are added in shards table for node1
-        shardMetadata = shardManager.getNodeShards(nodes.get(0));
+        shardMetadata = shardManager.getNodeShardsAndDeltas(nodes.get(0));
         actualUuidsMap = shardMetadata.stream().collect(toImmutableMap(ShardMetadata::getShardUuid, ShardMetadata::getDeltaUuid));
         expectedUuidsMap = ImmutableMap.of(originalUuids.get(0), Optional.of(anotherNewDeltaUuid1), anotherNewDeltaUuid1, Optional.empty());
         assertEquals(actualUuidsMap, expectedUuidsMap);
@@ -648,7 +648,7 @@ public class TestDatabaseShardManager
         shardManager.replaceShardUuids(transactionId, tableId, columns, replaceUuidMap, ImmutableSet.of(shardInfo(uuid4, nodes.get(0))), OptionalLong.of(0), true);
 
         // check that new shard are added, old shard and delta are deleted in shards table for node1
-        shardMetadata = shardManager.getNodeShards(nodes.get(0));
+        shardMetadata = shardManager.getNodeShardsAndDeltas(nodes.get(0));
         actualUuidsMap = shardMetadata.stream().collect(toImmutableMap(ShardMetadata::getShardUuid, ShardMetadata::getDeltaUuid));
         expectedUuidsMap = ImmutableMap.of(uuid4, Optional.empty());
         assertEquals(actualUuidsMap, expectedUuidsMap);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardDao.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestShardDao.java
@@ -188,8 +188,8 @@ public class TestShardDao
         assertEquals(dao.getShards(plainTableId), ImmutableSet.of(shardUuid1, shardUuid2));
         assertEquals(dao.getShards(bucketedTableId), ImmutableSet.of(shardUuid3, shardUuid4, shardUuid5));
 
-        assertEquals(dao.getNodeShards(nodeName1, null), ImmutableSet.of(shard3));
-        assertEquals(dao.getNodeShards(nodeName2, null), ImmutableSet.of(shard4, shard5));
+        assertEquals(dao.getNodeShardsAndDeltas(nodeName1, null), ImmutableSet.of(shard3));
+        assertEquals(dao.getNodeShardsAndDeltas(nodeName2, null), ImmutableSet.of(shard4, shard5));
         assertEquals(dao.getNodeSizes(), ImmutableSet.of(
                 new NodeSize(nodeName1, 33),
                 new NodeSize(nodeName2, 44 + 55)));
@@ -198,16 +198,16 @@ public class TestShardDao
         dao.insertShardNode(shardId2, nodeId1);
         dao.insertShardNode(shardId1, nodeId2);
 
-        assertEquals(dao.getNodeShards(nodeName1, null), ImmutableSet.of(shard1, shard2, shard3));
-        assertEquals(dao.getNodeShards(nodeName2, null), ImmutableSet.of(shard1, shard4, shard5));
+        assertEquals(dao.getNodeShardsAndDeltas(nodeName1, null), ImmutableSet.of(shard1, shard2, shard3));
+        assertEquals(dao.getNodeShardsAndDeltas(nodeName2, null), ImmutableSet.of(shard1, shard4, shard5));
         assertEquals(dao.getNodeSizes(), ImmutableSet.of(
                 new NodeSize(nodeName1, 11 + 22 + 33),
                 new NodeSize(nodeName2, 11 + 44 + 55)));
 
         dao.dropShardNodes(plainTableId);
 
-        assertEquals(dao.getNodeShards(nodeName1, null), ImmutableSet.of(shard3));
-        assertEquals(dao.getNodeShards(nodeName2, null), ImmutableSet.of(shard4, shard5));
+        assertEquals(dao.getNodeShardsAndDeltas(nodeName1, null), ImmutableSet.of(shard3));
+        assertEquals(dao.getNodeShardsAndDeltas(nodeName2, null), ImmutableSet.of(shard4, shard5));
         assertEquals(dao.getNodeSizes(), ImmutableSet.of(
                 new NodeSize(nodeName1, 33),
                 new NodeSize(nodeName2, 44 + 55)));

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardEjector.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestShardEjector.java
@@ -152,7 +152,7 @@ public class TestShardEjector
                 .map(ShardInfo::getShardUuid)
                 .collect(toSet());
 
-        Set<UUID> remaining = uuids(shardManager.getNodeShards("node1"));
+        Set<UUID> remaining = uuids(shardManager.getNodeShardsAndDeltas("node1"));
 
         for (UUID uuid : ejectedShards) {
             assertFalse(remaining.contains(uuid));
@@ -165,10 +165,10 @@ public class TestShardEjector
         }
 
         Set<UUID> others = ImmutableSet.<UUID>builder()
-                .addAll(uuids(shardManager.getNodeShards("node2")))
-                .addAll(uuids(shardManager.getNodeShards("node3")))
-                .addAll(uuids(shardManager.getNodeShards("node4")))
-                .addAll(uuids(shardManager.getNodeShards("node5")))
+                .addAll(uuids(shardManager.getNodeShardsAndDeltas("node2")))
+                .addAll(uuids(shardManager.getNodeShardsAndDeltas("node3")))
+                .addAll(uuids(shardManager.getNodeShardsAndDeltas("node4")))
+                .addAll(uuids(shardManager.getNodeShardsAndDeltas("node5")))
                 .build();
 
         assertTrue(others.containsAll(ejectedShards));

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestCompactionSetCreator.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestCompactionSetCreator.java
@@ -63,6 +63,19 @@ public class TestCompactionSetCreator
     }
 
     @Test
+    public void testNonTemporalOrganizationSetDelta()
+    {
+        List<ShardIndexInfo> inputShards = ImmutableList.of(
+                sharAndDeltaWithSize(10, 10),
+                sharAndDeltaWithSize(10, 10),
+                sharAndDeltaWithSize(10, 10));
+
+        Set<OrganizationSet> compactionSets = compactionSetCreator.createCompactionSets(tableInfo, inputShards);
+        assertEquals(compactionSets.size(), 1);
+        assertEquals(getOnlyElement(compactionSets).getShardsMap(), extractIndexes(inputShards, 0, 1, 2));
+    }
+
+    @Test
     public void testNonTemporalSizeBasedOrganizationSet()
     {
         List<ShardIndexInfo> inputShards = ImmutableList.of(
@@ -117,8 +130,8 @@ public class TestCompactionSetCreator
         assertEquals(actual.size(), 2);
 
         Set<OrganizationSet> expected = ImmutableSet.of(
-                new OrganizationSet(temporalTableInfo.getTableId(), false, extractIndexes(inputShards, 0, 3), OptionalInt.empty()),
-                new OrganizationSet(temporalTableInfo.getTableId(), false, extractIndexes(inputShards, 1, 2), OptionalInt.empty()));
+                new OrganizationSet(temporalTableInfo.getTableId(), false, extractIndexes(inputShards, 0, 3), OptionalInt.empty(), 0),
+                new OrganizationSet(temporalTableInfo.getTableId(), false, extractIndexes(inputShards, 1, 2), OptionalInt.empty(), 0));
         assertEquals(actual, expected);
     }
 
@@ -145,8 +158,8 @@ public class TestCompactionSetCreator
         assertEquals(compactionSets.size(), 2);
 
         Set<OrganizationSet> expected = ImmutableSet.of(
-                new OrganizationSet(tableId, false, extractIndexes(inputShards, 0, 1, 5, 6), OptionalInt.empty()),
-                new OrganizationSet(tableId, false, extractIndexes(inputShards, 2, 3, 4), OptionalInt.empty()));
+                new OrganizationSet(tableId, false, extractIndexes(inputShards, 0, 1, 5, 6), OptionalInt.empty(), 0),
+                new OrganizationSet(tableId, false, extractIndexes(inputShards, 2, 3, 4), OptionalInt.empty(), 0));
         assertEquals(compactionSets, expected);
     }
 
@@ -171,8 +184,8 @@ public class TestCompactionSetCreator
         assertEquals(actual.size(), 2);
 
         Set<OrganizationSet> expected = ImmutableSet.of(
-                new OrganizationSet(tableId, false, extractIndexes(inputShards, 0, 3, 5), OptionalInt.empty()),
-                new OrganizationSet(tableId, false, extractIndexes(inputShards, 1, 4), OptionalInt.empty()));
+                new OrganizationSet(tableId, false, extractIndexes(inputShards, 0, 3, 5), OptionalInt.empty(), 0),
+                new OrganizationSet(tableId, false, extractIndexes(inputShards, 1, 4), OptionalInt.empty(), 0));
         assertEquals(actual, expected);
     }
 
@@ -193,8 +206,8 @@ public class TestCompactionSetCreator
         assertEquals(actual.size(), 2);
 
         Set<OrganizationSet> expected = ImmutableSet.of(
-                new OrganizationSet(tableId, false, extractIndexes(inputShards, 0, 3, 5), OptionalInt.of(1)),
-                new OrganizationSet(tableId, false, extractIndexes(inputShards, 1, 2, 4), OptionalInt.of(2)));
+                new OrganizationSet(tableId, false, extractIndexes(inputShards, 0, 3, 5), OptionalInt.of(1), 0),
+                new OrganizationSet(tableId, false, extractIndexes(inputShards, 1, 2, 4), OptionalInt.of(2), 0));
         assertEquals(actual, expected);
     }
 
@@ -229,8 +242,8 @@ public class TestCompactionSetCreator
         assertEquals(actual.size(), 2);
 
         Set<OrganizationSet> expected = ImmutableSet.of(
-                new OrganizationSet(tableId, false, extractIndexes(inputShards, 0, 2), OptionalInt.of(1)),
-                new OrganizationSet(tableId, false, extractIndexes(inputShards, 1, 3), OptionalInt.of(2)));
+                new OrganizationSet(tableId, false, extractIndexes(inputShards, 0, 2), OptionalInt.of(1), 0),
+                new OrganizationSet(tableId, false, extractIndexes(inputShards, 1, 3), OptionalInt.of(2), 0));
         assertEquals(actual, expected);
     }
 
@@ -242,6 +255,20 @@ public class TestCompactionSetCreator
                 UUID.randomUUID(),
                 false,
                 Optional.empty(),
+                rows,
+                size,
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private static ShardIndexInfo sharAndDeltaWithSize(long rows, long size)
+    {
+        return new ShardIndexInfo(
+                1,
+                OptionalInt.empty(),
+                UUID.randomUUID(),
+                false,
+                Optional.of(UUID.randomUUID()),
                 rows,
                 size,
                 Optional.empty(),

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardCompactor.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardCompactor.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
@@ -43,13 +44,16 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.UUID;
 
 import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
+import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.raptor.storage.TestOrcStorageManager.createOrcStorageManager;
 import static com.facebook.presto.spi.block.SortOrder.ASC_NULLS_FIRST;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -120,15 +124,58 @@ public class TestShardCompactor
                 .sum();
         long expectedOutputShards = computeExpectedOutputShards(totalRows);
 
-        Set<UUID> inputUuids = inputShards.stream().map(ShardInfo::getShardUuid).collect(toSet());
+        Map<UUID, Optional<UUID>> inputUuids = new HashMap<>();
+        for (ShardInfo shardInfo : inputShards) {
+            inputUuids.put(shardInfo.getShardUuid(), Optional.empty());
+        }
 
         long transactionId = 1;
         ShardCompactor compactor = new ShardCompactor(storageManager, READER_ATTRIBUTES);
-        List<ShardInfo> outputShards = compactor.compact(transactionId, OptionalInt.empty(), inputUuids, getColumnInfo(columnIds, columnTypes));
+        List<ShardInfo> outputShards = compactor.compact(transactionId, false, OptionalInt.empty(), inputUuids, getColumnInfo(columnIds, columnTypes));
         assertEquals(outputShards.size(), expectedOutputShards);
 
         Set<UUID> outputUuids = outputShards.stream().map(ShardInfo::getShardUuid).collect(toSet());
-        assertShardEqualsIgnoreOrder(storageManager, inputUuids, outputUuids, columnIds, columnTypes);
+        assertShardEqualsIgnoreOrder(storageManager, inputUuids.keySet(), outputUuids, columnIds, columnTypes);
+    }
+
+    @Test
+    public void testShardCompactorWithDelta()
+            throws Exception
+    {
+        StorageManager storageManager = createOrcStorageManager(dbi, temporary, MAX_SHARD_ROWS);
+        List<Long> columnIds = ImmutableList.of(3L, 7L, 2L, 1L, 5L);
+        List<Type> columnTypes = ImmutableList.of(BIGINT, createVarcharType(20), DOUBLE, DATE, TIMESTAMP);
+
+        List<ShardInfo> inputShards = createShards(storageManager, columnIds, columnTypes, 3);
+        assertEquals(inputShards.size(), 3);
+
+        List<Long> deltaColumnIds = ImmutableList.of(1L);
+        List<Type> deltaColumnTypes = ImmutableList.of(BIGINT);
+        StoragePageSink deltaSink = createStoragePageSink(storageManager, deltaColumnIds, deltaColumnTypes);
+        List<Page> deltaPages = rowPagesBuilder(deltaColumnTypes)
+                .row(1L)
+                .row(2L)
+                .build();
+        deltaSink.appendPages(deltaPages);
+        List<ShardInfo> deltaShards = getFutureValue(deltaSink.commit());
+
+        long totalRows = inputShards.stream()
+                .mapToLong(ShardInfo::getRowCount)
+                .sum();
+        long expectedOutputShardsCount = computeExpectedOutputShards(totalRows - 2);
+
+        Map<UUID, Optional<UUID>> inputUuidsMap = new HashMap<>();
+        inputUuidsMap.put(inputShards.get(0).getShardUuid(), Optional.of(deltaShards.get(0).getShardUuid()));
+        inputUuidsMap.put(inputShards.get(1).getShardUuid(), Optional.empty());
+        inputUuidsMap.put(inputShards.get(2).getShardUuid(), Optional.empty());
+
+        long transactionId = 1;
+        ShardCompactor compactor = new ShardCompactor(storageManager, READER_ATTRIBUTES);
+        List<ShardInfo> outputShards = compactor.compact(transactionId, true, OptionalInt.empty(), inputUuidsMap, getColumnInfo(columnIds, columnTypes));
+        assertEquals(outputShards.size(), expectedOutputShardsCount);
+
+        Set<UUID> outputUuids = outputShards.stream().map(ShardInfo::getShardUuid).collect(toSet());
+        assertShardEqualsIgnoreOrder(storageManager, inputUuidsMap, outputUuids, columnIds, columnTypes);
     }
 
     @Test(dataProvider = "useOptimizedOrcWriter")
@@ -150,17 +197,20 @@ public class TestShardCompactor
         long totalRows = inputShards.stream().mapToLong(ShardInfo::getRowCount).sum();
         long expectedOutputShards = computeExpectedOutputShards(totalRows);
 
-        Set<UUID> inputUuids = inputShards.stream().map(ShardInfo::getShardUuid).collect(toSet());
+        Map<UUID, Optional<UUID>> inputUuids = new HashMap<>();
+        for (ShardInfo shardInfo : inputShards) {
+            inputUuids.put(shardInfo.getShardUuid(), Optional.empty());
+        }
 
         long transactionId = 1;
         ShardCompactor compactor = new ShardCompactor(storageManager, READER_ATTRIBUTES);
-        List<ShardInfo> outputShards = compactor.compactSorted(transactionId, OptionalInt.empty(), inputUuids, getColumnInfo(columnIds, columnTypes), sortColumnIds, sortOrders);
+        List<ShardInfo> outputShards = compactor.compactSorted(transactionId, false, OptionalInt.empty(), inputUuids, getColumnInfo(columnIds, columnTypes), sortColumnIds, sortOrders);
         List<UUID> outputUuids = outputShards.stream()
                 .map(ShardInfo::getShardUuid)
                 .collect(toList());
         assertEquals(outputShards.size(), expectedOutputShards);
 
-        assertShardEqualsSorted(storageManager, inputUuids, outputUuids, columnIds, columnTypes, sortIndexes, sortOrders);
+        assertShardEqualsSorted(storageManager, inputUuids.keySet(), outputUuids, columnIds, columnTypes, sortIndexes, sortOrders);
     }
 
     private static long computeExpectedOutputShards(long totalRows)
@@ -172,6 +222,15 @@ public class TestShardCompactor
             throws IOException
     {
         MaterializedResult inputRows = getMaterializedRows(storageManager, ImmutableList.copyOf(inputUuids), columnIds, columnTypes);
+        MaterializedResult outputRows = getMaterializedRows(storageManager, ImmutableList.copyOf(outputUuids), columnIds, columnTypes);
+
+        assertEqualsIgnoreOrder(outputRows, inputRows);
+    }
+
+    private void assertShardEqualsIgnoreOrder(StorageManager storageManager, Map<UUID, Optional<UUID>> inputUuidsMap, Set<UUID> outputUuids, List<Long> columnIds, List<Type> columnTypes)
+            throws IOException
+    {
+        MaterializedResult inputRows = getMaterializedRows(storageManager, ImmutableMap.copyOf(inputUuidsMap), columnIds, columnTypes);
         MaterializedResult outputRows = getMaterializedRows(storageManager, ImmutableList.copyOf(outputUuids), columnIds, columnTypes);
 
         assertEqualsIgnoreOrder(outputRows, inputRows);
@@ -237,7 +296,7 @@ public class TestShardCompactor
     {
         ImmutableList.Builder<Page> pages = ImmutableList.builder();
         for (UUID uuid : uuids) {
-            try (ConnectorPageSource pageSource = getPageSource(storageManager, columnIds, columnTypes, uuid)) {
+            try (ConnectorPageSource pageSource = getPageSource(storageManager, columnIds, columnTypes, uuid, Optional.empty(), false)) {
                 while (!pageSource.isFinished()) {
                     Page outputPage = pageSource.getNextPage();
                     if (outputPage == null) {
@@ -255,7 +314,7 @@ public class TestShardCompactor
     {
         MaterializedResult.Builder rows = MaterializedResult.resultBuilder(SESSION, columnTypes);
         for (UUID uuid : uuids) {
-            try (ConnectorPageSource pageSource = getPageSource(storageManager, columnIds, columnTypes, uuid)) {
+            try (ConnectorPageSource pageSource = getPageSource(storageManager, columnIds, columnTypes, uuid, Optional.empty(), false)) {
                 MaterializedResult result = materializeSourceDataStream(SESSION, pageSource, columnTypes);
                 rows.rows(result.getMaterializedRows());
             }
@@ -263,9 +322,24 @@ public class TestShardCompactor
         return rows.build();
     }
 
-    private ConnectorPageSource getPageSource(StorageManager storageManager, List<Long> columnIds, List<Type> columnTypes, UUID uuid)
+    private MaterializedResult getMaterializedRows(StorageManager storageManager, Map<UUID, Optional<UUID>> uuidsMap, List<Long> columnIds, List<Type> columnTypes)
+            throws IOException
     {
-        return storageManager.getPageSource(FileSystemContext.DEFAULT_RAPTOR_CONTEXT, uuid, Optional.empty(), false, OptionalInt.empty(), columnIds, columnTypes, TupleDomain.all(), READER_ATTRIBUTES);
+        MaterializedResult.Builder rows = MaterializedResult.resultBuilder(SESSION, columnTypes);
+        for (Map.Entry<UUID, Optional<UUID>> entry : uuidsMap.entrySet()) {
+            UUID uuid = entry.getKey();
+            Optional<UUID> deltaUuid = entry.getValue();
+            try (ConnectorPageSource pageSource = getPageSource(storageManager, columnIds, columnTypes, uuid, deltaUuid, true)) {
+                MaterializedResult result = materializeSourceDataStream(SESSION, pageSource, columnTypes);
+                rows.rows(result.getMaterializedRows());
+            }
+        }
+        return rows.build();
+    }
+
+    private ConnectorPageSource getPageSource(StorageManager storageManager, List<Long> columnIds, List<Type> columnTypes, UUID uuid, Optional<UUID> deltaShardUuid, boolean tableSupportsDeltaDelete)
+    {
+        return storageManager.getPageSource(FileSystemContext.DEFAULT_RAPTOR_CONTEXT, uuid, deltaShardUuid, tableSupportsDeltaDelete, OptionalInt.empty(), columnIds, columnTypes, TupleDomain.all(), READER_ATTRIBUTES);
     }
 
     private static List<ShardInfo> createSortedShards(StorageManager storageManager, List<Long> columnIds, List<Type> columnTypes, List<Integer> sortChannels, List<SortOrder> sortOrders, int shardCount)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizationManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizationManager.java
@@ -140,7 +140,7 @@ public class TestShardOrganizationManager
 
         assertEquals(actual.size(), 1);
         // Shards 0, 1 and 2 are overlapping, so we should get an organization set with these shards
-        assertEquals(getOnlyElement(actual).getShards(), extractIndexes(shards, 0, 1, 2));
+        assertEquals(getOnlyElement(actual).getShardsMap(), extractIndexes(shards, 0, 1, 2));
     }
 
     @Test
@@ -167,7 +167,7 @@ public class TestShardOrganizationManager
 
         // expect 2 organization sets, of overlapping shards (0, 2) and (1, 3)
         assertEquals(organizationSets.size(), 2);
-        assertEquals(actual, ImmutableSet.of(extractIndexes(shards, 0, 2), extractIndexes(shards, 1, 3)));
+        assertEquals(actual, ImmutableSet.of(extractIndexes(shards, 0, 2).keySet(), extractIndexes(shards, 1, 3).keySet()));
     }
 
     private static ShardIndexInfo shardWithSortRange(int bucketNumber, ShardRange sortRange)
@@ -176,6 +176,8 @@ public class TestShardOrganizationManager
                 1,
                 OptionalInt.of(bucketNumber),
                 UUID.randomUUID(),
+                false,
+                Optional.empty(),
                 1,
                 1,
                 Optional.of(sortRange),
@@ -188,6 +190,8 @@ public class TestShardOrganizationManager
                 1,
                 OptionalInt.of(bucketNumber),
                 UUID.randomUUID(),
+                false,
+                Optional.empty(),
                 1,
                 1,
                 Optional.of(sortRange),

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizer.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizer.java
@@ -13,11 +13,12 @@
  */
 package com.facebook.presto.raptor.storage.organization;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.Set;
 import java.util.UUID;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -35,18 +36,18 @@ public class TestShardOrganizer
     {
         ShardOrganizer organizer = createShardOrganizer();
 
-        Set<UUID> shards = ImmutableSet.of(UUID.randomUUID());
-        OrganizationSet organizationSet = new OrganizationSet(1L, shards, OptionalInt.empty());
+        Map<UUID, Optional<UUID>> shards = ImmutableMap.of(UUID.randomUUID(), Optional.empty());
+        OrganizationSet organizationSet = new OrganizationSet(1L, false, shards, OptionalInt.empty());
 
         organizer.enqueue(organizationSet);
 
-        assertTrue(organizer.inProgress(getOnlyElement(shards)));
+        assertTrue(organizer.inProgress(getOnlyElement(shards.keySet())));
         assertEquals(organizer.getShardsInProgress(), 1);
 
-        while (organizer.inProgress(getOnlyElement(shards))) {
+        while (organizer.inProgress(getOnlyElement(shards.keySet()))) {
             MILLISECONDS.sleep(10);
         }
-        assertFalse(organizer.inProgress(getOnlyElement(shards)));
+        assertFalse(organizer.inProgress(getOnlyElement(shards.keySet())));
         assertEquals(organizer.getShardsInProgress(), 0);
         organizer.shutdown();
     }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizer.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizer.java
@@ -37,7 +37,7 @@ public class TestShardOrganizer
         ShardOrganizer organizer = createShardOrganizer();
 
         Map<UUID, Optional<UUID>> shards = ImmutableMap.of(UUID.randomUUID(), Optional.empty());
-        OrganizationSet organizationSet = new OrganizationSet(1L, false, shards, OptionalInt.empty());
+        OrganizationSet organizationSet = new OrganizationSet(1L, false, shards, OptionalInt.empty(), 0);
 
         organizer.enqueue(organizationSet);
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizerUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/organization/TestShardOrganizerUtil.java
@@ -161,7 +161,7 @@ public class TestShardOrganizerUtil
 
         long transactionId = shardManager.beginTransaction();
         shardManager.commitShards(transactionId, tableInfo.getTableId(), COLUMNS, shards, Optional.empty(), 0);
-        Set<ShardMetadata> shardMetadatas = shardManager.getNodeShards("node1");
+        Set<ShardMetadata> shardMetadatas = shardManager.getNodeShardsAndDeltas("node1");
 
         Long temporalColumnId = metadataDao.getTemporalColumnId(tableInfo.getTableId());
         TableColumn temporalColumn = metadataDao.getTableColumn(tableInfo.getTableId(), temporalColumnId);
@@ -227,6 +227,8 @@ public class TestShardOrganizerUtil
                     tableId,
                     OptionalInt.empty(),
                     shard.getShardUuid(),
+                    false,
+                    Optional.empty(),
                     shard.getRowCount(),
                     shard.getUncompressedSize(),
                     sortRange,


### PR DESCRIPTION
```
== Raptor ==
- Add delta delete support in Raptor. If table property "table_supports_delta_delete" is set to true
when creating a Raptor table, DELETE query will write down "tombstones" of deleted data instead 
of rewriting files immediately. 
```
