### PR TITLE
Avoid Java stream in NodePartitioningManager#createArbitraryBucketToNode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
@@ -32,17 +32,16 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.split.EmptySplit;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableList;
 
 import javax.inject.Inject;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.ToIntFunction;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static com.facebook.presto.SystemSessionProperties.getMaxTasksPerStage;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -165,7 +164,7 @@ public class NodePartitioningManager
         return new FixedBucketNodeMap(
                 getSplitToBucket(session, partitioningHandle),
                 createArbitraryBucketToNode(
-                        new ArrayList<>(nodeScheduler.createNodeSelector(partitioningHandle.getConnectorId().get()).selectRandomNodes(getMaxTasksPerStage(session))),
+                        nodeScheduler.createNodeSelector(partitioningHandle.getConnectorId().get()).selectRandomNodes(getMaxTasksPerStage(session)),
                         connectorBucketNodeMap.getBucketCount()));
     }
 
@@ -218,15 +217,13 @@ public class NodePartitioningManager
 
     private static List<InternalNode> createArbitraryBucketToNode(List<InternalNode> nodes, int bucketCount)
     {
-        return cyclingShuffledStream(nodes)
-                .limit(bucketCount)
-                .collect(toImmutableList());
-    }
+        List<InternalNode> shuffledNodes = new ArrayList<>(nodes);
+        Collections.shuffle(shuffledNodes);
 
-    private static <T> Stream<T> cyclingShuffledStream(Collection<T> collection)
-    {
-        List<T> list = new ArrayList<>(collection);
-        Collections.shuffle(list);
-        return Stream.generate(() -> list).flatMap(List::stream);
+        ImmutableList.Builder<InternalNode> distribution = ImmutableList.builderWithExpectedSize(bucketCount);
+        for (int i = 0; i < bucketCount; i++) {
+            distribution.add(shuffledNodes.get(i % shuffledNodes.size()));
+        }
+        return distribution.build();
     }
 }


### PR DESCRIPTION
We recently observed two issues in production with
NodePartitioningManager#createArbitraryBucketToNode:

1. Under certain workloads, the Java Stream API shows non-trivial memory
allocation overhead:
```
--- Execution profile ---
Total samples:         3308476
Non-Java:              18 (0.00%)
Skipped:               1990244 (60.16%)

Frame buffer usage:    37.1651%

--- 5030131592 bytes (5.87%), 438 samples
  [ 0] java.util.stream.ReferencePipeline$Head
  [ 1] java.util.stream.StreamSupport.stream
  [ 2] java.util.Collection.stream
  [ 3] com.facebook.presto.sql.planner.NodePartitioningManager$$Lambda$3966.1318525599.apply
  [ 4] java.util.stream.ReferencePipeline$7$1.accept
  [ 5] java.util.stream.StreamSpliterators$InfiniteSupplyingSpliterator$OfRef.tryAdvance
  [ 6] java.util.stream.ReferencePipeline.forEachWithCancel
  [ 7] java.util.stream.AbstractPipeline.copyIntoWithCancel
  [ 8] java.util.stream.AbstractPipeline.copyInto
  [ 9] java.util.stream.AbstractPipeline.wrapAndCopyInto
  [10] java.util.stream.ReduceOps$ReduceOp.evaluateSequential
  [11] java.util.stream.AbstractPipeline.evaluate
  [12] java.util.stream.ReferencePipeline.collect
  [13] com.facebook.presto.sql.planner.NodePartitioningManager.createArbitraryBucketToNode
  [14] com.facebook.presto.sql.planner.NodePartitioningManager.getNodePartitioningMap
  [15] com.facebook.presto.execution.scheduler.SqlQueryScheduler.lambda$null$7
  [16] com.facebook.presto.execution.scheduler.SqlQueryScheduler$$Lambda$3930.304871149.apply
  [17] java.util.HashMap.computeIfAbsent
  [18] com.facebook.presto.execution.scheduler.SqlQueryScheduler.lambda$createStageExecutions$8
  [19] com.facebook.presto.execution.scheduler.SqlQueryScheduler$$Lambda$3921.1181870979.apply
  [20] com.facebook.presto.execution.scheduler.SqlQueryScheduler.getBucketToPartition
  [21] com.facebook.presto.execution.scheduler.SqlQueryScheduler.createStreamingLinkedStageExecutions
  [22] com.facebook.presto.execution.scheduler.SqlQueryScheduler.createStreamingLinkedStageExecutions
  [23] com.facebook.presto.execution.scheduler.SqlQueryScheduler.createStageExecutions
  [24] com.facebook.presto.execution.scheduler.SqlQueryScheduler.<init>
  [25] com.facebook.presto.execution.scheduler.SqlQueryScheduler.createSqlQueryScheduler
  [26] com.facebook.presto.execution.SqlQueryExecution.planDistribution
  [27] com.facebook.presto.execution.SqlQueryExecution.startExecution
  [28] com.facebook.presto.execution.SqlQueryExecution$$Lambda$3179.1952738377.run
  [29] java.util.concurrent.Executors$RunnableAdapter.call
  [30] java.util.concurrent.FutureTask.run
  [31] java.util.concurrent.ThreadPoolExecutor.runWorker
  [32] java.util.concurrent.ThreadPoolExecutor$Worker.run
  [33] java.lang.Thread.run
```

2. In some rare case on a long running coordinator (e.g. >10 days), we
see thread may stuck in the stream API call:
```
   java.lang.Thread.State: RUNNABLE
        at java.util.stream.StreamOpFlag.fromCharacteristics(java.base@10/StreamOpFlag.java:733)
        at java.util.stream.StreamSupport.stream(java.base@10/StreamSupport.java:70)
        at java.util.Collection.stream(java.base@10/Collection.java:659)
        at com.facebook.presto.sql.planner.NodePartitioningManager$$Lambda$3966/1318525599.apply(Unknown Source)
        at java.util.stream.ReferencePipeline$7$1.accept(java.base@10/ReferencePipeline.java:271)
        at java.util.stream.StreamSpliterators$InfiniteSupplyingSpliterator$OfRef.tryAdvance(java.base@10/StreamSpliterators.java:1360)
        at java.util.stream.ReferencePipeline.forEachWithCancel(java.base@10/ReferencePipeline.java:127)
        at java.util.stream.AbstractPipeline.copyIntoWithCancel(java.base@10/AbstractPipeline.java:502)
        at java.util.stream.AbstractPipeline.copyInto(java.base@10/AbstractPipeline.java:488)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(java.base@10/AbstractPipeline.java:474)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(java.base@10/ReduceOps.java:913)
        at java.util.stream.AbstractPipeline.evaluate(java.base@10/AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.collect(java.base@10/ReferencePipeline.java:578)
        at com.facebook.presto.sql.planner.NodePartitioningManager.createArbitraryBucketToNode(NodePartitioningManager.java:223)
        at com.facebook.presto.sql.planner.NodePartitioningManager.getNodePartitioningMap(NodePartitioningManager.java:128)
        at com.facebook.presto.execution.scheduler.SqlQueryScheduler.lambda$null$7(SqlQueryScheduler.java:355)
        at com.facebook.presto.execution.scheduler.SqlQueryScheduler$$Lambda$3930/304871149.apply(Unknown Source)
        at java.util.HashMap.computeIfAbsent(java.base@10/HashMap.java:1138)
        at com.facebook.presto.execution.scheduler.SqlQueryScheduler.lambda$createStageExecutions$8(SqlQueryScheduler.java:355)
        at com.facebook.presto.execution.scheduler.SqlQueryScheduler$$Lambda$3921/1181870979.apply(Unknown Source)
        at com.facebook.presto.execution.scheduler.SqlQueryScheduler.getBucketToPartition(SqlQueryScheduler.java:618)
```

The stream API is introduced for this method in
0195ffd4368b1595952d21477cf83df695719255, when migrating from map to
list for bucket-to-node. 

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== NO RELEASE NOTE ==
```
