### PR TITLE
Improve error handling for geometry deserialization edge cases

### DIFF
--- a/presto-geospatial-toolkit/src/test/java/com/facebook/presto/geospatial/serde/TestGeometrySerialization.java
+++ b/presto-geospatial-toolkit/src/test/java/com/facebook/presto/geospatial/serde/TestGeometrySerialization.java
@@ -17,10 +17,9 @@ import com.esri.core.geometry.Envelope;
 import com.esri.core.geometry.ogc.OGCGeometry;
 import io.airlift.slice.Slice;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.io.ParseException;
-import org.locationtech.jts.io.WKTReader;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.geospatial.GeometryUtils.jtsGeometryFromWkt;
 import static com.facebook.presto.geospatial.serde.EsriGeometrySerde.createFromEsriGeometry;
 import static com.facebook.presto.geospatial.serde.EsriGeometrySerde.deserialize;
 import static com.facebook.presto.geospatial.serde.EsriGeometrySerde.deserializeEnvelope;
@@ -197,14 +196,14 @@ public class TestGeometrySerialization
 
     private static void testJtsSerialization(String wkt)
     {
-        Geometry expected = createJtsGeometry(wkt);
+        Geometry expected = jtsGeometryFromWkt(wkt);
         Geometry actual = JtsGeometrySerde.deserialize(JtsGeometrySerde.serialize(expected));
         assertGeometryEquals(actual, expected);
     }
 
     private static void testCrossSerialization(String wkt)
     {
-        Geometry jtsGeometry = createJtsGeometry(wkt);
+        Geometry jtsGeometry = jtsGeometryFromWkt(wkt);
         OGCGeometry esriGeometry = OGCGeometry.fromText(wkt);
 
         Slice jtsSerialized = JtsGeometrySerde.serialize(jtsGeometry);
@@ -219,16 +218,6 @@ public class TestGeometrySerialization
     private static Slice geometryFromText(String wkt)
     {
         return serialize(OGCGeometry.fromText(wkt));
-    }
-
-    private static Geometry createJtsGeometry(String wkt)
-    {
-        try {
-            return new WKTReader().read(wkt);
-        }
-        catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private static void assertGeometryEquals(Geometry actual, Geometry expected)

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -15,6 +15,7 @@ package com.facebook.presto.plugin.geospatial;
 
 import com.esri.core.geometry.Envelope;
 import com.esri.core.geometry.GeometryCursor;
+import com.esri.core.geometry.GeometryException;
 import com.esri.core.geometry.ListeningGeometryCursor;
 import com.esri.core.geometry.MultiPath;
 import com.esri.core.geometry.MultiVertexGeometry;
@@ -325,7 +326,12 @@ public final class GeoFunctions
     @SqlType(VARBINARY)
     public static Slice stAsBinary(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
-        return wrappedBuffer(EsriGeometrySerde.deserialize(input).asBinary());
+        try {
+            return wrappedBuffer(EsriGeometrySerde.deserialize(input).asBinary());
+        }
+        catch (GeometryException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Invalid geometry: " + e.getMessage(), e);
+        }
     }
 
     @SqlNullable

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeometryType.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeometryType.java
@@ -13,7 +13,9 @@
  */
 package com.facebook.presto.plugin.geospatial;
 
+import com.esri.core.geometry.GeometryException;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.AbstractVariableWidthType;
@@ -21,6 +23,7 @@ import com.facebook.presto.spi.type.TypeSignature;
 import io.airlift.slice.Slice;
 
 import static com.facebook.presto.geospatial.serde.EsriGeometrySerde.deserialize;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 
 public class GeometryType
         extends AbstractVariableWidthType
@@ -83,6 +86,11 @@ public class GeometryType
             return null;
         }
         Slice slice = block.getSlice(position, 0, block.getSliceLength(position));
-        return deserialize(slice).asText();
+        try {
+            return deserialize(slice).asText();
+        }
+        catch (GeometryException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 }

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -1187,6 +1187,7 @@ public class TestGeoFunctions
 
         // invalid binary
         assertInvalidFunction("ST_GeomFromBinary(from_hex('deadbeef'))", "Invalid WKB");
+        assertInvalidFunction("ST_AsBinary(ST_GeometryFromText('POLYGON ((0 0, 1 1, 0 1, 1 0, 0 0))'))", INVALID_FUNCTION_ARGUMENT, "Invalid geometry: corrupted geometry");
     }
 
     private void assertGeomFromBinary(String wkt)


### PR DESCRIPTION
Certain geometries could be constructed (via GeometryFromText), but
could not be deserialized: it raised non-PrestoException exceptions that
bubbled up as non-catchable GenericInternalExceptions.  This is a bad
user experience!  This change catches those and raise catchable
PrestoExceptions.

```
== RELEASE NOTES ==

General Changes
* Improve error handling for geometry deserialization edge cases.
```
