### PR TITLE
[WIP] Add a way to force a single node plan

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -135,6 +135,7 @@ public final class SystemSessionProperties
     public static final String OPTIMIZE_FULL_OUTER_JOIN_WITH_COALESCE = "optimize_full_outer_join_with_coalesce";
     public static final String INDEX_LOADER_TIMEOUT = "index_loader_timeout";
     public static final String OPTIMIZED_REPARTITIONING_ENABLED = "optimized_repartitioning";
+    private static final String FORCE_SINGLE_NODE_PLAN = "force_single_node_plan";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -647,6 +648,11 @@ public final class SystemSessionProperties
                         featuresConfig.isTableWriterMergeOperatorEnabled(),
                         false),
                 booleanProperty(
+                        FORCE_SINGLE_NODE_PLAN,
+                        "Force single node plan that avoids fragmentation and exchanges",
+                        featuresConfig.isForceSingleNodePlan(),
+                        false),
+                booleanProperty(
                         OPTIMIZE_FULL_OUTER_JOIN_WITH_COALESCE,
                         "optimize partition properties for queries using COALESCE + FULL OUTER JOIN",
                         featuresConfig.isOptimizeFullOuterJoinWithCoalesce(),
@@ -1133,5 +1139,10 @@ public final class SystemSessionProperties
     public static boolean isOptimizedRepartitioningEnabled(Session session)
     {
         return session.getSystemProperty(OPTIMIZED_REPARTITIONING_ENABLED, Boolean.class);
+    }
+
+    public static boolean isForceSingleNodePlan(Session session)
+    {
+        return session.getSystemProperty(FORCE_SINGLE_NODE_PLAN, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -138,6 +138,7 @@ public class FeaturesConfig
     private boolean optimizedRepartitioningEnabled;
 
     private boolean pushdownSubfieldsEnabled;
+    private boolean forceSingleNodePlan;
 
     private boolean tableWriterMergeOperatorEnabled = true;
 
@@ -1113,6 +1114,18 @@ public class FeaturesConfig
     public FeaturesConfig setListNonBuiltInFunctions(boolean listNonBuiltInFunctions)
     {
         this.listNonBuiltInFunctions = listNonBuiltInFunctions;
+        return this;
+    }
+
+    public boolean isForceSingleNodePlan()
+    {
+        return forceSingleNodePlan;
+    }
+
+    @Config("optimizer.force-single-node-plan")
+    public FeaturesConfig setForceSingleNodePlan(boolean forceSingleNodePlan)
+    {
+        this.forceSingleNodePlan = forceSingleNodePlan;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -834,12 +834,19 @@ public class PlanFragmenter
                 return this;
             }
 
+            boolean forceSingleNodePlan = SystemSessionProperties.isForceSingleNodePlan(session);
+
             // If already system SINGLE or COORDINATOR_ONLY, leave it as is (this is for single-node execution)
-            if (currentPartitioning.isSingleNode()) {
+            if (forceSingleNodePlan && currentPartitioning.isCoordinatorOnly() || !forceSingleNodePlan && currentPartitioning.isSingleNode()) {
                 return this;
             }
 
             if (currentPartitioning.equals(distribution)) {
+                return this;
+            }
+
+            if (forceSingleNodePlan && currentPartitioning.isSingleNode() && distribution.isSingleNode()) {
+                partitioningHandle = Optional.of(distribution);
                 return this;
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -21,6 +21,7 @@ import com.facebook.presto.cost.TaskCountEstimator;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.Rule;
@@ -148,6 +149,7 @@ public class PlanOptimizers
     public PlanOptimizers(
             Metadata metadata,
             SqlParser sqlParser,
+            FeaturesConfig featuresConfig,
             MBeanExporter exporter,
             SplitManager splitManager,
             ConnectorPlanOptimizerManager planOptimizerManager,
@@ -160,7 +162,7 @@ public class PlanOptimizers
     {
         this(metadata,
                 sqlParser,
-                false,
+                featuresConfig.isForceSingleNodePlan(),
                 exporter,
                 splitManager,
                 planOptimizerManager,

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -122,7 +122,8 @@ public class TestFeaturesConfig
                 .setOptimizeFullOuterJoinWithCoalesce(true)
                 .setIndexLoaderTimeout(new Duration(20, SECONDS))
                 .setOptimizedRepartitioningEnabled(false)
-                .setListNonBuiltInFunctions(false));
+                .setListNonBuiltInFunctions(false)
+                .setForceSingleNodePlan(false));
     }
 
     @Test
@@ -204,6 +205,7 @@ public class TestFeaturesConfig
                 .put("index-loader-timeout", "10s")
                 .put("experimental.optimized-repartitioning", "true")
                 .put("list-non-built-in-functions", "true")
+                .put("optimizer.force-single-node-plan", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -281,7 +283,8 @@ public class TestFeaturesConfig
                 .setOptimizeFullOuterJoinWithCoalesce(false)
                 .setIndexLoaderTimeout(new Duration(10, SECONDS))
                 .setOptimizedRepartitioningEnabled(true)
-                .setListNonBuiltInFunctions(true);
+                .setListNonBuiltInFunctions(true)
+                .setForceSingleNodePlan(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
@@ -81,6 +81,7 @@ public class PinotConfig
     private int fetchRetryCount = 2;
     private boolean useDateTrunc;
     private int nonAggregateLimitForBrokerQueries = DEFAULT_NON_AGGREGATE_LIMIT_FOR_BROKER_QUERIES;
+    private boolean forceSingleNodePlan;
 
     @NotNull
     public Map<String, String> getExtraHttpHeaders()
@@ -414,6 +415,18 @@ public class PinotConfig
     public PinotConfig setNonAggregateLimitForBrokerQueries(int nonAggregateLimitForBrokerQueries)
     {
         this.nonAggregateLimitForBrokerQueries = nonAggregateLimitForBrokerQueries;
+        return this;
+    }
+
+    public boolean isForceSingleNodePlan()
+    {
+        return forceSingleNodePlan;
+    }
+
+    @Config("force-single-node-plan")
+    public PinotConfig setForceSingleNodePlan(boolean forceSingleNodePlan)
+    {
+        this.forceSingleNodePlan = forceSingleNodePlan;
         return this;
     }
 }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConnector.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConnector.java
@@ -55,15 +55,16 @@ public class PinotConnector
             PinotPageSourceProvider pageSourceProvider,
             PinotNodePartitioningProvider partitioningProvider,
             PinotSessionProperties pinotSessionProperties,
-            PinotConnectorPlanOptimizer planOptimizer)
+            PinotConnectorPlanOptimizer planOptimizer,
+            PinotConfig pinotConfig)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
-        this.partitioningProvider = requireNonNull(partitioningProvider, "partitioningProvider is null");
         this.sessionProperties = ImmutableList.copyOf(requireNonNull(pinotSessionProperties, "sessionProperties is null").getSessionProperties());
         this.planOptimizer = requireNonNull(planOptimizer, "plan optimizer is null");
+        this.partitioningProvider = pinotConfig.isForceSingleNodePlan() ? requireNonNull(partitioningProvider, "partitioningProvider is null") : null;
     }
 
     @Override
@@ -93,7 +94,12 @@ public class PinotConnector
     @Override
     public ConnectorNodePartitioningProvider getNodePartitioningProvider()
     {
-        return partitioningProvider;
+        if (partitioningProvider != null) {
+            return partitioningProvider;
+        }
+        else {
+            throw new UnsupportedOperationException("Don't have a valid node partitioning provider");
+        }
     }
 
     @Override

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotHandleResolver.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotHandleResolver.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 
 public class PinotHandleResolver
@@ -45,6 +46,12 @@ public class PinotHandleResolver
     public Class<? extends ConnectorSplit> getSplitClass()
     {
         return PinotSplit.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorPartitioningHandle> getPartitioningHandleClass()
+    {
+        return PinotPartitioningHandle.class;
     }
 
     @Override

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPartitioningHandle.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPartitioningHandle.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.pinot;
+
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PinotPartitioningHandle
+        implements ConnectorPartitioningHandle
+{
+    private final boolean isSingleNode;
+
+    @JsonCreator
+    public PinotPartitioningHandle(@JsonProperty("isSingleNode") boolean isSingleNode)
+    {
+        this.isSingleNode = isSingleNode;
+    }
+
+    @Override
+    @JsonProperty("isSingleNode")
+    public boolean isSingleNode()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
#13937 
When these configs are set in the config.properties and the
connector, we will force the use single stage/single task when there is complete pushdown.

```
== RELEASE NOTES ==

General Changes
* Added a config to force a single node plan
```
