### PR TITLE
Initialize HoodieROTablePathFilter with Configuration

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HdfsConfiguration.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HdfsConfiguration.java
@@ -21,4 +21,5 @@ import java.net.URI;
 public interface HdfsConfiguration
 {
     Configuration getConfiguration(HdfsContext context, URI uri);
+    Configuration getBaseConfiguration();
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HdfsEnvironment.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HdfsEnvironment.java
@@ -60,6 +60,11 @@ public class HdfsEnvironment
         return hdfsConfiguration.getConfiguration(context, path.toUri());
     }
 
+    public Configuration getBaseConfiguration()
+    {
+        return hdfsConfiguration.getBaseConfiguration();
+    }
+
     public FileSystem getFileSystem(HdfsContext context, Path path)
             throws IOException
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -165,7 +165,7 @@ public class BackgroundHiveSplitLoader
         this.partitions = new ConcurrentLazyQueue<>(requireNonNull(partitions, "partitions is null"));
         this.hdfsContext = new HdfsContext(session, table.getDatabaseName(), table.getTableName());
         this.schedulerUsesHostAddresses = schedulerUsesHostAddresses;
-        this.hoodiePathFilterSupplier = Suppliers.memoize(HoodieROTablePathFilter::new);
+        this.hoodiePathFilterSupplier = Suppliers.memoize(() -> new HoodieROTablePathFilter(hdfsEnvironment.getBaseConfiguration()));
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCachingHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCachingHdfsConfiguration.java
@@ -76,6 +76,12 @@ public class HiveCachingHdfsConfiguration
         return config;
     }
 
+    @Override
+    public Configuration getBaseConfiguration()
+    {
+        return hiveHdfsConfiguration.getBaseConfiguration();
+    }
+
     private static class CachingJobConf
             extends JobConf
             implements FileSystemFactory

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
@@ -69,4 +69,10 @@ public class HiveHdfsConfiguration
         }
         return config;
     }
+
+    @Override
+    public Configuration getBaseConfiguration()
+    {
+        return hadoopConfiguration.get();
+    }
 }


### PR DESCRIPTION
Currently there is a bug with Presto's use of HoodieROTablePathFilter
because it does not pass in the configuration object to initialize the
filesystem. This allows the HdfsEnvironment object to return the base
config for the PathFilter initialization so that it can be used for the hoodie PathFilter init. This is a followup to a bug within https://github.com/prestodb/presto/commit/9fd2459d98efd0809023b175ba53775466b74cc6 when using S3 hudi tables. The JIRA for this is here: https://issues.apache.org/jira/browse/HUDI-539

The corresponding Hudi change is located here: https://github.com/apache/incubator-hudi/pull/1413/commits

These combined hudi + presto changes have been tested to fix the issue in the JIRA.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==
Hive Changes
* presto-hive now passes Configuration to HoodieROTablePathFilter when initializing. This fixes a bug with querying s3-hudi tables through presto.


