### PR TITLE
Reuse buffers in BlockEncodingBuffer

### DIFF
--- a/presto-array/src/main/java/com/facebook/presto/array/Arrays.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/Arrays.java
@@ -104,6 +104,32 @@ public class Arrays
         return buffer;
     }
 
+    public static byte[] ensureCapacity(byte[] buffer, int capacity, ExpansionFactor expansionFactor, ExpansionOption expansionOption, ArrayAllocator allocator)
+    {
+        int newCapacity = (int) (capacity * expansionFactor.expansionFactor);
+
+        byte[] newBuffer;
+        if (buffer == null) {
+            newBuffer = allocator.borrowByteArray(newCapacity);
+        }
+        else if (buffer.length < capacity) {
+            newBuffer = allocator.borrowByteArray(newCapacity);
+            if (expansionOption == PRESERVE) {
+                System.arraycopy(buffer, 0, newBuffer, 0, Math.min(buffer.length, capacity));
+            }
+            allocator.returnArray(buffer);
+        }
+        else {
+            newBuffer = buffer;
+        }
+
+        if (expansionOption == INITIALIZE) {
+            java.util.Arrays.fill(newBuffer, (byte) 0);
+        }
+
+        return newBuffer;
+    }
+
     public static int[][] ensureCapacity(int[][] buffer, int capacity)
     {
         if (buffer == null || buffer.length < capacity) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
@@ -154,14 +154,12 @@ public class ArrayBlockEncodingBuffer
     @Override
     public void noMoreBatches()
     {
+        valuesBuffers.noMoreBatches();
         super.noMoreBatches();
-
         if (offsets != null) {
             bufferAllocator.returnArray(offsets);
             offsets = null;
         }
-
-        valuesBuffers.noMoreBatches();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
@@ -37,7 +37,6 @@ import static com.facebook.presto.array.Arrays.ExpansionOption.PRESERVE;
 import static com.facebook.presto.array.Arrays.ensureCapacity;
 import static com.facebook.presto.operator.UncheckedByteArrays.setLongUnchecked;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
-import static io.airlift.slice.SizeOf.sizeOf;
 import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
 
 public class Int128ArrayBlockEncodingBuffer
@@ -95,15 +94,25 @@ public class Int128ArrayBlockEncodingBuffer
     {
         bufferedPositionCount = 0;
         valuesBufferIndex = 0;
+        flushed = true;
         resetNullsBuffer();
+    }
+
+    @Override
+    public void noMoreBatches()
+    {
+        super.noMoreBatches();
+
+        if (flushed && valuesBuffer != null) {
+            bufferAllocator.returnArray(valuesBuffer);
+            valuesBuffer = null;
+        }
     }
 
     @Override
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE +
-                sizeOf(valuesBuffer) +
-                getNullsBufferRetainedSizeInBytes();
+        return INSTANCE_SIZE;
     }
 
     @Override
@@ -134,7 +143,7 @@ public class Int128ArrayBlockEncodingBuffer
 
     private void appendValuesToBuffer()
     {
-        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_LONG_INDEX_SCALE * 2, LARGE, PRESERVE);
+        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_LONG_INDEX_SCALE * 2, LARGE, PRESERVE, bufferAllocator);
 
         int[] positions = getPositions();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
@@ -37,7 +37,6 @@ import static com.facebook.presto.array.Arrays.ExpansionOption.PRESERVE;
 import static com.facebook.presto.array.Arrays.ensureCapacity;
 import static com.facebook.presto.operator.UncheckedByteArrays.setIntUnchecked;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
-import static io.airlift.slice.SizeOf.sizeOf;
 import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
 
 public class IntArrayBlockEncodingBuffer
@@ -95,15 +94,25 @@ public class IntArrayBlockEncodingBuffer
     {
         bufferedPositionCount = 0;
         valuesBufferIndex = 0;
+        flushed = true;
         resetNullsBuffer();
+    }
+
+    @Override
+    public void noMoreBatches()
+    {
+        super.noMoreBatches();
+
+        if (flushed && valuesBuffer != null) {
+            bufferAllocator.returnArray(valuesBuffer);
+            valuesBuffer = null;
+        }
     }
 
     @Override
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE +
-                sizeOf(valuesBuffer) +
-                getNullsBufferRetainedSizeInBytes();
+        return INSTANCE_SIZE;
     }
 
     @Override
@@ -134,7 +143,7 @@ public class IntArrayBlockEncodingBuffer
 
     private void appendValuesToBuffer()
     {
-        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE, LARGE, PRESERVE);
+        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE, LARGE, PRESERVE, bufferAllocator);
 
         int[] positions = getPositions();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
@@ -196,15 +196,14 @@ public class MapBlockEncodingBuffer
     @Override
     public void noMoreBatches()
     {
+        valueBuffers.noMoreBatches();
+        keyBuffers.noMoreBatches();
         super.noMoreBatches();
 
         if (offsets != null) {
             bufferAllocator.returnArray(offsets);
             offsets = null;
         }
-
-        keyBuffers.noMoreBatches();
-        valueBuffers.noMoreBatches();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
@@ -604,13 +604,14 @@ public class OptimizedPartitionedOutputOperator
                 blockEncodingBuffers[i].setupDecodedBlocksAndPositions(decodedBlocks[i], positions, positionCount);
             }
 
-            int[] serializedRowSizes = ensureCapacity(null, positionCount, SMALL, INITIALIZE, bufferAllocator);
+            int[] serializedRowSizes = ensureCapacity((int[]) null, positionCount, SMALL, INITIALIZE, bufferAllocator);
             try {
                 populateSerializedRowSizes(fixedWidthRowSize, variableWidthChannels, serializedRowSizes);
 
                 // Due to the limitation of buffer size, we append the data batch by batch
                 int offset = 0;
                 do {
+                    bufferFull = false;
                     int batchSize = calculateNextBatchSize(fixedWidthRowSize, variableWidthChannels, offset, serializedRowSizes);
 
                     for (int i = 0; i < channelCount; i++) {
@@ -623,7 +624,6 @@ public class OptimizedPartitionedOutputOperator
 
                     if (bufferFull) {
                         flush(outputBuffer);
-                        bufferFull = false;
                     }
                 }
                 while (offset < positionCount);

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
@@ -631,7 +631,7 @@ public class OptimizedPartitionedOutputOperator
             finally {
                 // Return the borrowed array for serializedRowSizes when the current page for the current partition is finished.
                 bufferAllocator.returnArray(serializedRowSizes);
-                for (int i = 0; i < channelCount; i++) {
+                for (int i = channelCount - 1; i >= 0; i--) {
                     blockEncodingBuffers[i].noMoreBatches();
                 }
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
@@ -174,15 +174,15 @@ public class RowBlockEncodingBuffer
     @Override
     public void noMoreBatches()
     {
+        for (int i = fieldBuffers.length - 1; i >= 0; i--) {
+            fieldBuffers[i].noMoreBatches();
+        }
+
         super.noMoreBatches();
 
         if (offsets != null) {
             bufferAllocator.returnArray(offsets);
             offsets = null;
-        }
-
-        for (int i = 0; i < fieldBuffers.length; i++) {
-            fieldBuffers[i].noMoreBatches();
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
@@ -37,7 +37,6 @@ import static com.facebook.presto.array.Arrays.ExpansionOption.PRESERVE;
 import static com.facebook.presto.array.Arrays.ensureCapacity;
 import static com.facebook.presto.operator.UncheckedByteArrays.setShortUnchecked;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
-import static io.airlift.slice.SizeOf.sizeOf;
 import static sun.misc.Unsafe.ARRAY_SHORT_INDEX_SCALE;
 
 public class ShortArrayBlockEncodingBuffer
@@ -95,15 +94,25 @@ public class ShortArrayBlockEncodingBuffer
     {
         bufferedPositionCount = 0;
         valuesBufferIndex = 0;
+        flushed = true;
         resetNullsBuffer();
+    }
+
+    @Override
+    public void noMoreBatches()
+    {
+        super.noMoreBatches();
+
+        if (flushed && valuesBuffer != null) {
+            bufferAllocator.returnArray(valuesBuffer);
+            valuesBuffer = null;
+        }
     }
 
     @Override
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE +
-                sizeOf(valuesBuffer) +
-                getNullsBufferRetainedSizeInBytes();
+        return INSTANCE_SIZE;
     }
 
     @Override
@@ -134,7 +143,7 @@ public class ShortArrayBlockEncodingBuffer
 
     private void appendValuesToBuffer()
     {
-        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_SHORT_INDEX_SCALE, LARGE, PRESERVE);
+        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_SHORT_INDEX_SCALE, LARGE, PRESERVE, bufferAllocator);
 
         int[] positions = getPositions();
         if (decodedBlock.mayHaveNull()) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkBlockFlattener.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkBlockFlattener.java
@@ -72,6 +72,18 @@ public class BenchmarkBlockFlattener
         }
 
         @Override
+        public byte[] borrowByteArray(int positionCount)
+        {
+            return new byte[positionCount];
+        }
+
+        @Override
+        public void returnArray(byte[] array)
+        {
+            // no op
+        }
+
+        @Override
         public int getBorrowedArrayCount()
         {
             return 0;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestSimpleArrayAllocator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestSimpleArrayAllocator.java
@@ -18,6 +18,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
+import static io.airlift.slice.SizeOf.sizeOfByteArray;
 import static io.airlift.slice.SizeOf.sizeOfIntArray;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
@@ -27,25 +28,43 @@ public class TestSimpleArrayAllocator
     @Test
     public void testNewLease()
     {
-        SimpleArrayAllocator allocator = new SimpleArrayAllocator(5);
+        SimpleArrayAllocator allocator = new SimpleArrayAllocator(10);
 
-        Deque<int[]> arrayList = new ArrayDeque<>();
+        Deque<int[]> intArrayList = new ArrayDeque<>();
         for (int i = 0; i < 5; i++) {
-            arrayList.push(allocator.borrowIntArray(10));
+            intArrayList.push(allocator.borrowIntArray(10));
         }
         assertEquals(allocator.getBorrowedArrayCount(), 5);
         assertEquals(allocator.getEstimatedSizeInBytes(), sizeOfIntArray(10) * 5);
 
+        Deque<byte[]> byteArrayList = new ArrayDeque<>();
         for (int i = 0; i < 5; i++) {
-            allocator.returnArray(arrayList.pop());
+            byteArrayList.push(allocator.borrowByteArray(10));
+        }
+        assertEquals(allocator.getBorrowedArrayCount(), 10);
+        assertEquals(allocator.getEstimatedSizeInBytes(), (sizeOfIntArray(10) + sizeOfByteArray(10)) * 5);
+
+        for (int i = 0; i < 5; i++) {
+            allocator.returnArray(intArrayList.pop());
+        }
+        assertEquals(allocator.getBorrowedArrayCount(), 5);
+        assertEquals(allocator.getEstimatedSizeInBytes(), (sizeOfIntArray(10) + sizeOfByteArray(10)) * 5);
+
+        for (int i = 0; i < 5; i++) {
+            allocator.returnArray(byteArrayList.pop());
         }
         assertEquals(allocator.getBorrowedArrayCount(), 0);
-        assertEquals(allocator.getEstimatedSizeInBytes(), sizeOfIntArray(10) * 5);
+        assertEquals(allocator.getEstimatedSizeInBytes(), (sizeOfIntArray(10) + sizeOfByteArray(10)) * 5);
 
-        int[] borrowed = allocator.borrowIntArray(101);
-        assertEquals(allocator.getEstimatedSizeInBytes(), sizeOfIntArray(101));
-        allocator.returnArray(borrowed);
-        assertEquals(allocator.getEstimatedSizeInBytes(), sizeOfIntArray(101));
+        int[] intBorrowed = allocator.borrowIntArray(101);
+        assertEquals(allocator.getEstimatedSizeInBytes(), sizeOfIntArray(101) + sizeOfByteArray(10) * 5);
+        allocator.returnArray(intBorrowed);
+        assertEquals(allocator.getEstimatedSizeInBytes(), sizeOfIntArray(101) + sizeOfByteArray(10) * 5);
+
+        byte[] byteBorrowed = allocator.borrowByteArray(101);
+        assertEquals(allocator.getEstimatedSizeInBytes(), sizeOfIntArray(101) + sizeOfByteArray(101));
+        allocator.returnArray(byteBorrowed);
+        assertEquals(allocator.getEstimatedSizeInBytes(), sizeOfIntArray(101) + sizeOfByteArray(101));
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayAllocator.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ArrayAllocator.java
@@ -30,6 +30,10 @@ public interface ArrayAllocator
 
     void returnArray(int[] array);
 
+    byte[] borrowByteArray(int positionCount);
+
+    void returnArray(byte[] array);
+
     /**
      * @return the number of borrowed arrays which have not been returned
      */

--- a/presto-spi/src/test/java/com/facebook/presto/spi/block/CountingArrayAllocator.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/block/CountingArrayAllocator.java
@@ -20,25 +20,39 @@ package com.facebook.presto.spi.block;
 public class CountingArrayAllocator
         implements ArrayAllocator
 {
-    private int borrowedArrays;
+    private int borrowedIntArrays;
+    private int borrowedByteArrays;
 
     @Override
     public int[] borrowIntArray(int positionCount)
     {
-        borrowedArrays++;
+        borrowedIntArrays++;
         return new int[positionCount];
     }
 
     @Override
     public void returnArray(int[] array)
     {
-        borrowedArrays--;
+        borrowedIntArrays--;
+    }
+
+    @Override
+    public byte[] borrowByteArray(int positionCount)
+    {
+        borrowedByteArrays++;
+        return new byte[positionCount];
+    }
+
+    @Override
+    public void returnArray(byte[] array)
+    {
+        borrowedByteArrays--;
     }
 
     @Override
     public int getBorrowedArrayCount()
     {
-        return borrowedArrays;
+        return borrowedIntArrays + borrowedByteArrays;
     }
 
     @Override


### PR DESCRIPTION
Partially resolves #14162

The buffers e.g. valuesBuffers in BlockEncodingBuffer can be reused
after the current partition get flushed and when there is no more
batches in the current page. This can save a lot of memory
when the page is very large and can fill the buffers every time.

```
== NO RELEASE NOTE ==
```
