### PR TITLE
Add peak task memory in resource estimates

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -709,6 +709,7 @@ public final class Session
         private Optional<Duration> executionTime = Optional.empty();
         private Optional<Duration> cpuTime = Optional.empty();
         private Optional<DataSize> peakMemory = Optional.empty();
+        private Optional<DataSize> peakTaskMemory = Optional.empty();
 
         public ResourceEstimateBuilder setExecutionTime(Duration executionTime)
         {
@@ -728,9 +729,15 @@ public final class Session
             return this;
         }
 
+        public ResourceEstimateBuilder setPeakTaskMemory(DataSize peakTaskMemory)
+        {
+            this.peakTaskMemory = Optional.of(peakTaskMemory);
+            return this;
+        }
+
         public ResourceEstimates build()
         {
-            return new ResourceEstimates(executionTime, cpuTime, peakMemory);
+            return new ResourceEstimates(executionTime, cpuTime, peakMemory, peakTaskMemory);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
@@ -419,6 +419,9 @@ public final class HttpRequestSessionContext
                     case ResourceEstimates.PEAK_MEMORY:
                         builder.setPeakMemory(DataSize.valueOf(value));
                         break;
+                    case ResourceEstimates.PEAK_TASK_MEMORY:
+                        builder.setPeakTaskMemory(DataSize.valueOf(value));
+                        break;
                     default:
                         throw badRequest(format("Unsupported resource name %s", name));
                 }

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestFileResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestFileResourceGroupConfigurationManager.java
@@ -40,7 +40,7 @@ import static org.testng.Assert.assertTrue;
 
 public class TestFileResourceGroupConfigurationManager
 {
-    private static final ResourceEstimates EMPTY_RESOURCE_ESTIMATES = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty());
+    private static final ResourceEstimates EMPTY_RESOURCE_ESTIMATES = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
 
     @Test
     public void testInvalid()

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestResourceGroupIdTemplate.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestResourceGroupIdTemplate.java
@@ -29,7 +29,7 @@ import static org.testng.Assert.assertFalse;
 
 public class TestResourceGroupIdTemplate
 {
-    private static final ResourceEstimates EMPTY_RESOURCE_ESTIMATES = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty());
+    private static final ResourceEstimates EMPTY_RESOURCE_ESTIMATES = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
 
     @Test
     public void testExpansion()

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestStaticSelector.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestStaticSelector.java
@@ -32,7 +32,7 @@ import static org.testng.Assert.assertEquals;
 
 public class TestStaticSelector
 {
-    private static final ResourceEstimates EMPTY_RESOURCE_ESTIMATES = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty());
+    private static final ResourceEstimates EMPTY_RESOURCE_ESTIMATES = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
 
     @Test
     public void testUserRegex()
@@ -112,7 +112,8 @@ public class TestStaticSelector
                                 new ResourceEstimates(
                                         Optional.of(Duration.valueOf("4m")),
                                         Optional.empty(),
-                                        Optional.of(DataSize.valueOf("400MB")))))
+                                        Optional.of(DataSize.valueOf("400MB")),
+                                        Optional.empty())))
                         .map(SelectionContext::getResourceGroupId),
                 Optional.of(resourceGroupId));
 
@@ -125,7 +126,8 @@ public class TestStaticSelector
                                 new ResourceEstimates(
                                         Optional.of(Duration.valueOf("4m")),
                                         Optional.empty(),
-                                        Optional.of(DataSize.valueOf("600MB")))))
+                                        Optional.of(DataSize.valueOf("600MB")),
+                                        Optional.empty())))
                         .map(SelectionContext::getResourceGroupId),
                 Optional.empty());
 
@@ -137,6 +139,7 @@ public class TestStaticSelector
                                 ImmutableSet.of(),
                                 new ResourceEstimates(
                                         Optional.of(Duration.valueOf("4m")),
+                                        Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty())))
                         .map(SelectionContext::getResourceGroupId),
@@ -164,7 +167,8 @@ public class TestStaticSelector
                                 new ResourceEstimates(
                                         Optional.of(Duration.valueOf("100h")),
                                         Optional.empty(),
-                                        Optional.of(DataSize.valueOf("4TB")))))
+                                        Optional.of(DataSize.valueOf("4TB")),
+                                        Optional.empty())))
                         .map(SelectionContext::getResourceGroupId),
                 Optional.empty());
 
@@ -177,7 +181,8 @@ public class TestStaticSelector
                                 new ResourceEstimates(
                                         Optional.empty(),
                                         Optional.empty(),
-                                        Optional.of(DataSize.valueOf("6TB")))))
+                                        Optional.of(DataSize.valueOf("6TB")),
+                                        Optional.empty())))
                         .map(SelectionContext::getResourceGroupId),
                 Optional.of(resourceGroupId));
 
@@ -190,7 +195,8 @@ public class TestStaticSelector
                                 new ResourceEstimates(
                                         Optional.of(Duration.valueOf("1s")),
                                         Optional.of(Duration.valueOf("1s")),
-                                        Optional.of(DataSize.valueOf("6TB")))))
+                                        Optional.of(DataSize.valueOf("6TB")),
+                                        Optional.empty())))
                         .map(SelectionContext::getResourceGroupId),
                 Optional.of(resourceGroupId));
     }

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbResourceGroupConfigurationManager.java
@@ -54,7 +54,7 @@ import static org.testng.Assert.fail;
 public class TestDbResourceGroupConfigurationManager
 {
     private static final String ENVIRONMENT = "test";
-    private static final ResourceEstimates EMPTY_RESOURCE_ESTIMATES = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty());
+    private static final ResourceEstimates EMPTY_RESOURCE_ESTIMATES = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
 
     static H2DaoProvider setup(String prefix)
     {

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbSourceExactMatchSelector.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbSourceExactMatchSelector.java
@@ -33,7 +33,7 @@ import static org.testng.Assert.assertEquals;
 public class TestDbSourceExactMatchSelector
 {
     private static final JsonCodec<ResourceGroupId> CODEC = JsonCodec.jsonCodec(ResourceGroupId.class);
-    private static final ResourceEstimates EMPTY_RESOURCE_ESTIMATES = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty());
+    private static final ResourceEstimates EMPTY_RESOURCE_ESTIMATES = new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     private H2ResourceGroupsDao dao;
 
     @BeforeClass

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionContext.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionContext.java
@@ -151,7 +151,7 @@ public class PrestoSparkSessionContext
     public ResourceEstimates getResourceEstimates()
     {
         // presto on spark does not use resource groups
-        return new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty());
+        return new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     @Nullable

--- a/presto-spi/src/main/java/com/facebook/presto/spi/session/ResourceEstimates.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/session/ResourceEstimates.java
@@ -32,20 +32,24 @@ public final class ResourceEstimates
     public static final String EXECUTION_TIME = "EXECUTION_TIME";
     public static final String CPU_TIME = "CPU_TIME";
     public static final String PEAK_MEMORY = "PEAK_MEMORY";
+    public static final String PEAK_TASK_MEMORY = "PEAK_TASK_MEMORY";
 
     private final Optional<Duration> executionTime;
     private final Optional<Duration> cpuTime;
     private final Optional<DataSize> peakMemory;
+    private final Optional<DataSize> peakTaskMemory;
 
     @JsonCreator
     public ResourceEstimates(
             @JsonProperty("executionTime") Optional<Duration> executionTime,
             @JsonProperty("cpuTime") Optional<Duration> cpuTime,
-            @JsonProperty("peakMemory") Optional<DataSize> peakMemory)
+            @JsonProperty("peakMemory") Optional<DataSize> peakMemory,
+            @JsonProperty("peakTaskMemory") Optional<DataSize> peakTaskMemory)
     {
         this.executionTime = requireNonNull(executionTime, "executionTime is null");
         this.cpuTime = requireNonNull(cpuTime, "cpuTime is null");
         this.peakMemory = requireNonNull(peakMemory, "peakMemory is null");
+        this.peakTaskMemory = requireNonNull(peakTaskMemory, "peakTaskMemory is null");
     }
 
     @JsonProperty
@@ -66,6 +70,12 @@ public final class ResourceEstimates
         return peakMemory;
     }
 
+    @JsonProperty
+    public Optional<DataSize> getPeakTaskMemory()
+    {
+        return peakTaskMemory;
+    }
+
     @Override
     public String toString()
     {
@@ -73,6 +83,7 @@ public final class ResourceEstimates
         sb.append("executionTime=").append(executionTime);
         sb.append(", cpuTime=").append(cpuTime);
         sb.append(", peakMemory=").append(peakMemory);
+        sb.append(", peakTaskMemory=").append(peakTaskMemory);
         sb.append('}');
         return sb.toString();
     }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
@@ -227,7 +227,8 @@ public class TestQueues
                     newSessionWithResourceEstimates(new ResourceEstimates(
                             Optional.of(Duration.valueOf("4m")),
                             Optional.empty(),
-                            Optional.of(DataSize.valueOf("400MB")))),
+                            Optional.of(DataSize.valueOf("400MB")),
+                            Optional.empty())),
                     LONG_LASTING_QUERY,
                     createResourceGroupId("global", "small"));
 
@@ -236,7 +237,8 @@ public class TestQueues
                     newSessionWithResourceEstimates(new ResourceEstimates(
                             Optional.of(Duration.valueOf("4m")),
                             Optional.empty(),
-                            Optional.of(DataSize.valueOf("600MB")))),
+                            Optional.of(DataSize.valueOf("600MB")),
+                            Optional.empty())),
                     LONG_LASTING_QUERY,
                     createResourceGroupId("global", "other"));
 
@@ -244,6 +246,7 @@ public class TestQueues
                     queryRunner,
                     newSessionWithResourceEstimates(new ResourceEstimates(
                             Optional.of(Duration.valueOf("4m")),
+                            Optional.empty(),
                             Optional.empty(),
                             Optional.empty())),
                     LONG_LASTING_QUERY,
@@ -254,7 +257,8 @@ public class TestQueues
                     newSessionWithResourceEstimates(new ResourceEstimates(
                             Optional.of(Duration.valueOf("1s")),
                             Optional.of(Duration.valueOf("1s")),
-                            Optional.of(DataSize.valueOf("6TB")))),
+                            Optional.of(DataSize.valueOf("6TB")),
+                            Optional.empty())),
                     LONG_LASTING_QUERY,
                     createResourceGroupId("global", "huge_memory"));
 
@@ -263,7 +267,8 @@ public class TestQueues
                     newSessionWithResourceEstimates(new ResourceEstimates(
                             Optional.of(Duration.valueOf("100h")),
                             Optional.empty(),
-                            Optional.of(DataSize.valueOf("4TB")))),
+                            Optional.of(DataSize.valueOf("4TB")),
+                            Optional.empty())),
                     LONG_LASTING_QUERY,
                     createResourceGroupId("global", "other"));
         }


### PR DESCRIPTION
Peak task total memory information is a critical information that we should provide support into the existing ResourceEstimates class because we can use it to redirect traffic from existing T6 (high memory) cluster to new T1 (low memory) clusters.

```
== NO RELEASE NOTE ==
```
