### PR TITLE
Configure DB Resource Group reload frequency

### DIFF
--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/DbResourceGroupConfigurationManager.java
@@ -137,7 +137,7 @@ public class DbResourceGroupConfigurationManager
     public void start()
     {
         if (started.compareAndSet(false, true)) {
-            configExecutor.scheduleWithFixedDelay(this::load, 1, 1, TimeUnit.SECONDS);
+            configExecutor.scheduleWithFixedDelay(this::load, 10, 10, TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
Making database resource group reload frequency configurable with name `resource-groups.reload-refresh-interval`. This helps reduce some load on the coordinator at the same time give flexibility on changing the frequency given we don't make resource group changes often.
Fixing issue: https://github.com/prestodb/presto/issues/13926
```
== RELEASE NOTES ==

General Changes
* Making database resource group reload frequency configurable
* ...