### PR TITLE
Fix hostname related assertion failure in PrestoSparkQueryRunner

### DIFF
--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -133,7 +133,8 @@ public class PrestoSparkQueryRunner
 
         SparkConf sparkConfiguration = new SparkConf()
                 .setMaster(format("local[%s]", nodeCount))
-                .setAppName("presto");
+                .setAppName("presto")
+                .set("spark.driver.host", "localhost");
         sparkContext = new SparkContext(sparkConfiguration);
         prestoSparkService = injector.getInstance(PrestoSparkService.class);
 


### PR DESCRIPTION
If the local hostname is not set in the system, the PrestoSparkQueryRunner
fails with the "java.lang.AssertionError: assertion failed: Expected hostname".

Following the workaround described in the issue:
https://issues.apache.org/jira/browse/SPARK-19394?focusedCommentId=15846109

```
== NO RELEASE NOTE ==
```
