### PR TITLE
Keep sum stat for string when min/max stat is too long in ORC writer

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -117,11 +117,6 @@ public class StringStatisticsBuilder
         }
         minimum = dropStringMinMaxIfNecessary(minimum);
         maximum = dropStringMinMaxIfNecessary(maximum);
-        if (minimum == null && maximum == null) {
-            // Create string stats only when min or max is not null.
-            // This corresponds to the behavior of metadata reader.
-            return Optional.empty();
-        }
         return Optional.of(new StringStatistics(minimum, maximum, sum));
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatisticsBuilder.java
@@ -127,7 +127,7 @@ public class TestStringStatisticsBuilder
     {
         assertMinMaxValuesWithLimit(MEDIUM_TOP_VALUE, null, ImmutableList.of(MEDIUM_TOP_VALUE, HIGH_BOTTOM_VALUE), 7);
         assertMinMaxValuesWithLimit(null, MEDIUM_TOP_VALUE, ImmutableList.of(LONG_BOTTOM_VALUE, MEDIUM_TOP_VALUE), 7);
-        assertMinMaxValuesWithLimit(null, null, ImmutableList.of(LONG_BOTTOM_VALUE), 6);
+        assertMinMaxValuesWithLimit(null, null, ImmutableList.of(LONG_BOTTOM_VALUE), 6, 20);
     }
 
     @Test
@@ -141,9 +141,9 @@ public class TestStringStatisticsBuilder
         statisticsList.add(stringColumnStatistics(null, MEDIUM_TOP_VALUE));
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), null, MEDIUM_TOP_VALUE);
         statisticsList.add(stringColumnStatistics(MEDIUM_TOP_VALUE, null));
-        assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), null, null);
+        assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), null, null, 400);
         statisticsList.add(stringColumnStatistics(MEDIUM_BOTTOM_VALUE, MEDIUM_BOTTOM_VALUE));
-        assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), null, null);
+        assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), null, null, 500);
     }
 
     @Test
@@ -275,6 +275,16 @@ public class TestStringStatisticsBuilder
         assertMinMax(builder.buildColumnStatistics().getStringStatistics(), expectedMin, expectedMax);
     }
 
+    private static void assertMinMaxValuesWithLimit(Slice expectedMin, Slice expectedMax, List<Slice> values, int limit, long expectedSum)
+    {
+        checkArgument(values != null && values.size() > 0);
+        StringStatisticsBuilder builder = new StringStatisticsBuilder(limit);
+        for (Slice value : values) {
+            builder.addValue(value);
+        }
+        assertMinMax(builder.buildColumnStatistics().getStringStatistics(), expectedMin, expectedMax, expectedSum);
+    }
+
     private static void assertMinMax(StringStatistics actualStringStatistics, Slice expectedMin, Slice expectedMax)
     {
         if (expectedMax == null && expectedMin == null) {
@@ -285,6 +295,14 @@ public class TestStringStatisticsBuilder
         assertNotNull(actualStringStatistics);
         assertEquals(actualStringStatistics.getMin(), expectedMin);
         assertEquals(actualStringStatistics.getMax(), expectedMax);
+    }
+
+    private static void assertMinMax(StringStatistics actualStringStatistics, Slice expectedMin, Slice expectedMax, long expectedSum)
+    {
+        assertNotNull(actualStringStatistics);
+        assertEquals(actualStringStatistics.getMin(), expectedMin);
+        assertEquals(actualStringStatistics.getMax(), expectedMax);
+        assertEquals(actualStringStatistics.getSum(), expectedSum);
     }
 
     private static ColumnStatistics stringColumnStatistics(Slice minimum, Slice maximum)


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Output (sum) string stat even if min/max values are too long. This is needed for the read-path to be able to better estimate the size of row.
```