### PR TITLE
Add CLA managers to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,17 @@
 
 In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you've done this for one repository in the [prestodb](https://github.com/prestodb) organization, you're good to go. If you are submitting a pull request for the first time, the communitybridge-easycla bot will notify you if you haven't signed, and will provide you with a link.  If you are contributing on behalf of a company, you might want to let the person who manages your corporate CLA whitelist know they will be receiving a request from you.
 
+## Corporate CLA managers
+
+If you are signing a corporate CLA then the CLA manager for your company will need to whitelist you. They will not get a notification that you are attempting to sign so you have to contact them directly.
+
+The CLA managers are as follows:
+
+### Facebook
+* Ariel Weisberg
+* Rohit Jain
+* Amit Chopra
+
 ## License
 
 By contributing to Presto, you agree that your contributions will be licensed under the [Apache License Version 2.0 (APLv2)](LICENSE).


### PR DESCRIPTION
Make it slightly more obvious who to contact when you need to sign a corporate CLA.

Still not great since you hit the bot and have to know you need to read CONTRIBUTING.md.

```
== NO RELEASE NOTE ==
```