### PR TITLE
[WIP] Fix predicate caching for Regex in Like

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -89,13 +89,13 @@ import com.facebook.presto.sql.tree.SubscriptExpression;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.sql.tree.WhenClause;
 import com.facebook.presto.type.LikeFunctions;
+import com.facebook.presto.type.RegexWrapper;
 import com.facebook.presto.util.Failures;
 import com.facebook.presto.util.FastutilSetHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Primitives;
-import io.airlift.joni.Regex;
 import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
@@ -166,7 +166,7 @@ public class ExpressionInterpreter
     private final Visitor visitor;
 
     // identity-based cache for LIKE expressions with constant pattern and escape char
-    private final IdentityHashMap<LikePredicate, Regex> likePatternCache = new IdentityHashMap<>();
+    private final IdentityHashMap<LikePredicate, RegexWrapper> likePatternCache = new IdentityHashMap<>();
     private final IdentityHashMap<InListExpression, Set<?>> inListCache = new IdentityHashMap<>();
 
     public static ExpressionInterpreter expressionInterpreter(Expression expression, Metadata metadata, Session session, Map<NodeRef<Expression>, Type> expressionTypes)
@@ -1023,7 +1023,7 @@ public class ExpressionInterpreter
             if (value instanceof Slice &&
                     pattern instanceof Slice &&
                     (escape == null || escape instanceof Slice)) {
-                Regex regex;
+                RegexWrapper regex;
                 if (escape == null) {
                     regex = LikeFunctions.likePattern((Slice) pattern);
                 }
@@ -1065,9 +1065,9 @@ public class ExpressionInterpreter
                     optimizedEscape);
         }
 
-        private Regex getConstantPattern(LikePredicate node)
+        private RegexWrapper getConstantPattern(LikePredicate node)
         {
-            Regex result = likePatternCache.get(node);
+            RegexWrapper result = likePatternCache.get(node);
 
             if (result == null) {
                 StringLiteral pattern = (StringLiteral) node.getPattern();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Interpreters.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Interpreters.java
@@ -19,7 +19,7 @@ import com.facebook.presto.spi.type.CharType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.type.LikeFunctions;
-import io.airlift.joni.Regex;
+import com.facebook.presto.type.RegexWrapper;
 import io.airlift.slice.Slice;
 
 import java.util.Map;
@@ -58,7 +58,7 @@ public class Interpreters
         throw new UnsupportedOperationException("Dereference a unsupported primitive type: " + javaType.getName());
     }
 
-    static boolean interpretLikePredicate(Type valueType, Slice value, Regex regex)
+    static boolean interpretLikePredicate(Type valueType, Slice value, RegexWrapper regex)
     {
         if (valueType instanceof VarcharType) {
             return LikeFunctions.likeVarchar(value, regex);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -44,10 +44,10 @@ import com.facebook.presto.sql.InterpretedFunctionInvoker;
 import com.facebook.presto.sql.planner.Interpreters.LambdaVariableResolver;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
+import com.facebook.presto.type.RegexWrapper;
 import com.facebook.presto.util.Failures;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Primitives;
-import io.airlift.joni.Regex;
 import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
@@ -877,15 +877,15 @@ public class RowExpressionInterpreter
 
             if (!hasUnresolvedValue(value) && !hasUnresolvedValue(nonCompiledPattern) && (!hasEscape || !hasUnresolvedValue(escape))) {
                 // fast path when we know the pattern and escape are constants
-                if (possibleCompiledPattern instanceof Regex) {
-                    return changed(interpretLikePredicate(argumentTypes.get(0), (Slice) value, (Regex) possibleCompiledPattern));
+                if (possibleCompiledPattern instanceof RegexWrapper) {
+                    return changed(interpretLikePredicate(argumentTypes.get(0), (Slice) value, (RegexWrapper) possibleCompiledPattern));
                 }
                 if (possibleCompiledPattern == null) {
                     return changed(null);
                 }
                 checkState((resolution.isCastFunction(((CallExpression) possibleCompiledPattern).getFunctionHandle())));
                 possibleCompiledPattern = functionInvoker.invoke(((CallExpression) possibleCompiledPattern).getFunctionHandle(), session, nonCompiledPattern);
-                return changed(interpretLikePredicate(argumentTypes.get(0), (Slice) value, (Regex) possibleCompiledPattern));
+                return changed(interpretLikePredicate(argumentTypes.get(0), (Slice) value, (RegexWrapper) possibleCompiledPattern));
             }
 
             // if pattern is a constant without % or _ replace with a comparison

--- a/presto-main/src/main/java/com/facebook/presto/type/LikeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LikeFunctions.java
@@ -56,7 +56,7 @@ public final class LikeFunctions
     @ScalarFunction(value = "like", hidden = true)
     @LiteralParameters("x")
     @SqlType(StandardTypes.BOOLEAN)
-    public static boolean likeChar(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice value, @SqlType(LikePatternType.NAME) Regex pattern)
+    public static boolean likeChar(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice value, @SqlType(LikePatternType.NAME) RegexWrapper pattern)
     {
         return likeVarchar(padSpaces(value, x.intValue()), pattern);
     }
@@ -65,7 +65,7 @@ public final class LikeFunctions
     @ScalarFunction(value = "like", hidden = true)
     @LiteralParameters("x")
     @SqlType(StandardTypes.BOOLEAN)
-    public static boolean likeVarchar(@SqlType("varchar(x)") Slice value, @SqlType(LikePatternType.NAME) Regex pattern)
+    public static boolean likeVarchar(@SqlType("varchar(x)") Slice value, @SqlType(LikePatternType.NAME) RegexWrapper pattern)
     {
         // Joni can infinite loop with UTF8Encoding when invalid UTF-8 is encountered.
         // NonStrictUTF8Encoding must be used to avoid this issue.
@@ -76,7 +76,7 @@ public final class LikeFunctions
     @ScalarOperator(OperatorType.CAST)
     @LiteralParameters("x")
     @SqlType(LikePatternType.NAME)
-    public static Regex castVarcharToLikePattern(@SqlType("varchar(x)") Slice pattern)
+    public static RegexWrapper castVarcharToLikePattern(@SqlType("varchar(x)") Slice pattern)
     {
         return likePattern(pattern);
     }
@@ -84,12 +84,12 @@ public final class LikeFunctions
     @ScalarOperator(OperatorType.CAST)
     @LiteralParameters("x")
     @SqlType(LikePatternType.NAME)
-    public static Regex castCharToLikePattern(@LiteralParameter("x") Long charLength, @SqlType("char(x)") Slice pattern)
+    public static RegexWrapper castCharToLikePattern(@LiteralParameter("x") Long charLength, @SqlType("char(x)") Slice pattern)
     {
         return likePattern(padSpaces(pattern, charLength.intValue()));
     }
 
-    public static Regex likePattern(Slice pattern)
+    public static RegexWrapper likePattern(Slice pattern)
     {
         return likePattern(pattern.toStringUtf8(), '0', false);
     }
@@ -97,7 +97,7 @@ public final class LikeFunctions
     @ScalarFunction(hidden = true)
     @LiteralParameters({"x", "y"})
     @SqlType(LikePatternType.NAME)
-    public static Regex likePattern(@SqlType("varchar(x)") Slice pattern, @SqlType("varchar(y)") Slice escape)
+    public static RegexWrapper likePattern(@SqlType("varchar(x)") Slice pattern, @SqlType("varchar(y)") Slice escape)
     {
         return likePattern(pattern.toStringUtf8(), getEscapeChar(escape), true);
     }
@@ -159,13 +159,13 @@ public final class LikeFunctions
         checkCondition(condition, INVALID_FUNCTION_ARGUMENT, "Escape character must be followed by '%%', '_' or the escape character itself");
     }
 
-    private static boolean regexMatches(Regex regex, byte[] bytes)
+    private static boolean regexMatches(RegexWrapper regex, byte[] bytes)
     {
-        return regex.matcher(bytes).match(0, bytes.length, Option.NONE) != -1;
+        return regex.getRegex().matcher(bytes).match(0, bytes.length, Option.NONE) != -1;
     }
 
     @SuppressWarnings("NestedSwitchStatement")
-    private static Regex likePattern(String patternString, char escapeChar, boolean shouldEscape)
+    private static RegexWrapper likePattern(String patternString, char escapeChar, boolean shouldEscape)
     {
         StringBuilder regex = new StringBuilder(patternString.length() * 2);
 
@@ -206,7 +206,7 @@ public final class LikeFunctions
         regex.append('$');
 
         byte[] bytes = regex.toString().getBytes(UTF_8);
-        return new Regex(bytes, 0, bytes.length, Option.MULTILINE, NonStrictUTF8Encoding.INSTANCE, SYNTAX);
+        return new RegexWrapper(new Regex(bytes, 0, bytes.length, Option.MULTILINE, NonStrictUTF8Encoding.INSTANCE, SYNTAX), patternString);
     }
 
     @SuppressWarnings("NumericCastThatLosesPrecision")

--- a/presto-main/src/main/java/com/facebook/presto/type/LikePatternType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LikePatternType.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.AbstractType;
 import com.facebook.presto.spi.type.TypeSignature;
-import io.airlift.joni.Regex;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 
@@ -32,7 +31,7 @@ public class LikePatternType
 
     public LikePatternType()
     {
-        super(new TypeSignature(NAME), Regex.class);
+        super(new TypeSignature(NAME), RegexWrapper.class);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/type/RegexWrapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RegexWrapper.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import io.airlift.joni.Regex;
+
+import java.util.Objects;
+
+public class RegexWrapper
+{
+    private final Regex regex;
+    private final String pattern;
+
+    public RegexWrapper(Regex regex, String pattern)
+    {
+        this.pattern = pattern;
+        this.regex = regex;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return pattern.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        RegexWrapper wrapper = (RegexWrapper) obj;
+        return Objects.equals(this.pattern, wrapper.pattern);
+    }
+
+    public Regex getRegex()
+    {
+        return regex;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestLikeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestLikeFunctions.java
@@ -15,7 +15,7 @@ package com.facebook.presto.sql;
 
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import com.facebook.presto.spi.PrestoException;
-import io.airlift.joni.Regex;
+import com.facebook.presto.type.RegexWrapper;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
@@ -39,7 +39,7 @@ public class TestLikeFunctions
     @Test
     public void testLikeBasic()
     {
-        Regex regex = likePattern(utf8Slice("f%b__"));
+        RegexWrapper regex = likePattern(utf8Slice("f%b__"));
         assertTrue(likeVarchar(utf8Slice("foobar"), regex));
 
         assertFunction("'foob' LIKE 'f%b__'", BOOLEAN, false);
@@ -49,7 +49,7 @@ public class TestLikeFunctions
     @Test
     public void testLikeChar()
     {
-        Regex regex = likePattern(utf8Slice("f%b__"));
+        RegexWrapper regex = likePattern(utf8Slice("f%b__"));
         assertTrue(likeChar(6L, utf8Slice("foobar"), regex));
         assertTrue(likeChar(6L, utf8Slice("foob"), regex));
         assertFalse(likeChar(7L, utf8Slice("foob"), regex));
@@ -61,7 +61,7 @@ public class TestLikeFunctions
     @Test
     public void testLikeSpacesInPattern()
     {
-        Regex regex = likePattern(utf8Slice("ala  "));
+        RegexWrapper regex = likePattern(utf8Slice("ala  "));
         assertTrue(likeVarchar(utf8Slice("ala  "), regex));
         assertFalse(likeVarchar(utf8Slice("ala"), regex));
 
@@ -73,28 +73,28 @@ public class TestLikeFunctions
     @Test
     public void testLikeNewlineInPattern()
     {
-        Regex regex = likePattern(utf8Slice("%o\nbar"));
+        RegexWrapper regex = likePattern(utf8Slice("%o\nbar"));
         assertTrue(likeVarchar(utf8Slice("foo\nbar"), regex));
     }
 
     @Test
     public void testLikeNewlineBeforeMatch()
     {
-        Regex regex = likePattern(utf8Slice("%b%"));
+        RegexWrapper regex = likePattern(utf8Slice("%b%"));
         assertTrue(likeVarchar(utf8Slice("foo\nbar"), regex));
     }
 
     @Test
     public void testLikeNewlineInMatch()
     {
-        Regex regex = likePattern(utf8Slice("f%b%"));
+        RegexWrapper regex = likePattern(utf8Slice("f%b%"));
         assertTrue(likeVarchar(utf8Slice("foo\nbar"), regex));
     }
 
     @Test(timeOut = 1000)
     public void testLikeUtf8Pattern()
     {
-        Regex regex = likePattern(utf8Slice("%\u540d\u8a89%"), utf8Slice("\\"));
+        RegexWrapper regex = likePattern(utf8Slice("%\u540d\u8a89%"), utf8Slice("\\"));
         assertFalse(likeVarchar(utf8Slice("foo"), regex));
     }
 
@@ -103,28 +103,28 @@ public class TestLikeFunctions
     public void testLikeInvalidUtf8Value()
     {
         Slice value = Slices.wrappedBuffer(new byte[] {'a', 'b', 'c', (byte) 0xFF, 'x', 'y'});
-        Regex regex = likePattern(utf8Slice("%b%"), utf8Slice("\\"));
+        RegexWrapper regex = likePattern(utf8Slice("%b%"), utf8Slice("\\"));
         assertTrue(likeVarchar(value, regex));
     }
 
     @Test
     public void testBackslashesNoSpecialTreatment()
     {
-        Regex regex = likePattern(utf8Slice("\\abc\\/\\\\"));
+        RegexWrapper regex = likePattern(utf8Slice("\\abc\\/\\\\"));
         assertTrue(likeVarchar(utf8Slice("\\abc\\/\\\\"), regex));
     }
 
     @Test
     public void testSelfEscaping()
     {
-        Regex regex = likePattern(utf8Slice("\\\\abc\\%"), utf8Slice("\\"));
+        RegexWrapper regex = likePattern(utf8Slice("\\\\abc\\%"), utf8Slice("\\"));
         assertTrue(likeVarchar(utf8Slice("\\abc%"), regex));
     }
 
     @Test
     public void testAlternateEscapedCharacters()
     {
-        Regex regex = likePattern(utf8Slice("xxx%x_abcxx"), utf8Slice("x"));
+        RegexWrapper regex = likePattern(utf8Slice("xxx%x_abcxx"), utf8Slice("x"));
         assertTrue(likeVarchar(utf8Slice("x%_abcx"), regex));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -33,6 +33,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
 import com.facebook.presto.sql.tree.Extract.Field;
 import com.facebook.presto.type.LikeFunctions;
+import com.facebook.presto.type.RegexWrapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -41,7 +42,6 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
-import io.airlift.joni.Regex;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.units.Duration;
@@ -1545,7 +1545,7 @@ public class TestExpressionCompiler
             for (String pattern : stringLefts) {
                 Boolean expected = null;
                 if (value != null && pattern != null) {
-                    Regex regex = LikeFunctions.likePattern(utf8Slice(pattern), utf8Slice("\\"));
+                    RegexWrapper regex = LikeFunctions.likePattern(utf8Slice(pattern), utf8Slice("\\"));
                     expected = LikeFunctions.likeVarchar(utf8Slice(value), regex);
                 }
                 assertExecute(generateExpression("%s like %s", value, pattern), BOOLEAN, expected);


### PR DESCRIPTION
The predicate caching for Expressions with Like does not work as we use Regex hashcode as a cache key which is not implemented in the joni Regex class. Because of this we keep missing the cache and this results in 6x regression in some queries which have large number of Like functions.

This PR creates a wrapper for Regex which implements the hashcode and equals.

```
== NO RELEASE NOTE ==
```
