### PR TITLE
Separate some modules to their own Travis jobs to reduce test times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,10 @@ env:
     - TEST_SPECIFIC_MODULES=presto-main
     - TEST_SPECIFIC_MODULES=presto-mongodb TEST_FLAGS="-P test-mongo-distributed-queries"
     - TEST_SPECIFIC_MODULES=presto-redis TEST_FLAGS="-P test-redis-integration-smoke-test"
-    - TEST_OTHER_MODULES=!presto-tests,!presto-raptor,!presto-accumulo,!presto-cassandra,!presto-hive,!presto-kudu,!presto-docs,!presto-server,!presto-server-rpm,!presto-main,!presto-mongodb,!presto-spark-package,!presto-spark-launcher,!presto-spark-testing,!presto-redis
+    - TEST_SPECIFIC_MODULES=presto-elasticsearch
+    - TEST_SPECIFIC_MODULES=presto-orc
+    - TEST_SPECIFIC_MODULES=presto-thrift-connector
+    - TEST_OTHER_MODULES=!presto-tests,!presto-raptor,!presto-accumulo,!presto-cassandra,!presto-hive,!presto-kudu,!presto-docs,!presto-server,!presto-server-rpm,!presto-main,!presto-mongodb,!presto-spark-package,!presto-spark-launcher,!presto-spark-testing,!presto-redis,!presto-elasticsearch,!presto-orc,!presto-thrift-connector
     - PRODUCT_TESTS_BASIC_ENVIRONMENT=true
     - PRODUCT_TESTS_SPECIFIC_ENVIRONMENT=true
     - PRODUCT_TESTS_SPECIFIC_ENVIRONMENT_2=true


### PR DESCRIPTION
```TEST_OTHER_MODULES``` job in travis is one of the longest running and often times out.

This PR separates ```presto-elasticsearch```, ```presto-orc``` and ```presto-thrift-connector``` into their own travis jobs to reduce the amount of time ```TEST_OTHER_MODULES``` job takes. 

On test runs this reduced the run time of ```TEST_OTHER_MODULES``` from about 60 minutes to 25 minutes

```
== NO RELEASE NOTE ==
```
