### PR TITLE
Optimize IN filter using bitmask

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -16,7 +16,7 @@ package com.facebook.presto.orc;
 import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.orc.TupleDomainFilter.BigintMultiRange;
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
-import com.facebook.presto.orc.TupleDomainFilter.BigintValues;
+import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingHashTable;
 import com.facebook.presto.orc.metadata.MetadataReader;
 import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.metadata.PostScript;
@@ -472,7 +472,7 @@ public class OrcSelectiveRecordReader
             return 50;
         }
 
-        if (filter instanceof BigintValues || filter instanceof BigintMultiRange) {
+        if (filter instanceof BigintValuesUsingHashTable || filter instanceof BigintMultiRange) {
             return 50;
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc;
 import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.orc.TupleDomainFilter.BigintMultiRange;
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
+import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingBitmask;
 import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingHashTable;
 import com.facebook.presto.orc.metadata.MetadataReader;
 import com.facebook.presto.orc.metadata.OrcType;
@@ -472,7 +473,7 @@ public class OrcSelectiveRecordReader
             return 50;
         }
 
-        if (filter instanceof BigintValuesUsingHashTable || filter instanceof BigintMultiRange) {
+        if (filter instanceof BigintValuesUsingHashTable || filter instanceof BigintValuesUsingBitmask || filter instanceof BigintMultiRange) {
             return 50;
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
@@ -505,7 +505,6 @@ public interface TupleDomainFilter
 
         private final long min;
         private final long max;
-        private final long[] values;
         private final long[] hashTable;
         private final int size;
         private boolean containsEmptyMarker;
@@ -520,7 +519,6 @@ public interface TupleDomainFilter
 
             this.min = min;
             this.max = max;
-            this.values = values;
             this.size = Integer.highestOneBit(values.length * 3);
             this.hashTable = new long[size];
             Arrays.fill(hashTable, EMPTY_MARKER);
@@ -601,7 +599,6 @@ public interface TupleDomainFilter
             return toStringHelper(this)
                     .add("min", min)
                     .add("max", max)
-                    .add("values", values)
                     .add("nullAllowed", nullAllowed)
                     .toString();
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc;
 import com.google.common.annotations.VisibleForTesting;
 
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -24,6 +25,7 @@ import static com.facebook.presto.orc.ByteArrayUtils.hash;
 import static com.facebook.presto.spi.type.UnscaledDecimal128Arithmetic.compare;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -501,18 +503,23 @@ public interface TupleDomainFilter
         // from Murmur hash
         private static final long M = 0xc6a4a7935bd1e995L;
 
+        private final long min;
+        private final long max;
         private final long[] values;
         private final long[] hashTable;
         private final int size;
         private boolean containsEmptyMarker;
 
-        private BigintValuesUsingHashTable(long[] values, boolean nullAllowed)
+        private BigintValuesUsingHashTable(long min, long max, long[] values, boolean nullAllowed)
         {
             super(true, nullAllowed);
 
             requireNonNull(values, "values is null");
+            checkArgument(min < max, "min must be less than max");
             checkArgument(values.length > 1, "values must contain at least 2 entries");
 
+            this.min = min;
+            this.max = max;
             this.values = values;
             this.size = Integer.highestOneBit(values.length * 3);
             this.hashTable = new long[size];
@@ -534,9 +541,9 @@ public interface TupleDomainFilter
             }
         }
 
-        public static BigintValuesUsingHashTable of(long[] values, boolean nullAllowed)
+        public static BigintValuesUsingHashTable of(long min, long max, long[] values, boolean nullAllowed)
         {
-            return new BigintValuesUsingHashTable(values, nullAllowed);
+            return new BigintValuesUsingHashTable(min, max, values, nullAllowed);
         }
 
         @Override
@@ -545,6 +552,11 @@ public interface TupleDomainFilter
             if (containsEmptyMarker && value == EMPTY_MARKER) {
                 return true;
             }
+
+            if (value < min || value > max) {
+                return false;
+            }
+
             int pos = (int) ((value * M) & (size - 1));
             for (int i = pos; i < pos + size; i++) {
                 int idx = i & (size - 1);
@@ -580,14 +592,91 @@ public interface TupleDomainFilter
         @Override
         public int hashCode()
         {
-            return Objects.hash(size, containsEmptyMarker, hashTable, nullAllowed);
+            return Objects.hash(min, max, size, containsEmptyMarker, hashTable, nullAllowed);
         }
 
         @Override
         public String toString()
         {
             return toStringHelper(this)
+                    .add("min", min)
+                    .add("max", max)
                     .add("values", values)
+                    .add("nullAllowed", nullAllowed)
+                    .toString();
+        }
+    }
+
+    class BigintValuesUsingBitmask
+            extends AbstractTupleDomainFilter
+    {
+        private final BitSet bitmask;
+        private final long min;
+        private final long max;
+
+        private BigintValuesUsingBitmask(long min, long max, long[] values, boolean nullAllowed)
+        {
+            super(true, nullAllowed);
+
+            requireNonNull(values, "values is null");
+            checkArgument(min < max, "min must be less than max");
+            checkArgument(values.length > 1, "values must contain at least 2 entries");
+
+            this.min = min;
+            this.max = max;
+            bitmask = new BitSet(toIntExact(max - min + 1));
+
+            for (int i = 0; i < values.length; i++) {
+                bitmask.set((int) (values[i] - min));
+            }
+        }
+
+        public static BigintValuesUsingBitmask of(long min, long max, long[] values, boolean nullAllowed)
+        {
+            return new BigintValuesUsingBitmask(min, max, values, nullAllowed);
+        }
+
+        @Override
+        public boolean testLong(long value)
+        {
+            if (value < min || value > max) {
+                return false;
+            }
+
+            return bitmask.get((int) (value - min));
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            BigintValuesUsingBitmask that = (BigintValuesUsingBitmask) o;
+            return min == that.min &&
+                    max == that.max &&
+                    bitmask.equals(that.bitmask) &&
+                    nullAllowed == that.nullAllowed;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(min, max, bitmask, nullAllowed);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("min", min)
+                    .add("max", max)
+                    .add("bitmask", bitmask)
                     .add("nullAllowed", nullAllowed)
                     .toString();
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
@@ -494,7 +494,7 @@ public interface TupleDomainFilter
         }
     }
 
-    class BigintValues
+    class BigintValuesUsingHashTable
             extends AbstractTupleDomainFilter
     {
         private static final long EMPTY_MARKER = 0xdeadbeefbadefeedL;
@@ -506,7 +506,7 @@ public interface TupleDomainFilter
         private final int size;
         private boolean containsEmptyMarker;
 
-        private BigintValues(long[] values, boolean nullAllowed)
+        private BigintValuesUsingHashTable(long[] values, boolean nullAllowed)
         {
             super(true, nullAllowed);
 
@@ -534,9 +534,9 @@ public interface TupleDomainFilter
             }
         }
 
-        public static BigintValues of(long[] values, boolean nullAllowed)
+        public static BigintValuesUsingHashTable of(long[] values, boolean nullAllowed)
         {
-            return new BigintValues(values, nullAllowed);
+            return new BigintValuesUsingHashTable(values, nullAllowed);
         }
 
         @Override
@@ -570,7 +570,7 @@ public interface TupleDomainFilter
                 return false;
             }
 
-            BigintValues that = (BigintValues) o;
+            BigintValuesUsingHashTable that = (BigintValuesUsingHashTable) o;
             return size == that.size &&
                     containsEmptyMarker == that.containsEmptyMarker &&
                     Arrays.equals(hashTable, that.hashTable) &&

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilterUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilterUtils.java
@@ -15,7 +15,7 @@ package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.TupleDomainFilter.BigintMultiRange;
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
-import com.facebook.presto.orc.TupleDomainFilter.BigintValues;
+import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingHashTable;
 import com.facebook.presto.orc.TupleDomainFilter.BooleanValue;
 import com.facebook.presto.orc.TupleDomainFilter.BytesRange;
 import com.facebook.presto.orc.TupleDomainFilter.BytesValues;
@@ -105,7 +105,7 @@ public class TupleDomainFilterUtils
                     .collect(toImmutableList());
 
             if (bigintRanges.stream().allMatch(BigintRange::isSingleValue)) {
-                return BigintValues.of(
+                return BigintValuesUsingHashTable.of(
                         bigintRanges.stream()
                                 .mapToLong(BigintRange::getLower)
                                 .toArray(),

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectSelectiveStreamReader.java
@@ -18,7 +18,6 @@ import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.TupleDomainFilter;
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
-import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingHashTable;
 import com.facebook.presto.orc.TupleDomainFilter.BytesRange;
 import com.facebook.presto.orc.TupleDomainFilter.BytesValues;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
@@ -51,6 +50,7 @@ import java.util.Optional;
 import static com.facebook.presto.array.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.TupleDomainFilter.IS_NOT_NULL;
 import static com.facebook.presto.orc.TupleDomainFilter.IS_NULL;
+import static com.facebook.presto.orc.TupleDomainFilterUtils.toBigintValues;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.SelectiveStreamReaders.initializeOutputPositions;
@@ -175,6 +175,7 @@ public class MapDirectSelectiveStreamReader
                         .map(path -> path.get(0))
                         .map(Subfield.LongSubscript.class::cast)
                         .mapToLong(Subfield.LongSubscript::getIndex)
+                        .distinct()
                         .toArray();
 
                 if (requiredIndices.length == 0) {
@@ -185,7 +186,7 @@ public class MapDirectSelectiveStreamReader
                     return BigintRange.of(requiredIndices[0], requiredIndices[0], false);
                 }
 
-                return BigintValuesUsingHashTable.of(requiredIndices, false);
+                return toBigintValues(requiredIndices, false);
             }
             case STRING:
             case CHAR:

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectSelectiveStreamReader.java
@@ -18,7 +18,7 @@ import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.TupleDomainFilter;
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
-import com.facebook.presto.orc.TupleDomainFilter.BigintValues;
+import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingHashTable;
 import com.facebook.presto.orc.TupleDomainFilter.BytesRange;
 import com.facebook.presto.orc.TupleDomainFilter.BytesValues;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
@@ -185,7 +185,7 @@ public class MapDirectSelectiveStreamReader
                     return BigintRange.of(requiredIndices[0], requiredIndices[0], false);
                 }
 
-                return BigintValues.of(requiredIndices, false);
+                return BigintValuesUsingHashTable.of(requiredIndices, false);
             }
             case STRING:
             case CHAR:

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBigintValues.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBigintValues.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingBitmask;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.Random;
+
+import static com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingBitmask.BigintValuesUsingHashTable;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@State(Scope.Thread)
+@OutputTimeUnit(MILLISECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 1000, timeUnit = MILLISECONDS)
+@Measurement(iterations = 10, time = 1000, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkBigintValues
+{
+    @Benchmark
+    public int lookupInHashTable(BenchmarkData data)
+    {
+        int hits = 0;
+        for (int i = 0; i < 10_000; i++) {
+            if (data.hashtableFilter.testLong(i)) {
+                hits++;
+            }
+        }
+
+        return hits;
+    }
+
+    @Benchmark
+    public int lookupInBitmask(BenchmarkData data)
+    {
+        int hits = 0;
+        for (int i = 0; i < 10_000; i++) {
+            if (data.bitmaskFilter.testLong(i)) {
+                hits++;
+            }
+        }
+
+        return hits;
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private long[] values;
+        private TupleDomainFilter hashtableFilter;
+        private TupleDomainFilter bitmaskFilter;
+
+        @Param({"5000", "1000", "100", "10"})
+        private int numValues;
+
+        @Setup
+        public void setup()
+                throws Exception
+        {
+            values = new long[numValues];
+            Random random = new Random(0);
+            for (int i = 0; i < numValues; i++) {
+                values[i] = random.nextInt(10_000);
+            }
+
+            hashtableFilter = BigintValuesUsingHashTable.of(0, 10_000, values, false);
+            bitmaskFilter = BigintValuesUsingBitmask.of(0, 10_000, values, false);
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkBigintValues.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatSelectiveStreamReader.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.orc;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingHashTable;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.Subfield;
@@ -54,6 +53,7 @@ import static com.facebook.presto.orc.TestMapFlatSelectiveStreamReader.ExpectedV
 import static com.facebook.presto.orc.TestingOrcPredicate.createOrcPredicate;
 import static com.facebook.presto.orc.TupleDomainFilter.IS_NOT_NULL;
 import static com.facebook.presto.orc.TupleDomainFilter.IS_NULL;
+import static com.facebook.presto.orc.TupleDomainFilterUtils.toBigintValues;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
@@ -383,7 +383,7 @@ public class TestMapFlatSelectiveStreamReader
         List<Integer> ids = IntStream.range(0, expectedValues.size()).map(i -> i % 10).boxed().collect(toImmutableList());
         ImmutableList<Type> types = ImmutableList.of(mapType, INTEGER);
 
-        Map<Integer, Map<Subfield, TupleDomainFilter>> filters = ImmutableMap.of(1, ImmutableMap.of(new Subfield("c"), BigintValuesUsingHashTable.of(new long[] {1, 5, 6}, true)));
+        Map<Integer, Map<Subfield, TupleDomainFilter>> filters = ImmutableMap.of(1, ImmutableMap.of(new Subfield("c"), toBigintValues(new long[] {1, 5, 6}, true)));
         assertFileContentsPresto(
                 types,
                 new File(getResource(testOrcFileName).getFile()),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatSelectiveStreamReader.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.orc;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.orc.TupleDomainFilter.BigintValues;
+import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingHashTable;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.Subfield;
@@ -383,7 +383,7 @@ public class TestMapFlatSelectiveStreamReader
         List<Integer> ids = IntStream.range(0, expectedValues.size()).map(i -> i % 10).boxed().collect(toImmutableList());
         ImmutableList<Type> types = ImmutableList.of(mapType, INTEGER);
 
-        Map<Integer, Map<Subfield, TupleDomainFilter>> filters = ImmutableMap.of(1, ImmutableMap.of(new Subfield("c"), BigintValues.of(new long[] {1, 5, 6}, true)));
+        Map<Integer, Map<Subfield, TupleDomainFilter>> filters = ImmutableMap.of(1, ImmutableMap.of(new Subfield("c"), BigintValuesUsingHashTable.of(new long[] {1, 5, 6}, true)));
         assertFileContentsPresto(
                 types,
                 new File(getResource(testOrcFileName).getFile()),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -62,6 +62,7 @@ import static com.facebook.presto.orc.OrcTester.quickSelectiveOrcTester;
 import static com.facebook.presto.orc.OrcTester.rowType;
 import static com.facebook.presto.orc.TupleDomainFilter.IS_NOT_NULL;
 import static com.facebook.presto.orc.TupleDomainFilter.IS_NULL;
+import static com.facebook.presto.orc.TupleDomainFilterUtils.toBigintValues;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.type.CharType.createCharType;
@@ -139,7 +140,7 @@ public class TestSelectiveOrcReader
                 .map(Integer::byteValue)
                 .collect(toList());
 
-        tester.testRoundTrip(TINYINT, byteValues, BigintValuesUsingHashTable.of(new long[] {1, 17}, false), IS_NULL);
+        tester.testRoundTrip(TINYINT, byteValues, BigintValuesUsingHashTable.of(1, 17, new long[] {1, 17}, false), IS_NULL);
 
         List<Map<Integer, Map<Subfield, TupleDomainFilter>>> filters = toSubfieldFilters(
                 ImmutableMap.of(0, BigintRange.of(1, 17, false)),
@@ -156,9 +157,9 @@ public class TestSelectiveOrcReader
                 ImmutableList.of(TINYINT, TINYINT, TINYINT),
                 ImmutableList.of(toByteArray(newArrayList(1, 2, null, 3, 4)), newArrayList(null, null, null, null, null), toByteArray(newArrayList(5, 6, null, 7, null))),
                 toSubfieldFilters(ImmutableMap.of(
-                        0, BigintValuesUsingHashTable.of(new long[] {1, 4}, false),
-                        1, BigintValuesUsingHashTable.of(new long[] {1, 5}, true),
-                        2, BigintValuesUsingHashTable.of(new long[] {5, 7}, true))));
+                        0, BigintValuesUsingHashTable.of(1, 4, new long[] {1, 4}, false),
+                        1, BigintValuesUsingHashTable.of(1, 5, new long[] {1, 5}, true),
+                        2, BigintValuesUsingHashTable.of(5, 7, new long[] {5, 7}, true))));
     }
 
     @Test
@@ -305,7 +306,7 @@ public class TestSelectiveOrcReader
             throws Exception
     {
         testRoundTripNumeric(limit(cycle(concat(intsBetween(0, 18), intsBetween(0, 18), ImmutableList.of(NUM_ROWS, 20_000, 400_000, NUM_ROWS, 20_000))), NUM_ROWS),
-                BigintValuesUsingHashTable.of(new long[] {0, 5, 10, 15, 20_000}, true));
+                toBigintValues(new long[] {0, 5, 10, 15, 20_000}, true));
     }
 
     @Test

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -15,7 +15,7 @@ package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.OrcTester.OrcReaderSettings;
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
-import com.facebook.presto.orc.TupleDomainFilter.BigintValues;
+import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingHashTable;
 import com.facebook.presto.orc.TupleDomainFilter.BooleanValue;
 import com.facebook.presto.orc.TupleDomainFilter.BytesRange;
 import com.facebook.presto.orc.TupleDomainFilter.BytesValues;
@@ -139,7 +139,7 @@ public class TestSelectiveOrcReader
                 .map(Integer::byteValue)
                 .collect(toList());
 
-        tester.testRoundTrip(TINYINT, byteValues, BigintValues.of(new long[] {1, 17}, false), IS_NULL);
+        tester.testRoundTrip(TINYINT, byteValues, BigintValuesUsingHashTable.of(new long[] {1, 17}, false), IS_NULL);
 
         List<Map<Integer, Map<Subfield, TupleDomainFilter>>> filters = toSubfieldFilters(
                 ImmutableMap.of(0, BigintRange.of(1, 17, false)),
@@ -156,9 +156,9 @@ public class TestSelectiveOrcReader
                 ImmutableList.of(TINYINT, TINYINT, TINYINT),
                 ImmutableList.of(toByteArray(newArrayList(1, 2, null, 3, 4)), newArrayList(null, null, null, null, null), toByteArray(newArrayList(5, 6, null, 7, null))),
                 toSubfieldFilters(ImmutableMap.of(
-                        0, BigintValues.of(new long[] {1, 4}, false),
-                        1, BigintValues.of(new long[] {1, 5}, true),
-                        2, BigintValues.of(new long[] {5, 7}, true))));
+                        0, BigintValuesUsingHashTable.of(new long[] {1, 4}, false),
+                        1, BigintValuesUsingHashTable.of(new long[] {1, 5}, true),
+                        2, BigintValuesUsingHashTable.of(new long[] {5, 7}, true))));
     }
 
     @Test
@@ -305,7 +305,7 @@ public class TestSelectiveOrcReader
             throws Exception
     {
         testRoundTripNumeric(limit(cycle(concat(intsBetween(0, 18), intsBetween(0, 18), ImmutableList.of(NUM_ROWS, 20_000, 400_000, NUM_ROWS, 20_000))), NUM_ROWS),
-                BigintValues.of(new long[] {0, 5, 10, 15, 20_000}, true));
+                BigintValuesUsingHashTable.of(new long[] {0, 5, 10, 15, 20_000}, true));
     }
 
     @Test

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilter.java
@@ -15,6 +15,7 @@ package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.TupleDomainFilter.BigintMultiRange;
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
+import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingBitmask;
 import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingHashTable;
 import com.facebook.presto.orc.TupleDomainFilter.BooleanValue;
 import com.facebook.presto.orc.TupleDomainFilter.BytesRange;
@@ -63,7 +64,24 @@ public class TestTupleDomainFilter
     @Test
     public void testBigintValuesUsingHashTable()
     {
-        TupleDomainFilter filter = BigintValuesUsingHashTable.of(new long[] {1, 10, 100, 1000}, false);
+        TupleDomainFilter filter = BigintValuesUsingHashTable.of(1, 1_000, new long[] {1, 10, 100, 1000}, false);
+
+        assertTrue(filter.testLong(1));
+        assertTrue(filter.testLong(10));
+        assertTrue(filter.testLong(100));
+        assertTrue(filter.testLong(1000));
+
+        assertFalse(filter.testNull());
+        assertFalse(filter.testLong(-1));
+        assertFalse(filter.testLong(2));
+        assertFalse(filter.testLong(102));
+        assertFalse(filter.testLong(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void testBigintValuesUsingBitmask()
+    {
+        TupleDomainFilter filter = BigintValuesUsingBitmask.of(1, 1_000, new long[] {1, 10, 100, 1000}, false);
 
         assertTrue(filter.testLong(1));
         assertTrue(filter.testLong(10));

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilter.java
@@ -15,7 +15,7 @@ package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.TupleDomainFilter.BigintMultiRange;
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
-import com.facebook.presto.orc.TupleDomainFilter.BigintValues;
+import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingHashTable;
 import com.facebook.presto.orc.TupleDomainFilter.BooleanValue;
 import com.facebook.presto.orc.TupleDomainFilter.BytesRange;
 import com.facebook.presto.orc.TupleDomainFilter.BytesValues;
@@ -61,9 +61,9 @@ public class TestTupleDomainFilter
     }
 
     @Test
-    public void testBigintValues()
+    public void testBigintValuesUsingHashTable()
     {
-        TupleDomainFilter filter = BigintValues.of(new long[] {1, 10, 100, 1000}, false);
+        TupleDomainFilter filter = BigintValuesUsingHashTable.of(new long[] {1, 10, 100, 1000}, false);
 
         assertTrue(filter.testLong(1));
         assertTrue(filter.testLong(10));

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilterUtils.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilterUtils.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.orc.TupleDomainFilter.BigintMultiRange;
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
+import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingBitmask;
 import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingHashTable;
 import com.facebook.presto.orc.TupleDomainFilter.BooleanValue;
 import com.facebook.presto.orc.TupleDomainFilter.BytesRange;
@@ -227,7 +228,8 @@ public class TestTupleDomainFilterUtils
         assertEquals(toFilter(not(greaterThan(C_BIGINT, bigintLiteral(2L)))), BigintRange.of(Long.MIN_VALUE, 2L, false));
         assertEquals(toFilter(not(greaterThanOrEqual(C_BIGINT, bigintLiteral(2L)))), BigintRange.of(Long.MIN_VALUE, 1L, false));
 
-        assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(1, 10, 100))), BigintValuesUsingHashTable.of(new long[] {1, 10, 100}, false));
+        assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(1, 10, 100_000))), BigintValuesUsingHashTable.of(1, 100_000, new long[] {1, 10, 100_000}, false));
+        assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(1, 10, 100))), BigintValuesUsingBitmask.of(1, 100, new long[] {1, 10, 100}, false));
         assertEquals(toFilter(not(in(C_BIGINT, ImmutableList.of(1, 10, 100)))), BigintMultiRange.of(ImmutableList.of(
                 BigintRange.of(Long.MIN_VALUE, 0L, false),
                 BigintRange.of(2L, 9L, false),
@@ -254,7 +256,8 @@ public class TestTupleDomainFilterUtils
                 BigintMultiRange.of(ImmutableList.of(
                         BigintRange.of(Long.MIN_VALUE, 1L, false),
                         BigintRange.of(3L, Long.MAX_VALUE, false)), true));
-        assertEquals(toFilter(or(in(C_BIGINT, ImmutableList.of(1, 10, 100)), isNull(C_BIGINT))), BigintValuesUsingHashTable.of(new long[] {1, 10, 100}, true));
+        assertEquals(toFilter(or(in(C_BIGINT, ImmutableList.of(1, 10, 100_000)), isNull(C_BIGINT))), BigintValuesUsingHashTable.of(1, 100_000, new long[] {1, 10, 100_000}, true));
+        assertEquals(toFilter(or(in(C_BIGINT, ImmutableList.of(1, 10, 100)), isNull(C_BIGINT))), BigintValuesUsingBitmask.of(1, 100, new long[] {1, 10, 100}, true));
         assertEquals(toFilter(or(not(in(C_BIGINT, ImmutableList.of(1, 10, 100))), isNull(C_BIGINT))), BigintMultiRange.of(ImmutableList.of(
                 BigintRange.of(Long.MIN_VALUE, 0L, false),
                 BigintRange.of(2L, 9L, false),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilterUtils.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilterUtils.java
@@ -19,7 +19,7 @@ import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.orc.TupleDomainFilter.BigintMultiRange;
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
-import com.facebook.presto.orc.TupleDomainFilter.BigintValues;
+import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingHashTable;
 import com.facebook.presto.orc.TupleDomainFilter.BooleanValue;
 import com.facebook.presto.orc.TupleDomainFilter.BytesRange;
 import com.facebook.presto.orc.TupleDomainFilter.BytesValues;
@@ -227,7 +227,7 @@ public class TestTupleDomainFilterUtils
         assertEquals(toFilter(not(greaterThan(C_BIGINT, bigintLiteral(2L)))), BigintRange.of(Long.MIN_VALUE, 2L, false));
         assertEquals(toFilter(not(greaterThanOrEqual(C_BIGINT, bigintLiteral(2L)))), BigintRange.of(Long.MIN_VALUE, 1L, false));
 
-        assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(1, 10, 100))), BigintValues.of(new long[] {1, 10, 100}, false));
+        assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(1, 10, 100))), BigintValuesUsingHashTable.of(new long[] {1, 10, 100}, false));
         assertEquals(toFilter(not(in(C_BIGINT, ImmutableList.of(1, 10, 100)))), BigintMultiRange.of(ImmutableList.of(
                 BigintRange.of(Long.MIN_VALUE, 0L, false),
                 BigintRange.of(2L, 9L, false),
@@ -254,7 +254,7 @@ public class TestTupleDomainFilterUtils
                 BigintMultiRange.of(ImmutableList.of(
                         BigintRange.of(Long.MIN_VALUE, 1L, false),
                         BigintRange.of(3L, Long.MAX_VALUE, false)), true));
-        assertEquals(toFilter(or(in(C_BIGINT, ImmutableList.of(1, 10, 100)), isNull(C_BIGINT))), BigintValues.of(new long[] {1, 10, 100}, true));
+        assertEquals(toFilter(or(in(C_BIGINT, ImmutableList.of(1, 10, 100)), isNull(C_BIGINT))), BigintValuesUsingHashTable.of(new long[] {1, 10, 100}, true));
         assertEquals(toFilter(or(not(in(C_BIGINT, ImmutableList.of(1, 10, 100))), isNull(C_BIGINT))), BigintMultiRange.of(ImmutableList.of(
                 BigintRange.of(Long.MIN_VALUE, 0L, false),
                 BigintRange.of(2L, 9L, false),


### PR DESCRIPTION
Fixes #13865

```
Benchmark                                (numValues)  Mode  Cnt  Score    Error  Units
BenchmarkBigintValues.lookupInBitmask           5000  avgt   20  0.020 ±  0.001  ms/op
BenchmarkBigintValues.lookupInBitmask           1000  avgt   20  0.016 ±  0.001  ms/op
BenchmarkBigintValues.lookupInBitmask            100  avgt   20  0.015 ±  0.002  ms/op
BenchmarkBigintValues.lookupInBitmask             10  avgt   20  0.017 ±  0.001  ms/op
BenchmarkBigintValues.lookupInHashTable         5000  avgt   20  0.100 ±  0.002  ms/op
BenchmarkBigintValues.lookupInHashTable         1000  avgt   20  0.087 ±  0.001  ms/op
BenchmarkBigintValues.lookupInHashTable          100  avgt   20  0.033 ±  0.001  ms/op
BenchmarkBigintValues.lookupInHashTable           10  avgt   20  0.038 ±  0.001  ms/op```
```
== NO RELEASE NOTE ==
```
