### PR TITLE
Add soft affinity in scheduling bucketed split for Hive Connector

### DIFF
--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleNodePartitioningProvider.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleNodePartitioningProvider.java
@@ -16,6 +16,7 @@ package com.facebook.presto.plugin.blackhole;
 import com.facebook.presto.spi.BucketFunction;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.ConnectorBucketNodeMap;
@@ -42,7 +43,7 @@ public class BlackHoleNodePartitioningProvider
     }
 
     @Override
-    public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
+    public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle, List<Node> sortedNodes)
     {
         // create one bucket per node
         return createBucketNodeMap(nodeManager.getRequiredWorkerNodes().size());

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/group/DynamicBucketNodeMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/group/DynamicBucketNodeMap.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.Split;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.ToIntFunction;
 
@@ -35,6 +36,17 @@ public class DynamicBucketNodeMap
     {
         super(splitToBucket);
         checkArgument(bucketCount > 0, "bucketCount must be positive");
+        this.bucketCount = bucketCount;
+    }
+
+    public DynamicBucketNodeMap(ToIntFunction<Split> splitToBucket, int bucketCount, List<InternalNode> bucketToPreferredNode)
+    {
+        super(splitToBucket);
+        checkArgument(bucketCount > 0, "bucketCount must be positive");
+        checkArgument(bucketToPreferredNode.size() == bucketCount, "bucketToPreferredNode size must be equal to bucketCount");
+        for (int bucketNumber = 0; bucketNumber < bucketCount; bucketNumber++) {
+            bucketToNode.put(bucketNumber, bucketToPreferredNode.get(bucketNumber));
+        }
         this.bucketCount = bucketCount;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchange.java
@@ -174,7 +174,8 @@ public class LocalExchange
         ConnectorBucketNodeMap connectorBucketNodeMap = partitioningProvider.getBucketNodeMap(
                 partitioning.getTransactionHandle().orElse(null),
                 session.toConnectorSession(partitioning.getConnectorId().get()),
-                partitioning.getConnectorHandle());
+                partitioning.getConnectorHandle(),
+                ImmutableList.of());
         checkArgument(connectorBucketNodeMap != null, "No partition map %s", partitioning);
 
         int bucketCount = connectorBucketNodeMap.getBucketCount();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
@@ -168,7 +168,11 @@ public class NodePartitioningManager
         NodeSelectionStrategy nodeSelectionStrategy = connectorBucketNodeMap.getNodeSelectionStrategy();
         switch (nodeSelectionStrategy) {
             case HARD_AFFINITY:
+                return new FixedBucketNodeMap(getSplitToBucket(session, partitioningHandle), getFixedMapping(connectorBucketNodeMap));
             case SOFT_AFFINITY:
+                if (preferDynamic) {
+                    return new DynamicBucketNodeMap(getSplitToBucket(session, partitioningHandle), connectorBucketNodeMap.getBucketCount(), getFixedMapping(connectorBucketNodeMap));
+                }
                 return new FixedBucketNodeMap(getSplitToBucket(session, partitioningHandle), getFixedMapping(connectorBucketNodeMap));
             case NO_PREFERENCE:
                 if (preferDynamic) {

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotNodePartitioningProvider.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotNodePartitioningProvider.java
@@ -16,6 +16,7 @@ package com.facebook.presto.pinot;
 import com.facebook.presto.spi.BucketFunction;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.connector.ConnectorBucketNodeMap;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
@@ -32,7 +33,8 @@ public class PinotNodePartitioningProvider
     public ConnectorBucketNodeMap getBucketNodeMap(
             ConnectorTransactionHandle transactionHandle,
             ConnectorSession session,
-            ConnectorPartitioningHandle partitioningHandle)
+            ConnectorPartitioningHandle partitioningHandle,
+            List<Node> sortedNodes)
     {
         return ConnectorBucketNodeMap.createBucketNodeMap(1);
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorNodePartitioningProvider.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorNodePartitioningProvider.java
@@ -33,6 +33,7 @@ import java.util.function.ToIntFunction;
 
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.facebook.presto.spi.connector.ConnectorBucketNodeMap.createBucketNodeMap;
+import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.HARD_AFFINITY;
 import static com.google.common.collect.Maps.uniqueIndex;
 import static java.util.Objects.requireNonNull;
 
@@ -48,7 +49,7 @@ public class RaptorNodePartitioningProvider
     }
 
     @Override
-    public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorPartitioningHandle partitioning)
+    public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorPartitioningHandle partitioning, List<Node> sortedNodes)
     {
         RaptorPartitioningHandle handle = (RaptorPartitioningHandle) partitioning;
 
@@ -62,7 +63,7 @@ public class RaptorNodePartitioningProvider
             }
             bucketToNode.add(node);
         }
-        return createBucketNodeMap(bucketToNode.build());
+        return createBucketNodeMap(bucketToNode.build(), HARD_AFFINITY);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorBucketNodeMap.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorBucketNodeMap.java
@@ -14,31 +14,36 @@
 package com.facebook.presto.spi.connector;
 
 import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 public final class ConnectorBucketNodeMap
 {
     private final int bucketCount;
     private final Optional<List<Node>> bucketToNode;
+    private final NodeSelectionStrategy nodeSelectionStrategy;
 
     public static ConnectorBucketNodeMap createBucketNodeMap(int bucketCount)
     {
-        return new ConnectorBucketNodeMap(bucketCount, Optional.empty());
+        return new ConnectorBucketNodeMap(bucketCount, Optional.empty(), NO_PREFERENCE);
     }
 
-    public static ConnectorBucketNodeMap createBucketNodeMap(List<Node> bucketToNode)
+    public static ConnectorBucketNodeMap createBucketNodeMap(List<Node> bucketToNode, NodeSelectionStrategy nodeSelectionStrategy)
     {
-        return new ConnectorBucketNodeMap(bucketToNode.size(), Optional.of(bucketToNode));
+        return new ConnectorBucketNodeMap(bucketToNode.size(), Optional.of(bucketToNode), nodeSelectionStrategy);
     }
 
-    private ConnectorBucketNodeMap(int bucketCount, Optional<List<Node>> bucketToNode)
+    private ConnectorBucketNodeMap(int bucketCount, Optional<List<Node>> bucketToNode, NodeSelectionStrategy nodeSelectionStrategy)
     {
+        this.nodeSelectionStrategy = requireNonNull(nodeSelectionStrategy, "nodeSelectionStrategy is null");
         if (bucketCount <= 0) {
             throw new IllegalArgumentException("bucketCount must be positive");
         }
@@ -54,9 +59,9 @@ public final class ConnectorBucketNodeMap
         return bucketCount;
     }
 
-    public boolean hasFixedMapping()
+    public NodeSelectionStrategy getNodeSelectionStrategy()
     {
-        return bucketToNode.isPresent();
+        return nodeSelectionStrategy;
     }
 
     public List<Node> getFixedMapping()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorNodePartitioningProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorNodePartitioningProvider.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi.connector;
 import com.facebook.presto.spi.BucketFunction;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.type.Type;
 
 import java.util.List;
@@ -40,7 +41,7 @@ public interface ConnectorNodePartitioningProvider
         return singletonList(NOT_PARTITIONED);
     }
 
-    ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle);
+    ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle, List<Node> sortedNodes);
 
     ToIntFunction<ConnectorSplit> getSplitBucketFunction(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle);
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeNodePartitioningProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeNodePartitioningProvider.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi.connector.classloader;
 import com.facebook.presto.spi.BucketFunction;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorBucketNodeMap;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
@@ -63,10 +64,10 @@ public final class ClassLoaderSafeNodePartitioningProvider
     }
 
     @Override
-    public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
+    public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle, List<Node> sortedNodes)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getBucketNodeMap(transactionHandle, session, partitioningHandle);
+            return delegate.getBucketNodeMap(transactionHandle, session, partitioningHandle, sortedNodes);
         }
     }
 

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsNodePartitioningProvider.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsNodePartitioningProvider.java
@@ -50,7 +50,7 @@ public class TpcdsNodePartitioningProvider
     }
 
     @Override
-    public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
+    public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle, List<Node> sortedNodes)
     {
         Set<Node> nodes = nodeManager.getRequiredWorkerNodes();
         checkState(!nodes.isEmpty(), "No TPCDS nodes available");

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchNodePartitioningProvider.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchNodePartitioningProvider.java
@@ -48,7 +48,7 @@ public class TpchNodePartitioningProvider
     }
 
     @Override
-    public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
+    public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle, List<Node> sortedNodes)
     {
         Set<Node> nodes = nodeManager.getRequiredWorkerNodes();
 


### PR DESCRIPTION
```
== RELEASE NOTES ==

SPI Changes
* Add parameter `NodeSelectionStrategy nodeSelectionStrategy` in method `createBucketNodeMap` in `ConnectorBucketNodeMap `, indicating which affinity strategy to use when we create bucket nodeMap.
* Add parameter `List<Node> sortedNodes` in method `getBucketNodeMap` in `ConnectorNodePartitioningProvider `, providing a sorted node list for connector to choose from when doing affinity scheduling.

General Changes
* Add soft affinity scheduling to bucketed split. It makes the best effort to fetch the same bucket data from the same worker. When using dynamic group scheduling, if the preferred workers are unavailable to handle the specific bucket splits, it will fallback to random workers. 

```