### PR TITLE
Optimize parquet gzip decompression

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
@@ -364,6 +364,19 @@ public class TestHiveFileFormats
     }
 
     @Test(dataProvider = "rowCount")
+    public void testParquetPageSourceGzip(int rowCount)
+            throws Exception
+    {
+        List<TestColumn> testColumns = getTestColumnsSupportedByParquet();
+        assertThatFileFormat(PARQUET)
+                .withColumns(testColumns)
+                .withSession(parquetPageSourceSession)
+                .withCompressionCodec(HiveCompressionCodec.GZIP)
+                .withRowsCount(rowCount)
+                .isReadableByPageSource(new ParquetPageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS, new HadoopFileOpener()));
+    }
+
+    @Test(dataProvider = "rowCount")
     public void testParquetPageSourceSchemaEvolution(int rowCount)
             throws Exception
     {


### PR DESCRIPTION
Cross contribution of https://github.com/prestosql/presto/pull/3175

Avoids creating an intermediate buffer (with the full `uncompressedSize` capacity) and copy from buffer to `DynamicSliceOutput` in parquet gzip decompression. Also avoids allocating the full 8k gzip input buffer size when the slice input is smaller. Finally, a validation check is added to verify the `uncompressedSize` was correct whereas previously the resulting slice would contain garbage data at the end (likely zeroed memory).

```
== NO RELEASE NOTE ==
```
