### PR TITLE
Always use JSON for PlanFragment serialization

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
@@ -114,12 +114,7 @@ public class TaskResource
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.responseExecutor = requireNonNull(responseExecutor, "responseExecutor is null");
         this.timeoutExecutor = requireNonNull(timeoutExecutor, "timeoutExecutor is null");
-        if (communicationConfig.isBinaryTransportEnabled()) {
-            this.planFragmentCodec = planFragmentSmileCodec;
-        }
-        else {
-            this.planFragmentCodec = wrapJsonCodec(planFragmentJsonCodec);
-        }
+        this.planFragmentCodec = wrapJsonCodec(planFragmentJsonCodec);
     }
 
     @GET

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -117,14 +117,13 @@ public class HttpRemoteTaskFactory
             this.taskStatusCodec = taskStatusSmileCodec;
             this.taskInfoCodec = taskInfoSmileCodec;
             this.taskUpdateRequestCodec = taskUpdateRequestSmileCodec;
-            this.planFragmentCodec = planFragmentSmileCodec;
         }
         else {
             this.taskStatusCodec = wrapJsonCodec(taskStatusJsonCodec);
             this.taskInfoCodec = wrapJsonCodec(taskInfoJsonCodec);
             this.taskUpdateRequestCodec = wrapJsonCodec(taskUpdateRequestJsonCodec);
-            this.planFragmentCodec = wrapJsonCodec(planFragmentJsonCodec);
         }
+        this.planFragmentCodec = wrapJsonCodec(planFragmentJsonCodec);
 
         this.updateScheduledExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("task-info-update-scheduler-%s"));
         this.errorScheduledExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("remote-task-error-delay-%s"));


### PR DESCRIPTION
SMILE support has flaky edge cases, and we cache the
serialization now which already has reduced the cost.

```
== NO RELEASE NOTE ==
```
