### PR TITLE
Improve determinism analysis of queries with top-level LIMIT clause

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DeterminismAnalyzer.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DeterminismAnalyzer.java
@@ -119,8 +119,12 @@ public class DeterminismAnalyzer
             }
 
             // Handle limit query
-            LimitQueryDeterminismAnalysis limitQueryAnalysis = new LimitQueryDeterminismAnalyzer(prestoAction, handleLimitQuery)
-                    .analyze(control, controlChecksum.getRowCount(), verificationContext);
+            LimitQueryDeterminismAnalysis limitQueryAnalysis = new LimitQueryDeterminismAnalyzer(
+                    prestoAction,
+                    handleLimitQuery,
+                    control.getQuery(),
+                    controlChecksum.getRowCount(),
+                    verificationContext).analyze();
 
             switch (limitQueryAnalysis) {
                 case NON_DETERMINISTIC:

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestLimitQueryDeterminismAnalyzer.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestLimitQueryDeterminismAnalyzer.java
@@ -17,11 +17,9 @@ import com.facebook.presto.jdbc.QueryStats;
 import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
-import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.verifier.prestoaction.PrestoAction;
 import com.google.common.collect.ImmutableList;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -31,12 +29,10 @@ import static com.facebook.presto.sql.SqlFormatter.formatSql;
 import static com.facebook.presto.sql.parser.IdentifierSymbol.AT_SIGN;
 import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
 import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
-import static com.facebook.presto.verifier.framework.ClusterType.CONTROL;
 import static com.facebook.presto.verifier.framework.LimitQueryDeterminismAnalysis.DETERMINISTIC;
 import static com.facebook.presto.verifier.framework.LimitQueryDeterminismAnalysis.FAILED_DATA_CHANGED;
 import static com.facebook.presto.verifier.framework.LimitQueryDeterminismAnalysis.NON_DETERMINISTIC;
 import static com.facebook.presto.verifier.framework.LimitQueryDeterminismAnalysis.NOT_RUN;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -75,80 +71,73 @@ public class TestLimitQueryDeterminismAnalyzer
         }
     }
 
-    private static final QualifiedName TABLE_NAME = QualifiedName.of("test");
     private static final long ROW_COUNT_WITH_LIMIT = 1000;
     private static final QueryStats QUERY_STATS = new QueryStats("id", "", false, false, 1, 2, 3, 4, 5, 0, 7, 8, 9, 10, 11, 0, Optional.empty());
     private static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build();
     private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
 
-    private AtomicLong rowCount = new AtomicLong();
-    private MockPrestoAction prestoAction;
-    private LimitQueryDeterminismAnalyzer analyzer;
-
-    @BeforeMethod
-    public void setup()
-    {
-        this.prestoAction = new MockPrestoAction(rowCount);
-        this.analyzer = new LimitQueryDeterminismAnalyzer(prestoAction, true);
-    }
-
     @Test
-    public void testNotRun()
+    public void testNotRunLimitNoOrderBy()
     {
+        MockPrestoAction prestoAction = createPrestoAction(1000);
+
         // Unsupported statement types
-        assertAnalysis("CREATE TABLE test (x varchar, ds varhcar) WITH (partitioned_by = ARRAY[\"ds\"])", NOT_RUN);
-        assertAnalysis("SELECT * FROM source LIMIT 10", NOT_RUN);
+        assertAnalysis(prestoAction, "CREATE TABLE test (x varchar, ds varhcar) WITH (partitioned_by = ARRAY[\"ds\"])", NOT_RUN);
+        assertAnalysis(prestoAction, "SELECT * FROM source LIMIT 10", NOT_RUN);
 
         // Order by clause
-        assertAnalysis("INSERT INTO test SELECT * FROM source UNION ALL SELECT * FROM source ORDER BY 1 LIMIT 1000", NOT_RUN);
-        assertAnalysis("INSERT INTO test SELECT * FROM source ORDER BY 1 LIMIT 1000", NOT_RUN);
+        assertAnalysis(prestoAction, "INSERT INTO test SELECT * FROM source UNION ALL SELECT * FROM source ORDER BY 1 LIMIT 1000", NOT_RUN);
+        assertAnalysis(prestoAction, "INSERT INTO test SELECT * FROM source ORDER BY 1 LIMIT 1000", NOT_RUN);
 
         // not outer limit clause
-        assertAnalysis("INSERT INTO test SELECT * FROM source UNION ALL SELECT * FROM source", NOT_RUN);
-        assertAnalysis("INSERT INTO test SELECT * FROM source", NOT_RUN);
-        assertAnalysis("INSERT INTO test SELECT * FROM (SELECT * FROM source LIMIT 1000)", NOT_RUN);
+        assertAnalysis(prestoAction, "INSERT INTO test SELECT * FROM source UNION ALL SELECT * FROM source", NOT_RUN);
+        assertAnalysis(prestoAction, "INSERT INTO test SELECT * FROM source", NOT_RUN);
+        assertAnalysis(prestoAction, "INSERT INTO test SELECT * FROM (SELECT * FROM source LIMIT 1000)", NOT_RUN);
     }
 
     @Test
-    public void testNonDeterministic()
+    public void testNonDeterministicLimitNoOrderBy()
     {
-        rowCount.set(1001);
-        assertAnalysis("INSERT INTO test SELECT * FROM source LIMIT 1000", NON_DETERMINISTIC);
-        assertRowCountQuery("SELECT count(1) FROM (SELECT * FROM source)");
+        MockPrestoAction prestoAction = createPrestoAction(1001);
 
-        assertAnalysis("CREATE TABLE test AS (WITH f AS (select * from g) ((SELECT * FROM source UNION ALL SELECT * FROM source LIMIT 1000)))", NON_DETERMINISTIC);
-        assertRowCountQuery("SELECT count(1) FROM (WITH f AS (select * from g) SELECT * FROM source UNION ALL SELECT * FROM source)");
+        assertAnalysis(prestoAction, "INSERT INTO test SELECT * FROM source LIMIT 1000", NON_DETERMINISTIC);
+        assertAnalyzerQuery(prestoAction, "SELECT count(1) FROM (SELECT * FROM source)");
 
-        assertAnalysis("CREATE TABLE test AS (WITH f AS (select * from g) (SELECT * FROM source LIMIT 1000))", NON_DETERMINISTIC);
-        assertRowCountQuery("SELECT count(1) FROM (WITH f AS (select * from g) SELECT * FROM source)");
+        assertAnalysis(prestoAction, "CREATE TABLE test AS (WITH f AS (select * from g) ((SELECT * FROM source UNION ALL SELECT * FROM source LIMIT 1000)))", NON_DETERMINISTIC);
+        assertAnalyzerQuery(prestoAction, "SELECT count(1) FROM (WITH f AS (select * from g) SELECT * FROM source UNION ALL SELECT * FROM source)");
+
+        assertAnalysis(prestoAction, "CREATE TABLE test AS (WITH f AS (select * from g) (SELECT * FROM source LIMIT 1000))", NON_DETERMINISTIC);
+        assertAnalyzerQuery(prestoAction, "SELECT count(1) FROM (WITH f AS (select * from g) SELECT * FROM source)");
+
+        assertAnalysis(prestoAction, "INSERT INTO test SELECT * FROM source LIMIT 2000", NON_DETERMINISTIC);
     }
 
     @Test
-    public void testDeterministic()
+    public void testDeterministicLimitNoOrderBy()
     {
-        rowCount.set(1000);
-        assertAnalysis("INSERT INTO test SELECT * FROM source LIMIT 1000", DETERMINISTIC);
+        assertAnalysis(createPrestoAction(1000), "INSERT INTO test SELECT * FROM source LIMIT 1000", DETERMINISTIC);
     }
 
     @Test
-    public void testFailedDataChanged()
+    public void testFailedDataChangedLimitNoOrderBy()
     {
-        rowCount.set(999);
-        assertAnalysis("INSERT INTO test SELECT * FROM source LIMIT 1000", FAILED_DATA_CHANGED);
+        assertAnalysis(createPrestoAction(999), "INSERT INTO test SELECT * FROM source LIMIT 1000", FAILED_DATA_CHANGED);
     }
 
-    private void assertAnalysis(String query, LimitQueryDeterminismAnalysis expectedAnalysis)
+    private static MockPrestoAction createPrestoAction(long rowCount)
+    {
+        return new MockPrestoAction(new AtomicLong(rowCount));
+    }
+
+    private static void assertAnalysis(PrestoAction prestoAction, String query, LimitQueryDeterminismAnalysis expectedAnalysis)
     {
         VerificationContext verificationContext = new VerificationContext();
-        LimitQueryDeterminismAnalysis analysis = analyzer.analyze(
-                new QueryBundle(
-                        TABLE_NAME,
-                        ImmutableList.of(),
-                        sqlParser.createStatement(query, PARSING_OPTIONS),
-                        ImmutableList.of(),
-                        CONTROL),
+        LimitQueryDeterminismAnalysis analysis = new LimitQueryDeterminismAnalyzer(
+                prestoAction,
+                true,
+                sqlParser.createStatement(query, PARSING_OPTIONS),
                 ROW_COUNT_WITH_LIMIT,
-                verificationContext);
+                verificationContext).analyze();
 
         assertEquals(analysis, expectedAnalysis);
         if (expectedAnalysis == NOT_RUN) {
@@ -159,11 +148,10 @@ public class TestLimitQueryDeterminismAnalyzer
         }
     }
 
-    private void assertRowCountQuery(String expectedQuery)
+    private static void assertAnalyzerQuery(MockPrestoAction prestoAction, String expectedQuery)
     {
         Statement expectedStatement = sqlParser.createStatement(expectedQuery, PARSING_OPTIONS);
         Statement actualStatement = prestoAction.getLastStatement();
-        String actualQuery = formatSql(actualStatement, Optional.empty());
-        assertEquals(actualStatement, expectedStatement, format("expected:\n[%s]\nbut found:\n[%s]", formatSql(expectedStatement, Optional.empty()), actualQuery));
+        assertEquals(formatSql(actualStatement, Optional.empty()), formatSql(expectedStatement, Optional.empty()));
     }
 }


### PR DESCRIPTION
```
== RELEASE NOTES ==

Verifier Changes
* Fix incorrect decision for determinism analysis of queries with top-level ``LIMIT`` clause. (:pr:`14176`)
* Improve query performance during determinism analysis of queries with top-level ``LIMIT`` clause.
```
