### PR TITLE
Reuse buffers in OptimizedPartitionedOutputOperator - part 1

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
@@ -67,6 +67,9 @@ public abstract class AbstractBlockEncodingBuffer
     // The allocator for internal buffers
     protected final ArrayAllocator bufferAllocator;
 
+    // Boolean indicating whether this is a buffer for a nested level block.
+    protected final boolean isNested;
+
     // The block after peeling off the Dictionary or RLE wrappings.
     protected Block decodedBlock;
 
@@ -114,12 +117,13 @@ public abstract class AbstractBlockEncodingBuffer
     // Boolean indicating whether there are any null values in the nullsBuffer. It is possible that all values are non-null.
     private boolean hasEncodedNulls;
 
-    protected AbstractBlockEncodingBuffer(ArrayAllocator bufferAllocator)
+    protected AbstractBlockEncodingBuffer(ArrayAllocator bufferAllocator, boolean isNested)
     {
         this.bufferAllocator = requireNonNull(bufferAllocator, "bufferAllocator is null");
+        this.isNested = isNested;
     }
 
-    public static BlockEncodingBuffer createBlockEncodingBuffers(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator)
+    public static BlockEncodingBuffer createBlockEncodingBuffers(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator, boolean isNested)
     {
         requireNonNull(decodedBlockNode, "decodedBlockNode is null");
         requireNonNull(bufferAllocator, "bufferAllocator is null");
@@ -143,39 +147,39 @@ public abstract class AbstractBlockEncodingBuffer
         verify(!(decodedBlock instanceof RunLengthEncodedBlock), "Nested RLEs and dictionaries are not supported");
 
         if (decodedBlock instanceof LongArrayBlock) {
-            return new LongArrayBlockEncodingBuffer(bufferAllocator);
+            return new LongArrayBlockEncodingBuffer(bufferAllocator, isNested);
         }
 
         if (decodedBlock instanceof Int128ArrayBlock) {
-            return new Int128ArrayBlockEncodingBuffer(bufferAllocator);
+            return new Int128ArrayBlockEncodingBuffer(bufferAllocator, isNested);
         }
 
         if (decodedBlock instanceof IntArrayBlock) {
-            return new IntArrayBlockEncodingBuffer(bufferAllocator);
+            return new IntArrayBlockEncodingBuffer(bufferAllocator, isNested);
         }
 
         if (decodedBlock instanceof ShortArrayBlock) {
-            return new ShortArrayBlockEncodingBuffer(bufferAllocator);
+            return new ShortArrayBlockEncodingBuffer(bufferAllocator, isNested);
         }
 
         if (decodedBlock instanceof ByteArrayBlock) {
-            return new ByteArrayBlockEncodingBuffer(bufferAllocator);
+            return new ByteArrayBlockEncodingBuffer(bufferAllocator, isNested);
         }
 
         if (decodedBlock instanceof VariableWidthBlock) {
-            return new VariableWidthBlockEncodingBuffer(bufferAllocator);
+            return new VariableWidthBlockEncodingBuffer(bufferAllocator, isNested);
         }
 
         if (decodedBlock instanceof ColumnarArray) {
-            return new ArrayBlockEncodingBuffer(decodedBlockNode, bufferAllocator);
+            return new ArrayBlockEncodingBuffer(decodedBlockNode, bufferAllocator, isNested);
         }
 
         if (decodedBlock instanceof ColumnarMap) {
-            return new MapBlockEncodingBuffer(decodedBlockNode, bufferAllocator);
+            return new MapBlockEncodingBuffer(decodedBlockNode, bufferAllocator, isNested);
         }
 
         if (decodedBlock instanceof ColumnarRow) {
-            return new RowBlockEncodingBuffer(decodedBlockNode, bufferAllocator);
+            return new RowBlockEncodingBuffer(decodedBlockNode, bufferAllocator, isNested);
         }
 
         throw new IllegalArgumentException("Unsupported encoding: " + decodedBlock.getClass().getSimpleName());

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
@@ -69,10 +69,10 @@ public class ArrayBlockEncodingBuffer
     // The AbstractBlockEncodingBuffer for the nested values Block of the ArrayBlock
     private final BlockEncodingBuffer valuesBuffers;
 
-    public ArrayBlockEncodingBuffer(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator)
+    public ArrayBlockEncodingBuffer(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator, boolean isNested)
     {
-        super(bufferAllocator);
-        valuesBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0), bufferAllocator);
+        super(bufferAllocator, isNested);
+        valuesBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0), bufferAllocator, true);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
@@ -27,6 +27,7 @@
  */
 package com.facebook.presto.operator.repartition;
 
+import com.facebook.presto.spi.block.ArrayAllocator;
 import com.facebook.presto.spi.block.ColumnarArray;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.SliceOutput;
@@ -69,9 +70,10 @@ public class ArrayBlockEncodingBuffer
     // The AbstractBlockEncodingBuffer for the nested values Block of the ArrayBlock
     private final BlockEncodingBuffer valuesBuffers;
 
-    public ArrayBlockEncodingBuffer(DecodedBlockNode decodedBlockNode)
+    public ArrayBlockEncodingBuffer(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator)
     {
-        valuesBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0));
+        super(bufferAllocator);
+        valuesBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0), bufferAllocator);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/BlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/BlockEncodingBuffer.java
@@ -48,6 +48,11 @@ public interface BlockEncodingBuffer
      */
     void resetBuffers();
 
+    /**
+     * Signals that this is the last batch in this page, so that the internal buffers in BlockEncodingBuffers can recycled.
+     */
+    void noMoreBatches();
+
     long getRetainedSizeInBytes();
 
     long getSerializedSizeInBytes();

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
@@ -51,9 +51,9 @@ public class ByteArrayBlockEncodingBuffer
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
 
-    public ByteArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator)
+    public ByteArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator, boolean isNested)
     {
-        super(bufferAllocator);
+        super(bufferAllocator, isNested);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
@@ -79,6 +79,7 @@ public class ByteArrayBlockEncodingBuffer
 
         appendValuesToBuffer();
         appendNulls();
+
         bufferedPositionCount += batchSize;
     }
 
@@ -108,7 +109,6 @@ public class ByteArrayBlockEncodingBuffer
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE +
-                getPositionsRetainedSizeInBytes() +
                 sizeOf(valuesBuffer) +
                 getNullsBufferRetainedSizeInBytes();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
@@ -27,6 +27,7 @@
  */
 package com.facebook.presto.operator.repartition;
 
+import com.facebook.presto.spi.block.ArrayAllocator;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
@@ -49,6 +50,11 @@ public class ByteArrayBlockEncodingBuffer
 
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
+
+    public ByteArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator)
+    {
+        super(bufferAllocator);
+    }
 
     @Override
     public void accumulateSerializedRowSizes(int[] serializedRowSizes)

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
@@ -27,6 +27,7 @@
  */
 package com.facebook.presto.operator.repartition;
 
+import com.facebook.presto.spi.block.ArrayAllocator;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
@@ -50,6 +51,11 @@ public class Int128ArrayBlockEncodingBuffer
 
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
+
+    public Int128ArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator)
+    {
+        super(bufferAllocator);
+    }
 
     @Override
     public void accumulateSerializedRowSizes(int[] serializedRowSizes)

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
@@ -72,6 +72,7 @@ public class Int128ArrayBlockEncodingBuffer
 
         appendValuesToBuffer();
         appendNulls();
+
         bufferedPositionCount += batchSize;
     }
 
@@ -101,7 +102,6 @@ public class Int128ArrayBlockEncodingBuffer
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE +
-                getPositionsRetainedSizeInBytes() +
                 sizeOf(valuesBuffer) +
                 getNullsBufferRetainedSizeInBytes();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
@@ -52,9 +52,9 @@ public class Int128ArrayBlockEncodingBuffer
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
 
-    public Int128ArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator)
+    public Int128ArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator, boolean isNested)
     {
-        super(bufferAllocator);
+        super(bufferAllocator, isNested);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
@@ -72,6 +72,7 @@ public class IntArrayBlockEncodingBuffer
 
         appendValuesToBuffer();
         appendNulls();
+
         bufferedPositionCount += batchSize;
     }
 
@@ -101,7 +102,6 @@ public class IntArrayBlockEncodingBuffer
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE +
-                getPositionsRetainedSizeInBytes() +
                 sizeOf(valuesBuffer) +
                 getNullsBufferRetainedSizeInBytes();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
@@ -52,9 +52,9 @@ public class IntArrayBlockEncodingBuffer
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
 
-    public IntArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator)
+    public IntArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator, boolean isNested)
     {
-        super(bufferAllocator);
+        super(bufferAllocator, isNested);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
@@ -27,6 +27,7 @@
  */
 package com.facebook.presto.operator.repartition;
 
+import com.facebook.presto.spi.block.ArrayAllocator;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
@@ -50,6 +51,11 @@ public class IntArrayBlockEncodingBuffer
 
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
+
+    public IntArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator)
+    {
+        super(bufferAllocator);
+    }
 
     @Override
     public void accumulateSerializedRowSizes(int[] serializedRowSizes)

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
@@ -38,9 +38,9 @@ public class LongArrayBlockEncodingBuffer
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
 
-    public LongArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator)
+    public LongArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator, boolean isNested)
     {
-        super(bufferAllocator);
+        super(bufferAllocator, isNested);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator.repartition;
 
+import com.facebook.presto.spi.block.ArrayAllocator;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
@@ -36,6 +37,11 @@ public class LongArrayBlockEncodingBuffer
 
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
+
+    public LongArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator)
+    {
+        super(bufferAllocator);
+    }
 
     @Override
     public void accumulateSerializedRowSizes(int[] serializedRowSizes)

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
@@ -58,6 +58,7 @@ public class LongArrayBlockEncodingBuffer
 
         appendValuesToBuffer();
         appendNulls();
+
         bufferedPositionCount += batchSize;
     }
 
@@ -87,7 +88,6 @@ public class LongArrayBlockEncodingBuffer
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE +
-                getPositionsRetainedSizeInBytes() +
                 sizeOf(valuesBuffer) +
                 getNullsBufferRetainedSizeInBytes();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
@@ -27,6 +27,7 @@
  */
 package com.facebook.presto.operator.repartition;
 
+import com.facebook.presto.spi.block.ArrayAllocator;
 import com.facebook.presto.spi.block.ColumnarMap;
 import com.facebook.presto.spi.type.TypeSerde;
 import com.google.common.annotations.VisibleForTesting;
@@ -88,10 +89,11 @@ public class MapBlockEncodingBuffer
     private final BlockEncodingBuffer keyBuffers;
     private final BlockEncodingBuffer valueBuffers;
 
-    public MapBlockEncodingBuffer(DecodedBlockNode decodedBlockNode)
+    public MapBlockEncodingBuffer(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator)
     {
-        keyBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0));
-        valueBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(1));
+        super(bufferAllocator);
+        keyBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0), bufferAllocator);
+        valueBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(1), bufferAllocator);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
@@ -88,11 +88,11 @@ public class MapBlockEncodingBuffer
     private final BlockEncodingBuffer keyBuffers;
     private final BlockEncodingBuffer valueBuffers;
 
-    public MapBlockEncodingBuffer(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator)
+    public MapBlockEncodingBuffer(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator, boolean isNested)
     {
-        super(bufferAllocator);
-        keyBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0), bufferAllocator);
-        valueBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(1), bufferAllocator);
+        super(bufferAllocator, isNested);
+        keyBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0), bufferAllocator, true);
+        valueBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(1), bufferAllocator, true);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
@@ -640,7 +640,7 @@ public class OptimizedPartitionedOutputOperator
             if (blockEncodingBuffers == null) {
                 BlockEncodingBuffer[] buffers = new BlockEncodingBuffer[channelCount];
                 for (int i = 0; i < channelCount; i++) {
-                    buffers[i] = createBlockEncodingBuffers(decodedBlocks[i]);
+                    buffers[i] = createBlockEncodingBuffers(decodedBlocks[i], bufferAllocator);
                 }
                 blockEncodingBuffers = buffers;
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
@@ -640,7 +640,7 @@ public class OptimizedPartitionedOutputOperator
             if (blockEncodingBuffers == null) {
                 BlockEncodingBuffer[] buffers = new BlockEncodingBuffer[channelCount];
                 for (int i = 0; i < channelCount; i++) {
-                    buffers[i] = createBlockEncodingBuffers(decodedBlocks[i], bufferAllocator);
+                    buffers[i] = createBlockEncodingBuffers(decodedBlocks[i], bufferAllocator, false);
                 }
                 blockEncodingBuffers = buffers;
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
@@ -631,6 +631,9 @@ public class OptimizedPartitionedOutputOperator
             finally {
                 // Return the borrowed array for serializedRowSizes when the current page for the current partition is finished.
                 bufferAllocator.returnArray(serializedRowSizes);
+                for (int i = 0; i < channelCount; i++) {
+                    blockEncodingBuffers[i].noMoreBatches();
+                }
             }
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
@@ -172,6 +172,21 @@ public class RowBlockEncodingBuffer
     }
 
     @Override
+    public void noMoreBatches()
+    {
+        super.noMoreBatches();
+
+        if (offsets != null) {
+            bufferAllocator.returnArray(offsets);
+            offsets = null;
+        }
+
+        for (int i = 0; i < fieldBuffers.length; i++) {
+            fieldBuffers[i].noMoreBatches();
+        }
+    }
+
+    @Override
     public long getRetainedSizeInBytes()
     {
         int size = 0;
@@ -180,9 +195,7 @@ public class RowBlockEncodingBuffer
         }
 
         return INSTANCE_SIZE +
-                getPositionsRetainedSizeInBytes() +
                 sizeOf(offsetsBuffer) +
-                sizeOf(offsets) +
                 getNullsBufferRetainedSizeInBytes() +
                 size;
     }
@@ -275,7 +288,8 @@ public class RowBlockEncodingBuffer
             return;
         }
 
-        offsets = ensureCapacity(offsets, positionCount + 1);
+        offsets = ensureCapacity(offsets, positionCount + 1, SMALL, NONE, bufferAllocator);
+        offsets[0] = 0;
 
         int[] positions = getPositions();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
@@ -71,14 +71,14 @@ public class RowBlockEncodingBuffer
     // The AbstractBlockEncodingBuffer for the nested field blocks of the RowBlock
     private final BlockEncodingBuffer[] fieldBuffers;
 
-    public RowBlockEncodingBuffer(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator)
+    public RowBlockEncodingBuffer(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator, boolean isNested)
     {
-        super(bufferAllocator);
+        super(bufferAllocator, isNested);
 
         List<DecodedBlockNode> childrenNodes = decodedBlockNode.getChildren();
         fieldBuffers = new AbstractBlockEncodingBuffer[childrenNodes.size()];
         for (int i = 0; i < childrenNodes.size(); i++) {
-            fieldBuffers[i] = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(i), bufferAllocator);
+            fieldBuffers[i] = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(i), bufferAllocator, true);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
@@ -27,6 +27,7 @@
  */
 package com.facebook.presto.operator.repartition;
 
+import com.facebook.presto.spi.block.ArrayAllocator;
 import com.facebook.presto.spi.block.ColumnarRow;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.SliceOutput;
@@ -71,12 +72,14 @@ public class RowBlockEncodingBuffer
     // The AbstractBlockEncodingBuffer for the nested field blocks of the RowBlock
     private final BlockEncodingBuffer[] fieldBuffers;
 
-    public RowBlockEncodingBuffer(DecodedBlockNode decodedBlockNode)
+    public RowBlockEncodingBuffer(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator)
     {
+        super(bufferAllocator);
+
         List<DecodedBlockNode> childrenNodes = decodedBlockNode.getChildren();
         fieldBuffers = new AbstractBlockEncodingBuffer[childrenNodes.size()];
         for (int i = 0; i < childrenNodes.size(); i++) {
-            fieldBuffers[i] = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(i));
+            fieldBuffers[i] = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(i), bufferAllocator);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
@@ -52,9 +52,9 @@ public class ShortArrayBlockEncodingBuffer
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
 
-    public ShortArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator)
+    public ShortArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator, boolean isNested)
     {
-        super(bufferAllocator);
+        super(bufferAllocator, isNested);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
@@ -72,6 +72,7 @@ public class ShortArrayBlockEncodingBuffer
 
         appendValuesToBuffer();
         appendNulls();
+
         bufferedPositionCount += batchSize;
     }
 
@@ -101,7 +102,6 @@ public class ShortArrayBlockEncodingBuffer
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE +
-                getPositionsRetainedSizeInBytes() +
                 sizeOf(valuesBuffer) +
                 getNullsBufferRetainedSizeInBytes();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
@@ -27,6 +27,7 @@
  */
 package com.facebook.presto.operator.repartition;
 
+import com.facebook.presto.spi.block.ArrayAllocator;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
@@ -50,6 +51,11 @@ public class ShortArrayBlockEncodingBuffer
 
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
+
+    public ShortArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator)
+    {
+        super(bufferAllocator);
+    }
 
     @Override
     public void accumulateSerializedRowSizes(int[] serializedRowSizes)

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/VariableWidthBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/VariableWidthBlockEncodingBuffer.java
@@ -68,9 +68,9 @@ public class VariableWidthBlockEncodingBuffer
     // The last offset in the offsets buffer
     private int lastOffset;
 
-    public VariableWidthBlockEncodingBuffer(ArrayAllocator bufferAllocator)
+    public VariableWidthBlockEncodingBuffer(ArrayAllocator bufferAllocator, boolean isNested)
     {
-        super(bufferAllocator);
+        super(bufferAllocator, isNested);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/VariableWidthBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/VariableWidthBlockEncodingBuffer.java
@@ -28,6 +28,7 @@
 package com.facebook.presto.operator.repartition;
 
 import com.facebook.presto.spi.block.AbstractVariableWidthBlock;
+import com.facebook.presto.spi.block.ArrayAllocator;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -66,6 +67,11 @@ public class VariableWidthBlockEncodingBuffer
 
     // The last offset in the offsets buffer
     private int lastOffset;
+
+    public VariableWidthBlockEncodingBuffer(ArrayAllocator bufferAllocator)
+    {
+        super(bufferAllocator);
+    }
 
     @Override
     public void accumulateSerializedRowSizes(int[] serializedRowSizes)

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/VariableWidthBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/VariableWidthBlockEncodingBuffer.java
@@ -91,6 +91,7 @@ public class VariableWidthBlockEncodingBuffer
 
         appendOffsetsAndSlices();
         appendNulls();
+
         bufferedPositionCount += batchSize;
     }
 
@@ -131,7 +132,6 @@ public class VariableWidthBlockEncodingBuffer
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE +
-                getPositionsRetainedSizeInBytes() +
                 sizeOf(offsetsBuffer) +
                 getNullsBufferRetainedSizeInBytes() +
                 sizeOf(sliceBuffer);

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
@@ -327,7 +327,7 @@ public class TestBlockEncodingBuffers
         BlockFlattener flattener = new BlockFlattener(new SimpleArrayAllocator());
         DecodedBlockNode decodedBlock = decodeBlock(flattener, blockLeaseCloser, block);
 
-        BlockEncodingBuffer buffers = createBlockEncodingBuffers(decodedBlock);
+        BlockEncodingBuffer buffers = createBlockEncodingBuffers(decodedBlock, new SimpleArrayAllocator(100));
 
         int[] positions = IntStream.range(0, block.getPositionCount() / 2).toArray();
         copyPositions(decodedBlock, buffers, positions, expectedRowSizes);

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
@@ -327,7 +327,7 @@ public class TestBlockEncodingBuffers
         BlockFlattener flattener = new BlockFlattener(new SimpleArrayAllocator());
         DecodedBlockNode decodedBlock = decodeBlock(flattener, blockLeaseCloser, block);
 
-        BlockEncodingBuffer buffers = createBlockEncodingBuffers(decodedBlock, new SimpleArrayAllocator(100));
+        BlockEncodingBuffer buffers = createBlockEncodingBuffers(decodedBlock, new SimpleArrayAllocator(100), false);
 
         int[] positions = IntStream.range(0, block.getPositionCount() / 2).toArray();
         copyPositions(decodedBlock, buffers, positions, expectedRowSizes);

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
@@ -327,7 +327,7 @@ public class TestBlockEncodingBuffers
         BlockFlattener flattener = new BlockFlattener(new SimpleArrayAllocator());
         DecodedBlockNode decodedBlock = decodeBlock(flattener, blockLeaseCloser, block);
 
-        BlockEncodingBuffer buffers = createBlockEncodingBuffers(decodedBlock, new SimpleArrayAllocator(100), false);
+        BlockEncodingBuffer buffers = createBlockEncodingBuffers(decodedBlock, new SimpleArrayAllocator(1000), false);
 
         int[] positions = IntStream.range(0, block.getPositionCount() / 2).toArray();
         copyPositions(decodedBlock, buffers, positions, expectedRowSizes);


### PR DESCRIPTION
Partially resolves #14162

OptimizedPartitionedOutputOperator persists a set of local buffers. For example, each PartitionBuffer has a serializedRowSizes array to hold the estimated sizes for each row. Each BlockEncodingBuffer has a offsetsCopy that holds the adjusted offsets for the whole block. These buffers can be reused under some circumstances. This PR reuses serializedRowSizes between different PartitionBuffers, reuse offsetsCopy between different BlockEncodingBuffers, reuse positions, mappedPositions and offsets between BlockEncodingBuffers. For pages with nested type columns like array, map and row with high cardinality, or the block is DictionaryBlock, these optimizations can save over 30% memory.

```
== NO RELEASE NOTE ==
```
