### PR TITLE
Fix the failure of row type must have at least one parameter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/RowParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RowParametricType.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.spi.type.NamedType;
 import com.facebook.presto.spi.type.NamedTypeSignature;
 import com.facebook.presto.spi.type.ParameterKind;
 import com.facebook.presto.spi.type.ParametricType;
@@ -26,6 +27,7 @@ import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.spi.type.TypeSignatureParameter;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.stream.Collectors.toList;
@@ -48,7 +50,9 @@ public final class RowParametricType
     @Override
     public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
     {
-        checkArgument(!parameters.isEmpty(), "Row type must have at least one parameter");
+        if (parameters.isEmpty()) {
+            parameters.add(TypeParameter.of(new NamedType(Optional.of(new RowFieldName(UnknownType.NAME, false)), UnknownType.UNKNOWN)));
+        }
         checkArgument(
                 parameters.stream().allMatch(parameter -> parameter.getKind() == ParameterKind.NAMED_TYPE),
                 "Expected only named types as a parameters, got %s",

--- a/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/type/TypeSignature.java
@@ -47,7 +47,7 @@ public class TypeSignature
 
     static {
         BASE_NAME_ALIAS_TO_CANONICAL.put("int", StandardTypes.INTEGER);
-
+        BASE_NAME_ALIAS_TO_CANONICAL.put("", "unknown");
         SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.TIME_WITH_TIME_ZONE);
         SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.TIMESTAMP_WITH_TIME_ZONE);
         SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.INTERVAL_DAY_TO_SECOND);

--- a/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/type/TestTypeSignature.java
@@ -248,9 +248,9 @@ public class TestTypeSignature
                 "map",
                 ImmutableList.of("bigint", "map(bigint,map(varchar,bigint))"));
 
-        assertSignatureFail("blah()");
-        assertSignatureFail("array()");
-        assertSignatureFail("map()");
+        assertSignature("blah()", "blah", ImmutableList.of("unknown"), "blah(unknown)");
+        assertSignature("array()", "array", ImmutableList.of("unknown"), "array(unknown)");
+        assertSignature("map()", "map", ImmutableList.of("unknown"), "map(unknown)");
         assertSignatureFail("x", ImmutableSet.of("x"));
 
         // ensure this is not treated as a row type


### PR DESCRIPTION
Sometimes the empty structs(row) might be a valid use case in some data format, but it will make the query failed by throwing an IlligleArgumentsException -- "Row type must have at least one parameter".  

I think this patch might be useful to handle the data in thrift and json format.  So I cherry-pick it from Twitter's fork.

This one might also fix the mongodb query issue #13547 


```
== NO RELEASE NOTE ==
```
