### PR TITLE
Remove version tags for presto projects from sub-module pom files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -452,6 +452,13 @@
 
             <dependency>
                 <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-server</artifactId>
+                <version>${project.version}</version>
+                <type>tar.gz</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-server-rpm</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -495,6 +502,24 @@
             <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-spark</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-spark-base</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-spark-launcher</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-spark-package</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -22,7 +22,6 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-pinot-toolkit</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/presto-server-rpm/pom.xml
+++ b/presto-server-rpm/pom.xml
@@ -27,7 +27,6 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-server</artifactId>
-            <version>${project.version}</version>
             <type>tar.gz</type>
             <scope>runtime</scope>
         </dependency>
@@ -51,7 +50,6 @@
                                 <artifactItem>
                                     <groupId>com.facebook.presto</groupId>
                                     <artifactId>presto-server</artifactId>
-                                    <version>${project.version}</version>
                                     <type>tar.gz</type>
                                     <outputDirectory>${project.build.outputDirectory}
                                     </outputDirectory>

--- a/presto-spark-testing/pom.xml
+++ b/presto-spark-testing/pom.xml
@@ -95,16 +95,12 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spark-launcher</artifactId>
-            <version>${project.version}</version>
-            <type>jar</type>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spark-package</artifactId>
-            <version>${project.version}</version>
-            <type>tar.gz</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-spark/pom.xml
+++ b/presto-spark/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spark-base</artifactId>
-            <version>${project.version}</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
We're seeing Nexus flakiness:
```
org.eclipse.aether.transfer.ArtifactNotFoundException: Could not find artifact
com.facebook.presto:presto-server:tar.gz:0.234-20200305.020634-32 in nexus

org.eclipse.aether.transfer.ArtifactNotFoundException: Could not find artifact
com.facebook.presto:presto-spark-package:tar.gz:0.234-20200304.195247-22
```

It's unclear to me why Maven are not useing locally built `tar.gz`, but is trying to download from Nexus instead. So this PR is only an attempt. Also, use `jar` instead of `tar.gz` for `presto-spark-package` in
`presto-spark-testing` for the same purpose.

```
== NO RELEASE NOTE ==
```
