### PR TITLE
Support for catalog refreshing dynamically by changing catalog configuration files

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/DynamicCatalogStore.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DynamicCatalogStore.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.connector.ConnectorManager;
+import com.facebook.presto.server.PrestoServer;
+import com.google.common.io.Files;
+import io.airlift.units.Duration;
+
+import javax.inject.Inject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.server.PrestoServer.updateDatasourcesWithSpecifiedAction;
+
+public class DynamicCatalogStore
+        extends StaticCatalogStore
+{
+    private static final Logger log = Logger.get(DynamicCatalogStore.class);
+    private final Duration watchTimeout;
+    private final boolean dynamicUpdateEanbled;
+
+    @Inject
+    public DynamicCatalogStore(ConnectorManager connectorManager, DynamicCatalogStoreConfig config)
+    {
+        super(connectorManager, config);
+        watchTimeout = config.getWatchTimeout();
+        dynamicUpdateEanbled = config.isDynamicUpdateEanbled();
+    }
+
+    public void loadCatalogs()
+            throws Exception
+    {
+        super.loadCatalogs();
+
+        if (dynamicUpdateEanbled) {
+            // update catalogs dynamically
+            new Thread(() -> {
+                try {
+                    log.info("-- Catalog watcher thread start --");
+                    startCatalogConfigWatcher(getCatalogConfigurationDir());
+                }
+                catch (Exception e) {
+                    log.error(e);
+                }
+            }).start();
+        }
+    }
+
+    private void startCatalogConfigWatcher(File catalogConfigurationDir) throws IOException, InterruptedException
+    {
+        WatchService watchService = FileSystems.getDefault().newWatchService();
+        Paths.get(catalogConfigurationDir.getAbsolutePath()).register(
+                watchService,
+                StandardWatchEventKinds.ENTRY_MODIFY,
+                StandardWatchEventKinds.ENTRY_CREATE,
+                StandardWatchEventKinds.ENTRY_DELETE);
+
+        while (true) {
+            WatchKey key = watchService.take();
+            for (WatchEvent<?> event : key.pollEvents()) {
+                if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                    log.info("New file in catalog directory : " + event.context());
+                    Path newCatalog = (Path) event.context();
+                    addCatalog(newCatalog);
+                }
+                else if (event.kind() == StandardWatchEventKinds.ENTRY_DELETE) {
+                    log.info("Delete file from catalog directory : " + event.context());
+                    Path deletedCatalog = (Path) event.context();
+                    deleteCatalog(deletedCatalog);
+                }
+                else if (event.kind() == StandardWatchEventKinds.ENTRY_MODIFY) {
+                    log.info("Modify file from catalog directory : " + event.context());
+                    Path modifiedCatalog = (Path) event.context();
+                    modifyCatalog(modifiedCatalog);
+                }
+            }
+            boolean valid = key.reset();
+            if (!valid) {
+                break;
+            }
+        }
+    }
+
+    private void addCatalog(Path catalogPath)
+    {
+        File file = new File(getCatalogConfigurationDir(), catalogPath.getFileName().toString());
+        if (file.isFile() && file.getName().endsWith(".properties")) {
+            try {
+                TimeUnit.SECONDS.sleep((long) watchTimeout.getValue(TimeUnit.SECONDS));
+                loadCatalog(file);
+                updateDatasourcesWithSpecifiedAction(Files.getNameWithoutExtension(catalogPath.getFileName().toString()), PrestoServer.DatasourceAction.ADD);
+            }
+            catch (Exception e) {
+                log.error(e);
+            }
+        }
+    }
+
+    private void deleteCatalog(Path catalogPath)
+    {
+        if (catalogPath.getFileName().toString().endsWith(".properties")) {
+            String catalogName = Files.getNameWithoutExtension(catalogPath.getFileName().toString());
+            log.info("-- Removing catalog %s", catalogName);
+            getConnectorManager().dropConnection(catalogName);
+            updateDatasourcesWithSpecifiedAction(catalogName, PrestoServer.DatasourceAction.DELETE);
+            log.info("-- Removed catalog %s", catalogName);
+        }
+    }
+
+    private void modifyCatalog(Path catalogPath)
+    {
+        deleteCatalog(catalogPath);
+        addCatalog(catalogPath);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DynamicCatalogStoreConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DynamicCatalogStoreConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.airlift.configuration.Config;
+import io.airlift.units.Duration;
+
+import java.util.concurrent.TimeUnit;
+
+public class DynamicCatalogStoreConfig
+        extends StaticCatalogStoreConfig
+{
+    private Duration watchTimeout = new Duration(5, TimeUnit.SECONDS);
+    private boolean dynamicUpdateEanbled;
+
+    public Duration getWatchTimeout()
+    {
+        return watchTimeout;
+    }
+
+    @Config("catalog.watch-timeout")
+    public DynamicCatalogStoreConfig setWatchTimeout(Duration watchTimeout)
+    {
+        this.watchTimeout = watchTimeout;
+        return this;
+    }
+
+    public boolean isDynamicUpdateEanbled()
+    {
+        return dynamicUpdateEanbled;
+    }
+
+    @Config("catalog.dynamic-update.enabled")
+    public DynamicCatalogStoreConfig setDynamicUpdateEanbled(boolean dynamicUpdateEanbled)
+    {
+        this.dynamicUpdateEanbled = dynamicUpdateEanbled;
+        return this;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/StaticCatalogStore.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/StaticCatalogStore.java
@@ -78,7 +78,7 @@ public class StaticCatalogStore
         catalogsLoaded.set(true);
     }
 
-    private void loadCatalog(File file)
+    void loadCatalog(File file)
             throws Exception
     {
         String catalogName = Files.getNameWithoutExtension(file.getName());
@@ -106,5 +106,15 @@ public class StaticCatalogStore
             }
         }
         return ImmutableList.of();
+    }
+
+    ConnectorManager getConnectorManager()
+    {
+        return connectorManager;
+    }
+
+    File getCatalogConfigurationDir()
+    {
+        return catalogConfigurationDir;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -68,6 +68,8 @@ import com.facebook.presto.metadata.AnalyzePropertyManager;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.ColumnPropertyManager;
 import com.facebook.presto.metadata.DiscoveryNodeManager;
+import com.facebook.presto.metadata.DynamicCatalogStore;
+import com.facebook.presto.metadata.DynamicCatalogStoreConfig;
 import com.facebook.presto.metadata.ForNodeManager;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.HandleJsonModule;
@@ -391,6 +393,8 @@ public class ServerMainModule
         // metadata
         binder.bind(StaticCatalogStore.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(StaticCatalogStoreConfig.class);
+        binder.bind(DynamicCatalogStore.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(DynamicCatalogStoreConfig.class);
         binder.bind(StaticFunctionNamespaceStore.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(StaticFunctionNamespaceStoreConfig.class);
         binder.bind(FunctionManager.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
Based on offical StaticCatalogStore, I have Inherited the class to support catalog refreshing dynamically, launch a seperated thread to sense file changes of catalog directory via java.nio.WatchService, and then update data source announcement.
otherwise, support customize wheter to enable the feature using etc/node.properties, default is disabled:
```
catalog.dynamic-update.enabled = true
```

```
== RELEASE NOTES ==

General Changes
* Support for catalog refreshing dynamically by changing catalog configuration files

```
