### PR TITLE
Make BenchmarkSelectiveStreamReaders load LazyBlock

### DIFF
--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -138,7 +138,7 @@ public class BenchmarkSelectiveStreamReaders
             }
 
             if (page.getPositionCount() > 0) {
-                blocks.add(page.getBlock(0));
+                blocks.add(page.getBlock(0).getLoadedBlock());
             }
         }
         return blocks;


### PR DESCRIPTION
PR #13782 introduced LazyBlock in OrcSelectiveRecordReader. This change ensures that the block is loaded for benchmarking.

== NO RELEASE NOTE ==