### PR TITLE
Update to Joda 2.10.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.drift.version>1.22</dep.drift.version>
-        <dep.joda.version>2.10</dep.joda.version>
+        <dep.joda.version>2.10.5</dep.joda.version>
         <dep.tempto.version>1.50</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Fix an issue where ``DATE_TRUNC`` may produce incorrect results at certain timestamp in ``America/Sao_Paulo``.
```
