### PR TITLE
Support verifying structured types containing DATE and UNKNOWN

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierUtil.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierUtil.java
@@ -28,7 +28,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
-import static com.facebook.presto.spi.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
 import static com.google.common.base.Functions.identity;
 import static com.google.common.collect.ImmutableList.toImmutableList;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierUtil.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierUtil.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.verifier.framework;
 
 import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.spi.type.TypeSignature;
 import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.tree.Identifier;
@@ -84,11 +86,13 @@ public class VerifierUtil
                         .collect(toImmutableMap(i -> callUnchecked(() -> metadata.getColumnName(i)), i -> i - 1)));
     }
 
-    public static List<TypeSignature> getColumnTypes(ResultSetMetaData metadata)
+    public static List<Type> getColumnTypes(TypeManager typeManager, ResultSetMetaData metadata)
     {
         return callUnchecked(() ->
                 IntStream.rangeClosed(1, metadata.getColumnCount())
-                        .mapToObj(i -> callUnchecked(() -> parseTypeSignature(metadata.getColumnTypeName(i))))
+                        .mapToObj(i -> callUnchecked(() -> metadata.getColumnTypeName(i)))
+                        .map(TypeSignature::parseTypeSignature)
+                        .map(typeManager::getType)
                         .collect(toImmutableList()));
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/VerificationQueryRewriterFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/VerificationQueryRewriterFactory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.verifier.rewrite;
 
+import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.Property;
 import com.facebook.presto.verifier.annotation.ForControl;
@@ -32,6 +33,7 @@ public class VerificationQueryRewriterFactory
         implements QueryRewriterFactory
 {
     private final SqlParser sqlParser;
+    private final TypeManager typeManager;
     private final List<Property> tablePropertyOverrides;
     private final QueryRewriteConfig controlConfig;
     private final QueryRewriteConfig testConfig;
@@ -39,11 +41,13 @@ public class VerificationQueryRewriterFactory
     @Inject
     public VerificationQueryRewriterFactory(
             SqlParser sqlParser,
+            TypeManager typeManager,
             List<Property> tablePropertyOverrides,
             @ForControl QueryRewriteConfig controlConfig,
             @ForTest QueryRewriteConfig testConfig)
     {
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.tablePropertyOverrides = requireNonNull(tablePropertyOverrides, "tablePropertyOverrides is null");
         this.controlConfig = requireNonNull(controlConfig, "controlConfig is null");
         this.testConfig = requireNonNull(testConfig, "testConfig is null");
@@ -54,6 +58,7 @@ public class VerificationQueryRewriterFactory
     {
         return new QueryRewriter(
                 sqlParser,
+                typeManager,
                 prestoAction,
                 tablePropertyOverrides,
                 ImmutableMap.of(

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
@@ -14,10 +14,15 @@
 package com.facebook.presto.verifier;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.plugin.memory.MemoryPlugin;
+import com.facebook.presto.spi.type.TypeManager;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.testing.mysql.MySqlOptions;
 import com.facebook.presto.testing.mysql.TestingMySqlServer;
 import com.facebook.presto.tests.StandaloneQueryRunner;
+import com.facebook.presto.type.TypeRegistry;
 import com.facebook.presto.verifier.checksum.ArrayColumnValidator;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.checksum.ColumnValidator;
@@ -55,9 +60,7 @@ public class VerifierTestUtil
             .setCommandTimeout(new Duration(90, SECONDS))
             .build();
 
-    private VerifierTestUtil()
-    {
-    }
+    private VerifierTestUtil() {}
 
     public static StandaloneQueryRunner setupPresto()
             throws Exception
@@ -123,5 +126,12 @@ public class VerifierTestUtil
                 Column.Category.MAP, MapColumnValidator::new);
         lazyValidators.putAll(validators);
         return new ChecksumValidator(validators);
+    }
+
+    public static TypeManager createTypeManager()
+    {
+        TypeManager typeManager = new TypeRegistry();
+        new FunctionManager(typeManager, new BlockEncodingManager(typeManager), new FeaturesConfig());
+        return typeManager;
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -13,11 +13,11 @@
  */
 package com.facebook.presto.verifier.framework;
 
+import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.tests.StandaloneQueryRunner;
-import com.facebook.presto.type.TypeRegistry;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.event.DeterminismAnalysisRun;
 import com.facebook.presto.verifier.event.VerifierQueryEvent;
@@ -50,6 +50,7 @@ import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
 import static com.facebook.presto.verifier.VerifierTestUtil.CATALOG;
 import static com.facebook.presto.verifier.VerifierTestUtil.SCHEMA;
 import static com.facebook.presto.verifier.VerifierTestUtil.createChecksumValidator;
+import static com.facebook.presto.verifier.VerifierTestUtil.createTypeManager;
 import static com.facebook.presto.verifier.VerifierTestUtil.setupPresto;
 import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.FAILED;
 import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.FAILED_RESOLVED;
@@ -99,6 +100,7 @@ public class TestDataVerification
         VerificationContext verificationContext = new VerificationContext();
         VerifierConfig verifierConfig = new VerifierConfig().setTestId(TEST_ID);
         RetryConfig retryConfig = new RetryConfig();
+        TypeManager typeManager = createTypeManager();
         PrestoAction prestoAction = new JdbcPrestoAction(
                 PrestoExceptionClassifier.createDefault(),
                 configuration,
@@ -110,12 +112,12 @@ public class TestDataVerification
                 retryConfig);
         QueryRewriter queryRewriter = new QueryRewriter(
                 new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN)),
+                typeManager,
                 prestoAction,
                 ImmutableList.of(),
                 ImmutableMap.of(CONTROL, QualifiedName.of("tmp_verifier_c"), TEST, QualifiedName.of("tmp_verifier_t")));
         ChecksumValidator checksumValidator = createChecksumValidator(verifierConfig);
         SourceQuery sourceQuery = new SourceQuery(SUITE, NAME, controlQuery, testQuery, configuration, configuration);
-        TypeRegistry typeManager = new TypeRegistry();
         return new DataVerification(
                 (verification, e) -> false,
                 prestoAction,

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -304,6 +304,23 @@ public class TestDataVerification
     }
 
     @Test
+    public void testSelectNonStorableStructuredColumns()
+    {
+        String query = "SELECT\n" +
+                "    ARRAY[DATE '2020-01-01'],\n" +
+                "    ARRAY[NULL],\n" +
+                "    MAP(\n" +
+                "        ARRAY[DATE '2020-01-01'], ARRAY[\n" +
+                "            CAST(ROW(1, 'a', DATE '2020-01-01') AS ROW(x int, y VARCHAR, z date))\n" +
+                "        ]\n" +
+                "    ),\n" +
+                "    ROW(NULL)";
+        Optional<VerifierQueryEvent> event = createVerification(query, query).run();
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    @Test
     public void testChecksumQueryCompilerError()
     {
         List<String> columns = IntStream.range(0, 1000).mapToObj(i -> "c" + i).collect(toImmutableList());

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDeterminismAnalyzer.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDeterminismAnalyzer.java
@@ -13,11 +13,11 @@
  */
 package com.facebook.presto.verifier.framework;
 
+import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.tree.QualifiedName;
-import com.facebook.presto.type.TypeRegistry;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.prestoaction.JdbcPrestoAction;
 import com.facebook.presto.verifier.prestoaction.PrestoAction;
@@ -36,6 +36,7 @@ import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
 import static com.facebook.presto.verifier.VerifierTestUtil.CATALOG;
 import static com.facebook.presto.verifier.VerifierTestUtil.SCHEMA;
 import static com.facebook.presto.verifier.VerifierTestUtil.createChecksumValidator;
+import static com.facebook.presto.verifier.VerifierTestUtil.createTypeManager;
 import static com.facebook.presto.verifier.framework.ClusterType.CONTROL;
 import static com.facebook.presto.verifier.framework.ClusterType.TEST;
 import static org.testng.Assert.assertFalse;
@@ -64,6 +65,7 @@ public class TestDeterminismAnalyzer
         VerificationContext verificationContext = new VerificationContext();
         VerifierConfig verifierConfig = new VerifierConfig().setTestId("test-id");
         RetryConfig retryConfig = new RetryConfig();
+        TypeManager typeManager = createTypeManager();
         PrestoAction prestoAction = new JdbcPrestoAction(
                 PrestoExceptionClassifier.createDefault(),
                 configuration,
@@ -73,12 +75,12 @@ public class TestDeterminismAnalyzer
                 retryConfig);
         QueryRewriter queryRewriter = new QueryRewriter(
                 sqlParser,
+                typeManager,
                 prestoAction,
                 ImmutableList.of(),
                 ImmutableMap.of(CONTROL, QualifiedName.of("tmp_verifier_c"), TEST, QualifiedName.of("tmp_verifier_t")));
         ChecksumValidator checksumValidator = createChecksumValidator(verifierConfig);
         SourceQuery sourceQuery = new SourceQuery("test", "", "", "", configuration, configuration);
-        TypeRegistry typeManager = new TypeRegistry();
 
         return new DeterminismAnalyzer(
                 sourceQuery,

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.sql.parser.IdentifierSymbol.AT_SIGN;
 import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
 import static com.facebook.presto.verifier.VerifierTestUtil.createChecksumValidator;
+import static com.facebook.presto.verifier.VerifierTestUtil.createTypeManager;
 import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.SKIPPED;
 import static com.facebook.presto.verifier.framework.ClusterType.CONTROL;
 import static com.facebook.presto.verifier.framework.ClusterType.TEST;
@@ -203,7 +204,7 @@ public class TestVerificationManager
                 new VerificationFactory(
                         SQL_PARSER,
                         (sourceQuery, verificationContext) -> prestoAction,
-                        presto -> new QueryRewriter(SQL_PARSER, presto, ImmutableList.of(), ImmutableMap.of(CONTROL, TABLE_PREFIX, TEST, TABLE_PREFIX)),
+                        presto -> new QueryRewriter(SQL_PARSER, createTypeManager(), presto, ImmutableList.of(), ImmutableMap.of(CONTROL, TABLE_PREFIX, TEST, TABLE_PREFIX)),
                         new FailureResolverManagerFactory(ImmutableSet.of(), ImmutableSet.of()),
                         new MockNodeResourceClient(),
                         createChecksumValidator(verifierConfig),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
 import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
 import static com.facebook.presto.verifier.VerifierTestUtil.CATALOG;
 import static com.facebook.presto.verifier.VerifierTestUtil.SCHEMA;
+import static com.facebook.presto.verifier.VerifierTestUtil.createTypeManager;
 import static com.facebook.presto.verifier.VerifierTestUtil.setupPresto;
 import static com.facebook.presto.verifier.framework.ClusterType.CONTROL;
 import static com.facebook.presto.verifier.framework.ClusterType.TEST;
@@ -231,6 +232,7 @@ public class TestQueryRewriter
     {
         return new QueryRewriter(
                 sqlParser,
+                createTypeManager(),
                 new JdbcPrestoAction(
                         PrestoExceptionClassifier.createDefault(),
                         CONFIGURATION,


### PR DESCRIPTION
```
== RELEASE NOTES ==

Verifier Changes
* Add support for verifying ``SELECT`` queries that produce structured types containing ``DATE`` or ``UNKNOWN`` (null).
```
