### PR TITLE
Enable listing SQL function with session property

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -137,6 +137,7 @@ public final class SystemSessionProperties
     public static final String INDEX_LOADER_TIMEOUT = "index_loader_timeout";
     public static final String OPTIMIZED_REPARTITIONING_ENABLED = "optimized_repartitioning";
     public static final String AGGREGATION_PARTITIONING_MERGING_STRATEGY = "aggregation_partitioning_merging_strategy";
+    public static final String LIST_BUILT_IN_FUNCTIONS_ONLY = "list_built_in_functions_only";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -678,7 +679,12 @@ public final class SystemSessionProperties
                         featuresConfig.getAggregationPartitioningMergingStrategy(),
                         false,
                         value -> AggregationPartitioningMergingStrategy.valueOf(((String) value).toUpperCase()),
-                        AggregationPartitioningMergingStrategy::name));
+                        AggregationPartitioningMergingStrategy::name),
+                booleanProperty(
+                        LIST_BUILT_IN_FUNCTIONS_ONLY,
+                        "Only List built-in functions in SHOW FUNCTIONS",
+                        featuresConfig.isListBuiltInFunctionsOnly(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -1152,5 +1158,10 @@ public final class SystemSessionProperties
     public static AggregationPartitioningMergingStrategy getAggregationPartitioningMergingStrategy(Session session)
     {
         return session.getSystemProperty(AGGREGATION_PARTITIONING_MERGING_STRATEGY, AggregationPartitioningMergingStrategy.class);
+    }
+
+    public static boolean isListBuiltInFunctionsOnly(Session session)
+    {
+        return session.getSystemProperty(LIST_BUILT_IN_FUNCTIONS_ONLY, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -59,7 +59,7 @@ public interface Metadata
 
     Type getType(TypeSignature signature);
 
-    List<SqlFunction> listFunctions();
+    List<SqlFunction> listFunctions(Session session);
 
     void registerBuiltInFunctions(List<? extends BuiltInFunction> functions);
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -266,10 +266,10 @@ public class MetadataManager
         return typeManager.getType(signature);
     }
 
-    public List<SqlFunction> listFunctions()
+    public List<SqlFunction> listFunctions(Session session)
     {
         // TODO: transactional when FunctionManager is made transactional
-        return functions.listFunctions();
+        return functions.listFunctions(session);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -145,7 +145,7 @@ public class FeaturesConfig
 
     private Duration indexLoaderTimeout = new Duration(20, SECONDS);
 
-    private boolean listNonBuiltInFunctions;
+    private boolean listBuiltInFunctionsOnly = true;
 
     public enum JoinReorderingStrategy
     {
@@ -1135,15 +1135,15 @@ public class FeaturesConfig
         return this;
     }
 
-    public boolean isListNonBuiltInFunctions()
+    public boolean isListBuiltInFunctionsOnly()
     {
-        return listNonBuiltInFunctions;
+        return listBuiltInFunctionsOnly;
     }
 
-    @Config("list-non-built-in-functions")
-    public FeaturesConfig setListNonBuiltInFunctions(boolean listNonBuiltInFunctions)
+    @Config("list-built-in-functions-only")
+    public FeaturesConfig setListBuiltInFunctionsOnly(boolean listBuiltInFunctionsOnly)
     {
-        this.listNonBuiltInFunctions = listNonBuiltInFunctions;
+        this.listBuiltInFunctionsOnly = listBuiltInFunctionsOnly;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -524,7 +524,7 @@ final class ShowQueriesRewrite
         protected Node visitShowFunctions(ShowFunctions node, Void context)
         {
             ImmutableList.Builder<Expression> rows = ImmutableList.builder();
-            for (SqlFunction function : metadata.listFunctions()) {
+            for (SqlFunction function : metadata.listFunctions(session)) {
                 rows.add(row(
                         function.getSignature().getName().getFunctionNamespace().equals(DEFAULT_NAMESPACE) ?
                                 new StringLiteral(function.getSignature().getNameSuffix()) :

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -70,7 +70,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public List<SqlFunction> listFunctions()
+    public List<SqlFunction> listFunctions(Session session)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionManager.java
@@ -148,7 +148,7 @@ public class TestFunctionManager
     {
         TypeRegistry typeManager = new TypeRegistry();
         FunctionManager functionManager = createFunctionManager(typeManager);
-        List<SqlFunction> functions = functionManager.listFunctions();
+        List<SqlFunction> functions = functionManager.listFunctions(TEST_SESSION);
         List<String> names = transform(functions, input -> input.getSignature().getNameSuffix());
 
         assertTrue(names.contains("length"), "Expected function names " + names + " to contain 'length'");

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -125,7 +125,7 @@ public class TestFeaturesConfig
                 .setOptimizeFullOuterJoinWithCoalesce(true)
                 .setIndexLoaderTimeout(new Duration(20, SECONDS))
                 .setOptimizedRepartitioningEnabled(false)
-                .setListNonBuiltInFunctions(false));
+                .setListBuiltInFunctionsOnly(true));
     }
 
     @Test
@@ -207,7 +207,7 @@ public class TestFeaturesConfig
                 .put("optimizer.optimize-full-outer-join-with-coalesce", "false")
                 .put("index-loader-timeout", "10s")
                 .put("experimental.optimized-repartitioning", "true")
-                .put("list-non-built-in-functions", "true")
+                .put("list-built-in-functions-only", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -286,7 +286,7 @@ public class TestFeaturesConfig
                 .setOptimizeFullOuterJoinWithCoalesce(false)
                 .setIndexLoaderTimeout(new Duration(10, SECONDS))
                 .setOptimizedRepartitioningEnabled(true)
-                .setListNonBuiltInFunctions(true);
+                .setListBuiltInFunctionsOnly(false);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
Resolves https://github.com/prestodb/presto/issues/13864

```
== RELEASE NOTES ==
General Changes
* Support hiding user-defined SQL functions in ``SHOW FUNCTIONS`` with session property ``list_built_in_functions_only``.
  This can also be achieved by configuration property ``list-built-in-functions-only``, which is repurposed from ``list-non-built-in-functions``.
```
