### PR TITLE
fix bug: mysql unsigned type for tinyint, smallint, int #13908

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -233,7 +233,7 @@ public class BaseJdbcClient
                 while (resultSet.next()) {
                     JdbcTypeHandle typeHandle = new JdbcTypeHandle(
                             resultSet.getInt("DATA_TYPE"),
-                            resultSet.getString("TYPE_NAME").contains("UNSIGNED"),
+                            resultSet.getString("TYPE_NAME").toUpperCase().contains("UNSIGNED"),
                             resultSet.getInt("COLUMN_SIZE"),
                             resultSet.getInt("DECIMAL_DIGITS"));
                     Optional<ReadMapping> columnMapping = toPrestoType(session, typeHandle);

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcClient.java
@@ -233,6 +233,7 @@ public class BaseJdbcClient
                 while (resultSet.next()) {
                     JdbcTypeHandle typeHandle = new JdbcTypeHandle(
                             resultSet.getInt("DATA_TYPE"),
+                            resultSet.getString("TYPE_NAME").contains("UNSIGNED"),
                             resultSet.getInt("COLUMN_SIZE"),
                             resultSet.getInt("DECIMAL_DIGITS"));
                     Optional<ReadMapping> columnMapping = toPrestoType(session, typeHandle);

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTypeHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTypeHandle.java
@@ -25,14 +25,17 @@ public final class JdbcTypeHandle
     private final int jdbcType;
     private final int columnSize;
     private final int decimalDigits;
+    private final boolean unsigned;
 
     @JsonCreator
     public JdbcTypeHandle(
             @JsonProperty("jdbcType") int jdbcType,
+            @JsonProperty("unsigned") boolean unsigned,
             @JsonProperty("columnSize") int columnSize,
             @JsonProperty("decimalDigits") int decimalDigits)
     {
         this.jdbcType = jdbcType;
+        this.unsigned = unsigned;
         this.columnSize = columnSize;
         this.decimalDigits = decimalDigits;
     }
@@ -41,6 +44,12 @@ public final class JdbcTypeHandle
     public int getJdbcType()
     {
         return jdbcType;
+    }
+
+    @JsonProperty
+    public boolean isUnsigned()
+    {
+        return unsigned;
     }
 
     @JsonProperty
@@ -73,7 +82,8 @@ public final class JdbcTypeHandle
         JdbcTypeHandle that = (JdbcTypeHandle) o;
         return jdbcType == that.jdbcType &&
                 columnSize == that.columnSize &&
-                decimalDigits == that.decimalDigits;
+                decimalDigits == that.decimalDigits &&
+                unsigned == that.unsigned;
     }
 
     @Override
@@ -81,6 +91,7 @@ public final class JdbcTypeHandle
     {
         return toStringHelper(this)
                 .add("jdbcType", jdbcType)
+                .add("unsigned", unsigned)
                 .add("columnSize", columnSize)
                 .add("decimalDigits", decimalDigits)
                 .toString();

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/StandardReadMappings.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/StandardReadMappings.java
@@ -176,13 +176,28 @@ public final class StandardReadMappings
                 return Optional.of(booleanReadMapping());
 
             case Types.TINYINT:
-                return Optional.of(tinyintReadMapping());
+                if (type.isUnsigned()) {
+                    return Optional.of(smallintReadMapping());
+                }
+                else {
+                    return Optional.of(tinyintReadMapping());
+                }
 
             case Types.SMALLINT:
-                return Optional.of(smallintReadMapping());
+                if (type.isUnsigned()) {
+                    return Optional.of(integerReadMapping());
+                }
+                else {
+                    return Optional.of(smallintReadMapping());
+                }
 
             case Types.INTEGER:
-                return Optional.of(integerReadMapping());
+                if (type.isUnsigned()) {
+                    return Optional.of(bigintReadMapping());
+                }
+                else {
+                    return Optional.of(integerReadMapping());
+                }
 
             case Types.BIGINT:
                 return Optional.of(bigintReadMapping());

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcTypeToPrestoType.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcTypeToPrestoType.java
@@ -35,7 +35,7 @@ import static org.testng.Assert.assertTrue;
 public class TestJdbcTypeToPrestoType
 {
     @Test
-    public void testUnsignedType()
+    public void testUnsignedNumberType()
     {
         ImmutableMap<JdbcTypeHandle, ReadMapping> jdbcTypeHandleTypeAndPrestoType = ImmutableMap.<JdbcTypeHandle, ReadMapping>builder()
                 .put(JDBC_TINYINT, tinyintReadMapping())

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcTypeToPrestoType.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcTypeToPrestoType.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.plugin.jdbc.StandardReadMappings.*;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.*;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertTrue;
+
+public class TestJdbcTypeToPrestoType
+{
+    @Test
+    public void testUnsignedType()
+    {
+        ImmutableMap<JdbcTypeHandle, ReadMapping> jdbcTypeHandleTypeAndPrestoType = ImmutableMap.<JdbcTypeHandle, ReadMapping>builder()
+            .put(JDBC_TINYINT, tinyintReadMapping())
+            .put(JDBC_TINYINT_UNSIGNED, smallintReadMapping())
+            .put(JDBC_SMALLINT, smallintReadMapping())
+            .put(JDBC_SMALLINT_UNSIGNED, integerReadMapping())
+            .put(JDBC_INTEGER, integerReadMapping())
+            .put(JDBC_INTEGER_UNSIGNED, bigintReadMapping())
+            .put(JDBC_BIGINT, bigintReadMapping())
+            .build();
+        jdbcTypeHandleTypeAndPrestoType.forEach((jdbcTypeHandle, expectReadMapping) -> {
+            Optional<ReadMapping> actualReadMapping = StandardReadMappings.jdbcTypeToPrestoType(jdbcTypeHandle);
+            assertTrue(actualReadMapping.isPresent());
+            assertEquals(actualReadMapping.get().getType(), expectReadMapping.getType());
+        });
+    }
+}

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcTypeToPrestoType.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcTypeToPrestoType.java
@@ -16,12 +16,20 @@ package com.facebook.presto.plugin.jdbc;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.plugin.jdbc.StandardReadMappings.*;
-import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.*;
-import static org.testng.Assert.assertEquals;
-
 import java.util.Optional;
 
+import static com.facebook.presto.plugin.jdbc.StandardReadMappings.bigintReadMapping;
+import static com.facebook.presto.plugin.jdbc.StandardReadMappings.integerReadMapping;
+import static com.facebook.presto.plugin.jdbc.StandardReadMappings.smallintReadMapping;
+import static com.facebook.presto.plugin.jdbc.StandardReadMappings.tinyintReadMapping;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_INTEGER;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_INTEGER_UNSIGNED;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_SMALLINT;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_SMALLINT_UNSIGNED;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_TINYINT;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_TINYINT_UNSIGNED;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestJdbcTypeToPrestoType
@@ -30,14 +38,14 @@ public class TestJdbcTypeToPrestoType
     public void testUnsignedType()
     {
         ImmutableMap<JdbcTypeHandle, ReadMapping> jdbcTypeHandleTypeAndPrestoType = ImmutableMap.<JdbcTypeHandle, ReadMapping>builder()
-            .put(JDBC_TINYINT, tinyintReadMapping())
-            .put(JDBC_TINYINT_UNSIGNED, smallintReadMapping())
-            .put(JDBC_SMALLINT, smallintReadMapping())
-            .put(JDBC_SMALLINT_UNSIGNED, integerReadMapping())
-            .put(JDBC_INTEGER, integerReadMapping())
-            .put(JDBC_INTEGER_UNSIGNED, bigintReadMapping())
-            .put(JDBC_BIGINT, bigintReadMapping())
-            .build();
+                .put(JDBC_TINYINT, tinyintReadMapping())
+                .put(JDBC_TINYINT_UNSIGNED, smallintReadMapping())
+                .put(JDBC_SMALLINT, smallintReadMapping())
+                .put(JDBC_SMALLINT_UNSIGNED, integerReadMapping())
+                .put(JDBC_INTEGER, integerReadMapping())
+                .put(JDBC_INTEGER_UNSIGNED, bigintReadMapping())
+                .put(JDBC_BIGINT, bigintReadMapping())
+                .build();
         jdbcTypeHandleTypeAndPrestoType.forEach((jdbcTypeHandle, expectReadMapping) -> {
             Optional<ReadMapping> actualReadMapping = StandardReadMappings.jdbcTypeToPrestoType(jdbcTypeHandle);
             assertTrue(actualReadMapping.isPresent());

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingJdbcTypeHandle.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingJdbcTypeHandle.java
@@ -19,20 +19,20 @@ public final class TestingJdbcTypeHandle
 {
     private TestingJdbcTypeHandle() {}
 
-    public static final JdbcTypeHandle JDBC_BOOLEAN = new JdbcTypeHandle(Types.BOOLEAN, 1, 0);
+    public static final JdbcTypeHandle JDBC_BOOLEAN = new JdbcTypeHandle(Types.BOOLEAN, false, 1, 0);
 
-    public static final JdbcTypeHandle JDBC_SMALLINT = new JdbcTypeHandle(Types.SMALLINT, 1, 0);
-    public static final JdbcTypeHandle JDBC_TINYINT = new JdbcTypeHandle(Types.TINYINT, 2, 0);
-    public static final JdbcTypeHandle JDBC_INTEGER = new JdbcTypeHandle(Types.INTEGER, 4, 0);
-    public static final JdbcTypeHandle JDBC_BIGINT = new JdbcTypeHandle(Types.BIGINT, 8, 0);
+    public static final JdbcTypeHandle JDBC_SMALLINT = new JdbcTypeHandle(Types.SMALLINT, false, 1, 0);
+    public static final JdbcTypeHandle JDBC_TINYINT = new JdbcTypeHandle(Types.TINYINT, false, 2, 0);
+    public static final JdbcTypeHandle JDBC_INTEGER = new JdbcTypeHandle(Types.INTEGER, false, 4, 0);
+    public static final JdbcTypeHandle JDBC_BIGINT = new JdbcTypeHandle(Types.BIGINT, false, 8, 0);
 
-    public static final JdbcTypeHandle JDBC_REAL = new JdbcTypeHandle(Types.REAL, 8, 0);
-    public static final JdbcTypeHandle JDBC_DOUBLE = new JdbcTypeHandle(Types.DOUBLE, 8, 0);
+    public static final JdbcTypeHandle JDBC_REAL = new JdbcTypeHandle(Types.REAL, false, 8, 0);
+    public static final JdbcTypeHandle JDBC_DOUBLE = new JdbcTypeHandle(Types.DOUBLE, false, 8, 0);
 
-    public static final JdbcTypeHandle JDBC_CHAR = new JdbcTypeHandle(Types.CHAR, 10, 0);
-    public static final JdbcTypeHandle JDBC_VARCHAR = new JdbcTypeHandle(Types.VARCHAR, 10, 0);
+    public static final JdbcTypeHandle JDBC_CHAR = new JdbcTypeHandle(Types.CHAR, false, 10, 0);
+    public static final JdbcTypeHandle JDBC_VARCHAR = new JdbcTypeHandle(Types.VARCHAR, false, 10, 0);
 
-    public static final JdbcTypeHandle JDBC_DATE = new JdbcTypeHandle(Types.DATE, 8, 0);
-    public static final JdbcTypeHandle JDBC_TIME = new JdbcTypeHandle(Types.TIME, 4, 0);
-    public static final JdbcTypeHandle JDBC_TIMESTAMP = new JdbcTypeHandle(Types.TIMESTAMP, 8, 0);
+    public static final JdbcTypeHandle JDBC_DATE = new JdbcTypeHandle(Types.DATE, false, 8, 0);
+    public static final JdbcTypeHandle JDBC_TIME = new JdbcTypeHandle(Types.TIME, false, 4, 0);
+    public static final JdbcTypeHandle JDBC_TIMESTAMP = new JdbcTypeHandle(Types.TIMESTAMP, false, 8, 0);
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingJdbcTypeHandle.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingJdbcTypeHandle.java
@@ -22,8 +22,11 @@ public final class TestingJdbcTypeHandle
     public static final JdbcTypeHandle JDBC_BOOLEAN = new JdbcTypeHandle(Types.BOOLEAN, false, 1, 0);
 
     public static final JdbcTypeHandle JDBC_SMALLINT = new JdbcTypeHandle(Types.SMALLINT, false, 1, 0);
+    public static final JdbcTypeHandle JDBC_SMALLINT_UNSIGNED = new JdbcTypeHandle(Types.SMALLINT, true, 1, 0);
     public static final JdbcTypeHandle JDBC_TINYINT = new JdbcTypeHandle(Types.TINYINT, false, 2, 0);
+    public static final JdbcTypeHandle JDBC_TINYINT_UNSIGNED = new JdbcTypeHandle(Types.TINYINT, true, 2, 0);
     public static final JdbcTypeHandle JDBC_INTEGER = new JdbcTypeHandle(Types.INTEGER, false, 4, 0);
+    public static final JdbcTypeHandle JDBC_INTEGER_UNSIGNED = new JdbcTypeHandle(Types.INTEGER, true, 4, 0);
     public static final JdbcTypeHandle JDBC_BIGINT = new JdbcTypeHandle(Types.BIGINT, false, 8, 0);
 
     public static final JdbcTypeHandle JDBC_REAL = new JdbcTypeHandle(Types.REAL, false, 8, 0);

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/optimization/TestJdbcComputePushdown.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/optimization/TestJdbcComputePushdown.java
@@ -239,12 +239,12 @@ public class TestJdbcComputePushdown
 
     private static JdbcColumnHandle integerJdbcColumnHandle(String name)
     {
-        return new JdbcColumnHandle(CONNECTOR_ID, name, new JdbcTypeHandle(Types.BIGINT, 10, 0), BIGINT, false);
+        return new JdbcColumnHandle(CONNECTOR_ID, name, new JdbcTypeHandle(Types.BIGINT, false, 10, 0), BIGINT, false);
     }
 
     private static JdbcColumnHandle booleanJdbcColumnHandle(String name)
     {
-        return new JdbcColumnHandle(CONNECTOR_ID, name, new JdbcTypeHandle(Types.BOOLEAN, 1, 0), BOOLEAN, false);
+        return new JdbcColumnHandle(CONNECTOR_ID, name, new JdbcTypeHandle(Types.BOOLEAN, false, 1, 0), BOOLEAN, false);
     }
 
     private static JdbcColumnHandle getColumnHandleForVariable(String name, Type type)


### PR DESCRIPTION
presto will throw Exception when a mysql table has a column like `state tinyint(1) unsigned` and the value is great then 127

```
mysql> CREATE TABLE test (state tinyint unsigned DEFAULT NULL);
mysql> insert into test (state) values (255),(1);
mysql> select * from test;
+-------+
| state |
+-------+
|   255 |
|     1 |
+-------+
```
when presto query this table, an error ocurred:
```
Query 20200113_021545_00002_gkbzt failed: '255' in column '1' is outside valid range for the datatype TINYINT.
```

error log is:
```
com.facebook.presto.spi.PrestoException: '255' in column '1' is outside valid range for the datatype TINYINT.
	at com.facebook.presto.plugin.jdbc.JdbcRecordCursor.handleSqlException(JdbcRecordCursor.java:236)
	at com.facebook.presto.plugin.jdbc.JdbcRecordCursor.getLong(JdbcRecordCursor.java:152)
	at com.facebook.presto.spi.RecordPageSource.getNextPage(RecordPageSource.java:120)
	at com.facebook.presto.operator.TableScanOperator.getOutput(TableScanOperator.java:251)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:379)
	at com.facebook.presto.operator.Driver.lambda$processFor$8(Driver.java:283)
	at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:675)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:276)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1077)
	at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:162)
	at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:483)
	at com.facebook.presto.$gen.Presto_null__testversion____20200113_021148_1.run(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: com.mysql.jdbc.exceptions.jdbc4.MySQLDataException: '255' in column '1' is outside valid range for the datatype TINYINT.
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.mysql.jdbc.Util.handleNewInstance(Util.java:425)
	at com.mysql.jdbc.Util.getInstance(Util.java:408)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:927)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:898)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:887)
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:861)
	at com.mysql.jdbc.ResultSetImpl.throwRangeException(ResultSetImpl.java:7025)
	at com.mysql.jdbc.ResultSetImpl.getByteFromString(ResultSetImpl.java:1708)
	at com.mysql.jdbc.ResultSetImpl.getByte(ResultSetImpl.java:1655)
	at com.facebook.presto.plugin.jdbc.JdbcRecordCursor.getLong(JdbcRecordCursor.java:149)
	... 13 more


2020-01-13T10:15:48.871+0800	INFO	query-execution-1	com.facebook.presto.event.QueryMonitor	TIMELINE: Query 20200113_021545_00002_gkbzt :: Transaction:[fc691771-e0e6-4305-91c0-4b0b621c28c3] :: elapsed 2111ms :: planning 537ms :: scheduling 1399ms :: running 163ms :: finishing 12ms :: begin 2020-01-13T10:15:46.459+08:00 :: end 2020-01-13T10:15:48.570+08:00

```

fix code is very simple, if a column is `unsigned`, just parse it as a higher level type, eg. `tinyint -> smallint`, `smallint -> int`, `int -> bigint`.

issus link to #13908 
