### PR TITLE
Add UDFs to label and normalize Myanmar script text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1588,6 +1588,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.google.myanmartools</groupId>
+                <artifactId>myanmar-tools</artifactId>
+                <version>1.1.3</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.facebook.presto.cassandra</groupId>
                 <artifactId>cassandra-server</artifactId>
                 <version>2.1.16-1</version>

--- a/presto-docs/src/main/sphinx/functions.rst
+++ b/presto-docs/src/main/sphinx/functions.rst
@@ -30,3 +30,4 @@ Functions and Operators
     functions/color
     functions/session
     functions/teradata
+    functions/myanmar

--- a/presto-docs/src/main/sphinx/functions/myanmar.rst
+++ b/presto-docs/src/main/sphinx/functions/myanmar.rst
@@ -1,0 +1,20 @@
+===================
+Myanmar Functions
+===================
+
+.. note::
+
+    Text written in Myanmar uses primarily the Zawgyi font encoding,
+    which is not compatible with Unicode. These functions provide
+    some utilities for comparing content in Myanmar despite the font
+    encoding.
+
+    See http://www.unicode.org/faq/myanmar.html for more information.
+
+.. function:: myanmar_font_encoding(text) -> varchar
+
+    Returns the font encoding of the text. Returns ``zawgyi`` if the content is Zawgyi encoded and ``unicode`` otherwise.
+
+.. function:: myanmar_normalize_unicode(text) -> varchar
+
+    Returns the text normalized as Unicode. Zawgyi text is converted to Unicode and Unicode text is left unchanged.

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -307,6 +307,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.myanmartools</groupId>
+            <artifactId>myanmar-tools</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>http-client</artifactId>
         </dependency>

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
@@ -127,6 +127,7 @@ import com.facebook.presto.operator.scalar.MapValues;
 import com.facebook.presto.operator.scalar.MathFunctions;
 import com.facebook.presto.operator.scalar.MathFunctions.LegacyLogFunction;
 import com.facebook.presto.operator.scalar.MultimapFromEntriesFunction;
+import com.facebook.presto.operator.scalar.MyanmarFunctions;
 import com.facebook.presto.operator.scalar.QuantileDigestFunctions;
 import com.facebook.presto.operator.scalar.Re2JRegexpFunctions;
 import com.facebook.presto.operator.scalar.Re2JRegexpReplaceLambdaFunction;
@@ -558,6 +559,7 @@ public class BuiltInFunctionNamespaceManager
                 .scalar(IpAddressOperators.IpAddressDistinctFromOperator.class)
                 .scalars(IpPrefixFunctions.class)
                 .scalars(IpPrefixOperators.class)
+                .scalars(MyanmarFunctions.class)
                 .scalar(IpPrefixOperators.IpPrefixDistinctFromOperator.class)
                 .scalars(LikeFunctions.class)
                 .scalars(ArrayFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MyanmarFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MyanmarFunctions.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.myanmartools.TransliterateZ2U;
+import com.google.myanmartools.ZawgyiDetector;
+import io.airlift.slice.Slice;
+
+import static io.airlift.slice.Slices.utf8Slice;
+
+public final class MyanmarFunctions
+{
+    private MyanmarFunctions() {}
+
+    static ZawgyiDetector detector = new ZawgyiDetector();
+    static TransliterateZ2U z2uTransliterator = new TransliterateZ2U("Zawgyi to Unicode");
+
+    @Description("labels whether input strings use Unicode or Zawgyi font encoding")
+    @ScalarFunction
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice myanmarFontEncoding(@SqlType(StandardTypes.VARCHAR) Slice slice)
+    {
+        if (detector.getZawgyiProbability(slice.toStringUtf8()) > 0.9) {
+            return utf8Slice("zawgyi");
+        }
+        else {
+            return utf8Slice("unicode");
+        }
+    }
+
+    @Description("transforms strings using Myanmar characters to a normalized Unicode form")
+    @ScalarFunction
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice myanmarNormalizeUnicode(@SqlType(StandardTypes.VARCHAR) Slice slice)
+    {
+        String[] rawInputPieces = slice.toStringUtf8().split("\n");
+        String[] normalizedPieces = new String[rawInputPieces.length];
+        for (int i = 0; i < rawInputPieces.length; i++) {
+            if (detector.getZawgyiProbability(rawInputPieces[i]) > 0.9) {
+                normalizedPieces[i] = z2uTransliterator.convert(rawInputPieces[i]);
+            }
+            else {
+                normalizedPieces[i] = rawInputPieces[i];
+            }
+        }
+        return utf8Slice(String.join("\n", normalizedPieces));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMyanmarFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMyanmarFunctions.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
+public class TestMyanmarFunctions
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testMyanmarFontEncoding()
+    {
+        assertFunction("myanmar_font_encoding(NULL)", VARCHAR, null);
+        assertFunction("myanmar_font_encoding('english string')", VARCHAR, "unicode");
+        assertFunction("myanmar_font_encoding('\u1095')", VARCHAR, "zawgyi");
+        assertFunction("myanmar_font_encoding('\u1021\u101E\u1004\u1039\u1038\u1019\u103D')", VARCHAR, "zawgyi");
+        assertFunction("myanmar_font_encoding('\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A')", VARCHAR, "unicode");
+    }
+
+    @Test
+    public void testMyanmarNormalizeUnicode()
+    {
+        assertFunction("myanmar_normalize_unicode(NULL)", VARCHAR, null);
+        assertFunction("myanmar_normalize_unicode('english string')", VARCHAR, "english string");
+        assertFunction("myanmar_normalize_unicode('\u1021\u101E\u1004\u1039\u1038\u1019\u103D')", VARCHAR, "\u1021\u101E\u1004\u103A\u1038\u1019\u103E");
+        assertFunction("myanmar_normalize_unicode('\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A')", VARCHAR, "\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A");
+        assertFunction("myanmar_normalize_unicode('\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A\n\u1021\u101E\u1004\u1039\u1038\u1019\u103D')", VARCHAR, "\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A\n\u1021\u101E\u1004\u103A\u1038\u1019\u103E");
+    }
+}


### PR DESCRIPTION
## RELEASE NOTES

### Context 
Text entered in Myanmar is often entered in non-Unicode-compliant Zawgyi. These are rendered differently based on the font encoding of devices in Myanmar. This means if someone entered Burmese-script text on a Zawgyi device, someone on a Unicode device could not read it, and vice versa.

Example:
* Unicode: နင် အခုဘယ်မှာလဲ? (readable)
* Zawgyi: နင္ အခုဘယ္မွာလဲ? (unreadable)

You can learn more about the overall issue at http://www.unicode.org/faq/myanmar.html

So if you query a search term in a Myanmar script in Presto, you'll only match text entered with the same font encoding.

These changes propose to functions to help resolve this:

* `MYANMAR_FONT_ENCODING(text)` which simply returns whether the encoding is Zawgyi or Unicode
* `MYANMAR_NORMALIZE_UNICODE(text)` which leaves Unicode as is and converts Zawgyi to Unicode using Google's Myanmar Tools algorithm: https://github.com/google/myanmar-tools