### PR TITLE
Enable zstd JNI decompression

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -153,7 +153,7 @@ public class HiveClientConfig
     private boolean pushdownFilterEnabled;
     private boolean rangeFiltersOnSubscriptsEnabled;
     private boolean adaptiveFilterReorderingEnabled = true;
-    private boolean zstdJniDecompressionEnabled;
+    private boolean zstdJniDecompressionEnabled = true;
 
     public int getMaxInitialSplits()
     {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageManagerConfig.java
@@ -72,7 +72,7 @@ public class StorageManagerConfig
     private int oneSplitPerBucketThreshold;
     private String shardDayBoundaryTimeZone = TimeZoneKey.UTC_KEY.getId();
     private int maxAllowedFilesPerWriter = Integer.MAX_VALUE;
-    private boolean zstdJniDecompressionEnabled;
+    private boolean zstdJniDecompressionEnabled = true;
 
     @NotNull
     public URI getDataDirectory()


### PR DESCRIPTION
Enabling zstd JNI decompression for Hive and Raptor connector.
    
It has been found that using JNI based ZSTD decompression saves 3% on CPU cycles when compared to java based zstd. Hence switching on this option by default.