### PR TITLE
Materialize LazyBlock in scan

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/project/InputPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/InputPageProjection.java
@@ -64,7 +64,7 @@ public class InputPageProjection
             result = block.copyPositions(selectedPositions.getPositions(), selectedPositions.getOffset(), selectedPositions.size());
         }
         else if (selectedPositions.getOffset() == 0 && selectedPositions.size() == page.getPositionCount()) {
-            result = block;
+            result = block.getLoadedBlock();
         }
         else {
             result = block.getRegion(selectedPositions.getOffset(), selectedPositions.size());

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
@@ -164,7 +164,6 @@ public class OptimizedPartitionedOutputOperator
             return;
         }
 
-        page = page.getLoadedPage();
         page = pagePreprocessor.apply(page);
         pagePartitioner.partitionPage(page);
 


### PR DESCRIPTION
Fix the problem downstream operators might receive LazyBlock after scan
introduced by https://github.com/prestodb/presto/pull/14169

```
== NO RELEASE NOTE ==
```
