### PR TITLE
Increase test runner heap size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <air.test.timezone>America/Bahia_Banderas</air.test.timezone>
         <air.test.parallel>methods</air.test.parallel>
         <air.test.thread-count>2</air.test.thread-count>
-        <air.test.jvmsize>2g</air.test.jvmsize>
+        <air.test.jvmsize>4g</air.test.jvmsize>
 
         <air.javadoc.lint>-missing</air.javadoc.lint>
     </properties>


### PR DESCRIPTION
Lately we've been observing high GC pressure when running unit and
integration tests. Increasing heap size is supposed to mitigate this issue.
Travis machines are equipped with 7.5GB of memory, thus the increase
from 2GB to 4GB should be fine.

```
== NO RELEASE NOTE ==
```
