### PR TITLE
Log number of splits received for Presto-on-Spark task

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -173,6 +173,12 @@ public class PrestoSparkTaskExecutorFactory
         // TODO: include attemptId in taskId
         TaskId taskId = new TaskId(new StageExecutionId(stageId, 0), partitionId);
 
+        log.info("Task [%s] received %d splits.",
+                taskId,
+                taskDescriptor.getSources().stream()
+                        .mapToInt(taskSource -> taskSource.getSplits().size())
+                        .sum());
+
         MemoryPool memoryPool = new MemoryPool(new MemoryPoolId("spark-executor-memory-pool"), maxTotalMemory);
         SpillSpaceTracker spillSpaceTracker = new SpillSpaceTracker(maxSpillMemory);
 


### PR DESCRIPTION
We have seen very uneven workload assignment in table scan phase when running Presto-on-Spark in production. Log the number of splits on each task to see if it's due to bad split assignment (bad hash function?)

<img width="1532" alt="Screen Shot 2020-02-04 at 10 39 29 PM" src="https://user-images.githubusercontent.com/799346/73817481-dbba1900-479f-11ea-9f65-7ff00f91696f.png">



```
== NO RELEASE NOTE ==
```
