### PR TITLE
Introduce bind user pattern to LdapAuthenticator

### DIFF
--- a/presto-password-authenticators/src/main/java/com/facebook/presto/password/LdapConfig.java
+++ b/presto-password-authenticators/src/main/java/com/facebook/presto/password/LdapConfig.java
@@ -25,6 +25,10 @@ import java.util.concurrent.TimeUnit;
 public class LdapConfig
 {
     private String ldapUrl;
+    private String bindUserDN;
+    private String bindPassword;
+    private String userLoginAttribute;
+    private String userAttributeSearchFilter;
     private String userBindSearchPattern;
     private String groupAuthorizationSearchPattern;
     private String userBaseDistinguishedName;
@@ -35,6 +39,32 @@ public class LdapConfig
     public String getLdapUrl()
     {
         return ldapUrl;
+    }
+
+    public String getBindUserDN()
+    {
+        return bindUserDN;
+    }
+
+    @Config("ldap.bind-user-dn")
+    @ConfigDescription("Bind User of LDAP Server")
+    public LdapConfig setBindUserDN(String bindUserDN)
+    {
+        this.bindUserDN = bindUserDN;
+        return this;
+    }
+
+    @Config("ldap.bind-password")
+    @ConfigDescription("Bind Password of LDAP Server")
+    public LdapConfig setBindPassword(String bindPassword)
+    {
+        this.bindPassword = bindPassword;
+        return this;
+    }
+
+    public String getBindPassword()
+    {
+        return bindPassword;
     }
 
     @Config("ldap.url")
@@ -95,6 +125,32 @@ public class LdapConfig
     public LdapConfig setLdapCacheTtl(Duration ldapCacheTtl)
     {
         this.ldapCacheTtl = ldapCacheTtl;
+        return this;
+    }
+
+    public String getUserLoginAttribute()
+    {
+        return userLoginAttribute;
+    }
+
+    @Config("ldap.user-login-attribute")
+    @ConfigDescription("Ldap search will return this user's attribute as a result of the auth process. Example: userPrincipalName")
+    public LdapConfig setUserLoginAttribute(String userLoginAttribute)
+    {
+        this.userLoginAttribute = userLoginAttribute;
+        return this;
+    }
+
+    public String getUserAttributeSearchFilter()
+    {
+        return userAttributeSearchFilter;
+    }
+
+    @Config("ldap.user-attribute-search-filter")
+    @ConfigDescription("Ldap attribute to validate the user-bind-pattern against. Example: sAMAccountName")
+    public LdapConfig setUserAttributeSearchFilter(String userAttributeSearchFilter)
+    {
+        this.userAttributeSearchFilter = userAttributeSearchFilter;
         return this;
     }
 }

--- a/presto-password-authenticators/src/test/java/com/facebook/presto/password/TestLdapConfig.java
+++ b/presto-password-authenticators/src/test/java/com/facebook/presto/password/TestLdapConfig.java
@@ -37,6 +37,10 @@ public class TestLdapConfig
     {
         assertRecordedDefaults(recordDefaults(LdapConfig.class)
                 .setLdapUrl(null)
+                .setBindUserDN(null)
+                .setBindPassword(null)
+                .setUserAttributeSearchFilter(null)
+                .setUserLoginAttribute(null)
                 .setUserBindSearchPattern(null)
                 .setUserBaseDistinguishedName(null)
                 .setGroupAuthorizationSearchPattern(null)
@@ -48,6 +52,10 @@ public class TestLdapConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("ldap.url", "ldaps://localhost:636")
+                .put("ldap.bind-user-dn", "bind-user-dn")
+                .put("ldap.bind-password", "bind-password")
+                .put("ldap.user-attribute-search-filter", "sAMAccountName")
+                .put("ldap.user-login-attribute", "userPrincipalName")
                 .put("ldap.user-bind-pattern", "uid=${USER},ou=org,dc=test,dc=com")
                 .put("ldap.user-base-dn", "dc=test,dc=com")
                 .put("ldap.group-auth-pattern", "&(objectClass=user)(memberOf=cn=group)(user=username)")
@@ -56,6 +64,10 @@ public class TestLdapConfig
 
         LdapConfig expected = new LdapConfig()
                 .setLdapUrl("ldaps://localhost:636")
+                .setBindUserDN("bind-user-dn")
+                .setBindPassword("bind-password")
+                .setUserAttributeSearchFilter("sAMAccountName")
+                .setUserLoginAttribute("userPrincipalName")
                 .setUserBindSearchPattern("uid=${USER},ou=org,dc=test,dc=com")
                 .setUserBaseDistinguishedName("dc=test,dc=com")
                 .setGroupAuthorizationSearchPattern("&(objectClass=user)(memberOf=cn=group)(user=username)")
@@ -69,6 +81,10 @@ public class TestLdapConfig
     {
         assertValidates(new LdapConfig()
                 .setLdapUrl("ldaps://localhost")
+                .setBindUserDN("bind-password")
+                .setBindUserDN("bind-user-dn")
+                .setUserAttributeSearchFilter("sAMAccountName")
+                .setUserLoginAttribute("userPrincipalName")
                 .setUserBindSearchPattern("uid=${USER},ou=org,dc=test,dc=com")
                 .setUserBaseDistinguishedName("dc=test,dc=com")
                 .setGroupAuthorizationSearchPattern("&(objectClass=user)(memberOf=cn=group)(user=username)"));


### PR DESCRIPTION
Providing a bind-user-dn and password to authenticate and check users
against ldap allows for greater flexibility regarding different ldap
setups. The initial login to ldap will be done by the bind-user-dn. Using
this context the username + attribute search filter are used to get the
user's ldap object. From this object we identify the user's login
attribute configured in "ldap.user-login-attribute". This attribute is
returned from the ldap object and the regular auth flow continues.

This implementation does not break any previous setup. If the ldap.bind-user-dn is not configured
the original authentication flow will be executed.

TODO before merging:
* Write Integration tests with LDAP
* Check for LDAP injection.

New properties:
- ldap.bind-user-dn
- ldap.bind-password
- ldap.user-login-attribute
- ldap.user-attribute-search-filter

Resloves: #11917

```
== RELEASE NOTES ==

Security Changes
* Add configuration property ``ldap.bind-user-dn``, ``ldap.bind-password``, 
   ``ldap.user-login-attribute`` and ``ldap.user-attribute-search-filter`` to configure how user's
   are authenticated against LDAP. If the ``ldap.bind-user-dn`` is set, LDAP will be searched on 
   behalf of this user instead of the logged in user. After a user matching the ``ldap.user-login- 
   attribute`` was found, it will be authenticated based on the ``user-attribute-search-filter``.
```

