### PR TITLE
Fix invalid plan for repeated lambdas in order by

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -95,7 +95,6 @@ import static com.facebook.presto.sql.relational.OriginalExpressionUtils.asSymbo
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Streams.stream;
 import static java.util.Objects.requireNonNull;
@@ -281,10 +280,12 @@ class QueryPlanner
 
     private PlanBuilder planBuilderFor(PlanBuilder builder, Scope scope, Iterable<? extends Expression> expressionsToRemap)
     {
-        Map<Expression, VariableReferenceExpression> expressionsToVariables = variablesForExpressions(builder, expressionsToRemap);
         PlanBuilder newBuilder = planBuilderFor(builder, scope);
-        expressionsToVariables.entrySet()
-                .forEach(entry -> newBuilder.getTranslations().put(entry.getKey(), entry.getValue()));
+        // We can't deduplicate expressions here because even if two expressions are equal,
+        // the TranslationMap maps sql names to symbols, and any lambda expressions will be
+        // resolved differently since the lambdaDeclarationToVariableMap is identity based.
+        stream(expressionsToRemap)
+                .forEach(expression -> newBuilder.getTranslations().put(expression, builder.translate(expression)));
         return newBuilder;
     }
 
@@ -937,12 +938,5 @@ class QueryPlanner
         return variables.stream()
                 .map(variable -> new SymbolReference(variable.getName()))
                 .collect(toImmutableList());
-    }
-
-    private static Map<Expression, VariableReferenceExpression> variablesForExpressions(PlanBuilder builder, Iterable<? extends Expression> expressions)
-    {
-        return stream(expressions)
-                .distinct()
-                .collect(toImmutableMap(expression -> expression, builder::translate));
     }
 }


### PR DESCRIPTION
Presto was creating invalid plans for queries with duplicate lambda
expressions in the order by clause because the expressions were
considered "equal" for some purposes, but not equal when converting the lambdas
to symbols.  This caused one of the expressions to not be mapped to an input
symbol. To resolve this, we don't deduplicate even seemingly equal expressions
in the order by clause so that we maintain translations for all the
expressions.

Example query:
```
SELECT
  COUNT(*)
FROM
  (values ARRAY['a', 'b']) as t(col1)
ORDER BY
  IF(
    SUM(
      REDUCE(
        col1,
        ROW(0),
        ("l", "r") -> "l",
        "x" -> 1
      )
    ) > 0,
    COUNT(*),
    SUM(
      REDUCE(
        col1,
        ROW(0),
        ("l", "r") -> "l",
        "x" -> 1
      )
    )
  )
```


This fixes the second part of #10694 

```
== RELEASE NOTES ==

General Changes
* Fix failures caused by invalid plans for queries with repeated lambda expressions in the order by clause.
```
