### PR TITLE
Improve skipping for PositionalFilter

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
@@ -224,14 +224,10 @@ public class BooleanSelectiveStreamReader
 
                 int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
                 if (succeedingPositionsToFail > 0) {
-                    int positionsToSkip = 0;
-                    for (int j = 0; j < succeedingPositionsToFail; j++) {
-                        i++;
-                        int nextPosition = positions[i];
-                        positionsToSkip += 1 + nextPosition - streamPosition;
-                        streamPosition = nextPosition + 1;
-                    }
+                    int positionsToSkip = positions[i + succeedingPositionsToFail] - positions[i];
                     skip(positionsToSkip);
+                    streamPosition += positionsToSkip;
+                    i += succeedingPositionsToFail;
                 }
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
@@ -212,14 +212,10 @@ public class ByteSelectiveStreamReader
                 outputPositionCount -= filter.getPrecedingPositionsToFail();
                 int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
                 if (succeedingPositionsToFail > 0) {
-                    int positionsToSkip = 0;
-                    for (int j = 0; j < succeedingPositionsToFail; j++) {
-                        i++;
-                        int nextPosition = positions[i];
-                        positionsToSkip += 1 + nextPosition - streamPosition;
-                        streamPosition = nextPosition + 1;
-                    }
+                    int positionsToSkip = positions[i + succeedingPositionsToFail] - positions[i];
                     skip(positionsToSkip);
+                    streamPosition += positionsToSkip;
+                    i += succeedingPositionsToFail;
                 }
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleSelectiveStreamReader.java
@@ -284,14 +284,10 @@ public class DoubleSelectiveStreamReader
                 outputPositionCount -= filter.getPrecedingPositionsToFail();
                 int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
                 if (succeedingPositionsToFail > 0) {
-                    int positionsToSkip = 0;
-                    for (int j = 0; j < succeedingPositionsToFail; j++) {
-                        i++;
-                        int nextPosition = positions[i];
-                        positionsToSkip += 1 + nextPosition - streamPosition;
-                        streamPosition = nextPosition + 1;
-                    }
+                    int positionsToSkip = positions[i + succeedingPositionsToFail] - positions[i];
                     skip(positionsToSkip);
+                    streamPosition += positionsToSkip;
+                    i += succeedingPositionsToFail;
                 }
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatSelectiveStreamReader.java
@@ -204,14 +204,10 @@ public class FloatSelectiveStreamReader
                 outputPositionCount -= filter.getPrecedingPositionsToFail();
                 int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
                 if (succeedingPositionsToFail > 0) {
-                    int positionsToSkip = 0;
-                    for (int j = 0; j < succeedingPositionsToFail; j++) {
-                        i++;
-                        int nextPosition = positions[i];
-                        positionsToSkip += 1 + nextPosition - streamPosition;
-                        streamPosition = nextPosition + 1;
-                    }
+                    int positionsToSkip = positions[i + succeedingPositionsToFail] - positions[i];
                     skip(positionsToSkip);
+                    streamPosition += positionsToSkip;
+                    i += succeedingPositionsToFail;
                 }
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
@@ -387,14 +387,10 @@ public class ListSelectiveStreamReader
 
                 int succeedingPositionsToFail = nullsFilter.getSucceedingPositionsToFail();
                 if (succeedingPositionsToFail > 0) {
-                    int positionsToSkip = 0;
-                    for (int j = 0; j < succeedingPositionsToFail; j++) {
-                        i++;
-                        int nextPosition = positions[i];
-                        positionsToSkip += 1 + nextPosition - streamPosition;
-                        streamPosition = nextPosition + 1;
-                    }
+                    int positionsToSkip = positions[i + succeedingPositionsToFail] - positions[i];
                     skippedElements += skip(positionsToSkip);
+                    streamPosition += positionsToSkip;
+                    i += succeedingPositionsToFail;
                 }
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDecimalSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDecimalSelectiveStreamReader.java
@@ -123,14 +123,10 @@ public class LongDecimalSelectiveStreamReader
                 outputPositionCount -= filter.getPrecedingPositionsToFail();
                 int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
                 if (succeedingPositionsToFail > 0) {
-                    int positionsToSkip = 0;
-                    for (int j = 0; j < succeedingPositionsToFail; j++) {
-                        i++;
-                        int nextPosition = positions[i];
-                        positionsToSkip += 1 + nextPosition - streamPosition;
-                        streamPosition = nextPosition + 1;
-                    }
+                    int positionsToSkip = positions[i + succeedingPositionsToFail] - positions[i];
                     skip(positionsToSkip);
+                    streamPosition += positionsToSkip;
+                    i += succeedingPositionsToFail;
                 }
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
@@ -176,14 +176,10 @@ public class LongDirectSelectiveStreamReader
 
                     int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
                     if (succeedingPositionsToFail > 0) {
-                        int positionsToSkip = 0;
-                        for (int j = 0; j < succeedingPositionsToFail; j++) {
-                            i++;
-                            int nextPosition = positions[i];
-                            positionsToSkip += 1 + nextPosition - streamPosition;
-                            streamPosition = nextPosition + 1;
-                        }
+                        int positionsToSkip = positions[i + succeedingPositionsToFail] - positions[i];
                         skip(positionsToSkip);
+                        streamPosition += positionsToSkip;
+                        i += succeedingPositionsToFail;
                     }
                 }
             }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ShortDecimalSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ShortDecimalSelectiveStreamReader.java
@@ -103,14 +103,10 @@ public class ShortDecimalSelectiveStreamReader
                 outputPositionCount -= filter.getPrecedingPositionsToFail();
                 int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
                 if (succeedingPositionsToFail > 0) {
-                    int positionsToSkip = 0;
-                    for (int j = 0; j < succeedingPositionsToFail; j++) {
-                        i++;
-                        int nextPosition = positions[i];
-                        positionsToSkip += 1 + nextPosition - streamPosition;
-                        streamPosition = nextPosition + 1;
-                    }
+                    int positionsToSkip = positions[i + succeedingPositionsToFail] - positions[i];
                     skip(positionsToSkip);
+                    streamPosition += positionsToSkip;
+                    i += succeedingPositionsToFail;
                 }
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
@@ -269,14 +269,10 @@ public class SliceDictionarySelectiveReader
                 outputPositionCount -= filter.getPrecedingPositionsToFail();
                 int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
                 if (succeedingPositionsToFail > 0) {
-                    int positionsToSkip = 0;
-                    for (int j = 0; j < succeedingPositionsToFail; j++) {
-                        i++;
-                        int nextPosition = positions[i];
-                        positionsToSkip += 1 + nextPosition - streamPosition;
-                        streamPosition = nextPosition + 1;
-                    }
+                    int positionsToSkip = positions[i + succeedingPositionsToFail] - positions[i];
                     skip(positionsToSkip);
+                    streamPosition += positionsToSkip;
+                    i += succeedingPositionsToFail;
                 }
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
@@ -255,14 +255,10 @@ public class SliceDirectSelectiveStreamReader
                 outputPositionCount -= filter.getPrecedingPositionsToFail();
                 int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
                 if (succeedingPositionsToFail > 0) {
-                    int positionsToSkip = 0;
-                    for (int j = 0; j < succeedingPositionsToFail; j++) {
-                        i++;
-                        int nextPosition = positions[i];
-                        positionsToSkip += 1 + nextPosition - streamPosition;
-                        streamPosition = nextPosition + 1;
-                    }
+                    int positionsToSkip = positions[i + succeedingPositionsToFail] - positions[i];
                     skipData(streamPosition, positionsToSkip);
+                    streamPosition += positionsToSkip;
+                    i += succeedingPositionsToFail;
                 }
             }
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
@@ -226,14 +226,10 @@ public class TimestampSelectiveStreamReader
 
                 int succeedingPositionsToFail = filter.getSucceedingPositionsToFail();
                 if (succeedingPositionsToFail > 0) {
-                    int positionsToSkip = 0;
-                    for (int j = 0; j < succeedingPositionsToFail; j++) {
-                        i++;
-                        int nextPosition = positions[i];
-                        positionsToSkip += 1 + nextPosition - streamPosition;
-                        streamPosition = nextPosition + 1;
-                    }
+                    int positionsToSkip = positions[i + succeedingPositionsToFail] - positions[i];
                     skip(positionsToSkip);
+                    streamPosition += positionsToSkip;
+                    i += succeedingPositionsToFail;
                 }
             }
         }


### PR DESCRIPTION
When skipping the succeeding positions to the failed position in a
nested StreamReader, the positions should all be continuous because
all the positions for the same top level cell should be selected.
Therefore the loop to calculate positions to skip is unnecessary.

```
== NO RELEASE NOTE ==
```
