### PR TITLE
Add release notes for 0.231

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.231
     release/release-0.230
     release/release-0.229
     release/release-0.228

--- a/presto-docs/src/main/sphinx/release/release-0.231.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.231.rst
@@ -1,0 +1,46 @@
+=============
+Release 0.231
+=============
+
+General Changes
+_______________
+* Add support for get partition names by filter.
+* Add forms of approx_percentile accepting an accuracy parameter.
+* Improve error handling for geometry deserialization edge cases.
+* Fix failures caused by invalid plans for queries with repeated lambda expressions in the order by clause.
+* Fix ScanFilterAndProjectOperator raw input bytes accounting for LazyBlocks.
+* Output (sum) string stat even if min/max values are too long. This is needed for the read-path to be able to better estimate the size of row.
+* Get PrestoS3FileSystem to work with the AWS Default Credentials Provider.
+* Optimizer performance for array_join.
+* Use more efficient implementation for ST_Buffer.  This produces fewer buffer points on rounded corners, which will produce very similar but different results.  JTS also better handles buffering with small (<1e-9) distances.
+* Fix an issue where server fails to start when two function namespace managers of the same type are specified.
+* OOM killer log output sorted to put memory heavy nodes and queries first.
+* Use JTS instead of Esri for many geometrical operations. + Polygon WKTs must have closed loops.  Previously Esri would close the loops for you. + Certain other invalid geometries will fail to be created from WKTs, such as `LINESTRING(0 0, 0 0, 0 0)`. + Returned WKTs may have a different point order. + Fixes incorrect calculation of extreme points in certain cases.
+* Fix SQL function compilation error when input parameters contain lambda.
+
+Verifier Changes
+________________
+* Add checks for the cardinalities sum when validating an array column.
+* Improve Verifier to skip verification when checksum query fails to compile.
+* Fix an issue where checksum query text and ID are not recorded if the checksum query fails.
+* Add new columns ``control_session_properties`` and `test_session_properties` to ``verifier_queries``, and remove column ``session_properties_json``. The value of the removed column can be copied to the two new columns for the schema change.
+* Add details of determinism analysis runs to the output.
+* Add configuration property ``max-determinism-analysis-runs`` to control maximum number of determinism analysis runs in case of column mismatch.
+* Add configuration property ``run-teardown-for-determinism-analysis`` to allow disabling teardown for determinism analysis runs.
+
+SPI Changes
+___________
+* Add API to check if the query is unexpectedly modified using the credentials passed in the identity.
+
+Hive Changes
+____________
+* Allow reading data from HDFS while caching the fetched data on local disks. Turn on the feature by specifying the cache directory config `cache.base-directory`.
+* Add support for parallel partition fetching for the Glue metastore.
+
+Parquet Changes
+_______________
+* Fix schema mismatch w/Parquet INT64 & Timestamp.
+
+Raptor Changes
+______________
+* Add the ability to read and write with delta deletes.


### PR DESCRIPTION
# Missing Release Notes
## Ariel Weisberg
- [ ] https://github.com/prestodb/presto/pull/13155 Cherry-pick documentation for cost, statistics, CBO (Merged by: Rebecca Schlussel)

## Jiexi Lin
- [ ] https://github.com/prestodb/presto/pull/11262 Merge partition preference when adding exchange nodes (Merged by: Jiexi Lin)

## Ke Wang
- [ ] https://github.com/prestodb/presto/pull/13849 Raptor background jobs (Merged by: Jiexi Lin)

## Rohit Jain
- [ ] https://github.com/prestodb/presto/pull/13905 Add max buffer size to Raptor session properties (Merged by: James Sun)

## Saksham Sachdev
- [ ] https://github.com/prestodb/presto/pull/13815 Revert "Consuming max buffer size from the session properties " (Merged by: Shixuan Fan)

## ptkool
- [ ] https://github.com/prestodb/presto/pull/13668 Fix IS DISTINCT FROM for decimals with precision > 18 (Merged by: Maria Basmanova)
- [ ] https://github.com/prestodb/presto/pull/10568 Add IGNORE NULLS clause to various Window functions (Merged by: Rongrong Zhong)

# Extracted Release Notes
- #13604 (Author: James A. Gill): Use JTS instead of ESRI for geometries, Parts 1 and 2
  - Use JTS instead of Esri for many geometrical operations. + Polygon WKTs must have closed loops.  Previously Esri would close the loops for you. + Certain other invalid geometries will fail to be created from WKTs, such as `LINESTRING(0 0, 0 0, 0 0)`. + Returned WKTs may have a different point order. + Fixes incorrect calculation of extreme points in certain cases.
- #13729 (Author: Anoop Johnson): Implement Parallel Partition Pruning for Glue Hive Metastore
  - Add support for parallel partition fetching for the Glue metastore.
- #13756 (Author: Ke Wang): Raptor read and write with delta delete functionality
  - Add the ability to read and write with delta deletes.
- #13758 (Author: Leiqing Cai): Verifier: Improve determinism analysis and checksum query recording
  - Fix an issue where checksum query text and ID are not recorded if the checksum query fails.
  - Add new columns ``control_session_properties`` and `test_session_properties` to ``verifier_queries``, and remove column ``session_properties_json``. The value of the removed column can be copied to the two new columns for the schema change.
  - Add details of determinism analysis runs to the output.
  - Add configuration property ``max-determinism-analysis-runs`` to control maximum number of determinism analysis runs in case of column mismatch.
  - Add configuration property ``run-teardown-for-determinism-analysis`` to allow disabling teardown for determinism analysis runs.
- #13796 (Author: Rongrong Zhong): Make SQL function work for input parameters with lambda
  - Fix SQL function compilation error when input parameters contain lambda.
- #13820 (Author: Ariel Weisberg): Sort OOM killer log output
  - OOM killer log output sorted to put memory heavy nodes and queries first.
- #13824 (Author: James A. Gill): Use JTS for ST_Buffer
  - Use more efficient implementation for ST_Buffer.  This produces fewer buffer points on rounded corners, which will produce very similar but different results.  JTS also better handles buffering with small (<1e-9) distances.
- #13842 (Author: Leiqing Cai): Fix function namespace manager instantiation failure
  - Fix an issue where server fails to start when two function namespace managers of the same type are specified.
- #13853 (Author: Leiqing Cai): Skip verification when checksum query fails to compile
  - Improve Verifier to skip verification when checksum query fails to compile.
- #13857 (Author: Ariel Weisberg): Fix schema mismatch w/Parquet INT64 & Timestamp
  - Fix schema mismatch w/Parquet INT64 & Timestamp.
- #13858 (Author: Anoop Johnson): Get PrestoS3FileSystem to work with the AWS Default Credentials Provider
  - Get PrestoS3FileSystem to work with the AWS Default Credentials Provider.
- #13871 (Author: James A. Gill): Add approx_percentile forms with accuracy
  - Add forms of approx_percentile accepting an accuracy parameter.
- #13873 (Author: James Petty): Fix raw input stats for ScanFilterAndProject
  - Fix ScanFilterAndProjectOperator raw input bytes accounting for LazyBlocks.
- #13874 (Author: Wenlei Xie): Optimize array_join by supporting PROVIDED_BLOCKBUILDER convention
  - Optimizer performance for array_join.
- #13878 (Author: Yi He): Add query integrity check in AccessControlManager
  - Add API to check if the query is unexpectedly modified using the credentials passed in the identity.
- #13879 (Author: Islam Ismailov): Keep sum stat for string when min/max stat is too long in ORC writer
  - Output (sum) string stat even if min/max values are too long. This is needed for the read-path to be able to better estimate the size of row.
- #13898 (Author: Ajay George): Add support for get partition names by filter
  - Add support for get partition names by filter.
- #13901 (Author: Rebecca Schlussel): Fix invalid plan for repeated lambdas in order by
  - Fix failures caused by invalid plans for queries with repeated lambda expressions in the order by clause.
- #13904 (Author: Rohit Jain): Add caching file system to hive connector
  - Allow reading data from HDFS while caching the fetched data on local disks. Turn on the feature by specifying the cache directory config `cache.base-directory`.
- #13916 (Author: Yi Shen): Add sum of cardinality for array column verifier results
  - Add checks for the cardinalities sum when validating an array column.
- #13922 (Author: James A. Gill): Improve error handling for geometry deserialization edge cases
  - Improve error handling for geometry deserialization edge cases.

# All Commits
- 9a9ed949fe8e8b1865067087a587b598ed39f309 Check retryable errors are all recoginzed (Leiqing Cai)
- ca6a2d30da7650c9bfb927a37419de5d61d9c0ff Allow more flexible construction of PrestoExceptionClassifier (Leiqing Cai)
- a5bb640346201a27d86ace9568fcbc5753c63a74 Add support for get partition names by filter (Ajay George)
- d22cd7dc5601f389d88bfe2fc1744ec2f7b4e210 Remove totalPartitions from TaskUpdateRequest (Andrii Rosa)
- 2b7926f6613e221ad3b8906e986dd8554bd97692 Add approx_percentile forms with accuracy (James A. Gill)
- 262b74ff7b38320e246d2f928927144359ccae19 Refactor approx_percentile functions (James A. Gill)
- fbb9e987f12a2d3b6ff2c0d041dbd6cf2f6fcca9 Capture geometry deserialization failures (James A. Gill)
- 910374b4975e62dee41b0d727ba15a10983c9ef2 Use helper method jtsGeometryFromWkt (James A. Gill)
- 82c9ea00140b38d8e688b73e33cc85f0daefa2f1 Publish tarball for Verifier (Leiqing Cai)
- 628afede26a354bb5b7bde970d61203f40a97c79 Fix corrupted verifier executable jar (Leiqing Cai)
- fd5954701491fca86fee90722f62050d2d06bb45 Fix invalid plan for repeated lambdas in order by (Rebecca Schlussel)
- f94809283ac923eeeb0152f27f64039646d1c49f Move OptimizeMixedDistinctAggregations below Logical Optimization (Saksham Sachdev)
- 3f8d9dadfb37df0c3da792f9dc851314b99c6ffe Inject cache manager for Raptor HdfsModule with provider (James Sun)
- 2762513b0d255184b5d6eda1b4c1db48e8f996cc Add caching file system to hive connector (Rohit Jain)
- 5e574285b11ebf621e1d3e6114336aaeb384338a Add high level CBO documentation (Ariel Weisberg)
- 73708387222da70c23c1301cdf6873bead405df5 Add documentation for cost and statistics (Lukasz Osipiuk)
- b21915299b609f673680275204a97e0b15812ef1 Increase visibility of the PrestoSystemRequirements (Andrii Rosa)
- 48fe432a86f13380899858a8ae8fbb9ec343dbfd Introduce RemoteSourceFactory abstraction (Andrii Rosa)
- 8a11650a586974374f97ba582388cc3e4affd3a7 Expose connector property for TPCH partitioning (Andrii Rosa)
- 0f14563c3cc7d067aea366974d1441c267aa7412 Make require Hadoop native configurable (Andrii Rosa)
- 072f6456ba788379218b2ce3c28b30da616ad91c Refactor TableScanOperator stats collection (James Petty)
- 0191168f2af77d4051342af3ecf7d8d3a4ce282e Fix raw input stats for ScanFilterAndProject (James Petty)
- 176e8f8a4db4ce50e02c0fb11da28702e52aeb89 Add checks for the cardinalities sum when validating an array column (Yi Shen)
- ad998854aff9e021083e244477dbf5f5fcd7a31f Repurpose OrderableArrayColumnValidator to support all array types (Yi Shen)
- 659c3ee91bbddfb0f61cce4c7bc544c4010f3633 Optimize ByteSelectiveStreamReader for no filter with nulls (Ying Su)
- bdea351ade9e88a83122733cfe5727f3f3634ef8 Allow hive outstanding splits size limit larger than 2GB (James Petty)
- 58247b0329002d8e570b02a3cb3e2db1400b977f Skip logging of GCStatusMonitor state if there is no activity (Ajay George)
- 3a4f2e3e53e741b82297c8f2416c78047f2aa308 Optimize boolean reader when reading contiguous rows with no nulls and no filter (Eugene Kalenkovich)
- 01852884c5cf834ec02cf5b17fb2fa1182a6e374 Clean up arrays in ORC dictionary after close (James Sun)
- b2a5e7031212d876518b214617f5e7ff75e5d7d6 Make BenchmarkSelectiveStreamReaders load LazyBlock (Eugene Kalenkovich)
- 9016a06b51db3d331f48eafe07831d35af393265 This patch updates the description for redis.key-prefix-schema-table to (Joseph Gmitter)
- 1a3d5ffd845d65f2dc729479a828b07947df37fc Fix IS DISTINCT FROM for long decimals (ptkool)
- 49ea39b6a98c88b26ff7d68d2c1b4d8007c41080 Add session property to disable adaptive filter reordering (Masha Basmanova)
- eb207f81fee9f400f7fb6ff0ce8d497d3979160f Cache results of TupleDomainFilterUtils::toFilter (Masha Basmanova)
- 7360bce7c16d690e21aeacd3caab60c042269f14 Add max buffer size to Raptor session properties (Rohit Jain)
- 84d9f0a6f1c6b83b5ec9b672251850991264480c Eliminate duplicate table name to avoid conflict in TestRaptorIntegrationSmokeTest (Ke Wang)
- 241a3f5e020b86e7cfe1088d9162504f2396f349 Keep sum stat for string when min/max stat is too long in ORC writer (Islam Ismailov)
- 25e1d79d32ae5ae2a115c5ef98057c379d9b7ba0 Add query integrity check in AccessControlManager (Yi He)
- c8fc21e67bf11f17fd4707654f2c09ac138a9cdc Integrate PrestoS3FileSystem with AWS Default Credentials Provider (Anoop Johnson)
- f4f888217c887845222e17648fa924678958ce87 Cache optimized RowExpression predicate (Bhavani Hari)
- 5177bea5654f55ed3b38ac67cb9597e2c5ec5052 Fix requiredField logic in StructSelectiveStreamReader (Bhavani Hari)
- 5f781d32e1fd1b0057b12fac033975b931a9c21d Add delta in reassign process (Ke Wang)
- a60985c7cb9c127eb8731ce231c4b62913cd8711 Add priority to Compaction process (Ke Wang)
- 618b0afe9276e4d6f6ccb052c36db7616f79149b Enable delta compaction and organization (Ke Wang)
- 145a652917870c84f48b0f24a4402725b24b3e48 Handle failed queries and execute remaining (Nikhil Collooru)
- 522c91248c7c4f6af5e6b648498df5b618304b18 Create benchmark runner entry point (Nikhil Collooru)
- 094536133461513a0a6428055887cb519d02310b Add benchmark runner logic (Nikhil Collooru)
- d58d6877326b61943c26c35efb89610f68536b11 Export results using event clients (Nikhil Collooru)
- 96d1a0420c46ed6a2442a3598dad5e7c9599e9c1 Support execution of concurrent phases (Nikhil Collooru)
- eacf13484139a85c53901f2045578c659a65a5b2 Provide retry utilities for benchmark runner (Nikhil Collooru)
- 2c4b93bee679fc6df38ff68611e13bd716d5bd50 Support querying Presto in benchmark runner (Nikhil Collooru)
- fdb76117b90544fcaed2d10f8b398bdfdcf333be Optimize array_join by supporting PROVIDED_BLOCKBUILDER convention (Wenlei Xie)
- ce688136d9a45af6aea8853b0da159198eb3c512 Move ExtractSpatialJoins to after LogicalOptimization (Saksham Sachdev)
- 82e90bf8ca557e864db4670c1c5349497138e252 Control merging partitioning in aggregation node via session property (Jiexi Lin)
- 43e8c02eacbe80c29be397f90d15062254cf0839 Force repartition when aggregation node has mixed grouping sets (Jiexi Lin)
- 8abba9e905c0a8b7225caea6746596507fb1fed6 Use JTS for ST_Buffer (James A. Gill)
- 584a92f362e4ad9546e0dbf7171ab8f6361ab1bd Add Benchmarks for ST_Buffer (James A. Gill)
- 7db5fbf09d5899a2fd837f39b72c565461acaa2e Add Geometry construction methods to GeometryBenchmarkUtils (James A. Gill)
- 7a38da852c2bdb43de3320683dab44d655ec17f8 Fix double and float comparisons for NaNs (Bhavani Hari)
- 78410289d39d36d07351dad918bd2e9bfbf43994 Refactor OrcPageSource (Ke Wang)
- c533c6f2d1d21cd14c117f7c1db57c339a80f2a7 Export statistics of delta delete (Ke Wang)
- e2af4369cfca4040d08079df2a0114823aa24b7f Commit protocol for rewrite delete, delta delete (Ke Wang)
- 2a97a86f2e46732be7ddb86fb38201504ccf3c89 Add delta delete functionality on worker (Ke Wang)
- 3749dad43496740b4baeac1520ebac10ed71e85c Enhance RaptorSplit and enable delta read (Ke Wang)
- e01dda24e674dca2fad109d41c337995a34cc7c2 Increase timeout in TestBackupManager#testCorruption (Leiqing Cai)
- 58b376713a6eaa49e3b1ffaf1ae441fe37d2609a Remove unused variable from BigintValuesUsingHashTable (Masha Basmanova)
- c7d8f5534e03271127ffd88f7c0419834b6ccc55 Use bitmask for IN filter when range of values is small (Masha Basmanova)
- 49a9cd9c5fbfc547e65d9d1c75ceac80475e6827 Rename BigintValues to BigintValuesUsingHashTable (Masha Basmanova)
- bdd91af8cfac6a2d4a560f4dc92218881738f7a3 Optimize and refactor array_distinct, array_filter and array_sort (Sreeni Viswanadha)
- a123e5c2a54bfdd7b2ee8860ae62671c146bbdd4 Enable subfield pruning to pass through arbitrary() function (Gautam Parai)
- 62c4524818a33c4d18472fa25c0be1e28781c647 Modify table definition for new testcases (Gautam Parai)
- cb4ffb3f4c20260553cb4e9952b83ee8858c2138 Disable TestDistributedSpilledQueries#testLimitWithJoin (Leiqing Cai)
- 55458740ea5552f70fe637de23a6cb08e5814da3 Skip verification when checksum query fail to compile (Leiqing Cai)
- bb17af3c68b0f45887f4cf97660e1ec7e892e322 Fix schema mismatch w/Parquet INT64 & Timestamp (Ariel Weisberg)
- 53bb79fcdb6b901f8c70b579c8287ce94f3f2b74 Fix SQL formatting for CREATE FUNCTION (Leiqing Cai)
- ab80d8d455e7751fb72a7707fd907f362fb0fde5 Fix function namespace manager instantiation failure (Leiqing Cai)
- c270e801662b2ab87169ea10c209a5e77bea7c62 Sort OOM killer log output (Ariel Weisberg)
- 762b183c7c0d2599fd882f6e6fb71cb228e90772 Fix selective stream readers (Masha Basmanova)
- 469637d75bab64782455d13b3cfe4452cee748f8 Set boolean value to 0 if the position is null (Andrii Rosa)
- 8c2dac4a038fba75a1857d7715c0436624712098 Check aggregation mask values for null (Andrii Rosa)
- 378e0631a28fbd826aab2713cf9a7eec5b05f734 Log queries and tasks memory reservation on full GC (Kelvin Fann)
- 77eb6e00e2120e97d4d70166419e10a5cefb5763 Create zero row files without overwrite flag (Andrii Rosa)
- efb0c6bac823fd1752f68e18be7a832fee3222e3 Rename PrestoResourceClient to NodeResourceClient (Nikhil Collooru)
- 692eb2d659b0ecc0ad66c65c7f5e9a936cbe5af7 Fix deserailization error in verifier (Nikhil Collooru)
- 95eb8a443eda4dd6c8463e221e35430aaabad959 Remove Unused Argument in ParquetPageSource (James Petty)
- 85fa3e7df41d7acb6c0a7d304eb58441d19449e7 Remove Redundant Parquet Column Index Lookups (James Petty)
- b6aa6e954680981651a2beb1239d017b56aa5261 Populate basic query info for skipped events in Verifier (Leiqing Cai)
- 95a6f6df1b7338b6318e11fde5713c80ca1bd479 Optimize zero row files creation for bucketed tables (Andrii Rosa)
- 0ade47431491c1fd272e4782d6af50cbfaf10104 Optimize loop over filter functions in applyFilterFunctions (Masha Basmanova)
- e91595d63fb8372f40b0415eab655b9c273e25f4 Reorder filters at runtime (Masha Basmanova)
- 789364e2d3ce8deb541a857ad4de250037d0e643 Track filter function performance (Masha Basmanova)
- 48e622014300b9c489081036dbc183eb9965c8f7 Add toString method to TIMESTAMP reader (Masha Basmanova)
- ac93bd66a88c703dababa68b444cb0d0efb99e7e Evaluate filter function as soon as all inputs have been read (Masha Basmanova)
- 5589d3dfc420d16591e4fdbd6fd704a81d152492 Read columns of primitive types first (Masha Basmanova)
- 3938c792e274b543862ec0bc72933a2c56d0d2fa Use a constant for empty page (Masha Basmanova)
- b526246cdb9d3f38e17d709abf1c4f7a9bd42b52 Fix BooleanInputStream#getSetBits (Masha Basmanova)
- 98b8c8d7ffdeea319b8e7bdd0577f2e9546868c1 Minor refactor to TableFinishOperator (Wenlei Xie)
- 46ae1085deb68dad344da9ae4160dbed8749da6d Rename GeometrySerde to EsriGeometrySerde (James A. Gill)
- ab3297768fdd90ff9a6a4804c23c850e09e48d10 Convert GeoFunctions to JTS: Part 2 (James A. Gill)
- a5eec6ca631244f9ee397a8a1fb03450a5713536 Convert WKT functions to JTS (James A. Gill)
- f66cb96ccd155bdfab6d4cf97f488aa54291dea3 Upgrade JTS to 1.16.1 (James Gill)
- 951eb8df59a3a954b62d00580b57d4939c293535 Reduce Memory used by Finished AsyncQueue Instances (James Petty)
- 0f7061f9b152998479040c24a0b9740ad7aa2579 Enable bucket pruning for IN predicates (Gautam Parai)
- 40d35ee4002228084476deddfd78f61ea9578b53 Display bucket pruning info in hive table layout (Gautam Parai)
- e94f2c19210c056c4613c9fbbbe231914ace42fd Revert "Consuming max buffer size from the session properties instead of configs in the Raptor page sink provider." (Saksham)
- 1d2be6c855fb62587f0d2943a4371fa01b86c307 Consuming max buffer size from the session properties instead of configs in the Raptor page sink provider. (Rohit Jain)
- b9780259ee705022cd6bfe9f28de355721963624 Implement Parallel Partition Pruning for Glue Hive Metastore (Anoop Johnson)
- 6436aa6ca8663cd31e2b1f7ffcd6670ecacef02a Fail creation of table with unsupported bucket count (Vic Zhang)
- f582c6ff85cb652d62f652e584b1067d66a3fe84 Add a method to compare SqlInvokedFunction (Leiqing Cai)
- 22f70d4bea0eb842146ee57f53049edc3eedb7af Fix pushdown for filters on multiple subfields of a struct (Masha Basmanova)
- 1d323240ef5628fb5fc05ebb866bc47bf218e888 Make SQL function work for input parameters with lambda (Rongrong Zhong)
- 91f3ce774f5ef41b7508dbab8c205de5b79485f8 Make TestUpgradeMetadata single threaded (Leiqing Cai)
- d838c9baa7e0922d9195abeb93657d5002a51221 Add an option to disable teardown for determinism analysis runs (Leiqing Cai)
- 2d5ded921fd550feac4176679a1c453cd1a9dbdf Fix variable name in VerifierConfig (Leiqing Cai)
- 5de945e7e894942e1ad244dd857e6c06bf4f2048 Make determinism analysis run count configurable (Leiqing Cai)
- bba5aa272fa4397f54d0fbc4689ffd585f565ecf Export determinism analysis details (Leiqing Cai)
- 7cedd3762cb43483465d3a2a8c41d332ccca55b2 Export checksum query and query id even if the query fails (Leiqing Cai)
- 2d3a241ea9425b4de5f93ebf7966a63956e96918 Make tableName required in QueryBundle (Leiqing Cai)
- ed547be3a602b70546b2e173e3c779f3b45e8f0a Move LimitQueryDeterminismAnalyzer.Analysis to top level (Leiqing Cai)
- e91519a384d18094ce19fee44c8bbfe84c6cfcf1 Use different columns for control and test session properties (Leiqing Cai)
- f074d639ba4e8186accfada14334051f28baf229 Move verifier_queries table creation SQL to VerifierDao (Leiqing Cai)
- bc565ebf60f0fc2ee5974df8b84d465d0d4f9ca6 Fix flaky test TestRetryDriver (Leiqing Cai)
- 70ab7acba57703e7a73019823d68b3240ed7b0d6 Check column exist before alter table for raptor delta delete (Ke Wang)
- 36e4e8677a073dbdb51bcf10b290e54369d4a56f Update hive.rst with Alluxio docs (Haoyuan Li)
- 7efeecc58fd612f3e8d1bf00f418dccb84d4d0ae Add support for null treatment clause to various window functions (ptkool)
- 350f1cde19ba53d2a884642003c8e2aa8377aa8e Create NestedField using lowercase field name (Masha Basmanova)
- e9c57c81439ebb581c7c942da066934fe1ae6546 Make subfield name matching case insensitive (Masha Basmanova)