### PR TITLE
Fix BenchmarkPartitionedOutputOperator

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
@@ -137,11 +137,9 @@ public class BenchmarkPartitionedOutputOperator
         @Param({"true", "false"})
         private boolean enableCompression;
 
-        @SuppressWarnings("unused")
         @Param({"1", "2"})
-        private int channelCount;
+        private int channelCount = 1;
 
-        @SuppressWarnings("unused")
         @Param({
                 "BIGINT",
                 "DICTIONARY(BIGINT)",
@@ -157,8 +155,9 @@ public class BenchmarkPartitionedOutputOperator
                 "MAP(BIGINT,BIGINT)",
                 "MAP(BIGINT,MAP(BIGINT,BIGINT))",
                 "ROW(BIGINT,BIGINT)",
-                "ROW(ARRAY(BIGINT),ARRAY(BIGINT))"})
-        private String type;
+                "ROW(ARRAY(BIGINT),ARRAY(BIGINT))"
+        })
+        private String type = "BIGINT";
 
         @SuppressWarnings("unused")
         @Param({"true", "false"})

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
@@ -57,6 +57,7 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Optional;
@@ -123,6 +124,22 @@ public class BenchmarkPartitionedOutputOperator
             operator.addInput(data.dataPage);
         }
         operator.finish();
+    }
+
+    @Test
+    public void verifyAddPage()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkPartitionedOutputOperator().addPage(data);
+    }
+
+    @Test
+    public void verifyOptimizedAddPage()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkPartitionedOutputOperator().optimizedAddPage(data);
     }
 
     @State(Scope.Thread)
@@ -368,10 +385,6 @@ public class BenchmarkPartitionedOutputOperator
     public static void main(String[] args)
             throws RunnerException
     {
-        BenchmarkData data = new BenchmarkData();
-        data.setup();
-        new BenchmarkPartitionedOutputOperator().optimizedAddPage(data);
-
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
                 .jvmArgs("-Xmx10g")


### PR DESCRIPTION
OptimizedPartitionedOutputFactory#createOutputOperator() now takes a new parameter `Optional<OutputPartitioning> outputPartitioning` and require it to be present. The change came from the "Refactor LocalExecutionPlanner" commit in https://github.com/prestodb/presto/pull/14099. However the call site in  BenchmarkPartitionedOutputOperator was passing in an empty `outputPartitioning`, which broke the benchmark with the following call stack:
```
java.lang.IllegalArgumentException: outputPartitioning is not present
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:141)
	at com.facebook.presto.operator.repartition.OptimizedPartitionedOutputOperator$OptimizedPartitionedOutputFactory.createOutputOperator(OptimizedPartitionedOutputOperator.java:286)
	at com.facebook.presto.operator.repartition.BenchmarkPartitionedOutputOperator$BenchmarkData.createOptimizedPartitionedOutputOperator(BenchmarkPartitionedOutputOperator.java:290)
	at com.facebook.presto.operator.repartition.BenchmarkPartitionedOutputOperator$BenchmarkData.access$000(BenchmarkPartitionedOutputOperator.java:127)
	at com.facebook.presto.operator.repartition.BenchmarkPartitionedOutputOperator.optimizedAddPage(BenchmarkPartitionedOutputOperator.java:119)
	at com.facebook.presto.operator.repartition.generated.BenchmarkPartitionedOutputOperator_optimizedAddPage_jmhTest.optimizedAddPage_avgt_jmhStub(BenchmarkPartitionedOutputOperator_optimizedAddPage_jmhTest.java:191)
	at com.facebook.presto.operator.repartition.generated.BenchmarkPartitionedOutputOperator_optimizedAddPage_jmhTest.optimizedAddPage_AverageTime(BenchmarkPartitionedOutputOperator_optimizedAddPage_jmhTest.java:154)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
This PR is to fix the problem.

```
== NO RELEASE NOTE ==
```
