### PR TITLE
Add release notes for 0.233

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.233
     release/release-0.232
     release/release-0.231
     release/release-0.230

--- a/presto-docs/src/main/sphinx/release/release-0.233.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.233.rst
@@ -1,0 +1,70 @@
+=============
+Release 0.233
+=============
+
+General Changes
+_______________
+* Fix an optimizer failure introduced in ``0.229``, where a ``LIKE`` pattern is deduced into a constant, e.g., ``col LIKE 'a' and col = 'b'``.
+* Fix correctness issue in queries with joins over ``UNNEST``. (:issue:`14257`).
+* Fix ``ArbitraryOutputBuffer`` to avoid skewing output data distribution. (:pr:`14083`).
+* Fix an issue where :func:`classification_fall_out` cannot be found.
+* Add support for async page transport with non-blocking IO. This can be enabled by the ``exchange.async-page-transport-enabled`` configuration property.
+* Add support to handle http request timeouts using multiple thread pools. This can be controlled by the ``task.http-timeout-concurrency`` configuration property.
+* Add support for soft affinity scheduling, which makes the best effort to fetch the same piece of data from the same worker,
+  while allowing fallback to random workers if the preferred workers are too busy to handle additional splits. (See :doc:`/develop/connectors`).
+* Add hash functions ``fnv1_32``, ``fnv1_64``, ``fnv1a_32``, and ``fnv1a_64``.
+* Add IP address functions :func:`ip_subnet_min`, :func:`ip_subnet_max`, :func:`ip_subnet_range`, and :func:`is_subnet_of`.
+* Improve performance of ``StreamingAggregationOperator``.
+
+Hive Changes
+____________
+* Fix an issue where Presto fail to start when configuration property  ``hive.s3-file-system-type`` is set to ``HADOOP_DEFAULT``.
+* Add directory listing cache for Hive Connector. This can be enabled by setting configuration property ``hive.file-status-cache-tables``.
+* Add support for storing column names and types for views in the Hive metastore. Views in the Hive connector can now only use types supported by Hive.
+* Add configuration property ``hive.insert-overwrite-immutable-partitions-enabled`` to allow admin to set insert overwrite
+  as the default insertion behavior for Hive connector.
+* Add configuration property ``hive.node-selection-strategy`` to choose ``NodeSelectionStrategy``. When ``SOFT_AFFINITY`` is selected,
+  scheduler will make the best effort to request the same worker to fetch the same file.
+* Remove configuration property ``hive.force-local-scheduling``. The same functionality can be achieved by setting
+  ``hive.node-selection-strategy`` to ``HARD_AFFINITY``.
+
+Verifier Changes
+________________
+* Fix an issue where invalid checksum queries can be generated for certain queries containing columns of ``RowType``.
+* Fix an issue where checksum query would fail for queries containing map columns whose key or value types are arrays or rows.
+* Fix incorrect decision for determinism analysis of queries with top-level ``LIMIT`` clause. (:pr:`14176`).
+* Add checks for keys, values, and cardinality sum when validating a map column.
+* Add support to disable individual failure resolvers (:pr:`14148`).
+* Add support to auto-resolve control checksum query failures with ``COMPILER_ERROR``, instead of skipping the verification.
+* Add support for specifying non-deterministic catalogs by the ``determinism.non-determinism-catalogs`` configuration property.
+  Queries explicitly referencing tables from those catalogs are treated as non-deterministic.
+* Improve query performance during determinism analysis of queries with top-level ``LIMIT`` clause.
+* Improve correctness check for floating point columns whose mean values of either the control query or the test query is closed to 0.
+
+Druid Changes
+_____________
+* Add Druid Connector.
+
+Geospatial Changes
+__________________
+* Improve :func:`ST_Points` to add support for major well-known spatial objects.
+  :func:`ST_Points` now supports ``POINT``, ``LINESTRING``, ``POLYGON``, ``MULTIPOINT``, ``MULTILINESTRING``, ``MULTIPOLYGON`` and ``GEOMETRYCOLLECTION``.
+* Improve :func:`ST_IsValid` and :func:`ST_IsSimple` to adhere to the ISO/OGC standards more closely.
+  The two functions used to return the same result but may now be different. Users should check both functions to be sure their geometries are well-behaved.
+  :func:`geometry_invalid_reason` will return different but semantically similar strings.
+* Improve performance of :func:`ST_Intersection` by simply returning the geometry if it has an enclosing envelope.
+  This can reduce CPU cost by up to ``10^5x`` for complex polygons.
+
+SPI Changes
+___________
+* Add parameter ``NodeSelectionStrategy nodeSelectionStrategy`` in method ``ConnectorBucketNodeMap#createBucketNodeMap`` to indicate
+  which affinity strategy to use when creating a bucket node map.
+* Add parameter ``List<Node> sortedNodes`` in method ``ConnectorNodePartitioningProvider#getBucketNodeMap`` to provide
+  a sorted list of nodes from which a connector can choose to perform affinity scheduling.
+* Add enum ``NodeSelectionStrategy``. ``NO_PREFERENCE`` indicates data is remotely accessible from workers,
+  ``HARD_AFFINITY`` to indicate data and workers are collocated, and ``SOFT_AFFINITY`` to indicate data is remotely accessible
+  but scheduler will make the best effort to fetch the same piece of data from the same worker.
+* Replace ``ConnectorSplit#isRemoteAccessible`` with ``getNodeSelectionStrategy``.
+* Replace ``ConnectorSplit#getAddresses`` with ``getPreferredNodes``, to provide hints to the scheduler where to schedule splits.
+* Replace the ``SchemaTableName`` parameter in ``ConnectorMetadata#createView`` with a ``ConnectorTableMetadata``.
+* Move ``JsonType`` to SPI.


### PR DESCRIPTION
# Missing Release Notes
## Bhavani Hari
- [x] https://github.com/prestodb/presto/pull/14161 Add classification_fallout function to FunctionManager (Merged by: Rongrong Zhong)

## Masha Basmanova
- [x] https://github.com/jinyangzhen/presto/pull/1 latest presto changes (Merged by: 星移)

## Sujay Jain
- [x] https://github.com/prestodb/presto/pull/14087 Revert "Improve error message for the array_agg function" (Merged by: Wenlei Xie)

## Tim Meehan
- [x] 0208f7304805d5bb12062afc5e7e6b2d0036a11a Always use JSON for PlanFragment serialization

## Ying Su
- [x] 9c1a7fecb7a584fbc07b0bb2f7040d915a662ae9 Materialize LazyBlock in scan

## Zhenxiao Luo
- [x] https://github.com/prestodb/presto/pull/14073 Fix Druid connector pom to new release (Merged by: Zhenxiao Luo)

# Extracted Release Notes
- #13823 (Author: Yifeng Jiang): Extend ST_Points to support major Well-Known spatial objects
  - Improve ST_Points to add support for major Well-Known spatial objects. ST_Points now supports POINT, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, MULTIPOLYGON and GEOMETRYCOLLECTION.
- #13907 (Author: Vic Zhang): Support non-blocking IO for page transport
  - Add configuration property `exchange.async-page-transport-enabled` to turn on non-blocking IO for page transport.
  - Add configuration property `exchange.async-page-transport-timeout` for server side timeout.
  - Use URL prefix '/v1/task/async' for async page transport request.
- #13966 (Author: Ke Wang): Add ability of soft affinity node selection
  - Introduce `NodeSelectionStrategy` with options `NO_PREFERENCE` to indicate data is remotely accessible from workers, `HARD_AFFINITY` to indicate data and workers are colocated, and `SOFT_AFFINITY` to indicate data is remotely accessible but scheduler will make the best effort to fetch the same piece of data from the same worker.
  - Replace `isRemoteAccessible()` in `ConnectorSplit` with `getNodeSelectionStrategy()`. `isRemoteAccessible()` is true if and only if `getNodeSelectionStrategy()` returns `HARD_AFFINITY`.
  - Replace `getAddresses()` in `ConnectorSplit` with `getPreferredNodes()`. The returned list of addresses hints the scheduler where to schedule splits.
  - Add soft affinity scheduling. It makes the best effort to fetch the same piece of data from the same worker. If the preferred workers are too busy to handle more splits, it will fallback to random workers. The option is enabled by connector indicated by `getNodeSelectionStrategy()`.
  - Add config `hive.node-selection-strategy` to choose `NodeSelectionStrategy`. When `SOFT_AFFINITY` is selected, scheduler will make the best effort to request the same worker to fetch the same file.
  - Deprecate `hive.force-local-scheduling` config. It will be replaced by setting `hive.node-selection-strategy` to `HARD_AFFINITY`.
- #13977 (Author: James Gill): Use JTS for ST_IsValid and ST_IsSimple
  - ST_IsValid and ST_IsSimple adhere to the ISO/OGC standards more closely.  In particular, previously ST_IsValid and ST_IsSimple always gave the same answer; now they may be different. Users should check both IsValid and IsSimple to be sure their geometries are well-behaved.
  - Geometry_invalid_reason will return different but semantically similar strings.  It will return the reason for invalidity if it exists; else it will return the reason for non-simplicity if it exists; else it will return null.
- #14042 (Author: Zhenxiao Luo): Presto Druid Connector
  - Add Druid Connector.
- #14045 (Author: Zhenxiao Luo): Add Hive directory listing cache
  - Add directory listing cache for Hive Connector.
- #14054 (Author: Brendan Driscoll): Improve verification for map columns
  - Add checks for keys, values, and cardinality sum when validating a map column.
- #14076 (Author: James Sun): Fix like pattern interpretation
  - Fix an optimizer failure introduced since 0.229, where a `LIKE` pattern can be deduced into a constant. For example, `col LIKE 'a' and col = 'b'`.
- #14083 (Author: James Petty): Balance ArbitraryOutputbuffer distribution over clients
  - Fix ArbitraryOutputBuffer to avoid skewing output data distribution.
- #14090 (Author: Nikhil Collooru): Add IPPREFIX functions
  - Add :func:`ip_subnet_min`, :func:`ip_subnet_max`, :func:`ip_subnet_range`, and :func:`is_subnet_of` functions.
- #14095 (Author: Ke Wang): Add soft affinity in scheduling bucketed split for Hive Connector
  - Add parameter `NodeSelectionStrategy nodeSelectionStrategy` in method `createBucketNodeMap` in `ConnectorBucketNodeMap `, indicating which affinity strategy to use when we create bucket nodeMap.
  - Add parameter `List<Node> sortedNodes` in method `getBucketNodeMap` in `ConnectorNodePartitioningProvider `, providing a sorted node list for connector to choose from when doing affinity scheduling.
  - Add soft affinity scheduling to bucketed split. It makes the best effort to fetch the same bucket data from the same worker. When using dynamic group scheduling, if the preferred workers are unavailable to handle the specific bucket splits, it will fallback to random workers.
- #14096 (Author: James Petty): Remove unnecessary copies in StreamingAggregationOperator
  - Improve performance of StreamingAggregationOperator.
- #14098 (Author: Andrew Smith): Provide view metadata to the Hive Metastore
  - Store column names and types for views in the metastore.  Views in the Hive connector can now only use types supported by Hive.
  - Change signature for createView in ConnectorMetadata to take a ConnectorTableMetadata instead of a SchemaTableName.
- #14103 (Author: Wenlei Xie): Allow insert overwrite as default behavior for Hive connector
  - Introduce  a new Hive client configuration`hive.insert-overwrite-immutable-partitions-enabled` to allow admin set insert overwrite as the default insertion behavior for Hive connector.
- #14106 (Author: James Gill): Add cheap ST_Intersection method for certain cases
  - When calculating `ST_Intersection` of a geometry with an enclosing envelope, just return the geometry.  This reduces the cost by up to 10^5x or more for complex polygons when this occurs.
- #14128 (Author: Zac Blanco): Add HadoopDefaultConfigurationUpdater
  - Allow server to start when `hive.s3-file-system-type` is set to HADOOP_DEFAULT.
- #14131 (Author: Vic Zhang): Use concurrent scheduler for timeout executor
  - Add configuration ``task.http-timeout-concurrency`` to improve performance of task timeout executors.
- #14134 (Author: Leiqing Cai): Fix checksum queries for columns of RowType
  - Fix an issue where invalid checksum queries can be generated for certain queries containing columns of ``RowType``.
- #14139 (Author: Widagdo Setiawan): Adding fnv1 and fnv1a hash functions
  - Added fnv1_32, fnv1_64, fnv1a_32, fnv1a_64,.
- #14147 (Author: Leiqing Cai): Use absolute error when a floating point column mean is close to 0
  - Improve correctness check for floating point columns whose mean values of either the control query or the test query is closed to 0.
- #14148 (Author: Leiqing Cai): Failure resolver improvements
  - Add support to disable individual failure resolvers (:pr:`14148`).
  - Add support to auto-resolve control checksum query failures with ``COMPILER_ERROR`, instead of skipping the verification.
- #14149 (Author: Leiqing Cai): Fix checksum column generation for map keys and map values
  - Fix an issue where checksum query would fail for queries containing map columns whose key or value types are arrays or rows.
- #14150 (Author: Leiqing Cai): Treat queriers referencing certain catalogs as non-deterministic
  - Add support for specifying non-deterministic catalogs by configuration property ``determinism.non-determinism-catalogs``. Queries explicitly referencing tables from those catalogs are treated as non-deterministic.
- #14155 (Author: Zhenxiao Luo): Predicate Pushdown for Druid connector
  - Add filter pushdown for Druid connector to improve query performance.
- #14165 (Author: Rongrong Zhong): Remove presto-thrift-connector-api's dependency on presto-main
  - Move `JsonType` to SPI.
- #14176 (Author: Leiqing Cai): Improve determinism analysis of queries with top-level LIMIT clause
  - Fix incorrect decision for determinism analysis of queries with top-level ``LIMIT`` clause. (:pr:`14176`).
  - Improve query performance during determinism analysis of queries with top-level ``LIMIT`` clause.

# All Commits
- 9c1a7fecb7a584fbc07b0bb2f7040d915a662ae9 Materialize LazyBlock in scan (Ying Su)
- 0208f7304805d5bb12062afc5e7e6b2d0036a11a Always use JSON for PlanFragment serialization (Tim Meehan)
- f39f9ab2dda1c1671e26cd93ca4da4896e6c35c9 Add configuration for async page transport timeout (Vic Zhang)
- 2eee499a2b13d92ce606aa4640628e2917771fd5 Create new URL for async page transport (Vic Zhang)
- 8b359693130dba3672bbeb895ecd4aeb4bd49689 Support non-blocking IO for page transport (Vic Zhang)
- 3952dce0a018fc1ffadea34a7a0f476068c8c999 Allow custom hive session in `AbstractTestHiveClient` (Mayank Garg)
- 6642993bfeba63b6a4278e9789a5f9c471285a80 Disable Redis integration test by default (Sujay Jain)
- efa663226fea916904b189ed045417e2cdaf1e70 Support ifNotExists when copying TPCH tables (Leiqing Cai)
- d52db96c0526f1dab2d0e7a03ba9f465763975ed Refactor cacheable for BucketNodeMap (Ke Wang)
- 66e4101f3bc88a92dd78827148828d5f51ac5c1f Resolve checksum query compiler error instead of skipping it (Leiqing Cai)
- c5e0c03fc747996d83db0386023d67f51be36a00 Distinguish between control, test, and determinism analysis checksum (Leiqing Cai)
- 03ff7c5b5924c22914cfb359bb886b17317585cc Allow failure resolvers to be disabled individually (Leiqing Cai)
- e56754e134fdeb188231609389e5f2207017fa66 Remove AbstractPrestoQueryFailureResolver (Leiqing Cai)
- 7c36df95506c191c4f7a0ac7dce36387a71c6d69 Separate QueryException into two classes (Leiqing Cai)
- 3f980812cc0096f3bfce55de7c1656f4044ec3f3 Fix and improve performance for limit query determinism analysis (Leiqing Cai)
- f083d2ab4f3d58ae6e5dcae4cded95c1c063132a Restructure LimitQueryDeterminismAnalyzer (Leiqing Cai)
- 778e885e0818ac1a857071277142611173e637ba Adding fnv1 and fnv1a hash functions (Widagdo Setiawan)
- d8eb92bdfac5f592e7fde20e527921a8fe764fb8 Assign HiveFileContext values from splitContext (Ke Wang)
- 8d4a18b5f8975d8817ebc09c0fba36eb0be74659 Fix SimpleNodeSelector node selection for HARD AFFINITY (Ke Wang)
- 58df37881b5e3fac8305093df1c355de49a7f6eb Introduce cacheable for bucketed splits (Ke Wang)
- e1e16b88a54459928a557e8abe523790c671b63a Fix generated nodeList when using DynamicBucketNodeMap (Ke Wang)
- 342afc8ef0cba8ed2c95f00bd8e1ce952e8ab484 Decide cacheable when scheduling unbucketed splits (Ke Wang)
- ae2af70730697a1e80d7c31dcc3c0ad1288b9549 Add SplitContext in SPI ConnectorPageSourceProvider (Ke Wang)
- 0cc2047c94062466cd37008735522b03e896f0eb Introduce SPI SplitContext in Split (Ke Wang)
- 070670eed066c0d0fe300ddd63d8d57300586a26 Disable Cassandra and Mongo integration tests (Leiqing Cai)
- e6b43bf7aa6b3ec4257a3d9a0a20a19d6c0b3f08 Disable failure detector for TestMemoryWorkerCrash (Rebecca Schlussel)
- 7809294e4799cc7419826712e24ce8c1214e1299 Use HiveFileContext for StripeMetadataSource (Ke Wang)
- d9eb1930ac964579ed173e370eacc71c4f3afc0a Update Verifier documentation (Leiqing Cai)
- ca8d9c84873245aae674dd0c20a35910f6fa4868 Add toString() to BlockEncodingBuffers and DecodedBlockNode (Ying Su)
- 9c842b7a15dfef356b0d128aadb1b90a30333c81 Add toString() to ColumnarXXX (Ying Su)
- 7218b40c97a87ae8263d4b0e732634ffc7f4054a Improve toString() for DictionaryBlock and RunLengthEncodedBlock (Ying Su)
- 16d300893cddcf97697d44712cd1baa9a37c18fc Streamline identity projections (Masha Basmanova)
- e18b45a8a1059b87917f0699a317ff4508d4d358 Optimize scan of integers with many nulls (Masha Basmanova)
- 74c874ffc6464e35c9404defe9d80bfa81043afc Extract readNoFilter and readWithFilter methods (Masha Basmanova)
- 816efa9cec39c7f8ca68808dc23f1bef3a289193 Fix predicate pushdown condition for Druid connector (Zhenxiao Luo)
- fcbfc61dd0535437717daef06e265c691dc220ba Fix Druid DeterminismEvaluator injector (Zhenxiao Luo)
- 5f7e1871b9bc45e5570d4ccc3c11ea3e1f600d7a Cache PlanFragment serialization (Tim Meehan)
- fedef207e2e66645858728ff5228ad1b7a2b6324 Add fromBytes to Codec (Tim Meehan)
- 50ddaa4d7c0b1c01c8dfb7a7683c752062c09e86 Remove presto-thrift-connector-spi to presto-main (Rongrong Zhong)
- f5e4998454cae78565ae58d9e488e7b5e4491e0a Move JsonType to presto-spi (Rongrong Zhong)
- d2cb512894abe9f6f47da5469e1bc1458e0836f8 Code cleanup for Druid predicate pushdown (Zhenxiao Luo)
- 63c5777de36b33ea4ec3af4d8f97164451e683ff Get rid of presto util dependency in Druid connector (Zhenxiao Luo)
- 88cdbdfb7c73bcbc74f6299180814ffb32bcb75a Add Testcase for Druid connector (Zhenxiao Luo)
- 72ca98f4d0c287a6a14a2181dfcf5a1e07672cd9 Predicate Pushdown for Druid connector (Zhenxiao Luo)
- bbd61d87823c4bea8c27ca848dfa279fcc963be1 Druid Connector PlanOptimizer (Zhenxiao Luo)
- 9be680beedfa4a169c31512f7dd14e2a934f9b24 Remove unnecessary maven-shade-plugin run from presto-spark-base (Andrii Rosa)
- 93dfdf6b0cd5394e35767363ecc1ff995dc2cc20 Reduce presto-spark-classloader-interface scope in presto-spark-base (Andrii Rosa)
- 5c305b4783f01a6a9e225eff233931d4a234dcd5 Remove dependencies from the shaded presto-launcher pom (Andrii Rosa)
- a0be44c38a9767a426aad781c5cea926ef67ef5b Provide view metadata to the Hive Metastore (Andrew Smith)
- bce54d8ce587e2286e09cf9164414f595c18a3f8 Add HadoopDefaultConfigurationUpdater (Zac Blanco)
- 7b8c2dabf723afba6309e5eb189b088e16b5b2c9 Make sure spark service is created only once (Andrii Rosa)
- 0f1ad662329cd49a7c92f165f19c1644c410284d Optimize presto on spark configuration deployment (Andrii Rosa)
- 8cfcd15b29db39dcbc8d2cb207d56a0a6c6ecc2d Minor refactor of array_position (Rongrong Zhong)
- e20ca08b3d136093e0eca2de1368326c3767a84c Use HiveFileContext for OrcFileTailSource (Ke Wang)
- 7ece9f70876a1fadd709212c2cd0ab412aea4f73 Add classification_fallout function to FunctionManager (Bhavani Hari)
- 6eb0293532a3151eb4818efdfec8c4b264a7a538 Implement row base exchange in Presto on Spark (Andrii Rosa)
- 2fd3fe8b20200317abf7e5fd28a8121314d209cc Refactor RemoteSourceFactory (Andrii Rosa)
- ad6a5b6a937ce81301ad30b1efc3bfd537dd5476 Refactor LocalExecutionPlanner (Andrii Rosa)
- 97817e0da533b286dbc4786290a1f6597dcc6160 Implement serialize/deserializePosition in Block/BlockBuilder (Andrii Rosa)
- f1e0a8033002c03c36d963f1c499e25b8128c154 Create normal block with all null positions in createAllNullsBlock (Andrii Rosa)
- 20aa3228be1317c74659be6a57003b79e738ae55 Use concurrent scheduler for timeout executor (Vic Zhang)
- f4bc471446a8b52d694b033011bbc057719f1c6c Use JTS for ST_IsValid, ST_IsSimple, and geometry_invalid_reason (James Gill)
- f6534c749ee6325464fc73eb0e7ec5a156eea927 Separate testing ST_IsValid from geometry_invalid_reason (James Gill)
- 4e81ed139235cf0599b9d17565524b3c1b24ca7e Increase test runner heap size (Andrii Rosa)
- 5455da8fdbeaf85430cb7a87430f76872550de40 Treat queriers referencing certain catalogs as non-deterministic (Leiqing Cai)
- d5dfeba5d754ddf4390e0405a3e232feaa6069ed Extract determinism analyzer to a separate class (Leiqing Cai)
- fb05233667d336bc31ab6a65601e9eb2d0fde5b2 Use absolute error when a floating point column mean is close to 0 (Leiqing Cai)
- 0d66630de79c723625628c4441a1ddd3ba58f550 Rename presto-hive-base to presto-hive-common (Wenlei Xie)
- 4236e477c986a3c9137098c2940758d24fb4dfcd Remove redundant default constructors in column validators (Leiqing Cai)
- 0edd3613133ec6acdb230bcf78c47347d59d60cf Fix checksum column generation for map keys and map values (Leiqing Cai)
- 2fb54ed0dc380791876810237c116f587efc2470 Support soft affinity in DynamicLifespanScheduler (Ke Wang)
- df528a013e5b622157c89435896adac045dc17fa Support soft affinity for bucketed splits (Ke Wang)
- 951c5653da4d3b7fb9c925f123d264a93daaba9d Use HiveFileContext for FileOpener and FileDescriptorSource (James Sun)
- 1e7780e7a151f43b3107267b0bdedde0686ce511 Optimize aggregation of nulls (Masha Basmanova)
- c756603f0768c807c4cac83cee009853f00136a4 Add position to 'position is not valid' error message (Masha Basmanova)
- 0ed6c7d1a22db120d340a5479bba8321fff7467c Provide additional details and docs for Alluxio (Haoyuan Li)
- 697eaea344c736efc9ced695635c5f2b598554e9 Fail task with large update size (Nikhil Collooru)
- 3994a9de7c5bc4300fd3efe89517cc69cb242a06 Create empty blocks when there is a mismatch in struct schema (Bhavani Hari)
- fec2fc15767c58d5c537679ed4bacd8c8cc8965d Disable hanging test in TestDistributedSpilledQueries (Leiqing Cai)
- adfbe159f104d8010986f5cbeb308a2c20b3b491 Fix checksum queries for columns of RowType (Leiqing Cai)
- 63f524003aedf6dd866cda90582b677b958197ef Use consistent naming convension for checksum column aliases (Leiqing Cai)
- a553d1cfb5a7df64e761f50b5e995e6152589607 Optimize scan of filter-only no-nulls integers (Masha Basmanova)
- 1b846503529114663fe5de5d0291bbf3f6c671df Optimize scan of floats with many nulls (Masha Basmanova)
- 6647e13f64883f7cfa89221d91b981bcc3a57618 Create presto-hive-base package (Shixuan Fan)
- e0d58cdb37afaddcc09f1201dcd0f7cdc89fb7d0 Add IPPREFIX functions (Nikhil Collooru)
- 99b0ac3ee5beadd958a8bab1e216361d928f4709 Update Airlift to 0.190 (Vic Zhang)
- 768b4a0fe9e9e37373a2b122d38d1c4ace967a99 Fix hash function for soft affnity in Hive (Ke Wang)
- 8e07e49f17ffcdbb84ad4f283ed332029ce4e4d4 Add Alluxio Catalog Service doc (Haoyuan Li)
- bfb18d6c21999f7fe9cb6fb9822af3ef1b6003a1 Add cheap ST_Intersection method for certain cases (James A. Gill)
- 3c674caef99f98a54a9acff406209505111bbfc6 Add Benchmark tests for ST_Intersection (James A. Gill)
- c49add003960896d25186f1fd0af9f13e9db15b3 Fix null pointer when creating ConnectorSession for LocalExchange (Ke Wang)
- 0529b4075be3e9e675719951c5b967fe95a9f3d8 Do not run docker based spark integration tests by default (Andrii Rosa)
- 6e24976c079481a4dd7d0220c1d2c6f3603b9daf Improve verification for map columns (Brendan Driscoll)
- 685303098bd3933e1669ca6ea045d92671df9a00 Add SampleNode stats and cost rule (Saumitra Shahapure)
- 4a914eb7512ee48699a2493c6604f232ce40384d Balance ArbitraryOutputbuffer distribution over clients (James Petty)
- a5195e88e0ee1fda7a47da977c0d81661e81e178 Allow insert overwrite as default behavior for Hive connector (Wenlei Xie)
- 5e4bfdf00a98046306a7d7057a352986ff290c2b Use INFO level log for Presto-on-Spark plan (Wenlei Xie)
- 68170388b2a40bd67d2a62029f756250941bfea1 Allow create table with customized table properties (James Sun)
- 22bcbbccb5fc1888dbde5d90dffc3c946a2d92cc Move Raptor metadata related singletons to metastore module (James Sun)
- ccbb3bf45b2c27ef75e470a211ad1a9c11c15d7e Remove forceLocalScheduling for hive connector (Ke Wang)
- 047b4c921bd5e352f0ed83aef540d16e38ba787e Add nodeSelectionStrategy to getInfo in HiveSplit (Ke Wang)
- da1161dcdd4e407636951b275aa4117fb485f5b7 Add simple soft affinity support for HiveSplit (Ke Wang)
- 55c5add33b008701f3511f74a3cba0bbbe81a0e1 Add SoftAffinityNodeSelection ability for unbucketed splits (Ke Wang)
- 76b4087fd9decdd32c79c79f7677d3048c1de38b Extract RandomNodeSelection logic from SimpleNodeSelector (Ke Wang)
- 7fd2c9a1c9d4255982fdb7724d6953ddc9a3f0b3 Refactor getAddresses in SPI ConnectorSplit (Ke Wang)
- a7c78f272b7ecb8f1f67679cbfd7806ac8ed0b3f Refactor isRemotelyAccessible in SPI ConnectorSplit (Ke Wang)
- a2d55c1deb74f2ababde29da804d235d44dccda8 Add nodeSelectionStrategy in Hive ClientConfig and SessionProperties (Ke Wang)
- e53af1ad6029c15c24ba2583569cda23625233d5 Move node select related class to nodeSelection package (Ke Wang)
- 85b45fb9a0ee676f8ae6434eb8efaf78f35d8bbe Extend ST_Points to support major Well-Known spatial objects (Yifeng Jiang)
- 980a75c937978951ddfa0c304d3cf1eab200cdaf Increase Heap size to fix test timeouts (Bhavani Hari)
- 26be3fde2dfa3042fd50389f1f4aee7bba2724d5 Run presto spark tests in forked VM (Andrii Rosa)
- 4ae5d1ecaf56ad7ef3d07bd86090eec806a9cf23 Remove unnecessary copies in StreamingAggregationOperator (James Petty)
- ceb5784d26c2128944c617fb4a24b01539f42d02 Implement CachingDirectoryListor with delegation (Zhenxiao Luo)
- f0b57fe7a09ce2b5bccfc1af99246ab26afbd8d3 Make file status cache disabled by default (Zhenxiao Luo)
- 954f1ce55d1941c63ac3a9a30cd215db4c91da5a Add Hive directory listing cache (qqibrow)
- ecb9167d40630f173625082a14d3a0b694c3ce4a Fix like pattern interpretation (James Sun)
- 52786cffbe0dba09a1d0b5c99e4a643147a4d533 Strip more dependencies from Hudi (Bhavani Sudha Saktheeswaran)
- d0973099fdeb38310f934beee96bc7383e4bd5aa Add getPartitionNames support to Alluxio Metastore (Haoyuan Li)
- 4ce85cf09d662b059ec3666ce6614b31d18d11ee Revert "Improve error message for the array_agg function" (sujay-jain)
- e06784343cecc5ba65dd381df4a58b6b857c3a21 Strip httpcomponents dependency from Hudi (James Sun)
- 419ba19044446634a168259ab6fe625fcf09126a Disable too-many-stages warning for exchange materialization (Wenlei Xie)
- 9fd2459d98efd0809023b175ba53775466b74cc6 Support PathFilter when fetching splits for Hudi tables (Bhavani Sudha Saktheeswaran)
- a5a93473d534ae89d55a802844aecd27d2bb00fe Fix hostname related assertion failure in PrestoSparkQueryRunner (Andrii Rosa)
- 303e640f5da27a8c3785aae2f4129fa2293d062f Fix Druid connector pom to new release (Zhenxiao Luo)
- 687f0b4f53c4ee37efe033374a25eb86f3876018 Fix Druid ErrorCode (Zhenxiao Luo)
- 905778ab6c4972c310d9ca7ceac1466a67004ce5 Remove unused files and comments from druid connector (Zhenxiao Luo)
- f0145ee9333397dce631559374858ad0eb9ccd4e Druid connector schema configurable (Zhenxiao Luo)
- 8c8c2aa197e19c0968679a457b044f7671b2a85c Add Druid connector documentation (Zhenxiao Luo)
- bf91489756cd4040138f26a6c8a5bc73e703b2c0 Fix getReadTimeNanos for DruidSegmentPageSource (Zhenxiao Luo)
- 92b1f31928f09cc06336a77e2044f24333515e2a Fix Druid 0.17.0 index generation (Zhenxiao Luo)
- a53178d7041549e9528ffcf5b41bd2c0b86653e8 Fix Druid metadata Json format (Zhenxiao Luo)
- ae7489eb2ada392f500a0a525efbef77ef55d99f Add DruidQueryRunner (Zhenxiao Luo)
- 9fcd940706624de7f4936b7f198062f0af0c6eb1 Remove unused variable and methods from druid connector (Zhenxiao Luo)
- e745e1074580d9e1a760cea673f20e8d3e891c3c Upgrade to druid 0.17.0 (Zhenxiao Luo)
- 895650fd26e7b16ef0f0b4050a58931461abed0b Fix coding style for Druid connector (Zhenxiao Luo)
- d03ffc9bcae50c4a5d94b87c27784acf7cb2d679 Presto Druid Connector (Hao Luo)