### PR TITLE
Disable hanging test in TestDistributedSpilledQueries

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
@@ -74,4 +74,10 @@ public class TestDistributedSpilledQueries
     {
         // TODO: disable until https://github.com/prestodb/presto/issues/13859 is resolved.
     }
+
+    @Override
+    public void testJoinDoubleClauseWithRightOverlap()
+    {
+        // TODO: disable until https://github.com/prestodb/presto/issues/13859 is resolved.
+    }
 }


### PR DESCRIPTION
```
2020-02-21T00:23:33.405-0600 WARNING No test started or completed in 8.00m. Running tests:
com.facebook.presto.tests.TestDistributedSpilledQueries::testJoinDoubleClauseWithRightOverlap running for 40.42m
```

```
== NO RELEASE NOTE ==
```
