### PR TITLE
Add JSON format for EXPLAIN with type LOGICAL and DISTRIBUTED

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -46,6 +46,8 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.planner.planPrinter.IOPlanPrinter.textIOPlan;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.graphvizDistributedPlan;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.graphvizLogicalPlan;
+import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.jsonDistributedPlan;
+import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.jsonLogicalPlan;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -167,10 +169,10 @@ public class QueryExplainer
                 return textIOPlan(plan.getRoot(), metadata, session);
             case LOGICAL:
                 plan = getLogicalPlan(session, statement, parameters, warningCollector);
-                return PlanPrinter.jsonLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionManager(), plan.getStatsAndCosts(), session);
+                return jsonLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionManager(), plan.getStatsAndCosts(), session);
             case DISTRIBUTED:
                 SubPlan subPlan = getDistributedPlan(session, statement, parameters, warningCollector);
-                return PlanPrinter.jsonDistributedPlan(subPlan);
+                return jsonDistributedPlan(subPlan);
             default:
                 throw new PrestoException(NOT_SUPPORTED, format("Unsupported explain plan type %s for JSON format", planType));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/QueryExplainer.java
@@ -160,10 +160,17 @@ public class QueryExplainer
             return explainTask(statement, task, parameters);
         }
 
+        Plan plan;
         switch (planType) {
             case IO:
-                Plan plan = getLogicalPlan(session, statement, parameters, warningCollector);
+                plan = getLogicalPlan(session, statement, parameters, warningCollector);
                 return textIOPlan(plan.getRoot(), metadata, session);
+            case LOGICAL:
+                plan = getLogicalPlan(session, statement, parameters, warningCollector);
+                return PlanPrinter.jsonLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionManager(), plan.getStatsAndCosts(), session);
+            case DISTRIBUTED:
+                SubPlan subPlan = getDistributedPlan(session, statement, parameters, warningCollector);
+                return PlanPrinter.jsonDistributedPlan(subPlan);
             default:
                 throw new PrestoException(NOT_SUPPORTED, format("Unsupported explain plan type %s for JSON format", planType));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/JsonRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/JsonRenderer.java
@@ -15,9 +15,12 @@ package com.facebook.presto.sql.planner.planPrinter;
 
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRawValue;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -27,11 +30,17 @@ public class JsonRenderer
         implements Renderer<String>
 {
     private static final JsonCodec<JsonRenderedNode> CODEC = JsonCodec.jsonCodec(JsonRenderedNode.class);
+    private static final JsonCodec<Map<PlanFragmentId, JsonPlanFragment>> PLAN_MAP_CODEC = JsonCodec.mapJsonCodec(PlanFragmentId.class, JsonPlanFragment.class);
 
     @Override
     public String render(PlanRepresentation plan)
     {
         return CODEC.toJson(renderJson(plan, plan.getRoot()));
+    }
+
+    public String render(Map<PlanFragmentId, JsonPlanFragment> fragmentJsonMap)
+    {
+        return PLAN_MAP_CODEC.toJson(fragmentJsonMap);
     }
 
     private JsonRenderedNode renderJson(PlanRepresentation plan, NodeRepresentation node)
@@ -107,6 +116,24 @@ public class JsonRenderer
         public List<String> getRemoteSources()
         {
             return remoteSources;
+        }
+    }
+
+    public static class JsonPlanFragment
+    {
+        @JsonRawValue
+        private final String plan;
+
+        @JsonCreator
+        public JsonPlanFragment(String plan)
+        {
+            this.plan = plan;
+        }
+
+        @JsonProperty
+        public String getPlan()
+        {
+            return this.plan;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -252,6 +252,16 @@ public class PlanPrinter
     public static String jsonLogicalPlan(
             PlanNode plan,
             TypeProvider types,
+            FunctionManager functionManager,
+            StatsAndCosts estimatedStatsAndCosts,
+            Session session)
+    {
+        return jsonLogicalPlan(plan, types, Optional.empty(), functionManager, estimatedStatsAndCosts, session, Optional.empty());
+    }
+
+    public static String jsonLogicalPlan(
+            PlanNode plan,
+            TypeProvider types,
             Optional<StageExecutionDescriptor> stageExecutionStrategy,
             FunctionManager functionManager,
             StatsAndCosts estimatedStatsAndCosts,
@@ -259,16 +269,6 @@ public class PlanPrinter
             Optional<Map<PlanNodeId, PlanNodeStats>> stats)
     {
         return new PlanPrinter(plan, types, stageExecutionStrategy, functionManager, estimatedStatsAndCosts, session, stats).toJson();
-    }
-
-    public static String jsonLogicalPlan(
-            PlanNode plan,
-            TypeProvider types,
-            FunctionManager functionManager,
-            StatsAndCosts estimatedStatsAndCosts,
-            Session session)
-    {
-        return jsonLogicalPlan(plan, types, Optional.empty(), functionManager, estimatedStatsAndCosts, session, Optional.empty());
     }
 
     public static String jsonDistributedPlan(StageInfo outputStageInfo)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4596,6 +4596,14 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testLogicalExplainJsonFormat()
+    {
+        String query = "SELECT * FROM orders";
+        MaterializedResult result = computeActual("EXPLAIN (TYPE LOGICAL, FORMAT JSON) " + query);
+        assertEquals(getOnlyElement(result.getOnlyColumnAsSet()), getJsonExplainPlan(query, LOGICAL));
+    }
+
+    @Test
     public void testDistributedExplain()
     {
         String query = "SELECT * FROM orders";
@@ -4617,6 +4625,14 @@ public abstract class AbstractTestQueries
         String query = "SELECT * FROM orders";
         MaterializedResult result = computeActual("EXPLAIN (TYPE DISTRIBUTED, FORMAT GRAPHVIZ) " + query);
         assertEquals(getOnlyElement(result.getOnlyColumnAsSet()), getGraphvizExplainPlan(query, DISTRIBUTED));
+    }
+
+    @Test
+    public void testDistributedExplainJsonFormat()
+    {
+        String query = "SELECT * FROM orders";
+        MaterializedResult result = computeActual("EXPLAIN (TYPE DISTRIBUTED, FORMAT JSON) " + query);
+        assertEquals(getOnlyElement(result.getOnlyColumnAsSet()), getJsonExplainPlan(query, DISTRIBUTED));
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -343,6 +343,16 @@ public abstract class AbstractTestQueryFramework
                 });
     }
 
+    public String getJsonExplainPlan(String query, ExplainType.Type planType)
+    {
+        QueryExplainer explainer = getQueryExplainer();
+        return transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())
+                .singleStatement()
+                .execute(queryRunner.getDefaultSession(), session -> {
+                    return explainer.getJsonPlan(session, sqlParser.createStatement(query, createParsingOptions(session)), planType, emptyList(), WarningCollector.NOOP);
+                });
+    }
+
     protected void assertPlan(@Language("SQL") String query, PlanMatchPattern pattern)
     {
         assertPlan(queryRunner.getDefaultSession(), query, pattern);


### PR DESCRIPTION
Add Json format for `EXPLAIN` with type `LOGICAL` and `DISTRIBUTED`. (Issue #11189)

- for both Logical and distributed type, I use `JsonRenderedNode` in  JsonRenderer ([link](https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/JsonRenderer.java#L57-L111))

- Distributed plan is using sorted map base on [QueryMonitor](https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java#L328). (Also moved `JsonPlanFragment` from QueryMonitor to JsonRenderer.)

- sample output in [this gist](https://gist.github.com/chyikwei/10fda9fe1bbb31f16ecfac5ff9b59938)

```
== RELEASE NOTES ==

General Changes
* Add JSON format for `EXPLAIN` with type `LOGICAL` and `DISTRIBUTED`.
