### PR TITLE
Optimize remaining expression and return empty result if its null/false 

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -85,6 +85,7 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictTableScan;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
@@ -181,6 +182,26 @@ public class TestHiveLogicalPlanner
                 output(exchange(project(
                         filter("mod(orderkey, 2) = 1",
                                 strictTableScan("lineitem", identityMap("linenumber", "orderkey")))))));
+        // Remaining predicate is NULL
+        assertPlan(pushdownFilterEnabled, "SELECT linenumber FROM lineitem WHERE cardinality(NULL) > 0",
+                output(values("linenumber")));
+
+        assertPlan(pushdownFilterEnabled, "SELECT linenumber FROM lineitem WHERE orderkey > 10 AND cardinality(NULL) > 0",
+                output(values("linenumber")));
+
+        // Remaining predicate is always FALSE
+        assertPlan(pushdownFilterEnabled, "SELECT linenumber FROM lineitem WHERE cardinality(ARRAY[1]) > 1",
+                output(values("linenumber")));
+
+        assertPlan(pushdownFilterEnabled, "SELECT linenumber FROM lineitem WHERE orderkey > 10 AND cardinality(ARRAY[1]) > 1",
+                output(values("linenumber")));
+
+        // TupleDomain predicate is always FALSE
+        assertPlan(pushdownFilterEnabled, "SELECT linenumber FROM lineitem WHERE orderkey = 1 AND orderkey = 2",
+                output(values("linenumber")));
+
+        assertPlan(pushdownFilterEnabled, "SELECT linenumber FROM lineitem WHERE orderkey = 1 AND orderkey = 2 AND linenumber % 2 = 1",
+                output(values("linenumber")));
 
         FunctionManager functionManager = getQueryRunner().getMetadata().getFunctionManager();
         FunctionResolution functionResolution = new FunctionResolution(functionManager);
@@ -332,6 +353,10 @@ public class TestHiveLogicalPlanner
 
         assertPushdownFilterOnSubfields("SELECT * FROM test_pushdown_filter_on_subfields WHERE c.a IS NOT NULL AND c.c IS NOT NULL",
                 ImmutableMap.of(new Subfield("c.a"), notNull(BIGINT), new Subfield("c.c"), notNull(new ArrayType(BIGINT))));
+
+        // TupleDomain predicate is always FALSE
+        assertPlan(pushdownFilterEnabled(), "SELECT id FROM test_pushdown_filter_on_subfields WHERE c.a = 1 AND c.a = 2",
+                output(values("id")));
 
         assertUpdate("DROP TABLE test_pushdown_filter_on_subfields");
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -644,6 +644,7 @@ public class TestHivePushdownFilterQueries
         // filter-only struct
         assertQueryUsingH2Cte("SELECT orderkey FROM lineitem_ex WHERE info IS NOT NULL");
         assertQueryUsingH2Cte("SELECT orderkey FROM lineitem_ex WHERE info IS NOT NULL AND info.orderkey = 16515", rewriter);
+        assertQueryReturnsEmptyResult("SELECT orderkey FROM lineitem_ex WHERE info IS NOT NULL AND info.orderkey = 16515 and info.orderkey = 16516");
         assertQueryUsingH2Cte("SELECT orderkey FROM lineitem_ex WHERE info IS NOT NULL AND info.orderkey + 1 = 16514", rewriter);
 
         // filters on subfields
@@ -1031,6 +1032,13 @@ public class TestHivePushdownFilterQueries
         finally {
             assertUpdate("DROP TABLE test_nan");
         }
+    }
+
+    @Test
+    public void testFilterFunctionsWithOptimization()
+    {
+        assertQuery("SELECT partkey FROM lineitem WHERE orderkey > 10 OR if(json_extract(json_parse('{}'), '$.a') IS NOT NULL, quantity * discount) > 0",
+                "SELECT partkey FROM lineitem WHERE orderkey > 10");
     }
 
     private Path getPartitionDirectory(String tableName, String partitionClause)


### PR DESCRIPTION
A SelectiveStreamReader should be created only if the column is in output or required in a filter function evaluation. In this case we get the columns to be read from unoptimized expression, but column mappings are created from optimized expression which will ignore this column if the expression resolves to "null", which will result in creating a SelectiveReader which is not required and hence throws an exception. The fix is to ignore the interim column if the optimized expression discards it.

Fixes #13992
```
== NO RELEASE NOTE ==
```
