### PR TITLE
Support internal communication with thrift

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -736,6 +736,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.facebook.drift</groupId>
+                <artifactId>drift-transport-spi</artifactId>
+                <version>${dep.drift.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.airlift.tpch</groupId>
                 <artifactId>tpch</artifactId>
                 <version>0.10</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1311,6 +1311,12 @@
                 <groupId>com.facebook.presto.cassandra</groupId>
                 <artifactId>cassandra-driver</artifactId>
                 <version>3.1.4-1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -87,6 +87,10 @@
                     <groupId>org.elasticsearch.plugin</groupId>
                     <artifactId>transport-netty4-client</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -157,6 +161,12 @@
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty4-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <version>${dep.elasticsearch.version}</version>
         </dependency>
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithThriftRpc.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithThriftRpc.java
@@ -28,7 +28,9 @@ public class TestHiveDistributedQueriesWithThriftRpc
     {
         super(() -> createQueryRunner(
                 getTables(),
-                ImmutableMap.of("internal-communication.task-communication-protocol", "THRIFT"),
+                ImmutableMap.of(
+                        "internal-communication.task-communication-protocol", "THRIFT",
+                        "internal-communication.server-info-communication-protocol", "THRIFT"),
                 ImmutableMap.of(),
                 Optional.empty()));
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithThriftRpc.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithThriftRpc.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.tests.AbstractTestDistributedQueries;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveQueryRunner.createQueryRunner;
+import static io.airlift.tpch.TpchTable.getTables;
+
+public class TestHiveDistributedQueriesWithThriftRpc
+        extends AbstractTestDistributedQueries
+{
+    public TestHiveDistributedQueriesWithThriftRpc()
+    {
+        super(() -> createQueryRunner(
+                getTables(),
+                ImmutableMap.of("internal-communication.task-communication-protocol", "THRIFT"),
+                ImmutableMap.of(),
+                Optional.empty()));
+    }
+
+    @Override
+    protected boolean supportsNotNullColumns()
+    {
+        return false;
+    }
+
+    @Override
+    public void testDelete()
+    {
+        // Hive connector currently does not support row-by-row delete
+    }
+
+    // Hive specific tests should normally go in TestHiveIntegrationSmokeTest
+}

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -197,6 +197,21 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-transport-netty</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-client</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.teradata</groupId>
             <artifactId>re2j-td</artifactId>
         </dependency>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -212,6 +212,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-codec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.teradata</groupId>
             <artifactId>re2j-td</artifactId>
         </dependency>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -208,6 +208,11 @@
 
         <dependency>
             <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-transport-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
             <artifactId>drift-client</artifactId>
         </dependency>
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/LocationFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/LocationFactory.java
@@ -26,6 +26,16 @@ public interface LocationFactory
 
     URI createLocalTaskLocation(TaskId taskId);
 
+    /**
+     * TODO: this method is required since not not all RPC call is supported by thrift.
+     *     It should be merged into {@code createTaskLocation} once full thrift support is in-place for v1/task
+     */
+    @Deprecated
+    URI createLegacyTaskLocation(InternalNode node, TaskId taskId);
+
+    /**
+     * TODO: implement full thrift support for v1/task
+     */
     URI createTaskLocation(InternalNode node, TaskId taskId);
 
     URI createMemoryInfoLocation(InternalNode node);

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
@@ -20,6 +20,8 @@ import com.facebook.presto.spi.plan.PlanNodeId;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import java.net.URI;
+
 public interface RemoteTask
 {
     TaskId getTaskId();
@@ -29,6 +31,11 @@ public interface RemoteTask
     TaskInfo getTaskInfo();
 
     TaskStatus getTaskStatus();
+
+    /**
+     * TODO: this should be merged into getTaskStatus once full thrift support is in-place for v1/task
+     */
+    URI getRemoteTaskLocation();
 
     void start();
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -365,7 +365,7 @@ public final class SqlStageExecution
             ImmutableMultimap.Builder<PlanNodeId, Split> newSplits = ImmutableMultimap.builder();
             for (RemoteTask sourceTask : sourceTasks) {
                 TaskStatus sourceTaskStatus = sourceTask.getTaskStatus();
-                newSplits.put(remoteSource.getId(), createRemoteSplitFor(task.getTaskId(), sourceTaskStatus.getSelf(), sourceTaskStatus.getTaskId()));
+                newSplits.put(remoteSource.getId(), createRemoteSplitFor(task.getTaskId(), sourceTask.getRemoteTaskLocation(), sourceTaskStatus.getTaskId()));
             }
             task.addSplits(newSplits.build());
         }
@@ -491,7 +491,7 @@ public final class SqlStageExecution
         sourceTasks.forEach((planNodeId, task) -> {
             TaskStatus status = task.getTaskStatus();
             if (status.getState() != TaskState.FINISHED) {
-                initialSplits.put(planNodeId, createRemoteSplitFor(taskId, status.getSelf(), status.getTaskId()));
+                initialSplits.put(planNodeId, createRemoteSplitFor(taskId, task.getRemoteTaskLocation(), status.getTaskId()));
             }
         });
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionId.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionId.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.execution;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.spi.QueryId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -25,6 +28,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class StageExecutionId
 {
     private final StageId stageId;
@@ -42,17 +46,20 @@ public class StageExecutionId
         return new StageExecutionId(new StageId(new QueryId(ids.get(0)), parseInt(ids.get(1))), parseInt(ids.get(2)));
     }
 
+    @ThriftConstructor
     public StageExecutionId(StageId stageId, int id)
     {
         this.stageId = requireNonNull(stageId, "stageId is null");
         this.id = id;
     }
 
+    @ThriftField(1)
     public StageId getStageId()
     {
         return stageId;
     }
 
+    @ThriftField(2)
     public int getId()
     {
         return id;

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageId.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageId.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.execution;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.spi.QueryId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -23,6 +26,7 @@ import java.util.Objects;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class StageId
 {
     @JsonCreator
@@ -47,11 +51,24 @@ public class StageId
         this.id = id;
     }
 
+    @ThriftConstructor
+    public StageId(String queryId, int id)
+    {
+        this(QueryId.valueOf(queryId), id);
+    }
+
     public QueryId getQueryId()
     {
         return queryId;
     }
 
+    @ThriftField(value = 1, name = "queryId")
+    public String getQueryIdString()
+    {
+        return queryId.toString();
+    }
+
+    @ThriftField(2)
     public int getId()
     {
         return id;

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskId.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskId.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.execution;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.spi.QueryId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -25,6 +28,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class TaskId
 {
     private final StageExecutionId stageExecutionId;
@@ -42,6 +46,7 @@ public class TaskId
         this(new StageExecutionId(new StageId(new QueryId(queryId), stageId), stageExecutionId), id);
     }
 
+    @ThriftConstructor
     public TaskId(StageExecutionId stageExecutionId, int id)
     {
         this.stageExecutionId = requireNonNull(stageExecutionId, "stageExecutionId");
@@ -49,11 +54,13 @@ public class TaskId
         this.id = id;
     }
 
+    @ThriftField(1)
     public StageExecutionId getStageExecutionId()
     {
         return stageExecutionId;
     }
 
+    @ThriftField(2)
     public int getId()
     {
         return id;

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/BufferResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/BufferResult.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.execution.buffer;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -23,6 +26,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class BufferResult
 {
     public static BufferResult emptyResults(String taskInstanceId, long token, boolean bufferComplete)
@@ -36,6 +40,7 @@ public class BufferResult
     private final boolean bufferComplete;
     private final List<SerializedPage> serializedPages;
 
+    @ThriftConstructor
     public BufferResult(String taskInstanceId, long token, long nextToken, boolean bufferComplete, List<SerializedPage> serializedPages)
     {
         checkArgument(!isNullOrEmpty(taskInstanceId), "taskInstanceId is null");
@@ -47,21 +52,31 @@ public class BufferResult
         this.serializedPages = ImmutableList.copyOf(requireNonNull(serializedPages, "serializedPages is null"));
     }
 
+    @ThriftField(1)
+    public String getTaskInstanceId()
+    {
+        return taskInstanceId;
+    }
+
+    @ThriftField(2)
     public long getToken()
     {
         return token;
     }
 
+    @ThriftField(3)
     public long getNextToken()
     {
         return nextToken;
     }
 
+    @ThriftField(4)
     public boolean isBufferComplete()
     {
         return bufferComplete;
     }
 
+    @ThriftField(5)
     public List<SerializedPage> getSerializedPages()
     {
         return serializedPages;
@@ -75,11 +90,6 @@ public class BufferResult
     public boolean isEmpty()
     {
         return serializedPages.isEmpty();
-    }
-
-    public String getTaskInstanceId()
-    {
-        return taskInstanceId;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBuffers.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBuffers.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.execution.buffer;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.sql.planner.PartitioningHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -248,6 +251,7 @@ public final class OutputBuffers
                 partition);
     }
 
+    @ThriftStruct
     public static class OutputBufferId
     {
         // this is needed by JAX-RS
@@ -258,6 +262,7 @@ public final class OutputBuffers
 
         private final int id;
 
+        @ThriftConstructor
         @JsonCreator
         public OutputBufferId(int id)
         {
@@ -278,6 +283,7 @@ public final class OutputBuffers
             return id == that.id;
         }
 
+        @ThriftField(1)
         @JsonValue
         public int getId()
         {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -177,7 +177,7 @@ public final class DiscoveryNodeManager
         // Add new nodes
         for (InternalNode node : aliveNodes) {
             nodeStates.putIfAbsent(node.getNodeIdentifier(),
-                    new RemoteNodeState(httpClient, uriBuilderFrom(node.getInternalUri()).appendPath("/v1/info/state").build()));
+                    new HttpRemoteNodeState(httpClient, uriBuilderFrom(node.getInternalUri()).appendPath("/v1/info/state").build()));
         }
 
         // Schedule refresh

--- a/presto-main/src/main/java/com/facebook/presto/metadata/HttpRemoteNodeState.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/HttpRemoteNodeState.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.airlift.http.client.FullJsonResponseHandler.JsonResponse;
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpClient.HttpResponseFuture;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.NodeState;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import io.airlift.units.Duration;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.facebook.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static com.facebook.airlift.http.client.HttpStatus.OK;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.units.Duration.nanosSince;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+
+@ThreadSafe
+public class HttpRemoteNodeState
+        implements RemoteNodeState
+{
+    private static final Logger log = Logger.get(HttpRemoteNodeState.class);
+
+    private final HttpClient httpClient;
+    private final URI stateInfoUri;
+    private final AtomicReference<Optional<NodeState>> nodeState = new AtomicReference<>(Optional.empty());
+    private final AtomicReference<Future<?>> future = new AtomicReference<>();
+    private final AtomicLong lastUpdateNanos = new AtomicLong();
+    private final AtomicLong lastWarningLogged = new AtomicLong();
+
+    public HttpRemoteNodeState(HttpClient httpClient, URI stateInfoUri)
+    {
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.stateInfoUri = requireNonNull(stateInfoUri, "stateInfoUri is null");
+    }
+
+    @Override
+    public Optional<NodeState> getNodeState()
+    {
+        return nodeState.get();
+    }
+
+    @Override
+    public synchronized void asyncRefresh()
+    {
+        Duration sinceUpdate = nanosSince(lastUpdateNanos.get());
+        if (nanosSince(lastWarningLogged.get()).toMillis() > 1_000 &&
+                sinceUpdate.toMillis() > 10_000 &&
+                future.get() != null) {
+            log.warn("Node state update request to %s has not returned in %s", stateInfoUri, sinceUpdate.toString(SECONDS));
+            lastWarningLogged.set(System.nanoTime());
+        }
+        if (sinceUpdate.toMillis() > 1_000 && future.get() == null) {
+            Request request = prepareGet()
+                    .setUri(stateInfoUri)
+                    .setHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                    .build();
+            HttpResponseFuture<JsonResponse<NodeState>> responseFuture = httpClient.executeAsync(request, createFullJsonResponseHandler(jsonCodec(NodeState.class)));
+            future.compareAndSet(null, responseFuture);
+
+            Futures.addCallback(responseFuture, new FutureCallback<JsonResponse<NodeState>>()
+            {
+                @Override
+                public void onSuccess(@Nullable JsonResponse<NodeState> result)
+                {
+                    lastUpdateNanos.set(System.nanoTime());
+                    future.compareAndSet(responseFuture, null);
+                    if (result != null) {
+                        if (result.hasValue()) {
+                            nodeState.set(Optional.ofNullable(result.getValue()));
+                        }
+                        if (result.getStatusCode() != OK.code()) {
+                            log.warn("Error fetching node state from %s returned status %d: %s", stateInfoUri, result.getStatusCode(), result.getStatusMessage());
+                            return;
+                        }
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable t)
+                {
+                    log.warn("Error fetching node state from %s: %s", stateInfoUri, t.getMessage());
+                    lastUpdateNanos.set(System.nanoTime());
+                    future.compareAndSet(responseFuture, null);
+                }
+            }, directExecutor());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/InternalNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/InternalNode.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.Node;
 
 import java.net.URI;
+import java.util.OptionalInt;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Strings.emptyToNull;
@@ -32,14 +33,21 @@ public class InternalNode
 {
     private final String nodeIdentifier;
     private final URI internalUri;
+    private final OptionalInt thriftPort;
     private final NodeVersion nodeVersion;
     private final boolean coordinator;
 
     public InternalNode(String nodeIdentifier, URI internalUri, NodeVersion nodeVersion, boolean coordinator)
     {
+        this(nodeIdentifier, internalUri, OptionalInt.empty(), nodeVersion, coordinator);
+    }
+
+    public InternalNode(String nodeIdentifier, URI internalUri, OptionalInt thriftPort, NodeVersion nodeVersion, boolean coordinator)
+    {
         nodeIdentifier = emptyToNull(nullToEmpty(nodeIdentifier).trim());
         this.nodeIdentifier = requireNonNull(nodeIdentifier, "nodeIdentifier is null or empty");
         this.internalUri = requireNonNull(internalUri, "internalUri is null");
+        this.thriftPort = requireNonNull(thriftPort, "thriftPort is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.coordinator = coordinator;
     }
@@ -61,6 +69,11 @@ public class InternalNode
     public URI getHttpUri()
     {
         return getInternalUri();
+    }
+
+    public OptionalInt getThriftPort()
+    {
+        return thriftPort;
     }
 
     public URI getInternalUri()
@@ -116,6 +129,7 @@ public class InternalNode
         return toStringHelper(this)
                 .add("nodeIdentifier", nodeIdentifier)
                 .add("internalUri", internalUri)
+                .add("thriftPort", thriftPort)
                 .add("nodeVersion", nodeVersion)
                 .toString();
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/RemoteNodeState.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/RemoteNodeState.java
@@ -13,102 +13,13 @@
  */
 package com.facebook.presto.metadata;
 
-import com.facebook.airlift.http.client.FullJsonResponseHandler.JsonResponse;
-import com.facebook.airlift.http.client.HttpClient;
-import com.facebook.airlift.http.client.HttpClient.HttpResponseFuture;
-import com.facebook.airlift.http.client.Request;
-import com.facebook.airlift.log.Logger;
 import com.facebook.presto.spi.NodeState;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import io.airlift.units.Duration;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.ThreadSafe;
-
-import java.net.URI;
 import java.util.Optional;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
-import static com.facebook.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
-import static com.facebook.airlift.http.client.HttpStatus.OK;
-import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
-import static com.facebook.airlift.json.JsonCodec.jsonCodec;
-import static com.google.common.net.MediaType.JSON_UTF_8;
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-import static io.airlift.units.Duration.nanosSince;
-import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-
-@ThreadSafe
-public class RemoteNodeState
+public interface RemoteNodeState
 {
-    private static final Logger log = Logger.get(RemoteNodeState.class);
+    Optional<NodeState> getNodeState();
 
-    private final HttpClient httpClient;
-    private final URI stateInfoUri;
-    private final AtomicReference<Optional<NodeState>> nodeState = new AtomicReference<>(Optional.empty());
-    private final AtomicReference<Future<?>> future = new AtomicReference<>();
-    private final AtomicLong lastUpdateNanos = new AtomicLong();
-    private final AtomicLong lastWarningLogged = new AtomicLong();
-
-    public RemoteNodeState(HttpClient httpClient, URI stateInfoUri)
-    {
-        this.httpClient = requireNonNull(httpClient, "httpClient is null");
-        this.stateInfoUri = requireNonNull(stateInfoUri, "stateInfoUri is null");
-    }
-
-    public Optional<NodeState> getNodeState()
-    {
-        return nodeState.get();
-    }
-
-    public synchronized void asyncRefresh()
-    {
-        Duration sinceUpdate = nanosSince(lastUpdateNanos.get());
-        if (nanosSince(lastWarningLogged.get()).toMillis() > 1_000 &&
-                sinceUpdate.toMillis() > 10_000 &&
-                future.get() != null) {
-            log.warn("Node state update request to %s has not returned in %s", stateInfoUri, sinceUpdate.toString(SECONDS));
-            lastWarningLogged.set(System.nanoTime());
-        }
-        if (sinceUpdate.toMillis() > 1_000 && future.get() == null) {
-            Request request = prepareGet()
-                    .setUri(stateInfoUri)
-                    .setHeader(CONTENT_TYPE, JSON_UTF_8.toString())
-                    .build();
-            HttpResponseFuture<JsonResponse<NodeState>> responseFuture = httpClient.executeAsync(request, createFullJsonResponseHandler(jsonCodec(NodeState.class)));
-            future.compareAndSet(null, responseFuture);
-
-            Futures.addCallback(responseFuture, new FutureCallback<JsonResponse<NodeState>>()
-            {
-                @Override
-                public void onSuccess(@Nullable JsonResponse<NodeState> result)
-                {
-                    lastUpdateNanos.set(System.nanoTime());
-                    future.compareAndSet(responseFuture, null);
-                    if (result != null) {
-                        if (result.hasValue()) {
-                            nodeState.set(Optional.ofNullable(result.getValue()));
-                        }
-                        if (result.getStatusCode() != OK.code()) {
-                            log.warn("Error fetching node state from %s returned status %d: %s", stateInfoUri, result.getStatusCode(), result.getStatusMessage());
-                            return;
-                        }
-                    }
-                }
-
-                @Override
-                public void onFailure(Throwable t)
-                {
-                    log.warn("Error fetching node state from %s: %s", stateInfoUri, t.getMessage());
-                    lastUpdateNanos.set(System.nanoTime());
-                    future.compareAndSet(responseFuture, null);
-                }
-            }, directExecutor());
-        }
-    }
+    void asyncRefresh();
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/ThriftRemoteNodeState.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/ThriftRemoteNodeState.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.drift.client.DriftClient;
+import com.facebook.presto.server.thrift.ThriftServerInfoClient;
+import com.facebook.presto.spi.NodeState;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.Duration;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.units.Duration.nanosSince;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class ThriftRemoteNodeState
+        implements RemoteNodeState
+{
+    private final ThriftServerInfoClient thriftClient;
+    private final AtomicReference<Optional<NodeState>> nodeState = new AtomicReference<>(Optional.empty());
+    private final AtomicBoolean requestInflight = new AtomicBoolean();
+    private final AtomicLong lastUpdateNanos = new AtomicLong();
+
+    public ThriftRemoteNodeState(DriftClient<ThriftServerInfoClient> thriftClient, URI stateInfoUri)
+    {
+        requireNonNull(stateInfoUri, "stateInfoUri is null");
+        checkState(stateInfoUri.getScheme().equals("thrift"), "unexpected scheme %s", stateInfoUri.getScheme());
+
+        this.thriftClient = requireNonNull(thriftClient, "thriftClient is null").get(Optional.of(stateInfoUri.getAuthority()));
+    }
+
+    @Override
+    public Optional<NodeState> getNodeState()
+    {
+        return nodeState.get();
+    }
+
+    @Override
+    public void asyncRefresh()
+    {
+        Duration sinceUpdate = nanosSince(lastUpdateNanos.get());
+
+        if (sinceUpdate.toMillis() > 1_000 && requestInflight.compareAndSet(false, true)) {
+            ListenableFuture<Integer> responseFuture = thriftClient.getServerState();
+
+            Futures.addCallback(responseFuture, new FutureCallback<Integer>()
+            {
+                @Override
+                public void onSuccess(@Nullable Integer result)
+                {
+                    lastUpdateNanos.set(System.nanoTime());
+                    requestInflight.compareAndSet(true, false);
+                    if (result != null) {
+                        nodeState.set(Optional.of(NodeState.valueOf(result)));
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable t)
+                {
+                    lastUpdateNanos.set(System.nanoTime());
+                    requestInflight.compareAndSet(true, false);
+                }
+            }, directExecutor());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java
@@ -200,7 +200,7 @@ public class ExchangeClient
                 resultClient = new HttpRpcShuffleClient(httpClient, location);
                 break;
             case "thrift":
-                resultClient = new ThriftRpcShuffleClient(driftClient, location, pageBufferClientCallbackExecutor);
+                resultClient = new ThriftRpcShuffleClient(driftClient, location);
                 break;
             default:
                 throw new PrestoException(GENERIC_INTERNAL_ERROR, "unsupported task result client scheme " + location.getScheme());

--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpRpcShuffleClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpRpcShuffleClient.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpStatus;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.Response;
+import com.facebook.airlift.http.client.ResponseHandler;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.execution.buffer.SerializedPage;
+import com.facebook.presto.operator.PageBufferClient.PagesResponse;
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.MediaType;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.slice.InputStreamSliceInput;
+import io.airlift.slice.SliceInput;
+import io.airlift.units.DataSize;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.util.List;
+
+import static com.facebook.airlift.http.client.HttpStatus.familyForStatusCode;
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.Request.Builder.prepareDelete;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.http.client.ResponseHandlerUtils.propagate;
+import static com.facebook.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static com.facebook.presto.PrestoMediaTypes.PRESTO_PAGES_TYPE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_BUFFER_COMPLETE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_MAX_SIZE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_PAGE_NEXT_TOKEN;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_PAGE_TOKEN;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_TASK_INSTANCE_ID;
+import static com.facebook.presto.execution.buffer.PagesSerdeUtil.readSerializedPages;
+import static com.facebook.presto.operator.PageBufferClient.PagesResponse.createEmptyPagesResponse;
+import static com.facebook.presto.operator.PageBufferClient.PagesResponse.createPagesResponse;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public final class HttpRpcShuffleClient
+        implements RpcShuffleClient
+{
+    private static final Logger log = Logger.get(HttpRpcShuffleClient.class);
+
+    private final HttpClient httpClient;
+    private final URI location;
+
+    public HttpRpcShuffleClient(HttpClient httpClient, URI location)
+    {
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.location = requireNonNull(location, "location is null");
+    }
+
+    @Override
+    public ListenableFuture<PagesResponse> getResults(long token, DataSize maxResponseSize)
+    {
+        URI uri = uriBuilderFrom(location).appendPath(String.valueOf(token)).build();
+        return httpClient.executeAsync(
+                prepareGet()
+                        .setHeader(PRESTO_MAX_SIZE, maxResponseSize.toString())
+                        .setUri(uri).build(),
+                new PageResponseHandler());
+    }
+
+    @Override
+    public void acknowledgeResultsAsync(long nextToken)
+    {
+        URI uri = uriBuilderFrom(location).appendPath(String.valueOf(nextToken)).appendPath("acknowledge").build();
+        httpClient.executeAsync(prepareGet().setUri(uri).build(), new ResponseHandler<Void, RuntimeException>()
+        {
+            @Override
+            public Void handleException(Request request, Exception exception)
+            {
+                log.debug(exception, "Acknowledge request failed: %s", uri);
+                return null;
+            }
+
+            @Override
+            public Void handle(Request request, Response response)
+            {
+                if (familyForStatusCode(response.getStatusCode()) != HttpStatus.Family.SUCCESSFUL) {
+                    log.debug("Unexpected acknowledge response code: %s", response.getStatusCode());
+                }
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public ListenableFuture<?> abortResults()
+    {
+        return httpClient.executeAsync(prepareDelete().setUri(location).build(), createStatusResponseHandler());
+    }
+
+    public static class PageResponseHandler
+            implements ResponseHandler<PagesResponse, RuntimeException>
+    {
+        @Override
+        public PagesResponse handleException(Request request, Exception exception)
+        {
+            throw propagate(request, exception);
+        }
+
+        @Override
+        public PagesResponse handle(Request request, Response response)
+        {
+            try {
+                // no content means no content was created within the wait period, but query is still ok
+                // if job is finished, complete is set in the response
+                if (response.getStatusCode() == HttpStatus.NO_CONTENT.code()) {
+                    return createEmptyPagesResponse(getTaskInstanceId(response), getToken(response), getNextToken(response), getComplete(response));
+                }
+
+                // otherwise we must have gotten an OK response, everything else is considered fatal
+                if (response.getStatusCode() != HttpStatus.OK.code()) {
+                    StringBuilder body = new StringBuilder();
+                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(response.getInputStream(), UTF_8))) {
+                        // Get up to 1000 lines for debugging
+                        for (int i = 0; i < 1000; i++) {
+                            String line = reader.readLine();
+                            // Don't output more than 100KB
+                            if (line == null || body.length() + line.length() > 100 * 1024) {
+                                break;
+                            }
+                            body.append(line + "\n");
+                        }
+                    }
+                    catch (RuntimeException | IOException e) {
+                        // Ignored. Just return whatever message we were able to decode
+                    }
+                    throw new PageTransportErrorException(format("Expected response code to be 200, but was %s %s:%n%s", response.getStatusCode(), response.getStatusMessage(), body.toString()));
+                }
+
+                // invalid content type can happen when an error page is returned, but is unlikely given the above 200
+                String contentType = response.getHeader(CONTENT_TYPE);
+                if (contentType == null) {
+                    throw new PageTransportErrorException(format("%s header is not set: %s", CONTENT_TYPE, response));
+                }
+                if (!mediaTypeMatches(contentType, PRESTO_PAGES_TYPE)) {
+                    throw new PageTransportErrorException(format("Expected %s response from server but got %s", PRESTO_PAGES_TYPE, contentType));
+                }
+
+                String taskInstanceId = getTaskInstanceId(response);
+                long token = getToken(response);
+                long nextToken = getNextToken(response);
+                boolean complete = getComplete(response);
+
+                try (SliceInput input = new InputStreamSliceInput(response.getInputStream())) {
+                    List<SerializedPage> pages = ImmutableList.copyOf(readSerializedPages(input));
+                    return createPagesResponse(taskInstanceId, token, nextToken, pages, complete);
+                }
+                catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            catch (PageTransportErrorException e) {
+                throw new PageTransportErrorException("Error fetching " + request.getUri().toASCIIString(), e);
+            }
+        }
+
+        private static String getTaskInstanceId(Response response)
+        {
+            String taskInstanceId = response.getHeader(PRESTO_TASK_INSTANCE_ID);
+            if (taskInstanceId == null) {
+                throw new PageTransportErrorException(format("Expected %s header", PRESTO_TASK_INSTANCE_ID));
+            }
+            return taskInstanceId;
+        }
+
+        private static long getToken(Response response)
+        {
+            String tokenHeader = response.getHeader(PRESTO_PAGE_TOKEN);
+            if (tokenHeader == null) {
+                throw new PageTransportErrorException(format("Expected %s header", PRESTO_PAGE_TOKEN));
+            }
+            return Long.parseLong(tokenHeader);
+        }
+
+        private static long getNextToken(Response response)
+        {
+            String nextTokenHeader = response.getHeader(PRESTO_PAGE_NEXT_TOKEN);
+            if (nextTokenHeader == null) {
+                throw new PageTransportErrorException(format("Expected %s header", PRESTO_PAGE_NEXT_TOKEN));
+            }
+            return Long.parseLong(nextTokenHeader);
+        }
+
+        private static boolean getComplete(Response response)
+        {
+            String bufferComplete = response.getHeader(PRESTO_BUFFER_COMPLETE);
+            if (bufferComplete == null) {
+                throw new PageTransportErrorException(format("Expected %s header", PRESTO_BUFFER_COMPLETE));
+            }
+            return Boolean.parseBoolean(bufferComplete);
+        }
+
+        private static boolean mediaTypeMatches(String value, MediaType range)
+        {
+            try {
+                return MediaType.parse(value).is(range);
+            }
+            catch (IllegalArgumentException | IllegalStateException e) {
+                return false;
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpRpcShuffleClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpRpcShuffleClient.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.http.client.HttpStatus;
 import com.facebook.airlift.http.client.Request;
 import com.facebook.airlift.http.client.Response;
 import com.facebook.airlift.http.client.ResponseHandler;
+import com.facebook.airlift.http.client.ResponseTooLargeException;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.execution.buffer.SerializedPage;
 import com.facebook.presto.operator.PageBufferClient.PagesResponse;
@@ -110,6 +111,15 @@ public final class HttpRpcShuffleClient
     public ListenableFuture<?> abortResults()
     {
         return httpClient.executeAsync(prepareDelete().setUri(location).build(), createStatusResponseHandler());
+    }
+
+    @Override
+    public Throwable rewriteException(Throwable throwable)
+    {
+        if (throwable instanceof ResponseTooLargeException) {
+            return new PageTooLargeException(throwable);
+        }
+        return throwable;
     }
 
     public static class PageResponseHandler

--- a/presto-main/src/main/java/com/facebook/presto/operator/PageBufferClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PageBufferClient.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator;
 
 import com.facebook.airlift.http.client.HttpUriBuilder;
-import com.facebook.airlift.http.client.ResponseTooLargeException;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.execution.buffer.SerializedPage;
 import com.facebook.presto.server.remotetask.Backoff;
@@ -342,7 +341,7 @@ public final class PageBufferClient
                 log.debug("Request to %s failed %s", uri, t);
                 checkNotHoldsLock(this);
 
-                t = rewriteException(t);
+                t = resultClient.rewriteException(t);
                 if (!(t instanceof PrestoException) && backoff.failure()) {
                     String message = format("%s (%s - %s failures, failure duration %s, total failed request time %s)",
                             WORKER_NODE_ERROR,
@@ -468,14 +467,6 @@ public final class PageBufferClient
                 .add("location", location)
                 .addValue(state)
                 .toString();
-    }
-
-    private static Throwable rewriteException(Throwable t)
-    {
-        if (t instanceof ResponseTooLargeException) {
-            return new PageTooLargeException();
-        }
-        return t;
     }
 
     public static class PagesResponse

--- a/presto-main/src/main/java/com/facebook/presto/operator/PageTooLargeException.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PageTooLargeException.java
@@ -20,8 +20,8 @@ import static com.facebook.presto.spi.StandardErrorCode.PAGE_TOO_LARGE;
 public class PageTooLargeException
         extends PrestoException
 {
-    public PageTooLargeException()
+    public PageTooLargeException(Throwable e)
     {
-        super(PAGE_TOO_LARGE, "Remote page is too large");
+        super(PAGE_TOO_LARGE, "Remote page is too large", e);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/RpcShuffleClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/RpcShuffleClient.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.operator.PageBufferClient.PagesResponse;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.DataSize;
+
+/**
+ * All methods in this class should be async
+ */
+public interface RpcShuffleClient
+{
+    ListenableFuture<PagesResponse> getResults(long token, DataSize maxResponseSize);
+
+    /**
+     * A fire and forget call to issue the ack to the buffer.
+     * No need to handle the response; it is ok for a server to miss the ack.
+     * {@param nextToken} N represents token N - 1 is to be acknowledged.
+     * The implementation needs to guarantee the function is non-blocking and result or failure is not important.
+     */
+    void acknowledgeResultsAsync(long nextToken);
+
+    /**
+     * Close remote buffer
+     */
+    ListenableFuture<?> abortResults();
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/RpcShuffleClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/RpcShuffleClient.java
@@ -36,4 +36,9 @@ public interface RpcShuffleClient
      * Close remote buffer
      */
     ListenableFuture<?> abortResults();
+
+    /**
+     * Rewrite network related exception to Presto exception
+     */
+    Throwable rewriteException(Throwable throwable);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/ThriftRpcShuffleClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ThriftRpcShuffleClient.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.drift.client.DriftClient;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.buffer.BufferResult;
+import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
+import com.facebook.presto.operator.PageBufferClient.PagesResponse;
+import com.facebook.presto.server.thrift.ThriftTaskClient;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.DataSize;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
+import static com.facebook.presto.operator.PageBufferClient.PagesResponse.createPagesResponse;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public final class ThriftRpcShuffleClient
+        implements RpcShuffleClient
+{
+    private static final Logger log = Logger.get(ThriftRpcShuffleClient.class);
+
+    private final ThriftTaskClient thriftClient;
+    private final Executor executor;
+    private final TaskId taskId;
+    private final OutputBufferId outputBufferId;
+
+    public ThriftRpcShuffleClient(DriftClient<ThriftTaskClient> driftClient, URI location, Executor executor)
+    {
+        requireNonNull(location, "location is null");
+
+        this.thriftClient = requireNonNull(driftClient, "thriftClient is null").get(Optional.of(location.getAuthority()));
+        this.executor = requireNonNull(executor, "executor is null");
+
+        // TODO: refactor the entire LocationFactory interfaces to completely replace URI with more efficient/expressive data structures
+        // location format: thrift://{ipAddress}:{thriftPort}/v1/task/{taskId}/results/{bufferId}/
+        String[] paths = location.getPath().split("/");
+        this.taskId = TaskId.valueOf(paths[3]);
+        this.outputBufferId = OutputBufferId.fromString(paths[5]);
+    }
+
+    @Override
+    public ListenableFuture<PagesResponse> getResults(long token, DataSize maxResponseSize)
+    {
+        ListenableFuture<BufferResult> future = thriftClient.getResults(taskId, outputBufferId, token, maxResponseSize.toBytes());
+        return Futures.transform(
+                future,
+                result -> createPagesResponse(
+                        result.getTaskInstanceId(),
+                        result.getToken(),
+                        result.getNextToken(),
+                        result.getSerializedPages(),
+                        result.isBufferComplete()),
+                directExecutor());
+    }
+
+    @Override
+    public void acknowledgeResultsAsync(long nextToken)
+    {
+        executor.execute(() -> {
+            try {
+                thriftClient.acknowledgeResults(taskId, outputBufferId, nextToken);
+            }
+            catch (Exception exception) {
+                log.debug(exception, "Acknowledge request failed: %s/%s/%s", taskId, outputBufferId, nextToken);
+            }
+        });
+    }
+
+    @Override
+    public ListenableFuture<?> abortResults()
+    {
+        return thriftClient.abortResults(taskId, outputBufferId);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ThriftRpcShuffleClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ThriftRpcShuffleClient.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.drift.client.DriftClient;
+import com.facebook.drift.transport.client.MessageTooLargeException;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
@@ -91,5 +92,14 @@ public final class ThriftRpcShuffleClient
     public ListenableFuture<?> abortResults()
     {
         return thriftClient.abortResults(taskId, outputBufferId);
+    }
+
+    @Override
+    public Throwable rewriteException(Throwable throwable)
+    {
+        if (throwable instanceof MessageTooLargeException) {
+            return new PageTooLargeException(throwable);
+        }
+        return throwable;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/AsyncHttpExecutionMBean.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/AsyncHttpExecutionMBean.java
@@ -31,7 +31,7 @@ public class AsyncHttpExecutionMBean
     private final ThreadPoolExecutorMBean timeoutExecutor;
 
     @Inject
-    public AsyncHttpExecutionMBean(@ForAsyncHttp ExecutorService responseExecutor, @ForAsyncHttp ScheduledExecutorService timeoutExecutor)
+    public AsyncHttpExecutionMBean(@ForAsyncRpc ExecutorService responseExecutor, @ForAsyncRpc ScheduledExecutorService timeoutExecutor)
     {
         requireNonNull(responseExecutor, "responseExecutor is null");
         requireNonNull(timeoutExecutor, "timeoutExecutor is null");

--- a/presto-main/src/main/java/com/facebook/presto/server/ForAsyncRpc.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ForAsyncRpc.java
@@ -26,6 +26,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target({FIELD, PARAMETER, METHOD})
 @Qualifier
-public @interface ForAsyncHttp
+public @interface ForAsyncRpc
 {
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/InternalCommunicationConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/InternalCommunicationConfig.java
@@ -36,6 +36,7 @@ public class InternalCommunicationConfig
     private boolean kerberosUseCanonicalHostname = true;
     private boolean binaryTransportEnabled;
     private DataSize maxTaskUpdateSize = new DataSize(16, MEGABYTE);
+    private CommunicationProtocol taskCommunicationProtocol = CommunicationProtocol.HTTP;
 
     public boolean isHttpsRequired()
     {
@@ -157,6 +158,25 @@ public class InternalCommunicationConfig
     public InternalCommunicationConfig setMaxTaskUpdateSize(DataSize maxTaskUpdateSize)
     {
         this.maxTaskUpdateSize = maxTaskUpdateSize;
+        return this;
+    }
+
+    public enum CommunicationProtocol
+    {
+        HTTP,
+        THRIFT
+    }
+
+    public CommunicationProtocol getTaskCommunicationProtocol()
+    {
+        return taskCommunicationProtocol;
+    }
+
+    @Config("internal-communication.task-communication-protocol")
+    @ConfigDescription("Set task communication protocol")
+    public InternalCommunicationConfig setTaskCommunicationProtocol(CommunicationProtocol taskCommunicationProtocol)
+    {
+        this.taskCommunicationProtocol = taskCommunicationProtocol;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/InternalCommunicationConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/InternalCommunicationConfig.java
@@ -37,6 +37,7 @@ public class InternalCommunicationConfig
     private boolean binaryTransportEnabled;
     private DataSize maxTaskUpdateSize = new DataSize(16, MEGABYTE);
     private CommunicationProtocol taskCommunicationProtocol = CommunicationProtocol.HTTP;
+    private CommunicationProtocol serverInfoCommunicationProtocol = CommunicationProtocol.HTTP;
 
     public boolean isHttpsRequired()
     {
@@ -177,6 +178,19 @@ public class InternalCommunicationConfig
     public InternalCommunicationConfig setTaskCommunicationProtocol(CommunicationProtocol taskCommunicationProtocol)
     {
         this.taskCommunicationProtocol = taskCommunicationProtocol;
+        return this;
+    }
+
+    public CommunicationProtocol getServerInfoCommunicationProtocol()
+    {
+        return serverInfoCommunicationProtocol;
+    }
+
+    @Config("internal-communication.server-info-communication-protocol")
+    @ConfigDescription("Set server info communication protocol to broadcast state info")
+    public InternalCommunicationConfig setServerInfoCommunicationProtocol(CommunicationProtocol serverInfoCommunicationProtocol)
+    {
+        this.serverInfoCommunicationProtocol = serverInfoCommunicationProtocol;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -93,6 +93,7 @@ import com.facebook.presto.operator.TableCommitContext;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.server.remotetask.HttpLocationFactory;
 import com.facebook.presto.server.thrift.FixedAddressSelector;
+import com.facebook.presto.server.thrift.ThriftServerInfoService;
 import com.facebook.presto.server.thrift.ThriftTaskClient;
 import com.facebook.presto.server.thrift.ThriftTaskService;
 import com.facebook.presto.spi.ConnectorSplit;
@@ -503,6 +504,7 @@ public class ServerMainModule
         // Thrift RPC
         binder.install(new DriftNettyServerModule());
         driftServerBinder(binder).bindService(ThriftTaskService.class);
+        driftServerBinder(binder).bindService(ThriftServerInfoService.class);
 
         // cleanup
         binder.bind(ExecutorCleanup.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -93,6 +93,7 @@ import com.facebook.presto.operator.TableCommitContext;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.server.remotetask.HttpLocationFactory;
 import com.facebook.presto.server.thrift.FixedAddressSelector;
+import com.facebook.presto.server.thrift.ThriftServerInfoClient;
 import com.facebook.presto.server.thrift.ThriftServerInfoService;
 import com.facebook.presto.server.thrift.ThriftTaskClient;
 import com.facebook.presto.server.thrift.ThriftTaskService;
@@ -264,6 +265,9 @@ public class ServerMainModule
                     config.setIdleTimeout(new Duration(30, SECONDS));
                     config.setRequestTimeout(new Duration(10, SECONDS));
                 });
+        driftClientBinder(binder).bindDriftClient(ThriftServerInfoClient.class, ForNodeManager.class)
+                .withAddressSelector(((addressSelectorBinder, annotation, prefix) ->
+                        addressSelectorBinder.bind(AddressSelector.class).annotatedWith(annotation).to(FixedAddressSelector.class)));
 
         // node scheduler
         // TODO: remove from NodePartitioningManager and move to CoordinatorModule

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
 import com.facebook.airlift.stats.GcMonitor;
 import com.facebook.airlift.stats.JmxGcMonitor;
 import com.facebook.airlift.stats.PauseMeter;
+import com.facebook.drift.transport.netty.server.DriftNettyServerModule;
 import com.facebook.presto.GroupByHashPageIndexerFactory;
 import com.facebook.presto.PagesIndexPageSorter;
 import com.facebook.presto.SystemSessionProperties;
@@ -170,6 +171,7 @@ import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder
 import static com.facebook.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 import static com.facebook.airlift.json.JsonBinder.jsonBinder;
 import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static com.facebook.drift.server.guice.DriftServerBinder.driftServerBinder;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.FLAT;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.LEGACY;
 import static com.facebook.presto.server.smile.SmileCodecBinder.smileCodecBinder;
@@ -487,6 +489,10 @@ public class ServerMainModule
         newExporter(binder).export(SpillerFactory.class).withGeneratedName();
         binder.bind(LocalSpillManager.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(NodeSpillConfig.class);
+
+        // Thrift RPC
+        binder.install(new DriftNettyServerModule());
+        driftServerBinder(binder);
 
         // cleanup
         binder.bind(ExecutorCleanup.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpLocationFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpLocationFactory.java
@@ -20,6 +20,7 @@ import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.server.InternalCommunicationConfig;
+import com.facebook.presto.server.InternalCommunicationConfig.CommunicationProtocol;
 import com.facebook.presto.spi.QueryId;
 
 import javax.inject.Inject;
@@ -34,17 +35,19 @@ public class HttpLocationFactory
 {
     private final InternalNodeManager nodeManager;
     private final URI baseUri;
+    private final CommunicationProtocol taskCommunicationProtocol;
 
     @Inject
     public HttpLocationFactory(InternalNodeManager nodeManager, HttpServerInfo httpServerInfo, InternalCommunicationConfig config)
     {
-        this(nodeManager, config.isHttpsRequired() ? httpServerInfo.getHttpsUri() : httpServerInfo.getHttpUri());
+        this(nodeManager, config.isHttpsRequired() ? httpServerInfo.getHttpsUri() : httpServerInfo.getHttpUri(), config.getTaskCommunicationProtocol());
     }
 
-    public HttpLocationFactory(InternalNodeManager nodeManager, URI baseUri)
+    public HttpLocationFactory(InternalNodeManager nodeManager, URI baseUri, CommunicationProtocol taskCommunicationProtocol)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.baseUri = requireNonNull(baseUri, "baseUri is null");
+        this.taskCommunicationProtocol = requireNonNull(taskCommunicationProtocol, "taskCommunicationProtocol is null");
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -124,6 +124,7 @@ public final class HttpRemoteTask
 
     private final TaskId taskId;
     private final URI taskLocation;
+    private final URI remoteTaskLocation;
 
     private final Session session;
     private final String nodeId;
@@ -190,6 +191,7 @@ public final class HttpRemoteTask
             TaskId taskId,
             String nodeId,
             URI location,
+            URI remoteLocation,
             PlanFragment planFragment,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
@@ -215,6 +217,7 @@ public final class HttpRemoteTask
         requireNonNull(taskId, "taskId is null");
         requireNonNull(nodeId, "nodeId is null");
         requireNonNull(location, "location is null");
+        requireNonNull(remoteLocation, "remoteLocation is null");
         requireNonNull(planFragment, "planFragment is null");
         requireNonNull(outputBuffers, "outputBuffers is null");
         requireNonNull(httpClient, "httpClient is null");
@@ -231,6 +234,7 @@ public final class HttpRemoteTask
         try (SetThreadName ignored = new SetThreadName("HttpRemoteTask-%s", taskId)) {
             this.taskId = taskId;
             this.taskLocation = location;
+            this.remoteTaskLocation = remoteLocation;
             this.session = session;
             this.nodeId = nodeId;
             this.planFragment = planFragment;
@@ -335,6 +339,12 @@ public final class HttpRemoteTask
     public TaskStatus getTaskStatus()
     {
         return taskStatusFetcher.getTaskStatus();
+    }
+
+    @Override
+    public URI getRemoteTaskLocation()
+    {
+        return remoteTaskLocation;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -83,7 +83,8 @@ public class HttpRemoteTaskFactory
     private final int maxTaskUpdateSizeInBytes;
 
     @Inject
-    public HttpRemoteTaskFactory(QueryManagerConfig config,
+    public HttpRemoteTaskFactory(
+            QueryManagerConfig config,
             TaskManagerConfig taskConfig,
             @ForScheduler HttpClient httpClient,
             LocationFactory locationFactory,
@@ -140,7 +141,8 @@ public class HttpRemoteTaskFactory
     }
 
     @Override
-    public RemoteTask createRemoteTask(Session session,
+    public RemoteTask createRemoteTask(
+            Session session,
             TaskId taskId,
             InternalNode node,
             PlanFragment fragment,
@@ -150,7 +152,8 @@ public class HttpRemoteTaskFactory
             boolean summarizeTaskInfo,
             TableWriteInfo tableWriteInfo)
     {
-        return new HttpRemoteTask(session,
+        return new HttpRemoteTask(
+                session,
                 taskId,
                 node.getNodeIdentifier(),
                 locationFactory.createTaskLocation(node, taskId),

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -156,6 +156,7 @@ public class HttpRemoteTaskFactory
                 session,
                 taskId,
                 node.getNodeIdentifier(),
+                locationFactory.createLegacyTaskLocation(node, taskId),
                 locationFactory.createTaskLocation(node, taskId),
                 fragment,
                 initialSplits,

--- a/presto-main/src/main/java/com/facebook/presto/server/thrift/FixedAddressSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/thrift/FixedAddressSelector.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.thrift;
+
+import com.facebook.drift.client.address.AddressSelector;
+import com.facebook.drift.client.address.SimpleAddressSelector.SimpleAddress;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HostAndPort;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class FixedAddressSelector
+        implements AddressSelector<SimpleAddress>
+
+{
+    @Override
+    public Optional<SimpleAddress> selectAddress(Optional<String> addressSelectionContext)
+    {
+        return selectAddress(addressSelectionContext, ImmutableSet.of());
+    }
+
+    @Override
+    public Optional<SimpleAddress> selectAddress(Optional<String> addressSelectionContext, Set<SimpleAddress> attempted)
+    {
+        checkArgument(addressSelectionContext.isPresent());
+
+        // TODO: We should make context generic type in Drift library to avoid parsing and create address every time
+        HostAndPort address = HostAndPort.fromString(addressSelectionContext.get());
+        return Optional.of(new SimpleAddress(address));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/thrift/ThriftServerInfoClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/thrift/ThriftServerInfoClient.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.thrift;
+
+import com.facebook.drift.annotations.ThriftMethod;
+import com.facebook.drift.annotations.ThriftService;
+import com.google.common.util.concurrent.ListenableFuture;
+
+@ThriftService("ThriftServerInfoService")
+public interface ThriftServerInfoClient
+{
+    /**
+     * Use integers to represent the ordinal of the enum.
+     * Use NodeState::valueOf to recover the enum from an integer
+     */
+    @ThriftMethod
+    ListenableFuture<Integer> getServerState();
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/thrift/ThriftServerInfoService.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/thrift/ThriftServerInfoService.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.thrift;
+
+import com.facebook.drift.annotations.ThriftMethod;
+import com.facebook.drift.annotations.ThriftService;
+import com.facebook.presto.server.GracefulShutdownHandler;
+import com.facebook.presto.server.ServerInfoResource;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+
+import javax.inject.Inject;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.spi.NodeState.ACTIVE;
+import static com.facebook.presto.spi.NodeState.SHUTTING_DOWN;
+import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+
+/**
+ * The corresponding Thrift implementation for {@link ServerInfoResource}.
+ * Only /state endpoint has been implemented.
+ */
+@ThriftService(value = "presto-info", idlName = "ThriftServerInfoService")
+public class ThriftServerInfoService
+{
+    private final GracefulShutdownHandler shutdownHandler;
+    private final ListeningExecutorService executor = listeningDecorator(newSingleThreadExecutor(daemonThreadsNamed("server-info-executor")));
+
+    @Inject
+    public ThriftServerInfoService(GracefulShutdownHandler shutdownHandler)
+    {
+        this.shutdownHandler = requireNonNull(shutdownHandler, "shutdownHandler is null");
+    }
+
+    /**
+     * Use integers to represent the ordinal of the enum.
+     * Use NodeState::valueOf to recover the enum from an integer
+     */
+    @ThriftMethod
+    public ListenableFuture<Integer> getServerState()
+    {
+        return executor.submit(() -> {
+            if (shutdownHandler.isShutdownRequested()) {
+                return SHUTTING_DOWN.getValue();
+            }
+            return ACTIVE.getValue();
+        });
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/thrift/ThriftTaskClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/thrift/ThriftTaskClient.java
@@ -28,7 +28,7 @@ public interface ThriftTaskClient
     ListenableFuture<BufferResult> getResults(TaskId taskId, OutputBufferId bufferId, long token, long maxSizeInBytes);
 
     @ThriftMethod
-    void acknowledgeResults(TaskId taskId, OutputBufferId bufferId, long token);
+    ListenableFuture<Void> acknowledgeResults(TaskId taskId, OutputBufferId bufferId, long token);
 
     @ThriftMethod
     ListenableFuture<Void> abortResults(TaskId taskId, OutputBufferId bufferId);

--- a/presto-main/src/main/java/com/facebook/presto/server/thrift/ThriftTaskClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/thrift/ThriftTaskClient.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.thrift;
+
+import com.facebook.drift.annotations.ThriftMethod;
+import com.facebook.drift.annotations.ThriftService;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.buffer.BufferResult;
+import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
+import com.google.common.util.concurrent.ListenableFuture;
+
+// TODO: the client currently only supports exchange; more methods (for /v1/task) should be supported
+@ThriftService("ThriftTaskService")
+public interface ThriftTaskClient
+{
+    @ThriftMethod
+    ListenableFuture<BufferResult> getResults(TaskId taskId, OutputBufferId bufferId, long token, long maxSizeInBytes);
+
+    @ThriftMethod
+    void acknowledgeResults(TaskId taskId, OutputBufferId bufferId, long token);
+
+    @ThriftMethod
+    ListenableFuture<Void> abortResults(TaskId taskId, OutputBufferId bufferId);
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/thrift/ThriftTaskService.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/thrift/ThriftTaskService.java
@@ -65,12 +65,13 @@ public class ThriftTaskService
     }
 
     @ThriftMethod
-    public void acknowledgeResults(TaskId taskId, OutputBufferId bufferId, long token)
+    public ListenableFuture<Void> acknowledgeResults(TaskId taskId, OutputBufferId bufferId, long token)
     {
         requireNonNull(taskId, "taskId is null");
         requireNonNull(bufferId, "bufferId is null");
 
         taskManager.acknowledgeTaskResults(taskId, bufferId, token);
+        return Futures.immediateFuture(null);
     }
 
     @ThriftMethod

--- a/presto-main/src/main/java/com/facebook/presto/server/thrift/ThriftTaskService.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/thrift/ThriftTaskService.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.thrift;
+
+import com.facebook.drift.annotations.ThriftMethod;
+import com.facebook.drift.annotations.ThriftService;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskManager;
+import com.facebook.presto.execution.buffer.BufferResult;
+import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
+import com.facebook.presto.server.ForAsyncRpc;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import javax.inject.Inject;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.airlift.concurrent.MoreFutures.addTimeout;
+import static com.facebook.presto.util.TaskUtils.DEFAULT_MAX_WAIT_TIME;
+import static com.facebook.presto.util.TaskUtils.randomizeWaitTime;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.util.Objects.requireNonNull;
+
+// TODO: the server currently only supports exchange; more end points (for /v1/task) should be supported
+@ThriftService(value = "presto-task", idlName = "ThriftTaskService")
+public class ThriftTaskService
+{
+    private final TaskManager taskManager;
+    private final ScheduledExecutorService timeoutExecutor;
+
+    @Inject
+    public ThriftTaskService(TaskManager taskManager, @ForAsyncRpc ScheduledExecutorService timeoutExecutor)
+    {
+        this.taskManager = requireNonNull(taskManager, "taskManager is null");
+        this.timeoutExecutor = requireNonNull(timeoutExecutor, "timeoutExecutor is null");
+    }
+
+    @ThriftMethod
+    public ListenableFuture<BufferResult> getResults(TaskId taskId, OutputBufferId bufferId, long token, long maxSizeInBytes)
+    {
+        requireNonNull(taskId, "taskId is null");
+        requireNonNull(bufferId, "bufferId is null");
+
+        ListenableFuture<BufferResult> bufferResultFuture = taskManager.getTaskResults(taskId, bufferId, token, new DataSize(maxSizeInBytes, BYTE));
+        Duration waitTime = randomizeWaitTime(DEFAULT_MAX_WAIT_TIME);
+        return addTimeout(
+                bufferResultFuture,
+                () -> BufferResult.emptyResults(taskManager.getTaskInstanceId(taskId), token, false),
+                waitTime,
+                timeoutExecutor);
+    }
+
+    @ThriftMethod
+    public void acknowledgeResults(TaskId taskId, OutputBufferId bufferId, long token)
+    {
+        requireNonNull(taskId, "taskId is null");
+        requireNonNull(bufferId, "bufferId is null");
+
+        taskManager.acknowledgeTaskResults(taskId, bufferId, token);
+    }
+
+    @ThriftMethod
+    public ListenableFuture<Void> abortResults(TaskId taskId, OutputBufferId bufferId)
+    {
+        requireNonNull(taskId, "taskId is null");
+        requireNonNull(bufferId, "bufferId is null");
+
+        // Use thrift server pool to abort tasks; it is dangerous to use a fixed thread pool to abort tasks.
+        // When having a surge of aborting results, a fixed thread pool may not be able to handle requests fast enough causing query to hang.
+        // TaskManager does not support async calls with a thread pool.
+        // Even getTaskResults is a fake async call with an immediate future wrapping around ClientBuffer::processRead.
+        // It might worth exploring true async RPC for /v1/task endpoint
+        taskManager.abortTaskResults(taskId, bufferId);
+        return Futures.immediateFuture(null);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/util/TaskUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/TaskUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import io.airlift.units.Duration;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TaskUtils
+{
+    public static final Duration DEFAULT_MAX_WAIT_TIME = new Duration(2, SECONDS);
+
+    private TaskUtils() {}
+
+    public static Duration randomizeWaitTime(Duration waitTime)
+    {
+        // Randomize in [T/2, T], so wait is not near zero and the client-supplied max wait time is respected
+        long halfWaitMillis = waitTime.toMillis() / 2;
+        return new Duration(halfWaitMillis + ThreadLocalRandom.current().nextLong(halfWaitMillis), MILLISECONDS);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -271,6 +271,12 @@ public class MockRemoteTaskFactory
         }
 
         @Override
+        public URI getRemoteTaskLocation()
+        {
+            return location;
+        }
+
+        @Override
         public TaskStatus getTaskStatus()
         {
             TaskStats stats = taskContext.getTaskStats();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -314,9 +314,15 @@ public class TestSqlTaskManager
         }
 
         @Override
-        public URI createTaskLocation(InternalNode node, TaskId taskId)
+        public URI createLegacyTaskLocation(InternalNode node, TaskId taskId)
         {
             return URI.create("http://fake.invalid/task/" + node.getNodeIdentifier() + "/" + taskId);
+        }
+
+        @Override
+        public URI createTaskLocation(InternalNode node, TaskId taskId)
+        {
+            return createLegacyTaskLocation(node, taskId);
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestDiscoveryNodeManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestDiscoveryNodeManager.java
@@ -22,6 +22,7 @@ import com.facebook.airlift.node.NodeConfig;
 import com.facebook.airlift.node.NodeInfo;
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.failureDetector.NoOpFailureDetector;
+import com.facebook.presto.operator.TestingDriftClient;
 import com.facebook.presto.server.InternalCommunicationConfig;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
@@ -86,7 +87,7 @@ public class TestDiscoveryNodeManager
     @Test
     public void testGetAllNodes()
     {
-        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion, testHttpClient, internalCommunicationConfig);
+        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
         try {
             AllNodes allNodes = manager.getAllNodes();
 
@@ -124,7 +125,7 @@ public class TestDiscoveryNodeManager
                 .setEnvironment("test")
                 .setNodeId(currentNode.getNodeIdentifier()));
 
-        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion, testHttpClient, internalCommunicationConfig);
+        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
         try {
             assertEquals(manager.getCurrentNode(), currentNode);
         }
@@ -136,7 +137,7 @@ public class TestDiscoveryNodeManager
     @Test
     public void testGetCoordinators()
     {
-        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion, testHttpClient, internalCommunicationConfig);
+        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
         try {
             assertEquals(manager.getCoordinators(), ImmutableSet.of(coordinator));
         }
@@ -149,14 +150,14 @@ public class TestDiscoveryNodeManager
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".* current node not returned .*")
     public void testGetCurrentNodeRequired()
     {
-        new DiscoveryNodeManager(selector, new NodeInfo("test"), new NoOpFailureDetector(), expectedVersion, testHttpClient, internalCommunicationConfig);
+        new DiscoveryNodeManager(selector, new NodeInfo("test"), new NoOpFailureDetector(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
     }
 
     @Test(timeOut = 60000)
     public void testNodeChangeListener()
             throws Exception
     {
-        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion, testHttpClient, internalCommunicationConfig);
+        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
         try {
             manager.startPollingNodeStates();
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClient.java
@@ -122,6 +122,7 @@ public class TestExchangeClient
                 true,
                 0.2,
                 new TestingHttpClient(processor, scheduler),
+                new TestingDriftClient<>(),
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor);
@@ -162,6 +163,7 @@ public class TestExchangeClient
                 true,
                 0.2,
                 new TestingHttpClient(processor, testingHttpClientExecutor),
+                new TestingDriftClient<>(),
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor);
@@ -235,6 +237,7 @@ public class TestExchangeClient
                 true,
                 0.2,
                 new TestingHttpClient(processor, testingHttpClientExecutor),
+                new TestingDriftClient<>(),
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor);
@@ -318,6 +321,7 @@ public class TestExchangeClient
                 true,
                 0.2,
                 new TestingHttpClient(processor, testingHttpClientExecutor),
+                new TestingDriftClient<>(),
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor);
@@ -383,6 +387,7 @@ public class TestExchangeClient
                 true,
                 0.2,
                 new TestingHttpClient(processor, testingHttpClientExecutor),
+                new TestingDriftClient<>(),
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor)) {
@@ -459,6 +464,7 @@ public class TestExchangeClient
                 true,
                 0.2,
                 new TestingHttpClient(processor, testingHttpClientExecutor),
+                new TestingDriftClient<>(),
                 scheduler,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                 pageBufferClientCallbackExecutor);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeOperator.java
@@ -92,6 +92,7 @@ public class TestExchangeOperator
                 true,
                 0.2,
                 httpClient,
+                new TestingDriftClient<>(),
                 scheduler,
                 systemMemoryUsageListener,
                 pageBufferClientCallbackExecutor);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMergeOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMergeOperator.java
@@ -83,7 +83,7 @@ public class TestMergeOperator
 
         taskBuffers = CacheBuilder.newBuilder().build(CacheLoader.from(TestingTaskBuffer::new));
         httpClient = new TestingHttpClient(new TestingExchangeHttpClientHandler(taskBuffers), executor);
-        exchangeClientFactory = new ExchangeClientFactory(new ExchangeClientConfig(), httpClient, executor);
+        exchangeClientFactory = new ExchangeClientFactory(new ExchangeClientConfig(), httpClient, new TestingDriftClient<>(), executor);
         orderingCompiler = new OrderingCompiler();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPageBufferClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPageBufferClient.java
@@ -101,7 +101,8 @@ public class TestPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        PageBufferClient client = new PageBufferClient(new TestingHttpClient(processor, scheduler),
+        PageBufferClient client = new PageBufferClient(
+                new HttpRpcShuffleClient(new TestingHttpClient(processor, scheduler), location),
                 new Duration(1, TimeUnit.MINUTES),
                 true,
                 location,
@@ -186,7 +187,8 @@ public class TestPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        PageBufferClient client = new PageBufferClient(new TestingHttpClient(processor, scheduler),
+        PageBufferClient client = new PageBufferClient(
+                new HttpRpcShuffleClient(new TestingHttpClient(processor, scheduler), location),
                 new Duration(1, TimeUnit.MINUTES),
                 true,
                 location,
@@ -198,7 +200,7 @@ public class TestPageBufferClient
 
         client.scheduleRequest(expectedMaxSize);
         beforeRequest.await(10, TimeUnit.SECONDS);
-        assertStatus(client, location, "running", 0, 1, 0, 0, "PROCESSING_REQUEST");
+        assertStatus(client, location, "running", 0, 1, 0, 0, "processing request");
         assertEquals(client.isRunning(), true);
         afterRequest.await(10, TimeUnit.SECONDS);
 
@@ -207,7 +209,7 @@ public class TestPageBufferClient
 
         client.close();
         beforeRequest.await(10, TimeUnit.SECONDS);
-        assertStatus(client, location, "closed", 0, 1, 1, 1, "PROCESSING_REQUEST");
+        assertStatus(client, location, "closed", 0, 1, 1, 1, "processing request");
         afterRequest.await(10, TimeUnit.SECONDS);
         requestComplete.await(10, TimeUnit.SECONDS);
         assertStatus(client, location, "closed", 0, 1, 2, 1, "not scheduled");
@@ -226,7 +228,8 @@ public class TestPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        PageBufferClient client = new PageBufferClient(new TestingHttpClient(processor, scheduler),
+        PageBufferClient client = new PageBufferClient(
+                new HttpRpcShuffleClient(new TestingHttpClient(processor, scheduler), location),
                 new Duration(1, TimeUnit.MINUTES),
                 true,
                 location,
@@ -294,7 +297,8 @@ public class TestPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        PageBufferClient client = new PageBufferClient(new TestingHttpClient(processor, scheduler),
+        PageBufferClient client = new PageBufferClient(
+                new HttpRpcShuffleClient(new TestingHttpClient(processor, scheduler), location),
                 new Duration(1, TimeUnit.MINUTES),
                 true,
                 location,
@@ -307,7 +311,7 @@ public class TestPageBufferClient
         // send request
         client.scheduleRequest(expectedMaxSize);
         beforeRequest.await(10, TimeUnit.SECONDS);
-        assertStatus(client, location, "running", 0, 1, 0, 0, "PROCESSING_REQUEST");
+        assertStatus(client, location, "running", 0, 1, 0, 0, "processing request");
         assertEquals(client.isRunning(), true);
         // request is pending, now close it
         client.close();
@@ -348,7 +352,8 @@ public class TestPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        PageBufferClient client = new PageBufferClient(new TestingHttpClient(processor, scheduler),
+        PageBufferClient client = new PageBufferClient(
+                new HttpRpcShuffleClient(new TestingHttpClient(processor, scheduler), location),
                 new Duration(30, TimeUnit.SECONDS),
                 true,
                 location,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPageBufferClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPageBufferClient.java
@@ -21,7 +21,7 @@ import com.facebook.airlift.http.client.testing.TestingResponse;
 import com.facebook.airlift.testing.TestingTicker;
 import com.facebook.presto.execution.buffer.PagesSerde;
 import com.facebook.presto.execution.buffer.SerializedPage;
-import com.facebook.presto.operator.HttpPageBufferClient.ClientCallback;
+import com.facebook.presto.operator.PageBufferClient.ClientCallback;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.Page;
 import com.google.common.collect.ImmutableListMultimap;
@@ -60,7 +60,7 @@ import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.testng.Assert.assertEquals;
 
-public class TestHttpPageBufferClient
+public class TestPageBufferClient
 {
     private ScheduledExecutorService scheduler;
     private ExecutorService pageBufferClientCallbackExecutor;
@@ -101,7 +101,7 @@ public class TestHttpPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
+        PageBufferClient client = new PageBufferClient(new TestingHttpClient(processor, scheduler),
                 new Duration(1, TimeUnit.MINUTES),
                 true,
                 location,
@@ -186,7 +186,7 @@ public class TestHttpPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
+        PageBufferClient client = new PageBufferClient(new TestingHttpClient(processor, scheduler),
                 new Duration(1, TimeUnit.MINUTES),
                 true,
                 location,
@@ -226,7 +226,7 @@ public class TestHttpPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
+        PageBufferClient client = new PageBufferClient(new TestingHttpClient(processor, scheduler),
                 new Duration(1, TimeUnit.MINUTES),
                 true,
                 location,
@@ -294,7 +294,7 @@ public class TestHttpPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
+        PageBufferClient client = new PageBufferClient(new TestingHttpClient(processor, scheduler),
                 new Duration(1, TimeUnit.MINUTES),
                 true,
                 location,
@@ -348,7 +348,7 @@ public class TestHttpPageBufferClient
         TestingClientCallback callback = new TestingClientCallback(requestComplete);
 
         URI location = URI.create("http://localhost:8080");
-        HttpPageBufferClient client = new HttpPageBufferClient(new TestingHttpClient(processor, scheduler),
+        PageBufferClient client = new PageBufferClient(new TestingHttpClient(processor, scheduler),
                 new Duration(30, TimeUnit.SECONDS),
                 true,
                 location,
@@ -405,7 +405,7 @@ public class TestHttpPageBufferClient
     }
 
     private static void assertStatus(
-            HttpPageBufferClient client,
+            PageBufferClient client,
             URI location, String status,
             int pagesReceived,
             int requestsScheduled,
@@ -472,28 +472,28 @@ public class TestHttpPageBufferClient
         }
 
         @Override
-        public boolean addPages(HttpPageBufferClient client, List<SerializedPage> pages)
+        public boolean addPages(PageBufferClient client, List<SerializedPage> pages)
         {
             this.pages.addAll(pages);
             return true;
         }
 
         @Override
-        public void requestComplete(HttpPageBufferClient client)
+        public void requestComplete(PageBufferClient client)
         {
             completedRequests.getAndIncrement();
             awaitDone();
         }
 
         @Override
-        public void clientFinished(HttpPageBufferClient client)
+        public void clientFinished(PageBufferClient client)
         {
             finishedBuffers.getAndIncrement();
             awaitDone();
         }
 
         @Override
-        public void clientFailed(HttpPageBufferClient client, Throwable cause)
+        public void clientFailed(PageBufferClient client, Throwable cause)
         {
             failedBuffers.getAndIncrement();
             failure.compareAndSet(null, cause);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPageBufferClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPageBufferClient.java
@@ -404,7 +404,7 @@ public class TestPageBufferClient
     @Test
     public void testErrorCodes()
     {
-        assertEquals(new PageTooLargeException().getErrorCode(), PAGE_TOO_LARGE.toErrorCode());
+        assertEquals(new PageTooLargeException(null).getErrorCode(), PAGE_TOO_LARGE.toErrorCode());
         assertEquals(new PageTransportErrorException("").getErrorCode(), PAGE_TRANSPORT_ERROR.toErrorCode());
         assertEquals(new PageTransportTimeoutException(HostAddress.fromParts("127.0.0.1", 8080), "", null).getErrorCode(), PAGE_TRANSPORT_TIMEOUT.toErrorCode());
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestingDriftClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestingDriftClient.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.drift.client.DriftClient;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class TestingDriftClient<T>
+        implements DriftClient<T>
+{
+    @Override
+    public T get(Optional<String> addressSelectionContext, Map<String, String> headers)
+    {
+        throw new UnsupportedOperationException("this client is never expected to be called");
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/TestInternalCommunicationConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestInternalCommunicationConfig.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.server;
 
+import com.facebook.presto.server.InternalCommunicationConfig.CommunicationProtocol;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
@@ -39,7 +40,8 @@ public class TestInternalCommunicationConfig
                 .setExcludeCipherSuites(null)
                 .setKerberosUseCanonicalHostname(true)
                 .setBinaryTransportEnabled(false)
-                .setMaxTaskUpdateSize(new DataSize(16, MEGABYTE)));
+                .setMaxTaskUpdateSize(new DataSize(16, MEGABYTE))
+                .setTaskCommunicationProtocol(CommunicationProtocol.HTTP));
     }
 
     @Test
@@ -56,6 +58,7 @@ public class TestInternalCommunicationConfig
                 .put("internal-communication.kerberos.use-canonical-hostname", "false")
                 .put("experimental.internal-communication.binary-transport-enabled", "true")
                 .put("experimental.internal-communication.max-task-update-size", "512MB")
+                .put("internal-communication.task-communication-protocol", "THRIFT")
                 .build();
 
         InternalCommunicationConfig expected = new InternalCommunicationConfig()
@@ -68,7 +71,8 @@ public class TestInternalCommunicationConfig
                 .setKerberosEnabled(true)
                 .setKerberosUseCanonicalHostname(false)
                 .setBinaryTransportEnabled(true)
-                .setMaxTaskUpdateSize(new DataSize(512, MEGABYTE));
+                .setMaxTaskUpdateSize(new DataSize(512, MEGABYTE))
+                .setTaskCommunicationProtocol(CommunicationProtocol.THRIFT);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestInternalCommunicationConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestInternalCommunicationConfig.java
@@ -41,7 +41,8 @@ public class TestInternalCommunicationConfig
                 .setKerberosUseCanonicalHostname(true)
                 .setBinaryTransportEnabled(false)
                 .setMaxTaskUpdateSize(new DataSize(16, MEGABYTE))
-                .setTaskCommunicationProtocol(CommunicationProtocol.HTTP));
+                .setTaskCommunicationProtocol(CommunicationProtocol.HTTP)
+                .setServerInfoCommunicationProtocol(CommunicationProtocol.HTTP));
     }
 
     @Test
@@ -59,6 +60,7 @@ public class TestInternalCommunicationConfig
                 .put("experimental.internal-communication.binary-transport-enabled", "true")
                 .put("experimental.internal-communication.max-task-update-size", "512MB")
                 .put("internal-communication.task-communication-protocol", "THRIFT")
+                .put("internal-communication.server-info-communication-protocol", "THRIFT")
                 .build();
 
         InternalCommunicationConfig expected = new InternalCommunicationConfig()
@@ -72,7 +74,8 @@ public class TestInternalCommunicationConfig
                 .setKerberosUseCanonicalHostname(false)
                 .setBinaryTransportEnabled(true)
                 .setMaxTaskUpdateSize(new DataSize(512, MEGABYTE))
-                .setTaskCommunicationProtocol(CommunicationProtocol.THRIFT);
+                .setTaskCommunicationProtocol(CommunicationProtocol.THRIFT)
+                .setServerInfoCommunicationProtocol(CommunicationProtocol.THRIFT);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestThriftServerInfoIntegration.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestThriftServerInfoIntegration.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.bootstrap.LifeCycleManager;
+import com.facebook.drift.client.DriftClientFactory;
+import com.facebook.drift.client.address.AddressSelector;
+import com.facebook.drift.client.address.SimpleAddressSelector;
+import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.drift.server.DriftServer;
+import com.facebook.drift.transport.netty.client.DriftNettyClientConfig;
+import com.facebook.drift.transport.netty.client.DriftNettyMethodInvokerFactory;
+import com.facebook.drift.transport.netty.server.DriftNettyServerModule;
+import com.facebook.drift.transport.netty.server.DriftNettyServerTransport;
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.StateMachine;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.execution.TaskManager;
+import com.facebook.presto.execution.TaskSource;
+import com.facebook.presto.execution.TaskState;
+import com.facebook.presto.execution.TaskStatus;
+import com.facebook.presto.execution.buffer.BufferResult;
+import com.facebook.presto.execution.buffer.OutputBuffers;
+import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
+import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.server.thrift.ThriftServerInfoClient;
+import com.facebook.presto.server.thrift.ThriftServerInfoService;
+import com.facebook.presto.spi.NodeState;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import io.airlift.units.DataSize;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.inject.Singleton;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.drift.client.ExceptionClassifier.NORMAL_RESULT;
+import static com.facebook.drift.server.guice.DriftServerBinder.driftServerBinder;
+import static com.facebook.drift.transport.netty.client.DriftNettyMethodInvokerFactory.createStaticDriftNettyMethodInvokerFactory;
+import static com.facebook.presto.spi.NodeState.ACTIVE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestThriftServerInfoIntegration
+{
+    private LifeCycleManager lifeCycleManager;
+    private int thriftServerPort;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        Bootstrap app = new Bootstrap(
+                new DriftNettyServerModule(),
+                new TestingThriftServerInfoModule());
+
+        app.setRequiredConfigurationProperties(ImmutableMap.of("presto.version", "test.0", "coordinator", "false"));
+
+        Injector injector = app
+                .strictConfig()
+                .doNotInitializeLogging()
+                .initialize();
+
+        lifeCycleManager = injector.getInstance(LifeCycleManager.class);
+        thriftServerPort = driftServerPort(injector.getInstance(DriftServer.class));
+    }
+
+    @AfterClass
+    public void teardown()
+    {
+        if (lifeCycleManager != null) {
+            lifeCycleManager.stop();
+        }
+    }
+
+    @Test
+    public void testServer()
+    {
+        AddressSelector<SimpleAddressSelector.SimpleAddress> addressSelector = new SimpleAddressSelector(
+                ImmutableSet.of(HostAndPort.fromParts("localhost", thriftServerPort)),
+                true);
+        try (DriftNettyMethodInvokerFactory<?> invokerFactory = createStaticDriftNettyMethodInvokerFactory(new DriftNettyClientConfig())) {
+            DriftClientFactory clientFactory = new DriftClientFactory(new ThriftCodecManager(), invokerFactory, addressSelector, NORMAL_RESULT);
+            ThriftServerInfoClient client = clientFactory.createDriftClient(ThriftServerInfoClient.class).get();
+
+            // get buffer result
+            NodeState state = NodeState.valueOf(client.getServerState().get());
+            assertEquals(state, ACTIVE);
+        }
+        catch (Exception e) {
+            fail();
+        }
+    }
+
+    private static int driftServerPort(DriftServer server)
+    {
+        return ((DriftNettyServerTransport) server.getServerTransport()).getPort();
+    }
+
+    public static class TestingThriftServerInfoModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            configBinder(binder).bindConfig(ServerConfig.class);
+
+            binder.bind(GracefulShutdownHandler.class).in(Scopes.SINGLETON);
+            binder.bind(ShutdownAction.class).to(TestingPrestoServer.TestShutdownAction.class).in(Scopes.SINGLETON);
+
+            binder.bind(ThriftServerInfoService.class).in(Scopes.SINGLETON);
+            driftServerBinder(binder).bindService(ThriftServerInfoService.class);
+        }
+
+        @Provides
+        @Singleton
+        public static TaskManager createTaskManager()
+        {
+            return new TaskManager() {
+                @Override
+                public List<TaskInfo> getAllTaskInfo()
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public TaskInfo getTaskInfo(TaskId taskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public TaskStatus getTaskStatus(TaskId taskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public ListenableFuture<TaskInfo> getTaskInfo(TaskId taskId, TaskState currentState)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public String getTaskInstanceId(TaskId taskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public ListenableFuture<TaskStatus> getTaskStatus(TaskId taskId, TaskState currentState)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public void updateMemoryPoolAssignments(MemoryPoolAssignmentsRequest assignments)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public TaskInfo updateTask(Session session, TaskId taskId, Optional<PlanFragment> fragment, List<TaskSource> sources, OutputBuffers outputBuffers, Optional<TableWriteInfo> tableWriteInfo)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public TaskInfo cancelTask(TaskId taskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public TaskInfo abortTask(TaskId taskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public ListenableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBufferId bufferId, long startingSequenceId, DataSize maxSize)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public void acknowledgeTaskResults(TaskId taskId, OutputBufferId bufferId, long sequenceId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public TaskInfo abortTaskResults(TaskId taskId, OutputBufferId bufferId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public void addStateChangeListener(TaskId taskId, StateMachine.StateChangeListener<TaskState> stateChangeListener)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public void removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
@@ -121,7 +121,8 @@ public class TestThriftTaskIntegration
             assertEquals(result.get().getTaskInstanceId(), "test");
 
             // ack buffer result
-            client.acknowledgeResults(TaskId.valueOf("queryid.0.0.0"), new OutputBufferId(1), 42);
+            client.acknowledgeResults(TaskId.valueOf("queryid.0.0.0"), new OutputBufferId(1), 42).get();    // sync
+            client.acknowledgeResults(TaskId.valueOf("queryid.0.0.0"), new OutputBufferId(1), 42);          // fire and forget
 
             // abort buffer result
             client.abortResults(TaskId.valueOf("queryid.0.0.0"), new OutputBufferId(1)).get();

--- a/presto-main/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.bootstrap.LifeCycleManager;
+import com.facebook.airlift.concurrent.BoundedExecutor;
+import com.facebook.drift.client.DriftClientFactory;
+import com.facebook.drift.client.address.AddressSelector;
+import com.facebook.drift.client.address.SimpleAddressSelector;
+import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.drift.server.DriftServer;
+import com.facebook.drift.transport.netty.client.DriftNettyClientConfig;
+import com.facebook.drift.transport.netty.client.DriftNettyMethodInvokerFactory;
+import com.facebook.drift.transport.netty.server.DriftNettyServerModule;
+import com.facebook.drift.transport.netty.server.DriftNettyServerTransport;
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.StateMachine;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.execution.TaskManager;
+import com.facebook.presto.execution.TaskSource;
+import com.facebook.presto.execution.TaskState;
+import com.facebook.presto.execution.TaskStatus;
+import com.facebook.presto.execution.buffer.BufferResult;
+import com.facebook.presto.execution.buffer.OutputBuffers;
+import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
+import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
+import com.facebook.presto.server.thrift.ThriftTaskClient;
+import com.facebook.presto.server.thrift.ThriftTaskService;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import io.airlift.units.DataSize;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.inject.Singleton;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.drift.client.ExceptionClassifier.NORMAL_RESULT;
+import static com.facebook.drift.server.guice.DriftServerBinder.driftServerBinder;
+import static com.facebook.drift.transport.netty.client.DriftNettyMethodInvokerFactory.createStaticDriftNettyMethodInvokerFactory;
+import static com.facebook.presto.execution.buffer.BufferResult.emptyResults;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestThriftTaskIntegration
+{
+    private LifeCycleManager lifeCycleManager;
+    private int thriftServerPort;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        Bootstrap app = new Bootstrap(
+                new DriftNettyServerModule(),
+                new TestingTaskThriftModule());
+
+        Injector injector = app
+                .strictConfig()
+                .doNotInitializeLogging()
+                .initialize();
+
+        lifeCycleManager = injector.getInstance(LifeCycleManager.class);
+        thriftServerPort = driftServerPort(injector.getInstance(DriftServer.class));
+    }
+
+    @AfterClass
+    public void teardown()
+    {
+        if (lifeCycleManager != null) {
+            lifeCycleManager.stop();
+        }
+    }
+
+    @Test
+    public void testServer()
+    {
+        AddressSelector<SimpleAddressSelector.SimpleAddress> addressSelector = new SimpleAddressSelector(
+                ImmutableSet.of(HostAndPort.fromParts("localhost", thriftServerPort)),
+                true);
+        try (DriftNettyMethodInvokerFactory<?> invokerFactory = createStaticDriftNettyMethodInvokerFactory(new DriftNettyClientConfig())) {
+            DriftClientFactory clientFactory = new DriftClientFactory(new ThriftCodecManager(), invokerFactory, addressSelector, NORMAL_RESULT);
+            ThriftTaskClient client = clientFactory.createDriftClient(ThriftTaskClient.class).get();
+
+            // get buffer result
+            ListenableFuture<BufferResult> result = client.getResults(TaskId.valueOf("queryid.0.0.0"), new OutputBufferId(1), 0, 100);
+            assertTrue(result.get().isBufferComplete());
+            assertTrue(result.get().getSerializedPages().isEmpty());
+            assertEquals(result.get().getToken(), 1);
+            assertEquals(result.get().getTaskInstanceId(), "test");
+
+            // ack buffer result
+            client.acknowledgeResults(TaskId.valueOf("queryid.0.0.0"), new OutputBufferId(1), 42);
+
+            // abort buffer result
+            client.abortResults(TaskId.valueOf("queryid.0.0.0"), new OutputBufferId(1)).get();
+        }
+        catch (Exception e) {
+            fail();
+        }
+    }
+
+    private static int driftServerPort(DriftServer server)
+    {
+        return ((DriftNettyServerTransport) server.getServerTransport()).getPort();
+    }
+
+    public static class TestingTaskThriftModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(ThriftTaskService.class).in(Scopes.SINGLETON);
+
+            driftServerBinder(binder).bindService(ThriftTaskService.class);
+        }
+
+        @Provides
+        @Singleton
+        @ForAsyncRpc
+        public static ExecutorService createAsyncHttpResponseCoreExecutor()
+        {
+            return newCachedThreadPool(daemonThreadsNamed("async-http-response-%s"));
+        }
+
+        @Provides
+        @Singleton
+        @ForAsyncRpc
+        public static BoundedExecutor createAsyncHttpResponseExecutor(@ForAsyncRpc ExecutorService coreExecutor)
+        {
+            return new BoundedExecutor(coreExecutor, 100);
+        }
+
+        @Provides
+        @Singleton
+        @ForAsyncRpc
+        public static ScheduledExecutorService createAsyncHttpTimeoutExecutor()
+        {
+            return newScheduledThreadPool(10, daemonThreadsNamed("async-http-timeout-%s"));
+        }
+
+        @Provides
+        @Singleton
+        public static TaskManager createTaskManager()
+        {
+            return new TaskManager() {
+                @Override
+                public List<TaskInfo> getAllTaskInfo()
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public TaskInfo getTaskInfo(TaskId taskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public TaskStatus getTaskStatus(TaskId taskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public ListenableFuture<TaskInfo> getTaskInfo(TaskId taskId, TaskState currentState)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public String getTaskInstanceId(TaskId taskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public ListenableFuture<TaskStatus> getTaskStatus(TaskId taskId, TaskState currentState)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public void updateMemoryPoolAssignments(MemoryPoolAssignmentsRequest assignments)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public TaskInfo updateTask(Session session, TaskId taskId, Optional<PlanFragment> fragment, List<TaskSource> sources, OutputBuffers outputBuffers, Optional<TableWriteInfo> tableWriteInfo)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public TaskInfo cancelTask(TaskId taskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public TaskInfo abortTask(TaskId taskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public ListenableFuture<BufferResult> getTaskResults(TaskId taskId, OutputBufferId bufferId, long startingSequenceId, DataSize maxSize)
+                {
+                    return Futures.immediateFuture(emptyResults("test", 1, true));
+                }
+
+                @Override
+                public void acknowledgeTaskResults(TaskId taskId, OutputBufferId bufferId, long sequenceId)
+                {
+                    assertEquals(taskId, TaskId.valueOf("queryid.0.0.0"));
+                    assertEquals(bufferId, new OutputBufferId(1));
+                    assertEquals(sequenceId, 42);
+                }
+
+                @Override
+                public TaskInfo abortTaskResults(TaskId taskId, OutputBufferId bufferId)
+                {
+                    assertEquals(taskId, TaskId.valueOf("queryid.0.0.0"));
+                    assertEquals(bufferId, new OutputBufferId(1));
+
+                    // null is not going to be consumed
+                    return null;
+                }
+
+                @Override
+                public void addStateChangeListener(TaskId taskId, StateMachine.StateChangeListener<TaskState> stateChangeListener)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public void removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+    }
+}

--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -15,7 +15,6 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <mongo-java.version>3.6.0</mongo-java.version>
         <mongo-server.version>1.5.0</mongo-server.version>
-        <netty.version>4.0.32.Final</netty.version>
     </properties>
 
     <dependencies>
@@ -23,6 +22,12 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
             <version>${mongo-java.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -159,6 +164,12 @@
             <groupId>de.bwaldvogel</groupId>
             <artifactId>mongo-java-server-core</artifactId>
             <version>${mongo-server.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
 
@@ -172,13 +183,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport</artifactId>
-            <version>${netty.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/SyncMemoryBackend.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/SyncMemoryBackend.java
@@ -17,8 +17,6 @@ import de.bwaldvogel.mongo.MongoBackend;
 import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
 import de.bwaldvogel.mongo.backend.memory.MemoryDatabase;
 import de.bwaldvogel.mongo.exception.MongoServerException;
-import io.netty.channel.Channel;
-import org.bson.BSONObject;
 
 public class SyncMemoryBackend
         extends MemoryBackend
@@ -37,13 +35,6 @@ public class SyncMemoryBackend
                 throws MongoServerException
         {
             super(backend, databaseName);
-        }
-
-        @Override
-        public synchronized BSONObject handleCommand(Channel channel, String command, BSONObject query)
-                throws MongoServerException
-        {
-            return super.handleCommand(channel, command, query);
         }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/NodeState.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/NodeState.java
@@ -15,7 +15,35 @@ package com.facebook.presto.spi;
 
 public enum NodeState
 {
-    ACTIVE,
-    INACTIVE,
-    SHUTTING_DOWN
+    ACTIVE(1),
+    INACTIVE(2),
+    SHUTTING_DOWN(3);
+
+    private final int value;
+
+    NodeState(int value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Recover NodeState from the ordinal.
+     * In general, ThriftEnum is the right annotation to use.
+     * But given the class is in SPI, use the following workaround.
+     */
+    public static NodeState valueOf(int value)
+    {
+        for (NodeState nodeState : values()) {
+            if (nodeState.getValue() == value) {
+                return nodeState;
+            }
+        }
+        throw new IllegalArgumentException("Invalid NodeState value: " + value);
+    }
+
+    // the value will be used for SerDe like thrift
+    public int getValue()
+    {
+        return value;
+    }
 }


### PR DESCRIPTION
HTTP is too unreliable to use for internal communication. Add thrift support.

```
== RELEASE NOTES ==

General Changes
* Allow Presto nodes to shuffle data with Thrift protocol. Use config `internal-communication.task-communication-protocol` to control between HTTP and Thrift.
* Allow Presto nodes to announce state with Thrift protocol. Use config `internal-communication.server-info-communication-protocol` to control between HTTP and Thrift.
```
