### PR TITLE
Add release notes for 0.234

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.234
     release/release-0.233.1
     release/release-0.233
     release/release-0.232

--- a/presto-docs/src/main/sphinx/release/release-0.234.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.234.rst
@@ -1,0 +1,44 @@
+=============
+Release 0.234
+=============
+
+General Changes
+_______________
+* Fix query failure for cross-joining bucketed tables with ``COALESCE`` when the bucket counts are compatible but mismatched.
+* Fix an issue where ``IGNORE NULLS`` is not respected for window functions.
+* Fix scheduling regression by setting the default scheduler to legacy scheduler.
+* Improve coordinator reliability by adding support to cap the number of total tasks running in a coordinator by pausing scheduling.
+  This can be enabled by the configuration property ``experimental.max-total-running-task-count-to-not-execute-new-query``.
+* Improve the scale writer heuristics by considering overall producer buffer utilization. This can be enabled by the session property
+  ``optimized_scale_writer_producer_buffer`` and the configuration property ``optimized-scale-writer-producer-buffer``.
+* Improve end point ``v1/resourceGroupState`` to supporting filtering of resource groups that are dynamically generated.
+* Improve connection pooling to avoid running out of sockets.
+* Add :ref:`khyperloglog_type` type and related functions.
+* Add support for forcing streaming exchange for Mark Distinct even if materialized exchange is enabled.
+  This can be enabled by the session property ``use_stream_exchange_for_mark_distinct``
+  and the configuration property ``query.use-streaming-exchange-for-mark-distinct``. (:pr:`14216`).
+
+Geospatial Changes
+__________________
+* Improve storage efficiency for Bing tiles by storing Bing tiles as ``BIGINT``. This also reduces bucket skew in certain cases.
+* Add support for spatial joins for join condition ``ST_Distance(p1, p2) < r``.
+
+Hive Changes
+____________
+* Add ``ZSTD`` support for writing ``ORC`` and ``DWRF`` files. This can be enabled by setting session property ``hive.compression_codec`` to ``ZSTD``.
+
+Verifier Changes
+________________
+* Add support for verifying ``SELECT`` queries that produce ``DATE`` or ``UNKNOWN`` (null) columns, or structured typed columns with ``DATE`` or ``UNKNOWN``.
+* Add support for auto-resolving control check query failures due to ``EXCEEDED_TIME_LIMIT``.
+* Add determinism analysis support for simple queries with top-level ``ORDER BY LIMIT`` clause. (:pr:`14181`).
+
+SPI Changes
+___________
+* Add parameter ``AccessControlContext`` to all methods in ``SystemAccessControl``.
+* Add ``firstDynamicSegmentPosition`` to SelectionContext.
+
+Druid Changes
+_____________
+* Add support for aggregation pushdown.
+* Add support for ``LIMIT`` evaluation pushdown.


### PR DESCRIPTION
# Missing Release Notes
## Cem Cayiroglu
- [x] https://github.com/prestodb/presto/pull/14177 A new end point to get resource group stats (Merged by: Andrii Rosa)

## Jonas Bauer
- [x] 54dd54cb681af311e9b6fb6910ae004dfa71988b Minor exception message fix for ArrayBlockBuilder

## Ke
- [x] 0834046fc180310fa1b33f7f150ca15f201ad5d1 Update connectors.rst
- [x] 8f1c09343bddd0c852d5fbacf43750543d34bdae Update connectors.rst
- [x] 446e7f57aa0114882569723efdcd035d15c5cd5d Update connectors.rst
- [x] 82f8a4be45ff1f09f69381a27ae9641622eaadae Update connectors.rst

## Rohit Jain
- [x] https://github.com/prestodb/presto/pull/14113 Add ZSTD support for writing ORC and DWRF tables (Merged by: Maria Basmanova)

## Sreeni Viswanadha
- [x] https://github.com/prestodb/presto/pull/14276 Fix bucket pruning when value is null and the predicate is 'IS NULL'. (Merged by: Rongrong Zhong)
- [x] https://github.com/prestodb/presto/pull/14221 Add @JsonProperty tag to ignoreNulls flag so it works in distributed … (Merged by: Rongrong Zhong)

# Extracted Release Notes
- #14119 (Author: Matías Correa): Add KHyperLogLog type and UDF
  - Add KHyperLogLog Type.
  - Add MAKE_KHYPERLOGLOG(K, V) -> KHYPERLOGLOG aggregate function.
  - Add KHyperLogLog related scalar functions.
- #14125 (Author: James A. Gill): Add cast bingtile to/from bigint
  - Add `cast(tile AS bigint)` and `cast(bigint_value AS bingtile)` to encode/decode Bing tiles to/from bigints.  This is a more efficient storage format that also reduces bucket skew in some cases.
- #14137 (Author: James A. Gill): Enable spatial join for spherical geography ST_Distance
  - Enable spatial joins for `ST_Distance(p1, p2) < r` for spherical geography points `p1` and `p2`.
- #14181 (Author: Leiqing Cai): Support determinism analysis for simple queries with top-level ORDER BY LIMIT clause
  - Support determinism analysis for simple queries with top-level ``ORDER BY LIMIT`` clause. (:pr:`14181`).
- #14193 (Author: Wenlei Xie): Improve scale writer creation based on producer buffer
  - Improve the scale writer heuristics by considering overall producer buffer utilization. This can be enabled by using the session property `optimized_scale_writer_producer_buffer` and the configuration property `optimized-scale-writer-producer-buffer`.
- #14194 (Author: Vic Zhang): Keep queries in the queue when task count is high
  - Add support for stopping new query execution when total number of tasks exceeds a set limit to help with reliability. The limit can be set by the cluster property by ``experimental.max-total-running-task-count-to-halt-scheduling``.
- #14200 (Author: Zhenxiao Luo): Limit pushdown for Druid connector
  - Add LIMIT evaluation pushdown to Druid connector.
- #14216 (Author: Ariel Weisberg): Allow forcing streaming exchange for Mark Distinct
  - Allow forcing streaming exchange for Mark Distinct using 'query.use-streaming-exchange-for-mark-distinct'.
- #14224 (Author: Zhenxiao Luo): Aggregation Pushdown for Druid connector
  - Aggregation Pushdown for Druid connector.
- #14225 (Author: Andrii Rosa): Optimize socket pooling
  - Optimize connection pooling to avoid running out of sockets in certain cases.
- #14230 (Author: Leiqing Cai): Auto resolve time limit exceeded on checksum queries
  - Add support to auto-resolve control check query failures due to ``EXCEEDED_TIME_LIMIT``.
- #14248 (Author: Nikhil Collooru): Add AccessControlContext to store client information for security purposes
  - All the methods in ``SystemAccessControl`` now take additional parameter ``AccessControlContext context``.
- #14264 (Author: Rebecca Schlussel): Set use-legacy-scheduler true by default
  - Change the default for configuration property ``use-legacy-scheduler`` to ``true`` in order to mitigate a regression in the new scheduler.
- #14266 (Author: Leiqing Cai): Support verifying SELECT queries with DATE or UNKNOWN columns
  - Add support for verifying ``SELECT`` queries that produce ``DATE`` or ``UNKNOWN`` (null) columns.
- #14267 (Author: Rongrong Zhong): Handle coalesce partition handle when bucket count does not match but compatible
  - Fix query failures with incompatible partition handle when session property ``partial_merge_pushdown_strategy`` is set to ``PUSH_THROUGH_LOW_MEMORY_OPERATORS`` and ``optimize_full_outer_join_with_coalesce`` is set to ``true`` and query has mismatched partition and uses ``FULL OUTER JOIN`` with ``COALESCE``.
- #14273 (Author: Leiqing Cai): Support verifying structured types containing DATE and UNKNOWN
  - Add support for verifying ``SELECT`` queries that produce structured types containing ``DATE`` or ``UNKNOWN`` (null).

# All Commits
- 0f2b203ee43142117e22809f4c1b728dbfd2f66b Reuse buffers in BlockEncodingBuffer (Ying Su)
- 5b8b26e15bc3f958b0dede3beb2d6a02f1ff6352 Add byte[] support to ArrayAllocator (Ying Su)
- 3c2e9eecd150c2e2381467893017d43ca92452a0 Return arrays in reverse order of borrowing (Ying Su)
- ec684fb0e5d353caa7a14c6fcd02ee67ae51113c Clean up queries in DispatchManager (Tim Meehan)
- efd979afa5efcf616ac1ae0b806fcad3a0cf1ab0 Add AccessControlContext to store client information for security purposes (Nikhil Collooru)
- 61e3c8805bf8cf45d871f6cfbce06c82cb5c1880 Move SerializedPage to SPI (Vic Zhang)
- 4e5dd5f990f8e27f83498a63a71d5aea94c27e33 Remove guava dependency from SerializedPage (Vic Zhang)
- 96409c39eba60b09fe4eb1a973a18bfbae5593f7 Move PageCodecMarker to SPI (Vic Zhang)
- 151f57bb6778016b11e51fa6c26b21f09af43765 Move BlockSerdeUtil to SPI (Vic Zhang)
- acb8af46e374402c1d4482e20b6cadcf1915d30c An end point to get resource group level stats (Cem Cayiroglu)
- e9b4d1fb4d5be5ec8fc9fe6b6fb1c17cf0382f0a Fix getRetainedSizeInBytes for DecodedBlockNode (Ying Su)
- 410dd0900390bf08f16a1a5030483c7d77cf1b0e Move RemoteSplit URI construction from coordinator to worker (Shixuan Fan)
- 59ddb0b2a5e827f4ea908cd2637b53441f2ec07c Remove unused ConnectorIdentity#{equals, hashCode} (Wenlei Xie)
- 7af7880282938066fe28eb0f29b31110948c0355 Add partitioned spherical spatial joins (James A. Gill)
- 0638aa062782a1cbd698c0490474863e96d910cf Extract spherical geography functions to SphericalGeoFunctions (James A. Gill)
- 9bebca50fc11732c884ce20fd38745530bc83ac0 Enable spatial join for spherical geography ST_Distance (James A. Gill)
- 8bc8c94825747e98e179da1d36593f64607f6149 Extract some spherical geometry functions to helper class (James A. Gill)
- 6028f4dd8c25ef475943c84a6236948fb2aabf2f Create ThriftBufferResult and ThriftSerializedPage (Vic Zhang)
- 5f21344035932afdbddd037ed9d5cea63025a880 Add PrestoSparkAuthenticatorProvider (Wenlei Xie)
- 9c32d6b57d033dd5226e83cd7c731b73f6db249c Introduce TokenAuthenticator (Wenlei Xie)
- 68e4367dc3abcb21dec09fd552212e130cd1871d Handle coalesce partition handle with mismatched bucket count (Rongrong Zhong)
- dd38222aa43968aabcdc61aeb2a9971f14a767ed Change default value for colocated_join to true (Rongrong Zhong)
- 6613a6a1be3f4c03e4bb77382cb71a7a0fbd42e4 Fix bucket pruning when value is null and the predicate is 'IS NULL'. (Sreeni Viswanadha)
- e90fd6baf9b47701ab8346df054ebf58878a43c2 Reuse positions, mappedPositions and offsets in BlockEncodingBuffer (Ying Su)
- acac2e4741016d9fece82832fd1db496302103c6 Add isNested flag to BlockEncodingBuffer (Ying Su)
- ed23d49411f66551bf6cc2f8cfcfe847c7ea34af Reuse offsetsCopy in BlockEncodingBuffer (Ying Su)
- df3b10a7630dc3a8d0a1aa2e46e7d46e99eb4d36 Add ArrayAllocator to BlockEncodingBuffer (Ying Su)
- d3f9cfc25faf3791d9c634cf2bd0c4e4317814fd Reuse serializedRowSizes buffer between different PartitionBuffers (Ying Su)
- 1bbd1310d3526cae9c7d82566d6dcefe3ec147e3 Support verifying structured types containing DATE and UNKNOWN (Leiqing Cai)
- ed7a6ef6cdd9d9326e1d0e38d41660a99c8b24e4 Use Type instead of TypeSignature in QueryRewriter (Leiqing Cai)
- 613e19e16d0d7c897adb2a6988e40aa32c216fb3 Remove usage of String.format in HTTP client hot path (James Petty)
- 5078fd67464fd2a6f5d82e46a12cf9ffd756fd34 Support verifying SELECT queries with UNKNOWN columns (Leiqing Cai)
- 65a29b3755421a8ffc21a8980402674125cec68c Support verifying SELECT queries with DATE columns (Leiqing Cai)
- ae3cafe490bc1db1e96fd5e4a0391971ff0f7bbd Improve JdbcPrestoAction (Leiqing Cai)
- 7dc045335195503c1f6c586c414a52a485d3deb7 Optimize parquet gzip decompression (James Petty)
- 075b70e46a69da2cc53bbb37c79939ead4b8ab69 Set use-legacy-scheduler true by default (Rebecca Schlussel)
- a3df4d1e2856e234c1d792ff8ee3b5ce04bdc00e Avoid Exceptions when closing queryRunner (Leiqing Cai)
- 0bfc8cc59e39684e4db31ca307b4da6e7993403d Add toString() to SimpleArrayAllocator (Ying Su)
- ac183423a7f2c07607eea80911859e415a0307d2 Add benchmarks for Parquet reader (Venki Korukanti)
- 32011d8849a44955eb60cf64cae720c400a22d3a Make PageReader class public (Venki Korukanti)
- a99684e12a569e2e315c959b0cca083140d6327c Removed unused method (Venki Korukanti)
- 528bd5c7d62e66f617637495a9958c2da81b5c4a Move ColumnIOConverter to presto-parquet package (Venki Korukanti)
- 5bad5a33bd0e2196f032f5d52b490f9c51f4ecc3 Add FileParquetDataSource for testing purpose (Venki Korukanti)
- fd5a7ddb40773c15163576e4e6632a67fbbc9483 Removed unused ParquetDataSource#size (Venki Korukanti)
- 11ae1f277400e157912296f20c3d6dd4f6b33480 Revert "Update connectors.rst" (Ke Wang)
- 0491783e950e2812b1c4b0a37b16553c050577f5 Fix subscript expression optimization during subfield pushdown (Bhavani Hari)
- caff58e35ec3fc73a01929c3d48fbf51bc638ce8 Disable Presto-on-Spark query stats collection (Wenlei Xie)
- ad1be427c1e48423c556a87d4b7227b90918a4e8 Aggregation Pushdown for Druid connector (Zhenxiao Luo)
- c61194f4cbe704f3c410b3d0526e7a9007b32201 Do not cancel running HTTP requests (Andrii Rosa)
- aa77278fd535551e46a80182143685af696b22e9 Update Airlift to 0.191 (Andrii Rosa)
- 7c7fa10c91271cc5f7b1abc5b30261ce253fc20b Remove overrides for idle connection timeout (Andrii Rosa)
- 7dda502dee9608a818219aa63f4f7158e6c2bf87 Refactor PrestoSparkLauncher (Andrii Rosa)
- 000fa29dcbf3958e988a20f92febe058baba9e6d Reduce positions array size in PartitionBuffer (Ying Su)
- dd86faafcdefe98ed6ba037018ab281aa589a5f9 Fix memory tracking for PartitionedOutputOperator (Ying Su)
- 2b4315460a22e4a1abe0abe48159f872c93331ec Add support for testing DictionaryBlock with non-zero offset (Ying Su)
- 660f0a715f565438de9f9b1723ae74ab2978380c Fix BlockFlattener when DictionaryBlock's idsOffset is nonzero (Ying Su)
- f88d6528e0050fda436264b4057c5cfea8efa199 Refactor TestBlockFlattenner (Ying Su)
- 5d1797c745fa406d4d5ab96423b1ca5f40a00157 Add ZSTD support for writing ORC and DWRF tables (Rohit Jain)
- b0814187bebbb25b28f768c0dc77dc901822116f Fix ArrayBlockEncodingBuffer#getRetainedSizeInBytes() (Ying Su)
- 39c43b66e1838090e278fd68e0eecc836c230bd3 Add @JsonProperty tag to ignoreNulls flag so it works in distributed execution as well. (Sreeni Viswanadha)
- f35c6608120572f8d81fe2beb0bc374021a90510 Keep queries in the queue when task count is high (Vic Zhang)
- f6fd9ef756eaa053cd2db702ddb3be4e6335ca77 Refactor TestQueryTaskLimit (Vic Zhang)
- f13cee1ccf62e2c3218c1ae2593ed30ddbd90b67 Add configuration property to control query queuing (Vic Zhang)
- 66e94ef1ea7debada9e44c918f2b79f27d07c5d0 Rename configuration properties for task count limit (Vic Zhang)
- f9bf064946accbf7c66f9cba592c84af76a90b95 Allow forcing streaming exchange for Mark Distinct (Ariel Weisberg)
- 4d5bcffdc471a8e887ac84c6f84be26ae7d070c6 Use static imports in TestAddExchangePlans (Ariel Weisberg)
- 7bfc20373981d931b6d18ca570915d4da518b1ae Add purger to ExecutingStatementResource (Tim Meehan)
- 3af06bd62c959414488ec14e6ee548f837fc98f7 Simplify token management in protocol Query (Tim Meehan)
- 916cc6ce61b3e6989d2b5973fbfe9714a16147cb Fix result caching in protocol Query (Tim Meehan)
- 4a992da4c7d2eaeb49765e1489f8836449cedb97 Catch errors from LocalDispatchQuery querySubmitter (Tim Meehan)
- 58c0b7ed8aed38b7eb6f3e310c46171e11ea8574 Change local dispatch to finish immediately after query submission (Tim Meehan)
- 87b87293db3a978bda076741703c9398d43b1fc0 Cleanup dispatcher executor management (Tim Meehan)
- c372011e7db53a6ffcbc23382751d6851001942c Fix handling of failures during query creation (Tim Meehan)
- 42b40c7e9aa54d4a54a17f13d3ab5f61f1b3d893 Simplify query manager stats tracking (Tim Meehan)
- 9c17fc1fae790148bc8e977558c4da4762e5c9b8 Rename SqlQueryManagerStats to QueryManagerStats (Tim Meehan)
- b93f31e0cf5d4cdbfa9551029910ca5123705095 Simplify DispatchInfo construction (Tim Meehan)
- 39d639fc53cd299d596fb8781dd6540c909ef58a Remove Optional from QueryStateMachine resourceGroup (Tim Meehan)
- 7999f849f62e072ebe3097a9a85f4044cd954f87 Improve query event stats for immediately failed queries (Tim Meehan)
- e23009a1c9ac3766b6d973ac72c6e7114e1aa183 Add LocalCoordinatorLocation (Tim Meehan)
- 2240313e603aa06ebd27d87c60a2dfcb1fcfb58d Add peak tasks to BasicQueryStats (Tim Meehan)
- a92f1616cf509d48133e171ee21ad982782ed521 Split out queued phase from QueryManager (Tim Meehan)
- f72d51120bcb9dd4e5571e5833085103fc80a61e Add DISPATCHING query states (Tim Meehan)
- 8b7c734ffd9112d8e166f2c1f9e5fe98f21a6fa5 Remove system startup minimum worker requirement (Tim Meehan)
- 153761bf66a10a7350e0e73456e74fe6b8e3ca76 Add query id to NoSuchElementException (Tim Meehan)
- 8d5283d7ab6e4ed0cc5bd303fc1497bfcface81c Optimize initial batch size for scan (Masha Basmanova)
- a902a34b9f066111deaa420c94d79f1f10d944ee Harden blockEncodingBuffers in OptimizedPartitionedOutputOperator (Ying Su)
- 0834046fc180310fa1b33f7f150ca15f201ad5d1 Update connectors.rst (Ke)
- 8f1c09343bddd0c852d5fbacf43750543d34bdae Update connectors.rst (Ke)
- 446e7f57aa0114882569723efdcd035d15c5cd5d Update connectors.rst (Ke)
- 82f8a4be45ff1f09f69381a27ae9641622eaadae Update connectors.rst (Ke)
- 3977cbf887bef782d2aaaecffb76fa206e107c65 Improve entropy for bing tile bigint encoding (James A. Gill)
- e167e4604d57a14712aa41bcbce1e625433c2994 Add BingTile cast to/from bigint (James A. Gill)
- 59f137a8dab4a380a0d97c914e06cd203f4924a5 Auto-resolve EXCEEDED_TIME_LIMIT on control checksum queries (Leiqing Cai)
- a021f7f9e50cad23854104ed2fbd371fb275a41c Fix reading a map column having negative integers as keys (Bhavani Hari)
- 0b7ab4b1a928b240d306af7d7c586e5c419e3f73 Rename PinotConnectorPlanOptimizer to PinotPlanOptimizer (James Sun)
- b03e989a9437624065eb9e92b16d707300371cb5 Rename DruidConnectorPlanOptimizer to DruidPlanOptimizer (James Sun)
- e57af67a9db67335552a0eaf4c5425851049d683 Fix typo in NodeSelectionStats (Shixuan Fan)
- f4b78693370a970d576f680b24877fd4e9a1852e Create KHyperLogLog type (Matías Correa)
- 411b5c64aa00f655a50fe3d819082a024e7c5f99 Add nodeSelectionStats to monitor affinity scheduler (Ke Wang)
- fd0ec6b42c549d7f3dc5650453ca73300a6a0af7 Add test methods to BenchmarkPartitionedOutputOperator (Ying Su)
- 65606a1d6db77a6f534c431076ccb69e8c4d4d15 Fix BenchmarkPartitionedOutputOperator (Ying Su)
- f5d93fbf3aacc60f672581fc2c1e1180c2b1f704 Minor fix to BenchmarkPartitionedOutputOperator (Ying Su)
- 2ab25438a2507b1438d60e7992714a261f9c9308 Improve scale writer creation based on producer buffer (Wenlei Xie)
- a4608e1d8c1beabb87aa8ca15968464e3e03d233 Fix candiateNodes selection for Soft Affinity (Ke Wang)
- 54dd54cb681af311e9b6fb6910ae004dfa71988b Minor exception message fix for ArrayBlockBuilder (Jonas Bauer)
- 0e144a6d592e564eaf054f5252d13eb6b1f44a98 Add allocation info to Task/Stage/QueryStats (Masha Basmanova)
- 76e311d337cccc146ed2718dd7490ea7691ff41a Add allocation info to PipelineStats (Masha Basmanova)
- ec3dd652afc36e671a131a91d2afbfde943ec8d4 Add allocation into to DriverStats (Masha Basmanova)
- e10de40d13894fcaab5d61268bf1f8d6fc6d8ac9 Refactor TestQueryStats (Masha Basmanova)
- 419d15563dd8a32ed9e13ae80dbf7066ad3bc0a3 Add allocation info to OperatorStats (Masha Basmanova)
- 5fe659f6f52964ac6b11a916d18b81557b35fb55 Track allocations per operator (Masha Basmanova)
- a9d1d337b0ba94a26f33082e8fb41715e968d776 Propagate flags to track allocation to OperationTimer (Masha Basmanova)
- a64e5d876f4d87df63f33e7a39665834cc6c67d3 Add config properties to enable tracking memory allocations (Masha Basmanova)
- 569be238fc441078cddf81d540c890489a8c977d Split test-hive-materialized on Travis (Leiqing Cai)
- 757fd25aee3604141df01fe6c7a0fd4b233db2b8 Remove version tags for presto projects from sub-module pom files (Leiqing Cai)
- b1c5015c19910808e599c49a54325556373f8016 Move Hive filter pushdown logic out of PickTableLayout (Saksham Sachdev)
- 9fa0caeeaa9d6df3368a78ce57b006b8cad16d1d Separate some modules into their own travis jobs to reduce test times (Sujay Jain)
- 5dadf5d9efbfc83628722da55a9392903f7d3551 Throw OrcCorruptionException for column type mismatch (Bhavani Hari)
- 05407a75d93d6c0b173d6f30d36a491636043b47 Remove unused HiveFileContext in OrcReader (James Sun)
- f8ee9fd00c75ec2c6a9a0cb1b59c99cf86c7d851 Add LIMIT evaluation pushdown to Druid connector (Zhenxiao Luo)
- d46146586c09e6478b27d5f9c4c60ace783ffc4b Allow column pruning in SHOW STATS (Masha Basmanova)
- d8d3939f3348451cdc9a2d322e9901856a488a7f Materialize LazyBlock in scan (Ying Su)
- b36f46321b4e83f2fcd32ca897f34cb489d7630b Break presto-tests Travis jobs to reduce test times (Bhavani Hari)
- 6d662bd06f953baa4a0278313941195e2489edb8 Fix finishStatisticsCollection to have correct ConnectorSession (Mayank Garg)
- b429ddb4eabd15ab1f7c06242b0ef39ab5bf0534 Wait for final task info on abort (Andrii Rosa)
- 1f774667198e72e29a124e8a39dc88b7a2e609d8 Always use JSON for PlanFragment serialization (Tim Meehan)
- 7aed00893642e967c0cc9d310ab31e83a6d0efa4 Support determinism analysis for simple ORDER BY LIMIT queries (Leiqing Cai)
- 1e070b2e42ff0c3a370bf4f410299786544a26c0 Improve Presto results conversion (Leiqing Cai)