### PR TITLE
Support MySQL-based FunctionNamespaceManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <module>presto-proxy</module>
         <module>presto-kudu</module>
         <module>presto-elasticsearch</module>
-        <module>presto-sql-function</module>
+        <module>presto-function-namespace-managers</module>
         <module>presto-expressions</module>
         <module>presto-benchmark-runner</module>
         <module>presto-spark-classloader-interface</module>
@@ -474,12 +474,6 @@
             <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-sqlserver</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.facebook.presto</groupId>
-                <artifactId>presto-sql-function</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/presto-docs/src/main/sphinx/admin.rst
+++ b/presto-docs/src/main/sphinx/admin.rst
@@ -11,4 +11,5 @@ Administration
     admin/spill
     admin/resource-groups
     admin/session-property-managers
+    admin/function-namespace-managers
     admin/dist-sort

--- a/presto-docs/src/main/sphinx/admin/function-namespace-managers.rst
+++ b/presto-docs/src/main/sphinx/admin/function-namespace-managers.rst
@@ -1,0 +1,92 @@
+===========================
+Function Namespace Managers
+===========================
+
+.. warning::
+
+    This is an experimental feature being actively developed. The way
+    Function Namespace Managers are configured might be changed.
+
+Function namespace managers support storing and retrieving SQL
+functions, allowing the Presto engine to perform actions such as
+creating, altering, deleting functions.
+
+A function namespace is in the format of ``catalog.schema`` (e.g.
+``example.test``). It can be thought of as a schema for storing
+functions. However, it is not a full fledged schema as it does not
+support storing tables and views, but only functions.
+
+Each Presto function, whether built-in or user-defined, resides in
+a function namespace. All built-in functions reside in the
+``presto.default`` function namespace. The qualified function name of
+a function is the function namespace in which it reside followed by
+its function name (e.g. ``example.test.func``). Built-in functions can
+be referenced in queries with their function namespaces omitted, while
+user-defined functions needs to be referenced by its qualified function
+name. A function is uniquely identified by its qualified function name
+and parameter type list.
+
+Each function namespace manager binds to a catalog name and manages all
+functions within that catalog. Using the catalog name of an existing
+connector is discouraged, as the behavior is not defined nor tested,
+and will be disallowed in the future.
+
+Currently, those catalog names do not correspond to real catalogs.
+They cannot be specified as the catalog in a session, nor do they
+support :doc:`/sql/create-schema`, :doc:`/sql/alter-schema`,
+:doc:`/sql/drop-schema`, or :doc:`/sql/show-schemas`. Instead,
+namespaces can be added using the methods described below.
+
+
+Configuration
+-------------
+
+Presto currently stores all function namespace manager related
+information in MySQL.
+
+To instantiate a MySQL-based function namespace manager that manages
+catalog ``example``, administrator needs to first have a running MySQL
+server. Suppose the MySQL server can be reached at ``localhost:1080``,
+add a file ``etc/function-namespace/example.properties`` with the
+following contents::
+
+    function-namespace-manager.name=mysql
+    database-url=localhost:1080
+    function-namespaces-table-name=example_function_namespaces
+    functions-table-name=example_sql_functions
+
+When Presto first starts with the above MySQL function namespace
+manager configuration, two MySQL tables will be created if they do
+not exist.
+
+- ``example_function_namespaces`` stores function namespaces of
+  the catalog ``example``.
+- ``example_sql_functions`` stores SQL-invoked functions of the
+  catalog ``example``.
+
+Multiple function namespace managers can be instantiated by placing
+multiple properties files under ``etc/function-namespace``. They
+may be configured to use the same tables. If so, each manager will
+only create and interact with entries of the catalog to which it binds.
+
+To create a new function namespace, insert into the
+``example_function_namespaces`` table::
+
+    INSERT INTO example_function_namespaces (catalog_name, schema_name)
+    VALUES('example', 'test');
+
+
+Configuration Reference
+-----------------------
+
+``function-namespace-manager.name`` is the type of the function namespace manager to instantiate. Currently, only ``mysql`` is supported.
+
+The following table lists all configuration properties supported by the MySQL function namespace manager.
+
+=========================================== ==================================================================================================
+Name                                        Description
+=========================================== ==================================================================================================
+``database-url``                            The URL of the MySQL database used by the MySQL function namespace manager.
+``function-namespaces-table-name``          The name of the table that stores all the function namespaces managed by this manager.
+``functions-table-name``                    The name of the table that stores all the functions managed by this manager.
+=========================================== ==================================================================================================

--- a/presto-docs/src/main/sphinx/sql.rst
+++ b/presto-docs/src/main/sphinx/sql.rst
@@ -7,11 +7,13 @@ This chapter describes the SQL syntax used in Presto.
 .. toctree::
     :maxdepth: 1
 
+    sql/alter-function
     sql/alter-schema
     sql/alter-table
     sql/analyze
     sql/call
     sql/commit
+    sql/create-function
     sql/create-role
     sql/create-schema
     sql/create-table
@@ -22,6 +24,7 @@ This chapter describes the SQL syntax used in Presto.
     sql/describe
     sql/describe-input
     sql/describe-output
+    sql/drop-function
     sql/drop-role
     sql/drop-schema
     sql/drop-table

--- a/presto-docs/src/main/sphinx/sql/alter-function.rst
+++ b/presto-docs/src/main/sphinx/sql/alter-function.rst
@@ -1,0 +1,43 @@
+==============
+ALTER FUNCTION
+==============
+
+Synopsis
+--------
+
+.. code-block:: none
+
+    ALTER FUNCTION qualified_function_name [ ( parameter_type[, ...] ) ]
+    RETURNS NULL ON NULL INPUT | CALLED ON NULL INPUT
+
+
+Description
+-----------
+
+Alter the definition of an existing function.
+
+Parameter type list must be specified if multiple signatures exist
+for the specified function name. If exactly one signature exists for
+the specified function name, parameter type list can be omitted.
+
+Currently, only modifying the null-call clause is supported.
+
+
+Examples
+--------
+
+Change the null-call clause of a function ``example.default.tan(double)``::
+
+    ALTER FUNCTION prod.default.tan(double)
+    CALLED ON NULL INPUT
+
+If only one function exists for ``example.default.tan``, parameter type list may be omitted::
+
+    ALTER FUNCTION prod.default.tan
+    CALLED ON NULL INPUT
+
+
+See Also
+--------
+
+:doc:`create-function`, :doc:`drop-function`, :doc:`show-functions`

--- a/presto-docs/src/main/sphinx/sql/create-function.rst
+++ b/presto-docs/src/main/sphinx/sql/create-function.rst
@@ -1,0 +1,84 @@
+===============
+CREATE FUNCTION
+===============
+
+Synopsis
+--------
+
+.. code-block:: none
+
+    CREATE [ OR REPLACE ] FUNCTION
+    qualified_function_name (
+      parameter_name parameter_type
+      [, ...]
+    )
+    RETURNS return_type
+    [ COMMENT function_description ]
+    [ LANGUAGE SQL ]
+    [ DETERMINISTIC | NOT DETERMINISTIC ]
+    [ RETURNS NULL ON NULL INPUT | CALLED ON NULL INPUT ]
+    [ RETURN expression ]
+
+
+Description
+-----------
+
+Create a new function with the specified definition.
+
+Each function is uniquely identified by its qualified function name
+and its parameter type list. ``qualified_function_name`` needs to be in
+the format of ``catalog.schema.function_name``.
+
+In order to create a function, the corresponding function namespace
+(in the format ``catalog.schema``) must first be managed by a function
+namespace manager (See :doc:`/admin/function-namespace-managers`).
+
+The optional ``OR REPLACE`` clause causes the query to quietly replace
+the existing function if a function with the identical signature (function
+name with parameter type list) exists.
+
+The ``return_type`` needs to match the actual type of the routine body
+``expression``, without performing type coercion.
+
+A set of routine characteristics can be specified to decorate the
+function and specify its behavior. Each kind of routine characteristic
+can be specified at most once.
+
+============================ ======================== ================================================================
+Routine Characteristic       Default Value            Description
+============================ ======================== ================================================================
+Language clause              SQL                      The language in which the function is defined.
+Deterministic characteristic NOT DETERMINISTIC        Whether the function is deterministic. ``NOT DETERMINISTIC``
+                                                      means that the function is possibly non-deterministic.
+Null-call clause             CALLED ON NULL INPUT     The behavior of the function in which ``null`` is supplied as
+                                                      the value of at least one argument.
+============================ ======================== ================================================================
+
+
+Examples
+--------
+
+Create a new function ``example.default.tan(double)``::
+
+    CREATE FUNCTION example.default.tan(x double)
+    RETURNS double
+    DETERMINISTIC
+    RETURNS NULL ON NULL INPUT
+    RETURN sin(x) / cos(x)
+
+Create the table ``example.default.tan(double)`` if it does not already
+exist, adding a function description and explicitly listing all the supported
+routine characteristics::
+
+    CREATE OR REPLACE FUNCTION example.default.tan(x double)
+    RETURNS double
+    COMMENT 'tangent trigonometric function'
+    LANGUAGE SQL
+    DETERMINISTIC
+    RETURNS NULL ON NULL INPUT
+    RETURN sin(x) / cos(x)
+
+See Also
+--------
+
+:doc:`alter-function`, :doc:`drop-function`, :doc:`show-functions`

--- a/presto-docs/src/main/sphinx/sql/drop-function.rst
+++ b/presto-docs/src/main/sphinx/sql/drop-function.rst
@@ -1,0 +1,45 @@
+=============
+DROP FUNCTION
+=============
+
+Synopsis
+--------
+
+.. code-block:: none
+
+    DROP FUNCTION [ IF EXISTS ] qualified_function_name [ ( parameter_type[, ...] ) ]
+
+
+Description
+-----------
+
+Drop an existing function.
+
+The optional ``IF EXISTS`` clause causes the ``NOT_FOUND`` error
+to be suppressed if the function does not exists.
+
+Each ``DROP FUNCTION`` statement can only drop one function
+at a time. If multiple functions are matched by not specifying
+the parameter type list, the query would fail.
+
+
+Examples
+--------
+
+Drop the function ``example.default.tan(double)``::
+
+    DROP FUNCTION example.default.tan(double)
+
+If only one function exists for ``example.default.tan``, parameter type list may be omitted::
+
+    DROP FUNCTION example.default.tan
+
+Drop the function ``example.default.tan(double)`` if it exists::
+
+    DROP FUNCTION IF EXISTS example.default.tan(double)
+
+
+See Also
+--------
+
+:doc:`create-function`, :doc:`alter-function`, :doc:`show-functions`

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -9,8 +9,8 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>presto-sql-function</artifactId>
-    <name>presto-sql-function</name>
+    <artifactId>presto-function-namespace-managers</artifactId>
+    <name>presto-function-namespace-managers</name>
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -18,6 +18,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spi</artifactId>
             <scope>provided</scope>
@@ -40,8 +50,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.facebook.airlift</groupId>
-            <artifactId>configuration</artifactId>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
         </dependency>
 
         <dependency>
@@ -49,7 +59,50 @@
             <artifactId>units</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-sqlobject</artifactId>
+        </dependency>
+
         <!-- for testing -->
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>testing-mysql-server-5</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -11,12 +11,18 @@
 
     <artifactId>presto-function-namespace-managers</artifactId>
     <name>presto-function-namespace-managers</name>
+    <packaging>presto-plugin</packaging>
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>configuration</artifactId>
@@ -57,6 +63,7 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -85,12 +92,6 @@
         </dependency>
 
         <!-- for testing -->
-        <dependency>
-            <groupId>com.facebook.airlift</groupId>
-            <artifactId>bootstrap</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>testing</artifactId>

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
 import com.facebook.presto.spi.function.QualifiedFunctionName;
 import com.facebook.presto.spi.function.ScalarFunctionImplementation;
 import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.function.SqlFunctionHandle;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
@@ -158,6 +159,16 @@ public abstract class AbstractSqlInvokedFunctionNamespaceManager
         checkCatalog(functionHandle);
         checkArgument(functionHandle instanceof SqlFunctionHandle, "Unsupported FunctionHandle type '%s'", functionHandle.getClass().getSimpleName());
         return implementationByHandle.getUnchecked((SqlFunctionHandle) functionHandle);
+    }
+
+    protected String getCatalogName()
+    {
+        return catalogName;
+    }
+
+    protected void checkCatalog(SqlFunction function)
+    {
+        checkCatalog(function.getSignature().getName());
     }
 
     protected void checkCatalog(QualifiedFunctionName functionName)

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.sqlfunction;
+package com.facebook.presto.functionNamespace;
 
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionMetadata;

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/FunctionNamespaceManagerPlugin.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/FunctionNamespaceManagerPlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace;
+
+import com.facebook.presto.functionNamespace.mysql.MySqlFunctionNamespaceManagerFactory;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
+import com.google.common.collect.ImmutableList;
+
+public class FunctionNamespaceManagerPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<FunctionNamespaceManagerFactory> getFunctionNamespaceManagerFactories()
+    {
+        return ImmutableList.of(new MySqlFunctionNamespaceManagerFactory());
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/InvalidFunctionHandleException.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/InvalidFunctionHandleException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace;
+
+import com.facebook.presto.spi.function.FunctionHandle;
+
+import static java.lang.String.format;
+
+public class InvalidFunctionHandleException
+        extends RuntimeException
+{
+    public InvalidFunctionHandleException(FunctionHandle functionHandle)
+    {
+        super(format("Invalid FunctionHandle: %s", functionHandle));
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/ServingCatalog.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/ServingCatalog.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ServingCatalog
+{
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/SqlInvokedFunctionNamespaceManagerConfig.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/SqlInvokedFunctionNamespaceManagerConfig.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.sqlfunction;
+package com.facebook.presto.functionNamespace;
 
 import com.facebook.airlift.configuration.Config;
 import io.airlift.units.Duration;

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/UuidFunctionNamespaceTransactionHandle.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/UuidFunctionNamespaceTransactionHandle.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.sqlfunction;
+package com.facebook.presto.functionNamespace;
 
 import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/DefineFunctionNamespacesTable.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/DefineFunctionNamespacesTable.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizingAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@SqlStatementCustomizingAnnotation(FunctionNamespacesTableCustomizerFactory.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
+public @interface DefineFunctionNamespacesTable
+{
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/DefineSqlFunctionsTable.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/DefineSqlFunctionsTable.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizingAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@SqlStatementCustomizingAnnotation(SqlFunctionsTableCustomizerFactory.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
+public @interface DefineSqlFunctionsTable
+{
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/FunctionNamespaceDao.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/FunctionNamespaceDao.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.facebook.presto.spi.function.RoutineCharacteristics;
+import com.facebook.presto.spi.function.SqlFunctionId;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.function.SqlParameter;
+import com.facebook.presto.spi.type.TypeSignature;
+import org.jdbi.v3.sqlobject.config.RegisterArgumentFactories;
+import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
+import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.config.RegisterRowMappers;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+import java.util.List;
+import java.util.Optional;
+
+@RegisterRowMappers({
+        @RegisterRowMapper(SqlInvokedFunctionRowMapper.class),
+        @RegisterRowMapper(SqlInvokedFunctionRecordRowMapper.class)
+})
+@RegisterArgumentFactories({
+        @RegisterArgumentFactory(SqlFunctionIdArgumentFactory.class),
+        @RegisterArgumentFactory(SqlParametersArgumentFactory.class),
+        @RegisterArgumentFactory(TypeSignatureArgumentFactory.class),
+        @RegisterArgumentFactory(RoutineCharacteristicsArgumentFactory.class),
+})
+@DefineFunctionNamespacesTable
+@DefineSqlFunctionsTable
+public interface FunctionNamespaceDao
+{
+    @SqlUpdate("CREATE TABLE IF NOT EXISTS <function_namespaces_table> (\n" +
+            "   catalog_name varchar(128) NOT NULL,\n" +
+            "   schema_name varchar(128) NOT NULL,\n" +
+            "   PRIMARY KEY (catalog_name, schema_name))")
+    void createFunctionNamespacesTableIfNotExists();
+
+    @SqlUpdate("CREATE TABLE IF NOT EXISTS <sql_functions_table> (\n" +
+            "  id bigint(20) NOT NULL AUTO_INCREMENT,\n" +
+            "  function_id varchar(700) NOT NULL,\n" +
+            "  version bigint(20) unsigned NOT NULL,\n" +
+            "  catalog_name varchar(128) NOT NULL,\n" +
+            "  schema_name varchar(128) NOT NULL,\n" +
+            "  function_name varchar(256) NOT NULL,\n" +
+            "  parameters varchar(40000) NOT NULL,\n" +
+            "  return_type varchar(256) NOT NULL,\n" +
+            "  routine_characteristics text NOT NULL,\n" +
+            "  body mediumtext,\n" +
+            "  description text,\n" +
+            "  deleted boolean NOT NULL DEFAULT false,\n" +
+            "  delete_time TIMESTAMP NULL DEFAULT NULL,\n" +
+            "  create_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,\n" +
+            "  update_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,\n" +
+            "  PRIMARY KEY (id),\n" +
+            "  UNIQUE KEY function_id_version (function_id, version),\n" +
+            "  KEY qualified_function_name (catalog_name, schema_name, function_name))")
+    void createSqlFunctionsTableIfNotExists();
+
+    @SqlQuery("SELECT\n" +
+            "   count(1) > 0\n" +
+            "FROM <function_namespaces_table>\n" +
+            "WHERE catalog_name = :catalog_name\n" +
+            "  AND schema_name = :schema_name")
+    boolean functionNamespaceExists(
+            @Bind("catalog_name") String catalogName,
+            @Bind("schema_name") String schemaName);
+
+    @SqlQuery("SELECT\n" +
+            "    t.catalog_name,\n" +
+            "    t.schema_name,\n" +
+            "    t.function_name,\n" +
+            "    t.parameters,\n" +
+            "    t.return_type,\n" +
+            "    t.description,\n" +
+            "    t.routine_characteristics,\n" +
+            "    t.body,\n" +
+            "    t.version\n" +
+            "FROM <sql_functions_table> t\n" +
+            "JOIN (\n" +
+            "    SELECT\n" +
+            "        function_id,\n" +
+            "        MAX(version) version\n" +
+            "    FROM <sql_functions_table>\n" +
+            "    WHERE catalog_name = :catalog_name\n" +
+            "    GROUP BY\n" +
+            "        function_id\n" +
+            ") v\n" +
+            "    ON t.function_id = v.function_id\n " +
+            "    AND t.version = v.version\n" +
+            "WHERE\n" +
+            "    NOT t.deleted")
+    List<SqlInvokedFunction> listFunctions(@Bind("catalog_name") String catalogNames);
+
+    @SqlQuery("SELECT\n" +
+            "    t.catalog_name,\n" +
+            "    t.schema_name,\n" +
+            "    t.function_name,\n" +
+            "    t.parameters,\n" +
+            "    t.return_type,\n" +
+            "    t.description,\n" +
+            "    t.routine_characteristics,\n" +
+            "    t.body,\n" +
+            "    t.version\n" +
+            "FROM <sql_functions_table> t\n" +
+            "JOIN (\n" +
+            "    SELECT\n" +
+            "        function_id,\n" +
+            "        MAX(version) version\n" +
+            "    FROM <sql_functions_table>\n" +
+            "    WHERE catalog_name = :catalog_name\n" +
+            "      AND schema_name = :schema_name\n" +
+            "      AND function_name = :function_name\n" +
+            "    GROUP BY\n" +
+            "        function_id\n" +
+            ") v\n" +
+            "    ON t.function_id = v.function_id\n " +
+            "    AND t.version = v.version\n" +
+            "WHERE\n" +
+            "    NOT t.deleted")
+    List<SqlInvokedFunction> getFunctions(
+            @Bind("catalog_name") String catalogName,
+            @Bind("schema_name") String schemaName,
+            @Bind("function_name") String functionName);
+
+    @SqlQuery("SELECT\n" +
+            "    catalog_name,\n" +
+            "    schema_name,\n" +
+            "    function_name,\n" +
+            "    parameters,\n" +
+            "    return_type,\n" +
+            "    description,\n" +
+            "    routine_characteristics,\n" +
+            "    body,\n" +
+            "    version\n" +
+            "FROM <sql_functions_table>\n" +
+            "WHERE\n" +
+            "    function_id = :function_id\n" +
+            "    AND version = :version")
+    Optional<SqlInvokedFunction> getFunction(
+            @Bind("function_id") SqlFunctionId functionId,
+            @Bind("version") long version);
+
+    @SqlQuery("SELECT\n" +
+            "    t.catalog_name,\n" +
+            "    t.schema_name,\n" +
+            "    t.function_name,\n" +
+            "    t.parameters,\n" +
+            "    t.return_type,\n" +
+            "    t.description,\n" +
+            "    t.routine_characteristics,\n" +
+            "    t.body,\n" +
+            "    t.version,\n" +
+            "    t.deleted\n" +
+            "FROM <sql_functions_table> t\n" +
+            "JOIN (\n" +
+            "    SELECT\n" +
+            "        MAX(version) version\n" +
+            "    FROM <sql_functions_table>\n" +
+            "    WHERE\n" +
+            "        function_id = :function_id\n" +
+            ") v\n" +
+            "ON\n" +
+            "    t.version = v.version\n" +
+            "WHERE\n" +
+            "    t.function_id = :function_id\n" +
+            "FOR UPDATE")
+    Optional<SqlInvokedFunctionRecord> getLatestRecordForUpdate(@Bind("function_id") SqlFunctionId functionId);
+
+    @SqlQuery("SELECT\n" +
+            "    t.catalog_name,\n" +
+            "    t.schema_name,\n" +
+            "    t.function_name,\n" +
+            "    t.parameters,\n" +
+            "    t.return_type,\n" +
+            "    t.description,\n" +
+            "    t.routine_characteristics,\n" +
+            "    t.body,\n" +
+            "    t.version,\n" +
+            "    t.deleted\n" +
+            "FROM <sql_functions_table> t\n" +
+            "JOIN (\n" +
+            "    SELECT\n" +
+            "        function_id,\n" +
+            "        MAX(version) version\n" +
+            "    FROM <sql_functions_table>\n" +
+            "    WHERE\n" +
+            "        catalog_name = :catalog_name\n" +
+            "        AND schema_name = :schema_name\n" +
+            "        AND function_name = :function_name\n" +
+            "    GROUP BY\n" +
+            "        function_id\n" +
+            ") v\n" +
+            "ON\n" +
+            "    t.function_id = v.function_id\n" +
+            "    AND t.version = v.version\n" +
+            "FOR UPDATE")
+    List<SqlInvokedFunctionRecord> getLatestRecordsForUpdate(
+            @Bind("catalog_name") String catalogName,
+            @Bind("schema_name") String schemaName,
+            @Bind("function_name") String functionName);
+
+    @SqlUpdate("INSERT INTO <sql_functions_table> (\n" +
+            "        function_id,\n" +
+            "        version,\n" +
+            "        catalog_name,\n" +
+            "        schema_name,\n" +
+            "        function_name,\n" +
+            "        parameters,\n" +
+            "        return_type,\n" +
+            "        description,\n" +
+            "        routine_characteristics,\n" +
+            "        body\n" +
+            "    )\n" +
+            "VALUES\n" +
+            "    (\n" +
+            "        :function_id,\n" +
+            "        :version,\n" +
+            "        :catalog_name,\n" +
+            "        :schema_name,\n" +
+            "        :function_name,\n" +
+            "        :parameters,\n" +
+            "        :return_type,\n" +
+            "        :description,\n" +
+            "        :routine_characteristics,\n" +
+            "        :body\n" +
+            "    )")
+    void insertFunction(
+            @Bind("function_id") SqlFunctionId functionId,
+            @Bind("version") long version,
+            @Bind("catalog_name") String catalogName,
+            @Bind("schema_name") String schemaName,
+            @Bind("function_name") String functionName,
+            @Bind("parameters") List<SqlParameter> parameters,
+            @Bind("return_type") TypeSignature returnType,
+            @Bind("description") String description,
+            @Bind("routine_characteristics") RoutineCharacteristics routineCharacteristics,
+            @Bind("body") String body);
+
+    @SqlUpdate("UPDATE\n" +
+            "    <sql_functions_table>\n" +
+            "SET\n" +
+            "    deleted = :deleted\n," +
+            "    delete_time = IF(:deleted, NOW(), null)\n" +
+            "WHERE\n" +
+            "    function_id = :function_id\n" +
+            "    AND version = :version")
+    int setDeletionStatus(
+            @Bind("function_id") SqlFunctionId functionId,
+            @Bind("version") long version,
+            @Bind("deleted") boolean deleted);
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/FunctionNamespacesTableCustomizerFactory.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/FunctionNamespacesTableCustomizerFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizer;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import static java.util.Objects.requireNonNull;
+
+public class FunctionNamespacesTableCustomizerFactory
+        implements SqlStatementCustomizerFactory
+{
+    private static final String FUNCTION_NAMESPACES_TABLE_KEY = "function_namespaces_table";
+
+    @Override
+    public SqlStatementCustomizer createForType(Annotation annotation, Class<?> sqlObjectType)
+    {
+        return statement -> statement.define(FUNCTION_NAMESPACES_TABLE_KEY, statement.getConfig(Config.class).getTableName());
+    }
+
+    @Override
+    public SqlStatementCustomizer createForMethod(Annotation annotation, Class<?> sqlObjectType, Method method)
+    {
+        return createForType(annotation, sqlObjectType);
+    }
+
+    public static class Config
+            implements JdbiConfig<Config>
+    {
+        private String tableName;
+
+        public Config()
+        {
+        }
+
+        private Config(Config other)
+        {
+            this.tableName = other.tableName;
+        }
+
+        public String getTableName()
+        {
+            return tableName;
+        }
+
+        public void setTableName(String tableName)
+        {
+            this.tableName = requireNonNull(tableName, "tableName is null");
+        }
+
+        @Override
+        public Config createCopy()
+        {
+            return new Config(this);
+        }
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlConnectionConfig.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlConnectionConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+public class MySqlConnectionConfig
+{
+    private String databaseUrl;
+
+    @NotNull
+    public String getDatabaseUrl()
+    {
+        return databaseUrl;
+    }
+
+    @Config("database-url")
+    public MySqlConnectionConfig setDatabaseUrl(String databaseUrl)
+    {
+        this.databaseUrl = databaseUrl;
+        return this;
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlConnectionModule.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlConnectionModule.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.google.inject.Binder;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+
+import java.sql.DriverManager;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+
+public class MySqlConnectionModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(MySqlConnectionConfig.class);
+
+        String databaseUrl = buildConfigObject(MySqlConnectionConfig.class).getDatabaseUrl();
+        binder.bind(Jdbi.class).toInstance(Jdbi.create(() -> DriverManager.getConnection(databaseUrl)).installPlugin(new SqlObjectPlugin()));
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManager.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.facebook.presto.functionNamespace.AbstractSqlInvokedFunctionNamespaceManager;
+import com.facebook.presto.functionNamespace.InvalidFunctionHandleException;
+import com.facebook.presto.functionNamespace.ServingCatalog;
+import com.facebook.presto.functionNamespace.SqlInvokedFunctionNamespaceManagerConfig;
+import com.facebook.presto.spi.CatalogSchemaName;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AlterRoutineCharacteristics;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.QualifiedFunctionName;
+import com.facebook.presto.spi.function.RoutineCharacteristics;
+import com.facebook.presto.spi.function.ScalarFunctionImplementation;
+import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.function.SqlFunction;
+import com.facebook.presto.spi.function.SqlFunctionHandle;
+import com.facebook.presto.spi.function.SqlFunctionId;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.type.TypeSignature;
+import org.jdbi.v3.core.Jdbi;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
+import static com.facebook.presto.spi.StandardErrorCode.AMBIGUOUS_FUNCTION_CALL;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+public class MySqlFunctionNamespaceManager
+        extends AbstractSqlInvokedFunctionNamespaceManager
+{
+    private static final int MAX_CATALOG_NAME_LENGTH = 128;
+    private static final int MAX_SCHEMA_NAME_LENGTH = 128;
+    private static final int MAX_FUNCTION_NAME_LENGTH = 256;
+    private static final int MAX_PARAMETER_TYPES_LENGTH = 500;
+    private static final int MAX_RETURN_TYPE_LENGTH = 256;
+
+    private final Jdbi jdbi;
+    private final FunctionNamespaceDao functionNamespaceDao;
+
+    @Inject
+    public MySqlFunctionNamespaceManager(
+            Jdbi jdbi,
+            FunctionNamespaceDao functionNamespaceDao,
+            SqlInvokedFunctionNamespaceManagerConfig managerConfig,
+            MySqlFunctionNamespaceManagerConfig dbManagerConfig,
+            @ServingCatalog String catalogName)
+    {
+        super(catalogName, managerConfig);
+        this.jdbi = requireNonNull(jdbi, "jdbi is null");
+        this.functionNamespaceDao = requireNonNull(functionNamespaceDao, "functionNamespaceDao is null");
+
+        jdbi.getConfig(FunctionNamespacesTableCustomizerFactory.Config.class)
+                .setTableName(dbManagerConfig.getFunctionNamespacesTableName());
+        jdbi.getConfig(SqlFunctionsTableCustomizerFactory.Config.class)
+                .setTableName(dbManagerConfig.getFunctionsTableName());
+    }
+
+    @PostConstruct
+    public void initialize()
+    {
+        functionNamespaceDao.createFunctionNamespacesTableIfNotExists();
+        functionNamespaceDao.createSqlFunctionsTableIfNotExists();
+    }
+
+    @Override
+    public Collection<SqlInvokedFunction> listFunctions()
+    {
+        return functionNamespaceDao.listFunctions(getCatalogName());
+    }
+
+    @Override
+    protected Collection<SqlInvokedFunction> fetchFunctionsDirect(QualifiedFunctionName functionName)
+    {
+        checkCatalog(functionName);
+        return functionNamespaceDao.getFunctions(
+                functionName.getFunctionNamespace().getCatalogName(),
+                functionName.getFunctionNamespace().getSchemaName(),
+                functionName.getFunctionName());
+    }
+
+    @Override
+    protected FunctionMetadata fetchFunctionMetadataDirect(SqlFunctionHandle functionHandle)
+    {
+        checkCatalog(functionHandle);
+        Optional<SqlInvokedFunction> function = functionNamespaceDao.getFunction(functionHandle.getFunctionId(), functionHandle.getVersion());
+        if (!function.isPresent()) {
+            throw new InvalidFunctionHandleException(functionHandle);
+        }
+        return sqlInvokedFunctionToMetadata(function.get());
+    }
+
+    @Override
+    protected ScalarFunctionImplementation fetchFunctionImplementationDirect(SqlFunctionHandle functionHandle)
+    {
+        checkCatalog(functionHandle);
+        Optional<SqlInvokedFunction> function = functionNamespaceDao.getFunction(functionHandle.getFunctionId(), functionHandle.getVersion());
+        if (!function.isPresent()) {
+            throw new InvalidFunctionHandleException(functionHandle);
+        }
+        return sqlInvokedFunctionToImplementation(function.get());
+    }
+
+    @Override
+    public void createFunction(SqlInvokedFunction function, boolean replace)
+    {
+        checkCatalog(function);
+        checkArgument(!function.getVersion().isPresent(), "function '%s' is already versioned", function);
+
+        QualifiedFunctionName functionName = function.getFunctionId().getFunctionName();
+        checkFieldLength("Catalog name", functionName.getFunctionNamespace().getCatalogName(), MAX_CATALOG_NAME_LENGTH);
+        checkFieldLength("Schema name", functionName.getFunctionNamespace().getSchemaName(), MAX_SCHEMA_NAME_LENGTH);
+        if (!functionNamespaceDao.functionNamespaceExists(functionName.getFunctionNamespace().getCatalogName(), functionName.getFunctionNamespace().getSchemaName())) {
+            throw new PrestoException(NOT_FOUND, format("Function namespace not found: %s", functionName.getFunctionNamespace()));
+        }
+        checkFieldLength("Function name", functionName.getFunctionName(), MAX_FUNCTION_NAME_LENGTH);
+        checkFieldLength(
+                "Parameter types",
+                function.getFunctionId().getArgumentTypes().stream()
+                        .map(TypeSignature::toString)
+                        .collect(joining(",")),
+                MAX_PARAMETER_TYPES_LENGTH);
+        checkFieldLength("Return type", function.getSignature().getReturnType().toString(), MAX_RETURN_TYPE_LENGTH);
+
+        jdbi.useTransaction(handle -> {
+            FunctionNamespaceDao transactionDao = handle.attach(FunctionNamespaceDao.class);
+            Optional<SqlInvokedFunctionRecord> latestVersion = transactionDao.getLatestRecordForUpdate(function.getFunctionId());
+            if (!replace && latestVersion.isPresent() && !latestVersion.get().isDeleted()) {
+                throw new PrestoException(ALREADY_EXISTS, "Function already exists: " + function.getFunctionId());
+            }
+
+            if (!latestVersion.isPresent() || !latestVersion.get().getFunction().hasSameDefinitionAs(function)) {
+                long newVersion = latestVersion.map(SqlInvokedFunctionRecord::getFunction).flatMap(SqlInvokedFunction::getVersion).orElse(0L) + 1;
+                insertSqlInvokedFunction(transactionDao, function, newVersion);
+            }
+            else if (latestVersion.get().isDeleted()) {
+                SqlInvokedFunction latest = latestVersion.get().getFunction();
+                checkState(latest.getVersion().isPresent(), "Function version missing: %s", latest.getFunctionId());
+                transactionDao.setDeletionStatus(latest.getFunctionId(), latest.getVersion().get(), false);
+            }
+        });
+        refreshFunctionsCache(functionName);
+    }
+
+    @Override
+    public void alterFunction(QualifiedFunctionName functionName, Optional<List<TypeSignature>> parameterTypes, AlterRoutineCharacteristics alterRoutineCharacteristics)
+    {
+        checkCatalog(functionName);
+        jdbi.useTransaction(handle -> {
+            FunctionNamespaceDao transactionDao = handle.attach(FunctionNamespaceDao.class);
+            List<SqlInvokedFunction> functions = getSqlFunctions(transactionDao, functionName, parameterTypes);
+
+            checkUnique(functions, functionName);
+            checkExists(functions, functionName, parameterTypes);
+
+            SqlInvokedFunction latest = functions.get(0);
+            RoutineCharacteristics.Builder routineCharacteristics = RoutineCharacteristics.builder(latest.getRoutineCharacteristics());
+            alterRoutineCharacteristics.getNullCallClause().ifPresent(routineCharacteristics::setNullCallClause);
+            SqlInvokedFunction altered = new SqlInvokedFunction(
+                    latest.getFunctionId().getFunctionName(),
+                    latest.getParameters(),
+                    latest.getSignature().getReturnType(),
+                    latest.getDescription(),
+                    routineCharacteristics.build(),
+                    latest.getBody(),
+                    Optional.empty());
+            if (!altered.hasSameDefinitionAs(latest)) {
+                checkState(latest.getVersion().isPresent(), "Function version missing: %s", latest.getFunctionId());
+                insertSqlInvokedFunction(transactionDao, altered, latest.getVersion().get() + 1);
+            }
+        });
+        refreshFunctionsCache(functionName);
+    }
+
+    @Override
+    public void dropFunction(QualifiedFunctionName functionName, Optional<List<TypeSignature>> parameterTypes, boolean exists)
+    {
+        checkCatalog(functionName);
+        jdbi.useTransaction(handle -> {
+            FunctionNamespaceDao transactionDao = handle.attach(FunctionNamespaceDao.class);
+            List<SqlInvokedFunction> functions = getSqlFunctions(transactionDao, functionName, parameterTypes);
+
+            checkUnique(functions, functionName);
+            checkExists(functions, functionName, parameterTypes);
+
+            SqlInvokedFunction latest = functions.get(0);
+            checkState(latest.getVersion().isPresent(), "Function version missing: %s", latest.getFunctionId());
+            transactionDao.setDeletionStatus(latest.getFunctionId(), latest.getVersion().get(), true);
+        });
+
+        refreshFunctionsCache(functionName);
+    }
+
+    private List<SqlInvokedFunction> getSqlFunctions(FunctionNamespaceDao functionNamespaceDao, QualifiedFunctionName functionName, Optional<List<TypeSignature>> parameterTypes)
+    {
+        List<SqlInvokedFunctionRecord> records = new ArrayList<>();
+        if (parameterTypes.isPresent()) {
+            functionNamespaceDao.getLatestRecordForUpdate(new SqlFunctionId(functionName, parameterTypes.get())).ifPresent(records::add);
+        }
+        else {
+            CatalogSchemaName functionNamespace = functionName.getFunctionNamespace();
+            records = functionNamespaceDao.getLatestRecordsForUpdate(functionNamespace.getCatalogName(), functionNamespace.getSchemaName(), functionName.getFunctionName());
+        }
+        return records.stream()
+                .filter(record -> !record.isDeleted())
+                .map(SqlInvokedFunctionRecord::getFunction)
+                .collect(toImmutableList());
+    }
+
+    private void insertSqlInvokedFunction(FunctionNamespaceDao functionNamespaceDao, SqlInvokedFunction function, long version)
+    {
+        QualifiedFunctionName functionName = function.getFunctionId().getFunctionName();
+        functionNamespaceDao.insertFunction(
+                function.getFunctionId(),
+                version,
+                functionName.getFunctionNamespace().getCatalogName(),
+                functionName.getFunctionNamespace().getSchemaName(),
+                functionName.getFunctionName(),
+                function.getParameters(),
+                function.getSignature().getReturnType(),
+                function.getDescription(),
+                function.getRoutineCharacteristics(),
+                function.getBody());
+    }
+
+    private static void checkFieldLength(String fieldName, String field, int maxLength)
+    {
+        if (field.length() > maxLength) {
+            throw new PrestoException(GENERIC_USER_ERROR, format("%s exceeds max length of %s: %s", fieldName, maxLength, field));
+        }
+    }
+
+    private static void checkUnique(List<SqlInvokedFunction> functions, QualifiedFunctionName functionName)
+    {
+        if (functions.size() > 1) {
+            String signatures = functions.stream()
+                    .map(SqlFunction::getSignature)
+                    .map(Signature::toString)
+                    .collect(joining("; "));
+            throw new PrestoException(AMBIGUOUS_FUNCTION_CALL, format("Function '%s' has multiple signatures: %s. Please specify parameter types.", functionName, signatures));
+        }
+    }
+
+    private static void checkExists(List<SqlInvokedFunction> functions, QualifiedFunctionName functionName, Optional<List<TypeSignature>> parameterTypes)
+    {
+        if (functions.isEmpty()) {
+            String formattedParameterTypes = parameterTypes.map(types -> types.stream()
+                    .map(TypeSignature::toString)
+                    .collect(joining(",", "(", ")"))).orElse("");
+            throw new PrestoException(NOT_FOUND, format("Function not found: %s%s", functionName, formattedParameterTypes));
+        }
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManagerConfig.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManagerConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+public class MySqlFunctionNamespaceManagerConfig
+{
+    private String functionNamespacesTableName = "function_namespaces";
+    private String functionsTableName = "sql_functions";
+
+    @NotNull
+    public String getFunctionNamespacesTableName()
+    {
+        return functionNamespacesTableName;
+    }
+
+    @Config("function-namespaces-table-name")
+    public MySqlFunctionNamespaceManagerConfig setFunctionNamespacesTableName(String functionNamespacesTableName)
+    {
+        this.functionNamespacesTableName = functionNamespacesTableName;
+        return this;
+    }
+
+    @NotNull
+    public String getFunctionsTableName()
+    {
+        return functionsTableName;
+    }
+
+    @Config("functions-table-name")
+    public MySqlFunctionNamespaceManagerConfig setFunctionsTableName(String functionsTableName)
+    {
+        this.functionsTableName = functionsTableName;
+        return this;
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManagerFactory.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManagerFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.presto.spi.function.FunctionHandleResolver;
+import com.facebook.presto.spi.function.FunctionNamespaceManager;
+import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
+import com.facebook.presto.spi.function.SqlFunctionHandle;
+import com.google.inject.Injector;
+
+import java.util.Map;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+
+public class MySqlFunctionNamespaceManagerFactory
+        implements FunctionNamespaceManagerFactory
+{
+    public static final String NAME = "mysql";
+
+    private static final SqlFunctionHandle.Resolver HANDLE_RESOLVER = new SqlFunctionHandle.Resolver();
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public FunctionHandleResolver getHandleResolver()
+    {
+        return HANDLE_RESOLVER;
+    }
+
+    @Override
+    public FunctionNamespaceManager<?> create(String catalogName, Map<String, String> config)
+    {
+        try {
+            Bootstrap app = new Bootstrap(
+                    new MySqlFunctionNamespaceManagerModule(catalogName),
+                    new MySqlConnectionModule());
+
+            Injector injector = app
+                    .strictConfig()
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+            return injector.getInstance(MySqlFunctionNamespaceManager.class);
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManagerModule.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManagerModule.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.facebook.presto.functionNamespace.ServingCatalog;
+import com.facebook.presto.functionNamespace.SqlInvokedFunctionNamespaceManagerConfig;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.TypeLiteral;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.SqlStatements;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.google.inject.Scopes.SINGLETON;
+import static java.util.Objects.requireNonNull;
+
+public class MySqlFunctionNamespaceManagerModule
+        implements Module
+{
+    private final String catalogName;
+
+    public MySqlFunctionNamespaceManagerModule(String catalogName)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(new TypeLiteral<String>() {}).annotatedWith(ServingCatalog.class).toInstance(catalogName);
+
+        configBinder(binder).bindConfig(SqlInvokedFunctionNamespaceManagerConfig.class);
+        configBinder(binder).bindConfig(MySqlFunctionNamespaceManagerConfig.class);
+        binder.bind(MySqlFunctionNamespaceManager.class).in(SINGLETON);
+    }
+
+    @Provides
+    @Singleton
+    public FunctionNamespaceDao provideFunctionNamespaceDao(Jdbi jdbi)
+    {
+        SqlStatements config = jdbi.getConfig(SqlStatements.class);
+        return jdbi.onDemand(FunctionNamespaceDao.class);
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/RoutineCharacteristicsArgumentFactory.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/RoutineCharacteristicsArgumentFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.spi.function.RoutineCharacteristics;
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.argument.ObjectArgument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static java.sql.Types.VARCHAR;
+
+public class RoutineCharacteristicsArgumentFactory
+        extends AbstractArgumentFactory<RoutineCharacteristics>
+{
+    private static final JsonCodec<RoutineCharacteristics> ROUTINE_CHARACTERISTICS_CODEC = jsonCodec(RoutineCharacteristics.class);
+
+    public RoutineCharacteristicsArgumentFactory()
+    {
+        super(VARCHAR);
+    }
+
+    @Override
+    protected Argument build(RoutineCharacteristics routineCharacteristics, ConfigRegistry config)
+    {
+        return new ObjectArgument(ROUTINE_CHARACTERISTICS_CODEC.toJson(routineCharacteristics), VARCHAR);
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlFunctionIdArgumentFactory.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlFunctionIdArgumentFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.facebook.presto.spi.function.SqlFunctionId;
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.argument.ObjectArgument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+import static java.sql.Types.VARCHAR;
+
+public class SqlFunctionIdArgumentFactory
+        extends AbstractArgumentFactory<SqlFunctionId>
+{
+    public SqlFunctionIdArgumentFactory()
+    {
+        super(VARCHAR);
+    }
+
+    @Override
+    public Argument build(SqlFunctionId value, ConfigRegistry config)
+    {
+        return new ObjectArgument(value.getId(), VARCHAR);
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlFunctionsTableCustomizerFactory.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlFunctionsTableCustomizerFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import org.jdbi.v3.core.config.JdbiConfig;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizer;
+import org.jdbi.v3.sqlobject.customizer.SqlStatementCustomizerFactory;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import static java.util.Objects.requireNonNull;
+
+public class SqlFunctionsTableCustomizerFactory
+        implements SqlStatementCustomizerFactory
+{
+    private static final String SQL_FUNCTIONS_TABLE_KEY = "sql_functions_table";
+
+    @Override
+    public SqlStatementCustomizer createForType(Annotation annotation, Class<?> sqlObjectType)
+    {
+        return statement -> statement.define(SQL_FUNCTIONS_TABLE_KEY, statement.getConfig(Config.class).getTableName());
+    }
+
+    @Override
+    public SqlStatementCustomizer createForMethod(Annotation annotation, Class<?> sqlObjectType, Method method)
+    {
+        return createForType(annotation, sqlObjectType);
+    }
+
+    public static class Config
+            implements JdbiConfig<Config>
+    {
+        private String tableName;
+
+        public Config()
+        {
+        }
+
+        private Config(Config other)
+        {
+            this.tableName = other.tableName;
+        }
+
+        public String getTableName()
+        {
+            return tableName;
+        }
+
+        public void setTableName(String tableName)
+        {
+            this.tableName = requireNonNull(tableName, "tableName is null");
+        }
+
+        @Override
+        public Config createCopy()
+        {
+            return new Config(this);
+        }
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlInvokedFunctionRecord.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlInvokedFunctionRecord.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+
+import static java.util.Objects.requireNonNull;
+
+public class SqlInvokedFunctionRecord
+{
+    private final SqlInvokedFunction function;
+    private final boolean deleted;
+
+    public SqlInvokedFunctionRecord(
+            SqlInvokedFunction function,
+            boolean deleted)
+    {
+        this.function = requireNonNull(function, "function is null");
+        this.deleted = deleted;
+    }
+
+    public SqlInvokedFunction getFunction()
+    {
+        return function;
+    }
+
+    public boolean isDeleted()
+    {
+        return deleted;
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlInvokedFunctionRecordRowMapper.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlInvokedFunctionRecordRowMapper.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class SqlInvokedFunctionRecordRowMapper
+        implements RowMapper<SqlInvokedFunctionRecord>
+{
+    @Override
+    public SqlInvokedFunctionRecord map(ResultSet rs, StatementContext ctx)
+            throws SQLException
+    {
+        return new SqlInvokedFunctionRecord(new SqlInvokedFunctionRowMapper().map(rs, ctx), rs.getBoolean("deleted"));
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlInvokedFunctionRowMapper.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlInvokedFunctionRowMapper.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.spi.CatalogSchemaName;
+import com.facebook.presto.spi.function.QualifiedFunctionName;
+import com.facebook.presto.spi.function.RoutineCharacteristics;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.function.SqlParameter;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
+
+public class SqlInvokedFunctionRowMapper
+        implements RowMapper<SqlInvokedFunction>
+{
+    private static final JsonCodec<List<SqlParameter>> SQL_PARAMETERS_CODEC = listJsonCodec(SqlParameter.class);
+    private static final JsonCodec<RoutineCharacteristics> ROUTINE_CHARACTERISTICS_CODEC = jsonCodec(RoutineCharacteristics.class);
+
+    @Override
+    public SqlInvokedFunction map(ResultSet rs, StatementContext ctx)
+            throws SQLException
+    {
+        String catalog = rs.getString("catalog_name");
+        String schema = rs.getString("schema_name");
+        String functionName = rs.getString("function_name");
+        List<SqlParameter> parameters = SQL_PARAMETERS_CODEC.fromJson(rs.getString("parameters"));
+        String returnType = rs.getString("return_type");
+        String description = rs.getString("description");
+        RoutineCharacteristics routineCharacteristics = ROUTINE_CHARACTERISTICS_CODEC.fromJson(rs.getString("routine_characteristics"));
+        String body = rs.getString("body");
+        long version = rs.getLong("version");
+
+        return new SqlInvokedFunction(
+                QualifiedFunctionName.of(new CatalogSchemaName(catalog, schema), functionName),
+                parameters,
+                parseTypeSignature(returnType),
+                description,
+                routineCharacteristics,
+                body,
+                Optional.of(version));
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlParametersArgumentFactory.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlParametersArgumentFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.spi.function.SqlParameter;
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.argument.ObjectArgument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+import java.util.List;
+
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static java.sql.Types.VARCHAR;
+
+public class SqlParametersArgumentFactory
+        extends AbstractArgumentFactory<List<SqlParameter>>
+{
+    private static final JsonCodec<List<SqlParameter>> CODEC = listJsonCodec(SqlParameter.class);
+
+    public SqlParametersArgumentFactory()
+    {
+        super(VARCHAR);
+    }
+
+    @Override
+    public Argument build(List<SqlParameter> parameters, ConfigRegistry config)
+    {
+        return new ObjectArgument(CODEC.toJson(parameters), VARCHAR);
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/TypeSignatureArgumentFactory.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/TypeSignatureArgumentFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.facebook.presto.spi.type.TypeSignature;
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.argument.ObjectArgument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+import static java.sql.Types.VARCHAR;
+
+public class TypeSignatureArgumentFactory
+        extends AbstractArgumentFactory<TypeSignature>
+{
+    public TypeSignatureArgumentFactory()
+    {
+        super(VARCHAR);
+    }
+
+    @Override
+    protected Argument build(TypeSignature typeSignature, ConfigRegistry config)
+    {
+        return new ObjectArgument(typeSignature.toString(), VARCHAR);
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/InMemoryFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/InMemoryFunctionNamespaceManager.java
@@ -45,9 +45,9 @@ public class InMemoryFunctionNamespaceManager
 {
     private final Map<SqlFunctionId, SqlInvokedFunction> latestFunctions = new ConcurrentHashMap<>();
 
-    public InMemoryFunctionNamespaceManager(SqlInvokedFunctionNamespaceManagerConfig config)
+    public InMemoryFunctionNamespaceManager(String catalogName, SqlInvokedFunctionNamespaceManagerConfig config)
     {
-        super(config);
+        super(catalogName, config);
     }
 
     @Override

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/InMemoryFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/InMemoryFunctionNamespaceManager.java
@@ -11,8 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.testing;
+package com.facebook.presto.functionNamespace.testing;
 
+import com.facebook.presto.functionNamespace.AbstractSqlInvokedFunctionNamespaceManager;
+import com.facebook.presto.functionNamespace.SqlInvokedFunctionNamespaceManagerConfig;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.AlterRoutineCharacteristics;
 import com.facebook.presto.spi.function.FunctionMetadata;
@@ -22,8 +24,6 @@ import com.facebook.presto.spi.function.SqlFunctionHandle;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.type.TypeSignature;
-import com.facebook.presto.sqlfunction.AbstractSqlInvokedFunctionNamespaceManager;
-import com.facebook.presto.sqlfunction.SqlInvokedFunctionNamespaceManagerConfig;
 
 import javax.annotation.concurrent.ThreadSafe;
 

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/SqlInvokedFunctionTestUtils.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/SqlInvokedFunctionTestUtils.java
@@ -35,8 +35,10 @@ public class SqlInvokedFunctionTestUtils
     }
 
     public static final String TEST_CATALOG = "unittest";
+    public static final String TEST_SCHEMA = "memory";
 
-    public static final QualifiedFunctionName POWER_TOWER = QualifiedFunctionName.of(new CatalogSchemaName(TEST_CATALOG, "memory"), "power_tower");
+    public static final QualifiedFunctionName POWER_TOWER = QualifiedFunctionName.of(new CatalogSchemaName(TEST_CATALOG, TEST_SCHEMA), "power_tower");
+    public static final QualifiedFunctionName TANGENT = QualifiedFunctionName.of(new CatalogSchemaName(TEST_CATALOG, TEST_SCHEMA), "tangent");
 
     public static final SqlInvokedFunction FUNCTION_POWER_TOWER_DOUBLE = new SqlInvokedFunction(
             POWER_TOWER,
@@ -63,5 +65,17 @@ public class SqlInvokedFunctionTestUtils
             "power tower",
             RoutineCharacteristics.builder().setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
             "RETURN pow(x, x)",
+            Optional.empty());
+
+    public static final SqlInvokedFunction FUNCTION_TANGENT = new SqlInvokedFunction(
+            TANGENT,
+            ImmutableList.of(new SqlParameter("x", parseTypeSignature(DOUBLE))),
+            parseTypeSignature(DOUBLE),
+            "tangent",
+            RoutineCharacteristics.builder()
+                    .setDeterminism(DETERMINISTIC)
+                    .setNullCallClause(RETURNS_NULL_ON_NULL_INPUT)
+                    .build(),
+            "RETURN sin(x) / cos(x)",
             Optional.empty());
 }

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/SqlInvokedFunctionTestUtils.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/SqlInvokedFunctionTestUtils.java
@@ -44,7 +44,7 @@ public class SqlInvokedFunctionTestUtils
             parseTypeSignature(DOUBLE),
             "power tower",
             RoutineCharacteristics.builder().setDeterminism(DETERMINISTIC).build(),
-            "pow(x, x)",
+            "RETURN pow(x, x)",
             Optional.empty());
 
     public static final SqlInvokedFunction FUNCTION_POWER_TOWER_DOUBLE_UPDATED = new SqlInvokedFunction(
@@ -53,7 +53,7 @@ public class SqlInvokedFunctionTestUtils
             parseTypeSignature(DOUBLE),
             "power tower",
             RoutineCharacteristics.builder().setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
-            "pow(x, x)",
+            "RETURN pow(x, x)",
             Optional.empty());
 
     public static final SqlInvokedFunction FUNCTION_POWER_TOWER_INT = new SqlInvokedFunction(
@@ -62,6 +62,6 @@ public class SqlInvokedFunctionTestUtils
             parseTypeSignature(INTEGER),
             "power tower",
             RoutineCharacteristics.builder().setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
-            "pow(x, x)",
+            "RETURN pow(x, x)",
             Optional.empty());
 }

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/SqlInvokedFunctionTestUtils.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/SqlInvokedFunctionTestUtils.java
@@ -34,7 +34,9 @@ public class SqlInvokedFunctionTestUtils
     {
     }
 
-    public static final QualifiedFunctionName POWER_TOWER = QualifiedFunctionName.of(new CatalogSchemaName("unittest", "memory"), "power_tower");
+    public static final String TEST_CATALOG = "unittest";
+
+    public static final QualifiedFunctionName POWER_TOWER = QualifiedFunctionName.of(new CatalogSchemaName(TEST_CATALOG, "memory"), "power_tower");
 
     public static final SqlInvokedFunction FUNCTION_POWER_TOWER_DOUBLE = new SqlInvokedFunction(
             POWER_TOWER,

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/SqlInvokedFunctionTestUtils.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/SqlInvokedFunctionTestUtils.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.sqlfunction.testing;
+package com.facebook.presto.functionNamespace.testing;
 
 import com.facebook.presto.spi.CatalogSchemaName;
 import com.facebook.presto.spi.function.QualifiedFunctionName;

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestSqlInvokedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestSqlInvokedFunctionNamespaceManager.java
@@ -30,6 +30,7 @@ import static com.facebook.presto.functionNamespace.testing.SqlInvokedFunctionTe
 import static com.facebook.presto.functionNamespace.testing.SqlInvokedFunctionTestUtils.FUNCTION_POWER_TOWER_DOUBLE_UPDATED;
 import static com.facebook.presto.functionNamespace.testing.SqlInvokedFunctionTestUtils.FUNCTION_POWER_TOWER_INT;
 import static com.facebook.presto.functionNamespace.testing.SqlInvokedFunctionTestUtils.POWER_TOWER;
+import static com.facebook.presto.functionNamespace.testing.SqlInvokedFunctionTestUtils.TEST_CATALOG;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
@@ -75,6 +76,7 @@ public class TestSqlInvokedFunctionNamespaceManager
     public void testTransactionalGetFunction()
     {
         InMemoryFunctionNamespaceManager functionNamespaceManager = new InMemoryFunctionNamespaceManager(
+                TEST_CATALOG,
                 new SqlInvokedFunctionNamespaceManagerConfig()
                         .setFunctionCacheExpiration(new Duration(0, MILLISECONDS))
                         .setFunctionInstanceCacheExpiration(new Duration(0, MILLISECONDS)));
@@ -145,7 +147,7 @@ public class TestSqlInvokedFunctionNamespaceManager
 
     private static InMemoryFunctionNamespaceManager createFunctionNamespaceManager()
     {
-        return new InMemoryFunctionNamespaceManager(new SqlInvokedFunctionNamespaceManagerConfig());
+        return new InMemoryFunctionNamespaceManager(TEST_CATALOG, new SqlInvokedFunctionNamespaceManagerConfig());
     }
 
     private static void assertPrestoException(Runnable runnable, ErrorCodeSupplier expectedErrorCode, String expectedMessageRegex)

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestSqlInvokedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestSqlInvokedFunctionNamespaceManager.java
@@ -11,15 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.metadata;
+package com.facebook.presto.functionNamespace;
 
+import com.facebook.presto.functionNamespace.testing.InMemoryFunctionNamespaceManager;
 import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
-import com.facebook.presto.sqlfunction.SqlInvokedFunctionNamespaceManagerConfig;
-import com.facebook.presto.testing.InMemoryFunctionNamespaceManager;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
@@ -27,21 +26,21 @@ import org.testng.annotations.Test;
 import java.util.Collection;
 import java.util.Optional;
 
+import static com.facebook.presto.functionNamespace.testing.SqlInvokedFunctionTestUtils.FUNCTION_POWER_TOWER_DOUBLE;
+import static com.facebook.presto.functionNamespace.testing.SqlInvokedFunctionTestUtils.FUNCTION_POWER_TOWER_DOUBLE_UPDATED;
+import static com.facebook.presto.functionNamespace.testing.SqlInvokedFunctionTestUtils.FUNCTION_POWER_TOWER_INT;
+import static com.facebook.presto.functionNamespace.testing.SqlInvokedFunctionTestUtils.POWER_TOWER;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
-import static com.facebook.presto.sqlfunction.testing.SqlInvokedFunctionTestUtils.FUNCTION_POWER_TOWER_DOUBLE;
-import static com.facebook.presto.sqlfunction.testing.SqlInvokedFunctionTestUtils.FUNCTION_POWER_TOWER_DOUBLE_UPDATED;
-import static com.facebook.presto.sqlfunction.testing.SqlInvokedFunctionTestUtils.FUNCTION_POWER_TOWER_INT;
-import static com.facebook.presto.sqlfunction.testing.SqlInvokedFunctionTestUtils.POWER_TOWER;
-import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-public class TestFunctionNamespaceManager
+public class TestSqlInvokedFunctionNamespaceManager
 {
     @Test
     public void testCreateFunction()
@@ -123,7 +122,7 @@ public class TestFunctionNamespaceManager
         assertEquals(function1, function2);
         assertNotSame(function1, function2);
 
-        // fetchFunctionMetadataDirect does not produce the same metdata reference
+        // fetchFunctionMetadataDirect does not produce the same metadata reference
         FunctionMetadata metadata1 = functionNamespaceManager.fetchFunctionMetadataDirect(function1.getRequiredFunctionHandle());
         FunctionMetadata metadata2 = functionNamespaceManager.fetchFunctionMetadataDirect(function2.getRequiredFunctionHandle());
         assertEquals(metadata1, metadata2);

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestSqlInvokedFunctionNamespaceManagerConfig.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestSqlInvokedFunctionNamespaceManagerConfig.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.sqlfunction;
+package com.facebook.presto.functionNamespace;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlConnectionConfig.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlConnectionConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestMySqlConnectionConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(MySqlConnectionConfig.class)
+                .setDatabaseUrl(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("database-url", "localhost:1080")
+                .build();
+        MySqlConnectionConfig expected = new MySqlConnectionConfig()
+                .setDatabaseUrl("localhost:1080");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManagerConfig.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManagerConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestMySqlFunctionNamespaceManagerConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(MySqlFunctionNamespaceManagerConfig.class)
+                .setFunctionNamespacesTableName("function_namespaces")
+                .setFunctionsTableName("sql_functions"));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("function-namespaces-table-name", "sql_function_namespaces")
+                .put("functions-table-name", "sql_invoked_functions")
+                .build();
+        MySqlFunctionNamespaceManagerConfig expected = new MySqlFunctionNamespaceManagerConfig()
+                .setFunctionNamespacesTableName("sql_function_namespaces")
+                .setFunctionsTableName("sql_invoked_functions");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -39,7 +39,8 @@ plugin.bundles=\
   ../presto-mysql/pom.xml,\
   ../presto-sqlserver/pom.xml, \
   ../presto-postgresql/pom.xml, \
-  ../presto-tpcds/pom.xml
+  ../presto-tpcds/pom.xml, \
+  ../presto-function-namespace-managers/pom.xml
 
 presto.version=testversion
 node-scheduler.include-coordinator=true

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -73,11 +73,6 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
-            <artifactId>presto-sql-function</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-expressions</artifactId>
         </dependency>
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespaceStore.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespaceStore.java
@@ -62,19 +62,15 @@ public class StaticFunctionNamespaceStore
     private void loadFunctionNamespaceManager(File file)
             throws Exception
     {
-        String functionNamespaceManagerId = getNameWithoutExtension(file.getName());
-
+        String catalogName = getNameWithoutExtension(file.getName());
         log.info("-- Loading function namespace manager from %s --", file);
         Map<String, String> properties = new HashMap<>(loadProperties(file));
 
         String functionNamespaceManagerName = properties.remove("function-namespace-manager.name");
         checkState(functionNamespaceManagerName != null, "Function namespace configuration %s does not contain function-namespace-manager.name", file.getAbsoluteFile());
 
-        String functionNamespaces = properties.remove("serving-namespaces");
-        checkState(functionNamespaces != null, "Function namespace configuration %s does not contain serving-namespaces", file.getAbsoluteFile());
-
-        functionManager.loadFunctionNamespaceManager(functionNamespaceManagerName, functionNamespaceManagerId, SPLITTER.splitToList(functionNamespaces), properties);
-        log.info("-- Added function namespaces [%s] using function namespace manager [%s] --", functionNamespaces, functionNamespaceManagerId);
+        functionManager.loadFunctionNamespaceManager(functionNamespaceManagerName, catalogName, properties);
+        log.info("-- Added function namespace manager [%s] --", catalogName);
     }
 
     private static List<File> listFiles(File dir)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -580,12 +580,12 @@ class StatementAnalyzer
             Scope functionScope = Scope.builder()
                     .withRelationType(RelationId.anonymous(), new RelationType(fields))
                     .build();
-            Type bodyType = analyzeExpression(node.getBody(), functionScope).getExpressionTypes().get(NodeRef.of(node.getBody()));
+            Type bodyType = analyzeExpression(node.getBody().getExpression(), functionScope).getExpressionTypes().get(NodeRef.of(node.getBody().getExpression()));
             if (!bodyType.equals(returnType)) {
                 throw new SemanticException(TYPE_MISMATCH, node, "Function implementation type '%s' does not match declared return type '%s'", bodyType, returnType);
             }
 
-            Analyzer.verifyNoAggregateWindowOrGroupingFunctions(analysis.getFunctionHandles(), metadata.getFunctionManager(), node.getBody(), "CREATE FUNCTION body");
+            Analyzer.verifyNoAggregateWindowOrGroupingFunctions(analysis.getFunctionHandles(), metadata.getFunctionManager(), node.getBody().getExpression(), "CREATE FUNCTION body");
 
             // TODO: Check body contains no SQL invoked functions
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlFunctionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlFunctionUtils.java
@@ -104,7 +104,8 @@ public final class SqlFunctionUtils
         ParsingOptions parsingOptions = ParsingOptions.builder()
                 .setDecimalLiteralTreatment(sqlFunctionProperties.isParseDecimalLiteralAsDouble() ? AS_DOUBLE : AS_DECIMAL)
                 .build();
-        return new SqlParser().createExpression(functionImplementation.getImplementation(), parsingOptions);
+        // TODO: Use injector-created SqlParser, which could potentially be different from the adhoc SqlParser.
+        return new SqlParser().createRoutineBody(functionImplementation.getImplementation(), parsingOptions).getExpression();
     }
 
     private static Map<String, Type> getFunctionArgumentTypes(FunctionMetadata functionMetadata, Metadata metadata)

--- a/presto-main/src/main/java/com/facebook/presto/transaction/DelegatingTransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/DelegatingTransactionManager.java
@@ -153,14 +153,14 @@ public class DelegatingTransactionManager
     }
 
     @Override
-    public void registerFunctionNamespaceManager(String functionNamespaceManagerName, FunctionNamespaceManager<?> functionNamespaceManager)
+    public void registerFunctionNamespaceManager(String catalogName, FunctionNamespaceManager<?> functionNamespaceManager)
     {
-        delegate.registerFunctionNamespaceManager(functionNamespaceManagerName, functionNamespaceManager);
+        delegate.registerFunctionNamespaceManager(catalogName, functionNamespaceManager);
     }
 
     @Override
-    public FunctionNamespaceTransactionHandle getFunctionNamespaceTransaction(TransactionId transactionId, String functionNamespaceManagerName)
+    public FunctionNamespaceTransactionHandle getFunctionNamespaceTransaction(TransactionId transactionId, String catalogName)
     {
-        return delegate.getFunctionNamespaceTransaction(transactionId, functionNamespaceManagerName);
+        return delegate.getFunctionNamespaceTransaction(transactionId, catalogName);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/transaction/InMemoryTransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/InMemoryTransactionManager.java
@@ -235,16 +235,16 @@ public class InMemoryTransactionManager
     }
 
     @Override
-    public synchronized void registerFunctionNamespaceManager(String functionNamespaceManagerId, FunctionNamespaceManager<?> functionNamespaceManager)
+    public synchronized void registerFunctionNamespaceManager(String catalogName, FunctionNamespaceManager<?> functionNamespaceManager)
     {
-        checkArgument(!functionNamespaceManagers.containsKey(functionNamespaceManagerId), "FunctionNamespaceManager %s is already registered", functionNamespaceManagerId);
-        functionNamespaceManagers.put(functionNamespaceManagerId, functionNamespaceManager);
+        checkArgument(!functionNamespaceManagers.containsKey(catalogName), "FunctionNamespaceManager is already registered for catalog [%s]", catalogName);
+        functionNamespaceManagers.put(catalogName, functionNamespaceManager);
     }
 
     @Override
-    public FunctionNamespaceTransactionHandle getFunctionNamespaceTransaction(TransactionId transactionId, String functionNamespaceManagerId)
+    public FunctionNamespaceTransactionHandle getFunctionNamespaceTransaction(TransactionId transactionId, String catalogName)
     {
-        return getTransactionMetadata(transactionId).getFunctionNamespaceTransaction(functionNamespaceManagerId).getTransactionHandle();
+        return getTransactionMetadata(transactionId).getFunctionNamespaceTransaction(catalogName).getTransactionHandle();
     }
 
     private void checkConnectorWrite(TransactionId transactionId, ConnectorId connectorId)
@@ -472,14 +472,14 @@ public class InMemoryTransactionManager
             return catalogMetadata;
         }
 
-        private synchronized FunctionNamespaceTransactionMetadata getFunctionNamespaceTransaction(String functionNamespaceManagerId)
+        private synchronized FunctionNamespaceTransactionMetadata getFunctionNamespaceTransaction(String catalogName)
         {
             checkOpenTransaction();
 
             return functionNamespaceTransactions.computeIfAbsent(
-                    functionNamespaceManagerId, id -> {
-                        verify(id != null, "Unknown function namespace manager: %s", id);
-                        FunctionNamespaceManager<?> functionNamespaceManager = functionNamespaceManagers.get(id);
+                    catalogName, catalog -> {
+                        verify(catalog != null, "catalog is null");
+                        FunctionNamespaceManager<?> functionNamespaceManager = functionNamespaceManagers.get(catalog);
                         FunctionNamespaceTransactionHandle transactionHandle = functionNamespaceManager.beginTransaction();
                         return new FunctionNamespaceTransactionMetadata(functionNamespaceManager, transactionHandle);
                     });

--- a/presto-main/src/main/java/com/facebook/presto/transaction/NoOpTransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/NoOpTransactionManager.java
@@ -98,7 +98,7 @@ public class NoOpTransactionManager
     }
 
     @Override
-    public void registerFunctionNamespaceManager(String functionNamespaceManagerName, FunctionNamespaceManager<?> functionNamespaceManager)
+    public void registerFunctionNamespaceManager(String catalogName, FunctionNamespaceManager<?> functionNamespaceManager)
     {
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/transaction/TransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/TransactionManager.java
@@ -54,9 +54,9 @@ public interface TransactionManager
 
     ConnectorTransactionHandle getConnectorTransaction(TransactionId transactionId, ConnectorId connectorId);
 
-    void registerFunctionNamespaceManager(String functionNamespaceManagerName, FunctionNamespaceManager<?> functionNamespaceManager);
+    void registerFunctionNamespaceManager(String catalogNames, FunctionNamespaceManager<?> functionNamespaceManager);
 
-    FunctionNamespaceTransactionHandle getFunctionNamespaceTransaction(TransactionId transactionId, String functionNamespaceManagerName);
+    FunctionNamespaceTransactionHandle getFunctionNamespaceTransaction(TransactionId transactionId, String catalogName);
 
     void checkAndSetActive(TransactionId transactionId);
 

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -26,6 +26,10 @@ standaloneExpression
     : expression EOF
     ;
 
+standaloneRoutineBody
+    : routineBody EOF
+    ;
+
 statement
     : query                                                            #statementDefault
     | USE schema=identifier                                            #use
@@ -170,6 +174,10 @@ alterRoutineCharacteristic
     ;
 
 routineBody
+    : returnStatement
+    ;
+
+returnStatement
     : RETURN expression
     ;
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -74,6 +74,7 @@ import com.facebook.presto.sql.tree.RenameColumn;
 import com.facebook.presto.sql.tree.RenameSchema;
 import com.facebook.presto.sql.tree.RenameTable;
 import com.facebook.presto.sql.tree.ResetSession;
+import com.facebook.presto.sql.tree.Return;
 import com.facebook.presto.sql.tree.Revoke;
 import com.facebook.presto.sql.tree.RevokeRoles;
 import com.facebook.presto.sql.tree.Rollback;
@@ -570,8 +571,9 @@ public final class SqlFormatter
             }
             builder.append("\n")
                     .append(formatRoutineCharacteristics(node.getCharacteristics()))
-                    .append("\nRETURN ")
-                    .append(formatExpression(node.getBody(), parameters));
+                    .append("\n");
+
+            process(node.getBody(), 0);
 
             return null;
         }
@@ -597,6 +599,15 @@ public final class SqlFormatter
             }
             builder.append(formatName(node.getFunctionName()));
             node.getParameterTypes().map(Formatter::formatTypeList).ifPresent(builder::append);
+
+            return null;
+        }
+
+        @Override
+        protected Void visitReturn(Return node, Integer indent)
+        {
+            append(indent, "RETURN ");
+            builder.append(formatExpression(node.getExpression(), parameters));
 
             return null;
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -118,6 +118,7 @@ import com.facebook.presto.sql.tree.RenameColumn;
 import com.facebook.presto.sql.tree.RenameSchema;
 import com.facebook.presto.sql.tree.RenameTable;
 import com.facebook.presto.sql.tree.ResetSession;
+import com.facebook.presto.sql.tree.Return;
 import com.facebook.presto.sql.tree.Revoke;
 import com.facebook.presto.sql.tree.RevokeRoles;
 import com.facebook.presto.sql.tree.Rollback;
@@ -216,6 +217,12 @@ class AstBuilder
     public Node visitStandaloneExpression(SqlBaseParser.StandaloneExpressionContext context)
     {
         return visit(context.expression());
+    }
+
+    @Override
+    public Node visitStandaloneRoutineBody(SqlBaseParser.StandaloneRoutineBodyContext context)
+    {
+        return visit(context.routineBody());
     }
 
     // ******************* statements **********************
@@ -421,7 +428,7 @@ class AstBuilder
                 getType(context.returnType),
                 comment,
                 getRoutineCharacteristics(context.routineCharacteristics()),
-                (Expression) visit(context.routineBody()));
+                (Return) visit(context.routineBody()));
     }
 
     @Override
@@ -445,7 +452,13 @@ class AstBuilder
     @Override
     public Node visitRoutineBody(SqlBaseParser.RoutineBodyContext context)
     {
-        return visit(context.expression());
+        return visit(context.returnStatement());
+    }
+
+    @Override
+    public Node visitReturnStatement(SqlBaseParser.ReturnStatementContext context)
+    {
+        return new Return((Expression) visit(context.expression()));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/SqlParser.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/SqlParser.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.parser;
 
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.Return;
 import com.facebook.presto.sql.tree.Statement;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
@@ -110,6 +111,11 @@ public class SqlParser
     public Expression createExpression(String expression, ParsingOptions parsingOptions)
     {
         return (Expression) invokeParser("expression", expression, SqlBaseParser::standaloneExpression, parsingOptions);
+    }
+
+    public Return createRoutineBody(String routineBody, ParsingOptions parsingOptions)
+    {
+        return (Return) invokeParser("routineBody", routineBody, SqlBaseParser::standaloneRoutineBody, parsingOptions);
     }
 
     private Node invokeParser(String name, String sql, Function<SqlBaseParser, ParserRuleContext> parseFunction, ParsingOptions parsingOptions)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -761,4 +761,9 @@ public abstract class AstVisitor<R, C>
     {
         return visitExpression(node, context);
     }
+
+    protected R visitReturn(Return node, C context)
+    {
+        return visitStatement(node, context);
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateFunction.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateFunction.java
@@ -31,19 +31,19 @@ public class CreateFunction
     private final String returnType;
     private final Optional<String> comment;
     private final RoutineCharacteristics characteristics;
-    private final Expression body;
+    private final Return body;
 
-    public CreateFunction(QualifiedName functionName, boolean replace, List<SqlParameterDeclaration> parameters, String returnType, Optional<String> comment, RoutineCharacteristics characteristics, Expression body)
+    public CreateFunction(QualifiedName functionName, boolean replace, List<SqlParameterDeclaration> parameters, String returnType, Optional<String> comment, RoutineCharacteristics characteristics, Return body)
     {
         this(Optional.empty(), replace, functionName, parameters, returnType, comment, characteristics, body);
     }
 
-    public CreateFunction(NodeLocation location, boolean replace, QualifiedName functionName, List<SqlParameterDeclaration> parameters, String returnType, Optional<String> comment, RoutineCharacteristics characteristics, Expression body)
+    public CreateFunction(NodeLocation location, boolean replace, QualifiedName functionName, List<SqlParameterDeclaration> parameters, String returnType, Optional<String> comment, RoutineCharacteristics characteristics, Return body)
     {
         this(Optional.of(location), replace, functionName, parameters, returnType, comment, characteristics, body);
     }
 
-    private CreateFunction(Optional<NodeLocation> location, boolean replace, QualifiedName functionName, List<SqlParameterDeclaration> parameters, String returnType, Optional<String> comment, RoutineCharacteristics characteristics, Expression body)
+    private CreateFunction(Optional<NodeLocation> location, boolean replace, QualifiedName functionName, List<SqlParameterDeclaration> parameters, String returnType, Optional<String> comment, RoutineCharacteristics characteristics, Return body)
     {
         super(location);
         this.functionName = requireNonNull(functionName, "functionName is null");
@@ -85,7 +85,7 @@ public class CreateFunction
         return characteristics;
     }
 
-    public Expression getBody()
+    public Return getBody()
     {
         return body;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Return.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Return.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class Return
+        extends Statement
+{
+    private final Expression expression;
+
+    public Return(Expression expression)
+    {
+        this(Optional.empty(), expression);
+    }
+
+    public Return(NodeLocation location, Expression expression)
+    {
+        this(Optional.of(location), expression);
+    }
+
+    private Return(Optional<NodeLocation> location, Expression expression)
+    {
+        super(location);
+        this.expression = requireNonNull(expression, "Expression is null");
+    }
+
+    public Expression getExpression()
+    {
+        return expression;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitReturn(this, context);
+    }
+
+    @Override
+    public List<Node> getChildren()
+    {
+        return ImmutableList.of(expression);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(expression);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        Return o = (Return) obj;
+        return Objects.equals(expression, o.expression);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("expression", expression)
+                .toString();
+    }
+}

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -102,6 +102,7 @@ import com.facebook.presto.sql.tree.RenameColumn;
 import com.facebook.presto.sql.tree.RenameSchema;
 import com.facebook.presto.sql.tree.RenameTable;
 import com.facebook.presto.sql.tree.ResetSession;
+import com.facebook.presto.sql.tree.Return;
 import com.facebook.presto.sql.tree.Revoke;
 import com.facebook.presto.sql.tree.RevokeRoles;
 import com.facebook.presto.sql.tree.Rollback;
@@ -1460,10 +1461,10 @@ public class TestSqlParser
                         "double",
                         Optional.of("tangent trigonometric function"),
                         new RoutineCharacteristics(SQL, DETERMINISTIC, RETURNS_NULL_ON_NULL_INPUT),
-                        new ArithmeticBinaryExpression(
+                        new Return(new ArithmeticBinaryExpression(
                                 DIVIDE,
                                 new FunctionCall(QualifiedName.of("sin"), ImmutableList.of(identifier("x"))),
-                                new FunctionCall(QualifiedName.of("cos"), ImmutableList.of(identifier("x"))))));
+                                new FunctionCall(QualifiedName.of("cos"), ImmutableList.of(identifier("x")))))));
 
         CreateFunction createFunctionRand = new CreateFunction(
                 QualifiedName.of("dev", "testing", "rand"),
@@ -1472,7 +1473,7 @@ public class TestSqlParser
                 "double",
                 Optional.empty(),
                 new RoutineCharacteristics(SQL, NOT_DETERMINISTIC, CALLED_ON_NULL_INPUT),
-                new FunctionCall(QualifiedName.of("rand"), ImmutableList.of()));
+                new Return(new FunctionCall(QualifiedName.of("rand"), ImmutableList.of())));
         assertStatement(
                 "CREATE OR REPLACE FUNCTION dev.testing.rand ()\n" +
                         "RETURNS double\n" +

--- a/presto-server/src/main/assembly/presto.xml
+++ b/presto-server/src/main/assembly/presto.xml
@@ -65,6 +65,10 @@
             <outputDirectory>plugin/session-property-managers</outputDirectory>
         </fileSet>
         <fileSet>
+            <directory>${project.build.directory}/dependency/presto-function-namespace-managers-${project.version}</directory>
+            <outputDirectory>plugin/function-namespace-managers</outputDirectory>
+        </fileSet>
+        <fileSet>
             <directory>${project.build.directory}/dependency/presto-jmx-${project.version}</directory>
             <outputDirectory>plugin/jmx</outputDirectory>
         </fileSet>

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManagerFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManagerFactory.java
@@ -21,5 +21,5 @@ public interface FunctionNamespaceManagerFactory
 
     FunctionHandleResolver getHandleResolver();
 
-    FunctionNamespaceManager<?> create(Map<String, String> config);
+    FunctionNamespaceManager<?> create(String catalogName, Map<String, String> config);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/RoutineCharacteristics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/RoutineCharacteristics.java
@@ -13,7 +13,11 @@
  */
 package com.facebook.presto.spi.function;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.facebook.presto.spi.function.RoutineCharacteristics.Determinism.DETERMINISTIC;
 import static com.facebook.presto.spi.function.RoutineCharacteristics.Determinism.NOT_DETERMINISTIC;
@@ -45,26 +49,30 @@ public class RoutineCharacteristics
     private final Determinism determinism;
     private final NullCallClause nullCallClause;
 
-    private RoutineCharacteristics(
-            Language language,
-            Determinism determinism,
-            NullCallClause nullCallClause)
+    @JsonCreator
+    public RoutineCharacteristics(
+            @JsonProperty("language") Optional<Language> language,
+            @JsonProperty("determinism") Optional<Determinism> determinism,
+            @JsonProperty("nullCallClause") Optional<NullCallClause> nullCallClause)
     {
-        this.language = requireNonNull(language, "language is null");
-        this.determinism = requireNonNull(determinism, "determinism is null");
-        this.nullCallClause = requireNonNull(nullCallClause, "nullCallClause is null");
+        this.language = language.orElse(SQL);
+        this.determinism = determinism.orElse(NOT_DETERMINISTIC);
+        this.nullCallClause = nullCallClause.orElse(CALLED_ON_NULL_INPUT);
     }
 
+    @JsonProperty
     public Language getLanguage()
     {
         return language;
     }
 
+    @JsonProperty
     public Determinism getDeterminism()
     {
         return determinism;
     }
 
+    @JsonProperty
     public NullCallClause getNullCallClause()
     {
         return nullCallClause;
@@ -119,9 +127,9 @@ public class RoutineCharacteristics
 
     public static class Builder
     {
-        private Language language = SQL;
-        private Determinism determinism = NOT_DETERMINISTIC;
-        private NullCallClause nullCallClause = CALLED_ON_NULL_INPUT;
+        private Language language;
+        private Determinism determinism;
+        private NullCallClause nullCallClause;
 
         private Builder() {}
 
@@ -152,7 +160,10 @@ public class RoutineCharacteristics
 
         public RoutineCharacteristics build()
         {
-            return new RoutineCharacteristics(language, determinism, nullCallClause);
+            return new RoutineCharacteristics(
+                    Optional.ofNullable(language),
+                    Optional.ofNullable(determinism),
+                    Optional.ofNullable(nullCallClause));
         }
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -335,10 +335,10 @@ public class DistributedQueryRunner
         log.info("Announced catalog %s (%s) in %s", catalogName, connectorId, nanosSince(start));
     }
 
-    public void loadFunctionNamespaceManager(String functionNamespaceManagerName, String functionNamespaceManagerId, List<String> catalogSchemaPrefix, Map<String, String> properties)
+    public void loadFunctionNamespaceManager(String functionNamespaceManagerName, String catalogName, Map<String, String> properties)
     {
         for (TestingPrestoServer server : servers) {
-            server.getMetadata().getFunctionManager().loadFunctionNamespaceManager(functionNamespaceManagerName, functionNamespaceManagerId, catalogSchemaPrefix, properties);
+            server.getMetadata().getFunctionManager().loadFunctionNamespaceManager(functionNamespaceManagerName, catalogName, properties);
         }
     }
 


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Add support for creating, altering, and dropping SQL functions with a MySQL-based storage. (:doc:`/admin/function-namespace-managers`)
```