### PR TITLE
Add HadoopDefaultConfigurationUpdater

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/HiveS3Module.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/HiveS3Module.java
@@ -54,6 +54,7 @@ public class HiveS3Module
         }
         else if (type == S3FileSystemType.HADOOP_DEFAULT) {
             // configuration is done using Hadoop configuration files
+            binder.bind(S3ConfigurationUpdater.class).to(HadoopDefaultConfigurationUpdater.class).in(Scopes.SINGLETON);
         }
         else {
             throw new RuntimeException("Unknown file system type: " + type);
@@ -81,6 +82,15 @@ public class HiveS3Module
             config.set("fs.s3.impl", EMR_FS_CLASS_NAME);
             config.set("fs.s3a.impl", EMR_FS_CLASS_NAME);
             config.set("fs.s3n.impl", EMR_FS_CLASS_NAME);
+        }
+    }
+
+    public static class HadoopDefaultConfigurationUpdater
+            implements S3ConfigurationUpdater
+    {
+        @Override
+        public void updateConfiguration(Configuration config)
+        {
         }
     }
 }


### PR DESCRIPTION
Without this change, when the `hive.s3-file-system-type` is set to
HADOOP_DEFAULT the server crashes due to a guice injection error

```
2020-02-20T03:10:22.218Z        ERROR   main    com.facebook.presto.server.PrestoServer Unable to create injector, see the following errors:
1) Explicit bindings are required and com.facebook.presto.hive.s3.S3ConfigurationUpdater is not explicitly bound.
  while locating com.facebook.presto.hive.s3.S3ConfigurationUpdater
    for the 2nd parameter of com.facebook.presto.hive.HdfsConfigurationInitializer.<init>(HdfsConfigurationInitializer.java:71)
  at com.facebook.presto.hive.HiveClientModule.configure(HiveClientModule.java:74)
1 error
com.google.inject.CreationException: Unable to create injector, see the following errors:
1) Explicit bindings are required and com.facebook.presto.hive.s3.S3ConfigurationUpdater is not explicitly bound.
  while locating com.facebook.presto.hive.s3.S3ConfigurationUpdater
    for the 2nd parameter of com.facebook.presto.hive.HdfsConfigurationInitializer.<init>(HdfsConfigurationInitializer.java:71)
  at com.facebook.presto.hive.HiveClientModule.configure(HiveClientModule.java:74)
1 error
        at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:543)
        at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:159)
        at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:106)
        at com.google.inject.Guice.createInjector(Guice.java:87)
        at io.airlift.bootstrap.Bootstrap.initialize(Bootstrap.java:240)
        at com.facebook.presto.hive.HiveConnectorFactory.create(HiveConnectorFactory.java:128)
        at com.facebook.presto.connector.ConnectorManager.createConnector(ConnectorManager.java:358)
        at com.facebook.presto.connector.ConnectorManager.addCatalogConnector(ConnectorManager.java:217)
        at com.facebook.presto.connector.ConnectorManager.createConnection(ConnectorManager.java:209)
        at com.facebook.presto.connector.ConnectorManager.createConnection(ConnectorManager.java:195)
```

This change adds a HadoopDefaultConfigurationUpdater class which is
essentially a no-op placeholder to prevent the error above.

```
== RELEASE NOTES ==
Hive Changes
* Allow server to start when `hive.s3-file-system-type` is set to HADOOP_DEFAULT
```
