### PR TITLE
Add cast bingtile to/from bigint

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -456,7 +456,15 @@ Bing Tiles
 
 These functions convert between geometries and
 `Bing tiles <https://msdn.microsoft.com/en-us/library/bb259689.aspx>`_.  For
-Bing tiles, ``x`` and ``y`` refer to ``tile_x`` and ``tile_y``.
+Bing tiles, ``x`` and ``y`` refer to ``tile_x`` and ``tile_y``.  Bing Tiles
+can be cast to and from BigInts, using an internal representation that encodes
+the ``zoom``, ``x``, and ``y`` efficiently::
+
+    cast(cast(tile AS BIGINT) AS BINGTILE)
+
+While every tile can be cast to a bigint, casting from a bigint that does not
+represent a valid tile will raise an exception.
+
 
 .. function:: bing_tile(x, y, zoom_level) -> BingTile
 

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/BingTile.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/BingTile.java
@@ -16,16 +16,24 @@ package com.facebook.presto.plugin.geospatial;
 import com.facebook.presto.spi.PrestoException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 
 import java.util.Objects;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
 
 public final class BingTile
 {
     public static final int MAX_ZOOM_LEVEL = 23;
+    @VisibleForTesting
+    static final int VERSION_OFFSET = 63 - 5;
+    private static final int VERSION = 0;
+    private static final int BITS_23 = (1 << 24) - 1;
+    private static final int BITS_5 = (1 << 6) - 1;
+    private static final int ZOOM_OFFSET = 31 - 5;
 
     private final int x;
     private final int y;
@@ -148,19 +156,38 @@ public final class BingTile
     }
 
     /**
-     * Encodes Bing tile as a 64-bit long: 23 bits for X, followed by 23 bits for Y,
-     * followed by 5 bits for zoomLevel
+     * Encodes Bing tile as a 64-bit long:
+     * Version (5 bits), 0 (4 bits), x (23 bits), Zoom (5 bits), 0 (4 bits), y (23 bits)
+     * (high bits left, low bits right).
+     *
+     * This arrangement maximizes low-bit entropy for the Java long hash function.
      */
     public long encode()
     {
-        return (((long) x) << 28) + (y << 5) + zoomLevel;
+        // Java's long hash function just XORs itself right shifted 32.
+        // This is used for bucketing, so if you have 2^k buckets, this only
+        // keeps the k lowest bits.  This puts the highest entropy bits
+        // (finest resolution x and y bits) in places that contribute to the
+        // low bits of the hash.
+        return (((long) VERSION << VERSION_OFFSET) | y | ((long) x << 32) | ((long) zoomLevel << ZOOM_OFFSET));
     }
 
     public static BingTile decode(long tile)
     {
-        int tileX = (int) (tile >> 28);
-        int tileY = (int) ((tile % (1 << 28)) >> 5);
-        int zoomLevel = (int) (tile % (1 << 5));
+        int version = (int) (tile >>> VERSION_OFFSET) & BITS_5;
+        if (version == 0) {
+            return decodeV0(tile);
+        }
+        else {
+            throw new IllegalArgumentException(format("Unknown Bing Tile encoding version: %s", version));
+        }
+    }
+
+    private static BingTile decodeV0(long tile)
+    {
+        int tileX = (int) (tile >>> 32) & BITS_23;
+        int tileY = (int) tile & BITS_23;
+        int zoomLevel = (int) (tile >>> ZOOM_OFFSET) & BITS_5;
 
         return new BingTile(tileX, tileY, zoomLevel);
     }

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestBingTileFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestBingTileFunctions.java
@@ -112,6 +112,9 @@ public class TestBingTileFunctions
 
         // X/Y too big
         assertBingTileCastInvalid(256L | (256L << 32) | (4L << 27));
+
+        // Wrong version
+        assertBingTileCastInvalid(1L << BingTile.VERSION_OFFSET);
     }
 
     private void assertBingTileCast(int x, int y, int zoom)


### PR DESCRIPTION
Externally, tiles are encoded in a string of chars '0' to '3' called a
quadkey.  Internally, Presto encodes a tile in 64 bits, represented by a
BIGINT.  Storing a tile as a bigint is not only more space/cpu efficient
than storing it as a quadkey, but it also avoids the bucket-skew problem
caused by the non-uniform distribution of `hash(quadkey) mod 2^k`.

```
== RELEASE NOTES ==

General Changes
* Add `cast(tile AS bigint)` and `cast(bigint_value AS bingtile)` to encode/decode Bing tiles to/from bigints.  This is a more efficient storage format that also reduces bucket skew in some cases.
```
