### PR TITLE
Enforce buffer size limits for BlockEncodingBuffer

### DIFF
--- a/presto-array/src/main/java/com/facebook/presto/array/Arrays.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/Arrays.java
@@ -19,6 +19,8 @@ import static com.facebook.presto.array.Arrays.ExpansionFactor.SMALL;
 import static com.facebook.presto.array.Arrays.ExpansionOption.INITIALIZE;
 import static com.facebook.presto.array.Arrays.ExpansionOption.NONE;
 import static com.facebook.presto.array.Arrays.ExpansionOption.PRESERVE;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 
 public class Arrays
 {
@@ -104,9 +106,9 @@ public class Arrays
         return buffer;
     }
 
-    public static byte[] ensureCapacity(byte[] buffer, int capacity, ExpansionFactor expansionFactor, ExpansionOption expansionOption, ArrayAllocator allocator)
+    public static byte[] ensureCapacity(byte[] buffer, int capacity, int estimatedMaxCapacity, ExpansionFactor expansionFactor, ExpansionOption expansionOption, ArrayAllocator allocator)
     {
-        int newCapacity = (int) (capacity * expansionFactor.expansionFactor);
+        int newCapacity = max(capacity, min((int) (capacity * expansionFactor.expansionFactor), estimatedMaxCapacity));
 
         byte[] newBuffer;
         if (buffer == null) {
@@ -115,7 +117,7 @@ public class Arrays
         else if (buffer.length < capacity) {
             newBuffer = allocator.borrowByteArray(newCapacity);
             if (expansionOption == PRESERVE) {
-                System.arraycopy(buffer, 0, newBuffer, 0, Math.min(buffer.length, capacity));
+                System.arraycopy(buffer, 0, newBuffer, 0, buffer.length);
             }
             allocator.returnArray(buffer);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
@@ -66,12 +66,12 @@ public class ArrayBlockEncodingBuffer
     private int lastOffset;
 
     // The AbstractBlockEncodingBuffer for the nested values Block of the ArrayBlock
-    private final BlockEncodingBuffer valuesBuffers;
+    private final AbstractBlockEncodingBuffer valuesBuffers;
 
     public ArrayBlockEncodingBuffer(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator, boolean isNested)
     {
         super(bufferAllocator, isNested);
-        valuesBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0), bufferAllocator, true);
+        valuesBuffers = (AbstractBlockEncodingBuffer) createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0), bufferAllocator, true);
     }
 
     @Override
@@ -84,7 +84,7 @@ public class ArrayBlockEncodingBuffer
         int[] offsetsCopy = ensureCapacity((int[]) null, positionCount + 1, SMALL, NONE, bufferAllocator);
         try {
             System.arraycopy(offsets, 0, offsetsCopy, 0, positionCount + 1);
-            ((AbstractBlockEncodingBuffer) valuesBuffers).accumulateSerializedRowSizes(offsetsCopy, positionCount, serializedRowSizes);
+            valuesBuffers.accumulateSerializedRowSizes(offsetsCopy, positionCount, serializedRowSizes);
         }
         finally {
             bufferAllocator.returnArray(offsetsCopy);
@@ -211,7 +211,7 @@ public class ArrayBlockEncodingBuffer
 
         populateNestedPositions(columnarArray);
 
-        ((AbstractBlockEncodingBuffer) valuesBuffers).setupDecodedBlockAndMapPositions(decodedBlockNode.getChildren().get(0));
+        valuesBuffers.setupDecodedBlockAndMapPositions(decodedBlockNode.getChildren().get(0));
     }
 
     @Override
@@ -229,13 +229,13 @@ public class ArrayBlockEncodingBuffer
             positionOffsets[i + 1] = offsets[offset];
         }
 
-        ((AbstractBlockEncodingBuffer) valuesBuffers).accumulateSerializedRowSizes(positionOffsets, positionCount, serializedRowSizes);
+        valuesBuffers.accumulateSerializedRowSizes(positionOffsets, positionCount, serializedRowSizes);
     }
 
     private void populateNestedPositions(ColumnarArray columnarArray)
     {
         // Reset nested level positions before checking positionCount. Failing to do so may result in valuesBuffers having stale values when positionCount is 0.
-        ((AbstractBlockEncodingBuffer) valuesBuffers).resetPositions();
+        valuesBuffers.resetPositions();
 
         if (positionCount == 0) {
             return;
@@ -256,7 +256,7 @@ public class ArrayBlockEncodingBuffer
 
             if (length > 0) {
                 // beginOffset is the absolute position in the nested block. We need to subtract the base offset from it to get the logical position.
-                ((AbstractBlockEncodingBuffer) valuesBuffers).appendPositionRange(beginOffset, length);
+                valuesBuffers.appendPositionRange(beginOffset, length);
             }
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/BlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/BlockEncodingBuffer.java
@@ -21,7 +21,7 @@ public interface BlockEncodingBuffer
     /**
      * Pass in the decoded block and positions in this block to copy. Called when a new page is being processed.
      */
-    void setupDecodedBlocksAndPositions(DecodedBlockNode decodedBlockNode, int[] positions, int positionCount);
+    void setupDecodedBlocksAndPositions(DecodedBlockNode decodedBlockNode, int[] positions, int positionCount, int partitionBufferCapacity, long estimatedSerializedPageSize);
 
     /**
      * Adds serialized row sizes to serializedRowSizes array. Called for top level columns.

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/DecodedBlockNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/DecodedBlockNode.java
@@ -43,6 +43,7 @@ class DecodedBlockNode
     private final List<DecodedBlockNode> children;
     private final long retainedSizeInBytes;
     private final long estimatedSerializedSizeInBytes;
+    private final long childrenEstimatedSerializedSizeInBytes;
 
     public DecodedBlockNode(Object decodedBlock, List<DecodedBlockNode> children)
     {
@@ -51,6 +52,7 @@ class DecodedBlockNode
 
         long retainedSize = INSTANCE_SIZE;
         long estimatedSerializedSize = 0;
+
         if (decodedBlock instanceof Block) {
             retainedSize += ((Block) decodedBlock).getRetainedSizeInBytes();
             // We use logical size as an estimation of the serialized size. For DictionaryBlock and RunLengthEncodedBlock, the logical size accounts for the size as if they were inflated.
@@ -68,8 +70,15 @@ class DecodedBlockNode
             retainedSize += ((ColumnarRow) decodedBlock).getRetainedSizeInBytes();
             estimatedSerializedSize += ((ColumnarRow) decodedBlock).getEstimatedSerializedSizeInBytes();
         }
+
         retainedSizeInBytes = retainedSize;
         estimatedSerializedSizeInBytes = estimatedSerializedSize;
+
+        long childrenEstimatedSerializedSize = 0;
+        for (int i = 0; i < children.size(); i++) {
+            childrenEstimatedSerializedSize += children.get(i).getEstimatedSerializedSizeInBytes();
+        }
+        childrenEstimatedSerializedSizeInBytes = childrenEstimatedSerializedSize;
     }
 
     public Object getDecodedBlock()
@@ -80,6 +89,11 @@ class DecodedBlockNode
     public List<DecodedBlockNode> getChildren()
     {
         return children;
+    }
+
+    public long getChildrenEstimatedSerializedSizeInBytes()
+    {
+        return childrenEstimatedSerializedSizeInBytes;
     }
 
     public long getRetainedSizeInBytes()

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/DecodedBlockNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/DecodedBlockNode.java
@@ -41,11 +41,27 @@ class DecodedBlockNode
     // The decodedBlock could be primitive block, Dictionary/Rle block, or ColumnarArray/Map/Row object
     private final Object decodedBlock;
     private final List<DecodedBlockNode> children;
+    private final long retainedSizeInBytes;
 
     public DecodedBlockNode(Object decodedBlock, List<DecodedBlockNode> children)
     {
         this.decodedBlock = requireNonNull(decodedBlock, "decodedBlock is null");
         this.children = requireNonNull(children, "children is null");
+
+        long retainedSize = INSTANCE_SIZE;
+        if (decodedBlock instanceof Block) {
+            retainedSize += ((Block) decodedBlock).getRetainedSizeInBytes();
+        }
+        else if (decodedBlock instanceof ColumnarArray) {
+            retainedSize += ((ColumnarArray) decodedBlock).getRetainedSizeInBytes();
+        }
+        else if (decodedBlock instanceof ColumnarMap) {
+            retainedSize += ((ColumnarMap) decodedBlock).getRetainedSizeInBytes();
+        }
+        else if (decodedBlock instanceof ColumnarRow) {
+            retainedSize += ((ColumnarRow) decodedBlock).getRetainedSizeInBytes();
+        }
+        retainedSizeInBytes = retainedSize;
     }
 
     public Object getDecodedBlock()
@@ -60,21 +76,7 @@ class DecodedBlockNode
 
     public long getRetainedSizeInBytes()
     {
-        long size = INSTANCE_SIZE;
-        if (decodedBlock instanceof Block) {
-            size += ((Block) decodedBlock).getRetainedSizeInBytes();
-        }
-        else if (decodedBlock instanceof ColumnarArray) {
-            size += ((ColumnarArray) decodedBlock).getRetainedSizeInBytes();
-        }
-        else if (decodedBlock instanceof ColumnarMap) {
-            size += ((ColumnarMap) decodedBlock).getRetainedSizeInBytes();
-        }
-        else if (decodedBlock instanceof ColumnarRow) {
-            size += ((ColumnarRow) decodedBlock).getRetainedSizeInBytes();
-        }
-
-        return size;
+        return retainedSizeInBytes;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
@@ -28,6 +28,7 @@
 package com.facebook.presto.operator.repartition;
 
 import com.facebook.presto.spi.block.ArrayAllocator;
+import com.facebook.presto.spi.block.Block;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
@@ -37,6 +38,7 @@ import static com.facebook.presto.array.Arrays.ExpansionOption.PRESERVE;
 import static com.facebook.presto.array.Arrays.ensureCapacity;
 import static com.facebook.presto.operator.UncheckedByteArrays.setLongUnchecked;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
 
 public class Int128ArrayBlockEncodingBuffer
@@ -50,6 +52,7 @@ public class Int128ArrayBlockEncodingBuffer
 
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
+    private int estimatedValueBufferMaxCapacity;
 
     public Int128ArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator, boolean isNested)
     {
@@ -134,6 +137,22 @@ public class Int128ArrayBlockEncodingBuffer
     }
 
     @Override
+    protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode, int partitionBufferCapacity, double decodedBlockPageSizeFraction)
+    {
+        requireNonNull(decodedBlockNode, "decodedBlockNode is null");
+        decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
+
+        double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
+        if (decodedBlock.mayHaveNull()) {
+            setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
+            estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Long.BYTES * 2 / POSITION_SIZE);
+        }
+        else {
+            estimatedValueBufferMaxCapacity = (int) targetBufferSize;
+        }
+    }
+
+    @Override
     protected void accumulateSerializedRowSizes(int[] positionOffsets, int positionCount, int[] serializedRowSizes)
     {
         for (int i = 0; i < positionCount; i++) {
@@ -143,7 +162,7 @@ public class Int128ArrayBlockEncodingBuffer
 
     private void appendValuesToBuffer()
     {
-        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_LONG_INDEX_SCALE * 2, LARGE, PRESERVE, bufferAllocator);
+        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_LONG_INDEX_SCALE * 2, estimatedValueBufferMaxCapacity, LARGE, PRESERVE, bufferAllocator);
 
         int[] positions = getPositions();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
@@ -28,6 +28,7 @@
 package com.facebook.presto.operator.repartition;
 
 import com.facebook.presto.spi.block.ArrayAllocator;
+import com.facebook.presto.spi.block.Block;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
@@ -37,6 +38,7 @@ import static com.facebook.presto.array.Arrays.ExpansionOption.PRESERVE;
 import static com.facebook.presto.array.Arrays.ensureCapacity;
 import static com.facebook.presto.operator.UncheckedByteArrays.setIntUnchecked;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
 
 public class IntArrayBlockEncodingBuffer
@@ -50,6 +52,7 @@ public class IntArrayBlockEncodingBuffer
 
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
+    private int estimatedValueBufferMaxCapacity;
 
     public IntArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator, boolean isNested)
     {
@@ -134,6 +137,22 @@ public class IntArrayBlockEncodingBuffer
     }
 
     @Override
+    protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode, int partitionBufferCapacity, double decodedBlockPageSizeFraction)
+    {
+        requireNonNull(decodedBlockNode, "decodedBlockNode is null");
+        decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
+
+        double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
+        if (decodedBlock.mayHaveNull()) {
+            setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
+            estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE);
+        }
+        else {
+            estimatedValueBufferMaxCapacity = (int) targetBufferSize;
+        }
+    }
+
+    @Override
     protected void accumulateSerializedRowSizes(int[] positionOffsets, int positionCount, int[] serializedRowSizes)
     {
         for (int i = 0; i < positionCount; i++) {
@@ -143,7 +162,7 @@ public class IntArrayBlockEncodingBuffer
 
     private void appendValuesToBuffer()
     {
-        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE, LARGE, PRESERVE, bufferAllocator);
+        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_INT_INDEX_SCALE, estimatedValueBufferMaxCapacity, LARGE, PRESERVE, bufferAllocator);
 
         int[] positions = getPositions();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.repartition;
 
 import com.facebook.presto.spi.block.ArrayAllocator;
+import com.facebook.presto.spi.block.Block;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
@@ -23,6 +24,7 @@ import static com.facebook.presto.array.Arrays.ExpansionOption.PRESERVE;
 import static com.facebook.presto.array.Arrays.ensureCapacity;
 import static com.facebook.presto.operator.UncheckedByteArrays.setLongUnchecked;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
 
 public class LongArrayBlockEncodingBuffer
@@ -36,6 +38,7 @@ public class LongArrayBlockEncodingBuffer
 
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
+    private int estimatedValueBufferMaxCapacity;
 
     public LongArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator, boolean isNested)
     {
@@ -120,6 +123,22 @@ public class LongArrayBlockEncodingBuffer
     }
 
     @Override
+    protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode, int partitionBufferCapacity, double decodedBlockPageSizeFraction)
+    {
+        requireNonNull(decodedBlockNode, "decodedBlockNode is null");
+        decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
+
+        double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
+        if (decodedBlock.mayHaveNull()) {
+            setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
+            estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Long.BYTES / POSITION_SIZE);
+        }
+        else {
+            estimatedValueBufferMaxCapacity = (int) targetBufferSize;
+        }
+    }
+
+    @Override
     protected void accumulateSerializedRowSizes(int[] positionOffsets, int positionCount, int[] serializedRowSizes)
     {
         for (int i = 0; i < positionCount; i++) {
@@ -129,7 +148,7 @@ public class LongArrayBlockEncodingBuffer
 
     private void appendValuesToBuffer()
     {
-        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_LONG_INDEX_SCALE, LARGE, PRESERVE, bufferAllocator);
+        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_LONG_INDEX_SCALE, estimatedValueBufferMaxCapacity, LARGE, PRESERVE, bufferAllocator);
 
         int[] positions = getPositions();
         if (decodedBlock.mayHaveNull()) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
@@ -84,14 +84,14 @@ public class MapBlockEncodingBuffer
     private ColumnarMap columnarMap;
 
     // The AbstractBlockEncodingBuffer for the nested key and value Block of the MapBlock
-    private final BlockEncodingBuffer keyBuffers;
-    private final BlockEncodingBuffer valueBuffers;
+    private final AbstractBlockEncodingBuffer keyBuffers;
+    private final AbstractBlockEncodingBuffer valueBuffers;
 
     public MapBlockEncodingBuffer(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator, boolean isNested)
     {
         super(bufferAllocator, isNested);
-        keyBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0), bufferAllocator, true);
-        valueBuffers = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(1), bufferAllocator, true);
+        keyBuffers = (AbstractBlockEncodingBuffer) createBlockEncodingBuffers(decodedBlockNode.getChildren().get(0), bufferAllocator, true);
+        valueBuffers = (AbstractBlockEncodingBuffer) createBlockEncodingBuffers(decodedBlockNode.getChildren().get(1), bufferAllocator, true);
     }
 
     @Override
@@ -104,10 +104,10 @@ public class MapBlockEncodingBuffer
         int[] offsetsCopy = ensureCapacity((int[]) null, positionCount + 1, SMALL, NONE, bufferAllocator);
         try {
             System.arraycopy(offsets, 0, offsetsCopy, 0, positionCount + 1);
-            ((AbstractBlockEncodingBuffer) keyBuffers).accumulateSerializedRowSizes(offsetsCopy, positionCount, serializedRowSizes);
+            keyBuffers.accumulateSerializedRowSizes(offsetsCopy, positionCount, serializedRowSizes);
 
             System.arraycopy(offsets, 0, offsetsCopy, 0, positionCount + 1);
-            ((AbstractBlockEncodingBuffer) valueBuffers).accumulateSerializedRowSizes(offsetsCopy, positionCount, serializedRowSizes);
+            valueBuffers.accumulateSerializedRowSizes(offsetsCopy, positionCount, serializedRowSizes);
         }
         finally {
             bufferAllocator.returnArray(offsetsCopy);
@@ -270,8 +270,8 @@ public class MapBlockEncodingBuffer
 
         populateNestedPositions();
 
-        ((AbstractBlockEncodingBuffer) keyBuffers).setupDecodedBlockAndMapPositions(decodedBlockNode.getChildren().get(0));
-        ((AbstractBlockEncodingBuffer) valueBuffers).setupDecodedBlockAndMapPositions(decodedBlockNode.getChildren().get(1));
+        keyBuffers.setupDecodedBlockAndMapPositions(decodedBlockNode.getChildren().get(0));
+        valueBuffers.setupDecodedBlockAndMapPositions(decodedBlockNode.getChildren().get(1));
     }
 
     @Override
@@ -296,8 +296,8 @@ public class MapBlockEncodingBuffer
         try {
             System.arraycopy(positionOffsets, 0, offsetsCopy, 0, positionCount + 1);
 
-            ((AbstractBlockEncodingBuffer) keyBuffers).accumulateSerializedRowSizes(positionOffsets, positionCount, serializedRowSizes);
-            ((AbstractBlockEncodingBuffer) valueBuffers).accumulateSerializedRowSizes(offsetsCopy, positionCount, serializedRowSizes);
+            keyBuffers.accumulateSerializedRowSizes(positionOffsets, positionCount, serializedRowSizes);
+            valueBuffers.accumulateSerializedRowSizes(offsetsCopy, positionCount, serializedRowSizes);
         }
         finally {
             bufferAllocator.returnArray(offsetsCopy);
@@ -307,8 +307,8 @@ public class MapBlockEncodingBuffer
     private void populateNestedPositions()
     {
         // Reset nested level positions before checking positionCount. Failing to do so may result in elementsBuffers having stale values when positionCount is 0.
-        ((AbstractBlockEncodingBuffer) keyBuffers).resetPositions();
-        ((AbstractBlockEncodingBuffer) valueBuffers).resetPositions();
+        keyBuffers.resetPositions();
+        valueBuffers.resetPositions();
 
         if (positionCount == 0) {
             return;
@@ -328,8 +328,8 @@ public class MapBlockEncodingBuffer
             offsets[i + 1] = offsets[i] + currentRowSize;
 
             if (currentRowSize > 0) {
-                ((AbstractBlockEncodingBuffer) keyBuffers).appendPositionRange(beginOffset, currentRowSize);
-                ((AbstractBlockEncodingBuffer) valueBuffers).appendPositionRange(beginOffset, currentRowSize);
+                keyBuffers.appendPositionRange(beginOffset, currentRowSize);
+                valueBuffers.appendPositionRange(beginOffset, currentRowSize);
             }
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
@@ -412,12 +412,12 @@ public class OptimizedPartitionedOutputOperator
 
             int partitionCount = partitionFunction.getPartitionCount();
 
-            int pageSize = max(1, min(DEFAULT_MAX_PAGE_SIZE_IN_BYTES, toIntExact(maxMemory.toBytes()) / partitionCount));
+            int partitionBufferCapacity = max(1, min(DEFAULT_MAX_PAGE_SIZE_IN_BYTES, toIntExact(maxMemory.toBytes()) / partitionCount));
             bufferAllocator = new SimpleArrayAllocator(maxBufferCount);
 
             partitionBuffers = new PartitionBuffer[partitionCount];
             for (int i = 0; i < partitionCount; i++) {
-                partitionBuffers[i] = new PartitionBuffer(i, sourceTypes.size(), pageSize, pagesAdded, rowsAdded, serde, lifespan, bufferAllocator);
+                partitionBuffers[i] = new PartitionBuffer(i, sourceTypes.size(), partitionBufferCapacity, pagesAdded, rowsAdded, serde, lifespan, bufferAllocator);
             }
 
             this.sourceTypes = sourceTypes;

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
@@ -68,7 +68,7 @@ public class RowBlockEncodingBuffer
     private int lastOffset;
 
     // The AbstractBlockEncodingBuffer for the nested field blocks of the RowBlock
-    private final BlockEncodingBuffer[] fieldBuffers;
+    private final AbstractBlockEncodingBuffer[] fieldBuffers;
 
     public RowBlockEncodingBuffer(DecodedBlockNode decodedBlockNode, ArrayAllocator bufferAllocator, boolean isNested)
     {
@@ -77,7 +77,7 @@ public class RowBlockEncodingBuffer
         List<DecodedBlockNode> childrenNodes = decodedBlockNode.getChildren();
         fieldBuffers = new AbstractBlockEncodingBuffer[childrenNodes.size()];
         for (int i = 0; i < childrenNodes.size(); i++) {
-            fieldBuffers[i] = createBlockEncodingBuffers(decodedBlockNode.getChildren().get(i), bufferAllocator, true);
+            fieldBuffers[i] = (AbstractBlockEncodingBuffer) createBlockEncodingBuffers(decodedBlockNode.getChildren().get(i), bufferAllocator, true);
         }
     }
 
@@ -247,7 +247,7 @@ public class RowBlockEncodingBuffer
         populateNestedPositions(columnarRow);
 
         for (int i = 0; i < fieldBuffers.length; i++) {
-            ((AbstractBlockEncodingBuffer) fieldBuffers[i]).setupDecodedBlockAndMapPositions(decodedBlockNode.getChildren().get(i));
+            fieldBuffers[i].setupDecodedBlockAndMapPositions(decodedBlockNode.getChildren().get(i));
         }
     }
 
@@ -272,7 +272,7 @@ public class RowBlockEncodingBuffer
         try {
             for (int i = 0; i < fieldBuffers.length; i++) {
                 System.arraycopy(positionOffsets, 0, offsetsCopy, 0, positionCount + 1);
-                ((AbstractBlockEncodingBuffer) fieldBuffers[i]).accumulateSerializedRowSizes(offsetsCopy, positionCount, serializedRowSizes);
+                fieldBuffers[i].accumulateSerializedRowSizes(offsetsCopy, positionCount, serializedRowSizes);
             }
         }
         finally {
@@ -284,7 +284,7 @@ public class RowBlockEncodingBuffer
     {
         // Reset nested level positions before checking positionCount. Failing to do so may result in elementsBuffers having stale values when positionCount is 0.
         for (int i = 0; i < fieldBuffers.length; i++) {
-            ((AbstractBlockEncodingBuffer) fieldBuffers[i]).resetPositions();
+            fieldBuffers[i].resetPositions();
         }
 
         if (positionCount == 0) {
@@ -306,7 +306,7 @@ public class RowBlockEncodingBuffer
 
             if (currentRowSize > 0) {
                 for (int j = 0; j < fieldBuffers.length; j++) {
-                    ((AbstractBlockEncodingBuffer) fieldBuffers[j]).appendPositionRange(beginOffset - columnarRowBaseOffset, currentRowSize);
+                    fieldBuffers[j].appendPositionRange(beginOffset - columnarRowBaseOffset, currentRowSize);
                 }
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
@@ -28,6 +28,7 @@
 package com.facebook.presto.operator.repartition;
 
 import com.facebook.presto.spi.block.ArrayAllocator;
+import com.facebook.presto.spi.block.Block;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
@@ -37,6 +38,7 @@ import static com.facebook.presto.array.Arrays.ExpansionOption.PRESERVE;
 import static com.facebook.presto.array.Arrays.ensureCapacity;
 import static com.facebook.presto.operator.UncheckedByteArrays.setShortUnchecked;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_SHORT_INDEX_SCALE;
 
 public class ShortArrayBlockEncodingBuffer
@@ -50,6 +52,7 @@ public class ShortArrayBlockEncodingBuffer
 
     private byte[] valuesBuffer;
     private int valuesBufferIndex;
+    private int estimatedValueBufferMaxCapacity;
 
     public ShortArrayBlockEncodingBuffer(ArrayAllocator bufferAllocator, boolean isNested)
     {
@@ -134,6 +137,22 @@ public class ShortArrayBlockEncodingBuffer
     }
 
     @Override
+    protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode, int partitionBufferCapacity, double decodedBlockPageSizeFraction)
+    {
+        requireNonNull(decodedBlockNode, "decodedBlockNode is null");
+        decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
+
+        double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
+        if (decodedBlock.mayHaveNull()) {
+            setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
+            estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Byte.BYTES / POSITION_SIZE);
+        }
+        else {
+            estimatedValueBufferMaxCapacity = (int) targetBufferSize;
+        }
+    }
+
+    @Override
     protected void accumulateSerializedRowSizes(int[] positionOffsets, int positionCount, int[] serializedRowSizes)
     {
         for (int i = 0; i < positionCount; i++) {
@@ -143,7 +162,7 @@ public class ShortArrayBlockEncodingBuffer
 
     private void appendValuesToBuffer()
     {
-        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_SHORT_INDEX_SCALE, LARGE, PRESERVE, bufferAllocator);
+        valuesBuffer = ensureCapacity(valuesBuffer, valuesBufferIndex + batchSize * ARRAY_SHORT_INDEX_SCALE, estimatedValueBufferMaxCapacity, LARGE, PRESERVE, bufferAllocator);
 
         int[] positions = getPositions();
         if (decodedBlock.mayHaveNull()) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
@@ -355,7 +355,7 @@ public class TestBlockEncodingBuffers
 
     private static void copyPositions(DecodedBlockNode decodedBlock, BlockEncodingBuffer buffer, int[] positions, int[] expectedRowSizes)
     {
-        buffer.setupDecodedBlocksAndPositions(decodedBlock, positions, positions.length);
+        buffer.setupDecodedBlocksAndPositions(decodedBlock, positions, positions.length, (int) decodedBlock.getRetainedSizeInBytes(), decodedBlock.getEstimatedSerializedSizeInBytes());
 
         ((AbstractBlockEncodingBuffer) buffer).checkValidPositions();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarRow.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarRow.java
@@ -59,10 +59,9 @@ public final class ColumnarRow
     {
         // build a mapping from the old dictionary to a new dictionary with nulls removed
         Block dictionary = dictionaryBlock.getDictionary();
-        int positionCount = dictionary.getPositionCount();
-        int[] newDictionaryIndex = new int[positionCount];
+        int[] newDictionaryIndex = new int[dictionary.getPositionCount()];
         int nextNewDictionaryIndex = 0;
-        for (int position = 0; position < positionCount; position++) {
+        for (int position = 0; position < dictionary.getPositionCount(); position++) {
             if (!dictionary.isNull(position)) {
                 newDictionaryIndex[position] = nextNewDictionaryIndex;
                 nextNewDictionaryIndex++;
@@ -70,6 +69,7 @@ public final class ColumnarRow
         }
 
         // reindex the dictionary
+        int positionCount = dictionaryBlock.getPositionCount();
         int[] dictionaryIds = new int[positionCount];
         int nonNullPositionCount = 0;
         for (int position = 0; position < positionCount; position++) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarRow.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarRow.java
@@ -25,6 +25,7 @@ public final class ColumnarRow
     private final Block nullCheckBlock;
     private final Block[] fields;
     private final long retainedSizeInBytes;
+    private final long estimatedSerializedSizeInBytes;
 
     public static ColumnarRow toColumnarRow(Block block)
     {
@@ -51,16 +52,17 @@ public final class ColumnarRow
             fieldBlocks[i] = rowBlock.getRawFieldBlocks()[i].getRegion(firstRowPosition, totalRowCount);
         }
 
-        return new ColumnarRow(block, fieldBlocks, block.getRetainedSizeInBytes());
+        return new ColumnarRow(block, fieldBlocks, block.getRetainedSizeInBytes(), block.getSizeInBytes());
     }
 
     private static ColumnarRow toColumnarRow(DictionaryBlock dictionaryBlock)
     {
         // build a mapping from the old dictionary to a new dictionary with nulls removed
         Block dictionary = dictionaryBlock.getDictionary();
-        int[] newDictionaryIndex = new int[dictionary.getPositionCount()];
+        int positionCount = dictionary.getPositionCount();
+        int[] newDictionaryIndex = new int[positionCount];
         int nextNewDictionaryIndex = 0;
-        for (int position = 0; position < dictionary.getPositionCount(); position++) {
+        for (int position = 0; position < positionCount; position++) {
             if (!dictionary.isNull(position)) {
                 newDictionaryIndex[position] = nextNewDictionaryIndex;
                 nextNewDictionaryIndex++;
@@ -68,9 +70,9 @@ public final class ColumnarRow
         }
 
         // reindex the dictionary
-        int[] dictionaryIds = new int[dictionaryBlock.getPositionCount()];
+        int[] dictionaryIds = new int[positionCount];
         int nonNullPositionCount = 0;
-        for (int position = 0; position < dictionaryBlock.getPositionCount(); position++) {
+        for (int position = 0; position < positionCount; position++) {
             if (!dictionaryBlock.isNull(position)) {
                 int oldDictionaryId = dictionaryBlock.getId(position);
                 dictionaryIds[nonNullPositionCount] = newDictionaryIndex[oldDictionaryId];
@@ -78,20 +80,34 @@ public final class ColumnarRow
             }
         }
 
-        ColumnarRow columnarRow = toColumnarRow(dictionaryBlock.getDictionary());
+        ColumnarRow columnarRow = toColumnarRow(dictionary);
         Block[] fields = new Block[columnarRow.getFieldCount()];
+        long averageRowSize = 0;
         for (int i = 0; i < columnarRow.getFieldCount(); i++) {
-            fields[i] = new DictionaryBlock(nonNullPositionCount, columnarRow.getField(i), dictionaryIds);
+            Block field = columnarRow.getField(i);
+            fields[i] = new DictionaryBlock(nonNullPositionCount, field, dictionaryIds);
+            averageRowSize += field.getSizeInBytes() / field.getPositionCount();
         }
-        return new ColumnarRow(dictionaryBlock, fields, INSTANCE_SIZE + dictionaryBlock.getRetainedSizeInBytes() + sizeOf(dictionaryIds));
+        return new ColumnarRow(
+                dictionaryBlock,
+                fields,
+                INSTANCE_SIZE + dictionaryBlock.getRetainedSizeInBytes() + sizeOf(dictionaryIds),
+                // The estimated serialized size is the sum of the following:
+                // 1) the offsets size: Integer.BYTES * positionCount. Note that even though ColumnarRow doesn't have the offsets array, the serialized RowBlock still has it. Please see RowBlockEncodingBuffer.
+                // 2) nulls array size: Byte.BYTES * positionCount
+                // 3) the estimated serialized size for the fields Blocks which were just constructed as new DictionaryBlocks:
+                //     the average row size: averageRowSize * the number of rows: nonNullPositionCount
+                (Integer.BYTES + Byte.BYTES) * positionCount + averageRowSize * nonNullPositionCount);
     }
 
     private static ColumnarRow toColumnarRow(RunLengthEncodedBlock rleBlock)
     {
         Block rleValue = rleBlock.getValue();
+        int positionCount = rleBlock.getPositionCount();
         ColumnarRow columnarRow = toColumnarRow(rleValue);
 
         Block[] fields = new Block[columnarRow.getFieldCount()];
+        long averageRowSize = 0;
         for (int i = 0; i < columnarRow.getFieldCount(); i++) {
             Block nullSuppressedField = columnarRow.getField(i);
             if (rleValue.isNull(0)) {
@@ -102,17 +118,28 @@ public final class ColumnarRow
                 fields[i] = nullSuppressedField;
             }
             else {
-                fields[i] = new RunLengthEncodedBlock(nullSuppressedField, rleBlock.getPositionCount());
+                fields[i] = new RunLengthEncodedBlock(nullSuppressedField, positionCount);
+                averageRowSize += nullSuppressedField.getSizeInBytes() / nullSuppressedField.getPositionCount();
             }
         }
-        return new ColumnarRow(rleBlock, fields, INSTANCE_SIZE + rleBlock.getRetainedSizeInBytes());
+        return new ColumnarRow(
+                rleBlock,
+                fields,
+                INSTANCE_SIZE + rleBlock.getRetainedSizeInBytes(),
+                // The estimated serialized size is the sum of the following:
+                // 1) the offsets size: Integer.BYTES * positionCount. Note that even though ColumnarRow doesn't have the offsets array, the serialized RowBlock still has it. Please see RowBlockEncodingBuffer.
+                // 2) nulls array size: Byte.BYTES * positionCount
+                // 3) the estimated serialized size for the fields Blocks which were just constructed as new RunLengthEncodedBlocks:
+                //     the average row size: averageRowSize * the number of rows: positionCount
+                (Integer.BYTES + Byte.BYTES) * positionCount + averageRowSize * positionCount);
     }
 
-    private ColumnarRow(Block nullCheckBlock, Block[] fields, long retainedSizeInBytes)
+    private ColumnarRow(Block nullCheckBlock, Block[] fields, long retainedSizeInBytes, long estimatedSerializedSizeInBytes)
     {
         this.nullCheckBlock = nullCheckBlock;
         this.fields = fields.clone();
         this.retainedSizeInBytes = retainedSizeInBytes;
+        this.estimatedSerializedSizeInBytes = estimatedSerializedSizeInBytes;
     }
 
     public int getPositionCount()
@@ -155,6 +182,11 @@ public final class ColumnarRow
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    public long getEstimatedSerializedSizeInBytes()
+    {
+        return estimatedSerializedSizeInBytes;
     }
 
     @Override


### PR DESCRIPTION
Partially resolves #14162
Depend on https://github.com/prestodb/presto/pull/14286

The byte[] buffers in BlockEncodingBuffer used to be grown by a factor
of 2. This could cause the buffers larger than necessary. Reducing
the expansionFactor has negative impact on performance. Therefore we
want to enforce stricter limit when growing these buffers. This PR
uses incoming blocks' retained sizes as an estimation for how large the
buffers can grow. It shows 30% to 40% memory usage reduction for fixed
width types and 10% reduction for variable width types for the
OptimizedPartitionedOutputOperator.

```
== NO RELEASE NOTE ==
```
