### PR TITLE
Misc optimizations

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/HmacFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/HmacFunctions.java
@@ -17,6 +17,8 @@ import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.StandardTypes;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import io.airlift.slice.Slice;
 
@@ -31,7 +33,7 @@ public final class HmacFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice hmacMd5(@SqlType(StandardTypes.VARBINARY) Slice slice, @SqlType(StandardTypes.VARBINARY) Slice key)
     {
-        return wrappedBuffer(Hashing.hmacMd5(key.getBytes()).hashBytes(slice.getBytes()).asBytes());
+        return computeHash(Hashing.hmacMd5(key.getBytes()), slice);
     }
 
     @Description("Compute HMAC with SHA1")
@@ -39,7 +41,7 @@ public final class HmacFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice hmacSha1(@SqlType(StandardTypes.VARBINARY) Slice slice, @SqlType(StandardTypes.VARBINARY) Slice key)
     {
-        return wrappedBuffer(Hashing.hmacSha1(key.getBytes()).hashBytes(slice.getBytes()).asBytes());
+        return computeHash(Hashing.hmacSha1(key.getBytes()), slice);
     }
 
     @Description("Compute HMAC with SHA256")
@@ -47,7 +49,7 @@ public final class HmacFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice hmacSha256(@SqlType(StandardTypes.VARBINARY) Slice slice, @SqlType(StandardTypes.VARBINARY) Slice key)
     {
-        return wrappedBuffer(Hashing.hmacSha256(key.getBytes()).hashBytes(slice.getBytes()).asBytes());
+        return computeHash(Hashing.hmacSha256(key.getBytes()), slice);
     }
 
     @Description("Compute HMAC with SHA512")
@@ -55,6 +57,18 @@ public final class HmacFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice hmacSha512(@SqlType(StandardTypes.VARBINARY) Slice slice, @SqlType(StandardTypes.VARBINARY) Slice key)
     {
-        return wrappedBuffer(Hashing.hmacSha512(key.getBytes()).hashBytes(slice.getBytes()).asBytes());
+        return computeHash(Hashing.hmacSha512(key.getBytes()), slice);
+    }
+
+    static Slice computeHash(HashFunction hash, Slice data)
+    {
+        HashCode result;
+        if (data.hasByteArray()) {
+            result = hash.hashBytes(data.byteArray(), data.byteArrayOffset(), data.length());
+        }
+        else {
+            result = hash.hashBytes(data.getBytes());
+        }
+        return wrappedBuffer(result.asBytes());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JoniRegexpFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JoniRegexpFunctions.java
@@ -53,9 +53,17 @@ public final class JoniRegexpFunctions
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean regexpLike(@SqlType("varchar(x)") Slice source, @SqlType(JoniRegexpType.NAME) Regex pattern)
     {
-        Matcher m = pattern.matcher(source.getBytes());
-        int offset = m.search(0, source.length(), Option.DEFAULT);
-        return offset != -1;
+        Matcher matcher;
+        int offset;
+        if (source.hasByteArray()) {
+            offset = source.byteArrayOffset();
+            matcher = pattern.matcher(source.byteArray(), offset, offset + source.length());
+        }
+        else {
+            offset = 0;
+            matcher = pattern.matcher(source.getBytes());
+        }
+        return matcher.search(offset, offset + source.length(), Option.DEFAULT) != -1;
     }
 
     @Description("removes substrings matching a regular expression")

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java
@@ -143,8 +143,7 @@ public final class JsonFunctions
         // If you make changes to this function (e.g. use parse JSON string into some internal representation),
         // make sure `$internal$json_string_to_array/map/row_cast` is changed accordingly.
         try (JsonParser parser = createJsonParser(JSON_FACTORY, slice)) {
-            byte[] in = slice.getBytes();
-            SliceOutput dynamicSliceOutput = new DynamicSliceOutput(in.length);
+            SliceOutput dynamicSliceOutput = new DynamicSliceOutput(slice.length());
             SORTED_MAPPER.writeValue((OutputStream) dynamicSliceOutput, SORTED_MAPPER.readValue(parser, Object.class));
             // nextToken() returns null if the input is parsed correctly,
             // but will throw an exception if there are trailing characters.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
@@ -30,6 +30,7 @@ import io.airlift.slice.XxHash64;
 import java.util.Base64;
 import java.util.zip.CRC32;
 
+import static com.facebook.presto.operator.scalar.HmacFunctions.computeHash;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.util.Failures.checkCondition;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
@@ -51,6 +52,9 @@ public final class VarbinaryFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice toBase64(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
+        if (slice.hasByteArray()) {
+            return Slices.wrappedBuffer(Base64.getEncoder().encode(slice.toByteBuffer()));
+        }
         return Slices.wrappedBuffer(Base64.getEncoder().encode(slice.getBytes()));
     }
 
@@ -61,6 +65,9 @@ public final class VarbinaryFunctions
     public static Slice fromBase64Varchar(@SqlType("varchar(x)") Slice slice)
     {
         try {
+            if (slice.hasByteArray()) {
+                return Slices.wrappedBuffer(Base64.getDecoder().decode(slice.toByteBuffer()));
+            }
             return Slices.wrappedBuffer(Base64.getDecoder().decode(slice.getBytes()));
         }
         catch (IllegalArgumentException e) {
@@ -74,6 +81,9 @@ public final class VarbinaryFunctions
     public static Slice fromBase64Varbinary(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
         try {
+            if (slice.hasByteArray()) {
+                return Slices.wrappedBuffer(Base64.getDecoder().decode(slice.toByteBuffer()));
+            }
             return Slices.wrappedBuffer(Base64.getDecoder().decode(slice.getBytes()));
         }
         catch (IllegalArgumentException e) {
@@ -86,7 +96,7 @@ public final class VarbinaryFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice toBase64Url(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
-        return Slices.wrappedBuffer(Base64.getUrlEncoder().encode(slice.getBytes()));
+        return Slices.wrappedBuffer(Base64.getUrlEncoder().encode(slice.toByteBuffer()));
     }
 
     @Description("decode URL safe base64 encoded binary data")
@@ -96,6 +106,9 @@ public final class VarbinaryFunctions
     public static Slice fromBase64UrlVarchar(@SqlType("varchar(x)") Slice slice)
     {
         try {
+            if (slice.hasByteArray()) {
+                return Slices.wrappedBuffer(Base64.getUrlDecoder().decode(slice.toByteBuffer()));
+            }
             return Slices.wrappedBuffer(Base64.getUrlDecoder().decode(slice.getBytes()));
         }
         catch (IllegalArgumentException e) {
@@ -109,6 +122,9 @@ public final class VarbinaryFunctions
     public static Slice fromBase64UrlVarbinary(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
         try {
+            if (slice.hasByteArray()) {
+                return Slices.wrappedBuffer(Base64.getUrlDecoder().decode(slice.toByteBuffer()));
+            }
             return Slices.wrappedBuffer(Base64.getUrlDecoder().decode(slice.getBytes()));
         }
         catch (IllegalArgumentException e) {
@@ -121,7 +137,14 @@ public final class VarbinaryFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice toHex(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
-        return Slices.utf8Slice(BaseEncoding.base16().encode(slice.getBytes()));
+        String encoded;
+        if (slice.hasByteArray()) {
+            encoded = BaseEncoding.base16().encode(slice.byteArray(), slice.byteArrayOffset(), slice.length());
+        }
+        else {
+            encoded = BaseEncoding.base16().encode(slice.getBytes());
+        }
+        return Slices.utf8Slice(encoded);
     }
 
     @Description("decode hex encoded binary data")
@@ -226,7 +249,7 @@ public final class VarbinaryFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice md5(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
-        return Slices.wrappedBuffer(Hashing.md5().hashBytes(slice.getBytes()).asBytes());
+        return computeHash(Hashing.md5(), slice);
     }
 
     @Description("compute sha1 hash")
@@ -234,7 +257,7 @@ public final class VarbinaryFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice sha1(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
-        return Slices.wrappedBuffer(Hashing.sha1().hashBytes(slice.getBytes()).asBytes());
+        return computeHash(Hashing.sha1(), slice);
     }
 
     @Description("compute sha256 hash")
@@ -242,7 +265,7 @@ public final class VarbinaryFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice sha256(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
-        return Slices.wrappedBuffer(Hashing.sha256().hashBytes(slice.getBytes()).asBytes());
+        return computeHash(Hashing.sha256(), slice);
     }
 
     @Description("compute sha512 hash")
@@ -250,7 +273,7 @@ public final class VarbinaryFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice sha512(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
-        return Slices.wrappedBuffer(Hashing.sha512().hashBytes(slice.getBytes()).asBytes());
+        return computeHash(Hashing.sha512(), slice);
     }
 
     private static int hexDigitCharToInt(byte b)

--- a/presto-main/src/main/java/com/facebook/presto/type/LikeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LikeFunctions.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.type.StandardTypes;
 import io.airlift.jcodings.specific.NonStrictUTF8Encoding;
+import io.airlift.joni.Matcher;
 import io.airlift.joni.Option;
 import io.airlift.joni.Regex;
 import io.airlift.joni.Syntax;
@@ -70,8 +71,17 @@ public final class LikeFunctions
     {
         // Joni can infinite loop with UTF8Encoding when invalid UTF-8 is encountered.
         // NonStrictUTF8Encoding must be used to avoid this issue.
-        byte[] bytes = value.getBytes();
-        return regexMatches(pattern, bytes);
+        Matcher matcher;
+        int offset;
+        if (value.hasByteArray()) {
+            offset = value.byteArrayOffset();
+            matcher = pattern.matcher(value.byteArray(), offset, offset + value.length());
+        }
+        else {
+            offset = 0;
+            matcher = pattern.matcher(value.getBytes());
+        }
+        return matcher.match(offset, offset + value.length(), Option.NONE) != -1;
     }
 
     @ScalarOperator(OperatorType.CAST)
@@ -158,11 +168,6 @@ public final class LikeFunctions
     private static void checkEscape(boolean condition)
     {
         checkCondition(condition, INVALID_FUNCTION_ARGUMENT, "Escape character must be followed by '%%', '_' or the escape character itself");
-    }
-
-    private static boolean regexMatches(Regex regex, byte[] bytes)
-    {
-        return regex.matcher(bytes).match(0, bytes.length, Option.NONE) != -1;
     }
 
     @SuppressWarnings("NestedSwitchStatement")

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/DictionaryPage.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/DictionaryPage.java
@@ -14,11 +14,9 @@
 package com.facebook.presto.parquet;
 
 import io.airlift.slice.Slice;
-
-import java.util.Arrays;
+import io.airlift.slice.Slices;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.util.Objects.requireNonNull;
 
 public class DictionaryPage
@@ -61,7 +59,7 @@ public class DictionaryPage
 
     public DictionaryPage copy()
     {
-        return new DictionaryPage(wrappedBuffer(Arrays.copyOf(slice.getBytes(), slice.length())), getUncompressedSize(), dictionarySize, encoding);
+        return new DictionaryPage(Slices.copyOf(slice), getUncompressedSize(), dictionarySize, encoding);
     }
 
     @Override

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/BinaryDictionary.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/BinaryDictionary.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.parquet.dictionary;
 
 import com.facebook.presto.parquet.DictionaryPage;
+import io.airlift.slice.Slice;
 import org.apache.parquet.io.api.Binary;
 
 import java.io.IOException;
@@ -37,13 +38,14 @@ public class BinaryDictionary
             throws IOException
     {
         super(dictionaryPage.getEncoding());
-        byte[] dictionaryBytes = dictionaryPage.getSlice().getBytes();
         content = new Binary[dictionaryPage.getDictionarySize()];
-        int offset = 0;
+        Slice dictionarySlice = dictionaryPage.getSlice();
+        byte[] dictionaryBytes = dictionarySlice.byteArray();
+        int offset = dictionarySlice.byteArrayOffset();
         if (length == null) {
             for (int i = 0; i < content.length; i++) {
                 int len = readIntLittleEndian(dictionaryBytes, offset);
-                offset += 4;
+                offset += Integer.BYTES;
                 content[i] = Binary.fromByteArray(dictionaryBytes, offset, len);
                 offset += len;
             }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/DoubleDictionary.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/DoubleDictionary.java
@@ -19,7 +19,6 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.values.plain.PlainValuesReader.DoublePlainValuesReader;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -34,8 +33,7 @@ public class DoubleDictionary
         super(dictionaryPage.getEncoding());
         content = new double[dictionaryPage.getDictionarySize()];
         DoublePlainValuesReader doubleReader = new DoublePlainValuesReader();
-        ByteBuffer byteBuffer = ByteBuffer.wrap(dictionaryPage.getSlice().getBytes());
-        ByteBufferInputStream inputStream = ByteBufferInputStream.wrap(ImmutableList.of(byteBuffer));
+        ByteBufferInputStream inputStream = ByteBufferInputStream.wrap(ImmutableList.of(dictionaryPage.getSlice().toByteBuffer()));
         doubleReader.initFromPage(dictionaryPage.getDictionarySize(), inputStream);
         for (int i = 0; i < content.length; i++) {
             content[i] = doubleReader.readDouble();

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/FloatDictionary.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/FloatDictionary.java
@@ -19,7 +19,6 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.values.plain.PlainValuesReader.FloatPlainValuesReader;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -34,8 +33,7 @@ public class FloatDictionary
         super(dictionaryPage.getEncoding());
         content = new float[dictionaryPage.getDictionarySize()];
         FloatPlainValuesReader floatReader = new FloatPlainValuesReader();
-        ByteBuffer byteBuffer = ByteBuffer.wrap(dictionaryPage.getSlice().getBytes());
-        ByteBufferInputStream inputStream = ByteBufferInputStream.wrap(ImmutableList.of(byteBuffer));
+        ByteBufferInputStream inputStream = ByteBufferInputStream.wrap(ImmutableList.of(dictionaryPage.getSlice().toByteBuffer()));
         floatReader.initFromPage(dictionaryPage.getDictionarySize(), inputStream);
         for (int i = 0; i < content.length; i++) {
             content[i] = floatReader.readFloat();

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/IntegerDictionary.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/IntegerDictionary.java
@@ -19,7 +19,6 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.values.plain.PlainValuesReader.IntegerPlainValuesReader;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -34,8 +33,7 @@ public class IntegerDictionary
         super(dictionaryPage.getEncoding());
         content = new int[dictionaryPage.getDictionarySize()];
         IntegerPlainValuesReader intReader = new IntegerPlainValuesReader();
-        ByteBuffer byteBuffer = ByteBuffer.wrap(dictionaryPage.getSlice().getBytes());
-        ByteBufferInputStream inputStream = ByteBufferInputStream.wrap(ImmutableList.of(byteBuffer));
+        ByteBufferInputStream inputStream = ByteBufferInputStream.wrap(ImmutableList.of(dictionaryPage.getSlice().toByteBuffer()));
         intReader.initFromPage(dictionaryPage.getDictionarySize(), inputStream);
         for (int i = 0; i < content.length; i++) {
             content[i] = intReader.readInteger();

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/LongDictionary.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/LongDictionary.java
@@ -19,7 +19,6 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.values.plain.PlainValuesReader.LongPlainValuesReader;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -34,8 +33,7 @@ public class LongDictionary
         super(dictionaryPage.getEncoding());
         content = new long[dictionaryPage.getDictionarySize()];
         LongPlainValuesReader longReader = new LongPlainValuesReader();
-        ByteBuffer byteBuffer = ByteBuffer.wrap(dictionaryPage.getSlice().getBytes());
-        ByteBufferInputStream inputStream = ByteBufferInputStream.wrap(ImmutableList.of(byteBuffer));
+        ByteBufferInputStream inputStream = ByteBufferInputStream.wrap(ImmutableList.of(dictionaryPage.getSlice().toByteBuffer()));
         longReader.initFromPage(dictionaryPage.getDictionarySize(), inputStream);
         for (int i = 0; i < content.length; i++) {
             content[i] = longReader.readLong();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/InMemoryRecordSet.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/InMemoryRecordSet.java
@@ -292,7 +292,7 @@ public class InMemoryRecordSet
                 completedBytes += ((Block) value).getSizeInBytes();
             }
             else if (value instanceof Slice) {
-                completedBytes += ((Slice) value).getBytes().length;
+                completedBytes += ((Slice) value).length();
             }
             else {
                 throw new IllegalArgumentException("Unknown type: " + value.getClass());


### PR DESCRIPTION
Cross contribution of https://github.com/prestosql/presto/pull/3292 with some additional changes to the parquet reader that were unnecessary the other PR.

Split into individual commits to make this easier to review. The general theme is replacing usages of `Slice#getBytes()` when a suitable alternative exists.

```
== NO RELEASE NOTE ==
```
