### PR TITLE
Use absolute error when a floating point column mean is close to 0

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/FloatingPointColumnValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/FloatingPointColumnValidator.java
@@ -157,15 +157,15 @@ public class FloatingPointColumnValidator
                     format("control(sum: %s) test(sum: %s)", controlSum, testSum)));
         }
 
-        // Use absolute error margin if either control sum or test sum is 0
-        if (controlSum == 0 || testSum == 0) {
-            double controlMean = controlSum / controlResult.getRowCount();
-            double testMean = testSum / controlResult.getRowCount();
-            double difference = abs(controlMean - testMean);
+        // Use absolute error margin if either control sum or test sum is 0.
+        // Row count won't be zero since otherwise controlSum and testSum will both be null, and this has already been handled above.
+        double controlMean = controlSum / controlResult.getRowCount();
+        double testMean = testSum / controlResult.getRowCount();
+        if (abs(controlMean) < absoluteErrorMargin || abs(testMean) < absoluteErrorMargin) {
             return ImmutableList.of(new ColumnMatchResult(
-                    difference < absoluteErrorMargin,
+                    abs(controlMean) < absoluteErrorMargin && abs(testMean) < absoluteErrorMargin,
                     column,
-                    format("control(mean: %s) test(mean: %s) difference: %s", controlMean, testMean, difference)));
+                    format("control(mean: %s) test(mean: %s)", controlMean, testMean)));
         }
 
         // Use relative error margin for the common cases

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
@@ -288,7 +288,7 @@ public class TestChecksumValidator
                 5,
                 ImmutableMap.<String, Object>builder()
                         .putAll(FLOATING_POINT_COUNTS)
-                        .put("double$sum", 0.0)
+                        .put("double$sum", -4.9e-12)
                         .put("real$sum", 4.9e-12)
                         .build());
         ChecksumResult testChecksum = new ChecksumResult(
@@ -318,8 +318,8 @@ public class TestChecksumValidator
         assertEquals(
                 checksumValidator.getMismatchedColumns(columns, controlChecksum, testChecksum),
                 ImmutableMap.builder()
-                        .put(DOUBLE_COLUMN, new ColumnMatchResult(false, DOUBLE_COLUMN, "control(mean: 0.0) test(mean: 1.0199999999999999E-12) difference: 1.0199999999999999E-12"))
-                        .put(REAL_COLUMN, new ColumnMatchResult(false, REAL_COLUMN, "control(mean: 1.0199999999999999E-12) test(mean: 0.0) difference: 1.0199999999999999E-12"))
+                        .put(DOUBLE_COLUMN, new ColumnMatchResult(false, DOUBLE_COLUMN, "control(mean: 0.0) test(mean: 1.0199999999999999E-12)"))
+                        .put(REAL_COLUMN, new ColumnMatchResult(false, REAL_COLUMN, "control(mean: 1.0199999999999999E-12) test(mean: 0.0)"))
                         .build());
     }
 


### PR DESCRIPTION
- Instead of requiring either the control mean or the test mean to be exactly 0, use the absolute error rule when at least one of them is close to 0.
- When checking a floating point column using the absolute error rule, match if both are control mean and test mean are within the absolute margin, mismatch otherwise.

```
== RELEASE NOTES ==

Verifier Changes
* Improve correctness check for floating point columns whose mean values of either the control query or the test query is closed to 0.
```
