### PR TITLE
Disable failure detector for TestMemoryWorkerCrash

### DIFF
--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/MemoryQueryRunner.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/MemoryQueryRunner.java
@@ -37,10 +37,10 @@ public final class MemoryQueryRunner
     public static DistributedQueryRunner createQueryRunner()
             throws Exception
     {
-        return createQueryRunner(ImmutableMap.of());
+        return createQueryRunner(ImmutableMap.of(), ImmutableMap.of());
     }
 
-    public static DistributedQueryRunner createQueryRunner(Map<String, String> extraProperties)
+    public static DistributedQueryRunner createQueryRunner(Map<String, String> coordinatorProperties, Map<String, String> extraProperties)
             throws Exception
     {
         Session session = testSessionBuilder()
@@ -48,7 +48,11 @@ public final class MemoryQueryRunner
                 .setSchema("default")
                 .build();
 
-        DistributedQueryRunner queryRunner = new DistributedQueryRunner(session, 4, extraProperties);
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                .setNodeCount(4)
+                .setCoordinatorProperties(coordinatorProperties)
+                .setExtraProperties(extraProperties)
+                .build();
 
         try {
             queryRunner.installPlugin(new MemoryPlugin());
@@ -71,7 +75,7 @@ public final class MemoryQueryRunner
             throws Exception
     {
         Logging.initialize();
-        DistributedQueryRunner queryRunner = createQueryRunner(ImmutableMap.of("http-server.http.port", "8080"));
+        DistributedQueryRunner queryRunner = createQueryRunner(ImmutableMap.of(), ImmutableMap.of("http-server.http.port", "8080"));
         Thread.sleep(10);
         Logger log = Logger.get(MemoryQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryWorkerCrash.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryWorkerCrash.java
@@ -16,10 +16,12 @@ package com.facebook.presto.plugin.memory;
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import static com.facebook.airlift.testing.Assertions.assertLessThan;
+import static com.facebook.presto.plugin.memory.MemoryQueryRunner.createQueryRunner;
 import static io.airlift.units.Duration.nanosSince;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -30,7 +32,8 @@ public class TestMemoryWorkerCrash
 {
     protected TestMemoryWorkerCrash()
     {
-        super(MemoryQueryRunner::createQueryRunner);
+        // failure detector causes test flakiness
+        super(() -> createQueryRunner(ImmutableMap.of("failure-detector.enabled", "false"), ImmutableMap.of()));
     }
 
     @Test


### PR DESCRIPTION
It causes the test to be flaky

Fixes #14170 

```
== NO RELEASE NOTE ==
```
