### PR TITLE
Add sum of cardinality for array column verifier results

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ChecksumValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ChecksumValidator.java
@@ -32,8 +32,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import static com.facebook.presto.sql.QueryUtil.simpleQuery;
+import static com.facebook.presto.verifier.framework.Column.Category.ARRAY;
 import static com.facebook.presto.verifier.framework.Column.Category.FLOATING_POINT;
-import static com.facebook.presto.verifier.framework.Column.Category.ORDERABLE_ARRAY;
 import static com.facebook.presto.verifier.framework.Column.Category.SIMPLE;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.function.Function.identity;
@@ -46,12 +46,12 @@ public class ChecksumValidator
     public ChecksumValidator(
             SimpleColumnValidator simpleColumnValidator,
             FloatingPointColumnValidator floatingPointColumnValidator,
-            OrderableArrayColumnValidator orderableArrayColumnValidator)
+            ArrayColumnValidator arrayColumnValidator)
     {
         this.columnValidators = ImmutableMap.of(
                 SIMPLE, simpleColumnValidator,
                 FLOATING_POINT, floatingPointColumnValidator,
-                ORDERABLE_ARRAY, orderableArrayColumnValidator);
+                ARRAY, arrayColumnValidator);
     }
 
     public Query generateChecksumQuery(QualifiedName tableName, List<Column> columns)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/Column.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/Column.java
@@ -28,8 +28,8 @@ import java.util.Set;
 import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.verifier.framework.Column.Category.ARRAY;
 import static com.facebook.presto.verifier.framework.Column.Category.FLOATING_POINT;
-import static com.facebook.presto.verifier.framework.Column.Category.ORDERABLE_ARRAY;
 import static com.facebook.presto.verifier.framework.Column.Category.SIMPLE;
 import static com.facebook.presto.verifier.framework.VerifierUtil.delimitedIdentifier;
 import static java.util.Objects.requireNonNull;
@@ -40,7 +40,7 @@ public class Column
     {
         SIMPLE,
         FLOATING_POINT,
-        ORDERABLE_ARRAY,
+        ARRAY,
     }
 
     private static final Set<Type> FLOATING_POINT_TYPES = ImmutableSet.of(DOUBLE, REAL);
@@ -85,9 +85,8 @@ public class Column
         if (FLOATING_POINT_TYPES.contains(type)) {
             category = FLOATING_POINT;
         }
-        else if (type instanceof ArrayType &&
-                ((ArrayType) type).getElementType().isOrderable()) {
-            category = ORDERABLE_ARRAY;
+        else if (type instanceof ArrayType) {
+            category = ARRAY;
         }
         else {
             category = SIMPLE;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
@@ -33,9 +33,9 @@ import com.facebook.presto.transaction.TransactionManagerConfig;
 import com.facebook.presto.type.TypeRegistry;
 import com.facebook.presto.verifier.annotation.ForControl;
 import com.facebook.presto.verifier.annotation.ForTest;
+import com.facebook.presto.verifier.checksum.ArrayColumnValidator;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.checksum.FloatingPointColumnValidator;
-import com.facebook.presto.verifier.checksum.OrderableArrayColumnValidator;
 import com.facebook.presto.verifier.checksum.SimpleColumnValidator;
 import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
 import com.facebook.presto.verifier.prestoaction.VerificationPrestoActionModule;
@@ -142,7 +142,7 @@ public class VerifierModule
         binder.bind(ChecksumValidator.class).in(SINGLETON);
         binder.bind(SimpleColumnValidator.class).in(SINGLETON);
         binder.bind(FloatingPointColumnValidator.class).in(SINGLETON);
-        binder.bind(OrderableArrayColumnValidator.class).in(SINGLETON);
+        binder.bind(ArrayColumnValidator.class).in(SINGLETON);
         binder.bind(new TypeLiteral<List<Predicate<SourceQuery>>>() {}).toProvider(new CustomQueryFilterProvider(customQueryFilterClasses));
         binder.bind(new TypeLiteral<List<Property>>() {}).toInstance(tablePropertyOverrides);
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
@@ -44,8 +44,8 @@ import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.SqlFormatter.formatSql;
 import static com.facebook.presto.sql.parser.IdentifierSymbol.AT_SIGN;
 import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
+import static com.facebook.presto.verifier.framework.Column.Category.ARRAY;
 import static com.facebook.presto.verifier.framework.Column.Category.FLOATING_POINT;
-import static com.facebook.presto.verifier.framework.Column.Category.ORDERABLE_ARRAY;
 import static com.facebook.presto.verifier.framework.Column.Category.SIMPLE;
 import static com.facebook.presto.verifier.framework.VerifierUtil.PARSING_OPTIONS;
 import static org.testng.Assert.assertEquals;
@@ -63,9 +63,9 @@ public class TestChecksumValidator
     private static final Column VARCHAR_COLUMN = new Column("varchar", SIMPLE, VARCHAR);
     private static final Column DOUBLE_COLUMN = new Column("double", FLOATING_POINT, DOUBLE);
     private static final Column REAL_COLUMN = new Column("real", FLOATING_POINT, REAL);
-    private static final Column INT_ARRAY_COLUMN = new Column("int_array", ORDERABLE_ARRAY, new ArrayType(INTEGER));
-    private static final Column ROW_ARRAY_COLUMN = new Column("row_array", ORDERABLE_ARRAY, typeRegistry.getType(parseTypeSignature("array(row(a int,b varchar))")));
-    private static final Column MAP_ARRAY_COLUMN = new Column("map_array", SIMPLE, typeRegistry.getType(parseTypeSignature("array(map(int,varchar))")));
+    private static final Column INT_ARRAY_COLUMN = new Column("int_array", ARRAY, new ArrayType(INTEGER));
+    private static final Column ROW_ARRAY_COLUMN = new Column("row_array", ARRAY, typeRegistry.getType(parseTypeSignature("array(row(a int,b varchar))")));
+    private static final Column MAP_ARRAY_COLUMN = new Column("map_array", ARRAY, typeRegistry.getType(parseTypeSignature("array(map(int,varchar))")));
 
     private static final double RELATIVE_ERROR_MARGIN = 1e-4;
     private static final double ABSOLUTE_ERROR_MARGIN = 1e-12;
@@ -82,7 +82,7 @@ public class TestChecksumValidator
     private final ChecksumValidator checksumValidator = new ChecksumValidator(
             new SimpleColumnValidator(),
             new FloatingPointColumnValidator(new VerifierConfig().setRelativeErrorMargin(RELATIVE_ERROR_MARGIN).setAbsoluteErrorMargin(ABSOLUTE_ERROR_MARGIN)),
-            new OrderableArrayColumnValidator());
+            new ArrayColumnValidator());
 
     @Test
     public void testChecksumQuery()

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -18,9 +18,9 @@ import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.tests.StandaloneQueryRunner;
 import com.facebook.presto.type.TypeRegistry;
+import com.facebook.presto.verifier.checksum.ArrayColumnValidator;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.checksum.FloatingPointColumnValidator;
-import com.facebook.presto.verifier.checksum.OrderableArrayColumnValidator;
 import com.facebook.presto.verifier.checksum.SimpleColumnValidator;
 import com.facebook.presto.verifier.event.DeterminismAnalysisRun;
 import com.facebook.presto.verifier.event.VerifierQueryEvent;
@@ -113,7 +113,7 @@ public class TestDataVerification
         ChecksumValidator checksumValidator = new ChecksumValidator(
                 new SimpleColumnValidator(),
                 new FloatingPointColumnValidator(verifierConfig),
-                new OrderableArrayColumnValidator());
+                new ArrayColumnValidator());
         SourceQuery sourceQuery = new SourceQuery(SUITE, NAME, controlQuery, testQuery, configuration, configuration);
         return new DataVerification(
                 (verification, e) -> false,

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -263,7 +263,9 @@ public class TestDataVerification
                         "COLUMN MISMATCH\n" +
                         "Control 1 rows, Test 1 rows\n" +
                         "Mismatched Columns:\n" +
-                        "  _col0 \\(array\\(row\\(integer, varchar\\(1\\)\\)\\)\\): control\\(checksum: 71 b5 2f 7f 1e 9b a6 a4\\) test\\(checksum: b4 3c 7d 02 2b 14 77 12\\)\n"));
+                        "  _col0 \\(array\\(row\\(integer, varchar\\(1\\)\\)\\)\\):" +
+                        " control\\(checksum: 71 b5 2f 7f 1e 9b a6 a4, cardinality_sum: 2\\)" +
+                        " test\\(checksum: b4 3c 7d 02 2b 14 77 12, cardinality_sum: 2\\)\n"));
 
         List<DeterminismAnalysisRun> runs = event.get().getDeterminismAnalysisDetails().getRuns();
         assertEquals(runs.size(), 2);

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
@@ -21,9 +21,9 @@ import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.type.TypeRegistry;
+import com.facebook.presto.verifier.checksum.ArrayColumnValidator;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.checksum.FloatingPointColumnValidator;
-import com.facebook.presto.verifier.checksum.OrderableArrayColumnValidator;
 import com.facebook.presto.verifier.checksum.SimpleColumnValidator;
 import com.facebook.presto.verifier.event.VerifierQueryEvent;
 import com.facebook.presto.verifier.prestoaction.NodeResourceClient;
@@ -210,7 +210,7 @@ public class TestVerificationManager
                         presto -> new QueryRewriter(SQL_PARSER, presto, ImmutableList.of(), ImmutableMap.of(CONTROL, TABLE_PREFIX, TEST, TABLE_PREFIX)),
                         new FailureResolverManagerFactory(ImmutableList.of(), new FailureResolverConfig().setEnabled(false)),
                         new MockNodeResourceClient(),
-                        new ChecksumValidator(new SimpleColumnValidator(), new FloatingPointColumnValidator(verifierConfig), new OrderableArrayColumnValidator()),
+                        new ChecksumValidator(new SimpleColumnValidator(), new FloatingPointColumnValidator(verifierConfig), new ArrayColumnValidator()),
                         verifierConfig,
                         new TypeRegistry(),
                         new FailureResolverConfig().setEnabled(false)),


### PR DESCRIPTION
For array column mismatch, this change adds additional information
of the total number of elements across all rows for the same column.

Part of #13809

```
== RELEASE NOTES ==

Verifier Changes
* Add checks for the cardinalities sum when validating an array column.