### PR TITLE
Fix finishStatisticsCollection to have correct ConnectorSession

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -778,7 +778,7 @@ public class MetadataManager
     {
         ConnectorId connectorId = tableHandle.getConnectorId();
         CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, connectorId);
-        catalogMetadata.getMetadata().finishStatisticsCollection(session.toConnectorSession(), tableHandle.getConnectorHandle(), computedStatistics);
+        catalogMetadata.getMetadata().finishStatisticsCollection(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), computedStatistics);
     }
 
     @Override


### PR DESCRIPTION
Without this fix, the ConnectionSession was created without any session properties and hence the implementation which tried to use session properties failed.

```
== NO RELEASE NOTE ==
```
