### PR TITLE
Run presto spark tests in forked VM

### DIFF
--- a/presto-spark-testing/pom.xml
+++ b/presto-spark-testing/pom.xml
@@ -122,16 +122,6 @@
                     </ignoredResourcePatterns>
                 </configuration>
             </plugin>
-
-            <!-- Workaround for "Corrupted STDOUT by directly writing to native stream in forked JVM 1" -->
-            <!-- https://stackoverflow.com/questions/55632614/maven-surefire-plugin-crahsing-jvm-on-java-11-corrupted-stdout-by-directly-writ -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkCount>0</forkCount>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
The tests no longer use stream redirects thus the workaround is
no longer needed.

```
== NO RELEASE NOTE ==
```
