### PR TITLE
Fix like pattern interpretation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -883,8 +883,19 @@ public class RowExpressionInterpreter
                 if (possibleCompiledPattern == null) {
                     return changed(null);
                 }
-                checkState((resolution.isCastFunction(((CallExpression) possibleCompiledPattern).getFunctionHandle())));
-                possibleCompiledPattern = functionInvoker.invoke(((CallExpression) possibleCompiledPattern).getFunctionHandle(), session, nonCompiledPattern);
+
+                checkState(possibleCompiledPattern instanceof CallExpression);
+                // this corresponds to ExpressionInterpreter::getConstantPattern
+                if (hasEscape) {
+                    // like_pattern(pattern, escape)
+                    possibleCompiledPattern = functionInvoker.invoke(((CallExpression) possibleCompiledPattern).getFunctionHandle(), session, nonCompiledPattern, escape);
+                }
+                else {
+                    // like_pattern(pattern)
+                    possibleCompiledPattern = functionInvoker.invoke(((CallExpression) possibleCompiledPattern).getFunctionHandle(), session, nonCompiledPattern);
+                }
+
+                checkState(possibleCompiledPattern instanceof Regex, "unexpected like pattern type " + possibleCompiledPattern.getClass());
                 return changed(interpretLikePredicate(argumentTypes.get(0), (Slice) value, (Regex) possibleCompiledPattern));
             }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -1289,6 +1289,9 @@ public class TestExpressionInterpreter
         assertOptimizedEquals("'a' LIKE unbound_string ESCAPE null", "null");
 
         assertOptimizedEquals("'%' LIKE 'z%' ESCAPE 'z'", "true");
+
+        assertRowExpressionEquals(SERIALIZABLE, "'%' LIKE 'z%' ESCAPE 'z'", "true");
+        assertRowExpressionEquals(SERIALIZABLE, "'%' LIKE 'z%'", "false");
     }
 
     @Test
@@ -1329,11 +1332,11 @@ public class TestExpressionInterpreter
         assertDoNotOptimize("transform(unbound_array, x -> x + x)", OPTIMIZED);
         assertOptimizedEquals("transform(ARRAY[1, 5], x -> x + x)", "transform(ARRAY[1, 5], x -> x + x)");
         assertOptimizedEquals("transform(sequence(1, 5), x -> x + x)", "transform(sequence(1, 5), x -> x + x)");
-        assertRowExpressionOptimizedEquals(
+        assertRowExpressionEquals(
                 OPTIMIZED,
                 "transform(sequence(1, unbound_long), x -> cast(json_parse('[1, 2]') AS ARRAY<INTEGER>)[1] + x)",
                 "transform(sequence(1, unbound_long), x -> 1 + x)");
-        assertRowExpressionOptimizedEquals(
+        assertRowExpressionEquals(
                 OPTIMIZED,
                 "transform(sequence(1, unbound_long), x -> cast(json_parse('[1, 2]') AS ARRAY<INTEGER>)[1] + 1)",
                 "transform(sequence(1, unbound_long), x -> 2)");
@@ -1382,7 +1385,7 @@ public class TestExpressionInterpreter
     @Test
     public void testMassiveArray()
     {
-        assertRowExpressionOptimizedEquals(
+        assertRowExpressionEquals(
                 OPTIMIZED,
                 "SEQUENCE(1, 999)",
                 format("ARRAY [%s]", Joiner.on(", ").join(IntStream.range(1, 1000).mapToObj(i -> "(BIGINT '" + i + "')").iterator())));
@@ -1525,7 +1528,7 @@ public class TestExpressionInterpreter
         assertEquals(optimize(actual), optimize(expected));
     }
 
-    private static void assertRowExpressionOptimizedEquals(Level level, @Language("SQL") String actual, @Language("SQL") String expected)
+    private static void assertRowExpressionEquals(Level level, @Language("SQL") String actual, @Language("SQL") String expected)
     {
         Object actualResult = optimize(toRowExpression(expression(actual)), level);
         Object expectedResult = optimize(toRowExpression(expression(expected)), level);


### PR DESCRIPTION
like pattern constant folding happens only when the optimization level
is above SERIALIZABLE. However, RowExpressionInterpreter::tryHandleLike
handles like function in a way that it will take the constant folded
like pattern result together with the original arguments. Under such
case, tryHandleLike expects the given constant folded like pattern
should always be a compiled Regex but is not in the above case.

The patch relaxes the restriction on the like pattern to be more
generic. As long as the return type is Regex, tryHandleLike should be
able to handle it.


```
== RELEASE NOTES ==

General Changes
* Fix an optimizer failure introduced since 0.229, where a `LIKE` pattern can be deduced into a constant. For example, `col LIKE 'a' and col = 'b'`
```
