### PR TITLE
Do not inline projections if cannot remove one ProjectNode

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -231,8 +231,7 @@ public class PlanOptimizers
                 statsCalculator,
                 estimatedExchangesCostCalculator,
                 ImmutableSet.of(
-                        new InlineProjections(metadata.getFunctionManager()),
-                        new RemoveRedundantIdentityProjections()));
+                        new InlineProjections(metadata.getFunctionManager())));
 
         IterativeOptimizer projectionPushDown = new IterativeOptimizer(
                 ruleStats,
@@ -357,7 +356,6 @@ public class PlanOptimizers
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(
                                 new InlineProjections(metadata.getFunctionManager()),
-                                new RemoveRedundantIdentityProjections(),
                                 new TransformCorrelatedSingleRowSubqueryToProject())),
                 new CheckSubqueryNodesAreRewritten(),
                 predicatePushDown,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestInlineProjections.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestInlineProjections.java
@@ -31,47 +31,70 @@ public class TestInlineProjections
         extends BaseRuleTest
 {
     @Test
-    public void test()
+    public void testExpressionFires()
     {
         tester().assertThat(new InlineProjections(getFunctionManager()))
                 .on(p ->
                         p.project(
                                 Assignments.builder()
                                         .put(p.variable("identity"), castToRowExpression("symbol")) // identity
-                                        .put(p.variable("multi_complex_1"), castToRowExpression("complex + 1")) // complex expression referenced multiple times
-                                        .put(p.variable("multi_complex_2"), castToRowExpression("complex + 2")) // complex expression referenced multiple times
+                                        .put(p.variable("multi_complex_1"), castToRowExpression("complex + 1")) // complex expression referenced once
                                         .put(p.variable("multi_literal_1"), castToRowExpression("literal + 1")) // literal referenced multiple times
                                         .put(p.variable("multi_literal_2"), castToRowExpression("literal + 2")) // literal referenced multiple times
-                                        .put(p.variable("single_complex"), castToRowExpression("complex_2 + 2")) // complex expression reference only once
-                                        .put(p.variable("try"), castToRowExpression("try(complex / literal)"))
                                         .build(),
                                 p.project(Assignments.builder()
                                                 .put(p.variable("symbol"), castToRowExpression("x"))
                                                 .put(p.variable("complex"), castToRowExpression("x * 2"))
                                                 .put(p.variable("literal"), castToRowExpression("1"))
-                                                .put(p.variable("complex_2"), castToRowExpression("x - 1"))
                                                 .build(),
                                         p.values(p.variable("x")))))
                 .matches(
                         project(
                                 ImmutableMap.<String, ExpressionMatcher>builder()
                                         .put("out1", PlanMatchPattern.expression("x"))
-                                        .put("out2", PlanMatchPattern.expression("y + 1"))
-                                        .put("out3", PlanMatchPattern.expression("y + 2"))
+                                        .put("out2", PlanMatchPattern.expression("x * 2 + 1"))
                                         .put("out4", PlanMatchPattern.expression("1 + 1"))
                                         .put("out5", PlanMatchPattern.expression("1 + 2"))
-                                        .put("out6", PlanMatchPattern.expression("x - 1 + 2"))
-                                        .put("out7", PlanMatchPattern.expression("try(y / 1)"))
                                         .build(),
-                                project(
-                                        ImmutableMap.of(
-                                                "x", PlanMatchPattern.expression("x"),
-                                                "y", PlanMatchPattern.expression("x * 2")),
-                                        values(ImmutableMap.of("x", 0)))));
+                                values(ImmutableMap.of("x", 0))));
     }
 
     @Test
-    public void testRowExpression()
+    public void testRowExpressionFires()
+    {
+        tester().assertThat(new InlineProjections(getFunctionManager()))
+                .on(p -> {
+                    p.variable("symbol");
+                    p.variable("complex");
+                    p.variable("literal");
+                    p.variable("x");
+                    return p.project(
+                            Assignments.builder()
+                                    .put(p.variable("identity"), p.rowExpression("symbol")) // identity
+                                    .put(p.variable("multi_complex_1"), p.rowExpression("complex + 1")) // complex expression referenced once
+                                    .put(p.variable("multi_literal_1"), p.rowExpression("literal + 1")) // literal referenced multiple times
+                                    .put(p.variable("multi_literal_2"), p.rowExpression("literal + 2")) // literal referenced multiple times
+                                    .build(),
+                            p.project(Assignments.builder()
+                                            .put(p.variable("symbol"), p.rowExpression("x"))
+                                            .put(p.variable("complex"), p.rowExpression("x * 2"))
+                                            .put(p.variable("literal"), p.rowExpression("1"))
+                                            .build(),
+                                    p.values(p.variable("x"))));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.<String, ExpressionMatcher>builder()
+                                        .put("out1", PlanMatchPattern.expression("x"))
+                                        .put("out2", PlanMatchPattern.expression("x * 2 + 1"))
+                                        .put("out4", PlanMatchPattern.expression("1 + 1"))
+                                        .put("out5", PlanMatchPattern.expression("1 + 2"))
+                                        .build(),
+                                values(ImmutableMap.of("x", 0))));
+    }
+
+    @Test
+    public void testComplexExpressionDoesNotFire()
     {
         // TODO add testing to expressions that need desugaring like 'try'
         tester().assertThat(new InlineProjections(getFunctionManager()))
@@ -98,21 +121,29 @@ public class TestInlineProjections
                                             .build(),
                                     p.values(p.variable("x"))));
                 })
-                .matches(
-                        project(
-                                ImmutableMap.<String, ExpressionMatcher>builder()
-                                        .put("out1", PlanMatchPattern.expression("x"))
-                                        .put("out2", PlanMatchPattern.expression("y + 1"))
-                                        .put("out3", PlanMatchPattern.expression("y + 2"))
-                                        .put("out4", PlanMatchPattern.expression("1 + 1"))
-                                        .put("out5", PlanMatchPattern.expression("1 + 2"))
-                                        .put("out6", PlanMatchPattern.expression("x - 1 + 2"))
-                                        .build(),
-                                project(
-                                        ImmutableMap.of(
-                                                "x", PlanMatchPattern.expression("x"),
-                                                "y", PlanMatchPattern.expression("x * 2")),
-                                        values(ImmutableMap.of("x", 0)))));
+                .doesNotFire();
+    }
+
+    @Test
+    public void testTryDoesNotFire()
+    {
+        tester().assertThat(new InlineProjections(getFunctionManager()))
+                .on(p -> {
+                    p.variable("try");
+                    p.variable("complex");
+                    p.variable("literal");
+                    p.variable("x");
+                    return p.project(
+                            Assignments.builder()
+                                    .put(p.variable("try"), castToRowExpression("try(complex / literal)")) // identity
+                                    .build(),
+                            p.project(Assignments.builder()
+                                            .put(p.variable("complex"), castToRowExpression("x * 2"))
+                                            .put(p.variable("literal"), castToRowExpression("1"))
+                                            .build(),
+                                    p.values(p.variable("x"))));
+                })
+                .doesNotFire();
     }
 
     @Test


### PR DESCRIPTION
The optimizer rule `InlineProjections` looks at plans with pattern
```
project
  |- project
```
When it sees this pattern, it tries to inline the projection from child project to parent. In `PlanOptimizers` we can see that this rule is normally combined with `RemoveRedundantIdentityProjections`. The idea is that if we inline all expressions from child to parent, we can remove one project node. Note that when we cannot remove one project node, this inlining is actually pushing the compute up. In most cases, this is harmless, though arguably not really an optimization. However, in one situation, this actually would cause less efficient query plan. Look at the following:
```
project (expr = ...v...)
    |- project (v = COALESCE(id_0, id_1), some other complex projections that cannot be inlined)
            |- full outer join on id_0 = id_1 
```
In this case, if the input is partitioned on `id_0` and `id_1` respectively, #12946 could know that the output is partitioned on `COALESCE(id_0, id_1)` thus avoiding potential shuffles for further operations. However, `InlineProjections` would inline the coalesce to parent project and rewrite to the following:
```
project (expr = ...COALESCE(id_0, id_1)...)
    |- project(some other complex projections that cannot be inlined)
            |- full outer join on id_0 = id_1
```
now we loose the knowledge that this full outer join is still partitioned on `COALESCE(id_0, id_1)` because `PropertyDerivasions` can only propagate partition properties from child to parent.

Since only inlining part of projection to parents would not cause benefit, but does cause harm in certain scenarios, we should only try to do inlining when we can remove one project node. This also removes the need of running a `RemoveRedundantIdentityProjections` right after.

```
== NO RELEASE NOTE ==
```
