### PR TITLE
Compare type by (name,type) pair rather than (index,type) pair during Parquet's schema mismatch checking

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -317,23 +317,20 @@ public class ParquetPageSourceFactory
             GroupType groupType = parquetType.asGroupType();
             switch (prestoType) {
                 case ROW:
-                    if (groupType.getFields().size() == type.getTypeParameters().size()) {
-                        RowType rowType = (RowType) type;
-                        Map<String, Type> prestoFieldMap = rowType.getFields().stream().collect(
-                                Collectors.toMap(
-                                        field -> field.getName().get().toLowerCase(Locale.ENGLISH),
-                                        field -> field.getType()));
-                        for (int i = 0; i < groupType.getFields().size(); i++) {
-                            org.apache.parquet.schema.Type parquetFieldType = groupType.getFields().get(i);
-                            String fieldName = parquetFieldType.getName().toLowerCase(Locale.ENGLISH);
-                            Type prestoFieldType = prestoFieldMap.get(fieldName);
-                            if (prestoFieldType != null && !checkSchemaMatch(parquetFieldType, prestoFieldType)) {
-                                return false;
-                            }
+                    RowType rowType = (RowType) type;
+                    Map<String, Type> prestoFieldMap = rowType.getFields().stream().collect(
+                            Collectors.toMap(
+                                    field -> field.getName().get().toLowerCase(Locale.ENGLISH),
+                                    field -> field.getType()));
+                    for (int i = 0; i < groupType.getFields().size(); i++) {
+                        org.apache.parquet.schema.Type parquetFieldType = groupType.getFields().get(i);
+                        String fieldName = parquetFieldType.getName().toLowerCase(Locale.ENGLISH);
+                        Type prestoFieldType = prestoFieldMap.get(fieldName);
+                        if (prestoFieldType != null && !checkSchemaMatch(parquetFieldType, prestoFieldType)) {
+                            return false;
                         }
-                        return true;
                     }
-                    return false;
+                    return true;
                 case MAP:
                     if (groupType.getFields().size() != 1) {
                         return false;


### PR DESCRIPTION
Regarding parquet's schema mismatch checking, the existing implementation is selecting each sub-field by its index, which might cause fake alert of mismatching. e.g.
struct<a bigint, b string>. might mismatch parquet's group type {b binary, a int64}, but actually they are the same type.

So we add a map of <name, type> to compare each sub-field by name->type pair rather than index->type pair.

```
== NO RELEASE NOTE ==
```
