### PR TITLE
[WIP] Prototype of v1/serializedstatement using byte array as serialization format

### DIFF
--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -24,6 +24,11 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-client</artifactId>
         </dependency>
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -18,7 +18,9 @@ import com.facebook.presto.client.Column;
 import com.facebook.presto.client.ErrorLocation;
 import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.QueryStatusInfo;
+import com.facebook.presto.client.SerializedData;
 import com.facebook.presto.client.StatementClient;
+import com.facebook.presto.execution.buffer.SerializedPage;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.security.SelectedRole;
 import com.google.common.base.Splitter;
@@ -289,6 +291,13 @@ public class Query
     private static OutputHandler createOutputHandler(OutputFormat format, Writer writer, List<String> fieldNames)
     {
         return new OutputHandler(createOutputPrinter(format, writer, fieldNames));
+    }
+
+    public static SerializedPage serializedDataToSerializedPage(String unparsed)
+    {
+        SerializedData serializedData = SerializedData.getSerializedData(unparsed);
+        SerializedPage ret = new SerializedPage(serializedData.getData(), serializedData.getPageCodecMarker(), serializedData.getPositionCount(), serializedData.getUncompressedSizeBytes());
+        return ret;
     }
 
     private static OutputPrinter createOutputPrinter(OutputFormat format, Writer writer, List<String> fieldNames)

--- a/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
@@ -161,6 +161,9 @@ final class FixJsonDataUtils
                 }
                 return Boolean.class.cast(value);
             case VARCHAR:
+                if (value instanceof SerializedData) {
+                    return value.toString();
+                }
             case JSON:
             case TIME:
             case TIME_WITH_TIME_ZONE:

--- a/presto-client/src/main/java/com/facebook/presto/client/SerializedData.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/SerializedData.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import java.util.Base64;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class SerializedData
+{
+    private byte[] data;
+    private byte pageCodecMarker;
+    private int positionCount;
+    private int uncompressedSizeBytes;
+
+    private static final Base64.Encoder encoder = Base64.getEncoder();
+    private static final Base64.Decoder decoder = Base64.getDecoder();
+
+    public SerializedData(byte[] data, byte pageCodecMarker, int positionCount, int uncompressedSizeBytes)
+    {
+        this.data = data;
+        this.pageCodecMarker = pageCodecMarker;
+        this.positionCount = positionCount;
+        this.uncompressedSizeBytes = uncompressedSizeBytes;
+    }
+
+    public static SerializedData getSerializedData(String input)
+    {
+        String[] items = input.split("\\|");
+        checkArgument(items.length == 4, "Should have only 4 items in encoded string");
+        return new SerializedData(
+                decoder.decode(items[3]),
+                Byte.valueOf(items[0]),
+                Integer.valueOf(items[1]),
+                Integer.valueOf(items[2]));
+    }
+
+    public byte[] getData()
+    {
+        return data;
+    }
+
+    public byte getPageCodecMarker()
+    {
+        return pageCodecMarker;
+    }
+
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    public int getUncompressedSizeBytes()
+    {
+        return uncompressedSizeBytes;
+    }
+
+    @Override
+    public String toString()
+    {
+        return pageCodecMarker +
+                "|" +
+                positionCount +
+                "|" +
+                uncompressedSizeBytes +
+                "|" +
+                encoder.encodeToString(data);
+    }
+}

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClientV1.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClientV1.java
@@ -139,7 +139,7 @@ class StatementClientV1
         if (url == null) {
             throw new ClientException("Invalid server URL: " + session.getServer());
         }
-        url = url.newBuilder().encodedPath("/v1/statement").build();
+        url = url.newBuilder().encodedPath("/v1/serializedstatement").build();
 
         Request.Builder builder = prepareRequest(url)
                 .post(RequestBody.create(MEDIA_TYPE_TEXT, query));

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -90,6 +90,7 @@ import com.facebook.presto.memory.TotalReservationLowMemoryKiller;
 import com.facebook.presto.memory.TotalReservationOnBlockedNodesLowMemoryKiller;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.operator.ForScheduler;
+import com.facebook.presto.server.protocol.SerializedStatementResource;
 import com.facebook.presto.server.protocol.StatementResource;
 import com.facebook.presto.server.remotetask.HttpRemoteTaskFactory;
 import com.facebook.presto.server.remotetask.RemoteTaskStats;
@@ -194,6 +195,8 @@ public class CoordinatorModule
         jsonCodecBinder(binder).bindJsonCodec(SelectedRole.class);
         jaxrsBinder(binder).bind(StatementResource.class);
         newExporter(binder).export(StatementResource.class).withGeneratedName();
+        jaxrsBinder(binder).bind(SerializedStatementResource.class);
+        newExporter(binder).export(SerializedStatementResource.class).withGeneratedName();
         binder.bind(StatementHttpExecutionMBean.class).in(Scopes.SINGLETON);
         newExporter(binder).export(StatementHttpExecutionMBean.class).withGeneratedName();
 

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/SerializedStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/SerializedStatementResource.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.protocol;
+
+import com.facebook.airlift.concurrent.BoundedExecutor;
+import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.operator.ExchangeClientSupplier;
+import com.facebook.presto.server.ForStatementResource;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.google.common.collect.Ordering;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.inject.Inject;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import java.util.OptionalLong;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.airlift.http.server.AsyncResponseHandler.bindAsyncResponse;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+
+@Path("/v1/serializedstatement")
+public class SerializedStatementResource
+        extends StatementResource
+{
+    @Inject
+    public SerializedStatementResource(
+            QueryManager queryManager,
+            SessionPropertyManager sessionPropertyManager,
+            ExchangeClientSupplier exchangeClientSupplier,
+            BlockEncodingSerde blockEncodingSerde,
+            @ForStatementResource BoundedExecutor responseExecutor,
+            @ForStatementResource ScheduledExecutorService timeoutExecutor)
+
+    {
+        super(queryManager, sessionPropertyManager, exchangeClientSupplier, blockEncodingSerde, responseExecutor, timeoutExecutor);
+    }
+
+    @Override
+    protected String getAllocationTag()
+    {
+        return SerializedStatementResource.class.getSimpleName();
+    }
+
+    @Override
+    protected Response getQueryResultsResponse(Query query, UriInfo uriInfo, String schema, DataSize targetResultSize)
+    {
+        QueryResults queryResults = query.getNextResultSerialized(OptionalLong.empty(), uriInfo, schema, targetResultSize);
+        return toResponse(query, queryResults);
+    }
+
+    @Override
+    protected void asyncQueryResults(Query query, OptionalLong token, Duration maxWait, DataSize targetResultSize, UriInfo uriInfo, String scheme, AsyncResponse asyncResponse)
+    {
+        Duration wait = WAIT_ORDERING.min(MAX_WAIT_TIME, maxWait);
+        if (targetResultSize == null) {
+            targetResultSize = DEFAULT_TARGET_RESULT_SIZE;
+        }
+        else {
+            targetResultSize = Ordering.natural().min(targetResultSize, MAX_TARGET_RESULT_SIZE);
+        }
+        ListenableFuture<QueryResults> queryResultsFuture = query.waitForResultsSerialized(token, uriInfo, scheme, wait, targetResultSize);
+
+        ListenableFuture<Response> response = Futures.transform(queryResultsFuture, queryResults -> toResponse(query, queryResults), directExecutor());
+
+        bindAsyncResponse(asyncResponse, response, responseExecutor);
+    }
+}


### PR DESCRIPTION
DO NOT MERGE - this is just a proof of concept. Lots of duplicated code, however this will be good to test if serialization will result in a speedup when client needs to consume many rows.

Will update with testing results, this is just the implementation.

How to test locally: 

`$ curl -XPOST -H 'X-Presto-User: sakshams' -H 'X-Presto-Schema: sf10' -H 'X-Presto-Catalog: tpch' -d 'select * from orders' 'localhost:8080/v1/serializedstatement/'`
`$ curl -XGET -H 'X-Presto-User: sakshams' -H 'X-Presto-Schema: sf10' -H 'X-Presto-Catalog: tpch' '<next-uri-returned-by-previous-curl>'`

```
== NO RELEASE NOTE ==
```
