### PR TITLE
Add support for instance count in ARRAY_POSITION.

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -63,6 +63,12 @@ Array Functions
 
     Returns the position of the first occurrence of the ``element`` in array ``x`` (or 0 if not found).
 
+.. function:: array_position(x, element, instance) -> bigint
+
+    If ``instance > 0``, returns the position of the `instance`-th occurrence of the ``element`` in array ``x``. If
+    ``instance < 0``, returns the position of the ``instance``-to-last occurrence of the ``element`` in array ``x``.
+    If no matching element instance is found, ``0`` is returned.
+
 .. function:: array_remove(x, element) -> array
 
     Remove all elements that equal ``element`` from array ``x``.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
@@ -89,6 +89,7 @@ import com.facebook.presto.operator.scalar.ArrayNgramsFunction;
 import com.facebook.presto.operator.scalar.ArrayNoneMatchFunction;
 import com.facebook.presto.operator.scalar.ArrayNotEqualOperator;
 import com.facebook.presto.operator.scalar.ArrayPositionFunction;
+import com.facebook.presto.operator.scalar.ArrayPositionWithIndexFunction;
 import com.facebook.presto.operator.scalar.ArrayRemoveFunction;
 import com.facebook.presto.operator.scalar.ArrayReverseFunction;
 import com.facebook.presto.operator.scalar.ArrayShuffleFunction;
@@ -561,6 +562,7 @@ public class BuiltInFunctionNamespaceManager
                 .scalar(ArrayContains.class)
                 .scalar(ArrayFilterFunction.class)
                 .scalar(ArrayPositionFunction.class)
+                .scalar(ArrayPositionWithIndexFunction.class)
                 .scalars(CombineHashFunction.class)
                 .scalars(JsonOperators.class)
                 .scalar(JsonOperators.JsonDistinctFromOperator.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayPositionFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayPositionFunction.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.operator.scalar;
 
+import com.facebook.presto.operator.scalar.ArrayPositionWithIndexFunction;
+
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.Description;
@@ -44,23 +46,7 @@ public final class ArrayPositionFunction
             @SqlType("array(T)") Block array,
             @SqlType("T") boolean element)
     {
-        int size = array.getPositionCount();
-        for (int i = 0; i < size; i++) {
-            if (!array.isNull(i)) {
-                boolean arrayValue = type.getBoolean(array, i);
-                try {
-                    Boolean result = (Boolean) equalMethodHandle.invokeExact(arrayValue, element);
-                    checkNotIndeterminate(result);
-                    if (result) {
-                        return i + 1; // result is 1-based (instead of 0)
-                    }
-                }
-                catch (Throwable t) {
-                    throw internalError(t);
-                }
-            }
-        }
-        return 0;
+        return ArrayPositionWithIndexFunction.arrayPositionWithIndex(type, equalMethodHandle, array, element, 1);
     }
 
     @TypeParameter("T")
@@ -71,23 +57,7 @@ public final class ArrayPositionFunction
             @SqlType("array(T)") Block array,
             @SqlType("T") long element)
     {
-        int size = array.getPositionCount();
-        for (int i = 0; i < size; i++) {
-            if (!array.isNull(i)) {
-                long arrayValue = type.getLong(array, i);
-                try {
-                    Boolean result = (Boolean) equalMethodHandle.invokeExact(arrayValue, element);
-                    checkNotIndeterminate(result);
-                    if (result) {
-                        return i + 1; // result is 1-based (instead of 0)
-                    }
-                }
-                catch (Throwable t) {
-                    throw internalError(t);
-                }
-            }
-        }
-        return 0;
+        return ArrayPositionWithIndexFunction.arrayPositionWithIndex(type, equalMethodHandle, array, element, 1);
     }
 
     @TypeParameter("T")
@@ -98,23 +68,7 @@ public final class ArrayPositionFunction
             @SqlType("array(T)") Block array,
             @SqlType("T") double element)
     {
-        int size = array.getPositionCount();
-        for (int i = 0; i < size; i++) {
-            if (!array.isNull(i)) {
-                double arrayValue = type.getDouble(array, i);
-                try {
-                    Boolean result = (Boolean) equalMethodHandle.invokeExact(arrayValue, element);
-                    checkNotIndeterminate(result);
-                    if (result) {
-                        return i + 1; // result is 1-based (instead of 0)
-                    }
-                }
-                catch (Throwable t) {
-                    throw internalError(t);
-                }
-            }
-        }
-        return 0;
+        return ArrayPositionWithIndexFunction.arrayPositionWithIndex(type, equalMethodHandle, array, element, 1);
     }
 
     @TypeParameter("T")
@@ -125,23 +79,7 @@ public final class ArrayPositionFunction
             @SqlType("array(T)") Block array,
             @SqlType("T") Slice element)
     {
-        int size = array.getPositionCount();
-        for (int i = 0; i < size; i++) {
-            if (!array.isNull(i)) {
-                Slice arrayValue = type.getSlice(array, i);
-                try {
-                    Boolean result = (Boolean) equalMethodHandle.invokeExact(arrayValue, element);
-                    checkNotIndeterminate(result);
-                    if (result) {
-                        return i + 1; // result is 1-based (instead of 0)
-                    }
-                }
-                catch (Throwable t) {
-                    throw internalError(t);
-                }
-            }
-        }
-        return 0;
+        return ArrayPositionWithIndexFunction.arrayPositionWithIndex(type, equalMethodHandle, array, element, 1);
     }
 
     @TypeParameter("T")
@@ -152,23 +90,7 @@ public final class ArrayPositionFunction
             @SqlType("array(T)") Block array,
             @SqlType("T") Block element)
     {
-        int size = array.getPositionCount();
-        for (int i = 0; i < size; i++) {
-            if (!array.isNull(i)) {
-                Object arrayValue = type.getObject(array, i);
-                try {
-                    Boolean result = (Boolean) equalMethodHandle.invoke(arrayValue, element);
-                    checkNotIndeterminate(result);
-                    if (result) {
-                        return i + 1; // result is 1-based (instead of 0)
-                    }
-                }
-                catch (Throwable t) {
-                    throw internalError(t);
-                }
-            }
-        }
-        return 0;
+        return ArrayPositionWithIndexFunction.arrayPositionWithIndex(type, equalMethodHandle, array, element, 1);
     }
 
     private static void checkNotIndeterminate(Boolean equalsResult)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayPositionWithIndexFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayPositionWithIndexFunction.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.OperatorDependency;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.facebook.presto.spi.type.Type;
+import io.airlift.slice.Slice;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.function.OperatorType.EQUAL;
+import static com.facebook.presto.util.Failures.internalError;
+
+@Description("Returns the position of the first occurrence of the given value in array (or 0 if not found)")
+@ScalarFunction("array_position")
+public final class ArrayPositionWithIndexFunction
+{
+    private ArrayPositionWithIndexFunction() {}
+
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BIGINT)
+    public static long arrayPositionWithIndex(
+            @TypeParameter("T") Type type,
+            @OperatorDependency(operator = EQUAL, argumentTypes = {"T", "T"}) MethodHandle equalMethodHandle,
+            @SqlType("array(T)") Block array,
+            @SqlType("T") boolean element,
+            @SqlType(StandardTypes.BIGINT) long instance)
+    {
+        int size = array.getPositionCount();
+        int instancesFound = 0;
+
+        int startIndex;
+        int stopIndex;
+        int stepSize;
+
+        switch (Long.signum(instance)) {
+            case 1:
+                startIndex = 0;
+                stopIndex = size;
+                stepSize = 1;
+                break;
+            case -1:
+                startIndex = size - 1;
+                stopIndex = -1;
+                stepSize = -1;
+                break;
+            default:
+                throw new PrestoException(NOT_SUPPORTED, "array_position cannot take a 0-valued instance argument.");
+        }
+
+        for (int i = startIndex; i != stopIndex; i += stepSize) {
+            if (!array.isNull(i)) {
+                boolean arrayValue = type.getBoolean(array, i);
+                try {
+                    Boolean result = (Boolean) equalMethodHandle.invokeExact(arrayValue, element);
+                    checkNotIndeterminate(result);
+                    if (result) {
+                        instancesFound++;
+                        if (instancesFound == Math.abs(instance)) {
+                            return i + 1; // result is 1-based (instead of 0)
+                        }
+                    }
+                }
+                catch (Throwable t) {
+                    throw internalError(t);
+                }
+            }
+        }
+        return 0;
+    }
+
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BIGINT)
+    public static long arrayPositionWithIndex(
+            @TypeParameter("T") Type type,
+            @OperatorDependency(operator = EQUAL, argumentTypes = {"T", "T"}) MethodHandle equalMethodHandle,
+            @SqlType("array(T)") Block array,
+            @SqlType("T") long element,
+            @SqlType(StandardTypes.BIGINT) long instance)
+    {
+        int size = array.getPositionCount();
+        int instancesFound = 0;
+
+        int startIndex;
+        int stopIndex;
+        int stepSize;
+
+        switch (Long.signum(instance)) {
+            case 1:
+                startIndex = 0;
+                stopIndex = size;
+                stepSize = 1;
+                break;
+            case -1:
+                startIndex = size - 1;
+                stopIndex = -1;
+                stepSize = -1;
+                break;
+            default:
+                throw new PrestoException(NOT_SUPPORTED, "array_position cannot take a 0-valued instance argument.");
+        }
+
+        for (int i = startIndex; i != stopIndex; i += stepSize) {
+            if (!array.isNull(i)) {
+                long arrayValue = type.getLong(array, i);
+                try {
+                    Boolean result = (Boolean) equalMethodHandle.invokeExact(arrayValue, element);
+                    checkNotIndeterminate(result);
+                    if (result) {
+                        instancesFound++;
+                        if (instancesFound == Math.abs(instance)) {
+                            return i + 1; // result is 1-based (instead of 0)
+                        }
+                    }
+                }
+                catch (Throwable t) {
+                    throw internalError(t);
+                }
+            }
+        }
+        return 0;
+    }
+
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BIGINT)
+    public static long arrayPositionWithIndex(
+            @TypeParameter("T") Type type,
+            @OperatorDependency(operator = EQUAL, argumentTypes = {"T", "T"}) MethodHandle equalMethodHandle,
+            @SqlType("array(T)") Block array,
+            @SqlType("T") double element,
+            @SqlType(StandardTypes.BIGINT) long instance)
+    {
+        int size = array.getPositionCount();
+        int instancesFound = 0;
+
+        int startIndex;
+        int stopIndex;
+        int stepSize;
+
+        switch (Long.signum(instance)) {
+            case 1:
+                startIndex = 0;
+                stopIndex = size;
+                stepSize = 1;
+                break;
+            case -1:
+                startIndex = size - 1;
+                stopIndex = -1;
+                stepSize = -1;
+                break;
+            default:
+                throw new PrestoException(NOT_SUPPORTED, "array_position cannot take a 0-valued instance argument.");
+        }
+
+        for (int i = startIndex; i != stopIndex; i += stepSize) {
+            if (!array.isNull(i)) {
+                double arrayValue = type.getDouble(array, i);
+                try {
+                    Boolean result = (Boolean) equalMethodHandle.invokeExact(arrayValue, element);
+                    checkNotIndeterminate(result);
+                    if (result) {
+                        instancesFound++;
+                        if (instancesFound == Math.abs(instance)) {
+                            return i + 1; // result is 1-based (instead of 0)
+                        }
+                    }
+                }
+                catch (Throwable t) {
+                    throw internalError(t);
+                }
+            }
+        }
+        return 0;
+    }
+
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BIGINT)
+    public static long arrayPositionWithIndex(
+            @TypeParameter("T") Type type,
+            @OperatorDependency(operator = EQUAL, argumentTypes = {"T", "T"}) MethodHandle equalMethodHandle,
+            @SqlType("array(T)") Block array,
+            @SqlType("T") Slice element,
+            @SqlType(StandardTypes.BIGINT) long instance)
+    {
+        int size = array.getPositionCount();
+        int instancesFound = 0;
+
+        int startIndex;
+        int stopIndex;
+        int stepSize;
+
+        switch (Long.signum(instance)) {
+            case 1:
+                startIndex = 0;
+                stopIndex = size;
+                stepSize = 1;
+                break;
+            case -1:
+                startIndex = size - 1;
+                stopIndex = -1;
+                stepSize = -1;
+                break;
+            default:
+                throw new PrestoException(NOT_SUPPORTED, "array_position cannot take a 0-valued instance argument.");
+        }
+
+        for (int i = startIndex; i != stopIndex; i += stepSize) {
+            if (!array.isNull(i)) {
+                Slice arrayValue = type.getSlice(array, i);
+                try {
+                    Boolean result = (Boolean) equalMethodHandle.invokeExact(arrayValue, element);
+                    checkNotIndeterminate(result);
+                    if (result) {
+                        instancesFound++;
+                        if (instancesFound == Math.abs(instance)) {
+                            return i + 1; // result is 1-based (instead of 0)
+                        }
+                    }
+                }
+                catch (Throwable t) {
+                    throw internalError(t);
+                }
+            }
+        }
+        return 0;
+    }
+
+    @TypeParameter("T")
+    @SqlType(StandardTypes.BIGINT)
+    public static long arrayPositionWithIndex(
+            @TypeParameter("T") Type type,
+            @OperatorDependency(operator = EQUAL, argumentTypes = {"T", "T"}) MethodHandle equalMethodHandle,
+            @SqlType("array(T)") Block array,
+            @SqlType("T") Block element,
+            @SqlType(StandardTypes.BIGINT) long instance)
+    {
+        int size = array.getPositionCount();
+        int instancesFound = 0;
+
+        int startIndex;
+        int stopIndex;
+        int stepSize;
+
+        switch (Long.signum(instance)) {
+            case 1:
+                startIndex = 0;
+                stopIndex = size;
+                stepSize = 1;
+                break;
+            case -1:
+                startIndex = size - 1;
+                stopIndex = -1;
+                stepSize = -1;
+                break;
+            default:
+                throw new PrestoException(NOT_SUPPORTED, "array_position cannot take a 0-valued instance argument.");
+        }
+
+        for (int i = startIndex; i != stopIndex; i += stepSize) {
+            if (!array.isNull(i)) {
+                Object arrayValue = type.getObject(array, i);
+                try {
+                    Boolean result = (Boolean) equalMethodHandle.invoke(arrayValue, element);
+                    checkNotIndeterminate(result);
+                    if (result) {
+                        instancesFound++;
+                        if (instancesFound == Math.abs(instance)) {
+                            return i + 1; // result is 1-based (instead of 0)
+                        }
+                    }
+                }
+                catch (Throwable t) {
+                    throw internalError(t);
+                }
+            }
+        }
+        return 0;
+    }
+
+    private static void checkNotIndeterminate(Boolean equalsResult)
+    {
+        if (equalsResult == null) {
+            throw new PrestoException(NOT_SUPPORTED, "array_position does not support arrays with elements that are null or contain null");
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -684,6 +684,82 @@ public class TestArrayOperators
 
         assertInvalidFunction("ARRAY_POSITION(ARRAY [ARRAY[null]], ARRAY[1])", NOT_SUPPORTED);
         assertInvalidFunction("ARRAY_POSITION(ARRAY [ARRAY[null]], ARRAY[null])", NOT_SUPPORTED);
+
+        // These should all be valid with respect to the ones above, since 1-index is the default.
+        assertFunction("ARRAY_POSITION(ARRAY [10, 20, 30, 40], 30, 1)", BIGINT, 3L);
+        assertFunction("ARRAY_POSITION(CAST (JSON '[]' as array(bigint)), 30, 1)", BIGINT, 0L);
+        assertFunction("ARRAY_POSITION(ARRAY [cast(NULL as bigint)], 30, 1)", BIGINT, 0L);
+        assertFunction("ARRAY_POSITION(ARRAY [cast(NULL as bigint), NULL, NULL], 30, 1)", BIGINT, 0L);
+        assertFunction("ARRAY_POSITION(ARRAY [NULL, NULL, 30, NULL], 30, 1)", BIGINT, 3L);
+
+        assertFunction("ARRAY_POSITION(ARRAY [1.1E0, 2.1E0, 3.1E0, 4.1E0], 3.1E0, 1)", BIGINT, 3L);
+        assertFunction("ARRAY_POSITION(ARRAY [false, false, true, true], true, 1)", BIGINT, 3L);
+        assertFunction("ARRAY_POSITION(ARRAY ['10', '20', '30', '40'], '30', 1)", BIGINT, 3L);
+
+        assertFunction("ARRAY_POSITION(ARRAY [DATE '2000-01-01', DATE '2000-01-02', DATE '2000-01-03', DATE '2000-01-04'], DATE '2000-01-03', 1)", BIGINT, 3L);
+        assertFunction("ARRAY_POSITION(ARRAY [ARRAY [1, 11], ARRAY [2, 12], ARRAY [3, 13], ARRAY [4, 14]], ARRAY [3, 13], 1)", BIGINT, 3L);
+
+        assertFunction("ARRAY_POSITION(ARRAY [], NULL, 1)", BIGINT, null);
+        assertFunction("ARRAY_POSITION(ARRAY [NULL], NULL, 1)", BIGINT, null);
+        assertFunction("ARRAY_POSITION(ARRAY [1, NULL, 2], NULL, 1)", BIGINT, null);
+        assertFunction("ARRAY_POSITION(ARRAY [1, CAST(NULL AS BIGINT), 2], CAST(NULL AS BIGINT), 1)", BIGINT, null);
+        assertFunction("ARRAY_POSITION(ARRAY [1, NULL, 2], CAST(NULL AS BIGINT), 1)", BIGINT, null);
+        assertFunction("ARRAY_POSITION(ARRAY [1, CAST(NULL AS BIGINT), 2], NULL, 1)", BIGINT, null);
+        assertFunction("ARRAY_POSITION(ARRAY [1.0, 2.0, 3.0, 4.0], 3.0, 1)", BIGINT, 3L);
+        assertFunction("ARRAY_POSITION(ARRAY [1.0, 2.0, 000000000000000000000003.000, 4.0], 3.0, 1)", BIGINT, 3L);
+        assertFunction("ARRAY_POSITION(ARRAY [1.0, 2.0, 3.0, 4.0], 000000000000000000000003.000, 1)", BIGINT, 3L);
+        assertFunction("ARRAY_POSITION(ARRAY [1.0, 2.0, 3.0, 4.0], 3, 1)", BIGINT, 3L);
+        assertFunction("ARRAY_POSITION(ARRAY [1.0, 2.0, 3, 4.0], 4.0, 1)", BIGINT, 4L);
+        assertFunction("ARRAY_POSITION(ARRAY [ARRAY[1]], ARRAY[1], 1)", BIGINT, 1L);
+
+        assertInvalidFunction("ARRAY_POSITION(ARRAY [ARRAY[null]], ARRAY[1], 1)", NOT_SUPPORTED);
+        assertInvalidFunction("ARRAY_POSITION(ARRAY [ARRAY[null]], ARRAY[null], 1)", NOT_SUPPORTED);
+        // End strictly n = 1 checks.
+
+        assertFunction("ARRAY_POSITION(ARRAY[1, 2, 3, 4], 1, -1)", BIGINT, 1L);
+        assertFunction("ARRAY_POSITION(ARRAY[4, 3, 2, 1], 1, -1)", BIGINT, 4L);
+        assertFunction("ARRAY_POSITION(ARRAY[1, 2, 3, 4, 1], 1, 2)", BIGINT, 5L);
+        assertFunction("ARRAY_POSITION(ARRAY[1, 2, 3, 4, 1], 1, -2)", BIGINT, 1L);
+        assertFunction("ARRAY_POSITION(ARRAY[1, 2, 3, 4, 1], 1, 3)", BIGINT, 0L);
+        assertFunction("ARRAY_POSITION(ARRAY[1, 2, 3, 4, 1], 1, -3)", BIGINT, 0L);
+        assertFunction("ARRAY_POSITION(ARRAY[1, 2, 3, 4, 1, 1], 1, 3)", BIGINT, 6L);
+        assertFunction("ARRAY_POSITION(ARRAY[1, 2, 3, 4, 1, 1], 1, -1)", BIGINT, 6L);
+        assertFunction("ARRAY_POSITION(ARRAY[1, 2, 3, 4, 1, 1], 1, -3)", BIGINT, 1L);
+
+        assertFunction("ARRAY_POSITION(ARRAY[true, false], true, -1)", BIGINT, 1L);
+        assertFunction("ARRAY_POSITION(ARRAY[true, false], false, -1)", BIGINT, 2L);
+        assertFunction("ARRAY_POSITION(ARRAY[true, true, true, true], true, 3)", BIGINT, 3L);
+        assertFunction("ARRAY_POSITION(ARRAY[true, true, true, true], true, 4)", BIGINT, 4L);
+        assertFunction("ARRAY_POSITION(ARRAY[true, true, true, true], true, 5)", BIGINT, 0L);
+        assertFunction("ARRAY_POSITION(ARRAY[true, true, true, true], true, -2)", BIGINT, 3L);
+        assertFunction("ARRAY_POSITION(ARRAY[true, true, true, true], true, -4)", BIGINT, 1L);
+        assertFunction("ARRAY_POSITION(ARRAY[true, true, true, true], true, -5)", BIGINT, 0L);
+
+        assertFunction("ARRAY_POSITION(ARRAY[1.0, 2.0, 3.0, 4.0], 1.0, -1)", BIGINT, 1L);
+        assertFunction("ARRAY_POSITION(ARRAY[1.0, 2.0, 3.0, 4.0], 2.0, -1)", BIGINT, 2L);
+        assertFunction("ARRAY_POSITION(ARRAY[1.0, 2.0, 1.0, 1.0, 2.0], 1.0, 2)", BIGINT, 3L);
+        assertFunction("ARRAY_POSITION(ARRAY[1.0, 2.0, 1.0, 1.0, 2.0], 1.0, 3)", BIGINT, 4L);
+        assertFunction("ARRAY_POSITION(ARRAY[1.0, 2.0, 1.0, 1.0, 2.0], 1.0, -2)", BIGINT, 3L);
+        assertFunction("ARRAY_POSITION(ARRAY[1.0, 2.0, 1.0, 1.0, 2.0], 1.0, -3)", BIGINT, 1L);
+        assertFunction("ARRAY_POSITION(ARRAY[1.0, 2.0, 1.0, 1.0, 2.0], 1.0, -6)", BIGINT, 0L);
+        assertFunction("ARRAY_POSITION(ARRAY[1.0, 2.0, 1.0, 1.0, 2.0], 1.0, 6)", BIGINT, 0L);
+
+        assertFunction("ARRAY_POSITION(ARRAY[ARRAY[1], ARRAY[2], ARRAY[3]], ARRAY[1], -1)", BIGINT, 1L);
+        assertFunction("ARRAY_POSITION(ARRAY[ARRAY[1], ARRAY[2], ARRAY[3]], ARRAY[3], -1)", BIGINT, 3L);
+        assertFunction("ARRAY_POSITION(ARRAY[ARRAY[1], ARRAY[2], ARRAY[3], ARRAY[1]], ARRAY[1], -1)", BIGINT, 4L);
+        assertFunction("ARRAY_POSITION(ARRAY[ARRAY[1], ARRAY[2], ARRAY[3], ARRAY[1]], ARRAY[1], -2)", BIGINT, 1L);
+        assertFunction("ARRAY_POSITION(ARRAY[ARRAY[1], ARRAY[2], ARRAY[3], ARRAY[1]], ARRAY[1], -3)", BIGINT, 0L);
+        assertFunction("ARRAY_POSITION(ARRAY[ARRAY[1], ARRAY[2], ARRAY[3], ARRAY[1]], ARRAY[1], 2)", BIGINT, 4L);
+        assertFunction("ARRAY_POSITION(ARRAY[ARRAY[1], ARRAY[2], ARRAY[3], ARRAY[1]], ARRAY[1], 3)", BIGINT, 0L);
+
+        assertFunction("ARRAY_POSITION(CAST(ARRAY[] AS ARRAY(BIGINT)), 1, -1)", BIGINT, 0L);
+        assertFunction("ARRAY_POSITION(ARRAY[1, 2, 3, 4], null, 2)", BIGINT, null);
+        assertFunction("ARRAY_POSITION(ARRAY[1, 2, 3, 4], null, -1)", BIGINT, null);
+        assertFunction("ARRAY_POSITION(ARRAY[1, 2, 3, 4], null, -4)", BIGINT, null);
+
+        assertInvalidFunction("ARRAY_POSITION(ARRAY [ARRAY[null]], ARRAY[1], -1)", NOT_SUPPORTED);
+        assertInvalidFunction("ARRAY_POSITION(ARRAY [ARRAY[null]], ARRAY[null], -1)", NOT_SUPPORTED);
+        assertInvalidFunction("ARRAY_POSITION(ARRAY [1, 2, 3, 4], 4, 0)", NOT_SUPPORTED);
     }
 
     @Test


### PR DESCRIPTION
This change implements the fix for issue [13861](https://github.com/prestodb/presto/issues/13861). We
create a version of ARRAY_POSITION that supports an
instance argument to specify the position of either the
i-th or the i-th-to-last instance of the given element.