### PR TITLE
Improve correctness check for queries that produce columns of RowType

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ChecksumValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ChecksumValidator.java
@@ -34,6 +34,7 @@ import java.util.Map.Entry;
 import static com.facebook.presto.sql.QueryUtil.simpleQuery;
 import static com.facebook.presto.verifier.framework.Column.Category.ARRAY;
 import static com.facebook.presto.verifier.framework.Column.Category.FLOATING_POINT;
+import static com.facebook.presto.verifier.framework.Column.Category.ROW;
 import static com.facebook.presto.verifier.framework.Column.Category.SIMPLE;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.function.Function.identity;
@@ -46,12 +47,14 @@ public class ChecksumValidator
     public ChecksumValidator(
             SimpleColumnValidator simpleColumnValidator,
             FloatingPointColumnValidator floatingPointColumnValidator,
-            ArrayColumnValidator arrayColumnValidator)
+            ArrayColumnValidator arrayColumnValidator,
+            RowColumnValidator rowColumnValidator)
     {
         this.columnValidators = ImmutableMap.of(
                 SIMPLE, simpleColumnValidator,
                 FLOATING_POINT, floatingPointColumnValidator,
-                ARRAY, arrayColumnValidator);
+                ARRAY, arrayColumnValidator,
+                ROW, rowColumnValidator);
     }
 
     public Query generateChecksumQuery(QualifiedName tableName, List<Column> columns)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/RowColumnValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/RowColumnValidator.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.checksum;
+
+import com.facebook.presto.spi.type.RowType;
+import com.facebook.presto.spi.type.RowType.Field;
+import com.facebook.presto.sql.tree.DereferenceExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.SingleColumn;
+import com.facebook.presto.sql.tree.SubscriptExpression;
+import com.facebook.presto.verifier.framework.Column;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.verifier.framework.VerifierUtil.delimitedIdentifier;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+
+public class RowColumnValidator
+        implements ColumnValidator
+{
+    @Inject
+    public RowColumnValidator()
+    {
+    }
+
+    @Override
+    public List<SingleColumn> generateChecksumColumns(Column column)
+    {
+        checkColumnType(column);
+
+        Expression checksum = new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(column.getIdentifier()));
+
+        ImmutableList.Builder<SingleColumn> columnsBuilder = ImmutableList.builder();
+        columnsBuilder.add(new SingleColumn(checksum, Optional.of(delimitedIdentifier(getChecksumAlias(column)))));
+
+        List<Field> fields = getFields(column);
+
+        for (int i = 0; i < getFields(column).size(); i++) {
+            Field field = fields.get(i);
+
+            Expression fieldExpression;
+
+            if (field.getName().isPresent()) {
+                fieldExpression = new DereferenceExpression(column.getIdentifier(), new Identifier(field.getName().get()));
+            }
+            else {
+                fieldExpression = new SubscriptExpression(column.getIdentifier(), new LongLiteral(String.valueOf(i + 1)));
+            }
+
+            Expression fieldChecksum = new FunctionCall(QualifiedName.of("checksum"), ImmutableList.of(fieldExpression));
+            columnsBuilder.add(new SingleColumn(fieldChecksum, Optional.of(delimitedIdentifier(getChecksumAlias(column, field, i)))));
+        }
+
+        return columnsBuilder.build();
+    }
+
+    @Override
+    public ColumnMatchResult validate(Column column, ChecksumResult controlResult, ChecksumResult testResult)
+    {
+        checkColumnType(column);
+
+        List<Field> fields = getFields(column);
+        List<String> aliases = ImmutableList.<String>builder()
+                .add(getChecksumAlias(column))
+                .addAll(IntStream.range(0, fields.size())
+                        .mapToObj(index -> getChecksumAlias(column, fields.get(index), index))
+                        .collect(Collectors.toList()))
+                .build();
+
+        return new ColumnMatchResult(
+                aliases.stream().allMatch(alias -> Objects.equals(controlResult.getChecksum(alias), testResult.getChecksum(alias))),
+                prepareMatchMessage(aliases, controlResult, testResult));
+    }
+
+    private static void checkColumnType(Column column)
+    {
+        checkArgument(column.getType() instanceof RowType, "Expect RowType, found %s", column.getType().getDisplayName());
+    }
+
+    private static List<Field> getFields(Column column)
+    {
+        return ((RowType) column.getType()).getFields();
+    }
+
+    private static String getChecksumAlias(Column column)
+    {
+        return column.getName() + "_checksum";
+    }
+
+    private static String getChecksumAlias(Column column, Field field, int fieldIndex)
+    {
+        return column.getName() + "$" + field.getName().orElse("$col" + (fieldIndex + 1)) + "_checksum";
+    }
+
+    private static String prepareMatchMessage(List<String> aliases, ChecksumResult controlResult, ChecksumResult testResult)
+    {
+        aliases = aliases.stream()
+                .filter(alias -> !Objects.equals(controlResult.getChecksum(alias), testResult.getChecksum(alias)))
+                .collect(Collectors.toList());
+
+        String control = aliases.stream()
+                .map(alias -> alias + ": " + controlResult.getChecksum(alias))
+                .collect(joining(", "));
+
+        String test = aliases.stream()
+                .map(alias -> alias + ": " + testResult.getChecksum(alias))
+                .collect(joining(", "));
+
+        return format("control(%s) test(%s)", control, test);
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/Column.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/Column.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.verifier.framework;
 
 import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.tree.Identifier;
@@ -30,6 +31,7 @@ import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.verifier.framework.Column.Category.ARRAY;
 import static com.facebook.presto.verifier.framework.Column.Category.FLOATING_POINT;
+import static com.facebook.presto.verifier.framework.Column.Category.ROW;
 import static com.facebook.presto.verifier.framework.Column.Category.SIMPLE;
 import static com.facebook.presto.verifier.framework.VerifierUtil.delimitedIdentifier;
 import static java.util.Objects.requireNonNull;
@@ -41,6 +43,7 @@ public class Column
         SIMPLE,
         FLOATING_POINT,
         ARRAY,
+        ROW,
     }
 
     private static final Set<Type> FLOATING_POINT_TYPES = ImmutableSet.of(DOUBLE, REAL);
@@ -87,6 +90,9 @@ public class Column
         }
         else if (type instanceof ArrayType) {
             category = ARRAY;
+        }
+        else if (type instanceof RowType) {
+            category = ROW;
         }
         else {
             category = SIMPLE;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
@@ -36,6 +36,7 @@ import com.facebook.presto.verifier.annotation.ForTest;
 import com.facebook.presto.verifier.checksum.ArrayColumnValidator;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.checksum.FloatingPointColumnValidator;
+import com.facebook.presto.verifier.checksum.RowColumnValidator;
 import com.facebook.presto.verifier.checksum.SimpleColumnValidator;
 import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
 import com.facebook.presto.verifier.prestoaction.VerificationPrestoActionModule;
@@ -143,6 +144,7 @@ public class VerifierModule
         binder.bind(SimpleColumnValidator.class).in(SINGLETON);
         binder.bind(FloatingPointColumnValidator.class).in(SINGLETON);
         binder.bind(ArrayColumnValidator.class).in(SINGLETON);
+        binder.bind(RowColumnValidator.class).in(SINGLETON);
         binder.bind(new TypeLiteral<List<Predicate<SourceQuery>>>() {}).toProvider(new CustomQueryFilterProvider(customQueryFilterClasses));
         binder.bind(new TypeLiteral<List<Property>>() {}).toInstance(tablePropertyOverrides);
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -21,6 +21,7 @@ import com.facebook.presto.type.TypeRegistry;
 import com.facebook.presto.verifier.checksum.ArrayColumnValidator;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.checksum.FloatingPointColumnValidator;
+import com.facebook.presto.verifier.checksum.RowColumnValidator;
 import com.facebook.presto.verifier.checksum.SimpleColumnValidator;
 import com.facebook.presto.verifier.event.DeterminismAnalysisRun;
 import com.facebook.presto.verifier.event.VerifierQueryEvent;
@@ -112,7 +113,8 @@ public class TestDataVerification
         ChecksumValidator checksumValidator = new ChecksumValidator(
                 new SimpleColumnValidator(),
                 new FloatingPointColumnValidator(verifierConfig),
-                new ArrayColumnValidator());
+                new ArrayColumnValidator(),
+                new RowColumnValidator());
         SourceQuery sourceQuery = new SourceQuery(SUITE, NAME, controlQuery, testQuery, configuration, configuration);
         return new DataVerification(
                 (verification, e) -> false,

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
@@ -24,6 +24,7 @@ import com.facebook.presto.type.TypeRegistry;
 import com.facebook.presto.verifier.checksum.ArrayColumnValidator;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.checksum.FloatingPointColumnValidator;
+import com.facebook.presto.verifier.checksum.RowColumnValidator;
 import com.facebook.presto.verifier.checksum.SimpleColumnValidator;
 import com.facebook.presto.verifier.event.VerifierQueryEvent;
 import com.facebook.presto.verifier.prestoaction.NodeResourceClient;
@@ -210,7 +211,11 @@ public class TestVerificationManager
                         presto -> new QueryRewriter(SQL_PARSER, presto, ImmutableList.of(), ImmutableMap.of(CONTROL, TABLE_PREFIX, TEST, TABLE_PREFIX)),
                         new FailureResolverManagerFactory(ImmutableList.of(), new FailureResolverConfig().setEnabled(false)),
                         new MockNodeResourceClient(),
-                        new ChecksumValidator(new SimpleColumnValidator(), new FloatingPointColumnValidator(verifierConfig), new ArrayColumnValidator()),
+                        new ChecksumValidator(
+                                new SimpleColumnValidator(),
+                                new FloatingPointColumnValidator(verifierConfig),
+                                new ArrayColumnValidator(),
+                                new RowColumnValidator()),
                         verifierConfig,
                         new TypeRegistry(),
                         new FailureResolverConfig().setEnabled(false)),


### PR DESCRIPTION
Improve struct correctness check output by adding checksum per struct field.

Part of #13809 

```
== RELEASE NOTES ==

Verifier Changes
* Add checks for the individual fields when validating a row column.

```
