### PR TITLE
Added function ST_Transform to module presto-geospatial. ST_Transform…

### DIFF
--- a/presto-geospatial/pom.xml
+++ b/presto-geospatial/pom.xml
@@ -167,6 +167,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.orbisgis</groupId>
+            <artifactId>cts</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
             <type>test-jar</type>


### PR DESCRIPTION
… returns a new geometry with its coordinates transformed to a different spatial reference system.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
