### PR TITLE
Fix reading a map column having negative integers as keys

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/SubfieldTokenizer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SubfieldTokenizer.java
@@ -180,7 +180,7 @@ class SubfieldTokenizer
 
     private static boolean isUnquotedSubscriptCharacter(char c)
     {
-        return c == '_' || isLetterOrDigit(c);
+        return c == '-' || c == '_' || isLetterOrDigit(c);
     }
 
     private Subfield.PathElement matchQuotedSubscript()

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestSubfieldTokenizer.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestSubfieldTokenizer.java
@@ -34,6 +34,7 @@ public class TestSubfieldTokenizer
         List<PathElement> elements = ImmutableList.of(
                 new NestedField("b"),
                 new Subfield.LongSubscript(2),
+                new Subfield.LongSubscript(-1),
                 new Subfield.StringSubscript("z"),
                 Subfield.allSubscripts(),
                 new Subfield.StringSubscript("34"),


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```
