### PR TITLE
Support mixed case fields in Elasticsearch

### DIFF
--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchClient.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchClient.java
@@ -251,6 +251,7 @@ public class ElasticsearchClient
         List<ColumnMetadata> result = new ArrayList<>();
         for (ElasticsearchColumn column : columns) {
             Map<String, Object> properties = new HashMap<>();
+            properties.put("originalColumnName", column.getName());
             properties.put("jsonPath", column.getJsonPath());
             properties.put("jsonType", column.getJsonType());
             properties.put("isList", column.isList());

--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchMetadata.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchMetadata.java
@@ -113,7 +113,7 @@ public class ElasticsearchMetadata
             int position = ordinalPosition == -1 ? index : ordinalPosition;
             columnHandles.put(column.getName(),
                     new ElasticsearchColumnHandle(
-                        column.getName(),
+                        String.valueOf(properties.get("originalColumnName")),
                         column.getType(),
                         String.valueOf(properties.get("jsonPath")),
                         String.valueOf(properties.get("jsonType")),

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
@@ -116,4 +116,30 @@ public class TestElasticsearchIntegrationSmokeTest
                 "SELECT name, fields.fielda, fields.fieldb FROM nested.data",
                 "VALUES ('nestfield', 32, 'valueb')");
     }
+
+    @Test
+    public void testMixedCaseFields()
+    {
+        embeddedElasticsearchNode.getClient()
+                .prepareIndex("person", "doc")
+                .setSource(ImmutableMap.<String, Object>builder()
+                        .put("Name", "John")
+                        .put("Age", 20)
+                        .build())
+                .get();
+
+        embeddedElasticsearchNode.getClient()
+                .admin()
+                .indices()
+                .refresh(refreshRequest("person"))
+                .actionGet();
+
+        assertQuery(
+                "SELECT Name, Age FROM test.person",
+                "VALUES ('John', 20)");
+
+        assertQuery(
+                "SELECT name, age FROM test.person",
+                "VALUES ('John', 20)");
+    }
 }

--- a/presto-elasticsearch/src/test/resources/queryrunner/test.person.json
+++ b/presto-elasticsearch/src/test/resources/queryrunner/test.person.json
@@ -1,0 +1,25 @@
+{
+  "tableName": "person",
+  "schemaName": "test",
+  "host": "localhost",
+  "port": "9300",
+  "clusterName": "test",
+  "index": "person",
+  "type": "doc",
+  "columns": [
+    {
+      "name": "Name",
+      "type": "varchar",
+      "jsonPath": "Name",
+      "jsonType": "varchar",
+      "ordinalPosition": "0"
+    },
+    {
+      "name": "Age",
+      "type": "integer",
+      "jsonPath": "Age",
+      "jsonType": "integer",
+      "ordinalPosition": "1"
+    }
+  ]
+}


### PR DESCRIPTION
Preserve the original (mixed-case) column name for further requests
to Elasticsearch instead of relying on the name from ColumnMetadata,
which is lower-cased.

Cherry-pick of https://github.com/prestosql/presto/commit/4217df64c4e1828d90ead0510b4ae70a9c651539

Co-authored-by: Martin Traverso <mtraverso@gmail.com>


== RELEASE NOTES ==

Elasticsearch Changes
* Add support for mixed-case column name for Elasticsearch Connector
