### PR TITLE
Disable Presto-on-Spark query stats collection

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -304,8 +304,8 @@ public class PrestoSparkQueryExecutionFactory
 
         private void queryCompletedEvent(Optional<Throwable> failure)
         {
-            QueryInfo queryInfo = createQueryInfo(failure);
-            // TODO: implement query monitor
+            // TODO: implement query monitor and collect query info
+            // QueryInfo queryInfo = createQueryInfo(failure);
             // queryMonitor.queryCompletedEvent(queryInfo);
         }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -331,9 +331,11 @@ public class PrestoSparkTaskExecutorFactory
 
             if (!rowBuffer.hasRowsBuffered()) {
                 verify(done, "all drivers must be done if no rows are in the buffer");
-                TaskStats taskStats = taskContext.getTaskStats();
-                byte[] taskStatsSerialized = taskStatsJsonCodec.toJsonBytes(taskStats);
-                taskStatsCollector.add(new SerializedTaskStats(taskStatsSerialized));
+
+                // TODO: Fix task stats collection
+                //  TaskStats taskStats = taskContext.getTaskStats();
+                //  byte[] taskStatsSerialized = taskStatsJsonCodec.toJsonBytes(taskStats);
+                //  taskStatsCollector.add(new SerializedTaskStats(taskStatsSerialized));
                 return endOfData();
             }
 


### PR DESCRIPTION
It is not working as expected at this moment. 
- Task stats collection shows as unreadable bytes on Spark UI
- Query info collection might cause excessive memory usage on Driver. 

```
== NO RELEASE NOTE ==
```
