### PR TITLE
Support caching all tables in file status cache

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -902,6 +902,7 @@ public class HiveClientConfig
     }
 
     @Config("hive.file-status-cache-tables")
+    @ConfigDescription("The tables that have file status cache enabled. Setting to '*' includes all tables.")
     public HiveClientConfig setFileStatusCacheTables(String fileStatusCacheTables)
     {
         this.fileStatusCacheTables = SPLITTER.splitToList(fileStatusCacheTables);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -201,10 +201,17 @@ public class TestBackgroundHiveSplitLoader
     }
 
     @Test
-    public void testCachedDirectoryLister()
+    public void testCachingDirectoryLister()
             throws Exception
     {
-        CachingDirectoryLister cachingDirectoryLister = new CachingDirectoryLister(new HadoopDirectoryLister(), new Duration(5, TimeUnit.MINUTES), 1000, ImmutableSet.of(new SchemaTableName("test_dbname", "test_table")));
+        testCachingDirectoryLister(new CachingDirectoryLister(new HadoopDirectoryLister(), new Duration(5, TimeUnit.MINUTES), 1000, ImmutableList.of("test_dbname.test_table")));
+        testCachingDirectoryLister(new CachingDirectoryLister(new HadoopDirectoryLister(), new Duration(5, TimeUnit.MINUTES), 1000, ImmutableList.of("*")));
+        assertThrows(IllegalArgumentException.class, () -> testCachingDirectoryLister(new CachingDirectoryLister(new HadoopDirectoryLister(), new Duration(5, TimeUnit.MINUTES), 1000, ImmutableList.of("*", "test_dbname.test_table"))));
+    }
+
+    private void testCachingDirectoryLister(CachingDirectoryLister cachingDirectoryLister)
+            throws Exception
+    {
         assertEquals(cachingDirectoryLister.getRequestCount(), 0);
 
         int totalCount = 1000;


### PR DESCRIPTION
```
== RELEASE NOTES ==
Hive Changes
* Added support in file status cache to cache all tables. This could be enabled by setting ``hive.file-status-cache-tables`` to ``*``.
```