### PR TITLE
Add approx_percentile forms with accuracy

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -211,11 +211,24 @@ Approximate Aggregate Functions
     given ``percentage``. The value of ``percentage`` must be between zero and
     one and must be constant for all input rows.
 
+.. function:: approx_percentile(x, percentage, accuracy) -> [same as x]
+
+    As ``approx_percentile(x, percentage)``, but with a maximum rank error of
+    ``accuracy``. The value of ``accuracy`` must be between zero and one
+    (exclusive) and must be constant for all input rows. Note that a lower
+    "accuracy" is really a lower error threshold, and thus more accurate. The
+    default accuracy is ``0.01``.
+
 .. function:: approx_percentile(x, percentages) -> array<[same as x]>
 
     Returns the approximate percentile for all input values of ``x`` at each of
     the specified percentages. Each element of the ``percentages`` array must be
     between zero and one, and the array must be constant for all input rows.
+
+.. function:: approx_percentile(x, percentages, accuracy) -> array<[same as x]>
+
+    As ``approx_percentile(x, percentages)``, but with a maximum rank error of
+    ``accuracy``.
 
 .. function:: approx_percentile(x, w, percentage) -> [same as x]
 
@@ -227,13 +240,8 @@ Approximate Aggregate Functions
 
 .. function:: approx_percentile(x, w, percentage, accuracy) -> [same as x]
 
-    Returns the approximate weighed percentile for all input values of ``x``
-    using the per-item weight ``w`` at the percentage ``p``, with a maximum rank
-    error of ``accuracy``. The weight must be an integer value of at least one.
-    It is effectively a replication count for the value ``x`` in the percentile
-    set. The value of ``p`` must be between zero and one and must be constant
-    for all input rows. ``accuracy`` must be a value greater than zero and less
-    than one, and it must be constant for all input rows.
+    As ``approx_percentile(x, w, percentage)``, but with a maximum rank error of
+    ``accuracy``.
 
 .. function:: approx_percentile(x, w, percentages) -> array<[same as x]>
 
@@ -243,6 +251,12 @@ Approximate Aggregate Functions
     effectively a replication count for the value ``x`` in the percentile set.
     Each element of the array must be between zero and one, and the array must
     be constant for all input rows.
+
+.. function:: approx_percentile(x, w, percentages, accuracy) -> array<[same as x]>
+
+    As ``approx_percentile(x, w, percentages)``, but with a maximum rank error of
+    ``accuracy``.
+
 
 .. function:: approx_set(x) -> HyperLogLog
     :noindex:

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileAggregations.java
@@ -46,6 +46,16 @@ public final class ApproximateDoublePercentileAggregations
     }
 
     @InputFunction
+    public static void input(
+            @AggregationState DigestAndPercentileState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType(StandardTypes.DOUBLE) double percentile,
+            @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        ApproximateLongPercentileAggregations.input(state, doubleToSortableLong(value), percentile, accuracy);
+    }
+
+    @InputFunction
     public static void weightedInput(
             @AggregationState DigestAndPercentileState state,
             @SqlType(StandardTypes.DOUBLE) double value,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileAggregations.java
@@ -37,19 +37,31 @@ public final class ApproximateDoublePercentileAggregations
     private ApproximateDoublePercentileAggregations() {}
 
     @InputFunction
-    public static void input(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double percentile)
+    public static void input(
+            @AggregationState DigestAndPercentileState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType(StandardTypes.DOUBLE) double percentile)
     {
         ApproximateLongPercentileAggregations.input(state, doubleToSortableLong(value), percentile);
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile)
+    public static void weightedInput(
+            @AggregationState DigestAndPercentileState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType(StandardTypes.BIGINT) long weight,
+            @SqlType(StandardTypes.DOUBLE) double percentile)
     {
         ApproximateLongPercentileAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentile);
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile, @SqlType(StandardTypes.DOUBLE) double accuracy)
+    public static void weightedInput(
+            @AggregationState DigestAndPercentileState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType(StandardTypes.BIGINT) long weight,
+            @SqlType(StandardTypes.DOUBLE) double percentile,
+            @SqlType(StandardTypes.DOUBLE) double accuracy)
     {
         ApproximateLongPercentileAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentile, accuracy);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
@@ -46,6 +46,16 @@ public final class ApproximateDoublePercentileArrayAggregations
     }
 
     @InputFunction
+    public static void input(
+            @AggregationState DigestAndPercentileArrayState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType("array(double)") Block percentilesArrayBlock,
+            @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        ApproximateLongPercentileArrayAggregations.input(state, doubleToSortableLong(value), percentilesArrayBlock, accuracy);
+    }
+
+    @InputFunction
     public static void weightedInput(
             @AggregationState DigestAndPercentileArrayState state,
             @SqlType(StandardTypes.DOUBLE) double value,
@@ -53,6 +63,17 @@ public final class ApproximateDoublePercentileArrayAggregations
             @SqlType("array(double)") Block percentilesArrayBlock)
     {
         ApproximateLongPercentileArrayAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentilesArrayBlock);
+    }
+
+    @InputFunction
+    public static void weightedInput(
+            @AggregationState DigestAndPercentileArrayState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType(StandardTypes.BIGINT) long weight,
+            @SqlType("array(double)") Block percentilesArrayBlock,
+            @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        ApproximateLongPercentileArrayAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentilesArrayBlock, accuracy);
     }
 
     @CombineFunction

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
@@ -37,13 +37,20 @@ public final class ApproximateDoublePercentileArrayAggregations
     private ApproximateDoublePercentileArrayAggregations() {}
 
     @InputFunction
-    public static void input(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType("array(double)") Block percentilesArrayBlock)
+    public static void input(
+            @AggregationState DigestAndPercentileArrayState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType("array(double)") Block percentilesArrayBlock)
     {
         ApproximateLongPercentileArrayAggregations.input(state, doubleToSortableLong(value), percentilesArrayBlock);
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType("array(double)") Block percentilesArrayBlock)
+    public static void weightedInput(
+            @AggregationState DigestAndPercentileArrayState state,
+            @SqlType(StandardTypes.DOUBLE) double value,
+            @SqlType(StandardTypes.BIGINT) long weight,
+            @SqlType("array(double)") Block percentilesArrayBlock)
     {
         ApproximateLongPercentileArrayAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentilesArrayBlock);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileAggregations.java
@@ -47,6 +47,16 @@ public final class ApproximateLongPercentileAggregations
     }
 
     @InputFunction
+    public static void input(
+            @AggregationState DigestAndPercentileState state,
+            @SqlType(StandardTypes.BIGINT) long value,
+            @SqlType(StandardTypes.DOUBLE) double percentile,
+            @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        addInput(state, value, DEFAULT_WEIGHT, percentile, accuracy);
+    }
+
+    @InputFunction
     public static void weightedInput(
             @AggregationState DigestAndPercentileState state,
             @SqlType(StandardTypes.BIGINT) long value,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileAggregations.java
@@ -32,67 +32,61 @@ import static com.google.common.base.Preconditions.checkState;
 @AggregationFunction("approx_percentile")
 public final class ApproximateLongPercentileAggregations
 {
+    static final double DEFAULT_ACCURACY = 0.01;
+    static final long DEFAULT_WEIGHT = 1;
+
     private ApproximateLongPercentileAggregations() {}
 
     @InputFunction
-    public static void input(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.DOUBLE) double percentile)
+    public static void input(
+            @AggregationState DigestAndPercentileState state,
+            @SqlType(StandardTypes.BIGINT) long value,
+            @SqlType(StandardTypes.DOUBLE) double percentile)
     {
-        QuantileDigest digest = state.getDigest();
-
-        if (digest == null) {
-            digest = new QuantileDigest(0.01);
-            state.setDigest(digest);
-            state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
-        }
-
-        state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
-        digest.add(value);
-        state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
-
-        // use last percentile
-        state.setPercentile(percentile);
+        addInput(state, value, DEFAULT_WEIGHT, percentile, DEFAULT_ACCURACY);
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile)
+    public static void weightedInput(
+            @AggregationState DigestAndPercentileState state,
+            @SqlType(StandardTypes.BIGINT) long value,
+            @SqlType(StandardTypes.BIGINT) long weight,
+            @SqlType(StandardTypes.DOUBLE) double percentile)
     {
         checkWeight(weight);
-
-        QuantileDigest digest = state.getDigest();
-
-        if (digest == null) {
-            digest = new QuantileDigest(0.01);
-            state.setDigest(digest);
-            state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
-        }
-
-        state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
-        digest.add(value, weight);
-        state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
-
-        // use last percentile
-        state.setPercentile(percentile);
+        addInput(state, value, weight, percentile, DEFAULT_ACCURACY);
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile, @SqlType(StandardTypes.DOUBLE) double accuracy)
+    public static void weightedInput(
+            @AggregationState DigestAndPercentileState state,
+            @SqlType(StandardTypes.BIGINT) long value,
+            @SqlType(StandardTypes.BIGINT) long weight,
+            @SqlType(StandardTypes.DOUBLE) double percentile,
+            @SqlType(StandardTypes.DOUBLE) double accuracy)
     {
         checkWeight(weight);
+        addInput(state, value, weight, percentile, accuracy);
+    }
 
+    private static void addInput(
+            @AggregationState DigestAndPercentileState state,
+            @SqlType(StandardTypes.BIGINT) long value,
+            @SqlType(StandardTypes.BIGINT) long weight,
+            @SqlType(StandardTypes.DOUBLE) double percentile,
+            @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
         QuantileDigest digest = state.getDigest();
 
-        if (digest == null) {
-            if (accuracy > 0 && accuracy < 1) {
-                digest = new QuantileDigest(accuracy);
-            }
-            else {
-                throw new IllegalArgumentException("Percentile accuracy must be strictly between 0 and 1");
-            }
+        if (state.getDigest() == null) {
+            checkAccuracy(accuracy);
+            digest = new QuantileDigest(accuracy);
             state.setDigest(digest);
-            state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
+        }
+        else {
+            state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
         }
 
-        state.addMemoryUsage(-digest.estimatedInMemorySizeInBytes());
         digest.add(value, weight);
         state.addMemoryUsage(digest.estimatedInMemorySizeInBytes());
 
@@ -133,7 +127,12 @@ public final class ApproximateLongPercentileAggregations
         }
     }
 
-    private static void checkWeight(long weight)
+    static void checkAccuracy(double accuracy)
+    {
+        checkCondition(0 < accuracy && accuracy < 1, INVALID_FUNCTION_ARGUMENT, "Percentile accuracy must be strictly between 0 and 1");
+    }
+
+    static void checkWeight(long weight)
     {
         checkCondition(weight > 0, INVALID_FUNCTION_ARGUMENT, "percentile weight must be > 0");
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateLongPercentileArrayAggregations.java
@@ -52,6 +52,16 @@ public final class ApproximateLongPercentileArrayAggregations
     }
 
     @InputFunction
+    public static void input(
+            @AggregationState DigestAndPercentileArrayState state,
+            @SqlType(StandardTypes.BIGINT) long value,
+            @SqlType("array(double)") Block percentilesArrayBlock,
+            @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        addInput(state, value, DEFAULT_WEIGHT, percentilesArrayBlock, accuracy);
+    }
+
+    @InputFunction
     public static void weightedInput(
             @AggregationState DigestAndPercentileArrayState state,
             @SqlType(StandardTypes.BIGINT) long value,
@@ -60,6 +70,18 @@ public final class ApproximateLongPercentileArrayAggregations
     {
         checkWeight(weight);
         addInput(state, value, weight, percentilesArrayBlock, DEFAULT_ACCURACY);
+    }
+
+    @InputFunction
+    public static void weightedInput(
+            @AggregationState DigestAndPercentileArrayState state,
+            @SqlType(StandardTypes.BIGINT) long value,
+            @SqlType(StandardTypes.BIGINT) long weight,
+            @SqlType("array(double)") Block percentilesArrayBlock,
+            @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        checkWeight(weight);
+        addInput(state, value, weight, percentilesArrayBlock, accuracy);
     }
 
     private static void addInput(

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileAggregations.java
@@ -48,6 +48,16 @@ public class ApproximateRealPercentileAggregations
     }
 
     @InputFunction
+    public static void input(
+            @AggregationState DigestAndPercentileState state,
+            @SqlType(StandardTypes.REAL) long value,
+            @SqlType(StandardTypes.DOUBLE) double percentile,
+            @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        ApproximateLongPercentileAggregations.input(state, floatToSortableInt(intBitsToFloat((int) value)), percentile, accuracy);
+    }
+
+    @InputFunction
     public static void weightedInput(
             @AggregationState DigestAndPercentileState state,
             @SqlType(StandardTypes.REAL) long value,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileAggregations.java
@@ -39,19 +39,31 @@ public class ApproximateRealPercentileAggregations
     private ApproximateRealPercentileAggregations() {}
 
     @InputFunction
-    public static void input(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.DOUBLE) double percentile)
+    public static void input(
+            @AggregationState DigestAndPercentileState state,
+            @SqlType(StandardTypes.REAL) long value,
+            @SqlType(StandardTypes.DOUBLE) double percentile)
     {
         ApproximateLongPercentileAggregations.input(state, floatToSortableInt(intBitsToFloat((int) value)), percentile);
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile)
+    public static void weightedInput(
+            @AggregationState DigestAndPercentileState state,
+            @SqlType(StandardTypes.REAL) long value,
+            @SqlType(StandardTypes.BIGINT) long weight,
+            @SqlType(StandardTypes.DOUBLE) double percentile)
     {
         ApproximateLongPercentileAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentile);
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile, @SqlType(StandardTypes.DOUBLE) double accuracy)
+    public static void weightedInput(
+            @AggregationState DigestAndPercentileState state,
+            @SqlType(StandardTypes.REAL) long value,
+            @SqlType(StandardTypes.BIGINT) long weight,
+            @SqlType(StandardTypes.DOUBLE) double percentile,
+            @SqlType(StandardTypes.DOUBLE) double accuracy)
     {
         ApproximateLongPercentileAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentile, accuracy);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileArrayAggregations.java
@@ -48,6 +48,16 @@ public class ApproximateRealPercentileArrayAggregations
     }
 
     @InputFunction
+    public static void input(
+            @AggregationState DigestAndPercentileArrayState state,
+            @SqlType(StandardTypes.REAL) long value,
+            @SqlType("array(double)") Block percentilesArrayBlock,
+            @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        ApproximateLongPercentileArrayAggregations.input(state, floatToSortableInt(intBitsToFloat((int) value)), percentilesArrayBlock, accuracy);
+    }
+
+    @InputFunction
     public static void weightedInput(
             @AggregationState DigestAndPercentileArrayState state,
             @SqlType(StandardTypes.REAL) long value,
@@ -55,6 +65,17 @@ public class ApproximateRealPercentileArrayAggregations
             @SqlType("array(double)") Block percentilesArrayBlock)
     {
         ApproximateLongPercentileArrayAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentilesArrayBlock);
+    }
+
+    @InputFunction
+    public static void weightedInput(
+            @AggregationState DigestAndPercentileArrayState state,
+            @SqlType(StandardTypes.REAL) long value,
+            @SqlType(StandardTypes.BIGINT) long weight,
+            @SqlType("array(double)") Block percentilesArrayBlock,
+            @SqlType(StandardTypes.DOUBLE) double accuracy)
+    {
+        ApproximateLongPercentileArrayAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentilesArrayBlock, accuracy);
     }
 
     @CombineFunction

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileArrayAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ApproximateRealPercentileArrayAggregations.java
@@ -39,13 +39,20 @@ public class ApproximateRealPercentileArrayAggregations
     private ApproximateRealPercentileArrayAggregations() {}
 
     @InputFunction
-    public static void input(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.REAL) long value, @SqlType("array(double)") Block percentilesArrayBlock)
+    public static void input(
+            @AggregationState DigestAndPercentileArrayState state,
+            @SqlType(StandardTypes.REAL) long value,
+            @SqlType("array(double)") Block percentilesArrayBlock)
     {
         ApproximateLongPercentileArrayAggregations.input(state, floatToSortableInt(intBitsToFloat((int) value)), percentilesArrayBlock);
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType("array(double)") Block percentilesArrayBlock)
+    public static void weightedInput(
+            @AggregationState DigestAndPercentileArrayState state,
+            @SqlType(StandardTypes.REAL) long value,
+            @SqlType(StandardTypes.BIGINT) long weight,
+            @SqlType("array(double)") Block percentilesArrayBlock)
     {
         ApproximateLongPercentileArrayAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentilesArrayBlock);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
@@ -40,23 +40,30 @@ public class TestApproximatePercentileAggregation
     private static final FunctionManager functionManager = MetadataManager.createTestMetadataManager().getFunctionManager();
 
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_AGGREGATION = getAggregation(DOUBLE, DOUBLE);
+    private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_AGGREGATION_WITH_ACCURACY = getAggregation(DOUBLE, DOUBLE, DOUBLE);
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION = getAggregation(DOUBLE, BIGINT, DOUBLE);
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY = getAggregation(DOUBLE, BIGINT, DOUBLE, DOUBLE);
 
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_AGGREGATION = getAggregation(BIGINT, DOUBLE);
+    private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_AGGREGATION_WITH_ACCURACY = getAggregation(BIGINT, DOUBLE, DOUBLE);
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION = getAggregation(BIGINT, BIGINT, DOUBLE);
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY = getAggregation(BIGINT, BIGINT, DOUBLE, DOUBLE);
 
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = getAggregation(DOUBLE, new ArrayType(DOUBLE));
+    private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION_WITH_ACCURACY = getAggregation(DOUBLE, new ArrayType(DOUBLE), DOUBLE);
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = getAggregation(DOUBLE, BIGINT, new ArrayType(DOUBLE));
 
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = getAggregation(BIGINT, new ArrayType(DOUBLE));
+    private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION_WITH_ACCURACY = getAggregation(BIGINT, new ArrayType(DOUBLE), DOUBLE);
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = getAggregation(BIGINT, BIGINT, new ArrayType(DOUBLE));
 
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_AGGREGATION = getAggregation(REAL, DOUBLE);
+    private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_AGGREGATION_WITH_ACCURACY = getAggregation(REAL, DOUBLE, DOUBLE);
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION = getAggregation(REAL, BIGINT, DOUBLE);
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY = getAggregation(REAL, BIGINT, DOUBLE, DOUBLE);
+
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = getAggregation(REAL, new ArrayType(DOUBLE));
+    private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION_WITH_ACCURACY = getAggregation(REAL, new ArrayType(DOUBLE), DOUBLE);
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = getAggregation(REAL, BIGINT, new ArrayType(DOUBLE));
 
     @Test
@@ -92,6 +99,13 @@ public class TestApproximatePercentileAggregation
                 3L,
                 createLongsBlock(1L, null, 2L, 2L, null, 2L, 2L, null, 2L, 2L, null, 3L, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
                 createRLEBlock(0.5, 21));
+
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_AGGREGATION_WITH_ACCURACY,
+                9900L,
+                createLongSequenceBlock(0, 10000),
+                createRLEBlock(0.99, 10000),
+                createRLEBlock(0.001, 10000));
 
         // array of approx_percentile
         assertAggregation(
@@ -129,6 +143,15 @@ public class TestApproximatePercentileAggregation
                 ImmutableList.of(1L, 3L),
                 createLongsBlock(1L, null, 2L, 2L, null, 2L, 2L, null, 2L, 2L, null, 3L, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
                 createRLEBlock(ImmutableList.of(0.01, 0.5), 21));
+
+        // This depends on internal details.  It's included to test that the
+        // accuracy parameter is actually being used.
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION_WITH_ACCURACY,
+                ImmutableList.of(127L, 5119L),
+                createLongSequenceBlock(0, 10_000),
+                createRLEBlock(ImmutableList.of(0.01, 0.5), 10_000),
+                createRLEBlock(0.1, 10_000));
 
         // weighted approx_percentile
         assertAggregation(
@@ -229,6 +252,13 @@ public class TestApproximatePercentileAggregation
                 createBlockOfReals(1.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 3.0f, 3.0f, null, 3.0f, null, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
                 createRLEBlock(0.5, 21));
 
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_AGGREGATION_WITH_ACCURACY,
+                9900.0f,
+                createSequenceBlockOfReal(0, 10000),
+                createRLEBlock(0.99, 10000),
+                createRLEBlock(0.001, 10000));
+
         // array of approx_percentile
         assertAggregation(
                 FLOAT_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
@@ -265,6 +295,13 @@ public class TestApproximatePercentileAggregation
                 ImmutableList.of(1.0f, 3.0f),
                 createBlockOfReals(1.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 3.0f, 3.0f, null, 3.0f, null, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
                 createRLEBlock(ImmutableList.of(0.01, 0.5), 21));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION_WITH_ACCURACY,
+                ImmutableList.of(1.0f, 3.0f),
+                createBlockOfReals(1.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 2.0f, 2.0f, null, 3.0f, 3.0f, null, 3.0f, null, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
+                createRLEBlock(ImmutableList.of(0.01, 0.5), 21),
+                createRLEBlock(0.001, 21));
 
         // weighted approx_percentile
         assertAggregation(
@@ -353,6 +390,13 @@ public class TestApproximatePercentileAggregation
                 createDoublesBlock(1.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 3.0, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
                 createRLEBlock(0.5, 21));
 
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_AGGREGATION_WITH_ACCURACY,
+                9900.0,
+                createDoubleSequenceBlock(0, 10000),
+                createRLEBlock(0.99, 10000),
+                createRLEBlock(0.001, 10000));
+
         // array of approx_percentile
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
@@ -389,6 +433,13 @@ public class TestApproximatePercentileAggregation
                 ImmutableList.of(1.0, 3.0),
                 createDoublesBlock(1.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 3.0, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
                 createRLEBlock(ImmutableList.of(0.01, 0.5), 21));
+
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION_WITH_ACCURACY,
+                ImmutableList.of(1.0, 3.0),
+                createDoublesBlock(1.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 2.0, 2.0, null, 3.0, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
+                createRLEBlock(ImmutableList.of(0.01, 0.5), 21),
+                createRLEBlock(0.001, 21));
 
         // weighted approx_percentile
         assertAggregation(

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestApproximatePercentileAggregation.java
@@ -69,7 +69,8 @@ public class TestApproximatePercentileAggregation
                 createLongsBlock(null, null),
                 createRLEBlock(0.5, 2));
 
-        assertAggregation(LONG_APPROXIMATE_PERCENTILE_AGGREGATION,
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_AGGREGATION,
                 1L,
                 createLongsBlock(null, 1L),
                 createRLEBlock(0.5, 2));
@@ -105,7 +106,8 @@ public class TestApproximatePercentileAggregation
                 createLongsBlock(null, null),
                 createRLEBlock(ImmutableList.of(0.5, 0.99), 2));
 
-        assertAggregation(LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION,
                 ImmutableList.of(1L, 1L),
                 createLongsBlock(null, 1L),
                 createRLEBlock(ImmutableList.of(0.5, 0.5), 2));


### PR DESCRIPTION
Previously you could only specify an accuracy to approx_percentile if
you also specified weights.  This adds an accuracy option for all forms.

```
== RELEASE NOTES ==

General Changes
* Add forms of approx_percentile accepting an accuracy parameter.

```
