### PR TITLE
Harden blockEncodingBuffers in OptimizedPartitionedOutputOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
@@ -618,10 +618,11 @@ public class OptimizedPartitionedOutputOperator
         {
             // Create buffers has to be done after seeing the first page.
             if (blockEncodingBuffers == null) {
-                blockEncodingBuffers = new BlockEncodingBuffer[channelCount];
+                BlockEncodingBuffer[] buffers = new BlockEncodingBuffer[channelCount];
                 for (int i = 0; i < channelCount; i++) {
-                    blockEncodingBuffers[i] = createBlockEncodingBuffers(decodedBlocks[i]);
+                    buffers[i] = createBlockEncodingBuffers(decodedBlocks[i]);
                 }
+                blockEncodingBuffers = buffers;
             }
         }
 


### PR DESCRIPTION
blockEncodingBuffers in OptimizedPartitionedOutputOperator#partitionBuffer is not supposed to be accessed by multiple threads, but it might be helpful to harden initializeBlockEncodingBuffers to make sure it never leaves blockEncodingBuffers partially initialized. This PR is to harden the blockEncodingBuffers when initializing them.

```
== NO RELEASE NOTE ==
```
