### PR TITLE
Cache results of TupleDomainFilterUtils::toFilter

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -20,6 +20,7 @@ import com.facebook.presto.hive.orc.DwrfBatchPageSourceFactory;
 import com.facebook.presto.hive.orc.DwrfSelectivePageSourceFactory;
 import com.facebook.presto.hive.orc.OrcBatchPageSourceFactory;
 import com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory;
+import com.facebook.presto.hive.orc.TupleDomainFilterCache;
 import com.facebook.presto.hive.parquet.ParquetPageSourceFactory;
 import com.facebook.presto.hive.rcfile.RcFilePageSourceFactory;
 import com.facebook.presto.hive.rule.HivePlanOptimizerProvider;
@@ -141,6 +142,7 @@ public class HiveClientModule
         configBinder(binder).bindConfig(OrcCacheConfig.class, connectorId);
 
         binder.bind(FileOpener.class).to(HadoopFileOpener.class).in(Scopes.SINGLETON);
+        binder.bind(TupleDomainFilterCache.class).in(Scopes.SINGLETON);
 
         Multibinder<HiveSelectivePageSourceFactory> selectivePageSourceFactoryBinder = newSetBinder(binder, HiveSelectivePageSourceFactory.class);
         selectivePageSourceFactoryBinder.addBinding().to(OrcSelectivePageSourceFactory.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfSelectivePageSourceFactory.java
@@ -61,6 +61,7 @@ public class DwrfSelectivePageSourceFactory
     private final OrcFileTailSource orcFileTailSource;
     private final StripeMetadataSource stripeMetadataSource;
     private final FileOpener fileOpener;
+    private final TupleDomainFilterCache tupleDomainFilterCache;
 
     @Inject
     public DwrfSelectivePageSourceFactory(
@@ -72,7 +73,8 @@ public class DwrfSelectivePageSourceFactory
             FileFormatDataSourceStats stats,
             OrcFileTailSource orcFileTailSource,
             StripeMetadataSource stripeMetadataSource,
-            FileOpener fileOpener)
+            FileOpener fileOpener,
+            TupleDomainFilterCache tupleDomainFilterCache)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
@@ -83,6 +85,7 @@ public class DwrfSelectivePageSourceFactory
         this.orcFileTailSource = requireNonNull(orcFileTailSource, "orcFileTailSource is null");
         this.stripeMetadataSource = requireNonNull(stripeMetadataSource, "stripeMetadataSource is null");
         this.fileOpener = requireNonNull(fileOpener, "fileOpener is null");
+        this.tupleDomainFilterCache = requireNonNull(tupleDomainFilterCache, "tupleDomainFilterCache is null");
     }
 
     @Override
@@ -139,6 +142,7 @@ public class DwrfSelectivePageSourceFactory
                 orcFileTailSource,
                 stripeMetadataSource,
                 extraFileInfo,
-                fileOpener));
+                fileOpener,
+                tupleDomainFilterCache));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/TupleDomainFilterCache.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/TupleDomainFilterCache.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.orc;
+
+import com.facebook.presto.orc.CacheStatsMBean;
+import com.facebook.presto.orc.TupleDomainFilter;
+import com.facebook.presto.spi.predicate.Domain;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import javax.annotation.Nullable;
+
+import static com.facebook.presto.orc.TupleDomainFilterUtils.toFilter;
+import static java.lang.System.identityHashCode;
+
+public final class TupleDomainFilterCache
+{
+    private final LoadingCache<DomainCacheKey, TupleDomainFilter> cache = CacheBuilder.newBuilder()
+            .recordStats()
+            .maximumSize(10_000)
+            .build(CacheLoader.from(cacheKey -> toFilter(cacheKey.getDomain())));
+    private final CacheStatsMBean cacheStats = new CacheStatsMBean(cache);
+
+    public TupleDomainFilter getFilter(Domain domain)
+    {
+        return cache.getUnchecked(new DomainCacheKey(domain));
+    }
+
+    @Nullable
+    @Managed
+    @Nested
+    public CacheStatsMBean getCache()
+    {
+        return cacheStats;
+    }
+
+    /**
+     * Converting Domain into TupleDomainFilter is expensive, hence, we use a cache keyed on Domain.
+     * However, by default, the cache uses Domain.hashCode and Domain.equals to check if key already
+     * exists. These methods are also expensive. Hence, we use this wrapper to replace Domain.hashCode
+     * and Domain.equals with much cheaper identity hashCode and equals. These work because the Domain
+     * objects come from HiveTableLayoutHandle which is reused across splits.
+     */
+    private static final class DomainCacheKey
+    {
+        private final Domain domain;
+
+        private DomainCacheKey(Domain domain)
+        {
+            this.domain = domain;
+        }
+
+        public Domain getDomain()
+        {
+            return domain;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            DomainCacheKey cacheKey = (DomainCacheKey) o;
+            return domain == cacheKey.domain;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return identityHashCode(domain);
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -26,6 +26,7 @@ import com.facebook.presto.hive.orc.DwrfBatchPageSourceFactory;
 import com.facebook.presto.hive.orc.DwrfSelectivePageSourceFactory;
 import com.facebook.presto.hive.orc.OrcBatchPageSourceFactory;
 import com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory;
+import com.facebook.presto.hive.orc.TupleDomainFilterCache;
 import com.facebook.presto.hive.parquet.ParquetPageSourceFactory;
 import com.facebook.presto.hive.rcfile.RcFilePageSourceFactory;
 import com.facebook.presto.hive.s3.HiveS3Config;
@@ -153,8 +154,8 @@ public final class HiveTestUtils
         FileFormatDataSourceStats stats = new FileFormatDataSourceStats();
         HdfsEnvironment testHdfsEnvironment = createTestHdfsEnvironment(hiveClientConfig, metastoreClientConfig);
         return ImmutableSet.<HiveSelectivePageSourceFactory>builder()
-                .add(new OrcSelectivePageSourceFactory(TYPE_MANAGER, FUNCTION_RESOLUTION, ROW_EXPRESSION_SERVICE, hiveClientConfig, testHdfsEnvironment, stats, new StorageOrcFileTailSource(), new StorageStripeMetadataSource(), new HadoopFileOpener()))
-                .add(new DwrfSelectivePageSourceFactory(TYPE_MANAGER, FUNCTION_RESOLUTION, ROW_EXPRESSION_SERVICE, hiveClientConfig, testHdfsEnvironment, stats, new StorageOrcFileTailSource(), new StorageStripeMetadataSource(), new HadoopFileOpener()))
+                .add(new OrcSelectivePageSourceFactory(TYPE_MANAGER, FUNCTION_RESOLUTION, ROW_EXPRESSION_SERVICE, hiveClientConfig, testHdfsEnvironment, stats, new StorageOrcFileTailSource(), new StorageStripeMetadataSource(), new HadoopFileOpener(), new TupleDomainFilterCache()))
+                .add(new DwrfSelectivePageSourceFactory(TYPE_MANAGER, FUNCTION_RESOLUTION, ROW_EXPRESSION_SERVICE, hiveClientConfig, testHdfsEnvironment, stats, new StorageOrcFileTailSource(), new StorageStripeMetadataSource(), new HadoopFileOpener(), new TupleDomainFilterCache()))
                 .build();
     }
 


### PR DESCRIPTION
Large IN predicates are expensive to convert to TupleDomainFilter. Hence, we'd like to convert these once per task as opposed to once per split.

```
== NO RELEASE NOTE ==
```
