### PR TITLE
Fix subscript expression optimization during subfield pushdown

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -427,6 +427,9 @@ public class TestHiveLogicalPlanner
         assertPushdownSubfields("SELECT c['cat'] FROM test_pushdown_map_subscripts", "test_pushdown_map_subscripts",
                 ImmutableMap.of("c", toSubfields("c[\"cat\"]")));
 
+        assertPushdownSubfields("SELECT c[JSON_EXTRACT_SCALAR(JSON_PARSE('{}'),'$.a')] FROM test_pushdown_map_subscripts", "test_pushdown_map_subscripts",
+                ImmutableMap.of());
+
         assertPushdownSubfields("SELECT mod(c['cat'], 2) FROM test_pushdown_map_subscripts WHERE c['dog'] > 10", "test_pushdown_map_subscripts",
                 ImmutableMap.of("c", toSubfields("c[\"cat\"]", "c[\"dog\"]")));
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -500,6 +500,7 @@ public class PushdownSubfields
 
                     if (indexExpression instanceof ConstantExpression) {
                         Object index = ((ConstantExpression) indexExpression).getValue();
+                        verify(index != null, "Struct field index cannot be null");
                         if (index instanceof Number) {
                             Optional<String> fieldName = baseType.getFields().get(((Number) index).intValue()).getName();
                             if (fieldName.isPresent()) {
@@ -520,6 +521,9 @@ public class PushdownSubfields
 
                     if (indexExpression instanceof ConstantExpression) {
                         Object index = ((ConstantExpression) indexExpression).getValue();
+                        if (index == null) {
+                            return Optional.empty();
+                        }
                         if (index instanceof Number) {
                             elements.add(new Subfield.LongSubscript(((Number) index).longValue()));
                             expression = arguments.get(0);


### PR DESCRIPTION
The latest code in the PushdownSubFields optimizes the subscript expression before creating the subfields. Therefore there are some cases where the optimization results in null in case of maps.
So when we try to extract the subfield with null it results in an NPE. Adding a `null` check to the index optimized expression resolves the issue.

```
== NO RELEASE NOTE ==
```

