### PR TITLE
Fix corrupted verifier executable jar

### DIFF
--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-base-jdbc</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -27,8 +33,8 @@
             <artifactId>presto-hive</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>com.facebook.presto.hive</groupId>
-                    <artifactId>hive-apache</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -38,8 +44,8 @@
             <artifactId>presto-hive-metastore</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>com.facebook.presto.hive</groupId>
-                    <artifactId>hive-apache</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -67,6 +73,12 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-thrift-connector</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
We're using only the `ErrorCode` classes in some submodules of presto and some dependency changes in those modules caused `maven-shade-plugin` to produce a corrupted executable jars.
Ideally, those type of issues can be avoided by moving to `maven-assembly-plugin`.

```
== NO RELEASE NOTE ==
```
