### PR TITLE
Extract common subexpression in page projection at codegen

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
@@ -215,7 +215,7 @@ public abstract class AbstractOperatorBenchmark
             VariableReferenceExpression variable = new VariableReferenceExpression("h" + channel, types.get(channel));
             variables.add(variable);
             variableToInputMapping.put(variable, channel);
-            projections.add(new PageProjectionWithOutputs(new InputPageProjection(channel, types.get(channel)), new int[] {channel}));
+            projections.add(new PageProjectionWithOutputs(new InputPageProjection(channel), new int[] {channel}));
         }
 
         Optional<RowExpression> hashExpression = HashGenerationOptimizer.getHashExpression(localQueryRunner.getMetadata().getFunctionManager(), variables.build());

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
@@ -72,7 +72,12 @@ public class HandTpchQuery6
         //    and quantity < 24;
         OperatorFactory tableScanOperator = createTableScanOperator(0, new PlanNodeId("test"), "lineitem", "extendedprice", "discount", "shipdate", "quantity");
 
-        List<Supplier<PageProjectionWithOutputs>> projection = new PageFunctionCompiler(localQueryRunner.getMetadata(), 0).compileProjections(session.getSqlFunctionProperties(), ImmutableList.of(field(0, BIGINT)), Optional.empty());
+        List<Supplier<PageProjectionWithOutputs>> projection = new PageFunctionCompiler(localQueryRunner.getMetadata(), 0)
+                .compileProjections(
+                        session.getSqlFunctionProperties(),
+                        ImmutableList.of(field(0, BIGINT)),
+                        false,
+                        Optional.empty());
 
         FilterAndProjectOperator.FilterAndProjectOperatorFactory tpchQuery6Operator = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
                 1,

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery6.java
@@ -22,6 +22,7 @@ import com.facebook.presto.operator.project.InputChannels;
 import com.facebook.presto.operator.project.PageFilter;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.operator.project.PageProjection;
+import com.facebook.presto.operator.project.PageProjectionWithOutputs;
 import com.facebook.presto.operator.project.SelectedPositions;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
@@ -76,7 +77,7 @@ public class HandTpchQuery6
         FilterAndProjectOperator.FilterAndProjectOperatorFactory tpchQuery6Operator = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
                 1,
                 new PlanNodeId("test"),
-                () -> new PageProcessor(Optional.of(new TpchQuery6Filter()), ImmutableList.of(projection.get())),
+                () -> new PageProcessor(Optional.of(new TpchQuery6Filter()), ImmutableList.of(new PageProjectionWithOutputs(projection.get(), new int[] {0}))),
                 ImmutableList.of(DOUBLE),
                 new DataSize(0, BYTE),
                 0);

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -149,6 +149,7 @@ public final class SystemSessionProperties
     public static final String PARTITIONING_PRECISION_STRATEGY = "partitioning_precision_strategy";
     public static final String EXPERIMENTAL_FUNCTIONS_ENABLED = "experimental_functions_enabled";
     public static final String USE_LEGACY_SCHEDULER = "use_legacy_scheduler";
+    public static final String OPTIMIZE_COMMON_SUB_EXPRESSIONS = "optimize_common_sub_expressions";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -752,11 +753,15 @@ public final class SystemSessionProperties
                         "Enable listing of functions marked as experimental",
                         featuresConfig.isExperimentalFunctionsEnabled(),
                         false),
-
                 booleanProperty(
                         USE_LEGACY_SCHEDULER,
                         "Use version of scheduler before refactorings for section retries",
                         featuresConfig.isUseLegacyScheduler(),
+                        false),
+                booleanProperty(
+                        OPTIMIZE_COMMON_SUB_EXPRESSIONS,
+                        "Extract and compute common sub-expressions in projection",
+                        featuresConfig.isOptimizeCommonSubExpressions(),
                         false));
     }
 
@@ -1282,5 +1287,10 @@ public final class SystemSessionProperties
     public static boolean isUseLegacyScheduler(Session session)
     {
         return session.getSystemProperty(USE_LEGACY_SCHEDULER, Boolean.class);
+    }
+
+    public static boolean isOptimizeCommonSubExpressions(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZE_COMMON_SUB_EXPRESSIONS, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/DynamicTupleFilterFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/DynamicTupleFilterFactory.java
@@ -85,6 +85,7 @@ public class DynamicTupleFilterFactory
                 IntStream.range(0, outputTypes.size())
                         .mapToObj(field -> Expressions.field(field, outputTypes.get(field)))
                         .collect(toImmutableList()),
+                false,
                 Optional.empty());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/DynamicTupleFilterFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/DynamicTupleFilterFactory.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.index;
 import com.facebook.presto.operator.OperatorFactory;
 import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.operator.project.PageProjection;
+import com.facebook.presto.operator.project.PageProjectionWithOutputs;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.SqlFunctionProperties;
@@ -98,8 +99,8 @@ public class DynamicTupleFilterFactory
         TuplePageFilter filter = new TuplePageFilter(filterTuple, filterTypes, outputFilterChannels);
         return () -> new PageProcessor(
                 Optional.of(filter),
-                outputProjections.stream()
-                        .map(Supplier::get)
+                IntStream.range(0, outputProjections.size())
+                        .mapToObj(index -> new PageProjectionWithOutputs(outputProjections.get(index).get(), new int[] {index}))
                         .collect(toImmutableList()), initialBatchSize);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/ConstantPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/ConstantPageProjection.java
@@ -33,21 +33,13 @@ public class ConstantPageProjection
 {
     private static final InputChannels INPUT_PARAMETERS = new InputChannels(ImmutableList.of());
 
-    private final Type type;
     private final Block value;
 
     public ConstantPageProjection(Object value, Type type)
     {
-        this.type = type;
         BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);
         writeNativeValue(type, blockBuilder, value);
         this.value = blockBuilder.build();
-    }
-
-    @Override
-    public Type getType()
-    {
-        return type;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/ConstantPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/ConstantPageProjection.java
@@ -24,6 +24,8 @@ import com.facebook.presto.spi.function.SqlFunctionProperties;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 
+import java.util.List;
+
 import static com.facebook.presto.spi.type.TypeUtils.writeNativeValue;
 
 public class ConstantPageProjection
@@ -61,8 +63,8 @@ public class ConstantPageProjection
     }
 
     @Override
-    public Work<Block> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+    public Work<List<Block>> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
     {
-        return new CompletedWork<>(new RunLengthEncodedBlock(value, selectedPositions.size()));
+        return new CompletedWork<>(ImmutableList.of(new RunLengthEncodedBlock(value, selectedPositions.size())));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/DictionaryAwarePageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/DictionaryAwarePageProjection.java
@@ -22,7 +22,6 @@ import com.facebook.presto.spi.block.DictionaryBlock;
 import com.facebook.presto.spi.block.DictionaryId;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.function.SqlFunctionProperties;
-import com.facebook.presto.spi.type.Type;
 
 import javax.annotation.Nullable;
 
@@ -51,12 +50,6 @@ public class DictionaryAwarePageProjection
         this.sourceIdFunction = sourceIdFunction;
         verify(projection.isDeterministic(), "projection must be deterministic");
         verify(projection.getInputChannels().size() == 1, "projection must have only one input");
-    }
-
-    @Override
-    public Type getType()
-    {
-        return projection.getType();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.SqlFunctionProperties;
 import com.facebook.presto.spi.relation.RowExpression;
-import com.facebook.presto.spi.type.Type;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
@@ -45,12 +44,6 @@ public class GeneratedPageProjection
         this.inputChannels = requireNonNull(inputChannels, "inputChannels is null");
         this.pageProjectionWorkFactory = requireNonNull(pageProjectionWorkFactory, "pageProjectionWorkFactory is null");
         this.blockBuilder = projection.getType().createBlockBuilder(null, 1);
-    }
-
-    @Override
-    public Type getType()
-    {
-        return projection.getType();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.type.Type;
 
 import java.lang.invoke.MethodHandle;
+import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -65,11 +66,11 @@ public class GeneratedPageProjection
     }
 
     @Override
-    public Work<Block> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+    public Work<List<Block>> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
     {
         blockBuilder = blockBuilder.newBlockBuilderLike(null);
         try {
-            return (Work<Block>) pageProjectionWorkFactory.invoke(blockBuilder, properties, page, selectedPositions);
+            return (Work<List<Block>>) pageProjectionWorkFactory.invoke(blockBuilder, properties, page, selectedPositions);
         }
         catch (Throwable e) {
             throw new RuntimeException(e);

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
@@ -20,30 +20,32 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.SqlFunctionProperties;
 import com.facebook.presto.spi.relation.RowExpression;
+import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public class GeneratedPageProjection
         implements PageProjection
 {
-    private final RowExpression projection;
+    private final List<RowExpression> projections;
     private final boolean isDeterministic;
     private final InputChannels inputChannels;
     private final MethodHandle pageProjectionWorkFactory;
 
-    private BlockBuilder blockBuilder;
+    private List<BlockBuilder> blockBuilders;
 
-    public GeneratedPageProjection(RowExpression projection, boolean isDeterministic, InputChannels inputChannels, MethodHandle pageProjectionWorkFactory)
+    public GeneratedPageProjection(List<RowExpression> projections, boolean isDeterministic, InputChannels inputChannels, MethodHandle pageProjectionWorkFactory)
     {
-        this.projection = requireNonNull(projection, "projection is null");
+        this.projections = ImmutableList.copyOf(requireNonNull(projections, "projections is null"));
         this.isDeterministic = isDeterministic;
         this.inputChannels = requireNonNull(inputChannels, "inputChannels is null");
         this.pageProjectionWorkFactory = requireNonNull(pageProjectionWorkFactory, "pageProjectionWorkFactory is null");
-        this.blockBuilder = projection.getType().createBlockBuilder(null, 1);
+        this.blockBuilders = projections.stream().map(RowExpression::getType).map(type -> type.createBlockBuilder(null, 1)).collect(toImmutableList());
     }
 
     @Override
@@ -61,9 +63,9 @@ public class GeneratedPageProjection
     @Override
     public Work<List<Block>> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
     {
-        blockBuilder = blockBuilder.newBlockBuilderLike(null);
+        blockBuilders = blockBuilders.stream().map(blockBuilder -> blockBuilder.newBlockBuilderLike(null)).collect(toImmutableList());
         try {
-            return (Work<List<Block>>) pageProjectionWorkFactory.invoke(blockBuilder, properties, page, selectedPositions);
+            return (Work<List<Block>>) pageProjectionWorkFactory.invoke(blockBuilders, properties, page, selectedPositions);
         }
         catch (Throwable e) {
             throw new RuntimeException(e);
@@ -74,7 +76,7 @@ public class GeneratedPageProjection
     public String toString()
     {
         return toStringHelper(this)
-                .add("projection", projection)
+                .add("projections", projections)
                 .toString();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/InputPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/InputPageProjection.java
@@ -19,7 +19,6 @@ import com.facebook.presto.operator.Work;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.SqlFunctionProperties;
-import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -29,19 +28,11 @@ import static java.util.Objects.requireNonNull;
 public class InputPageProjection
         implements PageProjection
 {
-    private final Type type;
     private final InputChannels inputChannels;
 
-    public InputPageProjection(int inputChannel, Type type)
+    public InputPageProjection(int inputChannel)
     {
-        this.type = type;
         this.inputChannels = new InputChannels(inputChannel);
-    }
-
-    @Override
-    public Type getType()
-    {
-        return type;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/InputPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/InputPageProjection.java
@@ -20,6 +20,9 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.SqlFunctionProperties;
 import com.facebook.presto.spi.type.Type;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -54,7 +57,7 @@ public class InputPageProjection
     }
 
     @Override
-    public Work<Block> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+    public Work<List<Block>> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
     {
         Block block = requireNonNull(page, "page is null").getBlock(0);
         requireNonNull(selectedPositions, "selectedPositions is null");
@@ -69,6 +72,6 @@ public class InputPageProjection
         else {
             result = block.getRegion(selectedPositions.getOffset(), selectedPositions.size());
         }
-        return new CompletedWork<>(result);
+        return new CompletedWork<>(ImmutableList.of(result));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
@@ -79,8 +79,9 @@ public class PageProcessor
     {
         List<Integer> outputChannels = projections.stream().map(PageProjectionWithOutputs::getOutputChannels).map(Arrays::stream).map(IntStream::boxed).flatMap(identity()).distinct().collect(toImmutableList());
         int outputCount = projections.stream().map(PageProjectionWithOutputs::getOutputCount).reduce(Integer::sum).orElse(0);
-        verify(outputChannels.size() == outputCount, format("outputChannels size: %d (%s), outputCount %d, projections: %s", outputChannels.size(), outputChannels, outputCount, projections));
-        verify(outputCount == 0 || outputChannels.stream().max(Integer::compareTo).orElse(0) == outputChannels.size() - 1, format("outputCount: %d, outputChannels: %s", outputCount, outputChannels));
+        verify(
+                outputChannels.size() == outputCount && (outputCount == 0 || outputChannels.stream().max(Integer::compareTo).orElse(0) == outputChannels.size() - 1),
+                format("Invalid outputChannels: outputCount: %d, outputChannels: %s", outputCount, outputChannels));
 
         this.filter = requireNonNull(filter, "filter is null")
                 .map(pageFilter -> {

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
@@ -31,6 +31,7 @@ import io.airlift.slice.SizeOf;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -38,6 +39,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.operator.WorkProcessor.ProcessState.finished;
 import static com.facebook.presto.operator.WorkProcessor.ProcessState.ofResult;
@@ -47,7 +49,9 @@ import static com.facebook.presto.spi.block.DictionaryId.randomDictionaryId;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 
 @NotThreadSafe
 public class PageProcessor
@@ -59,19 +63,25 @@ public class PageProcessor
     private final ExpressionProfiler expressionProfiler;
     private final DictionarySourceIdFunction dictionarySourceIdFunction = new DictionarySourceIdFunction();
     private final Optional<PageFilter> filter;
-    private final List<PageProjection> projections;
+    private final List<PageProjectionWithOutputs> projections;
+    private final int outputCount;
 
     private int projectBatchSize;
 
     @VisibleForTesting
-    public PageProcessor(Optional<PageFilter> filter, List<? extends PageProjection> projections, OptionalInt initialBatchSize)
+    public PageProcessor(Optional<PageFilter> filter, List<PageProjectionWithOutputs> projections, OptionalInt initialBatchSize)
     {
         this(filter, projections, initialBatchSize, new ExpressionProfiler());
     }
 
     @VisibleForTesting
-    public PageProcessor(Optional<PageFilter> filter, List<? extends PageProjection> projections, OptionalInt initialBatchSize, ExpressionProfiler expressionProfiler)
+    public PageProcessor(Optional<PageFilter> filter, List<PageProjectionWithOutputs> projections, OptionalInt initialBatchSize, ExpressionProfiler expressionProfiler)
     {
+        List<Integer> outputChannels = projections.stream().map(PageProjectionWithOutputs::getOutputChannels).map(Arrays::stream).map(IntStream::boxed).flatMap(identity()).distinct().collect(toImmutableList());
+        int outputCount = projections.stream().map(PageProjectionWithOutputs::getOutputCount).reduce(Integer::sum).orElse(0);
+        verify(outputChannels.size() == outputCount, format("outputChannels size: %d (%s), outputCount %d, projections: %s", outputChannels.size(), outputChannels, outputCount, projections));
+        verify(outputCount == 0 || outputChannels.stream().max(Integer::compareTo).orElse(0) == outputChannels.size() - 1, format("outputCount: %d, outputChannels: %s", outputCount, outputChannels));
+
         this.filter = requireNonNull(filter, "filter is null")
                 .map(pageFilter -> {
                     if (pageFilter.getInputChannels().size() == 1 && pageFilter.isDeterministic()) {
@@ -79,20 +89,22 @@ public class PageProcessor
                     }
                     return pageFilter;
                 });
+        this.outputCount = outputCount;
         this.projections = requireNonNull(projections, "projections is null").stream()
-                .map(projection -> {
+                .map(projectionWithOutputs -> {
+                    PageProjection projection = projectionWithOutputs.getPageProjection();
                     if (projection.getInputChannels().size() == 1 && projection.isDeterministic()
                             && !(projection instanceof InputPageProjection)) {
-                        return new DictionaryAwarePageProjection(projection, dictionarySourceIdFunction);
+                        return new PageProjectionWithOutputs(new DictionaryAwarePageProjection(projection, dictionarySourceIdFunction), projectionWithOutputs.getOutputChannels());
                     }
-                    return projection;
+                    return projectionWithOutputs;
                 })
                 .collect(toImmutableList());
         this.projectBatchSize = initialBatchSize.orElse(1);
         this.expressionProfiler = requireNonNull(expressionProfiler, "expressionProfiler is null");
     }
 
-    public PageProcessor(Optional<PageFilter> filter, List<? extends PageProjection> projections)
+    public PageProcessor(Optional<PageFilter> filter, List<PageProjectionWithOutputs> projections)
     {
         this(filter, projections, OptionalInt.of(1));
     }
@@ -146,7 +158,7 @@ public class PageProcessor
         // remember if we need to re-use the same batch size if we yield last time
         private boolean lastComputeYielded;
         private int lastComputeBatchSize;
-        private Work<Block> pageProjectWork;
+        private Work<List<Block>> pageProjectWork;
 
         private ProjectSelectedPositions(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, LocalMemoryContext memoryContext, Page page, SelectedPositions selectedPositions)
         {
@@ -157,7 +169,7 @@ public class PageProcessor
             this.page = page;
             this.memoryContext = memoryContext;
             this.selectedPositions = selectedPositions;
-            this.previouslyComputedResults = new Block[projections.size()];
+            this.previouslyComputedResults = new Block[outputCount];
         }
 
         @Override
@@ -269,11 +281,11 @@ public class PageProcessor
 
         private ProcessBatchResult processBatch(int batchSize)
         {
-            Block[] blocks = new Block[projections.size()];
+            Block[] blocks = new Block[outputCount];
 
             int pageSize = 0;
             SelectedPositions positionsBatch = selectedPositions.subRange(0, batchSize);
-            for (int i = 0; i < projections.size(); i++) {
+            for (PageProjectionWithOutputs projection : projections) {
                 if (yieldSignal.isSet()) {
                     return ProcessBatchResult.processBatchYield();
                 }
@@ -283,32 +295,39 @@ public class PageProcessor
                 }
 
                 // if possible, use previouslyComputedResults produced in prior optimistic failure attempt
-                PageProjection projection = projections.get(i);
-                if (previouslyComputedResults[i] != null && previouslyComputedResults[i].getPositionCount() >= batchSize) {
-                    blocks[i] = previouslyComputedResults[i].getRegion(0, batchSize);
+                int[] outputChannels = projection.getOutputChannels();
+                // The progress on all output channels of a projection should be the same, so we just use the first one.
+                if (previouslyComputedResults[outputChannels[0]] != null && previouslyComputedResults[outputChannels[0]].getPositionCount() >= batchSize) {
+                    for (int channel : outputChannels) {
+                        blocks[channel] = previouslyComputedResults[channel].getRegion(0, batchSize);
+                        pageSize += blocks[channel].getSizeInBytes();
+                    }
                 }
                 else {
                     if (pageProjectWork == null) {
                         expressionProfiler.start();
-                        pageProjectWork = projection.project(properties, yieldSignal, projection.getInputChannels().getInputChannels(page), positionsBatch);
+                        pageProjectWork = projection.project(properties, yieldSignal, projection.getPageProjection().getInputChannels().getInputChannels(page), positionsBatch);
                         expressionProfiler.stop(positionsBatch.size());
                     }
                     if (!pageProjectWork.process()) {
                         return ProcessBatchResult.processBatchYield();
                     }
-                    previouslyComputedResults[i] = pageProjectWork.getResult();
+                    List<Block> projectionOutputs = pageProjectWork.getResult();
+                    for (int j = 0; j < outputChannels.length; j++) {
+                        int channel = outputChannels[j];
+                        previouslyComputedResults[channel] = projectionOutputs.get(j);
+                        blocks[channel] = previouslyComputedResults[channel];
+                        pageSize += blocks[channel].getSizeInBytes();
+                    }
                     pageProjectWork = null;
-                    blocks[i] = previouslyComputedResults[i];
                 }
-
-                pageSize += blocks[i].getSizeInBytes();
             }
             return ProcessBatchResult.processBatchSuccess(new Page(positionsBatch.size(), blocks));
         }
     }
 
     @VisibleForTesting
-    public List<PageProjection> getProjections()
+    public List<PageProjectionWithOutputs> getProjections()
     {
         return projections;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProjection.java
@@ -20,6 +20,8 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.SqlFunctionProperties;
 import com.facebook.presto.spi.type.Type;
 
+import java.util.List;
+
 public interface PageProjection
 {
     Type getType();
@@ -28,5 +30,5 @@ public interface PageProjection
 
     InputChannels getInputChannels();
 
-    Work<Block> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions);
+    Work<List<Block>> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProjection.java
@@ -18,14 +18,11 @@ import com.facebook.presto.operator.Work;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.function.SqlFunctionProperties;
-import com.facebook.presto.spi.type.Type;
 
 import java.util.List;
 
 public interface PageProjection
 {
-    Type getType();
-
     boolean isDeterministic();
 
     InputChannels getInputChannels();

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProjectionWithOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProjectionWithOutputs.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.project;
+
+import com.facebook.presto.operator.DriverYieldSignal;
+import com.facebook.presto.operator.Work;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.function.SqlFunctionProperties;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class PageProjectionWithOutputs
+{
+    private final PageProjection pageProjection;
+    private final int[] outputChannels;
+
+    public PageProjectionWithOutputs(PageProjection pageProjection, int[] outputChannels)
+    {
+        this.pageProjection = requireNonNull(pageProjection, "pageProjection is null");
+        this.outputChannels = Arrays.copyOf(requireNonNull(outputChannels, "outputChannels is null"), outputChannels.length);
+    }
+
+    public PageProjection getPageProjection()
+    {
+        return pageProjection;
+    }
+
+    public int getOutputCount()
+    {
+        return outputChannels.length;
+    }
+
+    int[] getOutputChannels()
+    {
+        return outputChannels;
+    }
+
+    Work<List<Block>> project(SqlFunctionProperties sqlFunctionProperties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+    {
+        return pageProjection.project(sqlFunctionProperties, yieldSignal, page, selectedPositions);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("pageProjection", pageProjection)
+                .add("outputChannels", outputChannels)
+                .toString();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -150,6 +150,7 @@ public class FeaturesConfig
     private boolean listBuiltInFunctionsOnly = true;
     private boolean experimentalFunctionsEnabled;
     private boolean useLegacyScheduler = true;
+    private boolean optimizeCommonSubExpressions = true;
 
     private PartitioningPrecisionStrategy partitioningPrecisionStrategy = PartitioningPrecisionStrategy.AUTOMATIC;
 
@@ -1221,6 +1222,19 @@ public class FeaturesConfig
     public FeaturesConfig setUseLegacyScheduler(boolean useLegacyScheduler)
     {
         this.useLegacyScheduler = useLegacyScheduler;
+        return this;
+    }
+
+    public boolean isOptimizeCommonSubExpressions()
+    {
+        return optimizeCommonSubExpressions;
+    }
+
+    @Config("optimize-common-sub-expressions")
+    @ConfigDescription("Extract and compute common sub expression in projections")
+    public FeaturesConfig setOptimizeCommonSubExpressions(boolean optimizeCommonSubExpressions)
+    {
+        this.optimizeCommonSubExpressions = optimizeCommonSubExpressions;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CommonSubExpressionRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CommonSubExpressionRewriter.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.gen;
+
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.PlanVariableAllocator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.WHEN;
+import static com.facebook.presto.sql.relational.Expressions.subExpressions;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.function.Function.identity;
+
+public class CommonSubExpressionRewriter
+{
+    private CommonSubExpressionRewriter() {}
+
+    public static Map<Integer, Map<RowExpression, VariableReferenceExpression>> collectCSEByLevel(List<? extends RowExpression> expressions)
+    {
+        if (expressions.isEmpty()) {
+            return ImmutableMap.of();
+        }
+
+        CommonSubExpressionCollector expressionCollector = new CommonSubExpressionCollector();
+        expressions.forEach(expression -> expression.accept(expressionCollector, null));
+        if (expressionCollector.cseByLevel.isEmpty()) {
+            return ImmutableMap.of();
+        }
+
+        Map<Integer, Map<RowExpression, Integer>> cseByLevel = removeRedundantCSE(expressionCollector.cseByLevel, expressionCollector.expressionCount);
+
+        PlanVariableAllocator variableAllocator = new PlanVariableAllocator();
+        ImmutableMap.Builder<Integer, Map<RowExpression, VariableReferenceExpression>> commonSubExpressions = ImmutableMap.builder();
+        Map<RowExpression, VariableReferenceExpression> rewriteWith = new HashMap<>();
+        int startCSELevel = cseByLevel.keySet().stream().reduce(Math::min).get();
+        int maxCSELevel = cseByLevel.keySet().stream().reduce(Math::max).get();
+        for (int i = startCSELevel; i <= maxCSELevel; i++) {
+            if (cseByLevel.containsKey(i)) {
+                ExpressionRewriter rewriter = new ExpressionRewriter(rewriteWith);
+                ImmutableMap.Builder<RowExpression, VariableReferenceExpression> expressionVariableMapBuilder = ImmutableMap.builder();
+                for (Map.Entry<RowExpression, Integer> entry : cseByLevel.get(i).entrySet()) {
+                    RowExpression rewrittenExpression = entry.getKey().accept(rewriter, null);
+                    expressionVariableMapBuilder.put(rewrittenExpression, variableAllocator.newVariable(rewrittenExpression, "cse"));
+                }
+                Map<RowExpression, VariableReferenceExpression> expressionVariableMap = expressionVariableMapBuilder.build();
+                commonSubExpressions.put(i, expressionVariableMap);
+                rewriteWith.putAll(expressionVariableMap.entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue())));
+            }
+        }
+        return commonSubExpressions.build();
+    }
+
+    public static Map<Integer, Map<RowExpression, VariableReferenceExpression>> collectCSEByLevel(RowExpression expression)
+    {
+        return collectCSEByLevel(ImmutableList.of(expression));
+    }
+
+    public static List<RowExpression> getExpressionsWithCSE(List<? extends RowExpression> expressions)
+    {
+        if (expressions.isEmpty()) {
+            return ImmutableList.of();
+        }
+        CommonSubExpressionCollector expressionCollector = new CommonSubExpressionCollector();
+        expressions.forEach(expression -> expression.accept(expressionCollector, null));
+        Set<RowExpression> cse = expressionCollector.cseByLevel.values().stream().flatMap(Set::stream).collect(toImmutableSet());
+        SubExpressionChecker subExpressionChecker = new SubExpressionChecker(cse);
+        return expressions.stream().filter(expression -> expression.accept(subExpressionChecker, null)).collect(toImmutableList());
+    }
+
+    public static RowExpression rewriteExpressionWithCSE(RowExpression expression, Map<RowExpression, VariableReferenceExpression> rewriteWith)
+    {
+        ExpressionRewriter rewriter = new ExpressionRewriter(rewriteWith);
+        return expression.accept(rewriter, null);
+    }
+
+    private static Map<Integer, Map<RowExpression, Integer>> removeRedundantCSE(Map<Integer, Set<RowExpression>> cseByLevel, Map<RowExpression, Integer> expressionCount)
+    {
+        Map<Integer, Map<RowExpression, Integer>> results = new HashMap<>();
+        int startCSELevel = cseByLevel.keySet().stream().reduce(Math::max).get();
+        int stopCSELevel = cseByLevel.keySet().stream().reduce(Math::min).get();
+        for (int i = startCSELevel; i > stopCSELevel; i--) {
+            Map<RowExpression, Integer> expressions = cseByLevel.get(i).stream().filter(expression -> expressionCount.get(expression) > 0).collect(toImmutableMap(identity(), expressionCount::get));
+            if (!expressions.isEmpty()) {
+                results.put(i, expressions);
+            }
+            for (RowExpression expression : expressions.keySet()) {
+                int expressionOccurrence = expressionCount.get(expression);
+                subExpressions(expression).stream()
+                        .filter(subExpression -> !subExpression.equals(expression))
+                        .forEach(subExpression -> {
+                            if (expressionCount.containsKey(subExpression)) {
+                                expressionCount.put(subExpression, expressionCount.get(subExpression) - expressionOccurrence);
+                            }
+                        });
+            }
+        }
+        Map<RowExpression, Integer> expressions = cseByLevel.get(stopCSELevel).stream().filter(expression -> expressionCount.get(expression) > 0).collect(toImmutableMap(identity(), expression -> expressionCount.get(expression) + 1));
+        if (!expressions.isEmpty()) {
+            results.put(stopCSELevel, expressions);
+        }
+        return results;
+    }
+
+    static class SubExpressionChecker
+            implements RowExpressionVisitor<Boolean, Void>
+    {
+        private final Set<RowExpression> subExpressions;
+
+        SubExpressionChecker(Set<RowExpression> subExpressions)
+        {
+            this.subExpressions = subExpressions;
+        }
+
+        @Override
+        public Boolean visitCall(CallExpression call, Void context)
+        {
+            if (subExpressions.contains(call)) {
+                return true;
+            }
+            if (call.getArguments().isEmpty()) {
+                return false;
+            }
+            return call.getArguments().stream().anyMatch(expression -> expression.accept(this, null));
+        }
+
+        @Override
+        public Boolean visitInputReference(InputReferenceExpression reference, Void context)
+        {
+            return subExpressions.contains(reference);
+        }
+
+        @Override
+        public Boolean visitConstant(ConstantExpression literal, Void context)
+        {
+            return subExpressions.contains(literal);
+        }
+
+        @Override
+        public Boolean visitLambda(LambdaDefinitionExpression lambda, Void context)
+        {
+            return false;
+        }
+
+        @Override
+        public Boolean visitVariableReference(VariableReferenceExpression reference, Void context)
+        {
+            return subExpressions.contains(reference);
+        }
+
+        @Override
+        public Boolean visitSpecialForm(SpecialFormExpression specialForm, Void context)
+        {
+            if (subExpressions.contains(specialForm)) {
+                return true;
+            }
+            if (specialForm.getArguments().isEmpty()) {
+                return false;
+            }
+            return specialForm.getArguments().stream().anyMatch(expression -> expression.accept(this, null));
+        }
+    }
+
+    static class ExpressionRewriter
+            implements RowExpressionVisitor<RowExpression, Void>
+    {
+        private final Map<RowExpression, VariableReferenceExpression> expressionMap;
+
+        public ExpressionRewriter(Map<RowExpression, VariableReferenceExpression> expressionMap)
+        {
+            this.expressionMap = ImmutableMap.copyOf(expressionMap);
+        }
+
+        @Override
+        public RowExpression visitCall(CallExpression call, Void context)
+        {
+            RowExpression rewritten = new CallExpression(
+                    call.getDisplayName(),
+                    call.getFunctionHandle(),
+                    call.getType(),
+                    call.getArguments().stream().map(argument -> argument.accept(this, null)).collect(toImmutableList()));
+            if (expressionMap.containsKey(rewritten)) {
+                return expressionMap.get(rewritten);
+            }
+            return rewritten;
+        }
+
+        @Override
+        public RowExpression visitInputReference(InputReferenceExpression reference, Void context)
+        {
+            return reference;
+        }
+
+        @Override
+        public RowExpression visitConstant(ConstantExpression literal, Void context)
+        {
+            return literal;
+        }
+
+        @Override
+        public RowExpression visitLambda(LambdaDefinitionExpression lambda, Void context)
+        {
+            return lambda;
+        }
+
+        @Override
+        public RowExpression visitVariableReference(VariableReferenceExpression reference, Void context)
+        {
+            return reference;
+        }
+
+        @Override
+        public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Void context)
+        {
+            SpecialFormExpression rewritten = new SpecialFormExpression(
+                    specialForm.getForm(),
+                    specialForm.getType(),
+                    specialForm.getArguments().stream().map(argument -> argument.accept(this, null)).collect(toImmutableList()));
+            if (expressionMap.containsKey(rewritten)) {
+                return expressionMap.get(rewritten);
+            }
+            return rewritten;
+        }
+    }
+
+    static class CommonSubExpressionCollector
+            implements RowExpressionVisitor<Integer, Void>
+    {
+        private final Map<Integer, Set<RowExpression>> expressionsByLevel = new HashMap<>();
+        private final Map<Integer, Set<RowExpression>> cseByLevel = new HashMap<>();
+        private final Map<RowExpression, Integer> expressionCount = new HashMap<>();
+
+        private int addAtLevel(int level, RowExpression expression)
+        {
+            Set<RowExpression> rowExpressions = getExpresssionsAtLevel(level, expressionsByLevel);
+            expressionCount.putIfAbsent(expression, 1);
+            if (rowExpressions.contains(expression)) {
+                getExpresssionsAtLevel(level, cseByLevel).add(expression);
+                int count = expressionCount.get(expression) + 1;
+                expressionCount.put(expression, count);
+            }
+            rowExpressions.add(expression);
+            return level;
+        }
+
+        private static Set<RowExpression> getExpresssionsAtLevel(int level, Map<Integer, Set<RowExpression>> expressionsByLevel)
+        {
+            expressionsByLevel.putIfAbsent(level, new HashSet<>());
+            return expressionsByLevel.get(level);
+        }
+
+        @Override
+        public Integer visitCall(CallExpression call, Void collect)
+        {
+            if (call.getArguments().isEmpty()) {
+                // Do not track leaf expression
+                return 0;
+            }
+            return addAtLevel(call.getArguments().stream().map(argument -> argument.accept(this, collect)).reduce(Math::max).get() + 1, call);
+        }
+
+        @Override
+        public Integer visitInputReference(InputReferenceExpression reference, Void collect)
+        {
+            return 0;
+        }
+
+        @Override
+        public Integer visitConstant(ConstantExpression literal, Void collect)
+        {
+            return 0;
+        }
+
+        @Override
+        public Integer visitLambda(LambdaDefinitionExpression lambda, Void collect)
+        {
+            return 0;
+        }
+
+        @Override
+        public Integer visitVariableReference(VariableReferenceExpression reference, Void collect)
+        {
+            return 0;
+        }
+
+        @Override
+        public Integer visitSpecialForm(SpecialFormExpression specialForm, Void collect)
+        {
+            int level = specialForm.getArguments().stream().map(argument -> argument.accept(this, null)).reduce(Math::max).get() + 1;
+            if (specialForm.getForm() != WHEN) {
+                // WHEN is part of CASE expression. We do not have a separate code generator to generate code for WHEN expression separately so do not consider them as CSE
+                // TODO If we detect a whole WHEN statement as CSE we should probably only keep one
+                addAtLevel(level, specialForm);
+            }
+            return level;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/LambdaBytecodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/LambdaBytecodeGenerator.java
@@ -39,7 +39,6 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Primitives;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
@@ -64,11 +63,11 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.gen.BytecodeUtils.boxPrimitiveIfNecessary;
 import static com.facebook.presto.sql.gen.BytecodeUtils.unboxPrimitiveIfNecessary;
 import static com.facebook.presto.sql.gen.LambdaCapture.LAMBDA_CAPTURE_METHOD;
-import static com.facebook.presto.sql.gen.LambdaExpressionExtractor.extractLambdaExpressions;
 import static com.facebook.presto.util.CompilerUtils.defineClass;
 import static com.facebook.presto.util.CompilerUtils.makeClassName;
 import static com.facebook.presto.util.Failures.checkCondition;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 import static org.objectweb.asm.Type.getMethodType;
 import static org.objectweb.asm.Type.getType;
@@ -99,7 +98,19 @@ public class LambdaBytecodeGenerator
             SqlFunctionProperties sqlFunctionProperties,
             String methodNamePrefix)
     {
-        Set<LambdaDefinitionExpression> lambdaExpressions = ImmutableSet.copyOf(extractLambdaExpressions(expression));
+        return generateMethodsForLambda(containerClassDefinition, callSiteBinder, cachedInstanceBinder, ImmutableList.of(expression), metadata, sqlFunctionProperties, methodNamePrefix);
+    }
+
+    public static Map<LambdaDefinitionExpression, CompiledLambda> generateMethodsForLambda(
+            ClassDefinition containerClassDefinition,
+            CallSiteBinder callSiteBinder,
+            CachedInstanceBinder cachedInstanceBinder,
+            List<RowExpression> expressions,
+            Metadata metadata,
+            SqlFunctionProperties sqlFunctionProperties,
+            String methodNamePrefix)
+    {
+        Set<LambdaDefinitionExpression> lambdaExpressions = expressions.stream().map(LambdaExpressionExtractor::extractLambdaExpressions).flatMap(List::stream).collect(toImmutableSet());
         ImmutableMap.Builder<LambdaDefinitionExpression, CompiledLambda> compiledLambdaMap = ImmutableMap.builder();
 
         int counter = 0;
@@ -123,7 +134,7 @@ public class LambdaBytecodeGenerator
     /**
      * @return a MethodHandle field that represents the lambda expression
      */
-    public static CompiledLambda preGenerateLambdaExpression(
+    private static CompiledLambda preGenerateLambdaExpression(
             LambdaDefinitionExpression lambdaExpression,
             String methodName,
             ClassDefinition classDefinition,

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -33,6 +33,7 @@ import com.facebook.presto.operator.project.InputPageProjection;
 import com.facebook.presto.operator.project.PageFieldsToInputParametersRewriter;
 import com.facebook.presto.operator.project.PageFilter;
 import com.facebook.presto.operator.project.PageProjection;
+import com.facebook.presto.operator.project.PageProjectionWithOutputs;
 import com.facebook.presto.operator.project.SelectedPositions;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
@@ -49,6 +50,7 @@ import com.facebook.presto.sql.gen.LambdaBytecodeGenerator.CompiledLambda;
 import com.facebook.presto.sql.planner.CompilerConfig;
 import com.facebook.presto.sql.relational.Expressions;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -66,6 +68,7 @@ import java.util.Optional;
 import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.bytecode.Access.FINAL;
 import static com.facebook.presto.bytecode.Access.PRIVATE;
@@ -91,6 +94,7 @@ import static com.facebook.presto.util.CompilerUtils.defineClass;
 import static com.facebook.presto.util.CompilerUtils.makeClassName;
 import static com.facebook.presto.util.Reflection.constructorMethodHandle;
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public class PageFunctionCompiler
@@ -156,12 +160,25 @@ public class PageFunctionCompiler
         return filterCacheStats;
     }
 
+    public List<Supplier<PageProjectionWithOutputs>> compileProjections(SqlFunctionProperties sqlFunctionProperties, List<? extends RowExpression> projections, Optional<String> classNameSuffix)
+    {
+        return IntStream.range(0, projections.size())
+                .mapToObj(outputChannel -> toPageProjectionWithOutputs(compileProjection(sqlFunctionProperties, projections.get(outputChannel), classNameSuffix), new int[] {outputChannel}))
+                .collect(toImmutableList());
+    }
+
+    @VisibleForTesting
     public Supplier<PageProjection> compileProjection(SqlFunctionProperties sqlFunctionProperties, RowExpression projection, Optional<String> classNameSuffix)
     {
         if (projectionCache == null) {
             return compileProjectionInternal(sqlFunctionProperties, projection, classNameSuffix);
         }
         return projectionCache.getUnchecked(new CacheKey(sqlFunctionProperties, projection));
+    }
+
+    private Supplier<PageProjectionWithOutputs> toPageProjectionWithOutputs(Supplier<PageProjection> pageProjection, int[] outputChannels)
+    {
+        return () -> new PageProjectionWithOutputs(pageProjection.get(), outputChannels);
     }
 
     private Supplier<PageProjection> compileProjectionInternal(SqlFunctionProperties sqlFunctionProperties, RowExpression projection, Optional<String> classNameSuffix)

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -220,7 +220,7 @@ public class PageFunctionCompiler
         FieldDefinition pageField = classDefinition.declareField(a(PRIVATE), "page", Page.class);
         FieldDefinition selectedPositionsField = classDefinition.declareField(a(PRIVATE), "selectedPositions", SelectedPositions.class);
         FieldDefinition nextIndexOrPositionField = classDefinition.declareField(a(PRIVATE), "nextIndexOrPosition", int.class);
-        FieldDefinition resultField = classDefinition.declareField(a(PRIVATE), "result", Block.class);
+        FieldDefinition resultField = classDefinition.declareField(a(PRIVATE), "result", List.class);
 
         CachedInstanceBinder cachedInstanceBinder = new CachedInstanceBinder(classDefinition, callSiteBinder);
 
@@ -281,6 +281,7 @@ public class PageFunctionCompiler
         Variable to = scope.declareVariable("to", body, add(thisVariable.getField(selectedPositions).invoke("getOffset", int.class), thisVariable.getField(selectedPositions).invoke("size", int.class)));
         Variable positions = scope.declareVariable(int[].class, "positions");
         Variable index = scope.declareVariable(int.class, "index");
+        Variable blockList = scope.declareVariable(List.class, "blockList");
 
         IfStatement ifStatement = new IfStatement()
                 .condition(thisVariable.getField(selectedPositions).invoke("isList", boolean.class));
@@ -302,8 +303,11 @@ public class PageFunctionCompiler
                 .body(new BytecodeBlock()
                         .append(thisVariable.invoke("evaluate", void.class, thisVariable.getField(properties), thisVariable.getField(page), index))));
 
-        body.comment("result = this.blockBuilder.build(); return true;")
-                .append(thisVariable.setField(result, thisVariable.getField(blockBuilder).invoke("build", Block.class)))
+        body.comment("result = ImmutableList.of(this.blockBuilder.build(); return true;")
+                .append(thisVariable.getField(blockBuilder).invoke("build", Block.class))
+                .invokeStatic(ImmutableList.class, "of", ImmutableList.class, Object.class)
+                .putVariable(blockList)
+                .append(thisVariable.setField(result, blockList))
                 .push(true)
                 .retBoolean();
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -187,7 +187,7 @@ public class PageFunctionCompiler
 
         if (projection instanceof InputReferenceExpression) {
             InputReferenceExpression input = (InputReferenceExpression) projection;
-            InputPageProjection projectionFunction = new InputPageProjection(input.getField(), input.getType());
+            InputPageProjection projectionFunction = new InputPageProjection(input.getField());
             return () -> projectionFunction;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/RowExpressionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/RowExpressionCompiler.java
@@ -157,7 +157,6 @@ public class RowExpressionCompiler
                                     new ConstantExpression(null, call.getType()),
                                     function),
                             context.getOutputBlockVariable());
-
                 default:
                     throw new IllegalArgumentException(format("Unsupported function implementation type: %s", functionMetadata.getImplementationType()));
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -230,6 +230,7 @@ import static com.facebook.presto.SystemSessionProperties.getTaskConcurrency;
 import static com.facebook.presto.SystemSessionProperties.getTaskPartitionedWriterCount;
 import static com.facebook.presto.SystemSessionProperties.getTaskWriterCount;
 import static com.facebook.presto.SystemSessionProperties.isExchangeCompressionEnabled;
+import static com.facebook.presto.SystemSessionProperties.isOptimizeCommonSubExpressions;
 import static com.facebook.presto.SystemSessionProperties.isOptimizedRepartitioningEnabled;
 import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
@@ -1281,7 +1282,7 @@ public class LocalExecutionPlanner
             try {
                 if (columns != null) {
                     Supplier<CursorProcessor> cursorProcessor = expressionCompiler.compileCursorProcessor(session.getSqlFunctionProperties(), filterExpression, projections, sourceNode.getId());
-                    Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(session.getSqlFunctionProperties(), filterExpression, projections, Optional.of(context.getStageExecutionId() + "_" + planNodeId));
+                    Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(session.getSqlFunctionProperties(), filterExpression, projections, isOptimizeCommonSubExpressions(session), Optional.of(context.getStageExecutionId() + "_" + planNodeId));
 
                     SourceOperatorFactory operatorFactory = new ScanFilterAndProjectOperatorFactory(
                             context.getNextOperatorId(),
@@ -1299,7 +1300,7 @@ public class LocalExecutionPlanner
                     return new PhysicalOperation(operatorFactory, outputMappings, context, stageExecutionDescriptor.isScanGroupedExecution(sourceNode.getId()) ? GROUPED_EXECUTION : UNGROUPED_EXECUTION);
                 }
                 else {
-                    Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(session.getSqlFunctionProperties(), filterExpression, projections, Optional.of(context.getStageExecutionId() + "_" + planNodeId));
+                    Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(session.getSqlFunctionProperties(), filterExpression, projections, isOptimizeCommonSubExpressions(session), Optional.of(context.getStageExecutionId() + "_" + planNodeId));
 
                     OperatorFactory operatorFactory = new FilterAndProjectOperator.FilterAndProjectOperatorFactory(
                             context.getNextOperatorId(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanVariableAllocator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanVariableAllocator.java
@@ -163,6 +163,11 @@ public class PlanVariableAllocator
 
     public VariableReferenceExpression newVariable(RowExpression expression)
     {
+        return newVariable(expression, null);
+    }
+
+    public VariableReferenceExpression newVariable(RowExpression expression, String suffix)
+    {
         String nameHint = "expr";
         if (expression instanceof VariableReferenceExpression) {
             nameHint = ((VariableReferenceExpression) expression).getName();
@@ -170,6 +175,6 @@ public class PlanVariableAllocator
         else if (expression instanceof CallExpression) {
             nameHint = ((CallExpression) expression).getDisplayName();
         }
-        return newVariable(nameHint, expression.getType(), null);
+        return newVariable(nameHint, expression.getType(), suffix);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestColumnarPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestColumnarPageProcessor.java
@@ -81,6 +81,6 @@ public class TestColumnarPageProcessor
     private PageProcessor newPageProcessor()
     {
         return new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0))
-                .compilePageProcessor(SESSION.getSqlFunctionProperties(), Optional.empty(), ImmutableList.of(field(0, types.get(0)), field(1, types.get(1))), MAX_BATCH_SIZE).get();
+                .compilePageProcessor(SESSION.getSqlFunctionProperties(), Optional.empty(), ImmutableList.of(field(0, types.get(0)), field(1, types.get(1))), false, MAX_BATCH_SIZE).get();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
@@ -337,7 +337,7 @@ public class TestScanFilterAndProjectOperator
             projections.add(call("generic_long_page_col", functionManager.lookupFunction("generic_long_page_col" + i, fromTypes(BIGINT)), BIGINT, field(0, BIGINT)));
         }
         Supplier<CursorProcessor> cursorProcessor = expressionCompiler.compileCursorProcessor(driverContext.getSession().getSqlFunctionProperties(), Optional.empty(), projections.build(), "key");
-        Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(driverContext.getSession().getSqlFunctionProperties(), Optional.empty(), projections.build(), MAX_BATCH_SIZE);
+        Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(driverContext.getSession().getSqlFunctionProperties(), Optional.empty(), projections.build(), false, MAX_BATCH_SIZE);
 
         ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
                 0,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
@@ -23,6 +23,7 @@ import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.operator.index.PageRecordSet;
 import com.facebook.presto.operator.project.CursorProcessor;
 import com.facebook.presto.operator.project.PageProcessor;
+import com.facebook.presto.operator.project.PageProjectionWithOutputs;
 import com.facebook.presto.operator.project.TestPageProcessor.LazyPagePageProjection;
 import com.facebook.presto.operator.project.TestPageProcessor.SelectAllFilter;
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
@@ -201,7 +202,7 @@ public class TestScanFilterAndProjectOperator
 
         List<RowExpression> projections = ImmutableList.of(field(0, VARCHAR));
         Supplier<CursorProcessor> cursorProcessor = expressionCompiler.compileCursorProcessor(driverContext.getSession().getSqlFunctionProperties(), Optional.empty(), projections, "key");
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new LazyPagePageProjection()));
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new PageProjectionWithOutputs(new LazyPagePageProjection(), new int[] {0})));
 
         ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
                 0,

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
@@ -29,6 +29,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -182,7 +183,7 @@ public class TestDictionaryAwarePageProjection
         return new DictionaryBlock(dictionary, ids);
     }
 
-    private static Block projectWithYield(Work<Block> work, DriverYieldSignal yieldSignal)
+    private static List<Block> projectWithYield(Work<List<Block>> work, DriverYieldSignal yieldSignal)
     {
         int yieldCount = 0;
         while (true) {
@@ -219,8 +220,8 @@ public class TestDictionaryAwarePageProjection
     private static void testProjectRange(Block block, Class<? extends Block> expectedResultType, DictionaryAwarePageProjection projection, boolean forceYield)
     {
         DriverYieldSignal yieldSignal = new DriverYieldSignal();
-        Work<Block> work = projection.project(null, yieldSignal, new Page(block), SelectedPositions.positionsRange(5, 10));
-        Block result;
+        Work<List<Block>> work = projection.project(null, yieldSignal, new Page(block), SelectedPositions.positionsRange(5, 10));
+        List<Block> result;
         if (forceYield) {
             result = projectWithYield(work, yieldSignal);
         }
@@ -230,17 +231,17 @@ public class TestDictionaryAwarePageProjection
         }
         assertBlockEquals(
                 BIGINT,
-                result,
+                result.get(0),
                 block.getRegion(5, 10));
-        assertInstanceOf(result, expectedResultType);
+        assertInstanceOf(result.get(0), expectedResultType);
     }
 
     private static void testProjectList(Block block, Class<? extends Block> expectedResultType, DictionaryAwarePageProjection projection, boolean forceYield)
     {
         DriverYieldSignal yieldSignal = new DriverYieldSignal();
         int[] positions = {0, 2, 4, 6, 8, 10};
-        Work<Block> work = projection.project(null, yieldSignal, new Page(block), SelectedPositions.positionsList(positions, 0, positions.length));
-        Block result;
+        Work<List<Block>> work = projection.project(null, yieldSignal, new Page(block), SelectedPositions.positionsList(positions, 0, positions.length));
+        List<Block> result;
         if (forceYield) {
             result = projectWithYield(work, yieldSignal);
         }
@@ -250,21 +251,21 @@ public class TestDictionaryAwarePageProjection
         }
         assertBlockEquals(
                 BIGINT,
-                result,
+                result.get(0),
                 block.copyPositions(positions, 0, positions.length));
-        assertInstanceOf(result, expectedResultType);
+        assertInstanceOf(result.get(0), expectedResultType);
     }
 
     private static void testProjectFastReturnIgnoreYield(Block block, DictionaryAwarePageProjection projection)
     {
         DriverYieldSignal yieldSignal = new DriverYieldSignal();
-        Work<Block> work = projection.project(null, yieldSignal, new Page(block), SelectedPositions.positionsRange(5, 10));
+        Work<List<Block>> work = projection.project(null, yieldSignal, new Page(block), SelectedPositions.positionsRange(5, 10));
         yieldSignal.setWithDelay(1, executor);
         yieldSignal.forceYieldForTesting();
 
         // yield signal is ignored given the block has already been loaded
         assertTrue(work.process());
-        Block result = work.getResult();
+        Block result = work.getResult().get(0);
         yieldSignal.reset();
 
         assertBlockEquals(
@@ -308,13 +309,13 @@ public class TestDictionaryAwarePageProjection
         }
 
         @Override
-        public Work<Block> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+        public Work<List<Block>> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
         {
             return new TestPageProjectionWork(yieldSignal, page, selectedPositions);
         }
 
         private class TestPageProjectionWork
-                implements Work<Block>
+                implements Work<List<Block>>
         {
             private final DriverYieldSignal yieldSignal;
             private final Block block;
@@ -363,10 +364,10 @@ public class TestDictionaryAwarePageProjection
             }
 
             @Override
-            public Block getResult()
+            public List<Block> getResult()
             {
                 assertNotNull(result);
-                return result;
+                return ImmutableList.of(result);
             }
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestDictionaryAwarePageProjection.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.block.LazyBlock;
 import com.facebook.presto.spi.block.LongArrayBlock;
 import com.facebook.presto.spi.block.RunLengthEncodedBlock;
 import com.facebook.presto.spi.function.SqlFunctionProperties;
-import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -63,7 +62,6 @@ public class TestDictionaryAwarePageProjection
         DictionaryAwarePageProjection projection = createProjection();
         assertEquals(projection.isDeterministic(), true);
         assertEquals(projection.getInputChannels().getInputChannels(), ImmutableList.of(3));
-        assertEquals(projection.getType(), BIGINT);
     }
 
     @Test(dataProvider = "forceYield")
@@ -290,12 +288,6 @@ public class TestDictionaryAwarePageProjection
     private static class TestPageProjection
             implements PageProjection
     {
-        @Override
-        public Type getType()
-        {
-            return BIGINT;
-        }
-
         @Override
         public boolean isDeterministic()
         {

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
@@ -276,8 +276,8 @@ public class TestPageProcessor
     @Test
     public void testOptimisticProcessing()
     {
-        InvocationCountPageProjection firstProjection = new InvocationCountPageProjection(new InputPageProjection(0, VARCHAR));
-        InvocationCountPageProjection secondProjection = new InvocationCountPageProjection(new InputPageProjection(0, VARCHAR));
+        InvocationCountPageProjection firstProjection = new InvocationCountPageProjection(new InputPageProjection(0));
+        InvocationCountPageProjection secondProjection = new InvocationCountPageProjection(new InputPageProjection(0));
         PageProcessor pageProcessor = new PageProcessor(Optional.empty(), ImmutableList.of(new PageProjectionWithOutputs(firstProjection, new int[] {0}), new PageProjectionWithOutputs(secondProjection, new int[] {1})), OptionalInt.of(MAX_BATCH_SIZE));
 
         // process large page which will reduce batch size
@@ -350,7 +350,7 @@ public class TestPageProcessor
         DriverYieldSignal yieldSignal = new DriverYieldSignal();
         PageProcessor pageProcessor = new PageProcessor(
                 Optional.empty(),
-                IntStream.range(0, 20).mapToObj(i -> new PageProjectionWithOutputs(new YieldPageProjection(new InputPageProjection(0, VARCHAR)), new int[] {i})).collect(toImmutableList()),
+                IntStream.range(0, 20).mapToObj(i -> new PageProjectionWithOutputs(new YieldPageProjection(new InputPageProjection(0)), new int[] {i})).collect(toImmutableList()),
                 OptionalInt.of(MAX_BATCH_SIZE));
 
         Slice[] slices = new Slice[rows];
@@ -488,7 +488,7 @@ public class TestPageProcessor
 
     private PageProjectionWithOutputs createInputPageProjectionWithOutputs(int inputChannel, Type type, int outputChannel)
     {
-        return new PageProjectionWithOutputs(new InputPageProjection(inputChannel, type), new int[] {outputChannel});
+        return new PageProjectionWithOutputs(new InputPageProjection(inputChannel), new int[] {outputChannel});
     }
 
     private Iterator<Optional<Page>> processAndAssertRetainedPageSize(PageProcessor pageProcessor, Page inputPage)
@@ -521,12 +521,6 @@ public class TestPageProcessor
         public InvocationCountPageProjection(PageProjection delegate)
         {
             this.delegate = delegate;
-        }
-
-        @Override
-        public Type getType()
-        {
-            return delegate.getType();
         }
 
         @Override
@@ -605,12 +599,6 @@ public class TestPageProcessor
     public static class LazyPagePageProjection
             implements PageProjection
     {
-        @Override
-        public Type getType()
-        {
-            return BIGINT;
-        }
-
         @Override
         public boolean isDeterministic()
         {

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
@@ -44,6 +44,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.presto.block.BlockAssertions.createLongSequenceBlock;
@@ -65,6 +66,7 @@ import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.field;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.join;
 import static java.util.Collections.nCopies;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
@@ -120,7 +122,7 @@ public class TestPageProcessor
     {
         PageProcessor pageProcessor = new PageProcessor(
                 Optional.of(new TestingPageFilter(positionsRange(25, 50))),
-                ImmutableList.of(new InputPageProjection(0, BIGINT)),
+                ImmutableList.of(createInputPageProjectionWithOutputs(0, BIGINT, 0)),
                 OptionalInt.of(MAX_BATCH_SIZE));
 
         Page inputPage = new Page(createLongSequenceBlock(0, 100));
@@ -135,7 +137,7 @@ public class TestPageProcessor
     @Test
     public void testSelectAllFilter()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new InputPageProjection(0, BIGINT)), OptionalInt.of(MAX_BATCH_SIZE));
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(createInputPageProjectionWithOutputs(0, BIGINT, 0)), OptionalInt.of(MAX_BATCH_SIZE));
 
         Page inputPage = new Page(createLongSequenceBlock(0, 100));
 
@@ -149,7 +151,7 @@ public class TestPageProcessor
     @Test
     public void testSelectNoneFilter()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectNoneFilter()), ImmutableList.of(new InputPageProjection(0, BIGINT)));
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectNoneFilter()), ImmutableList.of(createInputPageProjectionWithOutputs(0, BIGINT, 0)));
 
         Page inputPage = new Page(createLongSequenceBlock(0, 100));
 
@@ -164,7 +166,7 @@ public class TestPageProcessor
     @Test
     public void testProjectEmptyPage()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new InputPageProjection(0, BIGINT)));
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(createInputPageProjectionWithOutputs(0, BIGINT, 0)));
 
         Page inputPage = new Page(createLongSequenceBlock(0, 0));
 
@@ -180,7 +182,7 @@ public class TestPageProcessor
     @Test
     public void testSelectNoneFilterLazyLoad()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectNoneFilter()), ImmutableList.of(new InputPageProjection(1, BIGINT)));
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectNoneFilter()), ImmutableList.of(createInputPageProjectionWithOutputs(1, BIGINT, 0)));
 
         // if channel 1 is loaded, test will fail
         Page inputPage = new Page(createLongSequenceBlock(0, 100), new LazyBlock(100, lazyBlock -> {
@@ -197,7 +199,7 @@ public class TestPageProcessor
     @Test
     public void testProjectLazyLoad()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new LazyPagePageProjection()), OptionalInt.of(MAX_BATCH_SIZE));
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new PageProjectionWithOutputs(new LazyPagePageProjection(), new int[] {0})), OptionalInt.of(MAX_BATCH_SIZE));
 
         // if channel 1 is loaded, test will fail
         Page inputPage = new Page(createLongSequenceBlock(0, 100), new LazyBlock(100, lazyBlock -> {
@@ -215,7 +217,7 @@ public class TestPageProcessor
     @Test
     public void testBatchedOutput()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.empty(), ImmutableList.of(new InputPageProjection(0, BIGINT)), OptionalInt.of(MAX_BATCH_SIZE));
+        PageProcessor pageProcessor = new PageProcessor(Optional.empty(), ImmutableList.of(createInputPageProjectionWithOutputs(0, BIGINT, 0)), OptionalInt.of(MAX_BATCH_SIZE));
 
         Page inputPage = new Page(createLongSequenceBlock(0, (int) (MAX_BATCH_SIZE * 2.5)));
 
@@ -234,7 +236,7 @@ public class TestPageProcessor
     @Test
     public void testAdaptiveBatchSize()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.empty(), ImmutableList.of(new InputPageProjection(0, VARCHAR)), OptionalInt.of(MAX_BATCH_SIZE));
+        PageProcessor pageProcessor = new PageProcessor(Optional.empty(), ImmutableList.of(createInputPageProjectionWithOutputs(0, VARCHAR, 0)), OptionalInt.of(MAX_BATCH_SIZE));
 
         // process large page which will reduce batch size
         Slice[] slices = new Slice[(int) (MAX_BATCH_SIZE * 2.5)];
@@ -276,7 +278,7 @@ public class TestPageProcessor
     {
         InvocationCountPageProjection firstProjection = new InvocationCountPageProjection(new InputPageProjection(0, VARCHAR));
         InvocationCountPageProjection secondProjection = new InvocationCountPageProjection(new InputPageProjection(0, VARCHAR));
-        PageProcessor pageProcessor = new PageProcessor(Optional.empty(), ImmutableList.of(firstProjection, secondProjection), OptionalInt.of(MAX_BATCH_SIZE));
+        PageProcessor pageProcessor = new PageProcessor(Optional.empty(), ImmutableList.of(new PageProjectionWithOutputs(firstProjection, new int[] {0}), new PageProjectionWithOutputs(secondProjection, new int[] {1})), OptionalInt.of(MAX_BATCH_SIZE));
 
         // process large page which will reduce batch size
         Slice[] slices = new Slice[(int) (MAX_BATCH_SIZE * 2.5)];
@@ -317,7 +319,7 @@ public class TestPageProcessor
     {
         PageProcessor pageProcessor = new PageProcessor(
                 Optional.of(new SelectAllFilter()),
-                ImmutableList.of(new InputPageProjection(0, VARCHAR), new InputPageProjection(1, VARCHAR)),
+                ImmutableList.of(createInputPageProjectionWithOutputs(0, VARCHAR, 0), createInputPageProjectionWithOutputs(1, VARCHAR, 1)),
                 OptionalInt.of(MAX_BATCH_SIZE));
 
         // create 2 columns X 800 rows of strings with each string's size = 10KB
@@ -348,7 +350,7 @@ public class TestPageProcessor
         DriverYieldSignal yieldSignal = new DriverYieldSignal();
         PageProcessor pageProcessor = new PageProcessor(
                 Optional.empty(),
-                Collections.nCopies(columns, new YieldPageProjection(new InputPageProjection(0, VARCHAR))),
+                IntStream.range(0, 20).mapToObj(i -> new PageProjectionWithOutputs(new YieldPageProjection(new InputPageProjection(0, VARCHAR)), new int[] {i})).collect(toImmutableList()),
                 OptionalInt.of(MAX_BATCH_SIZE));
 
         Slice[] slices = new Slice[rows];
@@ -400,7 +402,7 @@ public class TestPageProcessor
         ExpressionProfiler profiler = new ExpressionProfiler(testingTicker, SPLIT_RUN_QUANTA);
         for (int i = 0; i < 100; i++) {
             profiler.start();
-            Work<Block> work = projection.project(SESSION.getSqlFunctionProperties(), new DriverYieldSignal(), page, SelectedPositions.positionsRange(0, page.getPositionCount()));
+            Work<List<Block>> work = projection.project(SESSION.getSqlFunctionProperties(), new DriverYieldSignal(), page, SelectedPositions.positionsRange(0, page.getPositionCount()));
             if (i < 10) {
                 // increment the ticker with a large value to mark the expression as expensive
                 testingTicker.increment(10, SECONDS);
@@ -426,7 +428,7 @@ public class TestPageProcessor
         ExpressionProfiler profiler = new ExpressionProfiler(testingTicker, SPLIT_RUN_QUANTA);
         PageProcessor pageProcessor = new PageProcessor(
                 Optional.empty(),
-                ImmutableList.of(new InputPageProjection(0, BIGINT)),
+                ImmutableList.of(createInputPageProjectionWithOutputs(0, BIGINT, 0)),
                 OptionalInt.of(1),
                 profiler);
 
@@ -460,7 +462,7 @@ public class TestPageProcessor
         ExpressionProfiler profiler = new ExpressionProfiler(testingTicker, new Duration(0, MILLISECONDS));
         PageProcessor pageProcessor = new PageProcessor(
                 Optional.empty(),
-                ImmutableList.of(new InputPageProjection(0, BIGINT)),
+                ImmutableList.of(createInputPageProjectionWithOutputs(0, BIGINT, 0)),
                 OptionalInt.of(512),
                 profiler);
 
@@ -482,6 +484,11 @@ public class TestPageProcessor
             }
             previousPositionCount = positionCount;
         }
+    }
+
+    private PageProjectionWithOutputs createInputPageProjectionWithOutputs(int inputChannel, Type type, int outputChannel)
+    {
+        return new PageProjectionWithOutputs(new InputPageProjection(inputChannel, type), new int[] {outputChannel});
     }
 
     private Iterator<Optional<Page>> processAndAssertRetainedPageSize(PageProcessor pageProcessor, Page inputPage)
@@ -535,7 +542,7 @@ public class TestPageProcessor
         }
 
         @Override
-        public Work<Block> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+        public Work<List<Block>> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
         {
             setInvocationCount(getInvocationCount() + 1);
             return delegate.project(properties, yieldSignal, page, selectedPositions);
@@ -561,16 +568,16 @@ public class TestPageProcessor
         }
 
         @Override
-        public Work<Block> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+        public Work<List<Block>> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
         {
             return new YieldPageProjectionWork(properties, yieldSignal, page, selectedPositions);
         }
 
         private class YieldPageProjectionWork
-                implements Work<Block>
+                implements Work<List<Block>>
         {
             private final DriverYieldSignal yieldSignal;
-            private final Work<Block> work;
+            private final Work<List<Block>> work;
 
             public YieldPageProjectionWork(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
             {
@@ -588,7 +595,7 @@ public class TestPageProcessor
             }
 
             @Override
-            public Block getResult()
+            public List<Block> getResult()
             {
                 return work.getResult();
             }
@@ -617,9 +624,9 @@ public class TestPageProcessor
         }
 
         @Override
-        public Work<Block> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
+        public Work<List<Block>> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
         {
-            return new CompletedWork<>(page.getBlock(0).getLoadedBlock());
+            return new CompletedWork<>(ImmutableList.of(page.getBlock(0).getLoadedBlock()));
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -29,7 +29,7 @@ import com.facebook.presto.operator.SourceOperator;
 import com.facebook.presto.operator.SourceOperatorFactory;
 import com.facebook.presto.operator.project.CursorProcessor;
 import com.facebook.presto.operator.project.PageProcessor;
-import com.facebook.presto.operator.project.PageProjection;
+import com.facebook.presto.operator.project.PageProjectionWithOutputs;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorPageSource;
@@ -503,9 +503,9 @@ public final class FunctionAssertions
         }
     }
 
-    private long getRetainedSizeOfCachedInstance(PageProjection projection)
+    private long getRetainedSizeOfCachedInstance(PageProjectionWithOutputs projection)
     {
-        Field[] fields = projection.getClass().getDeclaredFields();
+        Field[] fields = projection.getPageProjection().getClass().getDeclaredFields();
         long retainedSize = 0;
         for (Field field : fields) {
             field.setAccessible(true);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPageProcessorCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestPageProcessorCompiler.java
@@ -95,7 +95,7 @@ public class TestPageProcessorCompiler
     @Test
     public void testSanityRLE()
     {
-        PageProcessor processor = compiler.compilePageProcessor(TEST_SESSION.getSqlFunctionProperties(), Optional.empty(), ImmutableList.of(field(0, BIGINT), field(1, VARCHAR)), MAX_BATCH_SIZE).get();
+        PageProcessor processor = compiler.compilePageProcessor(TEST_SESSION.getSqlFunctionProperties(), Optional.empty(), ImmutableList.of(field(0, BIGINT), field(1, VARCHAR)), false, MAX_BATCH_SIZE).get();
 
         Slice varcharValue = Slices.utf8Slice("hello");
         Page page = new Page(RunLengthEncodedBlock.create(BIGINT, 123L, 100), RunLengthEncodedBlock.create(VARCHAR, varcharValue, 100));
@@ -127,7 +127,7 @@ public class TestPageProcessorCompiler
         FunctionHandle lessThan = functionManager.resolveOperator(LESS_THAN, fromTypes(BIGINT, BIGINT));
         CallExpression filter = new CallExpression(LESS_THAN.name(), lessThan, BOOLEAN, ImmutableList.of(lengthVarchar, constant(10L, BIGINT)));
 
-        PageProcessor processor = compiler.compilePageProcessor(TEST_SESSION.getSqlFunctionProperties(), Optional.of(filter), ImmutableList.of(field(0, VARCHAR)), MAX_BATCH_SIZE).get();
+        PageProcessor processor = compiler.compilePageProcessor(TEST_SESSION.getSqlFunctionProperties(), Optional.of(filter), ImmutableList.of(field(0, VARCHAR)), false, MAX_BATCH_SIZE).get();
 
         Page page = new Page(createDictionaryBlock(createExpectedValues(10), 100));
         Page outputPage = getOnlyElement(
@@ -166,7 +166,7 @@ public class TestPageProcessorCompiler
         FunctionHandle lessThan = functionManager.resolveOperator(LESS_THAN, fromTypes(BIGINT, BIGINT));
         CallExpression filter = new CallExpression(LESS_THAN.name(), lessThan, BOOLEAN, ImmutableList.of(field(0, BIGINT), constant(10L, BIGINT)));
 
-        PageProcessor processor = compiler.compilePageProcessor(TEST_SESSION.getSqlFunctionProperties(), Optional.of(filter), ImmutableList.of(field(0, BIGINT)), MAX_BATCH_SIZE).get();
+        PageProcessor processor = compiler.compilePageProcessor(TEST_SESSION.getSqlFunctionProperties(), Optional.of(filter), ImmutableList.of(field(0, BIGINT)), false, MAX_BATCH_SIZE).get();
 
         Page page = new Page(createRLEBlock(5L, 100));
         Page outputPage = getOnlyElement(
@@ -187,7 +187,7 @@ public class TestPageProcessorCompiler
     @Test
     public void testSanityColumnarDictionary()
     {
-        PageProcessor processor = compiler.compilePageProcessor(TEST_SESSION.getSqlFunctionProperties(), Optional.empty(), ImmutableList.of(field(0, VARCHAR)), MAX_BATCH_SIZE).get();
+        PageProcessor processor = compiler.compilePageProcessor(TEST_SESSION.getSqlFunctionProperties(), Optional.empty(), ImmutableList.of(field(0, VARCHAR)), false, MAX_BATCH_SIZE).get();
 
         Page page = new Page(createDictionaryBlock(createExpectedValues(10), 100));
         Page outputPage = getOnlyElement(
@@ -215,7 +215,7 @@ public class TestPageProcessorCompiler
         InputReferenceExpression col0 = field(0, BIGINT);
         CallExpression lessThanRandomExpression = new CallExpression(LESS_THAN.name(), lessThan, BOOLEAN, ImmutableList.of(col0, random));
 
-        PageProcessor processor = compiler.compilePageProcessor(TEST_SESSION.getSqlFunctionProperties(), Optional.empty(), ImmutableList.of(lessThanRandomExpression), MAX_BATCH_SIZE).get();
+        PageProcessor processor = compiler.compilePageProcessor(TEST_SESSION.getSqlFunctionProperties(), Optional.empty(), ImmutableList.of(lessThanRandomExpression), false, MAX_BATCH_SIZE).get();
 
         assertFalse(new RowExpressionDeterminismEvaluator(metadataManager.getFunctionManager()).isDeterministic(lessThanRandomExpression));
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -131,7 +131,8 @@ public class TestFeaturesConfig
                 .setListBuiltInFunctionsOnly(true)
                 .setPartitioningPrecisionStrategy(PartitioningPrecisionStrategy.AUTOMATIC)
                 .setExperimentalFunctionsEnabled(false)
-                .setUseLegacyScheduler(true));
+                .setUseLegacyScheduler(true)
+                .setOptimizeCommonSubExpressions(true));
     }
 
     @Test
@@ -219,6 +220,7 @@ public class TestFeaturesConfig
                 .put("partitioning-precision-strategy", "PREFER_EXACT_PARTITIONING")
                 .put("experimental-functions-enabled", "true")
                 .put("use-legacy-scheduler", "false")
+                .put("optimize-common-sub-expressions", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -302,7 +304,8 @@ public class TestFeaturesConfig
                 .setListBuiltInFunctionsOnly(false)
                 .setPartitioningPrecisionStrategy(PartitioningPrecisionStrategy.PREFER_EXACT_PARTITIONING)
                 .setExperimentalFunctionsEnabled(true)
-                .setUseLegacyScheduler(false);
+                .setUseLegacyScheduler(false)
+                .setOptimizeCommonSubExpressions(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/CommonSubExpressionBenchmark.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/CommonSubExpressionBenchmark.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.gen;
+
+import com.facebook.presto.SequencePageBuilder;
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.warnings.WarningCollector;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.DriverYieldSignal;
+import com.facebook.presto.operator.project.PageProcessor;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.block.DictionaryBlock;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.relational.RowExpressionOptimizer;
+import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.NodeRef;
+import com.facebook.presto.testing.TestingSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.operator.scalar.FunctionAssertions.createExpression;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
+import static java.util.Collections.emptyList;
+import static java.util.Locale.ENGLISH;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+public class CommonSubExpressionBenchmark
+{
+    private static final Map<String, Type> TYPE_MAP = ImmutableMap.of("bigint", BIGINT, "varchar", VARCHAR, "json", VARCHAR);
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final Metadata METADATA = createTestMetadataManager();
+    private static final Session TEST_SESSION = TestingSession.testSessionBuilder().build();
+    private static final int POSITIONS = 1024;
+
+    private PageProcessor pageProcessor;
+    private Page inputPage;
+    private Map<String, Type> symbolTypes;
+    private Map<VariableReferenceExpression, Integer> sourceLayout;
+
+    @Param({"json", "bigint", "varchar"})
+    String functionType;
+
+    @Param({"true", "false"})
+    boolean optimizeCommonSubExpression;
+
+    @Param({"true", "false"})
+    boolean dictionaryBlocks;
+
+    @Setup
+    public void setup()
+    {
+        Type type = TYPE_MAP.get(this.functionType);
+
+        VariableReferenceExpression variable = new VariableReferenceExpression(type.getDisplayName().toLowerCase(ENGLISH) + "0", type);
+        symbolTypes = ImmutableMap.of(variable.getName(), type);
+        sourceLayout = ImmutableMap.of(variable, 0);
+        inputPage = createPage(functionType, dictionaryBlocks);
+
+        List<RowExpression> projections = getProjections(this.functionType);
+
+        MetadataManager metadata = createTestMetadataManager();
+        PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(metadata, 0);
+        pageProcessor = new ExpressionCompiler(metadata, pageFunctionCompiler).compilePageProcessor(TEST_SESSION.getSqlFunctionProperties(), Optional.of(getFilter(functionType)), projections, optimizeCommonSubExpression, Optional.empty()).get();
+    }
+
+    @Benchmark
+    public List<Optional<Page>> compute()
+    {
+        return ImmutableList.copyOf(
+                pageProcessor.process(
+                        null,
+                        new DriverYieldSignal(),
+                        newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
+                        inputPage));
+    }
+
+    private RowExpression getFilter(String functionType)
+    {
+        if (functionType.equals("varchar")) {
+            return rowExpression("cast(varchar0 as bigint) % 2 = 0");
+        }
+        if (functionType.equals("bigint")) {
+            return rowExpression("bigint0 % 2 = 0");
+        }
+        if (functionType.equals("json")) {
+            return rowExpression("rand() < 0.5");
+        }
+        throw new IllegalArgumentException("filter not supported for type : " + functionType);
+    }
+
+    private List<RowExpression> getProjections(String functionType)
+    {
+        ImmutableList.Builder<RowExpression> builder = ImmutableList.builder();
+        if (functionType.equals("bigint")) {
+            return ImmutableList.of(rowExpression("bigint0 + bigint0"), rowExpression("bigint0 + bigint0 + 5"));
+        }
+        else if (functionType.equals("varchar")) {
+            return ImmutableList.of(rowExpression("concat(varchar0, varchar0)"), rowExpression("concat(concat(varchar0, varchar0), 'foo')"));
+        }
+        else if (functionType.equals("json")) {
+            return ImmutableList.of(rowExpression("json_extract(json_parse(varchar0), '$.a')"), rowExpression("json_extract(json_parse(varchar0), '$.b')"));
+        }
+        throw new IllegalArgumentException();
+    }
+
+    private RowExpression rowExpression(String value)
+    {
+        Expression expression = createExpression(value, METADATA, TypeProvider.copyOf(symbolTypes));
+
+        Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, TypeProvider.copyOf(symbolTypes), expression, emptyList(), WarningCollector.NOOP);
+        RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, METADATA.getFunctionManager(), METADATA.getTypeManager(), TEST_SESSION);
+        RowExpressionOptimizer optimizer = new RowExpressionOptimizer(METADATA);
+        return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
+    }
+
+    private static Page createPage(String functionType, boolean dictionary)
+    {
+        List<Type> types = ImmutableList.of(TYPE_MAP.get(functionType));
+        switch (functionType) {
+            case "bigint":
+            case "varchar":
+                if (dictionary) {
+                    return SequencePageBuilder.createSequencePageWithDictionaryBlocks(types, POSITIONS);
+                }
+                else {
+                    return SequencePageBuilder.createSequencePage(types, POSITIONS);
+                }
+            case "json":
+                if (dictionary) {
+                    return createDictionaryStringJsonPage();
+                }
+                else {
+                    return createStringJsonPage();
+                }
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    private static Page createStringJsonPage()
+    {
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, POSITIONS);
+
+        for (int i = 0; i < POSITIONS; i++) {
+            VARCHAR.writeString(builder, "{\"a\": 1, \"b\": 2}");
+        }
+        return new Page(builder.build());
+    }
+
+    private static Page createDictionaryStringJsonPage()
+    {
+        int dictionarySize = POSITIONS / 5;
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, dictionarySize);
+        for (int i = 0; i < dictionarySize; i++) {
+            VARCHAR.writeString(builder, "{\"a\": 1, \"b\": 2}");
+        }
+        int[] ids = new int[POSITIONS];
+        for (int i = 0; i < POSITIONS; i++) {
+            ids[i] = i % dictionarySize;
+        }
+        return new Page(new DictionaryBlock(builder.build(), ids));
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + CommonSubExpressionBenchmark.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestCommonSubExpressionRewritter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestCommonSubExpressionRewritter.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.gen;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.warnings.WarningCollector;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.NodeRef;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
+import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
+import static com.facebook.presto.sql.gen.CommonSubExpressionRewriter.collectCSEByLevel;
+import static com.facebook.presto.sql.gen.CommonSubExpressionRewriter.getExpressionsWithCSE;
+import static com.facebook.presto.sql.gen.CommonSubExpressionRewriter.rewriteExpressionWithCSE;
+import static org.testng.Assert.assertEquals;
+
+public class TestCommonSubExpressionRewritter
+{
+    private static final Session SESSION = TEST_SESSION;
+    private static final Metadata METADATA = MetadataManager.createTestMetadataManager();
+    private static final TypeProvider TYPES = TypeProvider.viewOf(
+            ImmutableMap.<String, Type>builder()
+                    .put("x", BIGINT)
+                    .put("y", BIGINT)
+                    .put("z", BIGINT)
+                    .put("add$cse", BIGINT)
+                    .put("multiply$cse", BIGINT)
+                    .put("add$cse_0", BIGINT).build());
+
+    @Test
+    void testGetExpressionsWithCSE()
+    {
+        List<RowExpression> expressions = ImmutableList.of(rowExpression("x + y"), rowExpression("(x + y) * 2"), rowExpression("x + 2"));
+        List<RowExpression> expressionsWithCSE = getExpressionsWithCSE(expressions);
+        assertEquals(expressionsWithCSE, ImmutableList.of(rowExpression("x + y"), rowExpression("(x + y) * 2")));
+    }
+
+    @Test
+    void testCollectCSEByLevel()
+    {
+        List<RowExpression> expressions = ImmutableList.of(rowExpression("x * 2 + y + z"), rowExpression("(x * 2 + y + 1) * 2"), rowExpression("(x * 2)  + (x * 2 + y + z)"));
+        Map<Integer, Map<RowExpression, VariableReferenceExpression>> cseByLevel = collectCSEByLevel(expressions);
+        assertEquals(cseByLevel, ImmutableMap.of(
+                3, ImmutableMap.of(rowExpression("\"add$cse\" + z"), rowExpression("\"add$cse_0\"")),
+                2, ImmutableMap.of(rowExpression("\"multiply$cse\" + y"), rowExpression("\"add$cse\"")),
+                1, ImmutableMap.of(rowExpression("x * 2"), rowExpression("\"multiply$cse\""))));
+    }
+
+    @Test
+    void testNoRedundantCSE()
+    {
+        List<RowExpression> expressions = ImmutableList.of(rowExpression("x * 2 + y + z"), rowExpression("(x * 2 + y + z) * 2"), rowExpression("x * 2"));
+        Map<Integer, Map<RowExpression, VariableReferenceExpression>> cseByLevel = collectCSEByLevel(expressions);
+        // x * 2 + y is redundant thus should not appear in results
+        assertEquals(cseByLevel, ImmutableMap.of(
+                3, ImmutableMap.of(rowExpression("\"multiply$cse\" + y + z"), rowExpression("\"add$cse\"")),
+                1, ImmutableMap.of(rowExpression("x * 2"), rowExpression("\"multiply$cse\""))));
+    }
+
+    @Test
+    void testRewriteExpressionWithCSE()
+    {
+        assertEquals(
+                rewriteExpressionWithCSE(
+                        rowExpression("(x * y + z) * (y + z) + (x * y)"),
+                        ImmutableMap.of(
+                                rowExpression("x * y"), variable("multiply$cse"),
+                                rowExpression("y + z"), variable("add$cse"),
+                                rowExpression("\"multiply$cse\" + z"), variable("add$cse_0"))),
+                rowExpression("\"add$cse_0\" * \"add$cse\" + \"multiply$cse\""));
+    }
+
+    private VariableReferenceExpression variable(String variable)
+    {
+        return new VariableReferenceExpression(variable, TYPES.allTypes().get(variable));
+    }
+
+    private RowExpression rowExpression(String sql)
+    {
+        Expression expression = rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(sql));
+        Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(
+                SESSION,
+                METADATA,
+                new SqlParser(),
+                TYPES,
+                expression,
+                ImmutableList.of(),
+                WarningCollector.NOOP);
+        return SqlToRowExpressionTranslator.translate(
+                expression,
+                expressionTypes,
+                ImmutableMap.of(),
+                METADATA.getFunctionManager(),
+                METADATA.getTypeManager(),
+                SESSION);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.relation.CallExpression;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -90,7 +91,7 @@ public class TestPageFunctionCompiler
         String classSuffix = stageId + "_" + planNodeId;
         Supplier<PageProjection> projectionSupplier = functionCompiler.compileProjection(SESSION.getSqlFunctionProperties(), ADD_10_EXPRESSION, Optional.of(classSuffix));
         PageProjection projection = projectionSupplier.get();
-        Work<Block> work = projection.project(SESSION.getSqlFunctionProperties(), new DriverYieldSignal(), createLongBlockPage(0), SelectedPositions.positionsRange(0, 1));
+        Work<List<Block>> work = projection.project(SESSION.getSqlFunctionProperties(), new DriverYieldSignal(), createLongBlockPage(0), SelectedPositions.positionsRange(0, 1));
         // class name should look like PageProjectionOutput_20170707_223500_67496_zguwn_2_7_XX
         assertTrue(work.getClass().getSimpleName().startsWith("PageProjectionWork_" + stageId.replace('.', '_') + "_" + planNodeId));
     }
@@ -129,9 +130,9 @@ public class TestPageFunctionCompiler
 
     private Block project(PageProjection projection, Page page, SelectedPositions selectedPositions)
     {
-        Work<Block> work = projection.project(SESSION.getSqlFunctionProperties(), new DriverYieldSignal(), page, selectedPositions);
+        Work<List<Block>> work = projection.project(SESSION.getSqlFunctionProperties(), new DriverYieldSignal(), page, selectedPositions);
         assertTrue(work.process());
-        return work.getResult();
+        return work.getResult().get(0);
     }
 
     private static Page createLongBlockPage(long... values)

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
@@ -13,15 +13,18 @@
  */
 package com.facebook.presto.sql.gen;
 
+import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.Work;
 import com.facebook.presto.operator.project.PageProjection;
+import com.facebook.presto.operator.project.PageProjectionWithOutputs;
 import com.facebook.presto.operator.project.SelectedPositions;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.relation.CallExpression;
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -45,12 +48,33 @@ import static org.testng.Assert.fail;
 
 public class TestPageFunctionCompiler
 {
+    private static final FunctionManager FUNCTION_MANAGER = createTestMetadataManager().getFunctionManager();
+
     private static final CallExpression ADD_10_EXPRESSION = call(
             ADD.name(),
-            createTestMetadataManager().getFunctionManager().resolveOperator(ADD, fromTypes(BIGINT, BIGINT)),
+            FUNCTION_MANAGER.resolveOperator(ADD, fromTypes(BIGINT, BIGINT)),
             BIGINT,
             field(0, BIGINT),
             constant(10L, BIGINT));
+
+    private static final CallExpression ADD_X_Y = call(
+            ADD.name(),
+            FUNCTION_MANAGER.resolveOperator(ADD, fromTypes(BIGINT, BIGINT)),
+            BIGINT,
+            field(0, BIGINT),
+            field(1, BIGINT));
+
+    private static final CallExpression ADD_X_Y_Z = call(
+            ADD.name(),
+            FUNCTION_MANAGER.resolveOperator(ADD, fromTypes(BIGINT, BIGINT)),
+            BIGINT,
+            call(
+                    ADD.name(),
+                    FUNCTION_MANAGER.resolveOperator(ADD, fromTypes(BIGINT, BIGINT)),
+                    BIGINT,
+                    field(0, BIGINT),
+                    field(1, BIGINT)),
+            field(2, BIGINT));
 
     @Test
     public void testFailureDoesNotCorruptFutureResults()
@@ -61,12 +85,12 @@ public class TestPageFunctionCompiler
         PageProjection projection = projectionSupplier.get();
 
         // process good page and verify we got the expected number of result rows
-        Page goodPage = createLongBlockPage(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-        Block goodResult = project(projection, goodPage, SelectedPositions.positionsRange(0, goodPage.getPositionCount()));
+        Page goodPage = createLongBlockPage(1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        Block goodResult = project(projection, goodPage, SelectedPositions.positionsRange(0, goodPage.getPositionCount())).get(0);
         assertEquals(goodPage.getPositionCount(), goodResult.getPositionCount());
 
         // addition will throw due to integer overflow
-        Page badPage = createLongBlockPage(0, 1, 2, 3, 4, Long.MAX_VALUE);
+        Page badPage = createLongBlockPage(1, 0, 1, 2, 3, 4, Long.MAX_VALUE);
         try {
             project(projection, badPage, SelectedPositions.positionsRange(0, 100));
             fail("expected exception");
@@ -77,7 +101,7 @@ public class TestPageFunctionCompiler
 
         // running the good page should still work
         // if block builder in generated code was not reset properly, we could get junk results after the failure
-        goodResult = project(projection, goodPage, SelectedPositions.positionsRange(0, goodPage.getPositionCount()));
+        goodResult = project(projection, goodPage, SelectedPositions.positionsRange(0, goodPage.getPositionCount())).get(0);
         assertEquals(goodPage.getPositionCount(), goodResult.getPositionCount());
     }
 
@@ -91,7 +115,7 @@ public class TestPageFunctionCompiler
         String classSuffix = stageId + "_" + planNodeId;
         Supplier<PageProjection> projectionSupplier = functionCompiler.compileProjection(SESSION.getSqlFunctionProperties(), ADD_10_EXPRESSION, Optional.of(classSuffix));
         PageProjection projection = projectionSupplier.get();
-        Work<List<Block>> work = projection.project(SESSION.getSqlFunctionProperties(), new DriverYieldSignal(), createLongBlockPage(0), SelectedPositions.positionsRange(0, 1));
+        Work<List<Block>> work = projection.project(SESSION.getSqlFunctionProperties(), new DriverYieldSignal(), createLongBlockPage(1, 0), SelectedPositions.positionsRange(0, 1));
         // class name should look like PageProjectionOutput_20170707_223500_67496_zguwn_2_7_XX
         assertTrue(work.getClass().getSimpleName().startsWith("PageProjectionWork_" + stageId.replace('.', '_') + "_" + planNodeId));
     }
@@ -128,19 +152,52 @@ public class TestPageFunctionCompiler
                 noCacheCompiler.compileProjection(SESSION.getSqlFunctionProperties(), ADD_10_EXPRESSION, Optional.of("hint2")));
     }
 
-    private Block project(PageProjection projection, Page page, SelectedPositions selectedPositions)
+    @Test
+    public void testCommonSubExpression()
+    {
+        PageFunctionCompiler functionCompiler = new PageFunctionCompiler(createTestMetadataManager(), 0);
+
+        List<Supplier<PageProjectionWithOutputs>> pageProjectionsCSE = functionCompiler.compileProjections(SESSION.getSqlFunctionProperties(), ImmutableList.of(ADD_X_Y, ADD_X_Y_Z), true, Optional.empty());
+        assertEquals(pageProjectionsCSE.size(), 1);
+        List<Supplier<PageProjectionWithOutputs>> pageProjectionsNoCSE = functionCompiler.compileProjections(SESSION.getSqlFunctionProperties(), ImmutableList.of(ADD_X_Y, ADD_X_Y_Z), false, Optional.empty());
+        assertEquals(pageProjectionsNoCSE.size(), 2);
+
+        Page input = createLongBlockPage(3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        List<Block> cseResult = project(pageProjectionsCSE.get(0).get().getPageProjection(), input, SelectedPositions.positionsRange(0, input.getPositionCount()));
+        assertEquals(cseResult.size(), 2);
+        List<Block> noCseResult1 = project(pageProjectionsNoCSE.get(0).get().getPageProjection(), input, SelectedPositions.positionsRange(0, input.getPositionCount()));
+        assertEquals(noCseResult1.size(), 1);
+        List<Block> noCseResult2 = project(pageProjectionsNoCSE.get(1).get().getPageProjection(), input, SelectedPositions.positionsRange(0, input.getPositionCount()));
+        assertEquals(noCseResult2.size(), 1);
+        checkBlockEqual(cseResult.get(0), noCseResult1.get(0));
+        checkBlockEqual(cseResult.get(1), noCseResult2.get(0));
+    }
+
+    private void checkBlockEqual(Block a, Block b)
+    {
+        assertEquals(a.getPositionCount(), b.getPositionCount());
+        for (int i = 0; i < a.getPositionCount(); i++) {
+            assertEquals(a.getLong(i), b.getLong(i));
+        }
+    }
+
+    private List<Block> project(PageProjection projection, Page page, SelectedPositions selectedPositions)
     {
         Work<List<Block>> work = projection.project(SESSION.getSqlFunctionProperties(), new DriverYieldSignal(), page, selectedPositions);
         assertTrue(work.process());
-        return work.getResult().get(0);
+        return work.getResult();
     }
 
-    private static Page createLongBlockPage(long... values)
+    private static Page createLongBlockPage(int blockCount, long... values)
     {
-        BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(values.length);
-        for (long value : values) {
-            BIGINT.writeLong(builder, value);
+        Block[] blocks = new Block[blockCount];
+        for (int i = 0; i < blockCount; i++) {
+            BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(values.length);
+            for (long value : values) {
+                BIGINT.writeLong(builder, value);
+            }
+            blocks[i] = builder.build();
         }
-        return new Page(builder.build());
+        return new Page(blocks);
     }
 }


### PR DESCRIPTION
Testing with Facebook workload shows positive CPU improvements overall. There are known corner cases that might cause regression, namely, very long list of projects with common sub expressions. In this case, we will compile all projections with cse into a single PageProjection, this would result in large bytecode size, and for some reason, a very wide projection has performance regression (We see similar behavior for wide ROW). These will be addressed in a follow up PR. The optimization can be turned off if regression is observed.

```
== RELEASE NOTES ==

General Changes
* Add optimization for page projection by extract and compute common subexpressions among all projections first. This optimization can be turned off by session property ``optimize_common_sub_expressions``.
```