### PR TITLE
Revert "Add release notes for 0.231.1"

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,7 +5,6 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
-    release/release-0.231.1
     release/release-0.231
     release/release-0.230
     release/release-0.229

--- a/presto-docs/src/main/sphinx/release/release-0.231.1.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.231.1.rst
@@ -1,7 +1,0 @@
-===============
-Release 0.231.1
-===============
-
-General Changes
-_______________
-* Fix an issue where ``DATE_TRUNC`` may produce incorrect results at certain timestamps in ``America/Sao_Paulo``.


### PR DESCRIPTION
The next was not cherry-pick onto the release branch when creating 0.231.1, and thus 0.231.1 is identical to 0.231. The change will be available in 0.232, so thus we should add the release notes there.

```
== NO RELEASE NOTE ==
```
