### PR TITLE
Add session property to disable adaptive filter reordering

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -152,6 +152,7 @@ public class HiveClientConfig
 
     private boolean pushdownFilterEnabled;
     private boolean rangeFiltersOnSubscriptsEnabled;
+    private boolean adaptiveFilterReorderingEnabled = true;
     private boolean zstdJniDecompressionEnabled;
 
     public int getMaxInitialSplits()
@@ -1250,6 +1251,19 @@ public class HiveClientConfig
     public HiveClientConfig setRangeFiltersOnSubscriptsEnabled(boolean rangeFiltersOnSubscriptsEnabled)
     {
         this.rangeFiltersOnSubscriptsEnabled = rangeFiltersOnSubscriptsEnabled;
+        return this;
+    }
+
+    public boolean isAdaptiveFilterReorderingEnabled()
+    {
+        return adaptiveFilterReorderingEnabled;
+    }
+
+    @Config("hive.adaptive-filter-reordering-enabled")
+    @ConfigDescription("Experimental: enable adaptive filter reordering")
+    public HiveClientConfig setAdaptiveFilterReorderingEnabled(boolean adaptiveFilterReorderingEnabled)
+    {
+        this.adaptiveFilterReorderingEnabled = adaptiveFilterReorderingEnabled;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -89,6 +89,7 @@ public final class HiveSessionProperties
     private static final String TEMPORARY_TABLE_COMPRESSION_CODEC = "temporary_table_compression_codec";
     public static final String PUSHDOWN_FILTER_ENABLED = "pushdown_filter_enabled";
     public static final String RANGE_FILTERS_ON_SUBSCRIPTS_ENABLED = "range_filters_on_subscripts_enabled";
+    public static final String ADAPTIVE_FILTER_REORDERING_ENABLED = "adaptive_filter_reordering_enabled";
     public static final String VIRTUAL_BUCKET_COUNT = "virtual_bucket_count";
     public static final String MAX_BUCKETS_FOR_GROUPED_EXECUTION = "max_buckets_for_grouped_execution";
     public static final String OFFLINE_DATA_DEBUG_MODE_ENABLED = "offline_data_debug_mode_enabled";
@@ -385,6 +386,11 @@ public final class HiveSessionProperties
                         "Experimental: enable pushdown of range filters on subscripts (a[2] = 5) into ORC column readers",
                         hiveClientConfig.isRangeFiltersOnSubscriptsEnabled(),
                         false),
+                booleanProperty(
+                        ADAPTIVE_FILTER_REORDERING_ENABLED,
+                        "Experimental: enable adaptive filter reordering",
+                        hiveClientConfig.isAdaptiveFilterReorderingEnabled(),
+                        false),
                 integerProperty(
                         VIRTUAL_BUCKET_COUNT,
                         "Number of virtual bucket assigned for unbucketed tables",
@@ -672,6 +678,11 @@ public final class HiveSessionProperties
     public static boolean isRangeFiltersOnSubscriptsEnabled(ConnectorSession session)
     {
         return session.getProperty(RANGE_FILTERS_ON_SUBSCRIPTS_ENABLED, Boolean.class);
+    }
+
+    public static boolean isAdaptiveFilterReorderingEnabled(ConnectorSession session)
+    {
+        return session.getProperty(ADAPTIVE_FILTER_REORDERING_ENABLED, Boolean.class);
     }
 
     public static int getVirtualBucketCount(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -106,6 +106,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxMergeDista
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxReadBlockSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcStreamBufferSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcTinyStripeThreshold;
+import static com.facebook.presto.hive.HiveSessionProperties.isAdaptiveFilterReorderingEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isOrcBloomFiltersEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isOrcZstdJniDecompressionEnabled;
 import static com.facebook.presto.hive.HiveUtil.getPhysicalHiveColumnHandles;
@@ -594,6 +595,11 @@ public class OrcSelectivePageSourceFactory
                 .ifPresent(filterFunctions::add);
 
         if (TRUE_CONSTANT.equals(filter)) {
+            return filterFunctions.build();
+        }
+
+        if (!isAdaptiveFilterReorderingEnabled(session)) {
+            filterFunctions.add(new FilterFunction(session, determinismEvaluator.isDeterministic(filter), predicateCompiler.compilePredicate(session.getSqlFunctionProperties(), filter).get()));
             return filterFunctions.build();
         }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -122,7 +122,8 @@ public class TestHiveClientConfig
                 .setTemporaryTableCompressionCodec(SNAPPY)
                 .setPushdownFilterEnabled(false)
                 .setZstdJniDecompressionEnabled(false)
-                .setRangeFiltersOnSubscriptsEnabled(false));
+                .setRangeFiltersOnSubscriptsEnabled(false)
+                .setAdaptiveFilterReorderingEnabled(true));
     }
 
     @Test
@@ -209,6 +210,7 @@ public class TestHiveClientConfig
                 .put("hive.temporary-table-compression-codec", "NONE")
                 .put("hive.pushdown-filter-enabled", "true")
                 .put("hive.range-filters-on-subscripts-enabled", "true")
+                .put("hive.adaptive-filter-reordering-enabled", "false")
                 .put("hive.zstd-jni-decompression-enabled", "true")
                 .build();
 
@@ -294,7 +296,8 @@ public class TestHiveClientConfig
                 .setTemporaryTableCompressionCodec(NONE)
                 .setPushdownFilterEnabled(true)
                 .setZstdJniDecompressionEnabled(true)
-                .setRangeFiltersOnSubscriptsEnabled(true);
+                .setRangeFiltersOnSubscriptsEnabled(true)
+                .setAdaptiveFilterReorderingEnabled(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Sometimes adaptive filter reordering is not able to pick optimal filter order. We observed this in a query with a filter containing dozens of conjuncts on a single column plus some conjuncts on other columns:
```
c NOT LIKE '%cats%' 
AND c NOT LIKE '%gods%` 
AND c NOT LIKE ...
AND b LIKE '%heads%' 
AND b NOT LIKE '%tails%' 
AND c NOT LIKE `%crocodiles%
AND c NOT LIKE ...
```

In that particular case optimal filter order is to evaluate some filter on `c`, then some on `b`, then some more on `c`. Adaptive filter reordering currently is not able to generate that order as all conjuncts on a given column are always evaluated together. 

The new session property `hive.adaptive_filter_reordering_enabled` allows to disable adaptive filter reordering and evaluate filter in the order specified by the query. By default, adaptive filter reordering is enabled.

```
== NO RELEASE NOTE ==
```
