### PR TITLE
Provide view metadata to the Hive Metastore

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloMetadata.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloMetadata.java
@@ -143,8 +143,9 @@ public class AccumuloMetadata
     }
 
     @Override
-    public void createView(ConnectorSession session, SchemaTableName viewName, String viewData, boolean replace)
+    public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
     {
+        SchemaTableName viewName = viewMetadata.getTable();
         if (replace) {
             client.createOrReplaceView(viewName, viewData);
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -191,7 +191,6 @@ import static com.facebook.presto.hive.HiveTableProperties.getHiveStorageFormat;
 import static com.facebook.presto.hive.HiveTableProperties.getOrcBloomFilterColumns;
 import static com.facebook.presto.hive.HiveTableProperties.getOrcBloomFilterFpp;
 import static com.facebook.presto.hive.HiveTableProperties.getPartitionedBy;
-import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.hive.HiveType.toHiveType;
 import static com.facebook.presto.hive.HiveUtil.columnExtraInfo;
 import static com.facebook.presto.hive.HiveUtil.decodeViewData;
@@ -1662,7 +1661,7 @@ public class HiveMetadata
     }
 
     @Override
-    public void createView(ConnectorSession session, SchemaTableName viewName, String viewData, boolean replace)
+    public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put(TABLE_COMMENT, "Presto View")
@@ -1671,14 +1670,18 @@ public class HiveMetadata
                 .put(PRESTO_QUERY_ID_NAME, session.getQueryId())
                 .build();
 
-        Column dummyColumn = new Column("dummy", HIVE_STRING, Optional.empty());
+        List<Column> columns = viewMetadata.getColumns().stream()
+                .map(col -> new Column(col.getName(), toHiveType(typeTranslator, col.getType()), Optional.ofNullable(col.getComment())))
+                        .collect(toImmutableList());
+
+        SchemaTableName viewName = viewMetadata.getTable();
 
         Table.Builder tableBuilder = Table.builder()
                 .setDatabaseName(viewName.getSchemaName())
                 .setTableName(viewName.getTableName())
                 .setOwner(session.getUser())
                 .setTableType(VIRTUAL_VIEW)
-                .setDataColumns(ImmutableList.of(dummyColumn))
+                .setDataColumns(columns)
                 .setPartitionColumns(ImmutableList.of())
                 .setParameters(properties)
                 .setViewOriginalText(Optional.of(encodeViewData(viewData)))

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -3637,7 +3637,10 @@ public abstract class AbstractTestHiveClient
     {
         String viewData = "test data";
         try (Transaction transaction = newTransaction()) {
-            transaction.getMetadata().createView(newSession(), viewName, viewData, replace);
+            ConnectorTableMetadata viewMetadata1 = new ConnectorTableMetadata(
+                    viewName,
+                    ImmutableList.of(new ColumnMetadata("a", BIGINT)));
+            transaction.getMetadata().createView(newSession(), viewMetadata1, viewData, replace);
             transaction.commit();
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
@@ -20,6 +20,8 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.metadata.ViewDefinition;
 import com.facebook.presto.security.AccessControl;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Analyzer;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -88,9 +90,14 @@ public class CreateViewTask
                 .map(field -> new ViewColumn(field.getName().get(), field.getType()))
                 .collect(toImmutableList());
 
+        List<ColumnMetadata> columnMetadata = columns.stream()
+                .map(column -> new ColumnMetadata(column.getName(), column.getType()))
+                .collect(toImmutableList());
+
+        ConnectorTableMetadata viewMetadata = new ConnectorTableMetadata(name.asSchemaTableName(), columnMetadata);
         String data = codec.toJson(new ViewDefinition(sql, session.getCatalog(), session.getSchema(), columns, Optional.of(session.getUser())));
 
-        metadata.createView(session, name, data, statement.isReplace());
+        metadata.createView(session, name.getCatalogName(), viewMetadata, data, statement.isReplace());
 
         return immediateFuture(null);
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -342,7 +342,7 @@ public interface Metadata
     /**
      * Creates the specified view with the specified view definition.
      */
-    void createView(Session session, QualifiedObjectName viewName, String viewData, boolean replace);
+    void createView(Session session, String catalogName, ConnectorTableMetadata viewMetadata, String viewData, boolean replace);
 
     /**
      * Drops the specified view.

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -993,13 +993,13 @@ public class MetadataManager
     }
 
     @Override
-    public void createView(Session session, QualifiedObjectName viewName, String viewData, boolean replace)
+    public void createView(Session session, String catalogName, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
     {
-        CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, viewName.getCatalogName());
+        CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, catalogName);
         ConnectorId connectorId = catalogMetadata.getConnectorId();
         ConnectorMetadata metadata = catalogMetadata.getMetadata();
 
-        metadata.createView(session.toConnectorSession(connectorId), viewName.asSchemaTableName(), viewData, replace);
+        metadata.createView(session.toConnectorSession(connectorId), viewMetadata, viewData, replace);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingMetadata.java
@@ -191,8 +191,9 @@ public class TestingMetadata
     }
 
     @Override
-    public void createView(ConnectorSession session, SchemaTableName viewName, String viewData, boolean replace)
+    public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
     {
+        SchemaTableName viewName = viewMetadata.getTable();
         if (replace) {
             views.put(viewName, viewData);
         }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -388,7 +388,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public void createView(Session session, QualifiedObjectName viewName, String viewData, boolean replace)
+    public void createView(Session session, String catalogName, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -32,7 +32,6 @@ import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
-import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.metadata.SchemaPropertyManager;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.metadata.TablePropertyManager;
@@ -1640,7 +1639,10 @@ public class TestAnalyzer
                         Optional.of("s1"),
                         ImmutableList.of(new ViewColumn("a", BIGINT)),
                         Optional.of("user")));
-        inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v1"), viewData1, false));
+        ConnectorTableMetadata viewMetadata1 = new ConnectorTableMetadata(
+                new SchemaTableName("s1", "v1"),
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
+        inSetupTransaction(session -> metadata.createView(session, TPCH_CATALOG, viewMetadata1, viewData1, false));
 
         // stale view (different column type)
         String viewData2 = JsonCodec.jsonCodec(ViewDefinition.class).toJson(
@@ -1650,7 +1652,10 @@ public class TestAnalyzer
                         Optional.of("s1"),
                         ImmutableList.of(new ViewColumn("a", VARCHAR)),
                         Optional.of("user")));
-        inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v2"), viewData2, false));
+        ConnectorTableMetadata viewMetadata2 = new ConnectorTableMetadata(
+                new SchemaTableName("s1", "v2"),
+                ImmutableList.of(new ColumnMetadata("a", VARCHAR)));
+        inSetupTransaction(session -> metadata.createView(session, TPCH_CATALOG, viewMetadata2, viewData2, false));
 
         // view referencing table in different schema from itself and session
         String viewData3 = JsonCodec.jsonCodec(ViewDefinition.class).toJson(
@@ -1660,17 +1665,23 @@ public class TestAnalyzer
                         Optional.of("s2"),
                         ImmutableList.of(new ViewColumn("a", BIGINT)),
                         Optional.of("owner")));
-        inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(THIRD_CATALOG, "s3", "v3"), viewData3, false));
+        ConnectorTableMetadata viewMetadata3 = new ConnectorTableMetadata(
+                new SchemaTableName("s3", "v3"),
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
+        inSetupTransaction(session -> metadata.createView(session, THIRD_CATALOG, viewMetadata3, viewData3, false));
 
         // valid view with uppercase column name
         String viewData4 = JsonCodec.jsonCodec(ViewDefinition.class).toJson(
                 new ViewDefinition(
                         "select A from t1",
-                        Optional.of("tpch"),
+                        Optional.of(TPCH_CATALOG),
                         Optional.of("s1"),
                         ImmutableList.of(new ViewColumn("a", BIGINT)),
                         Optional.of("user")));
-        inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName("tpch", "s1", "v4"), viewData4, false));
+        ConnectorTableMetadata viewMetadata4 = new ConnectorTableMetadata(
+                new SchemaTableName("s1", "v4"),
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
+        inSetupTransaction(session -> metadata.createView(session, TPCH_CATALOG, viewMetadata4, viewData4, false));
 
         // recursive view referencing to itself
         String viewData5 = JsonCodec.jsonCodec(ViewDefinition.class).toJson(
@@ -1680,7 +1691,10 @@ public class TestAnalyzer
                         Optional.of("s1"),
                         ImmutableList.of(new ViewColumn("a", BIGINT)),
                         Optional.of("user")));
-        inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v5"), viewData5, false));
+        ConnectorTableMetadata viewMetadata5 = new ConnectorTableMetadata(
+                new SchemaTableName("s1", "v5"),
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
+        inSetupTransaction(session -> metadata.createView(session, TPCH_CATALOG, viewMetadata5, viewData5, false));
     }
 
     private void inSetupTransaction(Consumer<Session> consumer)

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryMetadata.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryMetadata.java
@@ -275,8 +275,9 @@ public class MemoryMetadata
     }
 
     @Override
-    public synchronized void createView(ConnectorSession session, SchemaTableName viewName, String viewData, boolean replace)
+    public synchronized void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
     {
+        SchemaTableName viewName = viewMetadata.getTable();
         checkSchemaExists(viewName.getSchemaName());
         if (getTableHandle(session, viewName) != null) {
             throw new PrestoException(ALREADY_EXISTS, "Table already exists: " + viewName);

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryMetadata.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryMetadata.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.plugin.memory;
 
+import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayout;
@@ -39,6 +40,7 @@ import java.util.Optional;
 import static com.facebook.airlift.testing.Assertions.assertEqualsIgnoreOrder;
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
@@ -183,24 +185,30 @@ public class TestMemoryMetadata
     public void testCreateViewWithoutReplace()
     {
         SchemaTableName test = new SchemaTableName("test", "test_view");
+        ConnectorTableMetadata viewMetadata = new ConnectorTableMetadata(
+                test,
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
         metadata.createSchema(SESSION, "test", ImmutableMap.of());
         try {
-            metadata.createView(SESSION, test, "test", false);
+            metadata.createView(SESSION, viewMetadata, "test", false);
         }
         catch (Exception e) {
             fail("should have succeeded");
         }
-        metadata.createView(SESSION, test, "test", false);
+        metadata.createView(SESSION, viewMetadata, "test", false);
     }
 
     @Test
     public void testCreateViewWithReplace()
     {
         SchemaTableName test = new SchemaTableName("test", "test_view");
+        ConnectorTableMetadata viewMetadata = new ConnectorTableMetadata(
+                test,
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
 
         metadata.createSchema(SESSION, "test", ImmutableMap.of());
-        metadata.createView(SESSION, test, "aaa", true);
-        metadata.createView(SESSION, test, "bbb", true);
+        metadata.createView(SESSION, viewMetadata, "aaa", true);
+        metadata.createView(SESSION, viewMetadata, "bbb", true);
 
         assertEquals(metadata.getViews(SESSION, test.toSchemaTablePrefix()).get(test).getViewData(), "bbb");
     }
@@ -209,14 +217,20 @@ public class TestMemoryMetadata
     public void testViews()
     {
         SchemaTableName test1 = new SchemaTableName("test", "test_view1");
+        ConnectorTableMetadata viewMetadata1 = new ConnectorTableMetadata(
+                test1,
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
         SchemaTableName test2 = new SchemaTableName("test", "test_view2");
+        ConnectorTableMetadata viewMetadata2 = new ConnectorTableMetadata(
+                test2,
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
 
         // create schema
         metadata.createSchema(SESSION, "test", ImmutableMap.of());
 
         // create views
-        metadata.createView(SESSION, test1, "test1", false);
-        metadata.createView(SESSION, test2, "test2", false);
+        metadata.createView(SESSION, viewMetadata1, "test1", false);
+        metadata.createView(SESSION, viewMetadata2, "test2", false);
 
         // verify listing
         List<SchemaTableName> list = metadata.listViews(SESSION, "test");
@@ -278,8 +292,11 @@ public class TestMemoryMetadata
         assertEquals(metadata.getTableHandle(SESSION, table1), null);
 
         SchemaTableName view2 = new SchemaTableName("test2", "test_schema_view2");
+        ConnectorTableMetadata viewMetadata2 = new ConnectorTableMetadata(
+                view2,
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
         try {
-            metadata.createView(SESSION, view2, "aaa", false);
+            metadata.createView(SESSION, viewMetadata2, "aaa", false);
             fail("Should fail because schema does not exist");
         }
         catch (PrestoException ex) {
@@ -289,8 +306,12 @@ public class TestMemoryMetadata
         assertEquals(metadata.getTableHandle(SESSION, view2), null);
 
         SchemaTableName view3 = new SchemaTableName("test3", "test_schema_view3");
+        ConnectorTableMetadata viewMetadata3 = new ConnectorTableMetadata(
+                view3,
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
+
         try {
-            metadata.createView(SESSION, view3, "bbb", true);
+            metadata.createView(SESSION, viewMetadata3, "bbb", true);
             fail("Should fail because schema does not exist");
         }
         catch (PrestoException ex) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
@@ -863,8 +863,9 @@ public class RaptorMetadata
     }
 
     @Override
-    public void createView(ConnectorSession session, SchemaTableName viewName, String viewData, boolean replace)
+    public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
     {
+        SchemaTableName viewName = viewMetadata.getTable();
         String schemaName = viewName.getSchemaName();
         String tableName = viewName.getTableName();
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorMetadata.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorMetadata.java
@@ -638,12 +638,18 @@ public class TestRaptorMetadata
     @Test
     public void testViews()
     {
-        SchemaTableName test1 = new SchemaTableName("test", "test_view1");
-        SchemaTableName test2 = new SchemaTableName("test", "test_view2");
+        ConnectorTableMetadata viewMetadata1 = new ConnectorTableMetadata(
+                new SchemaTableName("test", "test_view1"),
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
+        ConnectorTableMetadata viewMetadata2 = new ConnectorTableMetadata(
+                new SchemaTableName("test", "test_view2"),
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
+        SchemaTableName test1 = viewMetadata1.getTable();
+        SchemaTableName test2 = viewMetadata2.getTable();
 
         // create views
-        metadata.createView(SESSION, test1, "test1", false);
-        metadata.createView(SESSION, test2, "test2", false);
+        metadata.createView(SESSION, viewMetadata1, "test1", false);
+        metadata.createView(SESSION, viewMetadata2, "test2", false);
 
         // verify listing
         List<SchemaTableName> list = metadata.listViews(SESSION, "test");
@@ -675,24 +681,29 @@ public class TestRaptorMetadata
     @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "View already exists: test\\.test_view")
     public void testCreateViewWithoutReplace()
     {
-        SchemaTableName test = new SchemaTableName("test", "test_view");
+        ConnectorTableMetadata viewMetadata = new ConnectorTableMetadata(
+                new SchemaTableName("test", "test_view"),
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
         try {
-            metadata.createView(SESSION, test, "test", false);
+            metadata.createView(SESSION, viewMetadata, "test", false);
         }
         catch (Exception e) {
             fail("should have succeeded");
         }
 
-        metadata.createView(SESSION, test, "test", false);
+        metadata.createView(SESSION, viewMetadata, "test", false);
     }
 
     @Test
     public void testCreateViewWithReplace()
     {
-        SchemaTableName test = new SchemaTableName("test", "test_view");
+        ConnectorTableMetadata viewMetadata = new ConnectorTableMetadata(
+                new SchemaTableName("test", "test_view"),
+                ImmutableList.of(new ColumnMetadata("a", BIGINT)));
+        SchemaTableName test = viewMetadata.getTable();
 
-        metadata.createView(SESSION, test, "aaa", true);
-        metadata.createView(SESSION, test, "bbb", true);
+        metadata.createView(SESSION, viewMetadata, "aaa", true);
+        metadata.createView(SESSION, viewMetadata, "bbb", true);
 
         assertEquals(metadata.getViews(SESSION, test.toSchemaTablePrefix()).get(test).getViewData(), "bbb");
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -499,7 +499,7 @@ public interface ConnectorMetadata
     /**
      * Create the specified view. The data for the view is opaque to the connector.
      */
-    default void createView(ConnectorSession session, SchemaTableName viewName, String viewData, boolean replace)
+    default void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support creating views");
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -419,10 +419,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public void createView(ConnectorSession session, SchemaTableName viewName, String viewData, boolean replace)
+    public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.createView(session, viewName, viewData, replace);
+            delegate.createView(session, viewMetadata, viewData, replace);
         }
     }
 


### PR DESCRIPTION
Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

Hive Changes
* Store column names and types for views in the metastore

SPI Changes
* Change signature for createView in ConnectorMetadata to take a ConnectorTableMetadata instead of a SchemaTableName
```

