### PR TITLE
Set use-legacy-scheduler true by default

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
@@ -111,7 +111,8 @@ public class TestHiveRecoverableExecution
                 // set the timeout of the task update requests to something low to improve overall test latency
                 .put("scheduler.http-client.request-timeout", "5s")
                 // this effectively disables the retries
-                .put("query.remote-task.max-error-duration", "1s");
+                .put("query.remote-task.max-error-duration", "1s")
+                .put("use-legacy-scheduler", "false");
 
         return HiveQueryRunner.createQueryRunner(
                 ImmutableList.of(ORDERS),

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -149,7 +149,7 @@ public class FeaturesConfig
 
     private boolean listBuiltInFunctionsOnly = true;
     private boolean experimentalFunctionsEnabled;
-    private boolean useLegacyScheduler;
+    private boolean useLegacyScheduler = true;
 
     private PartitioningPrecisionStrategy partitioningPrecisionStrategy = PartitioningPrecisionStrategy.AUTOMATIC;
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -131,7 +131,7 @@ public class TestFeaturesConfig
                 .setListBuiltInFunctionsOnly(true)
                 .setPartitioningPrecisionStrategy(PartitioningPrecisionStrategy.AUTOMATIC)
                 .setExperimentalFunctionsEnabled(false)
-                .setUseLegacyScheduler(false));
+                .setUseLegacyScheduler(true));
     }
 
     @Test
@@ -218,7 +218,7 @@ public class TestFeaturesConfig
                 .put("list-built-in-functions-only", "false")
                 .put("partitioning-precision-strategy", "PREFER_EXACT_PARTITIONING")
                 .put("experimental-functions-enabled", "true")
-                .put("use-legacy-scheduler", "true")
+                .put("use-legacy-scheduler", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -302,7 +302,7 @@ public class TestFeaturesConfig
                 .setListBuiltInFunctionsOnly(false)
                 .setPartitioningPrecisionStrategy(PartitioningPrecisionStrategy.PREFER_EXACT_PARTITIONING)
                 .setExperimentalFunctionsEnabled(true)
-                .setUseLegacyScheduler(true);
+                .setUseLegacyScheduler(false);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
There was a regression with the refactored scheduler, that it could
cause high cpu usage on the coordinator.  Use legacy scheduler by
default until that's fixed.

```
== RELEASE NOTES ==

General Changes
* Change the default for configuration property ``use-legacy-scheduler`` to ``true`` in order to mitigate a regression in the new scheduler.

```

