### PR TITLE
Add classification_fallout function to FunctionManager

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
@@ -28,6 +28,7 @@ import com.facebook.presto.operator.aggregation.BitwiseOrAggregation;
 import com.facebook.presto.operator.aggregation.BooleanAndAggregation;
 import com.facebook.presto.operator.aggregation.BooleanOrAggregation;
 import com.facebook.presto.operator.aggregation.CentralMomentsAggregation;
+import com.facebook.presto.operator.aggregation.ClassificationFallOutAggregation;
 import com.facebook.presto.operator.aggregation.ClassificationMissRateAggregation;
 import com.facebook.presto.operator.aggregation.ClassificationPrecisionAggregation;
 import com.facebook.presto.operator.aggregation.ClassificationRecallAggregation;
@@ -481,6 +482,7 @@ public class BuiltInFunctionNamespaceManager
                 .aggregates(BitwiseOrAggregation.class)
                 .aggregates(BitwiseAndAggregation.class)
                 .aggregates(ClassificationMissRateAggregation.class)
+                .aggregates(ClassificationFallOutAggregation.class)
                 .aggregates(ClassificationPrecisionAggregation.class)
                 .aggregates(ClassificationRecallAggregation.class)
                 .aggregates(ClassificationThresholdsAggregation.class)


### PR DESCRIPTION
Before this change the function is not registered.

```
== RELEASE NOTE ==
General Changes
Fix function registration for :func:`classification_fallout function`

```
