### PR TITLE
Add join pushdown predicate at the end of the exisiting predicate

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1893,7 +1893,7 @@ public class HiveMetadata
                 .fromPredicate(session, filter, new SubfieldExtractor(functionResolution, rowExpressionService.getExpressionOptimizer(), session).toColumnExtractor());
         if (currentLayoutHandle.isPresent()) {
             HiveTableLayoutHandle currentHiveLayout = (HiveTableLayoutHandle) currentLayoutHandle.get();
-            decomposedFilter = intersectExtractionResult(decomposedFilter, new ExtractionResult(currentHiveLayout.getDomainPredicate(), currentHiveLayout.getRemainingPredicate()));
+            decomposedFilter = intersectExtractionResult(new ExtractionResult(currentHiveLayout.getDomainPredicate(), currentHiveLayout.getRemainingPredicate()), decomposedFilter);
         }
 
         if (decomposedFilter.getTupleDomain().isNone()) {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -729,6 +729,10 @@ public class TestHivePushdownFilterQueries
         // filter function on numeric and boolean columns
         assertFilterProject("if(is_returned, linenumber, orderkey) % 5 = 0", "linenumber");
 
+        // filter functions with join predicate pushdown
+        assertQueryReturnsEmptyResult("SELECT * FROM orders o, lineitem_ex l " +
+                "WHERE o.orderkey <> 100 AND cardinality(l.keys) >= 5 AND l.keys[5] <> 1 AND l.keys[5] = o.orderkey");
+
         // filter functions on array columns
         assertFilterProject("keys[1] % 5 = 0", "orderkey");
         assertFilterProject("nested_keys[1][1] % 5 = 0", "orderkey");


### PR DESCRIPTION
Currently, we add the join pushdown predicate at the start of the existing predicate, this will result in the evaluation of that without respecting the order of the existing ones.

Fixes #14065

```
== NO RELEASE NOTE ==
```
