### PR TITLE
A quick and dirty fix of CTAS failures: unable to rename from viewfs

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -430,6 +430,9 @@ public final class HiveWriteUtils
 
         // create a temporary directory on the same filesystem
         Path temporaryRoot = new Path(targetPath, temporaryPrefix);
+        if (!pathExists(context, hdfsEnvironment, temporaryRoot)) {
+            createDirectory(context, hdfsEnvironment, temporaryRoot);
+        }
         Path temporaryPath = new Path(temporaryRoot, randomUUID().toString());
 
         createDirectory(context, hdfsEnvironment, temporaryPath);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -419,7 +419,13 @@ public final class HiveWriteUtils
 
         // use relative temporary directory on ViewFS
         if (isViewFileSystem(context, hdfsEnvironment, targetPath)) {
-            temporaryPrefix = ".hive-staging";
+            if (pathExists(context, hdfsEnvironment, targetPath)) {
+                temporaryPrefix = ".hive-staging";
+            }
+            else {
+                //use the temporary folder in parent when target path does not exist
+                temporaryPrefix = "../.hive-staging";
+            }
         }
 
         // create a temporary directory on the same filesystem


### PR DESCRIPTION
Seeing the failure below when run CTAS on viewfs

`Unable to rename from viewfs://hadoop-dw2-nn.smf1.twitter.com/user/beinanw/warehouse/aaa/.hive-staging/538ee740-6cce-46b7-96a7-ca0fbfc52148 to viewfs://hadoop-dw2-nn.smf1.twitter.com/user/beinanw/warehouse/aaa: target directory already exists`

It seems that presto creates the temporary folder - ".hive-staging/{id}" just under the target folder, which would also create the target folder in advance if the target folder did not exist.  But for the new tables (such as the table crated by CTAS), the target folder should not be created until the prepareAddTable():SemiTransactionalHiveMetastore got called, otherwise we will see the failure above.

To fix this failure,  I make it check the existence of the target folder first.  If the target folder is not there, the temporary folder is created as {target_folder}/../.hive-staging/{id} rather than {target_folder}/.hive-staging/{id}.   In this case, the temporary folder will be created in the sibling folder of the target folder.  So the target folder won't be created in advance.




```
== NO RELEASE NOTE ==
```
