### PR TITLE
Skip printing header in GCStatusMonitor if there are no rows 

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/GcStatusMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/GcStatusMonitor.java
@@ -173,14 +173,16 @@ public class GcStatusMonitor
                     Long.toString(userMemoryReservation),
                     Long.toString(systemMemoryReservation));
         }).collect(toImmutableList());
-        logInfoTable(ImmutableList.<List<String>>builder().add(
-                ImmutableList.of(
-                        "Query ID",
-                        "Total Memory Reservation",
-                        "User Memory Reservation",
-                        "System Memory Reservation"))
-                .addAll(rows)
-                .build());
+        if (!rows.isEmpty()) {
+            logInfoTable(ImmutableList.<List<String>>builder().add(
+                    ImmutableList.of(
+                            "Query ID",
+                            "Total Memory Reservation",
+                            "User Memory Reservation",
+                            "System Memory Reservation"))
+                    .addAll(rows)
+                    .build());
+        }
     }
 
     private static void logTaskStats(List<QueryId> queryIds, ListMultimap<QueryId, SqlTask> tasksByQueryId)
@@ -213,21 +215,22 @@ public class GcStatusMonitor
                                 Long.toString(taskIOStats.getOutputPositions().getTotalCount()));
                     });
         }).collect(toImmutableList());
-
-        logInfoTable(ImmutableList.<List<String>>builder()
-                .add(ImmutableList.of(
-                        "Query ID",
-                        "Task ID",
-                        "State",
-                        "Created Ts",
-                        "User Memory",
-                        "System Memory",
-                        "Input Bytes",
-                        "Output Bytes",
-                        "Input Row Count",
-                        "Output Row Count"))
-                .addAll(rows)
-                .build());
+        if (!rows.isEmpty()) {
+            logInfoTable(ImmutableList.<List<String>>builder()
+                    .add(ImmutableList.of(
+                            "Query ID",
+                            "Task ID",
+                            "State",
+                            "Created Ts",
+                            "User Memory",
+                            "System Memory",
+                            "Input Bytes",
+                            "Output Bytes",
+                            "Input Row Count",
+                            "Output Row Count"))
+                    .addAll(rows)
+                    .build());
+        }
     }
 
     private static void logInfoTable(List<List<String>> table)


### PR DESCRIPTION
At present, GCStatusMonitor will print header even if there are no
active tasks. This is unnecessary and pollutes the log file

fixes https://github.com/prestodb/presto/issues/13918

```
== NO RELEASE NOTE ==
```