### PR TITLE
Fail task with large update size

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -642,7 +642,7 @@ public final class HttpRemoteTask
         byte[] taskUpdateRequestJson = taskUpdateRequestCodec.toBytes(updateRequest);
 
         if (taskUpdateRequestJson.length > maxTaskUpdateSizeInBytes) {
-            throw new PrestoException(EXCEEDED_TASK_UPDATE_SIZE_LIMIT, format("TaskUpdate size of %d Bytes has exceeded the limit of %d Bytes", taskUpdateRequestJson.length, maxTaskUpdateSizeInBytes));
+            failTask(new PrestoException(EXCEEDED_TASK_UPDATE_SIZE_LIMIT, format("TaskUpdate size of %d Bytes has exceeded the limit of %d Bytes", taskUpdateRequestJson.length, maxTaskUpdateSizeInBytes)));
         }
 
         if (fragment.isPresent()) {

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchTaskUpdateSizeLimitIntegrationTest.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTpchTaskUpdateSizeLimitIntegrationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+
+public class TestTpchTaskUpdateSizeLimitIntegrationTest
+        extends AbstractTestQueryFramework
+{
+    public TestTpchTaskUpdateSizeLimitIntegrationTest()
+    {
+        super(() -> createQueryRunner(ImmutableMap.of("experimental.internal-communication.max-task-update-size", "100B")));
+    }
+
+    @Test
+    public void testTaskUpdateSizeLimit()
+    {
+        assertQueryFails(
+                getSession(),
+                "SELECT * FROM ORDERS LIMIT 10",
+                "TaskUpdate size of [0-9]* Bytes has exceeded the limit of 100 Bytes");
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
@@ -16,18 +16,27 @@ package com.facebook.presto.tests.tpch;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.log.Logging;
 import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
 
 public final class TpchQueryRunner
 {
     private TpchQueryRunner() {}
 
+    public static DistributedQueryRunner createQueryRunner(Map<String, String> extraProperties)
+            throws Exception
+    {
+        return TpchQueryRunnerBuilder.builder()
+                .setExtraProperties(extraProperties)
+                .build();
+    }
+
     public static void main(String[] args)
             throws Exception
     {
         Logging.initialize();
-        DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder()
-                .setSingleExtraProperty("http-server.http.port", "8080")
-                .build();
+        DistributedQueryRunner queryRunner = createQueryRunner(ImmutableMap.of("http-server.http.port", "8080"));
         Thread.sleep(10);
         Logger log = Logger.get(TpchQueryRunner.class);
         log.info("======== SERVER STARTED ========");


### PR DESCRIPTION
Fail the query when the task update size
exceeds the limit set by the parameter
experimental.internal-communication.max-task-update-size.

This fixes issue #14129 

```
== NO RELEASE NOTE ==
```
