### PR TITLE
Support determinism analysis for simple queries with top-level ORDER BY LIMIT clause

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ChecksumResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ChecksumResult.java
@@ -21,6 +21,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -55,7 +56,7 @@ public class ChecksumResult
         return checksums.get(columnName);
     }
 
-    public static ChecksumResult fromResultSet(ResultSet resultSet)
+    public static Optional<ChecksumResult> fromResultSet(ResultSet resultSet)
             throws SQLException
     {
         long rowCount = resultSet.getLong(1);
@@ -83,6 +84,6 @@ public class ChecksumResult
                 checksums.put(columnName, new SqlVarbinary((byte[]) checksum));
             }
         }
-        return new ChecksumResult(rowCount, checksums);
+        return Optional.of(new ChecksumResult(rowCount, checksums));
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerificationUtil.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerificationUtil.java
@@ -83,7 +83,7 @@ public class DataVerificationUtil
     public static List<Column> getColumns(PrestoAction prestoAction, TypeManager typeManager, QualifiedName tableName)
     {
         return prestoAction
-                .execute(new ShowColumns(tableName), DESCRIBE, resultSet -> Column.fromResultSet(typeManager, resultSet))
+                .execute(new ShowColumns(tableName), DESCRIBE, resultSet -> Optional.of(Column.fromResultSet(typeManager, resultSet)))
                 .getResults();
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/LimitQueryDeterminismAnalyzer.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/LimitQueryDeterminismAnalyzer.java
@@ -162,7 +162,7 @@ public class LimitQueryDeterminismAnalyzer
                 new TableSubquery(newLimitQuery));
 
         QueryResult<Long> result = callWithQueryStatsConsumer(
-                () -> prestoAction.execute(rowCountQuery, DETERMINISM_ANALYSIS, resultSet -> resultSet.getLong(1)),
+                () -> prestoAction.execute(rowCountQuery, DETERMINISM_ANALYSIS, resultSet -> Optional.of(resultSet.getLong(1))),
                 stats -> verificationContext.setLimitQueryAnalysisQueryId(stats.getQueryId()));
 
         long rowCountHigherLimit = getOnlyElement(result.getResults());

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryResult.java
@@ -29,7 +29,7 @@ public class QueryResult<R>
     public QueryResult(List<R> results, List<String> columnNames, QueryStats queryStats)
     {
         this.results = ImmutableList.copyOf(results);
-        this.columnNames = requireNonNull(columnNames, "columnNames is null");
+        this.columnNames = ImmutableList.copyOf(columnNames);
         this.queryStats = requireNonNull(queryStats, "queryStats is null");
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/JdbcPrestoAction.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/JdbcPrestoAction.java
@@ -128,7 +128,7 @@ public class JdbcPrestoAction
                             columnNames.add(resultSet.getMetaData().getColumnName(i));
                         }
                         while (resultSet.next()) {
-                            rows.add(converter.get().apply(resultSet));
+                            converter.get().apply(resultSet).ifPresent(rows::add);
                         }
                     }
                 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/PrestoAction.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/PrestoAction.java
@@ -17,26 +17,29 @@ import com.facebook.presto.jdbc.QueryStats;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.verifier.framework.QueryResult;
 import com.facebook.presto.verifier.framework.QueryStage;
-import com.google.common.collect.ImmutableList;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.unmodifiableList;
 
 public interface PrestoAction
 {
     @FunctionalInterface
     interface ResultSetConverter<R>
     {
-        R apply(ResultSet resultSet)
+        Optional<R> apply(ResultSet resultSet)
                 throws SQLException;
 
         ResultSetConverter<List<Object>> DEFAULT = resultSet -> {
-            ImmutableList.Builder<Object> row = ImmutableList.builder();
-            for (int i = 0; i < resultSet.getMetaData().getColumnCount(); i++) {
+            List<Object> row = new ArrayList<>();
+            for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); i++) {
                 row.add(resultSet.getObject(i));
             }
-            return row.build();
+            return Optional.of(unmodifiableList(row));
         };
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/TooManyOpenPartitionsFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/TooManyOpenPartitionsFailureResolver.java
@@ -81,7 +81,7 @@ public class TooManyOpenPartitionsFailureResolver
                 e -> {
                     try {
                         ShowCreate showCreate = new ShowCreate(TABLE, test.get().getTableName());
-                        String showCreateResult = getOnlyElement(prestoAction.execute(showCreate, DESCRIBE, resultSet -> resultSet.getString(1)).getResults());
+                        String showCreateResult = getOnlyElement(prestoAction.execute(showCreate, DESCRIBE, resultSet -> Optional.of(resultSet.getString(1))).getResults());
                         CreateTable createTable = (CreateTable) sqlParser.createStatement(showCreateResult, ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build());
                         List<Property> bucketCountProperty = createTable.getProperties().stream()
                                 .filter(property -> property.getName().getValue().equals(BUCKET_COUNT_PROPERTY))

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/prestoaction/TestJdbcPrestoAction.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/prestoaction/TestJdbcPrestoAction.java
@@ -105,7 +105,7 @@ public class TestJdbcPrestoAction
         QueryResult<Integer> result = prestoAction.execute(
                 sqlParser.createStatement("SELECT x FROM (VALUES (1), (2), (3)) t(x)", PARSING_OPTIONS),
                 QUERY_STAGE,
-                resultSet -> resultSet.getInt("x") * resultSet.getInt("x"));
+                resultSet -> Optional.of(resultSet.getInt("x") * resultSet.getInt("x")));
         assertEquals(result.getQueryStats().getState(), FINISHED.name());
         assertEquals(result.getResults(), ImmutableList.of(1, 4, 9));
     }


### PR DESCRIPTION
Support determinism analysis for simple queries with top-level ORDER
BY LIMIT clause. Select, Insert, and CreateTableAsSelect are supported,
but only when the query part is a Select query, not a SetOperation(
i.e., Union, Intersect, and Except).

`INSERT INTO ...SELECT ... ORDER BY ... LIMIT ...` is supported.
`INSERT INTO ... SELECT ... UNION ALL ... SELECT ... ORDER BY ...                                                                                                                                                                           
LIMIT ...` is not supported.

To check for determinism of ORDER BY LIMIT queries, we run the Select
query with limit N + 1, project all the necessary ORDER BY columns,
and check whether there is a tie on the ORDER BY columns for the
n-th row and the (n+1)-th row.
```
== RELEASE NOTES ==

Verifier Changes
* Support determinism analysis for simple queries with top-level ``ORDER BY LIMIT`` clause. (:pr:`14181`)
```
