### PR TITLE
Remove workaround for ConcurrentMap.compute

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
@@ -195,19 +195,7 @@ public class PipelineContext
         // merge the operator stats into the operator summary
         List<OperatorStats> operators = driverStats.getOperatorStats();
         for (OperatorStats operator : operators) {
-            // TODO: replace with ConcurrentMap.compute() when we migrate to java 8
-            OperatorStats updated;
-            OperatorStats current;
-            do {
-                current = operatorSummaries.get(operator.getOperatorId());
-                if (current != null) {
-                    updated = current.add(operator);
-                }
-                else {
-                    updated = operator;
-                }
-            }
-            while (!compareAndSet(operatorSummaries, operator.getOperatorId(), current, updated));
+            operatorSummaries.compute(operator.getOperatorId(), (operatorId, summaryStats) -> summaryStats == null ? operator : summaryStats.add(operator));
         }
 
         rawInputDataSize.update(driverStats.getRawInputDataSize().toBytes());
@@ -485,15 +473,6 @@ public class PipelineContext
         return drivers.stream()
                 .map(driver -> driver.accept(visitor, context))
                 .collect(toList());
-    }
-
-    private static <K, V> boolean compareAndSet(ConcurrentMap<K, V> map, K key, V oldValue, V newValue)
-    {
-        if (oldValue == null) {
-            return map.putIfAbsent(key, newValue) == null;
-        }
-
-        return map.replace(key, oldValue, newValue);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
We have been using java 8 features for a long time, so we can remove this
workaround from PipelineContext.

```
== NO RELEASE NOTE ==
```
