### PR TITLE
Avoid Exceptions when closing queryRunner

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.airlift.testing.Assertions.assertContains;
+import static com.facebook.airlift.testing.Closeables.closeQuietly;
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_EXECUTION_TIME;
 import static com.facebook.presto.execution.QueryState.FAILED;
 import static com.facebook.presto.execution.QueryState.FINISHED;
@@ -86,7 +87,7 @@ public class TestQueuesDb
     @AfterMethod(alwaysRun = true)
     public void tearDown()
     {
-        queryRunner.close();
+        closeQuietly(queryRunner);
         queryRunner = null;
     }
 


### PR DESCRIPTION
This is to deflake `TestQueuesDb` and `TestQueues`.

```
== NO RELEASE NOTE ==
```
