### PR TITLE
Fix schema mismatch w/Parquet INT64 & Timestamp

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -373,7 +373,7 @@ public class ParquetPageSourceFactory
         PrimitiveTypeName parquetTypeName = parquetType.asPrimitiveType().getPrimitiveTypeName();
         switch (parquetTypeName) {
             case INT64:
-                return prestoType.equals(BIGINT) || prestoType.equals(DECIMAL);
+                return prestoType.equals(BIGINT) || prestoType.equals(DECIMAL) || prestoType.equals(TIMESTAMP);
             case INT32:
                 return prestoType.equals(INTEGER) || prestoType.equals(SMALLINT) || prestoType.equals(DATE) || prestoType.equals(DECIMAL) || prestoType.equals(TINYINT);
             case BOOLEAN:


### PR DESCRIPTION
Schema checks are too strict and prevent timestamp type from being read as int64 from Parquet files.
Fixes: #13855

```
== RELEASE NOTES ==
Parquet Changes
* Fix schema mismatch w/Parquet INT64 & Timestamp 
```