### PR TITLE
Update IllegalStateException thrown in beginBlockEntry to correctly reflect entry state

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayBlockBuilder.java
@@ -189,7 +189,7 @@ public class ArrayBlockBuilder
     public SingleArrayBlockWriter beginBlockEntry()
     {
         if (currentEntryOpened) {
-            throw new IllegalStateException("Expected current entry to be closed but was closed");
+            throw new IllegalStateException("Expected current entry to be closed but was opened");
         }
         currentEntryOpened = true;
         return new SingleArrayBlockWriter(values, values.getPositionCount());


### PR DESCRIPTION
When attempting to begin an entry on an already open block writer, the error message does not accurately reflect the current state. This is a minor change to make the exception message more explicit at a glance, without having to reference the stack trace for debugging. 

```
== NO RELEASE NOTE ==
```
