### PR TITLE
Add stats and cost rule for IntersectNode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorWithEstimatedExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorWithEstimatedExchanges.java
@@ -16,6 +16,7 @@ package com.facebook.presto.cost;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.IntersectNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.UnionNode;
 import com.facebook.presto.sql.planner.iterative.GroupReference;
@@ -160,6 +161,14 @@ public class CostCalculatorWithEstimatedExchanges
             // that is not aways true
             // but this estimate is better that returning UNKNOWN, as it sets
             // cumulative cost to unknown
+            double inputSizeInBytes = getStats(node).getOutputSizeInBytes(node.getOutputVariables());
+            return calculateRemoteGatherCost(inputSizeInBytes);
+        }
+
+        @Override
+        public LocalCostEstimate visitIntersect(IntersectNode node, Void context)
+        {
+            // Similar to Union
             double inputSizeInBytes = getStats(node).getOutputSizeInBytes(node.getOutputVariables());
             return calculateRemoteGatherCost(inputSizeInBytes);
         }

--- a/presto-main/src/main/java/com/facebook/presto/cost/IntersectStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/IntersectStatsRule.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.IntersectNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+
+import java.util.Optional;
+
+import static com.facebook.presto.cost.PlanNodeStatsEstimateMath.addStatsAndIntersect;
+import static com.facebook.presto.sql.planner.plan.Patterns.intersect;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class IntersectStatsRule
+        extends SimpleStatsRule<IntersectNode>
+{
+    private static final Pattern<IntersectNode> PATTERN = intersect();
+
+    public IntersectStatsRule(StatsNormalizer normalizer)
+    {
+        super(normalizer);
+    }
+
+    @Override
+    public Pattern<IntersectNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    protected Optional<PlanNodeStatsEstimate> doCalculate(
+            IntersectNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types)
+    {
+        checkArgument(!node.getSources().isEmpty(), "Empty intersection is not supported");
+
+        Optional<PlanNodeStatsEstimate> estimate = Optional.empty();
+        for (int i = 0; i < node.getSources().size(); i++) {
+            PlanNode source = node.getSources().get(i);
+            PlanNodeStatsEstimate sourceStats = statsProvider.getStats(source);
+
+            PlanNodeStatsEstimate sourceStatsWithMappedSymbols = mapToOutputSymbols(sourceStats, node, i);
+
+            if (estimate.isPresent()) {
+                estimate = Optional.of(addStatsAndIntersect(estimate.get(), sourceStatsWithMappedSymbols));
+            }
+            else {
+                estimate = Optional.of(sourceStatsWithMappedSymbols);
+            }
+        }
+
+        return estimate;
+    }
+
+    private PlanNodeStatsEstimate mapToOutputSymbols(PlanNodeStatsEstimate estimate, IntersectNode node, int index)
+    {
+        PlanNodeStatsEstimate.Builder mapped = PlanNodeStatsEstimate.builder().setOutputRowCount(estimate.getOutputRowCount());
+        node.getOutputVariables().forEach(variable -> mapped.addVariableStatistics(
+                variable, estimate.getVariableStatistics(node.getVariableMapping().get(variable).get(index))));
+
+        return mapped.build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
@@ -61,6 +61,7 @@ public class StatsCalculatorModule
         rules.add(new UnnestStatsRule());
         rules.add(new SortStatsRule());
         rules.add(new SampleStatsRule(normalizer));
+        rules.add(new IntersectStatsRule(normalizer));
 
         return new ComposableStatsCalculator(rules.build());
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
@@ -17,6 +17,7 @@ import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.matching.Property;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.IntersectNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -157,6 +158,11 @@ public class Patterns
     public static Pattern<UnionNode> union()
     {
         return typeOf(UnionNode.class);
+    }
+
+    public static Pattern<IntersectNode> intersect()
+    {
+        return typeOf(IntersectNode.class);
     }
 
     public static Pattern<ValuesNode> values()

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestIntersectStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestIntersectStatsRule.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+
+public class TestIntersectStatsRule
+        extends BaseStatsCalculatorTest
+{
+    @Test
+    public void testIntersect()
+    {
+        // Test cases:
+        // i11 and i12 have separated low and high values, all known stats
+        // i21 and i22 have overlapping low and high values and unknown distinct values
+        // i31 has all known statistics and i32 has all null values
+        // i41 and i42 have exact same values
+        tester().assertStatsFor(
+                pb -> pb.intersect(
+                        ImmutableListMultimap.<VariableReferenceExpression, VariableReferenceExpression>builder()
+                                .putAll(pb.variable("o1"), pb.variable("i11"), pb.variable("i21"))
+                                .putAll(pb.variable("o2"), pb.variable("i12"), pb.variable("i22"))
+                                .putAll(pb.variable("o3"), pb.variable("i13"), pb.variable("i23"))
+                                .putAll(pb.variable("o4"), pb.variable("i14"), pb.variable("i24"))
+                                .build(),
+                        ImmutableList.of(
+                                pb.values(
+                                        pb.variable("i11"), pb.variable("i12"),
+                                        pb.variable("i13"), pb.variable("i14")),
+                                pb.values(
+                                        pb.variable("i21"), pb.variable("i22"),
+                                        pb.variable("i23"), pb.variable("i24"))))
+        ).withSourceStats(0, PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(10)
+                .addVariableStatistics(
+                        new VariableReferenceExpression("i11", BIGINT),
+                        VariableStatsEstimate.builder()
+                                .setLowValue(1)
+                                .setHighValue(10)
+                                .setDistinctValuesCount(10)
+                                .setNullsFraction(0)
+                                .build())
+                .addVariableStatistics(
+                        new VariableReferenceExpression("i12", BIGINT),
+                        VariableStatsEstimate.builder()
+                                .setLowValue(1)
+                                .setHighValue(10)
+                                .setDistinctValuesCount(10)
+                                .setNullsFraction(0)
+                                .build())
+                .addVariableStatistics(
+                        new VariableReferenceExpression("i13", BIGINT),
+                        VariableStatsEstimate.builder()
+                                .setLowValue(1)
+                                .setHighValue(10)
+                                .setDistinctValuesCount(10)
+                                .setNullsFraction(0)
+                                .build())
+                .addVariableStatistics(
+                        new VariableReferenceExpression("i14", BIGINT),
+                        VariableStatsEstimate.builder()
+                                .setLowValue(15)
+                                .setHighValue(25)
+                                .setDistinctValuesCount(10)
+                                .setNullsFraction(0)
+                                .build()).build())
+                .withSourceStats(1, PlanNodeStatsEstimate.builder()
+                .setOutputRowCount(5)
+                .addVariableStatistics(
+                        new VariableReferenceExpression("i21", BIGINT),
+                        VariableStatsEstimate.builder()
+                                .setLowValue(1)
+                                .setHighValue(10)
+                                .setDistinctValuesCount(10)
+                                .setNullsFraction(0)
+                                .build())
+                .addVariableStatistics(
+                        new VariableReferenceExpression("i22", BIGINT),
+                        VariableStatsEstimate.builder()
+                                .setLowValue(5)
+                                .setHighValue(10)
+                                .setDistinctValuesCount(3)
+                                .setNullsFraction(0.4)
+                                .build())
+                .addVariableStatistics(
+                        new VariableReferenceExpression("i23", BIGINT),
+                        VariableStatsEstimate.builder()
+                                .setLowValue(7)
+                                .setHighValue(15)
+                                .setDistinctValuesCount(3)
+                                .setNullsFraction(0)
+                                .build())
+                .addVariableStatistics(
+                        new VariableReferenceExpression("i24", BIGINT),
+                        VariableStatsEstimate.builder()
+                                .setLowValue(20)
+                                .setHighValue(25)
+                                .setDistinctValuesCount(3)
+                                .setNullsFraction(0)
+                                .build()).build())
+                .check(check -> check
+                .outputRowsCount(1.875)
+                .variableStats(
+                        new VariableReferenceExpression("o1", BIGINT),
+                        assertion -> assertion
+                                .lowValue(1)
+                                .highValue(10)
+                                .distinctValuesCount(1.875)
+                                .nullsFraction(0))
+                .variableStats(
+                        new VariableReferenceExpression("o2", BIGINT),
+                        assertion -> assertion
+                                .lowValue(5)
+                                .highValue(10)
+                                .distinctValuesCount(0.9375)
+                                .nullsFraction(0.5))
+                .variableStats(
+                        new VariableReferenceExpression("o3", BIGINT),
+                        assertion -> assertion
+                                .lowValue(7)
+                                .highValue(10)
+                                .distinctValuesCount(1.875)
+                                .nullsFraction(0))
+                .variableStats(
+                        new VariableReferenceExpression("o4", BIGINT),
+                        assertion -> assertion
+                                .lowValue(20)
+                                .highValue(25)
+                                .distinctValuesCount(1.875)
+                                .nullsFraction(0)));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.plan.AggregationNode.Aggregation;
 import com.facebook.presto.spi.plan.AggregationNode.Step;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.IntersectNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
 import com.facebook.presto.spi.plan.Ordering;
@@ -757,6 +758,12 @@ public class PlanBuilder
     {
         Map<VariableReferenceExpression, List<VariableReferenceExpression>> mapping = fromListMultimap(outputsToInputs);
         return new UnionNode(idAllocator.getNextId(), sources, ImmutableList.copyOf(mapping.keySet()), mapping);
+    }
+
+    public IntersectNode intersect(ListMultimap<VariableReferenceExpression, VariableReferenceExpression> outputsToInputs, List<PlanNode> sources)
+    {
+        Map<VariableReferenceExpression, List<VariableReferenceExpression>> mapping = fromListMultimap(outputsToInputs);
+        return new IntersectNode(idAllocator.getNextId(), sources, ImmutableList.copyOf(mapping.keySet()), mapping);
     }
 
     public TableWriterNode tableWriter(List<VariableReferenceExpression> columns, List<String> columnNames, PlanNode source)


### PR DESCRIPTION
Adding stats and cost rule for IntersectNode, so that more efficient plan can be generated for the query containing intersect operator

```
== NO RELEASE NOTE ==
```
