### PR TITLE
Fix SQL Server type mapping for boolean and varchar and add DTO read support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -859,7 +859,7 @@
             <dependency>
                 <groupId>com.microsoft.sqlserver</groupId>
                 <artifactId>mssql-jdbc</artifactId>
-                <version>7.0.0.jre8</version>
+                <version>7.2.2.jre8</version>
             </dependency>
 
             <dependency>

--- a/presto-docs/src/main/sphinx/connector/sqlserver.rst
+++ b/presto-docs/src/main/sphinx/connector/sqlserver.rst
@@ -67,8 +67,8 @@ that catalog name instead of ``sqlserver`` in the above examples.
 SQL Server Connector Limitations
 --------------------------------
 
-Presto supports connecting to SQL Server 2016, SQL Server 2014, SQL Server 2012
-and Azure SQL Database.
+Presto supports connecting to SQL Server 2016, SQL Server 2014, SQL Server 2012,
+SQL Server 2008 R2, SQL Server 2008 and Azure SQL Database.
 
 Presto supports the following SQL Server data types.
 The following table shows the mappings between SQL Server and Presto data types.
@@ -76,13 +76,32 @@ The following table shows the mappings between SQL Server and Presto data types.
 ============================= ============================
 SQL Server Type               Presto Type
 ============================= ============================
-``bigint``                    ``bigint``
+``bit``                       ``boolean``
+``tinyint``                   ``tinyint``
 ``smallint``                  ``smallint``
 ``int``                       ``integer``
+``bigint``                    ``bigint``
+``real``                      ``real``
 ``float``                     ``double``
-``char(n)``                   ``char(n)``
-``varchar(n)``                ``varchar(n)``
+``decimal``                   ``decimal``
+``numeric``                   ``decimal``
+``char``                      ``char``
+``varchar``                   ``varchar``
+``nchar``                     ``char``
+``nvarchar``                  ``varchar``
+``text``                      ``varchar``
+``ntext``                     ``varchar``
+``binary``                    ``varbinary``
+``varbinary``                 ``varbinary``
 ``date``                      ``date``
+``time``                      ``time``
+``smalldatetime``             ``timestamp``
+``datetime``                  ``timestamp``
+``datetime2``                 ``timestamp``
+``datetimeoffset``            ``timestamp with time zone``
+``smallmoney``                ``decimal(10, 4)``
+``money``                     ``decimal(19, 4)``
+``uniqueidentifier``          ``char(36)``
 ============================= ============================
 
 Complete list of `SQL Server data types

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/sqlserver/SqlServerDataTypesTableDefinition.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/sqlserver/SqlServerDataTypesTableDefinition.java
@@ -44,7 +44,7 @@ public class SqlServerDataTypesTableDefinition
     private static final String INSERT_DDL =
             "CREATE TABLE %NAME% (bi bigint, si smallint, i int, f float," +
                     "c char(4), vc varchar(6), " +
-                    "pf30 float(30), d date) ";
+                    "pf30 float(30), d date, b bit) ";
 
     static {
         RelationalDataSource dataSource = () -> {

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/sqlserver/TestInsert.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/sqlserver/TestInsert.java
@@ -67,7 +67,7 @@ public class TestInsert
     {
         String sql = format(
                 "INSERT INTO %s.%s values (BIGINT '%s', SMALLINT '%s', INTEGER '%s', DOUBLE '%s', " +
-                        "CHAR 'a   ', 'aa', DOUBLE '%s', DATE '%s')",
+                        "CHAR 'a   ', 'aa', DOUBLE '%s', DATE '%s', false)",
                 SQLSERVER, INSERT_TABLE_NAME, Long.valueOf("-9223372036854775807"), Short.MIN_VALUE, Integer.MIN_VALUE,
                 Double.MIN_VALUE, Double.MIN_VALUE, Date.valueOf("1970-01-01"));
         // Min value for BIGINT would be updated to "-9223372036854775808" post https://github.com/prestodb/presto/issues/4571
@@ -80,7 +80,8 @@ public class TestInsert
                 .executeQuery(sql);
 
         assertThat(queryResult).contains(
-                row(Long.valueOf("-9223372036854775807"), Short.MIN_VALUE, Integer.MIN_VALUE, Double.MIN_VALUE, "a   ", "aa", Double.MIN_VALUE, Date.valueOf("1970-01-01")));
+                row(Long.valueOf("-9223372036854775807"), Short.MIN_VALUE, Integer.MIN_VALUE, Double.MIN_VALUE,
+                        "a   ", "aa", Double.MIN_VALUE, Date.valueOf("1970-01-01"), Boolean.FALSE));
     }
 
     @Test(groups = {SQL_SERVER, PROFILE_SPECIFIC_TESTS})
@@ -88,7 +89,7 @@ public class TestInsert
     {
         String sql = format(
                 "INSERT INTO %s.%s values (BIGINT '%s', SMALLINT '%s', INTEGER '%s', DOUBLE '%s', " +
-                        "CHAR 'aaaa', 'aaaaaa', DOUBLE '%s', DATE '%s' )",
+                        "CHAR 'aaaa', 'aaaaaa', DOUBLE '%s', DATE '%s', true)",
                 SQLSERVER, INSERT_TABLE_NAME, Long.MAX_VALUE, Short.MAX_VALUE, Integer.MAX_VALUE,
                 Double.MAX_VALUE, Double.valueOf("12345678912.3456756"), Date.valueOf("9999-12-31"));
         onPresto().executeQuery(sql);
@@ -100,15 +101,15 @@ public class TestInsert
                 .executeQuery(sql);
 
         assertThat(queryResult).contains(
-                row(Long.MAX_VALUE, Short.MAX_VALUE, Integer.MAX_VALUE, Double.MAX_VALUE, "aaaa", "aaaaaa", Double.valueOf("12345678912.3456756"),
-                        Date.valueOf("9999-12-31")));
+                row(Long.MAX_VALUE, Short.MAX_VALUE, Integer.MAX_VALUE, Double.MAX_VALUE,
+                        "aaaa", "aaaaaa", Double.valueOf("12345678912.3456756"), Date.valueOf("9999-12-31"), Boolean.TRUE));
     }
 
     @Test(groups = {SQL_SERVER, PROFILE_SPECIFIC_TESTS})
     public void testInsertNull()
     {
         String sql = format(
-                "INSERT INTO %s.%s values (null, null, null, null, null, null, null, null)",
+                "INSERT INTO %s.%s values (null, null, null, null, null, null, null, null, null)",
                 SQLSERVER, INSERT_TABLE_NAME);
         onPresto().executeQuery(sql);
 
@@ -118,6 +119,6 @@ public class TestInsert
         QueryResult queryResult = onSqlServer()
                 .executeQuery(sql);
 
-        assertThat(queryResult).contains(row(null, null, null, null, null, null, null, null));
+        assertThat(queryResult).contains(row(null, null, null, null, null, null, null, null, null));
     }
 }


### PR DESCRIPTION
Restores #13113

Corrects some type mapping for table creation with SQL Server:
- `bit` instead of `boolean`
- `varchar(max)` for unbounded `varchar`

Adds support for reading `datetimeoffset` as a Presto `timestamp with time zone` with the proper offset.

```
== RELEASE NOTES ==

SQL Server Connector Changes
* Fix table creation with ``boolean`` and ``varchar`` columns that are larger than 8000 characters.
* Add support for reading ``datetimeoffset`` columns as a ``timestamp with time zone``.
```