### PR TITLE
Fix compile error for java 9&11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -746,12 +746,6 @@
             </dependency>
 
             <dependency>
-                <groupId>io.airlift</groupId>
-                <artifactId>joda-to-java-time-bridge</artifactId>
-                <version>3</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.facebook.drift</groupId>
                 <artifactId>drift-api</artifactId>
                 <version>${dep.drift.version}</version>

--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -74,12 +74,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/presto-cache/pom.xml
+++ b/presto-cache/pom.xml
@@ -62,6 +62,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <optional>true</optional>

--- a/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
+++ b/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
@@ -2235,3 +2235,4 @@
 2226 Asia/Atyrau
 2227 Asia/Famagusta
 2228 Europe/Saratov
+2229 Asia/Qostanay

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimeZoneKey.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimeZoneKey.java
@@ -213,7 +213,7 @@ public class TestTimeZoneKey
             hasher.putString(timeZoneKey.getId(), StandardCharsets.UTF_8);
         }
         // Zone file should not (normally) be changed, so let's make this more difficult
-        assertEquals(hasher.hash().asLong(), -4582158485614614451L, "zone-index.properties file contents changed!");
+        assertEquals(hasher.hash().asLong(), -972834036790299986L, "zone-index.properties file contents changed!");
     }
 
     public void assertTimeZoneNotSupported(String zoneId)

--- a/presto-hive-metastore/pom.xml
+++ b/presto-hive-metastore/pom.xml
@@ -137,12 +137,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-          </dependency>
-
-        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -198,12 +198,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
         </dependency>

--- a/presto-i18n-functions/pom.xml
+++ b/presto-i18n-functions/pom.xml
@@ -26,13 +26,6 @@
             <artifactId>myanmar-tools</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-
         <!-- Presto SPI -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -75,12 +75,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -59,12 +59,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -187,11 +187,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.facebook.drift</groupId>
             <artifactId>drift-server</artifactId>
         </dependency>
@@ -449,9 +444,6 @@
                     <excludes>
                         <exclude>**/TestLocalExecutionPlanner.java</exclude>
                     </excludes>
-                    <systemPropertyVariables>
-                        <org.joda.time.DateTimeZone.Provider>io.airlift.jodabridge.JdkBasedZoneInfoProvider</org.joda.time.DateTimeZone.Provider>
-                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
@@ -14,10 +14,8 @@
 package com.facebook.presto.util;
 
 import com.facebook.presto.common.type.TimeZoneKey;
-import io.airlift.jodabridge.JdkBasedZoneInfoProvider;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.time.ZoneId;
@@ -32,26 +30,12 @@ import static org.testng.Assert.assertEquals;
 
 public class TestTimeZoneUtils
 {
-    @BeforeClass
-    protected void validateJodaZoneInfoProvider()
-    {
-        try {
-            JdkBasedZoneInfoProvider.registerAsJodaZoneInfoProvider();
-        }
-        catch (RuntimeException e) {
-            throw new RuntimeException("Set the following system property to JVM running the test: -Dorg.joda.time.DateTimeZone.Provider=com.facebook.presto.tz.JdkBasedZoneInfoProvider");
-        }
-    }
-
     @Test
     public void test()
     {
         TimeZoneKey.getTimeZoneKey("GMT-13:00");
 
-        TreeSet<String> jodaZones = new TreeSet<>(DateTimeZone.getAvailableIDs());
         TreeSet<String> jdkZones = new TreeSet<>(ZoneId.getAvailableZoneIds());
-        // We use JdkBasedZoneInfoProvider for joda
-        assertEquals(jodaZones, jdkZones);
 
         for (String zoneId : new TreeSet<>(jdkZones)) {
             if (zoneId.startsWith("Etc/") || zoneId.startsWith("GMT") || zoneId.startsWith("SystemV/")) {

--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -36,12 +36,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -67,12 +67,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-raptor/pom.xml
+++ b/presto-raptor/pom.xml
@@ -113,12 +113,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>

--- a/presto-rcfile/pom.xml
+++ b/presto-rcfile/pom.xml
@@ -33,12 +33,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -52,12 +52,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>1.8.1</version>

--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -68,12 +68,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>

--- a/presto-teradata-functions/pom.xml
+++ b/presto-teradata-functions/pom.xml
@@ -32,12 +32,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
         </dependency>

--- a/presto-tpcds/pom.xml
+++ b/presto-tpcds/pom.xml
@@ -37,12 +37,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>joda-to-java-time-bridge</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>


### PR DESCRIPTION
1. Fix  javax.annotations.PreDestroy class not found when compiling with java 11.
This class is required by presto-cache/src/main/java/com/facebook/presto/cache/LocalRangeCacheManager.java

Because javax.annotation had been removed in jdk 11,  we should add this dependency explicitly in the pom.xml of presto-cache

2. Fix incompatible type error on java 9 & 11
```
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /Users/beinanw/w/presto/presto-main/src/main/java/com/facebook/presto/transaction/InMemoryTransactionManager.java:[587,46] incompatible types: inference variable T has incompatible bounds
    lower bounds: com.google.common.util.concurrent.ListenableFuture<? extends capture#1 of ? extends java.lang.Object>,java.lang.Object
    lower bounds: com.google.common.util.concurrent.ListenableFuture<? extends java.lang.Object>
```
This error can be reproduced on 9.181 and 11.0.6 . 

I think it’s caused by an unspecified behavior (or a bug) in some newer version of JDK 9 & 11

See the discussion below:

https://bugs.openjdk.java.net/browse/JDK-8206142

https://bugs.openjdk.java.net/browse/JDK-8016196

So I add the type parameter explicitly to prevent javac to deduce the type. 

The two commits below are fixing the unit test failures for the jdk/jre release after Dec 2018

3. Add the new timezone Asia/Qostanay into zone-index.properties

4. Upgrade joda time for the newly added timezone

```
== NO RELEASE NOTE ==
```
