### PR TITLE
Fix requiredField logic in StructSelectiveStreamReader

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -622,9 +622,11 @@ public class TestHivePushdownFilterQueries
         assertQueryUsingH2Cte("SELECT info.orderkey, info.linenumber FROM lineitem_ex", rewriter);
 
         assertQueryUsingH2Cte("SELECT info.linenumber, info.shipdate.ship_year FROM lineitem_ex WHERE orderkey < 1000", rewriter);
+        assertQueryUsingH2Cte("SELECT info.orderkey FROM lineitem_ex WHERE orderkey = 16515", rewriter);
 
         assertQueryUsingH2Cte("SELECT info.orderkey FROM lineitem_ex WHERE info IS NULL", rewriter);
         assertQueryUsingH2Cte("SELECT info.orderkey FROM lineitem_ex WHERE info IS NOT NULL", rewriter);
+        assertQueryUsingH2Cte("SELECT info.orderkey FROM lineitem_ex WHERE info IS NOT NULL AND orderkey = 16515", rewriter);
 
         assertQueryUsingH2Cte("SELECT info, dates FROM lineitem_ex WHERE info.orderkey % 7 = 0", rewriter);
         assertQueryUsingH2Cte("SELECT info.orderkey, dates FROM lineitem_ex WHERE info.orderkey % 7 = 0", rewriter);
@@ -641,6 +643,8 @@ public class TestHivePushdownFilterQueries
 
         // filter-only struct
         assertQueryUsingH2Cte("SELECT orderkey FROM lineitem_ex WHERE info IS NOT NULL");
+        assertQueryUsingH2Cte("SELECT orderkey FROM lineitem_ex WHERE info IS NOT NULL AND info.orderkey = 16515", rewriter);
+        assertQueryUsingH2Cte("SELECT orderkey FROM lineitem_ex WHERE info IS NOT NULL AND info.orderkey + 1 = 16514", rewriter);
 
         // filters on subfields
         assertQueryUsingH2Cte("SELECT info.orderkey, info.linenumber FROM lineitem_ex WHERE info.linenumber = 2", rewriter);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
@@ -153,7 +153,7 @@ public class StructSelectiveStreamReader
                 StreamDescriptor nestedStream = nestedStreams.get(i);
                 String fieldName = nestedStream.getFieldName().toLowerCase(Locale.ENGLISH);
                 Optional<Type> fieldOutputType = nestedTypes.isPresent() ? Optional.of(nestedTypes.get().get(i)) : Optional.empty();
-                boolean requiredField = requiredFields.map(names -> names.containsKey(fieldName)).orElse(true);
+                boolean requiredField = requiredFields.map(names -> names.containsKey(fieldName)).orElse(outputRequired);
 
                 if (requiredField || fieldsWithFilters.contains(fieldName)) {
                     Map<Subfield, TupleDomainFilter> nestedFilters = filters.entrySet().stream()


### PR DESCRIPTION
This fixes the following exception

```
Caused by: java.lang.IllegalArgumentException: filter must be present if outputRequired is false
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:141)
	at com.facebook.presto.orc.reader.DoubleSelectiveStreamReader.<init>(DoubleSelectiveStreamReader.java:92)
	at com.facebook.presto.orc.reader.SelectiveStreamReaders.createStreamReader(SelectiveStreamReaders.java:70)
	at com.facebook.presto.orc.reader.StructSelectiveStreamReader.<init>(StructSelectiveStreamReader.java:164)
	at com.facebook.presto.orc.reader.SelectiveStreamReaders.createStreamReader(SelectiveStreamReaders.java:84)
	at com.facebook.presto.orc.OrcSelectiveRecordReader.createStreamReaders(OrcSelectiveRecordReader.java:581)
	at com.facebook.presto.orc.OrcSelectiveRecordReader.<init>(OrcSelectiveRecordReader.java:176)
	at com.facebook.presto.orc.OrcReader.createSelectiveRecordReader(OrcReader.java:234)
	at com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory.createOrcPageSource(OrcSelectivePageSourceFactory.java:363)
```

```
== NO RELEASE NOTE ==
```
