### PR TITLE
A new end point to get resource group stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/NoOpResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/NoOpResourceGroupManager.java
@@ -37,7 +37,7 @@ public final class NoOpResourceGroupManager
     }
 
     @Override
-    public ResourceGroupInfo getResourceGroupInfo(ResourceGroupId id)
+    public ResourceGroupInfo getResourceGroupInfo(ResourceGroupId id, boolean includeQueryInfo, boolean summarizeSubgroups, boolean includeStaticSubgroupsOnly)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupManager.java
@@ -37,7 +37,7 @@ public interface ResourceGroupManager<C>
 
     SelectionContext<C> selectGroup(SelectionCriteria criteria);
 
-    ResourceGroupInfo getResourceGroupInfo(ResourceGroupId id);
+    ResourceGroupInfo getResourceGroupInfo(ResourceGroupId id, boolean includeQueryInfo, boolean summarizeSubgroups, boolean includeStaticSubgroupsOnly);
 
     List<ResourceGroupInfo> getPathToRoot(ResourceGroupId id);
 

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupInfo.java
@@ -16,6 +16,7 @@ package com.facebook.presto.server;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupState;
 import com.facebook.presto.spi.resourceGroups.SchedulingPolicy;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.airlift.units.DataSize;
 
@@ -51,26 +52,22 @@ public class ResourceGroupInfo
     private final List<ResourceGroupInfo> subGroups;
     private final List<QueryStateInfo> runningQueries;
 
+    @JsonCreator
     public ResourceGroupInfo(
-            ResourceGroupId id,
-            ResourceGroupState state,
-
-            SchedulingPolicy schedulingPolicy,
-            int schedulingWeight,
-
-            DataSize softMemoryLimit,
-            int softConcurrencyLimit,
-            int hardConcurrencyLimit,
-            int maxQueuedQueries,
-
-            DataSize memoryUsage,
-            int numQueuedQueries,
-            int numRunningQueries,
-            int numEligibleSubGroups,
-
-            List<ResourceGroupInfo> subGroups,
-
-            List<QueryStateInfo> runningQueries)
+            @JsonProperty("id") ResourceGroupId id,
+            @JsonProperty("state") ResourceGroupState state,
+            @JsonProperty("schedulingPolicy") SchedulingPolicy schedulingPolicy,
+            @JsonProperty("schedulingWeight") int schedulingWeight,
+            @JsonProperty("softMemoryLimit") DataSize softMemoryLimit,
+            @JsonProperty("softConcurrencyLimit") int softConcurrencyLimit,
+            @JsonProperty("hardConcurrencyLimit") int hardConcurrencyLimit,
+            @JsonProperty("maxQueuedQueries") int maxQueuedQueries,
+            @JsonProperty("memoryUsage") DataSize memoryUsage,
+            @JsonProperty("numQueuedQueries") int numQueuedQueries,
+            @JsonProperty("numRunningQueries") int numRunningQueries,
+            @JsonProperty("numEligibleSubGroups") int numEligibleSubGroups,
+            @JsonProperty("subGroups") List<ResourceGroupInfo> subGroups,
+            @JsonProperty("runningQueries") List<QueryStateInfo> runningQueries)
     {
         this.id = requireNonNull(id, "id is null");
         this.state = requireNonNull(state, "state is null");

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupStateInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupStateInfoResource.java
@@ -17,11 +17,13 @@ import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 
 import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 
@@ -51,7 +53,11 @@ public class ResourceGroupStateInfoResource
     @Produces(MediaType.APPLICATION_JSON)
     @Encoded
     @Path("{resourceGroupId: .+}")
-    public ResourceGroupInfo getQueryStateInfos(@PathParam("resourceGroupId") String resourceGroupIdString)
+    public ResourceGroupInfo getQueryStateInfos(
+            @PathParam("resourceGroupId") String resourceGroupIdString,
+            @QueryParam("includeQueryInfo") @DefaultValue("true") boolean includeQueryInfo,
+            @QueryParam("summarizeSubgroups") @DefaultValue("true") boolean summarizeSubgroups,
+            @QueryParam("includeStaticSubgroupsOnly") @DefaultValue("false") boolean includeStaticSubgroupsOnly)
     {
         if (!isNullOrEmpty(resourceGroupIdString)) {
             try {
@@ -59,7 +65,10 @@ public class ResourceGroupStateInfoResource
                         new ResourceGroupId(
                                 Arrays.stream(resourceGroupIdString.split("/"))
                                         .map(ResourceGroupStateInfoResource::urlDecode)
-                                        .collect(toImmutableList())));
+                                        .collect(toImmutableList())),
+                        includeQueryInfo,
+                        summarizeSubgroups,
+                        includeStaticSubgroupsOnly);
             }
             catch (NoSuchElementException e) {
                 throw new WebApplicationException(NOT_FOUND);

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/BenchmarkResourceGroup.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/BenchmarkResourceGroup.java
@@ -77,7 +77,7 @@ public class BenchmarkResourceGroup
             root.setHardConcurrencyLimit(queries);
             InternalResourceGroup group = root;
             for (int i = 0; i < children; i++) {
-                group = root.getOrCreateSubGroup(String.valueOf(i));
+                group = root.getOrCreateSubGroup(String.valueOf(i), true);
                 group.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
                 group.setMaxQueuedQueries(queries);
                 group.setHardConcurrencyLimit(queries);

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
@@ -53,6 +53,8 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Collections.reverse;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 public class TestResourceGroups
@@ -83,15 +85,15 @@ public class TestResourceGroups
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(1);
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1");
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(4);
         group1.setHardConcurrencyLimit(1);
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2");
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(4);
         group2.setHardConcurrencyLimit(1);
-        InternalResourceGroup group3 = root.getOrCreateSubGroup("3");
+        InternalResourceGroup group3 = root.getOrCreateSubGroup("3", true);
         group3.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group3.setMaxQueuedQueries(4);
         group3.setHardConcurrencyLimit(1);
@@ -138,11 +140,11 @@ public class TestResourceGroups
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(1);
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1");
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(4);
         group1.setHardConcurrencyLimit(2);
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2");
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(4);
         group2.setHardConcurrencyLimit(2);
@@ -160,17 +162,17 @@ public class TestResourceGroups
         assertEquals(query2a.getState(), QUEUED);
 
         assertEquals(root.getInfo().getNumEligibleSubGroups(), 2);
-        assertEquals(root.getOrCreateSubGroup("1").getQueuedQueries(), 2);
-        assertEquals(root.getOrCreateSubGroup("2").getQueuedQueries(), 1);
+        assertEquals(root.getOrCreateSubGroup("1", true).getQueuedQueries(), 2);
+        assertEquals(root.getOrCreateSubGroup("2", true).getQueuedQueries(), 1);
         assertEquals(root.getSchedulingPolicy(), FAIR);
         root.setSchedulingPolicy(QUERY_PRIORITY);
         assertEquals(root.getInfo().getNumEligibleSubGroups(), 2);
-        assertEquals(root.getOrCreateSubGroup("1").getQueuedQueries(), 2);
-        assertEquals(root.getOrCreateSubGroup("2").getQueuedQueries(), 1);
+        assertEquals(root.getOrCreateSubGroup("1", true).getQueuedQueries(), 2);
+        assertEquals(root.getOrCreateSubGroup("2", true).getQueuedQueries(), 1);
 
         assertEquals(root.getSchedulingPolicy(), QUERY_PRIORITY);
-        assertEquals(root.getOrCreateSubGroup("1").getSchedulingPolicy(), QUERY_PRIORITY);
-        assertEquals(root.getOrCreateSubGroup("2").getSchedulingPolicy(), QUERY_PRIORITY);
+        assertEquals(root.getOrCreateSubGroup("1", true).getSchedulingPolicy(), QUERY_PRIORITY);
+        assertEquals(root.getOrCreateSubGroup("2", true).getSchedulingPolicy(), QUERY_PRIORITY);
     }
 
     @Test(timeOut = 10_000)
@@ -180,11 +182,11 @@ public class TestResourceGroups
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(1);
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1");
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(4);
         group1.setHardConcurrencyLimit(2);
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2");
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(4);
         group2.setHardConcurrencyLimit(2);
@@ -247,7 +249,7 @@ public class TestResourceGroups
         root.setSoftMemoryLimit(new DataSize(10, BYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(3);
-        InternalResourceGroup subgroup = root.getOrCreateSubGroup("subgroup");
+        InternalResourceGroup subgroup = root.getOrCreateSubGroup("subgroup", true);
         subgroup.setSoftMemoryLimit(new DataSize(1, BYTE));
         subgroup.setMaxQueuedQueries(4);
         subgroup.setHardConcurrencyLimit(3);
@@ -338,11 +340,11 @@ public class TestResourceGroups
         // Start with zero capacity, so that nothing starts running until we've added all the queries
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(QUERY_PRIORITY);
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1");
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(100);
         group1.setHardConcurrencyLimit(1);
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2");
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(100);
         group2.setHardConcurrencyLimit(1);
@@ -388,12 +390,12 @@ public class TestResourceGroups
         // Start with zero capacity, so that nothing starts running until we've added all the queries
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(WEIGHTED);
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1");
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(2);
         group1.setHardConcurrencyLimit(2);
         group1.setSoftConcurrencyLimit(2);
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2");
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(2);
         group2.setHardConcurrencyLimit(2);
@@ -438,14 +440,14 @@ public class TestResourceGroups
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(WEIGHTED_FAIR);
 
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1");
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(50);
         group1.setHardConcurrencyLimit(2);
         group1.setSoftConcurrencyLimit(2);
         group1.setSchedulingWeight(1);
 
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2");
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(50);
         group2.setHardConcurrencyLimit(2);
@@ -481,21 +483,21 @@ public class TestResourceGroups
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(WEIGHTED_FAIR);
 
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1");
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(50);
         group1.setHardConcurrencyLimit(2);
         group1.setSoftConcurrencyLimit(2);
         group1.setSchedulingWeight(1);
 
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2");
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(50);
         group2.setHardConcurrencyLimit(2);
         group2.setSoftConcurrencyLimit(2);
         group2.setSchedulingWeight(1);
 
-        InternalResourceGroup group3 = root.getOrCreateSubGroup("3");
+        InternalResourceGroup group3 = root.getOrCreateSubGroup("3", true);
         group3.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group3.setMaxQueuedQueries(50);
         group3.setHardConcurrencyLimit(2);
@@ -540,14 +542,14 @@ public class TestResourceGroups
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(WEIGHTED_FAIR);
 
-        InternalResourceGroup group1 = root.getOrCreateSubGroup("1");
+        InternalResourceGroup group1 = root.getOrCreateSubGroup("1", true);
         group1.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group1.setMaxQueuedQueries(50);
         group1.setHardConcurrencyLimit(2);
         group1.setSoftConcurrencyLimit(2);
         group1.setSchedulingWeight(1);
 
-        InternalResourceGroup group2 = root.getOrCreateSubGroup("2");
+        InternalResourceGroup group2 = root.getOrCreateSubGroup("2", true);
         group2.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         group2.setMaxQueuedQueries(50);
         group2.setHardConcurrencyLimit(2);
@@ -581,34 +583,34 @@ public class TestResourceGroups
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(WEIGHTED);
 
-        InternalResourceGroup rootA = root.getOrCreateSubGroup("a");
+        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true);
         rootA.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootA.setMaxQueuedQueries(20);
         rootA.setHardConcurrencyLimit(2);
 
-        InternalResourceGroup rootB = root.getOrCreateSubGroup("b");
+        InternalResourceGroup rootB = root.getOrCreateSubGroup("b", true);
         rootB.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootB.setMaxQueuedQueries(20);
         rootB.setHardConcurrencyLimit(2);
         rootB.setSchedulingWeight(2);
         rootB.setSchedulingPolicy(QUERY_PRIORITY);
 
-        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x");
+        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", true);
         rootAX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAX.setMaxQueuedQueries(10);
         rootAX.setHardConcurrencyLimit(10);
 
-        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y");
+        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y", true);
         rootAY.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAY.setMaxQueuedQueries(10);
         rootAY.setHardConcurrencyLimit(10);
 
-        InternalResourceGroup rootBX = rootB.getOrCreateSubGroup("x");
+        InternalResourceGroup rootBX = rootB.getOrCreateSubGroup("x", true);
         rootBX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootBX.setMaxQueuedQueries(10);
         rootBX.setHardConcurrencyLimit(10);
 
-        InternalResourceGroup rootBY = rootB.getOrCreateSubGroup("y");
+        InternalResourceGroup rootBY = rootB.getOrCreateSubGroup("y", true);
         rootBY.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootBY.setMaxQueuedQueries(10);
         rootBY.setHardConcurrencyLimit(10);
@@ -670,24 +672,24 @@ public class TestResourceGroups
         root.setHardConcurrencyLimit(10);
         root.setSchedulingPolicy(WEIGHTED);
 
-        InternalResourceGroup rootA = root.getOrCreateSubGroup("a");
+        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true);
         rootA.setSoftMemoryLimit(new DataSize(10, MEGABYTE));
         rootA.setMaxQueuedQueries(20);
         rootA.setHardConcurrencyLimit(0);
 
-        InternalResourceGroup rootB = root.getOrCreateSubGroup("b");
+        InternalResourceGroup rootB = root.getOrCreateSubGroup("b", true);
         rootB.setSoftMemoryLimit(new DataSize(5, MEGABYTE));
         rootB.setMaxQueuedQueries(20);
         rootB.setHardConcurrencyLimit(1);
         rootB.setSchedulingWeight(2);
         rootB.setSchedulingPolicy(QUERY_PRIORITY);
 
-        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x");
+        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", true);
         rootAX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAX.setMaxQueuedQueries(10);
         rootAX.setHardConcurrencyLimit(10);
 
-        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y");
+        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y", true);
         rootAY.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAY.setMaxQueuedQueries(10);
         rootAY.setHardConcurrencyLimit(10);
@@ -696,7 +698,7 @@ public class TestResourceGroups
         queries.addAll(fillGroupTo(rootAY, ImmutableSet.of(), 5, false));
         queries.addAll(fillGroupTo(rootB, ImmutableSet.of(), 10, true));
 
-        ResourceGroupInfo rootInfo = root.getFullInfo();
+        ResourceGroupInfo rootInfo = root.getResourceGroupInfo(true, true, false);
         assertEquals(rootInfo.getId(), root.getId());
         assertEquals(rootInfo.getState(), CAN_RUN);
         assertEquals(rootInfo.getSoftMemoryLimit(), root.getSoftMemoryLimit());
@@ -730,6 +732,83 @@ public class TestResourceGroups
     }
 
     @Test
+    public void testGetStaticResourceGroupInfo()
+    {
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        root.setSoftMemoryLimit(new DataSize(1, GIGABYTE));
+        root.setMaxQueuedQueries(100);
+        root.setHardConcurrencyLimit(10);
+        root.setSchedulingPolicy(WEIGHTED);
+
+        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true);
+        rootA.setSoftMemoryLimit(new DataSize(10, MEGABYTE));
+        rootA.setMaxQueuedQueries(100);
+        rootA.setHardConcurrencyLimit(0);
+
+        InternalResourceGroup rootB = root.getOrCreateSubGroup("b", true);
+        rootB.setSoftMemoryLimit(new DataSize(5, MEGABYTE));
+        rootB.setMaxQueuedQueries(100);
+        rootB.setHardConcurrencyLimit(1);
+        rootB.setSchedulingWeight(2);
+        rootB.setSchedulingPolicy(QUERY_PRIORITY);
+
+        // x is a dynamic resource group
+        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", false);
+        rootAX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
+        rootAX.setMaxQueuedQueries(10);
+        rootAX.setHardConcurrencyLimit(10);
+
+        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y", true);
+        rootAY.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
+        rootAY.setMaxQueuedQueries(10);
+        rootAY.setHardConcurrencyLimit(10);
+
+        for (int i = 0; i < 10; i++) {
+            InternalResourceGroup subGroup = rootAX.getOrCreateSubGroup("ax" + i, false);
+            subGroup.setSoftMemoryLimit(new DataSize(i, MEGABYTE));
+            subGroup.setMaxQueuedQueries(10);
+            subGroup.setHardConcurrencyLimit(10);
+        }
+
+        for (int i = 0; i < 10; i++) {
+            fillGroupTo(rootAX.getOrCreateSubGroup("ax" + i, true), ImmutableSet.of(), 1, false);
+        }
+        fillGroupTo(rootAY, ImmutableSet.of(), 5, false);
+        fillGroupTo(rootB, ImmutableSet.of(), 10, true);
+
+        ResourceGroupInfo rootInfo = root.getResourceGroupInfo(false, false, true);
+        assertEquals(rootInfo.getId(), root.getId());
+        assertNotNull(rootInfo.getSubGroups());
+        assertEquals(rootInfo.getSubGroups().size(), 2);
+        Optional<ResourceGroupInfo> rootAInfo = getResourceGroupInfoForId(rootA, rootInfo);
+        assertTrue(rootAInfo.isPresent());
+        assertNotNull(rootAInfo.get().getSubGroups());
+        assertEquals(rootAInfo.get().getSubGroups().size(), 1);
+        Optional<ResourceGroupInfo> rootAXInfo = getResourceGroupInfoForId(rootAX, rootAInfo.get());
+        // dynamic resource groups should not be returned.
+        assertFalse(rootAXInfo.isPresent());
+        Optional<ResourceGroupInfo> rootAYInfo = getResourceGroupInfoForId(rootAY, rootAInfo.get());
+        assertTrue(rootAYInfo.isPresent());
+        assertNotNull(rootAYInfo.get().getSubGroups());
+        assertEquals(rootAYInfo.get().getSubGroups().size(), 0);
+        Optional<ResourceGroupInfo> rootBInfo = getResourceGroupInfoForId(rootB, rootInfo);
+        assertTrue(rootBInfo.isPresent());
+        assertNotNull(rootBInfo.get().getSubGroups());
+        assertEquals(rootBInfo.get().getSubGroups().size(), 0);
+    }
+
+    private Optional<ResourceGroupInfo> getResourceGroupInfoForId(InternalResourceGroup rootA, ResourceGroupInfo rootInfo)
+    {
+        assertNotNull(rootInfo.getSubGroups());
+        for (ResourceGroupInfo subGroup : rootInfo.getSubGroups()) {
+            if (subGroup.getId().equals(rootA.getId())) {
+                return Optional.of(subGroup);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Test
     public void testGetBlockedQueuedQueries()
     {
         RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
@@ -738,32 +817,32 @@ public class TestResourceGroups
         // Start with zero capacity, so that nothing starts running until we've added all the queries
         root.setHardConcurrencyLimit(0);
 
-        InternalResourceGroup rootA = root.getOrCreateSubGroup("a");
+        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true);
         rootA.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootA.setMaxQueuedQueries(20);
         rootA.setHardConcurrencyLimit(8);
 
-        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x");
+        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", true);
         rootAX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAX.setMaxQueuedQueries(10);
         rootAX.setHardConcurrencyLimit(8);
 
-        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y");
+        InternalResourceGroup rootAY = rootA.getOrCreateSubGroup("y", true);
         rootAY.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAY.setMaxQueuedQueries(10);
         rootAY.setHardConcurrencyLimit(5);
 
-        InternalResourceGroup rootB = root.getOrCreateSubGroup("b");
+        InternalResourceGroup rootB = root.getOrCreateSubGroup("b", true);
         rootB.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootB.setMaxQueuedQueries(20);
         rootB.setHardConcurrencyLimit(8);
 
-        InternalResourceGroup rootBX = rootB.getOrCreateSubGroup("x");
+        InternalResourceGroup rootBX = rootB.getOrCreateSubGroup("x", true);
         rootBX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootBX.setMaxQueuedQueries(10);
         rootBX.setHardConcurrencyLimit(8);
 
-        InternalResourceGroup rootBY = rootB.getOrCreateSubGroup("y");
+        InternalResourceGroup rootBY = rootB.getOrCreateSubGroup("y", true);
         rootBY.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootBY.setMaxQueuedQueries(10);
         rootBY.setHardConcurrencyLimit(5);

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -51,12 +51,12 @@ public class TestQueryStateInfo
         root.setHardConcurrencyLimit(0);
         root.setSchedulingPolicy(WEIGHTED);
 
-        InternalResourceGroup rootA = root.getOrCreateSubGroup("a");
+        InternalResourceGroup rootA = root.getOrCreateSubGroup("a", true);
         rootA.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootA.setMaxQueuedQueries(20);
         rootA.setHardConcurrencyLimit(0);
 
-        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x");
+        InternalResourceGroup rootAX = rootA.getOrCreateSubGroup("x", true);
         rootAX.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         rootAX.setMaxQueuedQueries(10);
         rootAX.setHardConcurrencyLimit(0);

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/ResourceGroupIdTemplate.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/ResourceGroupIdTemplate.java
@@ -21,8 +21,10 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -66,6 +68,13 @@ public class ResourceGroupIdTemplate
             }
         }
         return id;
+    }
+
+    public OptionalInt getFirstDynamicSegment()
+    {
+        return IntStream.range(0, segments.size())
+                .filter(i -> segments.get(i).hasVariables())
+                .findFirst();
     }
 
     public List<ResourceGroupNameTemplate> getSegments()

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/ResourceGroupNameTemplate.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/ResourceGroupNameTemplate.java
@@ -70,6 +70,11 @@ public class ResourceGroupNameTemplate
                 .collect(toImmutableSet());
     }
 
+    public boolean hasVariables()
+    {
+        return fragments.stream().anyMatch(NameFragment::isVariable);
+    }
+
     public String expandTemplate(VariableMap variables)
     {
         StringBuilder builder = new StringBuilder();

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/StaticSelector.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/StaticSelector.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -118,8 +119,9 @@ public class StaticSelector
 
         VariableMap map = new VariableMap(variables);
         ResourceGroupId id = group.expandTemplate(map);
+        OptionalInt firstDynamicSegment = group.getFirstDynamicSegment();
 
-        return Optional.of(new SelectionContext<>(id, map));
+        return Optional.of(new SelectionContext<>(id, map, firstDynamicSegment));
     }
 
     private static void addNamedGroups(Pattern pattern, HashSet<String> variables)

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestResourceGroupIdTemplate.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestResourceGroupIdTemplate.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.regex.Pattern;
 
 import static org.testng.Assert.assertEquals;
@@ -39,6 +40,15 @@ public class TestResourceGroupIdTemplate
         assertEquals(template.expandTemplate(new VariableMap(ImmutableMap.of("USER", "u", "SOURCE", "s"))), expected);
         template = new ResourceGroupIdTemplate("test.${USER}");
         assertEquals(template.expandTemplate(new VariableMap(ImmutableMap.of("USER", "alice.smith", "SOURCE", "s"))), new ResourceGroupId(new ResourceGroupId("test"), "alice.smith"));
+    }
+
+    @Test
+    public void testFirstDynamicSegment()
+    {
+        ResourceGroupIdTemplate template = new ResourceGroupIdTemplate("test.${USER}.${SOURCE}");
+        assertEquals(template.getFirstDynamicSegment(), OptionalInt.of(1));
+        template = new ResourceGroupIdTemplate("test.pipeline.job_${pipeline}_user:${USER}.${USER}");
+        assertEquals(template.getFirstDynamicSegment(), OptionalInt.of(2));
     }
 
     @Test

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbResourceGroupConfigurationManager.java
@@ -121,7 +121,7 @@ public class TestDbResourceGroupConfigurationManager
         manager.configure(global, new SelectionContext<>(global.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
         assertEqualsResourceGroup(global, "1MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, new Duration(1, HOURS), new Duration(1, DAYS));
         exported.set(false);
-        InternalResourceGroup sub = global.getOrCreateSubGroup("sub");
+        InternalResourceGroup sub = global.getOrCreateSubGroup("sub", true);
         manager.configure(sub, new SelectionContext<>(sub.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
         assertEqualsResourceGroup(sub, "2MB", 4, 3, 3, FAIR, 5, false, new Duration(Long.MAX_VALUE, MILLISECONDS), new Duration(Long.MAX_VALUE, MILLISECONDS));
     }
@@ -199,7 +199,7 @@ public class TestDbResourceGroupConfigurationManager
         AtomicBoolean exported = new AtomicBoolean();
         InternalResourceGroup global = new InternalResourceGroup.RootInternalResourceGroup("global", (group, export) -> exported.set(export), directExecutor());
         manager.configure(global, new SelectionContext<>(global.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
-        InternalResourceGroup globalSub = global.getOrCreateSubGroup("sub");
+        InternalResourceGroup globalSub = global.getOrCreateSubGroup("sub", true);
         manager.configure(globalSub, new SelectionContext<>(globalSub.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
         // Verify record exists
         assertEqualsResourceGroup(globalSub, "2MB", 4, 3, 3, FAIR, 5, false, new Duration(Long.MAX_VALUE, MILLISECONDS), new Duration(Long.MAX_VALUE, MILLISECONDS));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/SelectionContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/SelectionContext.java
@@ -13,17 +13,28 @@
  */
 package com.facebook.presto.spi.resourceGroups;
 
+import java.util.OptionalInt;
+
 import static java.util.Objects.requireNonNull;
 
 public final class SelectionContext<T>
 {
     private final ResourceGroupId resourceGroupId;
     private final T context;
+    private final OptionalInt firstDynamicSegmentPosition;
+
+    public SelectionContext(ResourceGroupId resourceGroupId, T context, OptionalInt firstDynamicSegmentPosition)
+    {
+        this.resourceGroupId = requireNonNull(resourceGroupId, "resourceGroupId is null");
+        this.context = requireNonNull(context, "context is null");
+        this.firstDynamicSegmentPosition = requireNonNull(firstDynamicSegmentPosition, "firstDynamicSegmentPosition is null");
+    }
 
     public SelectionContext(ResourceGroupId resourceGroupId, T context)
     {
         this.resourceGroupId = requireNonNull(resourceGroupId, "resourceGroupId is null");
         this.context = requireNonNull(context, "context is null");
+        this.firstDynamicSegmentPosition = OptionalInt.empty();
     }
 
     public ResourceGroupId getResourceGroupId()
@@ -34,5 +45,10 @@ public final class SelectionContext<T>
     public T getContext()
     {
         return context;
+    }
+
+    public OptionalInt getFirstDynamicSegmentPosition()
+    {
+        return firstDynamicSegmentPosition;
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroupIntegration.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroupIntegration.java
@@ -77,7 +77,7 @@ public class TestResourceGroupIntegration
         long startTime = System.nanoTime();
         while (true) {
             SECONDS.sleep(1);
-            ResourceGroupInfo global = getResourceGroupManager(queryRunner).getResourceGroupInfo(new ResourceGroupId("global"));
+            ResourceGroupInfo global = getResourceGroupManager(queryRunner).getResourceGroupInfo(new ResourceGroupId("global"), true, true, true);
             if (global.getSoftMemoryLimit().toBytes() > 0) {
                 break;
             }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -97,7 +97,7 @@ public class TestQueuesDb
     {
         queryRunner.execute("SELECT COUNT(*), clerk FROM orders GROUP BY clerk");
         while (true) {
-            ResourceGroupInfo global = queryRunner.getCoordinator().getResourceGroupManager().get().getResourceGroupInfo(new ResourceGroupId(new ResourceGroupId("global"), "bi-user"));
+            ResourceGroupInfo global = queryRunner.getCoordinator().getResourceGroupManager().get().getResourceGroupInfo(new ResourceGroupId(new ResourceGroupId("global"), "bi-user"), true, true, true);
             if (global.getSoftMemoryLimit().toBytes() > 0) {
                 break;
             }


### PR DESCRIPTION
A load balancer can use resource group level stats to do better
load balancing. The new endpoint returns a ResourceGroupInfo.
ResourceGroupInfo contains a list of ResourceGroupInfo's as its subtrees.
ResourceGroupInfo consists of basic stats (running and queued query counts)
and actual queries as strings. This method leaves the queries empty
since it is not needed. The end method does not return the dynamically
generated the resource groups.