### PR TITLE
Promote Elasticsearch scan performance with index sorting

### DIFF
--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchQueryBuilder.java
@@ -33,7 +33,6 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
-import org.elasticsearch.search.sort.SortOrder;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -55,6 +54,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.action.search.SearchType.QUERY_THEN_FETCH;
+import static org.elasticsearch.search.sort.SortOrder.ASC;
 
 public class ElasticsearchQueryBuilder
 {
@@ -103,6 +103,9 @@ public class ElasticsearchQueryBuilder
         List<String> fields = columns.stream()
                 .map(ElasticsearchColumnHandle::getColumnName)
                 .collect(toList());
+        // Scroll requests have optimizations that make them faster when the sort order is _doc.
+        // If you want to iterate over all documents regardless of the order, this is the most efficient option
+        // With this settings, the performance can promote several times.
         SearchRequestBuilder searchRequestBuilder = client.prepareSearch(indices)
                 .setTypes(type)
                 .setSearchType(QUERY_THEN_FETCH)
@@ -110,10 +113,7 @@ public class ElasticsearchQueryBuilder
                 .setFetchSource(fields.toArray(new String[0]), null)
                 .setQuery(buildSearchQuery())
                 .setPreference("_shards:" + shard)
-                // Scroll requests have optimizations that make them faster when the sort order is _doc.
-                // If you want to iterate over all documents regardless of the order, this is the most efficient option
-                // With this settings, the performance can promote several times.
-                .addSort("_doc", SortOrder.ASC)
+                .addSort("_doc", ASC)
                 .setSize(scrollSize);
         LOG.debug("Elasticsearch Request: %s", searchRequestBuilder);
         return searchRequestBuilder;

--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchQueryBuilder.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.search.sort.SortOrder;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -109,6 +110,10 @@ public class ElasticsearchQueryBuilder
                 .setFetchSource(fields.toArray(new String[0]), null)
                 .setQuery(buildSearchQuery())
                 .setPreference("_shards:" + shard)
+                // Scroll requests have optimizations that make them faster when the sort order is _doc.
+                // If you want to iterate over all documents regardless of the order, this is the most efficient option
+                // With this settings, the performance can promote several times.
+                .addSort("_doc", SortOrder.ASC)
                 .setSize(scrollSize);
         LOG.debug("Elasticsearch Request: %s", searchRequestBuilder);
         return searchRequestBuilder;


### PR DESCRIPTION
>  Scroll requests have optimizations that make them faster when the sort order is _doc. If you want to iterate over all documents regardless of the order, this is the most efficient option

 [https://www.elastic.co/guide/en/elasticsearch/reference/7.5/search-request-body.html#request-body-search-scroll](scroll request)

When Elasticsearch process the scroll request with `_doc` sort,  it will use `MinDocQuery` combined with the user's original query , which show as below:

https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java#L175-L182

This `scan-scroll` request we also used on `Apache - incubator-doris`:

https://github.com/apache/incubator-doris/blob/master/be/src/exec/es/es_scroll_query.cpp#L118-L120

This PR would promote about 30%+  scan-filter  performance for presto-elsticsearch-connector 

