### PR TITLE
Upgrade presto pinot connector to be compatible with new Broker routing and time boundary APIs in Pinot 0.3.0 release

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotClusterInfoFetcher.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotClusterInfoFetcher.java
@@ -477,8 +477,8 @@ public class PinotClusterInfoFetcher
                  * Sample error message:
                  *     Unexpected response status: 404 for request  to url http://127.0.0.1:8000/debug/timeBoundary/baseballStats, with headers ...
                  */
-                String[] errMsgSplits = e.getMessage().split(" ");
-                if (errMsgSplits.length >= 4 && errMsgSplits[3].equalsIgnoreCase(TIME_BOUNDARY_NOT_FOUND_ERROR_CODE)) {
+                String[] errorMessageSplits = e.getMessage().split(" ");
+                if (errorMessageSplits.length >= 4 && errorMessageSplits[3].equalsIgnoreCase(TIME_BOUNDARY_NOT_FOUND_ERROR_CODE)) {
                     return timeBoundaryJsonCodec.fromJson("{}");
                 }
             }

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/MetadataUtil.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/MetadataUtil.java
@@ -43,6 +43,7 @@ public final class MetadataUtil
     public static final JsonCodec<PinotClusterInfoFetcher.GetTables> TABLES_JSON_CODEC;
     public static final JsonCodec<PinotClusterInfoFetcher.BrokersForTable> BROKERS_FOR_TABLE_JSON_CODEC;
     public static final JsonCodec<PinotClusterInfoFetcher.RoutingTables> ROUTING_TABLES_JSON_CODEC;
+    public static final JsonCodec<PinotClusterInfoFetcher.RoutingTablesV2> ROUTING_TABLES_V2_JSON_CODEC;
     public static final JsonCodec<PinotClusterInfoFetcher.TimeBoundary> TIME_BOUNDARY_JSON_CODEC;
 
     private MetadataUtil()
@@ -82,6 +83,7 @@ public final class MetadataUtil
         TABLES_JSON_CODEC = codecFactory.jsonCodec(PinotClusterInfoFetcher.GetTables.class);
         BROKERS_FOR_TABLE_JSON_CODEC = codecFactory.jsonCodec(PinotClusterInfoFetcher.BrokersForTable.class);
         ROUTING_TABLES_JSON_CODEC = codecFactory.jsonCodec(PinotClusterInfoFetcher.RoutingTables.class);
+        ROUTING_TABLES_V2_JSON_CODEC = codecFactory.jsonCodec(PinotClusterInfoFetcher.RoutingTablesV2.class);
         TIME_BOUNDARY_JSON_CODEC = codecFactory.jsonCodec(PinotClusterInfoFetcher.TimeBoundary.class);
     }
 }

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/MockPinotClusterInfoFetcher.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/MockPinotClusterInfoFetcher.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import static com.facebook.presto.pinot.MetadataUtil.BROKERS_FOR_TABLE_JSON_CODEC;
 import static com.facebook.presto.pinot.MetadataUtil.ROUTING_TABLES_JSON_CODEC;
+import static com.facebook.presto.pinot.MetadataUtil.ROUTING_TABLES_V2_JSON_CODEC;
 import static com.facebook.presto.pinot.MetadataUtil.TABLES_JSON_CODEC;
 import static com.facebook.presto.pinot.MetadataUtil.TIME_BOUNDARY_JSON_CODEC;
 
@@ -38,6 +39,7 @@ public class MockPinotClusterInfoFetcher
                 TABLES_JSON_CODEC,
                 BROKERS_FOR_TABLE_JSON_CODEC,
                 ROUTING_TABLES_JSON_CODEC,
+                ROUTING_TABLES_V2_JSON_CODEC,
                 TIME_BOUNDARY_JSON_CODEC);
     }
 

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotClusterInfoFetcher.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotClusterInfoFetcher.java
@@ -73,7 +73,7 @@ public class TestPinotClusterInfoFetcher
         PinotConfig pinotConfig = new PinotConfig()
                 .setMetadataCacheExpiry(new Duration(0, TimeUnit.MILLISECONDS))
                 .setControllerUrls("localhost:7900");
-        PinotClusterInfoFetcher pinotClusterInfoFetcher = new PinotClusterInfoFetcher(pinotConfig, new PinotMetrics(), httpClient, MetadataUtil.TABLES_JSON_CODEC, MetadataUtil.BROKERS_FOR_TABLE_JSON_CODEC, MetadataUtil.ROUTING_TABLES_JSON_CODEC, MetadataUtil.TIME_BOUNDARY_JSON_CODEC);
+        PinotClusterInfoFetcher pinotClusterInfoFetcher = new PinotClusterInfoFetcher(pinotConfig, new PinotMetrics(), httpClient, MetadataUtil.TABLES_JSON_CODEC, MetadataUtil.BROKERS_FOR_TABLE_JSON_CODEC, MetadataUtil.ROUTING_TABLES_JSON_CODEC, MetadataUtil.ROUTING_TABLES_V2_JSON_CODEC, MetadataUtil.TIME_BOUNDARY_JSON_CODEC);
         ImmutableSet<String> brokers = ImmutableSet.copyOf(pinotClusterInfoFetcher.getAllBrokersForTable("dummy"));
         Assert.assertEquals(ImmutableSet.of("dummy-broker-host1-datacenter1:6513", "dummy-broker-host2-datacenter1:6513", "dummy-broker-host3-datacenter1:6513", "dummy-broker-host4-datacenter1:6513"), brokers);
     }


### PR DESCRIPTION
Recently Pinot upgraded the Broker side routing table API and changed the behavior of timeBoundary query API. This PR aims to be compatible with new changes.

```
== RELEASE NOTES ==

Pinot Changes
* Adding support for new Pinot Routing Table APIs.
```