### PR TITLE
Add ZSTD support for writing ORC and DWRF tables

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWritableTableHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWritableTableHandle.java
@@ -14,12 +14,14 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.metastore.HivePageSinkMetadata;
+import com.facebook.presto.spi.PrestoException;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static java.util.Objects.requireNonNull;
 
 public class HiveWritableTableHandle
@@ -57,6 +59,13 @@ public class HiveWritableTableHandle
         this.tableStorageFormat = requireNonNull(tableStorageFormat, "tableStorageFormat is null");
         this.partitionStorageFormat = requireNonNull(partitionStorageFormat, "partitionStorageFormat is null");
         this.compressionCodec = requireNonNull(compressionCodec, "compressionCodec is null");
+
+        if (!compressionCodec.isSupportedStorageFormat(tableStorageFormat)) {
+            throw new PrestoException(GENERIC_USER_ERROR, String.format("%s compression is not supported with %s", compressionCodec.name(), tableStorageFormat.name()));
+        }
+        if (!compressionCodec.isSupportedStorageFormat(partitionStorageFormat)) {
+            throw new PrestoException(GENERIC_USER_ERROR, String.format("%s compression is not supported with %s", compressionCodec.name(), partitionStorageFormat.name()));
+        }
     }
 
     @JsonProperty

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/ConfigurationUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/ConfigurationUtils.java
@@ -113,7 +113,7 @@ public final class ConfigurationUtils
             config.unset(FileOutputFormat.COMPRESS_CODEC);
         }
         // For Parquet
-        config.set(ParquetOutputFormat.COMPRESSION, compression.getParquetCompressionCodec().name());
+        compression.getParquetCompressionCodec().ifPresent(codec -> config.set(ParquetOutputFormat.COMPRESSION, codec.name()));
         // For SequenceFile
         config.set(FileOutputFormat.COMPRESS_TYPE, BLOCK.toString());
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -119,7 +119,7 @@ public class TestHivePageSink
                 assertGreaterThan(uncompressedLength, 0L);
 
                 for (HiveCompressionCodec codec : HiveCompressionCodec.values()) {
-                    if (codec == NONE) {
+                    if (codec == NONE || !codec.isSupportedStorageFormat(format)) {
                         continue;
                     }
                     config.setCompressionCodec(codec);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -314,7 +314,7 @@ public class OrcTester
         orcTester.nullTestsEnabled = true;
         orcTester.skipBatchTestsEnabled = true;
         orcTester.formats = ImmutableSet.of(ORC_12, ORC_11, DWRF);
-        orcTester.compressions = ImmutableSet.of(ZLIB);
+        orcTester.compressions = ImmutableSet.of(ZLIB, ZSTD);
         orcTester.useSelectiveOrcReader = true;
 
         return orcTester;


### PR DESCRIPTION
 Add ZSTD support for writing ORC and DWRF tables
To enable ZSTD compression, use session property hive.compression_codec='ZSTD'.

== RELEASE NOTES ==

Hive Changes
*  Add ZSTD support for writing ORC and DWRF tables. To enable ZSTD compression, use session property hive.compression_codec='ZSTD'.