### PR TITLE
Propagate deprecated.legacy-map-subscript to selective map reader

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -380,6 +380,7 @@ public class OrcSelectivePageSourceFactory
                     start,
                     length,
                     hiveStorageTimeZone,
+                    session.getSqlFunctionProperties().isLegacyMapSubscript(),
                     systemMemoryUsage,
                     Optional.empty(),
                     INITIAL_BATCH_SIZE);

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.SystemSessionProperties.isLegacyMapSubscript;
 import static com.facebook.presto.SystemSessionProperties.isLegacyRowFieldOrdinalAccessEnabled;
 import static com.facebook.presto.SystemSessionProperties.isLegacyTimestamp;
 import static com.facebook.presto.SystemSessionProperties.isParseDecimalLiteralsAsDouble;
@@ -419,6 +420,7 @@ public final class Session
                 .setTimeZoneKey(timeZoneKey)
                 .setLegacyRowFieldOrdinalAccessEnabled(isLegacyRowFieldOrdinalAccessEnabled(this))
                 .setLegacyTimestamp(isLegacyTimestamp(this))
+                .setLegacyMapSubscript(isLegacyMapSubscript(this))
                 .setParseDecimalLiteralAsDouble(isParseDecimalLiteralsAsDouble(this))
                 .build();
     }

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -105,6 +105,7 @@ public final class SystemSessionProperties
     public static final String AGGREGATION_OPERATOR_UNSPILL_MEMORY_LIMIT = "aggregation_operator_unspill_memory_limit";
     public static final String OPTIMIZE_DISTINCT_AGGREGATIONS = "optimize_mixed_distinct_aggregations";
     public static final String LEGACY_ROW_FIELD_ORDINAL_ACCESS = "legacy_row_field_ordinal_access";
+    public static final String LEGACY_MAP_SUBSCRIPT = "do_not_use_legacy_map_subscript";
     public static final String ITERATIVE_OPTIMIZER = "iterative_optimizer_enabled";
     public static final String ITERATIVE_OPTIMIZER_TIMEOUT = "iterative_optimizer_timeout";
     public static final String EXCHANGE_COMPRESSION = "exchange_compression";
@@ -496,6 +497,11 @@ public final class SystemSessionProperties
                         "Allow accessing anonymous row field with .field0, .field1, ...",
                         featuresConfig.isLegacyRowFieldOrdinalAccess(),
                         false),
+                booleanProperty(
+                        LEGACY_MAP_SUBSCRIPT,
+                        "Do not fail the query if map key is missing",
+                        featuresConfig.isLegacyMapSubscript(),
+                        true),
                 booleanProperty(
                         ITERATIVE_OPTIMIZER,
                         "Experimental: enable iterative optimizer",
@@ -950,6 +956,11 @@ public final class SystemSessionProperties
     public static boolean isLegacyRowFieldOrdinalAccessEnabled(Session session)
     {
         return session.getSystemProperty(LEGACY_ROW_FIELD_ORDINAL_ACCESS, Boolean.class);
+    }
+
+    public static boolean isLegacyMapSubscript(Session session)
+    {
+        return session.getSystemProperty(LEGACY_MAP_SUBSCRIPT, Boolean.class);
     }
 
     public static boolean isNewOptimizerEnabled(Session session)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -200,6 +200,7 @@ public class OrcReader
             long offset,
             long length,
             DateTimeZone hiveStorageTimeZone,
+            boolean legacyMapSubscript,
             AggregatedMemoryContext systemMemoryUsage,
             Optional<OrcWriteValidation> writeValidation,
             int initialBatchSize)
@@ -225,6 +226,7 @@ public class OrcReader
                 decompressor,
                 footer.getRowsInRowGroup(),
                 hiveStorageTimeZone,
+                legacyMapSubscript,
                 hiveWriterVersion,
                 metadataReader,
                 orcReaderOptions.getMaxMergeDistance(),

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -161,6 +161,7 @@ public class OrcSelectiveRecordReader
             Optional<OrcDecompressor> decompressor,
             int rowsInRowGroup,
             DateTimeZone hiveStorageTimeZone,
+            boolean legacyMapSubscript,
             PostScript.HiveWriterVersion hiveWriterVersion,
             MetadataReader metadataReader,
             DataSize maxMergeDistance,
@@ -177,6 +178,7 @@ public class OrcSelectiveRecordReader
                         orcDataSource,
                         types,
                         hiveStorageTimeZone,
+                        legacyMapSubscript,
                         includedColumns,
                         outputColumns,
                         filters,
@@ -553,6 +555,7 @@ public class OrcSelectiveRecordReader
             OrcDataSource orcDataSource,
             List<OrcType> types,
             DateTimeZone hiveStorageTimeZone,
+            boolean legacyMapSubscript,
             Map<Integer, Type> includedColumns,
             List<Integer> outputColumns,
             Map<Integer, Map<Subfield, TupleDomainFilter>> filters,
@@ -584,6 +587,7 @@ public class OrcSelectiveRecordReader
                         outputRequired ? Optional.of(includedColumns.get(columnId)) : Optional.empty(),
                         Optional.ofNullable(requiredSubfields.get(columnId)).orElse(ImmutableList.of()),
                         hiveStorageTimeZone,
+                        legacyMapSubscript,
                         systemMemoryContext);
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
@@ -120,6 +120,7 @@ public class ListSelectiveStreamReader
             int subfieldLevel,  // 0 - top level
             Optional<Type> outputType,
             DateTimeZone hiveStorageTimeZone,
+            boolean legacyMapSubscript,
             AggregatedMemoryContext systemMemoryContext)
     {
         requireNonNull(filters, "filters is null");
@@ -199,7 +200,7 @@ public class ListSelectiveStreamReader
                     .collect(toImmutableList());
         }
 
-        this.elementStreamReader = createNestedStreamReader(elementStreamDescriptor, level + 1, Optional.ofNullable(this.listFilter), elementOutputType, elementSubfields, hiveStorageTimeZone, systemMemoryContext);
+        this.elementStreamReader = createNestedStreamReader(elementStreamDescriptor, level + 1, Optional.ofNullable(this.listFilter), elementOutputType, elementSubfields, hiveStorageTimeZone, legacyMapSubscript, systemMemoryContext);
         this.systemMemoryContext = systemMemoryContext.newLocalMemoryContext(ListSelectiveStreamReader.class.getSimpleName());
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectSelectiveStreamReader.java
@@ -69,6 +69,7 @@ public class MapDirectSelectiveStreamReader
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapDirectSelectiveStreamReader.class).instanceSize();
 
     private final StreamDescriptor streamDescriptor;
+    private final boolean legacyMapSubscript;
     private final boolean nullsAllowed;
     private final boolean nonNullsAllowed;
     private final boolean outputRequired;
@@ -112,11 +113,13 @@ public class MapDirectSelectiveStreamReader
             List<Subfield> requiredSubfields,
             Optional<Type> outputType,
             DateTimeZone hiveStorageTimeZone,
+            boolean legacyMapSubscript,
             AggregatedMemoryContext systemMemoryContext)
     {
         checkArgument(filters.keySet().stream().map(Subfield::getPath).allMatch(List::isEmpty), "filters on nested columns are not supported yet");
 
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
+        this.legacyMapSubscript = legacyMapSubscript;
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null").newLocalMemoryContext(MapDirectSelectiveStreamReader.class.getSimpleName());
         this.outputRequired = requireNonNull(outputType, "outputType is null").isPresent();
         this.outputType = outputType.map(MapType.class::cast).orElse(null);
@@ -141,8 +144,8 @@ public class MapDirectSelectiveStreamReader
                         .collect(toImmutableList());
             }
 
-            this.keyReader = SelectiveStreamReaders.createStreamReader(nestedStreams.get(0), keyFilter, keyOutputType, ImmutableList.of(), hiveStorageTimeZone, systemMemoryContext.newAggregatedMemoryContext());
-            this.valueReader = SelectiveStreamReaders.createStreamReader(nestedStreams.get(1), ImmutableMap.of(), valueOutputType, elementRequiredSubfields, hiveStorageTimeZone, systemMemoryContext.newAggregatedMemoryContext());
+            this.keyReader = SelectiveStreamReaders.createStreamReader(nestedStreams.get(0), keyFilter, keyOutputType, ImmutableList.of(), hiveStorageTimeZone, legacyMapSubscript, systemMemoryContext.newAggregatedMemoryContext());
+            this.valueReader = SelectiveStreamReaders.createStreamReader(nestedStreams.get(1), ImmutableMap.of(), valueOutputType, elementRequiredSubfields, hiveStorageTimeZone, legacyMapSubscript, systemMemoryContext.newAggregatedMemoryContext());
         }
         else {
             this.keyReader = null;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapSelectiveStreamReader.java
@@ -54,11 +54,12 @@ public class MapSelectiveStreamReader
             List<Subfield> requiredSubfields,
             Optional<Type> outputType,
             DateTimeZone hiveStorageTimeZone,
+            boolean legacyMapSubscript,
             AggregatedMemoryContext systemMemoryContext)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
-        directReader = new MapDirectSelectiveStreamReader(streamDescriptor, filters, requiredSubfields, outputType, hiveStorageTimeZone, systemMemoryContext);
-        flatReader = new MapFlatSelectiveStreamReader(streamDescriptor, filters, requiredSubfields, outputType, hiveStorageTimeZone, systemMemoryContext);
+        directReader = new MapDirectSelectiveStreamReader(streamDescriptor, filters, requiredSubfields, outputType, hiveStorageTimeZone, legacyMapSubscript, systemMemoryContext);
+        flatReader = new MapFlatSelectiveStreamReader(streamDescriptor, filters, requiredSubfields, outputType, hiveStorageTimeZone, legacyMapSubscript, systemMemoryContext);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
@@ -102,6 +102,7 @@ public class StructSelectiveStreamReader
             List<Subfield> requiredSubfields,
             Optional<Type> outputType,
             DateTimeZone hiveStorageTimeZone,
+            boolean legacyMapSubscript,
             AggregatedMemoryContext systemMemoryContext)
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
@@ -167,6 +168,7 @@ public class StructSelectiveStreamReader
                             fieldOutputType,
                             nestedRequiredSubfields,
                             hiveStorageTimeZone,
+                            legacyMapSubscript,
                             systemMemoryContext.newAggregatedMemoryContext());
                     nestedReaders.put(fieldName, nestedReader);
                 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -210,6 +210,7 @@ public class BenchmarkSelectiveStreamReaders
                     0,
                     dataSource.getSize(),
                     UTC, // arbitrary
+                    true,
                     newSimpleAggregatedMemoryContext(),
                     Optional.empty(),
                     INITIAL_BATCH_SIZE);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -195,6 +195,7 @@ public class OrcTester
     public static final DataSize MAX_BLOCK_SIZE = new DataSize(1, Unit.MEGABYTE);
     public static final DateTimeZone HIVE_STORAGE_TIME_ZONE = DateTimeZone.forID("America/Bahia_Banderas");
 
+    private static final boolean LEGACY_MAP_SUBSCRIPT = true;
     private static final TypeManager TYPE_MANAGER = new TypeRegistry();
     private static final List<Integer> PRIME_NUMBERS = ImmutableList.of(5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97);
 
@@ -1402,6 +1403,7 @@ public class OrcTester
                 0,
                 orcDataSource.getSize(),
                 HIVE_STORAGE_TIME_ZONE,
+                LEGACY_MAP_SUBSCRIPT,
                 newSimpleAggregatedMemoryContext(),
                 Optional.empty(),
                 initialBatchSize);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlFunctionProperties.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlFunctionProperties.java
@@ -25,17 +25,20 @@ public class SqlFunctionProperties
     private final boolean legacyRowFieldOrdinalAccessEnabled;
     private final TimeZoneKey timeZoneKey;
     private final boolean legacyTimestamp;
+    private final boolean legacyMapSubscript;
 
     private SqlFunctionProperties(
             boolean parseDecimalLiteralAsDouble,
             boolean legacyRowFieldOrdinalAccessEnabled,
             TimeZoneKey timeZoneKey,
-            boolean legacyTimestamp)
+            boolean legacyTimestamp,
+            boolean legacyMapSubscript)
     {
         this.parseDecimalLiteralAsDouble = parseDecimalLiteralAsDouble;
         this.legacyRowFieldOrdinalAccessEnabled = legacyRowFieldOrdinalAccessEnabled;
         this.timeZoneKey = requireNonNull(timeZoneKey, "timeZoneKey is null");
         this.legacyTimestamp = legacyTimestamp;
+        this.legacyMapSubscript = legacyMapSubscript;
     }
 
     public boolean isParseDecimalLiteralAsDouble()
@@ -59,6 +62,11 @@ public class SqlFunctionProperties
         return legacyTimestamp;
     }
 
+    public boolean isLegacyMapSubscript()
+    {
+        return legacyMapSubscript;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -72,13 +80,14 @@ public class SqlFunctionProperties
         return Objects.equals(parseDecimalLiteralAsDouble, that.parseDecimalLiteralAsDouble) &&
                 Objects.equals(legacyRowFieldOrdinalAccessEnabled, that.legacyRowFieldOrdinalAccessEnabled) &&
                 Objects.equals(timeZoneKey, that.timeZoneKey) &&
-                Objects.equals(legacyTimestamp, that.legacyTimestamp);
+                Objects.equals(legacyTimestamp, that.legacyTimestamp) &&
+                Objects.equals(legacyMapSubscript, that.legacyMapSubscript);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(parseDecimalLiteralAsDouble, legacyRowFieldOrdinalAccessEnabled, timeZoneKey, legacyTimestamp);
+        return Objects.hash(parseDecimalLiteralAsDouble, legacyRowFieldOrdinalAccessEnabled, timeZoneKey, legacyTimestamp, legacyMapSubscript);
     }
 
     public static Builder builder()
@@ -92,6 +101,7 @@ public class SqlFunctionProperties
         private boolean legacyRowFieldOrdinalAccessEnabled;
         private TimeZoneKey timeZoneKey;
         private boolean legacyTimestamp;
+        private boolean legacyMapSubscript;
 
         private Builder() {}
 
@@ -119,9 +129,15 @@ public class SqlFunctionProperties
             return this;
         }
 
+        public Builder setLegacyMapSubscript(boolean legacyMapSubscript)
+        {
+            this.legacyMapSubscript = legacyMapSubscript;
+            return this;
+        }
+
         public SqlFunctionProperties build()
         {
-            return new SqlFunctionProperties(parseDecimalLiteralAsDouble, legacyRowFieldOrdinalAccessEnabled, timeZoneKey, legacyTimestamp);
+            return new SqlFunctionProperties(parseDecimalLiteralAsDouble, legacyRowFieldOrdinalAccessEnabled, timeZoneKey, legacyTimestamp, legacyMapSubscript);
         }
     }
 }


### PR DESCRIPTION
`deprecated.legacy-map-subscript` configuration properties affects the behavior of map subscript operator. When `cat` key doesn't exist, `m["cat"]` returns null if `deprecated.legacy-map-subscript` is true and throws an exception if `deprecated.legacy-map-subscript` is false.

MapSelectiveStreamReader needs access to this property to properly implement pushdown of range filters on elements.

```
== NO RELEASE NOTE ==
```
