### PR TITLE
Add release notes for 0.232

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.232
     release/release-0.231
     release/release-0.230
     release/release-0.229

--- a/presto-docs/src/main/sphinx/release/release-0.232.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.232.rst
@@ -1,0 +1,54 @@
+=============
+Release 0.232
+=============
+
+General Changes
+_______________
+* Fix an issue where ``DATE_TRUNC`` may produce incorrect results at certain timestamp in ``America/Sao_Paulo``.
+* Improve built-in function resolution performance by caching function resolution results.
+* Add a MySQL-based function namespace manager implementation that supports creating, altering, and dropping SQL functions (:doc:`/admin/function-namespace-managers`).
+* Add support for retrying failed stages from a materialized point instead of failing the entire query. The number of retries allowed can be configured using the configuration property ``max-stage-retries`` and session property ``max_stage_retries``. The default value is zero. To take advantage of this feature, exchange_materialization_strategy must be set to ``ALL``.
+* Add configuration property ``use-legacy-scheduler`` and session property ``use_legacy_scheduler`` to use a version of the query scheduler before refactorings to enable full stage retries. The default value is false. This is a temporary property to provide an easy way to roll back in case of bugs in the new scheduler. This property will be removed in a couple releases once we have confidence in the stability of the new scheduler.
+* Add ``query_max_total_memory_per_node`` and ``query_max_memory_per_node`` session properties.
+* Add support to show whether functions have variable arity in ``SHOW FUNCTIONS``.
+* Add support to show whether functions are built-in in ``SHOW FUNCTIONS``.
+* Add ``use_exact_partitioning`` session property that forces repartitioning if repartitioning is possible.
+* Add support for ``ALTER FUNCTION``.
+* Add configuration property ``resource-groups.reload-refresh-interval`` to control the frequency of reloading resource group information from the database. The default value is 10 seconds.
+* Add support for using the Thrift protocol to shuffle data. This can be configured using the configuration property ``internal-communication.task-communication-protocol``. Possible values are HTTP or Thrift.
+* Add support for using the Thrift protocol to announce node state. This can be configured using the configuration property ``internal-communication.server-info-communication-protocol``. Possible values are HTTP or Thrift.
+* Add session property ``list_built_in_functions_only`` to support hiding user-defined SQL functions in ``SHOW FUNCTIONS``.
+* Add experimental functions ``tdigest_agg``, ``merge(tdigest)``, ``value_at_quantile(tdigest, quantile)``, ``values_at_quantiles(tdigest, quantiles)``, ``quantile_at_value(tdigest, quantile)``, ``quantiles_at_values(tdigest, quantile)`` for creating, merging, and querying t-digests.
+  These can be enabled by using the session property ``experimental_functions_enabled`` and the configuration property ``experimental-functions-enabled``.
+
+Hive Changes
+____________
+* Fix an issue where queries could fail with buffer overflow when writing ORC files.
+* Add support for handling statistics to the Alluxio metastore.
+* Add Alluxio metastore which connects to the Alluxio catalog service <https://docs.alluxio.io/os/user/2.1/en/core-services/Catalog.html>.
+* Add session property ``shuffle_partitioned_columns_for_table_write`` to make Presto shuffle data on the partition columns before writing to partitioned unbucketed Hive tables.
+  This increases the maximum number of partitions that can be written in a single query by a factor of the total number of writing workers.
+  The property is ``false`` by default. (:pr:`14010`).
+* Expose Hive table properties via system table$properties table.
+* Change error code from ``HIVE_METASTORE_ERROR`` to ``HIVE_TABLE_DROPPED_DURING_QUERY`` when a ``DROP TABLE`` query fails due to another query dropping the table before this query has finished.
+* Upgrade Alluxio version from 2.1.1 to 2.1.2.
+
+Kudu Changes
+_____________
+* Add ``Kerberos`` authentication.
+
+Kafka Changes
+_____________
+* Update ``Kafka`` connector to 2.3.1, which improves implementation and performance (:pr:`13709`).
+
+Pinot Changes
+_____________
+* Replace config ``pinot.prefer-broker-queries`` with the inverse config ``pinot.forbid-broker-queries``.
+
+Verifier Changes
+________________
+* Add specific validation checks for the individual fields when validating a row column.
+
+SPI Changes
+___________
+* Replace ``IsHidden`` attribute on AggregationFunction and ScalarFunction with ``visibility`` which can be of the following values ``PUBLIC``, ``EXPERIMENTAL``, ``HIDDEN``.


### PR DESCRIPTION
# Missing Release Notes
## Andrii Rosa
- [x] 2b5647665a431daebbf35a80f3e9ed74f95d1296 Run presto spark tests in forked VM
- [x] e8b6042da7c8cf2fbae68339565e5239f40d4419 Fix hostname related assertion failure in PrestoSparkQueryRunner

## Da Cheng
- [x] https://github.com/prestodb/presto/pull/13709 Update Kafka connector to 2.3.1 (Merged by: Zhenxiao Luo)

## Haoyuan Li
- [x] https://github.com/prestodb/presto/pull/13986 Add Alluxio Hive metastore (Merged by: James Sun)

## YuBin Li
- [x] https://github.com/prestodb/presto/pull/14007 Support kerberos authentication for Kudu connector (Merged by: Wenlei Xie)

## qqibrow
- [x] https://github.com/prestodb/presto/pull/14017 Fix Elasticsearch connector documentation (Merged by: Wenlei Xie)

## sujay-jain
- [x] 7700a59080cc24c69aa9a2ca47e87bc0dd0a924b Revert "Improve error message for the array_agg function"

## wuyunfeng01
- [x] https://github.com/prestodb/presto/pull/13987 Promote Elasticsearch scan performance with index sorting (Merged by: Zhenxiao Luo)

# Extracted Release Notes
- #13354 (Author: Ariel Weisberg): Add use-exact-partitioning-enabled session property
  - Add use_exact_partitioning session property that forces repartitioning if repartitioning is possible.
- #13717 (Author: Rebecca Schlussel): Support retries of streaming sections
  - Add support for retrying failed stages from a materialized point instead of failing the entire query.  The number of retries allowed can be configured using the configuration property max-stage-retries and session property max_stage_retries. The default value is zero.  To take advantage of this feature, exchange_materialization_strategy must be set to 'ALL'.
  - Add configuration property use-legacy-scheduler and session property use_legacy_scheduler to use a version of the query scheduler from before refactorings to enable full stage retries.  The default value is false. This is a temporary property to provide an easy way to roll back in case of bugs in the new scheduler.  This property will be removed in a couple releases once we have confidence in the stability of the new scheduler.
- #13799 (Author: Leiqing Cai): Support ALTER FUNCTION
  - Add support for ``ALTER FUNCTION``.
- #13894 (Author: James Sun): Support internal communication with thrift
  - Allow Presto nodes to shuffle data with Thrift protocol. Use config `internal-communication.task-communication-protocol` to control between HTTP and Thrift.
  - Allow Presto nodes to announce state with Thrift protocol. Use config `internal-communication.server-info-communication-protocol` to control between HTTP and Thrift.
- #13931 (Author: Swapnil Tailor): Configure DB Resource Group reload frequency
  - Making database resource group reload frequency configurable.
  - ...
- #13934 (Author: Vic Zhang): Update error code when table is dropped during query execution
  - When ``DROP TABLE`` query fails because the table has being dropped by other query before this query finishes,  change error code name from ``HIVE_METASTORE_ERROR`` to  ``HIVE_TABLE_DROPPED_DURING_QUERY``.
- #13940 (Author: Timothy Meehan): Add t-digest functions to Presto
  - Add tdigest_agg, merge(tdigest), value_at_quantile(tdigest, quantile), values_at_quantiles(tdigest, quantiles), quantile_at_value(tdigest, quantile), quantiles_at_values(tdigest, quantile) for creating, merging, and querying t-digests.
  - IsHidden attribute on AggregationFunction and ScalarFunction removed and replaced with visibility.
- #13949 (Author: Leiqing Cai): Enable listing SQL function with session property
  - Support hiding user-defined SQL functions in ``SHOW FUNCTIONS`` with session property ``list_built_in_functions_only``. This can also be achieved by configuration property ``list-built-in-functions-only``, which is repurposed from ``list-non-built-in-functions``.
- #13972 (Author: Leiqing Cai): Support MySQL-based FunctionNamespaceManager
  - Add a MySQL-based function namespace manager implementation that supports creating, altering, and dropping SQL functions. (:doc:`/admin/function-namespace-managers`).
- #13974 (Author: Leiqing Cai): Extend SHOW FUNCTIONS
  - Add support to show whether functions have variable arity in ``SHOW FUNCTIONS``.
  - Add support to show whether functions are built-in in ``SHOW FUNCTIONS``.
- #13982 (Author: Rongrong Zhong): Cache builtin function resolution result
  - Improve built-in function resolution performance by caching function resolution results.
- #13998 (Author: Igor Kruk): Improve correctness check for queries that produce columns of RowType
  - Add checks for the individual fields when validating a row column.
- #14010 (Author: Wenlei Xie): Support shuffle on Hive partition columns before write
  - Allow shuffle on partitioned columns when writing to partitioned unbucketed Hive tables. This increase the number of maximum partitions written in single query by a factor of number of total writing workers.This behavior has to be explicitly enabled by Connector session property `shuffle_partitioned_columns_for_table_write`. #14010.
- #14014 (Author: James Gill): Upgrade slice to 0.38
  - Upgrade airlift/slice to 0.38.
- #14016 (Author: Ariel Weisberg): Add task memory related session properties 
  - Added query_max_total_memory_per_node and query_max_memory_per_node session properties.
- #14018 (Author: Haoyuan Li): Add statistics handling to the Alluxio metastore support
  - Add statistics handling to the Alluxio metastore support.
- #14036 (Author: Igor Kruk): Improve correctness check for RowType columns
  - Add specific validation checks for the individual fields when validating a row column.
- #14039 (Author: Islam Ismailov): Account for page header in ORC output buffer
  - Add page header size accounting to ORC output buffer to avoid possible overflow.
- #14043 (Author: qqibrow): Expose Hive table properties via system table$properties table
  - Expose Hive table properties via system table$properties table.
- #14047 (Author: Haoyuan Li): Update Alluxio version from 2.1.1 to 2.1.2
  - Update Alluxio version from 2.1.1 to 2.1.2.
- #14057 (Author: Devesh Agrawal): Pinot bugs and making it work with the latest trunk pinot
  - Replace config `pinot.prefer-broker-queries` with the inverse config `pinot.forbid-broker-queries`.
- #14059 (Author: Leiqing Cai): Update to Joda 2.10.5
  - Fix an issue where ``DATE_TRUNC`` may produce incorrect results at certain timestamp in ``America/Sao_Paulo``.

# All Commits
- 2b5647665a431daebbf35a80f3e9ed74f95d1296 Run presto spark tests in forked VM (Andrii Rosa)
- 7700a59080cc24c69aa9a2ca47e87bc0dd0a924b Revert "Improve error message for the array_agg function" (sujay-jain)
- e8b6042da7c8cf2fbae68339565e5239f40d4419 Fix hostname related assertion failure in PrestoSparkQueryRunner (Andrii Rosa)
- 44c044ad827365369f9f255cbb272b3f07c4b30c Add documentation for SQL functions (Leiqing Cai)
- fbe0b3dca58a1804b20e2aa9e849a92efce854c6 Introduce MySql-based function namespace manager (Leiqing Cai)
- a59bef803a0f4b2450a6475459e120f6e6c9d7df Introduce db based function namespace manager (Leiqing Cai)
- c2c90c079c95e54e69eda99eaa052cf661f7c42d Use Return statement as the body for SQL-invoked functions (Leiqing Cai)
- dc129d8b15e8a262319a7053319b77265e508756 Require function namespace manager to bind with catalog names (Leiqing Cai)
- 56d063b80c9e6c7a4d672edd5a60f6da9f8e9dd8 Remove dependency of presto-sql-function from presto-main (Leiqing Cai)
- 2de5d7f6aa365500d6e6be1fb040edf6c7a89713 Improve correctness check for RowType columns (Igor Kruk)
- 4c2010e59ccf7bdcb1b549e1bfe18675ee6ed560 Add retriedCpuTime to QueryCompletedEvent (Rebecca Schlussel)
- 6525ea9b1ded94c34f0e93b210afa273f2ce0f4a Naming cleanup in SqlQueryScheduler (Rebecca Schlussel)
- 615feb51b8e72ac2c266d4685ff36431336b5746 Add support for retrying streaming sections (Rebecca Schlussel)
- e5eda5733d7ab114107f91b034a5169ebf665bbe Introduce LegacySqlQueryScheduler (Rebecca Schlussel)
- fe6ebcfea6d70f14264561cb9617c1c72eb2c700 Reorder fields and methods in SqlQueryScheduler (Rebecca Schlussel)
- 4fd684b3609bdc9fd68e5af6d225aa8d6a62e8bc Make FixedSourcePartitionedScheduler more thread safe (Rebecca Schlussel)
- f789c543fae3bf2afe7c589877df112c94a24221 Introduce method for empty StageExecutionInfo (Rebecca Schlussel)
- 2e4d5a3e799110552d84e1706d8b5e247ac47c3a Remove id from StageExecutionInfo (Rebecca Schlussel)
- b84f177d5fe37017123946cbefb3b5ffd2cf845d Make ExecutionSchedule return StageExecutionAndScheduler (Rebecca Schlussel)
- 3185bf49ffb2500b7a70f36c411c2353bffce774 Extract SectionExecutionFactory from SqlQueryScheduler (Rebecca Schlussel)
- 08793ed316806d1c1b2a7933c4b1c7979c7e4aeb Add exponential decay config to failure detector (Andrii Rosa)
- 3eef1b02da1fd8d09f3992a54f6499695aa6b4cb Enable failure detector in tests (Rebecca Schlussel)
- b9376252c71985f28638aad3c08a9b9b76c18ae6 Remove unused code from TestStageExecutionStateMachine (Rebecca Schlussel)
- 85ed09a43001cd0d239d673f5d12ce7818f6ff23 Add configuration property max-stage-retries (Rebecca Schlussel)
- e650db3092c8ac9da8bdb5210dbdfd4768335ed6 Minor refactor in SqlQueryScheduler (Rebecca Schlussel)
- 7a4a741e11d3c13bbc6521505ac35244c00beb5a Move opening split source to scheduler creation time (Rebecca Schlussel)
- 4fd9aafc21639f4d52afbf47f230da1a762a977e Log number of splits received for Presto-on-Spark task (Wenlei Xie)
- b4909218346dff3896be54750080c7bbc646f4d2 Update Airlift to 0.189 (Andrii Rosa)
- a3f9aa3566675f4b5fea33a96abc58fddbf56a21 Fail with informative error message if no Pinot expression is selected (Devesh Agrawal)
- 1701b2267360e52ec1a819abbc494a58a14a9844 Avoid passing Content-Type header when Pinot request body is empty (Devesh Agrawal)
- 74ad34b2cd27d3ec1d308878d844c807003647c3 Rename preferBrokerQueries to its negate format forbidBrokerQueries (Devesh Agrawal)
- b05e09ebec004c5ccf7a9f5c05181fcb71d2998f Fix bug with pinot column scan index generation (Devesh Agrawal)
- 4c7fc034bbcb0a490e8bcaa8842a6d1ea833623a Add join pushdown predicate at the end of the exisiting predicate (Bhavani Hari)
- f63875571e29aade4663cb7e6447d42126add407 Allocate CPU quanta per query instead of per task (Andrii Rosa)
- 46e6c9259c7ede6044e6c8f25e9527eb6ace2e15 Update proto utilities for the Database objects (Haoyuan Li)
- 5833338c127c380f505873614d25862921437e75 Support shuffle on Hive partition columns before write (Wenlei Xie)
- b4a186ce04eb2c26958ee3a7940c0b259a948648 Rename TableWriterNode#partitioningScheme to tablePartitioningScheme (Wenlei Xie)
- 5a7074b1165eac3dd202306a44380f793bad885d Adding LIKE operator description (Oskar Austegard)
- 47afe84967b61483e67fea08a8e1d4e94067f169 Update to Joda 2.10.5 (Leiqing Cai)
- 10893a67c817ea0f9d169719c7f7e39d16f8a1c8 Account for page header in ORC output buffer (Islam Ismailov)
- 8ac000dab6366917d3148e99655ffb635dd5c153 Add peak task memory in resource estimates (Andrés Flores)
- 1b45f4958ab600958136f33a3beade7209919973 Update alluxio version (Haoyuan Li)
- 2dd6798d277269dce0a5558cefc0c8d9a2d29bd8 Fix recoverable grouped execution eligibility (Shixuan Fan)
- 4f1380006f660e214ce55bff107a8a9c629a5156 Replace Joda-Time libraries with java.time (Ajay George)
- 05310b74f5f7a86130f142da5700ca66c08b1b78 Add statistics handling to the Alluxio metastore support (Haoyuan Li)
- fc8cb11bafb067d8be2c7e19a11c6be59298102e Expose Hive table properties via system table$properties table (qqibrow)
- 0c5aa2dc3728c53e6c2658cdf222fff04a398a8c Improve correctness check for queries that produce columns of RowType (Igor Kruk)
- fc3d1ee6580ea2cffc495de0fdc357e966564001 Add task memory related session properties (Ariel Weisberg)
- 8eb01928c1e6e24ba3a6261c97255fd6351cbbc6 Upgrade Kafka Connector to 2.3.1 (Da Cheng)
- 1ec81384fc9b1d06c71f325ef0d2b34f8993c762 Support kerberos authentication for Kudu connector (YuBin Li)
- 66fb17c2b1dfd876912a15969864bafa801bb5e0 Fix target path typo in HiveWriter (James Sun)
- a26f440944689cb907c77d272e180b570cd2d39c Optimize T-Digest structure for small distributions (Timothy Meehan)
- 8296be0c8610858ac9bdca31477be46fa900ec5c Move PushdownSubfields below logical optimization (Saksham Sachdev)
- 30f1db0aa8c444c1ed750e1bda95891b04a79808 Cache mvnw (Tim Meehan)
- dcbbe44166fcbca84b4219d97b5c6d738486f132 Fix Elasticsearch connector documentation (Zhenxiao Luo)
- 8a1bb1bab7b143108df10cd1ac909d809d33fd20 Extend SHOW FUNCTIONS to display whether functions are built-in (Leiqing Cai)
- c3b04323a4565c65805ec1c0e391cfb663498506 Extend SHOW FUNCTIONS to display whether functions have variable arity (Leiqing Cai)
- 283e30075c7c9b1b3391a1747af39b0e51e48aa5 Fix testShowFunctions (Leiqing Cai)
- b1cda9788996b492ae3fe2b1b72df227ad89d02f Upgrade slice to 0.38 (James Gill)
- c4878275a2bead060da509a183de46b310c99e08 Improve error message for the array_agg function (Sujay Jain)
- 6eed9b9b5eec8b134ed4868e82e226a1fce90396 Support mixed case fields in Elasticsearch (Zhenxiao Luo)
- a9bbc6e38e5cfbbcbf63b766798ad41e80e096ad Set predicate in EMPTY_TABLE_LAYOUT to none (Bhavani Hari)
- 5106dc1440b1ec4a660b752425ff5a44d9b15428 Add Alluxio Hive metastore (haoyuan)
- ce5eeb77387c7ea9e76473d1e7d93ad06a95e2c0 Update error code when table is dropped during query execution (Vic Zhang)
- 823da6f3e68121d8bbcbf310dffd8fa164e58cf8 Evaluate filter only once per dictionary value (Masha Basmanova)
- d5ee715bb6b165fb6567b663c74ca5ecf21cc6ab Separate filter and no-filter code paths (Masha Basmanova)
- ae5e74cf7ea9bef904b35bb17bb7afa82e003b7a Fix flaky TestRowExpressionPredicateExtractor (Ajay George)
- cd41fa58c8975550329bf901378aa2d59079e813 Format comment and modify import style (wuyunfeng01)
- ab55def6dfa025299e5e7cce6df04f1f7343de09 Promote Elasticsearch scan performance with index sorting (wuyunfeng01)
- b34278e2c47569bdb0dafa7c41732bf27438df22 Properly handle optimizable filter expressions (Bhavani Hari)
- fb37c6e90c132fe85e92d155797e34a73cc59af5 Add t-digest functions to Presto (Tim Meehan)
- d09e4df79f5b7c122c70dca8d080f5be423ee59d Migrate function isHidden to new visibility enum (Tim Meehan)
- 63cf099c741aff1ac4da41bda8e75b5f1d5adecd Allow FunctionNamespaceManager in DistributedQueryRunner (Rongrong Zhong)
- 683474aaad754219fe59d85b81322d2fc54d72be Cache builtin function resolution result (Rongrong Zhong)
- 2e96b922e26444027ca63ee6f2e16737517bfab7 Update access modifiers in BenchmarkSelectiveStreamReaders (Ying Su)
- f555aa69f51685a737b66c76c798d93f097901b7 Avoid Java stream in NodePartitioningManager#createArbitraryBucketToNode (Wenlei Xie)
- 20c7af79dc4dcb4e9b0dc7cc167a3506692c9bc3 Make acknowledgeResults to return future (James Sun)
- 9d47a24d17a8078893e2531066906665053c0ce8 Add server info client side thrift implementation (James Sun)
- 8ffd650b58d233d67fcff5948d5d3aca5b77039c Abstract RemoteNodeState HTTP implementation to HttpRemoteNodeState (James Sun)
- 7416a8c0bf4f9ffb0bf09fc82a8b04427c59fd88 Add server info server side thrift implementation (James Sun)
- 9d030b5a18304c84b459674d9c8732e58723fd93 Update NodeState with enum values (James Sun)
- 8e44e9b83a87d98fa3d34eddbb20b7ee72cc4092 Add TestHiveDistributedQueriesWithThriftRpc (James Sun)
- be031b148c7a32c19dca93dc0ac87eb8771648f5 Rewrite page too large exception based on network protocols (James Sun)
- 785eb79149186413e0ea5da1d260ff8a1c821acc Add thrift support for v1/task/results (James Sun)
- a2e20c7afa4a44ed0cd1401c631be3913895fa79 Add thrift communication protocol config (James Sun)
- 6c9afc4ff3851d914a7b3bc4df9203d270e5e53c Add ThriftRpcShuffleClient implementation (James Sun)
- 2f18683f4aab3051e47123a158f95b299bd859a1 Abstract exchange HTTP client to RpcShuffleClient (James Sun)
- 5e8cae87adf74e8668b2ff0b793a5e9b3cdc2cf8 Rename HttpPageBufferClient to PageBufferClient (James Sun)
- f3443e717e0fd4d6b7c54aefbc3faf242d800773 Add thrift support for exchange server (James Sun)
- 125d77a9a0d3acc97e26568b0889b4eb88ecf1f5 Announce thrift port for PrestoServer (James Sun)
- 1f28b21d7d66e963fabcaa2b2b49cbf45695b76b Initial support with Thrift RPC (Wenlei Xie)
- 4b944705a8babd518e67b23507e74e85e3974341 Strip netty dependency from presto-cassandra (James Sun)
- a49a812ac05cc77f8ec0360a8c79e55f8a75b505 Remove netty dependency from presto-mongodb (James Sun)
- 0c28697354545613c1f3fb6babf1be5d886caea6 Strip netty dependency from presto-elasticsearch (James Sun)
- 53e3648980aedbd9e5686b1fd79f283414c1d221 Fix null pointer when using ConnectorSession (Ke Wang)
- c0fe70217928dd65930c5bfd15e6c785eacecc98 Make presto-spark extensible to additional modules (Wenlei Xie)
- e64c4e26df7691fa819a804a90b52ff992bdff46 Propagate legacyMapSubscript to selective map reader (Masha Basmanova)
- b7a74a2a9b68b9078724b3c73e70c4c3a2723d9b Add legacyMapSubscript to SqlFunctionProperties (Masha Basmanova)
- 500c6baf578148ec102f7d8c1bae3656f0a8eb7f Add legacy_map_subscript hidden session property (Masha Basmanova)
- dcf7f66a823cd0fb85c7193749bce63e65302524 Add comment to ActualProperties.Global.nullsAndAnyReplicated (Ariel Weisberg)
- 9218834e5f06ed251282ac4628a3ef849460c38c Make PreferredProperties.mergeWithParent methods private (Ariel Weisberg)
- 9a68dfeeeffc7e4a8f4abc4f1e62dc354ef2ae7f Add partitioning_precision_strategy session property (Ariel Weisberg)
- 652ca6aff79600a3a3c8c380855b296eb961f8d6 Fix Pinot segment page source to use ColumnDataType (Devesh Agrawal)
- b6325d975cc2bcb387406fac9960334f27902fe8 Refactor ReorderJoins to use RowExpressions (Saksham Sachdev)
- eabf46febfd10628c71a093d9818518f10594f31 Increase heap memory to avoid continuous Full GCs (Ajay George)
- ff6dd730616962021be095fc0e9bde038f67fd81 Update to Airbase 98 and Aiftlift 0.188 (Leiqing Cai)
- 32ca53947691b80ac3c5112862b5a1a66ad09e51 Configure DB Resource Group reload frequency (Swapnil Tailor)
- 386164e888fdbf69cb735b10c942e23a3b2afca6 Support ALTER FUNCTION (Leiqing Cai)
- 48b2fee2253ee5cdb7c7c55070f00307755e64e1 Add syntax support for ALTER FUNCTION (Leiqing Cai)
- 68f2d6fb87b6be178a6c9e3c8301bd697c3cec25 Format parameter types in one line in DROP FUNCTION (Leiqing Cai)
- 0278615238cc12b9e3119c96ade4fa0774ff8c0f Use builder to construct RoutineCharacteristics (Leiqing Cai)
- 76ee53ce94713710e1a907443f28e6d8295ab205 Add end-to-end test for Presto on Spark using Docker (Andrii Rosa)
- a7aa3425871eb771fc29a6d0a0f57169ca2c21dd Add Spark launcher (Andrii Rosa)
- f0741135cf18bf235683b56f4937bef9fd0b0f9d Generate Presto on Spark tar.gz package (Andrii Rosa)
- cb5a00d1e311536f864db0a6eeffc1d03dfee793 Presto on Spark initial commit (Andrii Rosa)
- cc398f55f1b2f05ce84f0cdca20f549e134a4d3a Add benchmark for BytesValues (Ke Wang)
- fc695e0c85ab532e9abe0c673d15fbe66d00bfe0 Optimize NOT IN filter for strings (Ke Wang)
- 422d7a9223c0ebfd40188cd5724d80e6529b57fb Rename isNanAllowed function and update comment (Ke Wang)
- 479e6552eff9f6e1776e3f40913d053e934241c5 Enable listing SQL functions with session property (Leiqing Cai)