### PR TITLE
Generalize batch processing for no filter case for ByteSelectiveStreamReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
@@ -17,6 +17,8 @@ import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.spi.type.Type;
 
+import javax.annotation.Nullable;
+
 import java.util.function.Predicate;
 
 import static java.lang.Math.max;
@@ -69,6 +71,24 @@ final class ReaderUtils
             else {
                 values[i] = 0;
             }
+        }
+    }
+
+    public static void packBytesForPositions(byte[] values, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            values[i] = values[positions[i]];
+        }
+    }
+
+    public static void packBooleansForPositions(@Nullable boolean[] values, int[] positions, int positionCount)
+    {
+        if (values == null) {
+            return;
+        }
+
+        for (int i = 0; i < positionCount; i++) {
+            values[i] = values[positions[i]];
         }
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -36,6 +36,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
+import javafx.util.Pair;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -57,18 +58,21 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
-import static com.facebook.presto.orc.OrcTester.writeOrcColumnHive;
+import static com.facebook.presto.orc.OrcTester.writeOrcColumnsHive;
 import static com.facebook.presto.orc.TupleDomainFilter.LongDecimalRange;
 import static com.facebook.presto.orc.metadata.CompressionKind.NONE;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -81,6 +85,7 @@ import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -118,7 +123,9 @@ public class BenchmarkSelectiveStreamReaders
             }
 
             if (page.getPositionCount() > 0) {
-                blocks.add(page.getBlock(0).getLoadedBlock());
+                for (int i = 0; i < page.getChannelCount(); i++) {
+                    blocks.add(page.getBlock(i).getLoadedBlock());
+                }
             }
         }
 
@@ -132,12 +139,13 @@ public class BenchmarkSelectiveStreamReaders
 
         private final Random random = new Random(0);
 
-        private Type type;
         private File temporaryDirectory;
         private File orcFile;
-        private Optional<TupleDomainFilter> filter;
-        private boolean filterAllowNull;
-        private float selectionRateForNonNull;
+        private Type type;
+        private int channelCount;
+        private int nonEmptyFilterCount;
+        private List<Optional<TupleDomainFilter>> filters = new ArrayList<>();
+        private List<Float> filterRates = new ArrayList<>();
 
         @Param({
                 "boolean",
@@ -165,13 +173,30 @@ public class BenchmarkSelectiveStreamReaders
                 "NONE",
                 "ALL"
         })
-        private Nulls withNulls = Nulls.NONE;
+        private Nulls withNulls = Nulls.PARTIAL;
 
         // 0 means no rows will be filtered out, 1 means all rows will be filtered out, -1 means no filter.
         // When withNulls is ALL, only -1, 0, 1 are meaningful. Other values are regarded as 1.
-        @SuppressWarnings("unused")
-        @Param({"-1", "0", "0.1", "0.5", "0.9", "1"})
-        private float filterRate = 0.1f;
+        // "|" is the column delimiter.
+        @Param({
+                "-1",
+                "0",
+                "0.1",
+                "0.5",
+                "0.9",
+                "1",
+                "0.0|-1",
+                "0.1|-1",
+                "0.2|-1",
+                "0.3|-1",
+                "0.4|-1",
+                "0.5|-1",
+                "0.6|-1",
+                "0.8|-1",
+                "0.9|-1",
+                "1|-1",
+        })
+        private String filterRateSignature = "0.1|-1";
 
         @Setup
         public void setup()
@@ -186,9 +211,23 @@ public class BenchmarkSelectiveStreamReaders
 
             temporaryDirectory = createTempDir();
             orcFile = new File(temporaryDirectory, randomUUID().toString());
-            writeOrcColumnHive(orcFile, ORC_12, NONE, type, createValues());
 
-            filter = getFilter();
+            filterRates = Arrays.stream(filterRateSignature.split("\\|")).map(r -> Float.parseFloat(r)).collect(toImmutableList());
+            channelCount = filterRates.size();
+
+            List<List<?>> values = new ArrayList<>();
+            for (int i = 0; i < channelCount; i++) {
+                float filterRate = filterRates.get(i);
+                Pair<Boolean, Float> filterInfoForNonNull = getFilterInfoForNonNull(filterRate);
+                values.add(createValues(type, filterRate));
+                Optional<TupleDomainFilter> filter = getFilter(type, filterRate, filterInfoForNonNull.getKey(), filterInfoForNonNull.getValue());
+                filters.add(filter);
+                if (filter.isPresent()) {
+                    nonEmptyFilterCount++;
+                }
+            }
+
+            writeOrcColumnsHive(orcFile, ORC_12, NONE, Collections.nCopies(channelCount, type), values);
         }
 
         @TearDown
@@ -210,9 +249,11 @@ public class BenchmarkSelectiveStreamReaders
                     OrcReaderTestingUtils.createDefaultTestConfig());
 
             return orcReader.createSelectiveRecordReader(
-                    ImmutableMap.of(0, type),
-                    ImmutableList.of(0),
-                    filter.isPresent() ? ImmutableMap.of(0, ImmutableMap.of(new Subfield("c"), filter.get())) : ImmutableMap.of(),
+                    IntStream.range(0, channelCount).boxed().collect(Collectors.toMap(Function.identity(), i -> type)),
+                    IntStream.range(0, channelCount).boxed().collect(Collectors.toList()),
+                    nonEmptyFilterCount > 0 ?
+                            IntStream.range(0, channelCount).filter(i -> filters.get(i).isPresent()).boxed().collect(Collectors.toMap(Function.identity(), i -> ImmutableMap.of(new Subfield("c"), filters.get(i).orElse(null))))
+                            : ImmutableMap.of(),
                     ImmutableList.of(),
                     ImmutableMap.of(),
                     ImmutableMap.of(),
@@ -228,13 +269,11 @@ public class BenchmarkSelectiveStreamReaders
                     INITIAL_BATCH_SIZE);
         }
 
-        private Optional<TupleDomainFilter> getFilter()
+        private Optional<TupleDomainFilter> getFilter(Type type, float filterRate, boolean filterAllowNull, float selectionRateForNonNull)
         {
             if (filterRate == NO_FILTER) {
                 return Optional.empty();
             }
-
-            setupFilterRateForNonNull();
 
             if (type == BOOLEAN) {
                 return Optional.of(BooleanValue.of(true, filterAllowNull));
@@ -295,20 +334,20 @@ public class BenchmarkSelectiveStreamReaders
             throw new UnsupportedOperationException("Unsupported type: " + type);
         }
 
-        private final List<?> createValues()
+        private List<?> createValues(Type type, float filterRate)
         {
             switch (withNulls) {
                 case ALL:
                     return NULL_VALUES;
                 case PARTIAL:
                     // Let the null rate be 0.5 * (1 - filterRate)
-                    return IntStream.range(0, ROWS).mapToObj(i -> random.nextFloat() > 0.5 * (filterRate == -1 ? 1 : 1 - filterRate) ? createValue() : null).collect(toList());
+                    return IntStream.range(0, ROWS).mapToObj(j -> random.nextFloat() > 0.5 * (filterRate == -1 ? 1 : 1 - filterRate) ? createValue(type, filterRate) : null).collect(toList());
                 default:
-                    return IntStream.range(0, ROWS).mapToObj(i -> createValue()).collect(toList());
+                    return IntStream.range(0, ROWS).mapToObj(j -> createValue(type, filterRate)).collect(toList());
             }
         }
 
-        private final Object createValue()
+        private final Object createValue(Type type, float filterRate)
         {
             if (type == BOOLEAN) {
                 // We need to specialize BOOLEAN case because we can't specify filterRate by manipulating the filter value in getFilter.
@@ -371,21 +410,15 @@ public class BenchmarkSelectiveStreamReaders
             throw new UnsupportedOperationException("Unsupported type: " + type);
         }
 
-        private void setupFilterRateForNonNull()
+        private Pair<Boolean, Float> getFilterInfoForNonNull(float filterRate)
         {
             switch (withNulls) {
                 case NONE:
-                    filterAllowNull = false;  // doesn't matter
-                    selectionRateForNonNull = 1 - filterRate;
-                    break;
+                    return new Pair<>(false, 1 - filterRate);
                 case PARTIAL:
-                    filterAllowNull = true;  // doesn't matter
-                    selectionRateForNonNull = (1 - filterRate) / (1 + filterRate);  // This is because we assumed the null rate is 0.5
-                    break;
+                    return new Pair<>(true, (1 - filterRate) / (1 + filterRate));
                 case ALL:
-                    filterAllowNull = filterRate == 0 ? true : false;  // filterRate belonging to (0, 1] is regarded as 1
-                    selectionRateForNonNull = 1;  // This value doesn't matter
-                    break;
+                    return new Pair<>((filterRate == 0 ? true : false), 1f);
                 default:
                     throw new UnsupportedOperationException("Unsupported withNulls: " + withNulls);
             }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -107,29 +107,11 @@ public class BenchmarkSelectiveStreamReaders
     private static final int MAX_STRING_LENGTH = 10;
 
     @Benchmark
-    public Object readAllNull(AllNullBenchmarkData data)
-            throws Throwable
-    {
-        return readAllBlocks(data.createRecordReader(Optional.empty()));
-    }
-
-    @Benchmark
-    public Object read(BenchmarkData data)
+    public List<Block> readAllBlocks(BenchmarkData data)
             throws IOException
     {
-        return readAllBlocks(data.createRecordReader(Optional.empty()));
-    }
+        OrcSelectiveRecordReader recordReader = data.createRecordReader();
 
-    @Benchmark
-    public Object readWithFilter(BenchmarkData data)
-            throws IOException
-    {
-        return readAllBlocks(data.createRecordReader(data.getFilter()));
-    }
-
-    private static List<Block> readAllBlocks(OrcSelectiveRecordReader recordReader)
-            throws IOException
-    {
         List<Block> blocks = new ArrayList<>();
         while (true) {
             Page page = recordReader.getNextPage();
@@ -141,18 +123,51 @@ public class BenchmarkSelectiveStreamReaders
                 blocks.add(page.getBlock(0).getLoadedBlock());
             }
         }
+
         return blocks;
     }
 
-    private abstract static class AbstractBenchmarkData
+    @State(Scope.Thread)
+    public static class BenchmarkData
     {
-        protected final Random random = new Random(0);
+        private final Random random = new Random(0);
+
         private Type type;
         private File temporaryDirectory;
         private File orcFile;
-        private String typeSignature;
+        private Optional<TupleDomainFilter> filter;
+        
+        @Param({
+                "boolean",
 
-        public void setup(String typeSignature)
+                "integer",
+                "bigint",
+                "smallint",
+                "tinyint",
+
+                "date",
+                "timestamp",
+
+                "real",
+                "double",
+                "decimal(10,5)",
+                "decimal(30,10)",
+
+                "varchar_direct",
+                "varchar_dictionary"
+        })
+        private String typeSignature = "boolean";
+
+        @SuppressWarnings("unused")
+        @Param({
+                "PARTIAL",
+                "NONE",
+                "ALL"
+        })
+        private Nulls withNulls = Nulls.PARTIAL;
+
+        @Setup
+        public void setup()
                 throws Exception
         {
             if (typeSignature.startsWith("varchar")) {
@@ -161,10 +176,12 @@ public class BenchmarkSelectiveStreamReaders
             else {
                 type = new TypeRegistry().getType(TypeSignature.parseTypeSignature(typeSignature));
             }
-            this.typeSignature = typeSignature;
+
             temporaryDirectory = createTempDir();
             orcFile = new File(temporaryDirectory, randomUUID().toString());
             writeOrcColumnHive(orcFile, ORC_12, NONE, type, createValues());
+
+            filter = getFilter();
         }
 
         @TearDown
@@ -174,19 +191,7 @@ public class BenchmarkSelectiveStreamReaders
             deleteRecursively(temporaryDirectory.toPath(), ALLOW_INSECURE);
         }
 
-        public Type getType()
-        {
-            return type;
-        }
-
-        public String getTypeSignature()
-        {
-            return typeSignature;
-        }
-
-        protected abstract List<?> createValues();
-
-        public OrcSelectiveRecordReader createRecordReader(Optional<TupleDomainFilter> filter)
+        public OrcSelectiveRecordReader createRecordReader()
                 throws IOException
         {
             OrcDataSource dataSource = new FileOrcDataSource(orcFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
@@ -215,95 +220,8 @@ public class BenchmarkSelectiveStreamReaders
                     Optional.empty(),
                     INITIAL_BATCH_SIZE);
         }
-    }
 
-    @State(Scope.Thread)
-    public static class AllNullBenchmarkData
-            extends AbstractBenchmarkData
-    {
-        @SuppressWarnings("unused")
-        @Param({
-                "boolean",
-
-                "integer",
-                "bigint",
-                "smallint",
-                "tinyint",
-
-                "date",
-                "timestamp",
-
-                "real",
-                "double",
-                "decimal(10,5)",
-                "decimal(30,10)",
-
-                "varchar_direct",
-                "varchar_dictionary"
-        })
-        private String typeSignature;
-
-        @Setup
-        public void setup()
-                throws Exception
-        {
-            setup(typeSignature);
-        }
-
-        @Override
-        protected final List<?> createValues()
-        {
-            return NULL_VALUES;
-        }
-    }
-
-    @State(Scope.Thread)
-    public static class BenchmarkData
-            extends AbstractBenchmarkData
-    {
-        @SuppressWarnings("unused")
-        @Param({
-                "boolean",
-
-                "integer",
-                "bigint",
-                "smallint",
-                "tinyint",
-
-                "date",
-                "timestamp",
-
-                "real",
-                "double",
-                "decimal(10,5)",
-                "decimal(30,10)",
-
-                "varchar_direct",
-                "varchar_dictionary"
-        })
-        private String typeSignature;
-
-        @SuppressWarnings("unused")
-        @Param({"true", "false"})
-        private boolean withNulls;
-
-        private Optional<TupleDomainFilter> filter;
-
-        @Setup
-        public void setup()
-                throws Exception
-        {
-            setup(typeSignature);
-
-            this.filter = getFilter(getType());
-        }
-
-        public Optional<TupleDomainFilter> getFilter()
-        {
-            return filter;
-        }
-
-        private static Optional<TupleDomainFilter> getFilter(Type type)
+        private Optional<TupleDomainFilter> getFilter()
         {
             if (type == BOOLEAN) {
                 return Optional.of(BooleanValue.of(true, true));
@@ -335,55 +253,59 @@ public class BenchmarkSelectiveStreamReaders
             throw new UnsupportedOperationException("Unsupported type: " + type);
         }
 
-        @Override
-        protected final List<?> createValues()
+        private List<?> createValues()
         {
-            if (withNulls) {
-                return IntStream.range(0, ROWS).mapToObj(i -> i % 2 == 0 ? createValue() : null).collect(toList());
+            switch (withNulls) {
+                case ALL:
+                    return NULL_VALUES;
+                case PARTIAL:
+                    // Let the null rate be 0.5
+                    return IntStream.range(0, ROWS).mapToObj(i -> random.nextFloat() > 0.5 ? createValue() : null).collect(toList());
+                default:
+                    return IntStream.range(0, ROWS).mapToObj(i -> createValue()).collect(toList());
             }
-            return IntStream.range(0, ROWS).mapToObj(i -> createValue()).collect(toList());
         }
 
-        private final Object createValue()
+        private Object createValue()
         {
-            if (getType() == BOOLEAN) {
+            if (type == BOOLEAN) {
                 return random.nextBoolean();
             }
 
-            if (getType() == BIGINT) {
+            if (type == BIGINT) {
                 return random.nextLong();
             }
 
-            if (getType() == INTEGER) {
+            if (type == INTEGER) {
                 return random.nextInt();
             }
 
-            if (getType() == SMALLINT) {
+            if (type == SMALLINT) {
                 return (short) random.nextInt();
             }
 
-            if (getType() == TINYINT) {
+            if (type == TINYINT) {
                 return (byte) random.nextInt();
             }
 
-            if (getType() == DATE) {
+            if (type == DATE) {
                 return new SqlDate(random.nextInt());
             }
 
-            if (getType() == TIMESTAMP) {
+            if (type == TIMESTAMP) {
                 return new SqlTimestamp(random.nextLong(), TimeZoneKey.UTC_KEY);
             }
 
-            if (getType() == REAL) {
+            if (type == REAL) {
                 return random.nextFloat();
             }
 
-            if (getType() == DOUBLE) {
+            if (type == DOUBLE) {
                 return random.nextDouble();
             }
 
-            if (getType() instanceof DecimalType) {
-                if (Decimals.isShortDecimal(getType())) {
+            if (type instanceof DecimalType) {
+                if (Decimals.isShortDecimal(type)) {
                     return new SqlDecimal(BigInteger.valueOf(random.nextLong() % 10_000_000_000L), SHORT_DECIMAL_TYPE.getPrecision(), SHORT_DECIMAL_TYPE.getScale());
                 }
                 else {
@@ -391,14 +313,19 @@ public class BenchmarkSelectiveStreamReaders
                 }
             }
 
-            if (getType() == VARCHAR) {
+            if (type == VARCHAR) {
                 if (typeSignature.equals("varchar_dictionary")) {
                     return Strings.repeat("0", MAX_STRING_LENGTH);
                 }
                 return randomAsciiString(random, MAX_STRING_LENGTH);
             }
 
-            throw new UnsupportedOperationException("Unsupported type: " + getType());
+            throw new UnsupportedOperationException("Unsupported type: " + type);
+        }
+
+        public enum Nulls
+        {
+            PARTIAL, NONE, ALL;
         }
     }
 
@@ -414,6 +341,11 @@ public class BenchmarkSelectiveStreamReaders
     public static void main(String[] args)
             throws Throwable
     {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        BenchmarkSelectiveStreamReaders benchmarkSelectiveStreamReaders = new BenchmarkSelectiveStreamReaders();
+        benchmarkSelectiveStreamReaders.readAllBlocks(data);
+
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
                 .include(".*" + BenchmarkSelectiveStreamReaders.class.getSimpleName() + ".*")

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -35,7 +35,6 @@ import com.facebook.presto.type.TypeRegistry;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.primitives.Longs;
 import io.airlift.units.DataSize;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -104,7 +103,6 @@ public class BenchmarkSelectiveStreamReaders
     private static final List<?> NULL_VALUES = Collections.nCopies(ROWS, null);
     private static final DecimalType SHORT_DECIMAL_TYPE = DecimalType.createDecimalType(10, 5);
     private static final DecimalType LONG_DECIMAL_TYPE = DecimalType.createDecimalType(30, 10);
-    private static final int MAX_STRING_LENGTH = 10;
 
     @Benchmark
     public List<Block> readAllBlocks(BenchmarkData data)
@@ -130,13 +128,17 @@ public class BenchmarkSelectiveStreamReaders
     @State(Scope.Thread)
     public static class BenchmarkData
     {
+        private static final int NO_FILTER = -1;
+
         private final Random random = new Random(0);
 
         private Type type;
         private File temporaryDirectory;
         private File orcFile;
         private Optional<TupleDomainFilter> filter;
-        
+        private boolean filterAllowNull;
+        private float selectionRateForNonNull;
+
         @Param({
                 "boolean",
 
@@ -158,13 +160,18 @@ public class BenchmarkSelectiveStreamReaders
         })
         private String typeSignature = "boolean";
 
-        @SuppressWarnings("unused")
         @Param({
                 "PARTIAL",
                 "NONE",
                 "ALL"
         })
-        private Nulls withNulls = Nulls.PARTIAL;
+        private Nulls withNulls = Nulls.NONE;
+
+        // 0 means no rows will be filtered out, 1 means all rows will be filtered out, -1 means no filter.
+        // When withNulls is ALL, only -1, 0, 1 are meaningful. Other values are regarded as 1.
+        @SuppressWarnings("unused")
+        @Param({"-1", "0", "0.1", "0.5", "0.9", "1"})
+        private float filterRate = 0.1f;
 
         @Setup
         public void setup()
@@ -223,53 +230,91 @@ public class BenchmarkSelectiveStreamReaders
 
         private Optional<TupleDomainFilter> getFilter()
         {
-            if (type == BOOLEAN) {
-                return Optional.of(BooleanValue.of(true, true));
+            if (filterRate == NO_FILTER) {
+                return Optional.empty();
             }
 
-            if (type == TINYINT || type == BIGINT || type == INTEGER || type == SMALLINT || type == DATE || type == TIMESTAMP) {
-                return Optional.of(BigintRange.of(0, Long.MAX_VALUE, true));
+            setupFilterRateForNonNull();
+
+            if (type == BOOLEAN) {
+                return Optional.of(BooleanValue.of(true, filterAllowNull));
+            }
+
+            if (type == BIGINT) {
+                return Optional.of(BigintRange.of((long) (Long.MIN_VALUE * selectionRateForNonNull), (long) (Long.MAX_VALUE * selectionRateForNonNull), filterAllowNull));
+            }
+
+            if (type == INTEGER || type == DATE || type == TIMESTAMP) {
+                return Optional.of(BigintRange.of((long) (Integer.MIN_VALUE * selectionRateForNonNull), (long) (Integer.MAX_VALUE * selectionRateForNonNull), filterAllowNull));
+            }
+
+            if (type == INTEGER) {
+                return Optional.of(BigintRange.of((long) (Integer.MIN_VALUE * selectionRateForNonNull), (long) (Integer.MAX_VALUE * selectionRateForNonNull), filterAllowNull));
+            }
+
+            if (type == SMALLINT) {
+                return Optional.of(BigintRange.of((long) (Short.MIN_VALUE * selectionRateForNonNull), (long) (Short.MAX_VALUE * selectionRateForNonNull), filterAllowNull));
+            }
+
+            if (type == TINYINT) {
+                return Optional.of(BigintRange.of((long) (Byte.MIN_VALUE * selectionRateForNonNull), (long) (Byte.MAX_VALUE * selectionRateForNonNull), filterAllowNull));
             }
 
             if (type == REAL) {
-                return Optional.of(FloatRange.of(0, true, true, Integer.MAX_VALUE, true, true, true));
+                return Optional.of(FloatRange.of(0, false, false, selectionRateForNonNull, false, true, filterAllowNull));
             }
 
             if (type == DOUBLE) {
-                return Optional.of(DoubleRange.of(.5, false, false, 2, false, false, false));
+                return Optional.of(DoubleRange.of(0, false, false, selectionRateForNonNull, false, true, filterAllowNull));
             }
 
             if (type instanceof DecimalType) {
                 if (((DecimalType) type).isShort()) {
-                    return Optional.of(BigintRange.of(0, Long.MAX_VALUE, true));
+                    return Optional.of(BigintRange.of((long) (-10_000_000_000L * selectionRateForNonNull), (long) (10_000_000_000L * selectionRateForNonNull), filterAllowNull));
                 }
-                return Optional.of(LongDecimalRange.of(0, 0, false, true, Long.MAX_VALUE, Long.MAX_VALUE, false, true, true));
+                return Optional.of(LongDecimalRange.of(
+                        (long) (-10_000_000_000L * selectionRateForNonNull),
+                        (long) (-10_000_000_000L * selectionRateForNonNull),
+                        false,
+                        true,
+                        (long) (10_000_000_000L * selectionRateForNonNull),
+                        (long) (10_000_000_000L * selectionRateForNonNull),
+                        false,
+                        true,
+                        filterAllowNull));
             }
 
             if (type instanceof VarcharType) {
-                return Optional.of(BytesRange.of("0".getBytes(), false, Longs.toByteArray(Long.MAX_VALUE), false, true));
+                if (typeSignature.equals("varchar_dictionary")) {
+                    return Optional.of(BytesRange.of("000000000".getBytes(), false, "000000000".getBytes(), filterRate == 1 ? true : false, filterAllowNull));
+                }
+
+                return Optional.of(BytesRange.of("000000000".getBytes(), false, String.format("%09d", (int) (999_999_999 * selectionRateForNonNull) - 1).getBytes(), filterRate == 1 ? true : false, filterAllowNull));
             }
 
             throw new UnsupportedOperationException("Unsupported type: " + type);
         }
 
-        private List<?> createValues()
+        private final List<?> createValues()
         {
             switch (withNulls) {
                 case ALL:
                     return NULL_VALUES;
                 case PARTIAL:
-                    // Let the null rate be 0.5
-                    return IntStream.range(0, ROWS).mapToObj(i -> random.nextFloat() > 0.5 ? createValue() : null).collect(toList());
+                    // Let the null rate be 0.5 * (1 - filterRate)
+                    return IntStream.range(0, ROWS).mapToObj(i -> random.nextFloat() > 0.5 * (filterRate == -1 ? 1 : 1 - filterRate) ? createValue() : null).collect(toList());
                 default:
                     return IntStream.range(0, ROWS).mapToObj(i -> createValue()).collect(toList());
             }
         }
 
-        private Object createValue()
+        private final Object createValue()
         {
             if (type == BOOLEAN) {
-                return random.nextBoolean();
+                // We need to specialize BOOLEAN case because we can't specify filterRate by manipulating the filter value in getFilter.
+                // Since the filters allows null, so all nulls would all be selected. To make the total selected positions equal to ( 1- filterRate) * positionCount,
+                // we need to adapt the filterRate for non null values as follows:
+                return random.nextFloat() <= (1 - filterRate) / (1 + filterRate);
             }
 
             if (type == BIGINT) {
@@ -293,7 +338,9 @@ public class BenchmarkSelectiveStreamReaders
             }
 
             if (type == TIMESTAMP) {
-                return new SqlTimestamp(random.nextLong(), TimeZoneKey.UTC_KEY);
+                // We use int because longs will be converted to int when being written.
+                long value = random.nextInt();
+                return new SqlTimestamp(value, TimeZoneKey.UTC_KEY);
             }
 
             if (type == REAL) {
@@ -315,12 +362,33 @@ public class BenchmarkSelectiveStreamReaders
 
             if (type == VARCHAR) {
                 if (typeSignature.equals("varchar_dictionary")) {
-                    return Strings.repeat("0", MAX_STRING_LENGTH);
+                    return Strings.repeat("0", 9);
                 }
-                return randomAsciiString(random, MAX_STRING_LENGTH);
+
+                return randomAsciiString(random);
             }
 
             throw new UnsupportedOperationException("Unsupported type: " + type);
+        }
+
+        private void setupFilterRateForNonNull()
+        {
+            switch (withNulls) {
+                case NONE:
+                    filterAllowNull = false;  // doesn't matter
+                    selectionRateForNonNull = 1 - filterRate;
+                    break;
+                case PARTIAL:
+                    filterAllowNull = true;  // doesn't matter
+                    selectionRateForNonNull = (1 - filterRate) / (1 + filterRate);  // This is because we assumed the null rate is 0.5
+                    break;
+                case ALL:
+                    filterAllowNull = filterRate == 0 ? true : false;  // filterRate belonging to (0, 1] is regarded as 1
+                    selectionRateForNonNull = 1;  // This value doesn't matter
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unsupported withNulls: " + withNulls);
+            }
         }
 
         public enum Nulls
@@ -329,13 +397,9 @@ public class BenchmarkSelectiveStreamReaders
         }
     }
 
-    private static String randomAsciiString(Random random, int maxLength)
+    private static String randomAsciiString(Random random)
     {
-        char[] value = new char[random.nextInt(maxLength)];
-        for (int i = 0; i < value.length; i++) {
-            value[i] = (char) random.nextInt(Byte.MAX_VALUE);
-        }
-        return new String(value);
+        return String.format("%09d", random.nextInt(999_999_999));
     }
 
     public static void main(String[] args)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1711,7 +1711,7 @@ public class OrcTester
         return writeOrcColumnsHive(outputFile, format, compression, ImmutableList.of(type), ImmutableList.of(values));
     }
 
-    private static DataSize writeOrcColumnsHive(File outputFile, Format format, CompressionKind compression, List<Type> types, List<List<?>> values)
+    public static DataSize writeOrcColumnsHive(File outputFile, Format format, CompressionKind compression, List<Type> types, List<List<?>> values)
             throws Exception
     {
         RecordWriter recordWriter;


### PR DESCRIPTION
Benchmark results for two columns. The threshold filter rate to use batch processing is 0.5.
(filterRates = -1 means no filter, 0.1 means 10% rows are filtered out, 0.05\|-1 means there're two columns, the first column has filter rate 0.05, the second column doesn't have any filter).
Unit is s/op


HasNull | NONE | NONE | NONE | PARTIAL | PARTIAL | PARTIAL
-- | -- | -- | -- | -- | -- | --
FilterRates | baseline | readNoFilter | Gain | baseline | readNoFilter | Gain
-1 | 0.045 | 0.024 | 46.7% | 0.095 | 0.077 | 18.9%
0.0\|-1 | 0.106 | 0.084 | 20.8% | 0.221 | 0.178 | 19.5%
0.05\|-1 | 0.104 | 0.093 | 10.6% | 0.246 | 0.183 | 25.6%
0.1\|-1 | 0.107 | 0.095 | 11.2% | 0.221 | 0.187 | 15.4%
0.2\|-1 | 0.126 | 0.106 | 15.9% | 0.259 | 0.195 | 24.7%
0.3\|-1 | 0.145 | 0.113 | 22.1% | 0.258 | 0.202 | 21.7%
0.4\|-1 | 0.149 | 0.121 | 18.8% | 0.263 | 0.202 | 23.2%
0.5\|-1 | 0.154 | 0.130 | 15.6% | 0.256 | 0.227 | 11.3%
0.6\|-1 | 0.141 | 0.145 | -2.8% | 0.248 | 0.253 | -2.0%
0.8\|-1 | 0.131 | 0.124 | 5.3% | 0.226 | 0.216 | 4.4%
0.9\|-1 | 0.111 | 0.110 | 0.9% | 0.175 | 0.163 | 6.9%
1\|-1 | 0.102 | 0.104 | -2.0% | 0.103 | 0.100 | 2.9%





```
== NO RELEASE NOTE ==
```
