### PR TITLE
Upgrade slice to 0.38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dep.antlr.version>4.7.1</dep.antlr.version>
         <dep.airlift.version>0.188</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.slice.version>0.36</dep.slice.version>
+        <dep.slice.version>0.38</dep.slice.version>
         <dep.testing-mysql-server-5.version>0.6</dep.testing-mysql-server-5.version>
         <dep.aws-sdk.version>1.11.445</dep.aws-sdk.version>
         <dep.okhttp.version>3.9.0</dep.okhttp.version>

--- a/presto-main/src/main/java/com/facebook/presto/type/setdigest/SetDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/setdigest/SetDigest.java
@@ -19,7 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Shorts;
 import io.airlift.slice.DynamicSliceOutput;
-import io.airlift.slice.Murmur3;
+import io.airlift.slice.Murmur3Hash128;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
@@ -185,13 +185,13 @@ public class SetDigest
 
     public void add(long value)
     {
-        addHash(Murmur3.hash64(value));
+        addHash(Murmur3Hash128.hash64(value));
         hll.add(value);
     }
 
     public void add(Slice value)
     {
-        addHash(Murmur3.hash64(value));
+        addHash(Murmur3Hash128.hash64(value));
         hll.add(value);
     }
 


### PR DESCRIPTION
Previous version was 0.36.  There was one minor incompatibility.

```
== RELEASE NOTES ==

General Changes
* Upgrade airlift/slice to 0.38.
```
