### PR TITLE
Optimize T-Digest structure for small distributions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -42,6 +42,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.util.AbstractCollection;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -59,8 +60,10 @@ import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.Slices.wrappedDoubleArray;
+import static java.lang.Double.isNaN;
 import static java.lang.Math.ceil;
 import static java.lang.Math.max;
+import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.lang.System.arraycopy;
@@ -102,53 +105,51 @@ public class TDigest
 
     private final double publicCompression;
     private final double compression;
+    private final int maxCentroidCount;
+    private final int maxBufferSize;
 
     // points to the first unused centroid
     private int activeCentroids;
-
     private double totalWeight;
-
-    private final double[] weight;
-
-    private final double[] mean;
-
-    private double unmergedWeight;
+    private double[] weight;
+    private double[] mean;
 
     // this is the index of the next temporary centroid
     // this is a more Java-like convention than activeCentroids uses
     private int tempUsed;
-    private final double[] tempWeight;
-    private final double[] tempMean;
+    private double unmergedWeight;
+    private double[] tempWeight;
+    private double[] tempMean;
 
     // array used for sorting the temp centroids
     // to avoid allocations during operation
-    private final int[] order;
+    private int[] order;
 
     private TDigest(double compression)
     {
         // ensure compression >= 10
-        // default size = 2 * ceil(compression)
-        // default bufferSize = 5 * size
-        // ensure size > 2 * compression + weightLimitFudge
-        // ensure bufferSize > 2 * size
-
+        // default maxCentroidCount = 2 * ceil(compression)
+        // default maxBufferSize = 5 * maxCentroidCount
+        // ensure maxCentroidCount > 2 * compression + weightLimitFudge
+        // ensure maxBufferSize > 2 * maxCentroidCount
+        checkArgument(!isNaN(compression));
         checkArgument(compression <= MAX_COMPRESSION_FACTOR, "Compression factor cannot exceed %s", MAX_COMPRESSION_FACTOR);
         this.publicCompression = max(compression, 10);
         // publicCompression is how many centroids the user asked for
         // compression is how many we actually keep
-        this.compression = 2 * publicCompression;
+        this.compression = 2 * this.publicCompression;
 
         // having a big buffer is good for speed
-        int bufferSize = 5 * (int) ceil(this.publicCompression + sizeFudge);
-        int size = (int) ceil(this.compression + sizeFudge);
+        this.maxBufferSize = 5 * (int) ceil(this.publicCompression + sizeFudge);
+        this.maxCentroidCount = (int) ceil(this.compression + sizeFudge);
 
-        weight = new double[size];
-        mean = new double[size];
-        tempWeight = new double[bufferSize];
-        tempMean = new double[bufferSize];
-        order = new int[bufferSize];
+        this.weight = new double[1];
+        this.mean = new double[1];
+        this.tempWeight = new double[1];
+        this.tempMean = new double[1];
+        this.order = new int[1];
 
-        activeCentroids = 0;
+        this.activeCentroids = 0;
     }
 
     public static TDigest createTDigest(double compression)
@@ -175,6 +176,8 @@ public class TDigest
             r.setMinMax(min, max);
             r.totalWeight = sliceInput.readDouble();
             r.activeCentroids = sliceInput.readInt();
+            r.weight = new double[r.activeCentroids];
+            r.mean = new double[r.activeCentroids];
             sliceInput.readBytes(wrappedDoubleArray(r.weight), r.activeCentroids * SIZE_OF_DOUBLE);
             sliceInput.readBytes(wrappedDoubleArray(r.mean), r.activeCentroids * SIZE_OF_DOUBLE);
             sliceInput.close();
@@ -192,12 +195,19 @@ public class TDigest
 
     public void add(double x, long w)
     {
-        checkArgument(!Double.isNaN(x), "Cannot add NaN to t-digest");
+        checkArgument(!isNaN(x), "Cannot add NaN to t-digest");
         checkArgument(w > 0L, "weight must be > 0");
 
-        if (tempUsed >= tempWeight.length - activeCentroids - 1) {
+        if (tempWeight.length == tempUsed) {
+            tempWeight = Arrays.copyOf(tempWeight, min(tempWeight.length * 2, maxBufferSize));
+            tempMean = Arrays.copyOf(tempMean, min(tempMean.length * 2, maxBufferSize));
+            order = Arrays.copyOf(order, min(order.length * 2, maxBufferSize));
+        }
+
+        if (tempUsed >= maxBufferSize - activeCentroids - 1) {
             mergeNewValues();
         }
+
         int where = tempUsed++;
         tempWeight[where] = w;
         tempMean[where] = x;
@@ -238,6 +248,12 @@ public class TDigest
         }
 
         if (force || unmergedWeight > 0) {
+            // ensure buffer is big enough to hold current centroids and incoming values
+            if (activeCentroids + tempUsed >= tempWeight.length) {
+                tempWeight = Arrays.copyOf(tempWeight, min(max(tempWeight.length * 2, activeCentroids + tempUsed + 1), maxBufferSize));
+                tempMean = Arrays.copyOf(tempMean, min(max(tempMean.length * 2, activeCentroids + tempUsed + 1), maxBufferSize));
+                order = Arrays.copyOf(order, min(max(order.length * 2, activeCentroids + tempUsed + 1), maxBufferSize));
+            }
             // note that we run the merge in reverse every other merge to avoid left-to-right bias in merging
             merge(tempMean, tempWeight, tempUsed, order, unmergedWeight, mergeCount % 2 == 1, compression);
             mergeCount++;
@@ -258,9 +274,7 @@ public class TDigest
         arraycopy(weight, 0, incomingWeight, incomingCount, activeCentroids);
         incomingCount += activeCentroids;
 
-        if (incomingOrder == null) {
-            incomingOrder = new int[incomingCount];
-        }
+        checkArgument(incomingOrder != null, "Incoming order array was null");
         sort(incomingOrder, incomingMean, incomingCount);
 
         if (runBackwards) {
@@ -279,13 +293,11 @@ public class TDigest
         for (int i = 1; i < incomingCount; i++) {
             int ix = incomingOrder[i];
             double proposedWeight = weight[activeCentroids] + incomingWeight[ix];
-            boolean addThis;
 
             double q0 = weightSoFar / totalWeight;
             double q2 = (weightSoFar + proposedWeight) / totalWeight;
-            addThis = proposedWeight <= totalWeight * Math.min(maxSize(q0, normalizer), maxSize(q2, normalizer));
 
-            if (addThis) {
+            if (proposedWeight <= totalWeight * min(maxSize(q0, normalizer), maxSize(q2, normalizer))) {
                 // next point can be merged into existing centroid
                 weight[activeCentroids] += incomingWeight[ix];
                 mean[activeCentroids] = mean[activeCentroids] + (incomingMean[ix] - mean[activeCentroids]) * incomingWeight[ix] / weight[activeCentroids];
@@ -296,12 +308,20 @@ public class TDigest
                 weightSoFar += weight[activeCentroids];
 
                 activeCentroids++;
+                if (mean.length == activeCentroids) {
+                    mean = Arrays.copyOf(mean, min(mean.length * 2, maxCentroidCount));
+                    weight = Arrays.copyOf(weight, min(weight.length * 2, maxCentroidCount));
+                }
                 mean[activeCentroids] = incomingMean[ix];
                 weight[activeCentroids] = incomingWeight[ix];
                 incomingWeight[ix] = 0;
             }
         }
         activeCentroids++;
+        if (mean.length == activeCentroids) {
+            mean = Arrays.copyOf(mean, min(mean.length * 2, maxCentroidCount));
+            weight = Arrays.copyOf(weight, min(weight.length * 2, maxCentroidCount));
+        }
 
         // sanity check
         double sum = 0;
@@ -316,7 +336,7 @@ public class TDigest
         }
 
         if (totalWeight > 0) {
-            min = Math.min(min, mean[0]);
+            min = min(min, mean[0]);
             max = max(max, mean[activeCentroids - 1]);
         }
     }


### PR DESCRIPTION
Dynamically increase the size of underlying arrays as values are added to digest.

Benchmark results comparing before/after optimization are displayed below:

```
BenchmarkTDigest.benchmarkCopyBEFORE		N/A	avgt	30	3328.574 ±  79.584 ns/op
BenchmarkTDigest.benchmarkCopyAFTER		N/A	avgt	30	1969.757 ±  19.348 ns/op
BenchmarkTDigest.benchmarkDeserializeBEFORE	N/A	avgt	30	1623.594 ± 111.647 ns/op
BenchmarkTDigest.benchmarkDeserializeAFTER	N/A	avgt	30	 165.251 ±   5.514 ns/op
BenchmarkTDigest.benchmarkInsertsBEFORE		N/A	avgt	30	  67.205 ±   0.796 ns/op
BenchmarkTDigest.benchmarkInsertsAFTER		N/A	avgt	30	  69.787 ±   2.767 ns/op
BenchmarkTDigest.benchmarkMergeBEFORE		N/A	avgt	30	4736.826 ±  24.052 ns/op
BenchmarkTDigest.benchmarkMergeAFTER		N/A	avgt	30	2181.707 ±  49.311 ns/op
BenchmarkTDigest.benchmarkSerializeBEFORE	N/A	avgt	30	2423.662 ± 138.643 ns/op
BenchmarkTDigest.benchmarkSerializeAFTER	N/A	avgt	30	 133.829 ±   4.896 ns/op
```

```
== NO RELEASE NOTE ==
```
Replaces #13160