### PR TITLE
[WIP] Delay task start till split source is done or blocked for fixed splits

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -72,6 +72,21 @@ public class QueryManagerConfig
 
     private int querySubmissionMaxThreads = Runtime.getRuntime().availableProcessors() * 2;
 
+    private boolean delayTaskStartUntilNoMoreSplits;
+
+    public boolean isDelayTaskStartUntilNoMoreSplits()
+    {
+        return delayTaskStartUntilNoMoreSplits;
+    }
+
+    @Config("query.delay-task-start")
+    @ConfigDescription("Delay task start until no more splits signal is given")
+    public QueryManagerConfig setDelayTaskStartUntilNoMoreSplits(boolean delayTaskStartUntilNoMoreSplits)
+    {
+        this.delayTaskStartUntilNoMoreSplits = delayTaskStartUntilNoMoreSplits;
+        return this;
+    }
+
     @Min(1)
     public int getScheduleSplitBatchSize()
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
@@ -66,4 +66,6 @@ public interface RemoteTask
     int getPartitionedSplitCount();
 
     int getQueuedPartitionedSplitCount();
+
+    default void ensureStarted() {}
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
@@ -36,5 +36,6 @@ public interface RemoteTaskFactory
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             boolean summarizeTaskInfo,
-            TableWriteInfo tableWriteInfo);
+            TableWriteInfo tableWriteInfo,
+            boolean doDelayedTaskStart);
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/TrackingRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TrackingRemoteTaskFactory.java
@@ -52,7 +52,8 @@ public class TrackingRemoteTaskFactory
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             boolean summarizeTaskInfo,
-            TableWriteInfo tableWriteInfo)
+            TableWriteInfo tableWriteInfo,
+            boolean doDelayedTaskStart)
     {
         RemoteTask task = remoteTaskFactory.createRemoteTask(session,
                 taskId,
@@ -63,7 +64,8 @@ public class TrackingRemoteTaskFactory
                 outputBuffers,
                 partitionedSplitCountTracker,
                 summarizeTaskInfo,
-                tableWriteInfo);
+                tableWriteInfo,
+                doDelayedTaskStart);
 
         task.addStateChangeListener(new UpdateQueryStats(stateMachine));
         return task;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedCountScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedCountScheduler.java
@@ -40,7 +40,7 @@ public class FixedCountScheduler
     public FixedCountScheduler(SqlStageExecution stage, List<InternalNode> partitionToNode)
     {
         requireNonNull(stage, "stage is null");
-        this.taskScheduler = stage::scheduleTask;
+        this.taskScheduler = (node, partition, totalPartitions) -> stage.scheduleTask(node, partition, totalPartitions, false);
         this.partitionToNode = requireNonNull(partitionToNode, "partitionToNode is null");
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -66,6 +66,7 @@ public class FixedSourcePartitionedScheduler
     private boolean scheduledTasks;
     private boolean anySourceSchedulingFinished;
     private final Optional<LifespanScheduler> groupedLifespanScheduler;
+    private final boolean doDelayedTaskStart;
 
     private final Queue<Integer> tasksToRecover = new ConcurrentLinkedQueue<>();
 
@@ -79,7 +80,8 @@ public class FixedSourcePartitionedScheduler
             int splitBatchSize,
             OptionalInt concurrentLifespansPerTask,
             NodeSelector nodeSelector,
-            List<ConnectorPartitionHandle> partitionHandles)
+            List<ConnectorPartitionHandle> partitionHandles,
+            boolean doDelayedTaskStart)
     {
         requireNonNull(stage, "stage is null");
         requireNonNull(splitSources, "splitSources is null");
@@ -90,6 +92,7 @@ public class FixedSourcePartitionedScheduler
         this.stage = stage;
         this.nodes = ImmutableList.copyOf(nodes);
         this.partitionHandles = ImmutableList.copyOf(partitionHandles);
+        this.doDelayedTaskStart = doDelayedTaskStart;
 
         checkArgument(splitSources.keySet().equals(ImmutableSet.copyOf(schedulingOrder)));
 
@@ -119,7 +122,8 @@ public class FixedSourcePartitionedScheduler
                     splitSource,
                     splitPlacementPolicy,
                     Math.max(splitBatchSize / concurrentLifespans, 1),
-                    groupedExecutionForScanNode);
+                    groupedExecutionForScanNode,
+                    doDelayedTaskStart);
 
             if (stageExecutionDescriptor.isStageGroupedExecution() && !groupedExecutionForScanNode) {
                 sourceScheduler = new AsGroupedSourceScheduler(sourceScheduler);
@@ -174,7 +178,7 @@ public class FixedSourcePartitionedScheduler
             OptionalInt totalPartitions = OptionalInt.of(nodes.size());
             newTasks = Streams.mapWithIndex(
                     nodes.stream(),
-                    (node, id) -> stage.scheduleTask(node, toIntExact(id), totalPartitions))
+                    (node, id) -> stage.scheduleTask(node, toIntExact(id), totalPartitions, doDelayedTaskStart))
                     .filter(Optional::isPresent)
                     .map(Optional::get)
                     .collect(toImmutableList());

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScaledWriterScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScaledWriterScheduler.java
@@ -120,7 +120,7 @@ public class ScaledWriterScheduler
 
         ImmutableList.Builder<RemoteTask> tasks = ImmutableList.builder();
         for (InternalNode node : nodes) {
-            Optional<RemoteTask> remoteTask = stage.scheduleTask(node, scheduledNodes.size(), OptionalInt.empty());
+            Optional<RemoteTask> remoteTask = stage.scheduleTask(node, scheduledNodes.size(), OptionalInt.empty(), false);
             remoteTask.ifPresent(task -> {
                 tasks.add(task);
                 scheduledNodes.add(node);

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -150,7 +150,8 @@ public class HttpRemoteTaskFactory
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             boolean summarizeTaskInfo,
-            TableWriteInfo tableWriteInfo)
+            TableWriteInfo tableWriteInfo,
+            boolean delayTaskStart)
     {
         return new HttpRemoteTask(session,
                 taskId,
@@ -176,6 +177,7 @@ public class HttpRemoteTaskFactory
                 stats,
                 isBinaryTransportEnabled,
                 tableWriteInfo,
-                maxTaskUpdateSizeInBytes);
+                maxTaskUpdateSizeInBytes,
+                delayTaskStart);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -131,6 +131,7 @@ public class MockRemoteTaskFactory
         for (Split sourceSplit : splits) {
             initialSplits.put(sourceId, sourceSplit);
         }
+
         return createRemoteTask(
                 TEST_SESSION,
                 taskId,
@@ -141,7 +142,8 @@ public class MockRemoteTaskFactory
                 createInitialEmptyOutputBuffers(BROADCAST),
                 partitionedSplitCountTracker,
                 true,
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
+                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                false);
     }
 
     @Override
@@ -155,7 +157,8 @@ public class MockRemoteTaskFactory
             OutputBuffers outputBuffers,
             PartitionedSplitCountTracker partitionedSplitCountTracker,
             boolean summarizeTaskInfo,
-            TableWriteInfo tableWriteInfo)
+            TableWriteInfo tableWriteInfo,
+            boolean doDelayedTaskStart)
     {
         return new MockRemoteTask(taskId, fragment, node.getNodeIdentifier(), executor, scheduledExecutor, initialSplits, totalPartitions, partitionedSplitCountTracker);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -55,7 +55,8 @@ public class TestQueryManagerConfig
                 .setInitializationTimeout(new Duration(5, TimeUnit.MINUTES))
                 .setRequiredWorkers(1)
                 .setRequiredWorkersMaxWait(new Duration(5, TimeUnit.MINUTES))
-                .setQuerySubmissionMaxThreads(Runtime.getRuntime().availableProcessors() * 2));
+                .setQuerySubmissionMaxThreads(Runtime.getRuntime().availableProcessors() * 2)
+                .setDelayTaskStartUntilNoMoreSplits(false));
     }
 
     @Test
@@ -88,6 +89,7 @@ public class TestQueryManagerConfig
                 .put("query-manager.initialization-required-workers", "200")
                 .put("query-manager.initialization-timeout", "1m")
                 .put("query-manager.required-workers", "333")
+                .put("query.delay-task-start", "true")
                 .put("query-manager.required-workers-max-wait", "33m")
                 .put("query-manager.query-submission-max-threads", "5")
                 .build();
@@ -120,7 +122,8 @@ public class TestQueryManagerConfig
                 .setInitializationTimeout(new Duration(1, TimeUnit.MINUTES))
                 .setRequiredWorkers(333)
                 .setRequiredWorkersMaxWait(new Duration(33, TimeUnit.MINUTES))
-                .setQuerySubmissionMaxThreads(5);
+                .setQuerySubmissionMaxThreads(5)
+                .setDelayTaskStartUntilNoMoreSplits(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -129,7 +129,7 @@ public class TestSqlStageExecution
                             URI.create("http://10.0.0." + (i / 10_000) + ":" + (i % 10_000)),
                             NodeVersion.UNKNOWN,
                             false);
-                    stage.scheduleTask(node, i, OptionalInt.empty());
+                    stage.scheduleTask(node, i, OptionalInt.empty(), false);
                     latch.countDown();
                 }
             }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -321,7 +321,8 @@ public class TestSourcePartitionedScheduler
                     TABLE_SCAN_NODE_ID,
                     new ConnectorAwareSplitSource(CONNECTOR_ID, TestingTransactionHandle.create(), createFixedSplitSource(20, TestingSplit::createRemoteSplit)),
                     new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(CONNECTOR_ID), stage::getAllTasks),
-                    2);
+                    2,
+                    false);
             scheduler.schedule();
 
             fail("expected PrestoException");
@@ -448,7 +449,8 @@ public class TestSourcePartitionedScheduler
         NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, nodeSchedulerConfig, nodeTaskMap);
         SplitSource splitSource = new ConnectorAwareSplitSource(CONNECTOR_ID, TestingTransactionHandle.create(), connectorSplitSource);
         SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(splitSource.getConnectorId()), stage::getAllTasks);
-        return newSourcePartitionedSchedulerAsStageScheduler(stage, TABLE_SCAN_NODE_ID, splitSource, placementPolicy, splitBatchSize);
+
+        return newSourcePartitionedSchedulerAsStageScheduler(stage, TABLE_SCAN_NODE_ID, splitSource, placementPolicy, splitBatchSize, false);
     }
 
     private static SubPlan createPlan()


### PR DESCRIPTION
#13937 
When the config is enabled, The HttpRemoteTask is not actually started until either noMoreSplits or ensureStarted is called and ensureStarted is called when the scheduler needs to block. This helps reduce scheduling latency where we know the splits are fixed like pinot and not for queries on hive where split computation and executions are pipelined

This is only added in the FixedSourcePartitionedScheduler code path and not in grouped execution or scaled writers kind of scheduling where you need to start right away. 
```
== RELEASE NOTES ==

General Changes
* Config to delay task start till split source is done or blocked.