### PR TITLE
Adding SampleNode stats and cost rule.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/ComposableStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ComposableStatsCalculator.java
@@ -80,6 +80,10 @@ public class ComposableStatsCalculator
         return rule.calculate((T) node, sourceStats, lookup, session, types);
     }
 
+    /**
+     * It's preferable to extend SimpleStatsRule than using this Rule interface directly.
+     * SimpleStatsRule has an advantage that PlanNodeStatsEstimates get normalized.
+     */
     public interface Rule<T extends PlanNode>
     {
         Pattern<T> getPattern();

--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorUsingExchanges.java
@@ -32,6 +32,7 @@ import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
+import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SortNode;
 import com.facebook.presto.sql.planner.plan.SpatialJoinNode;
@@ -307,6 +308,13 @@ public class CostCalculatorUsingExchanges
             double memoryCost = getStats(node).getOutputSizeInBytes(node.getOutputVariables());
             LocalCostEstimate localCost = LocalCostEstimate.of(cpuCost, memoryCost, 0);
             return costForAccumulation(node, localCost);
+        }
+
+        @Override
+        public PlanCostEstimate visitSample(SampleNode node, Void context)
+        {
+            LocalCostEstimate localCost = LocalCostEstimate.ofCpu(getStats(node.getSource()).getOutputSizeInBytes(node.getOutputVariables()));
+            return costForStreaming(node, localCost);
         }
 
         private PlanCostEstimate costForSource(PlanNode node, LocalCostEstimate localCost)

--- a/presto-main/src/main/java/com/facebook/presto/cost/SampleStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/SampleStatsRule.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.plan.SampleNode;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.plan.Patterns.sample;
+
+public class SampleStatsRule
+        extends SimpleStatsRule<SampleNode>
+{
+    private static final Pattern<SampleNode> PATTERN = sample();
+
+    public SampleStatsRule(StatsNormalizer normalizer)
+    {
+        super(normalizer);
+    }
+
+    @Override
+    public Pattern<SampleNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    protected Optional<PlanNodeStatsEstimate> doCalculate(SampleNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    {
+        PlanNodeStatsEstimate sourceStats = statsProvider.getStats(node.getSource());
+        return Optional.of(PlanNodeStatsEstimate.buildFrom(sourceStats)
+                .setOutputRowCount(sourceStats.getOutputRowCount() * node.getSampleRatio())
+                .build());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
@@ -60,6 +60,7 @@ public class StatsCalculatorModule
         rules.add(new RowNumberStatsRule(normalizer));
         rules.add(new UnnestStatsRule());
         rules.add(new SortStatsRule());
+        rules.add(new SampleStatsRule(normalizer));
 
         return new ComposableStatsCalculator(rules.build());
     }

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestSampleStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestSampleStatsRule.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.plan.SampleNode;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+
+public class TestSampleStatsRule
+        extends BaseStatsCalculatorTest
+{
+    @Test
+    public void testSample()
+    {
+        tester().assertStatsFor(pb ->
+                pb.sample(0.5, SampleNode.Type.BERNOULLI, pb.values(
+                        pb.variable("i1", BIGINT), pb.variable("i2", BIGINT))))
+                .withSourceStats(0, PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(100)
+                        .addVariableStatistics(new VariableReferenceExpression("i1", BIGINT), VariableStatsEstimate.builder()
+                                .setLowValue(1)
+                                .setHighValue(100)
+                                .setDistinctValuesCount(5)
+                                .setNullsFraction(0)
+                                .build())
+                        .addVariableStatistics(new VariableReferenceExpression("i2", BIGINT), VariableStatsEstimate.builder()
+                                .setLowValue(1)
+                                .setHighValue(20)
+                                .setDistinctValuesCount(20)
+                                .setNullsFraction(0.2)
+                                .build())
+                        .build())
+                .check(check ->
+                        check.outputRowsCount(50)
+                                .variableStats(new VariableReferenceExpression("i1", BIGINT), assertion -> assertion
+                                        .lowValue(1)
+                                        .highValue(100)
+                                        .distinctValuesCount(5)
+                                        .nullsFraction(0))
+                                .variableStats(new VariableReferenceExpression("i2", BIGINT), assertion -> assertion
+                                        .lowValue(1)
+                                        .highValue(20)
+                                        .distinctValuesCount(20)
+                                        .nullsFraction(0.2)));
+
+        tester().assertStatsFor(pb ->
+                pb.sample(0.2, SampleNode.Type.SYSTEM, pb.values(
+                        pb.variable("i1", BIGINT), pb.variable("i2", BIGINT))))
+                .withSourceStats(0, PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(100)
+                        .addVariableStatistics(new VariableReferenceExpression("i1", BIGINT), VariableStatsEstimate.builder()
+                                .setLowValue(1)
+                                .setHighValue(100)
+                                .setDistinctValuesCount(5)
+                                .setNullsFraction(0)
+                                .build())
+                        .addVariableStatistics(new VariableReferenceExpression("i2", BIGINT), VariableStatsEstimate.builder()
+                                .setLowValue(1)
+                                .setHighValue(20)
+                                .setDistinctValuesCount(20)
+                                .setNullsFraction(0)
+                                .build())
+                        .build())
+                .check(check ->
+                        check.outputRowsCount(20)
+                                .variableStats(new VariableReferenceExpression("i1", BIGINT), assertion -> assertion
+                                        .lowValue(1)
+                                        .highValue(100)
+                                        .distinctValuesCount(5)
+                                        .nullsFraction(0))
+                                .variableStats(new VariableReferenceExpression("i2", BIGINT), assertion -> assertion
+                                        .lowValue(1)
+                                        .highValue(20)
+                                        .distinctValuesCount(20)
+                                        .nullsFraction(0)));
+    }
+}


### PR DESCRIPTION
Adding Stats and cost rules for Sample node, so that more efficient plan is generated for the query with sample operator.

```
== NO RELEASE NOTE ==
```
