### PR TITLE
Fix checksum column generation for map keys and map values

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ArrayColumnValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ArrayColumnValidator.java
@@ -26,8 +26,6 @@ import com.facebook.presto.sql.tree.TryExpression;
 import com.facebook.presto.verifier.framework.Column;
 import com.google.common.collect.ImmutableList;
 
-import javax.inject.Inject;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -39,11 +37,6 @@ import static java.lang.String.format;
 public class ArrayColumnValidator
         implements ColumnValidator
 {
-    @Inject
-    public ArrayColumnValidator()
-    {
-    }
-
     @Override
     public List<SingleColumn> generateChecksumColumns(Column column)
     {

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/MapColumnValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/MapColumnValidator.java
@@ -23,8 +23,6 @@ import com.facebook.presto.sql.tree.SingleColumn;
 import com.facebook.presto.verifier.framework.Column;
 import com.google.common.collect.ImmutableList;
 
-import javax.inject.Inject;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -38,9 +36,6 @@ import static java.lang.String.format;
 public class MapColumnValidator
         implements ColumnValidator
 {
-    @Inject
-    public MapColumnValidator() {}
-
     @Override
     public List<SingleColumn> generateChecksumColumns(Column column)
     {

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/SimpleColumnValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/SimpleColumnValidator.java
@@ -19,8 +19,6 @@ import com.facebook.presto.sql.tree.SingleColumn;
 import com.facebook.presto.verifier.framework.Column;
 import com.google.common.collect.ImmutableList;
 
-import javax.inject.Inject;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,11 +29,6 @@ import static java.lang.String.format;
 public class SimpleColumnValidator
         implements ColumnValidator
 {
-    @Inject
-    public SimpleColumnValidator()
-    {
-    }
-
     @Override
     public List<SingleColumn> generateChecksumColumns(Column column)
     {

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
@@ -68,7 +68,7 @@ public class TestChecksumValidator
     private static final Column INT_ARRAY_COLUMN = createColumn("int_array", new ArrayType(INTEGER));
     private static final Column ROW_ARRAY_COLUMN = createColumn("row_array", typeRegistry.getType(parseTypeSignature("array(row(a int,b varchar))")));
     private static final Column MAP_ARRAY_COLUMN = createColumn("map_array", typeRegistry.getType(parseTypeSignature("array(map(int,varchar))")));
-    private static final Column MAP_COLUMN = createColumn("map", typeRegistry.getType(parseTypeSignature("map(int,varchar)")));
+    private static final Column MAP_COLUMN = createColumn("map", typeRegistry.getType(parseTypeSignature("map(int,array(varchar))")));
     private static final Column MAP_NON_ORDERABLE_COLUMN = createColumn("map_non_orderable", typeRegistry.getType(parseTypeSignature("map(map(int,varchar),map(int,varchar))")));
     private static final Column ROW_COLUMN = createColumn("row", typeRegistry.getType(parseTypeSignature("row(i int, varchar, d double, a array(int), r row(double, b bigint))")));
 
@@ -140,7 +140,7 @@ public class TestChecksumValidator
                         ", COALESCE(\"sum\"(\"cardinality\"(\"map_array\")), 0) \"map_array$cardinality_sum\"" +
                         ", \"checksum\"(\"map\") \"map$checksum\"\n" +
                         ", \"checksum\"(\"array_sort\"(\"map_keys\"(\"map\"))) \"map$keys_checksum\"\n" +
-                        ", \"checksum\"(\"array_sort\"(\"map_values\"(\"map\"))) \"map$values_checksum\"\n" +
+                        ", COALESCE(\"checksum\"(TRY(\"array_sort\"(\"map_values\"(\"map\")))), \"checksum\"(\"map_values\"(\"map\"))) \"map$values_checksum\"\n" +
                         ", COALESCE(\"sum\"(\"cardinality\"(\"map\")), 0) \"map$cardinality_sum\"" +
                         ", \"checksum\"(\"map_non_orderable\") \"map_non_orderable$checksum\"\n" +
                         ", \"checksum\"(\"map_keys\"(\"map_non_orderable\")) \"map_non_orderable$keys_checksum\"\n" +


### PR DESCRIPTION
Map keys and map values are both arrays. When checksuming an array,
we need to handle the case in which the array element is orderable                                                                                                                                                                                                       
but the sorting fails.

The sort of an array would fail in certain cases when the array
elements are array with nulls or row with nulls. As an example,
array_sort(ARRAY[ARRAY[null], ARRAY[1]]) would fail.

This has been properly handled in ArrayColumnValidator, so we should
apply the same logic to the keys checksum and the values checksum
for an map column.

```
== RELEASE NOTES ==

General Changes
* Fix an issue where checksum query would fail for queries containing map columns whose key or value types are arrays or rows.
```
