### PR TITLE
Remove unnecessary copies in StreamingAggregationOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/StreamingAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/StreamingAggregationOperator.java
@@ -226,8 +226,9 @@ public class StreamingAggregationOperator
 
     private void addRowsToAggregates(Page page, int startPosition, int endPosition)
     {
+        Page region = page.getRegion(startPosition, endPosition - startPosition + 1);
         for (Aggregator aggregator : aggregates) {
-            aggregator.processPage(page.getRegion(startPosition, endPosition - startPosition + 1));
+            aggregator.processPage(region);
         }
     }
 


### PR DESCRIPTION
The previous implementation copied the aggregation group out of the
page for each aggregation operator which is wasteful and extremely
slow when the number of aggregates performed is large.

Performance improvement depends on the number of aggregations and
the number of groups contained in the page, but some workloads can
improve throughput by more than 100% and generate significantly
less garbage.

Cross port of https://github.com/prestosql/presto/pull/2822

```
== RELEASE NOTES ==

General Changes
* Improve performance of StreamingAggregationOperator
```
