### PR TITLE
Add SqlBaseParser initializer hook and refreshable ATN caches

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AntlrATNCacheFields.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AntlrATNCacheFields.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.parser;
+
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.atn.ATN;
+import org.antlr.v4.runtime.atn.LexerATNSimulator;
+import org.antlr.v4.runtime.atn.ParserATNSimulator;
+import org.antlr.v4.runtime.atn.PredictionContextCache;
+import org.antlr.v4.runtime.dfa.DFA;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public final class AntlrATNCacheFields
+{
+    private final ATN atn;
+    private final PredictionContextCache predictionContextCache;
+    private final DFA[] decisionToDFA;
+
+    public AntlrATNCacheFields(ATN atn)
+    {
+        this.atn = requireNonNull(atn, "atn is null");
+        this.predictionContextCache = new PredictionContextCache();
+        this.decisionToDFA = createDecisionToDFA(atn);
+    }
+
+    @SuppressWarnings("ObjectEquality")
+    public void configureLexer(Lexer lexer)
+    {
+        requireNonNull(lexer, "lexer is null");
+        // Intentional identity equals comparison
+        checkArgument(atn == lexer.getATN(), "Lexer ATN mismatch: expected %s, found %s", atn, lexer.getATN());
+        lexer.setInterpreter(new LexerATNSimulator(lexer, atn, decisionToDFA, predictionContextCache));
+    }
+
+    @SuppressWarnings("ObjectEquality")
+    public void configureParser(Parser parser)
+    {
+        requireNonNull(parser, "parser is null");
+        // Intentional identity equals comparison
+        checkArgument(atn == parser.getATN(), "Parser ATN mismatch: expected %s, found %s", atn, parser.getATN());
+        parser.setInterpreter(new ParserATNSimulator(parser, atn, decisionToDFA, predictionContextCache));
+    }
+
+    private static DFA[] createDecisionToDFA(ATN atn)
+    {
+        DFA[] decisionToDFA = new DFA[atn.getNumberOfDecisions()];
+        for (int i = 0; i < decisionToDFA.length; i++) {
+            decisionToDFA[i] = new DFA(atn.getDecisionState(i), i);
+        }
+        return decisionToDFA;
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/RefreshableSqlBaseParserInitializer.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/RefreshableSqlBaseParserInitializer.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.parser;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+@ThreadSafe
+public final class RefreshableSqlBaseParserInitializer
+        implements BiConsumer<SqlBaseLexer, SqlBaseParser>
+{
+    private final AtomicReference<SqlBaseParserAndLexerATNCaches> caches = new AtomicReference<>();
+
+    public RefreshableSqlBaseParserInitializer()
+    {
+        refresh();
+    }
+
+    public void refresh()
+    {
+        caches.set(new SqlBaseParserAndLexerATNCaches());
+    }
+
+    @Override
+    public void accept(SqlBaseLexer lexer, SqlBaseParser parser)
+    {
+        SqlBaseParserAndLexerATNCaches caches = this.caches.get();
+        caches.lexer.configureLexer(lexer);
+        caches.parser.configureParser(parser);
+    }
+
+    private static final class SqlBaseParserAndLexerATNCaches
+    {
+        public final AntlrATNCacheFields lexer = new AntlrATNCacheFields(SqlBaseLexer._ATN);
+        public final AntlrATNCacheFields parser = new AntlrATNCacheFields(SqlBaseParser._ATN);
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/SqlParser.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/SqlParser.java
@@ -38,6 +38,7 @@ import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -55,6 +56,7 @@ public class SqlParser
             throw new ParsingException(message, e, line, charPositionInLine);
         }
     };
+    private static final BiConsumer<SqlBaseLexer, SqlBaseParser> DEFAULT_PARSER_INITIALIZER = (SqlBaseLexer lexer, SqlBaseParser parser) -> {};
 
     private static final ErrorHandler PARSER_ERROR_HANDLER = ErrorHandler.builder()
             .specialRule(SqlBaseParser.RULE_expression, "<expression>")
@@ -69,6 +71,7 @@ public class SqlParser
             .ignoredRule(SqlBaseParser.RULE_nonReserved)
             .build();
 
+    private final BiConsumer<SqlBaseLexer, SqlBaseParser> initializer;
     private final EnumSet<IdentifierSymbol> allowedIdentifierSymbols;
     private boolean enhancedErrorHandlerEnabled;
 
@@ -80,6 +83,12 @@ public class SqlParser
     @Inject
     public SqlParser(SqlParserOptions options)
     {
+        this(options, DEFAULT_PARSER_INITIALIZER);
+    }
+
+    public SqlParser(SqlParserOptions options, BiConsumer<SqlBaseLexer, SqlBaseParser> initializer)
+    {
+        this.initializer = requireNonNull(initializer, "initializer is null");
         requireNonNull(options, "options is null");
         allowedIdentifierSymbols = EnumSet.copyOf(options.getAllowedIdentifierSymbols());
         enhancedErrorHandlerEnabled = options.isEnhancedErrorHandlerEnabled();
@@ -124,6 +133,7 @@ public class SqlParser
             SqlBaseLexer lexer = new SqlBaseLexer(new CaseInsensitiveStream(CharStreams.fromString(sql)));
             CommonTokenStream tokenStream = new CommonTokenStream(lexer);
             SqlBaseParser parser = new SqlBaseParser(tokenStream);
+            initializer.accept(lexer, parser);
 
             // Override the default error strategy to not attempt inserting or deleting a token.
             // Otherwise, it messes up error reporting


### PR DESCRIPTION
Cross contribution of https://github.com/prestosql/presto/pull/3186

Adds utility classes that enable explicit initialization and management of antlr parser and lexer ATN caches. Without them, these fields are static constants that can grow to retain multiple GB of heap space depending on input query strings.

These utilities are currently not wired into anything but can be used to periodically refresh the parser cache if desired.

```
== NO RELEASE NOTE ==
```
