### PR TITLE
Increase heap memory to avoid continuous Full GCs

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -508,6 +508,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
+                            <argLine>-Xms4g -Xmx4g</argLine>
                             <includes>
                                 <include>**/TestHivePushdownFilterQueries.java</include>
                                 <include>**/TestHivePushdownIntegrationSmokeTest.java</include>


### PR DESCRIPTION
`test-hive-pushdown-filter-queries-basic` test needs a larger heap to
smoothly run to completion. With the current default heap size of 2GB
we consistently see Full GCs. This change will increase it to 4GB.

fixes https://github.com/prestodb/presto/issues/13965

```
== NO RELEASE NOTE ==
```