### PR TITLE
Optimize long reader when reading contiguous rows with no nulls and no filter

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
@@ -178,9 +178,7 @@ public class LongDirectSelectiveStreamReader
             }
             else {
                 // no nulls
-                for (int i = 0; i < positionCount; i++) {
-                    values[i] = dataStream.next();
-                }
+                dataStream.next(values, positionCount);
             }
             outputPositionCount = positionCount;
             return positionCount;


### PR DESCRIPTION
Similar to https://github.com/prestodb/presto/pull/13603

Part of https://github.com/prestodb/presto/issues/13848

Optimize long reader when reading contiguous rows with no nulls and no filter

JMH benchmark results show improvement when there is no nulls and no filters.

```
Before:
Benchmark                             (typeSignature)  (withNulls)  Mode  Cnt  Score   Error  Units
BenchmarkSelectiveStreamReaders.read          integer        false  avgt   20  0.157 ± 0.014   s/op
BenchmarkSelectiveStreamReaders.read           bigint        false  avgt   20  0.215 ± 0.027   s/op
BenchmarkSelectiveStreamReaders.read         smallint        false  avgt   20  0.145 ± 0.017   s/op
BenchmarkSelectiveStreamReaders.read          tinyint        false  avgt   20  0.050 ± 0.004   s/op
BenchmarkSelectiveStreamReaders.read             date        false  avgt   20  0.178 ± 0.047   s/op

After:
Benchmark                             (typeSignature)  (withNulls)  Mode  Cnt  Score   Error  Units
BenchmarkSelectiveStreamReaders.read          integer        false  avgt   20  0.134 ± 0.013   s/op
BenchmarkSelectiveStreamReaders.read           bigint        false  avgt   20  0.159 ± 0.020   s/op
BenchmarkSelectiveStreamReaders.read         smallint        false  avgt   20  0.106 ± 0.006   s/op
BenchmarkSelectiveStreamReaders.read          tinyint        false  avgt   20  0.049 ± 0.004   s/op
BenchmarkSelectiveStreamReaders.read             date        false  avgt   20  0.125 ± 0.007   s/op
```

== NO RELEASE NOTE ==

