### PR TITLE
Simple PageFile format

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveStorageFormat.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveStorageFormat.java
@@ -83,7 +83,12 @@ public enum HiveStorageFormat
             LazySimpleSerDe.class.getName(),
             TextInputFormat.class.getName(),
             HiveIgnoreKeyTextOutputFormat.class.getName(),
-            new DataSize(8, Unit.MEGABYTE));
+            new DataSize(8, Unit.MEGABYTE)),
+    PAGEFILE(
+            "",  // SerDe is not applicable for PAGEFILE
+            "PageInputFormat",
+            "PageOutputFormat",
+            new DataSize(0, Unit.MEGABYTE));  // memory usage is not applicable for PAGEFILE
 
     private final String serde;
     private final String inputFormat;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -165,6 +165,8 @@ public class HiveClientConfig
     private long fileStatusCacheMaxSize;
     private List<String> fileStatusCacheTables = ImmutableList.of();
 
+    private DataSize pageFileStripeMaxSize = new DataSize(24, MEGABYTE);
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -1337,6 +1339,18 @@ public class HiveClientConfig
     public HiveClientConfig setAdaptiveFilterReorderingEnabled(boolean adaptiveFilterReorderingEnabled)
     {
         this.adaptiveFilterReorderingEnabled = adaptiveFilterReorderingEnabled;
+        return this;
+    }
+
+    public DataSize getPageFileStripeMaxSize()
+    {
+        return pageFileStripeMaxSize;
+    }
+
+    @Config("hive.pagefile.writer.stripe-max-size")
+    public HiveClientConfig setPageFileStripeMaxSize(DataSize pageFileStripeMaxSize)
+    {
+        this.pageFileStripeMaxSize = pageFileStripeMaxSize;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -27,6 +27,8 @@ import com.facebook.presto.hive.orc.DwrfSelectivePageSourceFactory;
 import com.facebook.presto.hive.orc.OrcBatchPageSourceFactory;
 import com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory;
 import com.facebook.presto.hive.orc.TupleDomainFilterCache;
+import com.facebook.presto.hive.pagefile.PageFilePageSourceFactory;
+import com.facebook.presto.hive.pagefile.PageFileWriterFactory;
 import com.facebook.presto.hive.parquet.ParquetPageSourceFactory;
 import com.facebook.presto.hive.rcfile.RcFilePageSourceFactory;
 import com.facebook.presto.hive.rule.HivePlanOptimizerProvider;
@@ -147,6 +149,7 @@ public class HiveClientModule
         pageSourceFactoryBinder.addBinding().to(DwrfBatchPageSourceFactory.class).in(Scopes.SINGLETON);
         pageSourceFactoryBinder.addBinding().to(ParquetPageSourceFactory.class).in(Scopes.SINGLETON);
         pageSourceFactoryBinder.addBinding().to(RcFilePageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(PageFilePageSourceFactory.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(OrcCacheConfig.class, connectorId);
 
@@ -170,6 +173,7 @@ public class HiveClientModule
         configBinder(binder).bindConfig(OrcFileWriterConfig.class);
         fileWriterFactoryBinder.addBinding().to(OrcFileWriterFactory.class).in(Scopes.SINGLETON);
         fileWriterFactoryBinder.addBinding().to(RcFileFileWriterFactory.class).in(Scopes.SINGLETON);
+        fileWriterFactoryBinder.addBinding().to(PageFileWriterFactory.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(ParquetFileWriterConfig.class);
         binder.install(new MetastoreClientModule());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnectorFactory.java
@@ -28,6 +28,7 @@ import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
@@ -122,6 +123,7 @@ public class HiveConnectorFactory
                         binder.bind(FunctionMetadataManager.class).toInstance(context.getFunctionMetadataManager());
                         binder.bind(RowExpressionService.class).toInstance(context.getRowExpressionService());
                         binder.bind(FilterStatsCalculatorService.class).toInstance(context.getFilterStatsCalculatorService());
+                        binder.bind(BlockEncodingSerde.class).toInstance(context.getBlockEncodingSerde());
                     });
 
             Injector injector = app

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -63,6 +63,7 @@ public final class HiveSessionProperties
     private static final String ORC_OPTIMIZED_WRITER_MAX_STRIPE_SIZE = "orc_optimized_writer_max_stripe_size";
     private static final String ORC_OPTIMIZED_WRITER_MAX_STRIPE_ROWS = "orc_optimized_writer_max_stripe_rows";
     private static final String ORC_OPTIMIZED_WRITER_MAX_DICTIONARY_MEMORY = "orc_optimized_writer_max_dictionary_memory";
+    private static final String PAGEFILE_WRITER_MAX_STRIPE_SIZE = "pagefile_writer_max_stripe_size";
     private static final String HIVE_STORAGE_FORMAT = "hive_storage_format";
     private static final String COMPRESSION_CODEC = "compression_codec";
     private static final String RESPECT_TABLE_FORMAT = "respect_table_format";
@@ -241,6 +242,11 @@ public final class HiveSessionProperties
                         ORC_OPTIMIZED_WRITER_MAX_DICTIONARY_MEMORY,
                         "Experimental: ORC: Max dictionary memory",
                         orcFileWriterConfig.getDictionaryMaxMemory(),
+                        false),
+                dataSizeSessionProperty(
+                        PAGEFILE_WRITER_MAX_STRIPE_SIZE,
+                        "PAGEFILE: Max stripe size",
+                        hiveClientConfig.getPageFileStripeMaxSize(),
                         false),
                 stringProperty(
                         HIVE_STORAGE_FORMAT,
@@ -551,6 +557,11 @@ public final class HiveSessionProperties
     public static DataSize getOrcOptimizedWriterMaxDictionaryMemory(ConnectorSession session)
     {
         return session.getProperty(ORC_OPTIMIZED_WRITER_MAX_DICTIONARY_MEMORY, DataSize.class);
+    }
+
+    public static DataSize getPageFileStripeMaxSize(ConnectorSession session)
+    {
+        return session.getProperty(PAGEFILE_WRITER_MAX_STRIPE_SIZE, DataSize.class);
     }
 
     public static HiveStorageFormat getHiveStorageFormat(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -17,6 +17,7 @@ import com.facebook.presto.hadoop.TextLineLengthLimitExceededException;
 import com.facebook.presto.hive.avro.PrestoAvroSerDe;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.hive.pagefile.PageInputFormat;
 import com.facebook.presto.hive.util.FooterAwareRecordReader;
 import com.facebook.presto.orc.OrcReader;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -309,6 +310,10 @@ public final class HiveUtil
         if ("parquet.hive.DeprecatedParquetInputFormat".equals(inputFormatName) ||
                 "parquet.hive.MapredParquetInputFormat".equals(inputFormatName)) {
             return MapredParquetInputFormat.class;
+        }
+
+        if (PageInputFormat.class.getSimpleName().equals(inputFormatName)) {
+            return PageInputFormat.class;
         }
 
         Class<?> clazz = conf.getClassByName(inputFormatName);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageDataOutput.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageDataOutput.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.pagefile;
+
+import com.facebook.presto.orc.stream.DataOutput;
+import com.facebook.presto.spi.page.SerializedPage;
+import io.airlift.slice.SliceOutput;
+
+import static com.facebook.presto.spi.page.PagesSerdeUtil.writeSerializedPage;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static java.util.Objects.requireNonNull;
+
+public class PageDataOutput
+        implements DataOutput
+{
+    private final SerializedPage serializedPage;
+
+    public PageDataOutput(SerializedPage serializedPage)
+    {
+        this.serializedPage = requireNonNull(serializedPage, "serializedPage is null");
+    }
+
+    @Override
+    public long size()
+    {
+        return SIZE_OF_INT * 3 + SIZE_OF_BYTE + serializedPage.getSizeInBytes();
+    }
+
+    @Override
+    public void writeData(SliceOutput sliceOutput)
+    {
+        writeSerializedPage(sliceOutput, serializedPage);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSource.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.pagefile;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.page.PagesSerde;
+import io.airlift.slice.InputStreamSliceInput;
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.page.PagesSerdeUtil.readPages;
+import static java.util.Objects.requireNonNull;
+
+public class PageFilePageSource
+        implements ConnectorPageSource
+{
+    private final FSDataInputStream inputStream;
+    private final Iterator<Page> pageReader;
+    private final int[] hiveColumnIndexes;
+
+    private boolean closed;
+    private long completedPositions;
+    private long completedBytes;
+    private long readTimeNanos;
+    private long memoryUsageBytes;
+
+    public PageFilePageSource(
+            FSDataInputStream inputStream,
+            PagesSerde pagesSerde,
+            List<HiveColumnHandle> columns)
+    {
+        this.inputStream = requireNonNull(inputStream, "inputStream is null");
+        pageReader = readPages(
+                requireNonNull(pagesSerde, "pagesSerde is null"),
+                new InputStreamSliceInput(inputStream));
+
+        int size = requireNonNull(columns, "columns is null").size();
+        this.hiveColumnIndexes = new int[size];
+
+        for (int columnIndex = 0; columnIndex < size; columnIndex++) {
+            HiveColumnHandle column = columns.get(columnIndex);
+            hiveColumnIndexes[columnIndex] = column.getHiveColumnIndex();
+        }
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return completedBytes;
+    }
+
+    @Override
+    public long getCompletedPositions()
+    {
+        return completedPositions;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return closed || !pageReader.hasNext();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        if (isFinished()) {
+            return null;
+        }
+        long start = System.nanoTime();
+
+        Page page = pageReader.next();
+
+        Block[] blocks = new Block[hiveColumnIndexes.length];
+        for (int fieldId = 0; fieldId < blocks.length; fieldId++) {
+            if (hiveColumnIndexes[fieldId] >= page.getChannelCount()) {
+                throw new PrestoException(
+                        NOT_SUPPORTED,
+                        "schema evolution is not supported for PageFile format");
+            }
+            blocks[fieldId] = page.getBlock(hiveColumnIndexes[fieldId]);
+        }
+
+        readTimeNanos += System.nanoTime() - start;
+        completedPositions += page.getPositionCount();
+        long pageSizeInBytes = page.getSizeInBytes();
+        completedBytes += pageSizeInBytes;
+        memoryUsageBytes = Math.max(memoryUsageBytes, pageSizeInBytes);
+        return new Page(page.getPositionCount(), blocks);
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return memoryUsageBytes;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        inputStream.close();
+        closed = true;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSourceFactory.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.pagefile;
+
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveBatchPageSourceFactory;
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HiveFileContext;
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.page.PagesSerde;
+import com.facebook.presto.spi.predicate.TupleDomain;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.Path;
+import org.joda.time.DateTimeZone;
+
+import javax.inject.Inject;
+
+import java.io.FileNotFoundException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
+import static com.google.common.base.Strings.nullToEmpty;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class PageFilePageSourceFactory
+        implements HiveBatchPageSourceFactory
+{
+    private final HdfsEnvironment hdfsEnvironment;
+    private final PagesSerde pagesSerde;
+
+    @Inject
+    public PageFilePageSourceFactory(
+            HdfsEnvironment hdfsEnvironment,
+            BlockEncodingSerde blockEncodingSerde)
+    {
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        pagesSerde = new PagesSerde(
+                requireNonNull(blockEncodingSerde, "blockEncodingSerde is null"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    @Override
+    public Optional<? extends ConnectorPageSource> createPageSource(
+            Configuration configuration,
+            ConnectorSession session,
+            Path path,
+            long start,
+            long length,
+            long fileSize,
+            Storage storage,
+            Map<String, String> tableParameters,
+            List<HiveColumnHandle> columns,
+            TupleDomain<HiveColumnHandle> effectivePredicate,
+            DateTimeZone hiveStorageTimeZone,
+            HiveFileContext hiveFileContext)
+    {
+        if (!PageInputFormat.class.getSimpleName().equals(storage.getStorageFormat().getInputFormat())) {
+            return Optional.empty();
+        }
+
+        FSDataInputStream inputStream;
+        try {
+            inputStream = hdfsEnvironment.getFileSystem(session.getUser(), path, configuration).openFile(path, hiveFileContext);
+        }
+        catch (Exception e) {
+            if (nullToEmpty(e.getMessage()).trim().equals("Filesystem closed") ||
+                    e instanceof FileNotFoundException) {
+                throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, e);
+            }
+            throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, splitError(e, path, start, length), e);
+        }
+
+        return Optional.of(new PageFilePageSource(inputStream, pagesSerde, columns));
+    }
+
+    private static String splitError(Throwable t, Path path, long start, long length)
+    {
+        return format("Error opening Hive split %s (offset=%s, length=%s): %s", path, start, length, t.getMessage());
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriter.java
@@ -18,6 +18,7 @@ import com.facebook.presto.orc.DataSink;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.page.PagesSerde;
+import io.airlift.units.DataSize;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
@@ -40,9 +41,10 @@ public class PageFileWriter
     public PageFileWriter(
             DataSink dataSink,
             PagesSerde pagesSerde,
+            DataSize pageFileStripeMaxSize,
             Callable<Void> rollbackAction)
     {
-        pageWriter = new PageWriter(dataSink);
+        pageWriter = new PageWriter(dataSink, pageFileStripeMaxSize);
         this.pagesSerde = requireNonNull(pagesSerde, "pagesSerde is null");
         this.rollbackAction = requireNonNull(rollbackAction, "rollbackAction is null");
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriter.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.pagefile;
+
+import com.facebook.presto.hive.HiveFileWriter;
+import com.facebook.presto.orc.DataSink;
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.page.PagesSerde;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.Callable;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
+import static java.util.Objects.requireNonNull;
+
+public class PageFileWriter
+        implements HiveFileWriter
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(PageFileWriter.class).instanceSize();
+
+    private final PageWriter pageWriter;
+    private final Callable<Void> rollbackAction;
+    private final PagesSerde pagesSerde;
+
+    public PageFileWriter(
+            DataSink dataSink,
+            PagesSerde pagesSerde,
+            Callable<Void> rollbackAction)
+    {
+        pageWriter = new PageWriter(dataSink);
+        this.pagesSerde = requireNonNull(pagesSerde, "pagesSerde is null");
+        this.rollbackAction = requireNonNull(rollbackAction, "rollbackAction is null");
+    }
+
+    @Override
+    public long getWrittenBytes()
+    {
+        return pageWriter.getWrittenBytes();
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return INSTANCE_SIZE + pageWriter.getRetainedBytes();
+    }
+
+    @Override
+    public void appendRows(Page dataPage)
+    {
+        try {
+            pageWriter.write(pagesSerde.serialize(dataPage));
+        }
+        catch (IOException | UncheckedIOException e) {
+            throw new PrestoException(HIVE_WRITER_DATA_ERROR, e);
+        }
+    }
+
+    @Override
+    public void commit()
+    {
+        try {
+            pageWriter.close();
+        }
+        catch (IOException | UncheckedIOException e) {
+            try {
+                rollbackAction.call();
+            }
+            catch (Exception ignored) {
+                // ignore
+            }
+            throw new PrestoException(HIVE_WRITER_CLOSE_ERROR, "Error committing write to Hive", e);
+        }
+    }
+
+    @Override
+    public void rollback()
+    {
+        try {
+            try {
+                pageWriter.close();
+            }
+            finally {
+                rollbackAction.call();
+            }
+        }
+        catch (Exception e) {
+            throw new PrestoException(HIVE_WRITER_CLOSE_ERROR, "Error rolling back write to Hive", e);
+        }
+    }
+
+    @Override
+    public long getValidationCpuNanos()
+    {
+        return 0;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriterFactory.java
@@ -36,6 +36,7 @@ import java.util.Properties;
 import java.util.concurrent.Callable;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
+import static com.facebook.presto.hive.HiveSessionProperties.getPageFileStripeMaxSize;
 import static com.facebook.presto.hive.HiveStorageFormat.PAGEFILE;
 import static java.util.Objects.requireNonNull;
 
@@ -80,7 +81,7 @@ public class PageFileWriterFactory
                 fileSystem.delete(path, false);
                 return null;
             };
-            return Optional.of(new PageFileWriter(dataSink, pagesSerde, rollbackAction));
+            return Optional.of(new PageFileWriter(dataSink, pagesSerde, getPageFileStripeMaxSize(session), rollbackAction));
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_WRITER_OPEN_ERROR, "Error creating pagefile", e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriterFactory.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.pagefile;
+
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveFileWriter;
+import com.facebook.presto.hive.HiveFileWriterFactory;
+import com.facebook.presto.hive.metastore.StorageFormat;
+import com.facebook.presto.orc.DataSink;
+import com.facebook.presto.orc.OutputStreamDataSink;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
+import com.facebook.presto.spi.page.PagesSerde;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
+import static com.facebook.presto.hive.HiveStorageFormat.PAGEFILE;
+import static java.util.Objects.requireNonNull;
+
+public class PageFileWriterFactory
+        implements HiveFileWriterFactory
+{
+    private final HdfsEnvironment hdfsEnvironment;
+    private final PagesSerde pagesSerde;
+
+    @Inject
+    public PageFileWriterFactory(
+            HdfsEnvironment hdfsEnvironment,
+            BlockEncodingSerde blockEncodingSerde)
+    {
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+
+        pagesSerde = new PagesSerde(
+                requireNonNull(blockEncodingSerde, "blockEncodingSerde is null"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    @Override
+    public Optional<HiveFileWriter> createFileWriter(
+            Path path,
+            List<String> inputColumnNames,
+            StorageFormat storageFormat,
+            Properties schema,
+            JobConf configuration,
+            ConnectorSession session)
+    {
+        if (!storageFormat.getOutputFormat().equals(PAGEFILE.getOutputFormat())) {
+            return Optional.empty();
+        }
+
+        try {
+            FileSystem fileSystem = hdfsEnvironment.getFileSystem(session.getUser(), path, configuration);
+            DataSink dataSink = createPageDataSink(fileSystem, path);
+
+            Callable<Void> rollbackAction = () -> {
+                fileSystem.delete(path, false);
+                return null;
+            };
+            return Optional.of(new PageFileWriter(dataSink, pagesSerde, rollbackAction));
+        }
+        catch (IOException e) {
+            throw new PrestoException(HIVE_WRITER_OPEN_ERROR, "Error creating pagefile", e);
+        }
+    }
+
+    protected DataSink createPageDataSink(FileSystem fileSystem, Path path)
+            throws IOException
+    {
+        return new OutputStreamDataSink(fileSystem.create(path));
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageInputFormat.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageInputFormat.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.pagefile;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+
+public class PageInputFormat
+        extends FileInputFormat<NullWritable, NullWritable>
+{
+    @Override
+    public RecordReader<NullWritable, NullWritable> getRecordReader(InputSplit inputSplit, JobConf jobConf, Reporter reporter)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    protected boolean isSplitable(FileSystem fs, Path file)
+    {
+        return false;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageWriter.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.pagefile;
+
+import com.facebook.presto.orc.DataSink;
+import com.facebook.presto.orc.stream.DataOutput;
+import com.facebook.presto.spi.page.SerializedPage;
+import io.airlift.units.DataSize;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.Objects.requireNonNull;
+
+public class PageWriter
+        implements Closeable
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(PageWriter.class).instanceSize();
+
+    private final DataSink dataSink;
+    private long bufferedBytes;
+    private long retainedBytes;
+    private long maxBufferedBytes = new DataSize(128, MEGABYTE).toBytes();
+    private boolean closed;
+    private List<DataOutput> bufferedPages;
+
+    public PageWriter(DataSink dataSink)
+    {
+        this.dataSink = requireNonNull(dataSink, "pageDataSink is null");
+        bufferedPages = new ArrayList<>();
+    }
+
+    /**
+     * Number of bytes already flushed to the data sink.
+     */
+    public long getWrittenBytes()
+    {
+        return dataSink.size();
+    }
+
+    public void write(SerializedPage page)
+            throws IOException
+    {
+        PageDataOutput pageDataOutput = new PageDataOutput(page);
+        long writtenSize = pageDataOutput.size();
+        if (maxBufferedBytes - bufferedBytes < writtenSize) {
+            dataSink.write(bufferedPages);
+            bufferedPages.clear();
+            bufferedBytes = 0;
+            retainedBytes = 0;
+        }
+        bufferedPages.add(pageDataOutput);
+        bufferedBytes += writtenSize;
+        retainedBytes += page.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (!bufferedPages.isEmpty()) {
+            dataSink.write(bufferedPages);
+        }
+        dataSink.close();
+    }
+
+    public long getRetainedBytes()
+    {
+        return INSTANCE_SIZE + retainedBytes + dataSink.getRetainedSizeInBytes();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageWriter.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
 
 public class PageWriter
@@ -35,13 +34,14 @@ public class PageWriter
     private final DataSink dataSink;
     private long bufferedBytes;
     private long retainedBytes;
-    private long maxBufferedBytes = new DataSize(128, MEGABYTE).toBytes();
+    private long maxBufferedBytes;
     private boolean closed;
     private List<DataOutput> bufferedPages;
 
-    public PageWriter(DataSink dataSink)
+    public PageWriter(DataSink dataSink, DataSize pageFileStripeMaxSize)
     {
         this.dataSink = requireNonNull(dataSink, "pageDataSink is null");
+        this.maxBufferedBytes = requireNonNull(pageFileStripeMaxSize, "pageFileStripeMaxSize is null").toBytes();
         bufferedPages = new ArrayList<>();
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -190,6 +190,7 @@ import static com.facebook.presto.hive.HiveStorageFormat.AVRO;
 import static com.facebook.presto.hive.HiveStorageFormat.DWRF;
 import static com.facebook.presto.hive.HiveStorageFormat.JSON;
 import static com.facebook.presto.hive.HiveStorageFormat.ORC;
+import static com.facebook.presto.hive.HiveStorageFormat.PAGEFILE;
 import static com.facebook.presto.hive.HiveStorageFormat.PARQUET;
 import static com.facebook.presto.hive.HiveStorageFormat.RCBINARY;
 import static com.facebook.presto.hive.HiveStorageFormat.RCTEXT;
@@ -1280,8 +1281,8 @@ public abstract class AbstractTestHiveClient
         boolean pushdownFilterEnabled = getHiveClientConfig().isPushdownFilterEnabled();
 
         for (HiveStorageFormat storageFormat : createTableFormats) {
-            // TODO: fix coercion for JSON
-            if (storageFormat == JSON) {
+            // TODO: fix coercion for JSON or PAGEFILE
+            if (storageFormat == JSON || storageFormat == PAGEFILE) {
                 continue;
             }
             SchemaTableName temporaryMismatchSchemaTable = temporaryTable("mismatch_schema");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -41,6 +41,7 @@ import com.facebook.presto.hive.metastore.thrift.TestingHiveCluster;
 import com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore;
 import com.facebook.presto.hive.orc.OrcBatchPageSource;
 import com.facebook.presto.hive.orc.OrcSelectivePageSource;
+import com.facebook.presto.hive.pagefile.PageFilePageSource;
 import com.facebook.presto.hive.parquet.ParquetPageSource;
 import com.facebook.presto.hive.rcfile.RcFilePageSource;
 import com.facebook.presto.metadata.MetadataManager;
@@ -4909,6 +4910,8 @@ public abstract class AbstractTestHiveClient
                 return OrcBatchPageSource.class;
             case PARQUET:
                 return ParquetPageSource.class;
+            case PAGEFILE:
+                return PageFilePageSource.class;
             default:
                 throw new AssertionError("File type does not use a PageSource: " + hiveStorageFormat);
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -27,6 +27,7 @@ import com.facebook.presto.hive.orc.DwrfSelectivePageSourceFactory;
 import com.facebook.presto.hive.orc.OrcBatchPageSourceFactory;
 import com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory;
 import com.facebook.presto.hive.orc.TupleDomainFilterCache;
+import com.facebook.presto.hive.pagefile.PageFilePageSourceFactory;
 import com.facebook.presto.hive.pagefile.PageFileWriterFactory;
 import com.facebook.presto.hive.parquet.ParquetPageSourceFactory;
 import com.facebook.presto.hive.rcfile.RcFilePageSourceFactory;
@@ -147,6 +148,7 @@ public final class HiveTestUtils
                 .add(new OrcBatchPageSourceFactory(TYPE_MANAGER, hiveClientConfig, testHdfsEnvironment, stats, new StorageOrcFileTailSource(), new StorageStripeMetadataSource()))
                 .add(new DwrfBatchPageSourceFactory(TYPE_MANAGER, hiveClientConfig, testHdfsEnvironment, stats, new StorageOrcFileTailSource(), new StorageStripeMetadataSource()))
                 .add(new ParquetPageSourceFactory(TYPE_MANAGER, testHdfsEnvironment, stats))
+                .add(new PageFilePageSourceFactory(testHdfsEnvironment, new BlockEncodingManager(TYPE_MANAGER)))
                 .build();
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -27,6 +27,7 @@ import com.facebook.presto.hive.orc.DwrfSelectivePageSourceFactory;
 import com.facebook.presto.hive.orc.OrcBatchPageSourceFactory;
 import com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory;
 import com.facebook.presto.hive.orc.TupleDomainFilterCache;
+import com.facebook.presto.hive.pagefile.PageFileWriterFactory;
 import com.facebook.presto.hive.parquet.ParquetPageSourceFactory;
 import com.facebook.presto.hive.rcfile.RcFilePageSourceFactory;
 import com.facebook.presto.hive.s3.HiveS3Config;
@@ -172,6 +173,7 @@ public final class HiveTestUtils
         HdfsEnvironment testHdfsEnvironment = createTestHdfsEnvironment(hiveClientConfig, metastoreClientConfig);
         return ImmutableSet.<HiveFileWriterFactory>builder()
                 .add(new RcFileFileWriterFactory(testHdfsEnvironment, TYPE_MANAGER, new NodeVersion("test_version"), hiveClientConfig, new FileFormatDataSourceStats()))
+                .add(new PageFileWriterFactory(testHdfsEnvironment, new BlockEncodingManager(TYPE_MANAGER)))
                 .add(getDefaultOrcFileWriterFactory(hiveClientConfig, metastoreClientConfig))
                 .build();
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -130,7 +130,8 @@ public class TestHiveClientConfig
                 .setAdaptiveFilterReorderingEnabled(true)
                 .setFileStatusCacheExpireAfterWrite(new Duration(0, TimeUnit.SECONDS))
                 .setFileStatusCacheMaxSize(0)
-                .setFileStatusCacheTables(""));
+                .setFileStatusCacheTables("")
+                .setPageFileStripeMaxSize(new DataSize(24, Unit.MEGABYTE)));
     }
 
     @Test
@@ -224,6 +225,7 @@ public class TestHiveClientConfig
                 .put("hive.file-status-cache-tables", "foo.bar1, foo.bar2")
                 .put("hive.file-status-cache-size", "1000")
                 .put("hive.file-status-cache-expire-time", "30m")
+                .put("hive.pagefile.writer.stripe-max-size", "1kB")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -314,7 +316,8 @@ public class TestHiveClientConfig
                 .setAdaptiveFilterReorderingEnabled(false)
                 .setFileStatusCacheTables("foo.bar1,foo.bar2")
                 .setFileStatusCacheMaxSize(1000)
-                .setFileStatusCacheExpireAfterWrite(new Duration(30, TimeUnit.MINUTES));
+                .setFileStatusCacheExpireAfterWrite(new Duration(30, TimeUnit.MINUTES))
+                .setPageFileStripeMaxSize(new DataSize(1, Unit.KILOBYTE));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -63,6 +63,7 @@ import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTAN
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveCompressionCodec.NONE;
 import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
+import static com.facebook.presto.hive.HiveStorageFormat.PAGEFILE;
 import static com.facebook.presto.hive.HiveTestUtils.PAGE_SORTER;
 import static com.facebook.presto.hive.HiveTestUtils.ROW_EXPRESSION_SERVICE;
 import static com.facebook.presto.hive.HiveTestUtils.TYPE_MANAGER;
@@ -120,6 +121,10 @@ public class TestHivePageSink
 
                 for (HiveCompressionCodec codec : HiveCompressionCodec.values()) {
                     if (codec == NONE || !codec.isSupportedStorageFormat(format)) {
+                        continue;
+                    }
+                    // No compression support needed for PAGEFILE
+                    if (format == PAGEFILE) {
                         continue;
                     }
                     config.setCompressionCodec(codec);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/HiveFileFormatBenchmark.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/HiveFileFormatBenchmark.java
@@ -128,6 +128,7 @@ public class HiveFileFormatBenchmark
             "PRESTO_ORC",
             "PRESTO_DWRF",
             "PRESTO_PARQUET",
+            "PRESTO_PAGE",
             "HIVE_RCBINARY",
             "HIVE_RCTEXT",
             "HIVE_ORC",

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/TestHiveFileFormatBenchmark.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/TestHiveFileFormatBenchmark.java
@@ -28,12 +28,15 @@ public class TestHiveFileFormatBenchmark
     {
         executeBenchmark(DataSet.LINEITEM, HiveCompressionCodec.SNAPPY, FileFormat.PRESTO_RCBINARY);
         executeBenchmark(DataSet.LINEITEM, HiveCompressionCodec.SNAPPY, FileFormat.PRESTO_ORC);
+        executeBenchmark(DataSet.LINEITEM, HiveCompressionCodec.SNAPPY, FileFormat.PRESTO_PAGE);
         executeBenchmark(DataSet.LINEITEM, HiveCompressionCodec.SNAPPY, FileFormat.HIVE_RCBINARY);
         executeBenchmark(DataSet.MAP_VARCHAR_DOUBLE, HiveCompressionCodec.SNAPPY, FileFormat.PRESTO_RCBINARY);
         executeBenchmark(DataSet.MAP_VARCHAR_DOUBLE, HiveCompressionCodec.SNAPPY, FileFormat.PRESTO_ORC);
+        executeBenchmark(DataSet.MAP_VARCHAR_DOUBLE, HiveCompressionCodec.SNAPPY, FileFormat.PRESTO_PAGE);
         executeBenchmark(DataSet.MAP_VARCHAR_DOUBLE, HiveCompressionCodec.SNAPPY, FileFormat.HIVE_RCBINARY);
         executeBenchmark(DataSet.LARGE_MAP_VARCHAR_DOUBLE, HiveCompressionCodec.SNAPPY, FileFormat.PRESTO_RCBINARY);
         executeBenchmark(DataSet.LARGE_MAP_VARCHAR_DOUBLE, HiveCompressionCodec.SNAPPY, FileFormat.PRESTO_ORC);
+        executeBenchmark(DataSet.LARGE_MAP_VARCHAR_DOUBLE, HiveCompressionCodec.SNAPPY, FileFormat.PRESTO_PAGE);
         executeBenchmark(DataSet.LARGE_MAP_VARCHAR_DOUBLE, HiveCompressionCodec.SNAPPY, FileFormat.HIVE_RCBINARY);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorContextInstance.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorContextInstance.java
@@ -16,6 +16,7 @@ package com.facebook.presto.connector;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
@@ -36,6 +37,7 @@ public class ConnectorContextInstance
     private final PageIndexerFactory pageIndexerFactory;
     private final RowExpressionService rowExpressionService;
     private final FilterStatsCalculatorService filterStatsCalculatorService;
+    private final BlockEncodingSerde blockEncodingSerde;
 
     public ConnectorContextInstance(
             NodeManager nodeManager,
@@ -45,7 +47,8 @@ public class ConnectorContextInstance
             PageSorter pageSorter,
             PageIndexerFactory pageIndexerFactory,
             RowExpressionService rowExpressionService,
-            FilterStatsCalculatorService filterStatsCalculatorService)
+            FilterStatsCalculatorService filterStatsCalculatorService,
+            BlockEncodingSerde blockEncodingSerde)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -55,6 +58,7 @@ public class ConnectorContextInstance
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
         this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
+        this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
     }
 
     @Override
@@ -103,5 +107,11 @@ public class ConnectorContextInstance
     public FilterStatsCalculatorService getFilterStatsCalculatorService()
     {
         return filterStatsCalculatorService;
+    }
+
+    @Override
+    public BlockEncodingSerde getBlockEncodingSerde()
+    {
+        return blockEncodingSerde;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -388,7 +388,8 @@ public class LocalQueryRunner
                 new RowExpressionDomainTranslator(metadata),
                 new RowExpressionPredicateCompiler(metadata),
                 new RowExpressionDeterminismEvaluator(metadata.getFunctionManager()),
-                new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer));
+                new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer),
+                blockEncodingManager);
 
         GlobalSystemConnectorFactory globalSystemConnectorFactory = new GlobalSystemConnectorFactory(ImmutableSet.of(
                 new NodeSystemTable(nodeManager),

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorContext.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
@@ -66,6 +67,7 @@ public class TestingConnectorContext
     private final PredicateCompiler predicateCompiler = new RowExpressionPredicateCompiler(metadata);
     private final DeterminismEvaluator determinismEvaluator = new RowExpressionDeterminismEvaluator(functionManager);
     private final FilterStatsCalculatorService filterStatsCalculatorService = new ConnectorFilterStatsCalculatorService(new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata), new StatsNormalizer()));
+    private final BlockEncodingSerde blockEncodingSerde = new BlockEncodingManager(typeManager);
 
     @Override
     public NodeManager getNodeManager()
@@ -144,5 +146,11 @@ public class TestingConnectorContext
     public FilterStatsCalculatorService getFilterStatsCalculatorService()
     {
         return filterStatsCalculatorService;
+    }
+
+    @Override
+    public BlockEncodingSerde getBlockEncodingSerde()
+    {
+        return blockEncodingSerde;
     }
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveStorageFormats.java
@@ -58,7 +58,8 @@ public class TestHiveStorageFormats
                 {storageFormat("RCTEXT", ImmutableMap.of("hive.rcfile_optimized_writer_enabled", "true", "hive.rcfile_optimized_writer_validate", "true"))},
                 {storageFormat("SEQUENCEFILE")},
                 {storageFormat("TEXTFILE")},
-                {storageFormat("AVRO")}
+                {storageFormat("AVRO")},
+                {storageFormat("PAGEFILE")}
         };
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorContext.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi.connector;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
@@ -60,6 +61,11 @@ public interface ConnectorContext
     }
 
     default FilterStatsCalculatorService getFilterStatsCalculatorService()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default BlockEncodingSerde getBlockEncodingSerde()
     {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
There is no split support yet. All pages are written continuously to a single file.

Existing tests in `HiveIntegrationSmokeTes` and `TestHivePageSink` cover new formats.

Attached benchmark result shows much faster read/write compared with ORC format. Reading from PageFile format is 4X faster; Writing PageFile format is 40X faster.

![91361137_564002691179682_3632670565724061696_n](https://user-images.githubusercontent.com/6372365/78816759-2a528200-79a0-11ea-83da-295952a6bd3a.png)
