### PR TITLE
Fix bucket pruning when value is null and the predicate is 'IS NULL'.

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/predicate/TupleDomain.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/predicate/TupleDomain.java
@@ -155,9 +155,14 @@ public final class TupleDomain<T>
             return Optional.empty();
         }
 
-        return Optional.of(ranges.stream()
+        Set<NullableValue> fixedValueSet = ranges.stream()
                 .map(range -> new NullableValue(domain.getType(), range.getSingleValue()))
-                .collect(Collectors.toSet()));
+                .collect(Collectors.toSet());
+        if (domain.isNullAllowed()) {
+            fixedValueSet.add(new NullableValue(domain.getType(), null));
+        }
+
+        return Optional.of(fixedValueSet);
     }
 
     /**


### PR DESCRIPTION
When filtering in buckets with matching values, handle NULL properly.

```
== RELEASE NOTES ==
Fixed bucket pruning when the predicate is IS NULL and the table actually has rows with that value which we were previously not considering.
```
