### PR TITLE
Optimize ByteSelectiveStreamReader for no filter with nulls

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
@@ -59,6 +59,19 @@ final class ReaderUtils
         return result;
     }
 
+    public static void unpackByteNulls(byte[] values, boolean[] isNull, int positionCount, int nonNullCount)
+    {
+        int position = nonNullCount - 1;
+        for (int i = positionCount - 1; i >= 0; i--) {
+            if (!isNull[i]) {
+                values[i] = values[position--];
+            }
+            else {
+                values[i] = 0;
+            }
+        }
+    }
+
     public static short[] unpackShortNulls(short[] values, boolean[] isNull)
     {
         short[] result = new short[isNull.length];


### PR DESCRIPTION
Benchmark shows 25% improvements:

Before:
Benchmark                             Mode  Cnt  Score   Error  Units
BenchmarkSelectiveStreamReaders.read  avgt   20  0.055 ± 0.002   s/op

After:
Benchmark                             Mode  Cnt  Score   Error  Units
BenchmarkSelectiveStreamReaders.read  avgt   20  0.041 ± 0.002   s/op


```
== NO RELEASE NOTE ==
```
