### PR TITLE
EXPLAIN (TYPE IO) support for Aria

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -713,6 +713,17 @@ public class HiveMetadata
         return ((HiveColumnHandle) columnHandle).getColumnMetadata(typeManager);
     }
 
+    /**
+     * Returns a TupleDomain of constraints that is suitable for Explain (Type IO)
+     *
+     * Only Hive partition columns that are used in IO planning.
+     */
+    @Override
+    public TupleDomain<ColumnHandle> toExplainIOConstraints(ConnectorSession session, ConnectorTableHandle tableHandle, TupleDomain<ColumnHandle> constraints)
+    {
+        return constraints.transform(columnHandle -> ((HiveColumnHandle) columnHandle).isPartitionKey() ? columnHandle : null);
+    }
+
     @Override
     public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties)
     {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -93,14 +93,12 @@ import static com.facebook.presto.hive.HiveSessionProperties.RCFILE_OPTIMIZED_WR
 import static com.facebook.presto.hive.HiveSessionProperties.SORTED_WRITE_TEMP_PATH_SUBDIRECTORY_COUNT;
 import static com.facebook.presto.hive.HiveSessionProperties.SORTED_WRITE_TO_TEMP_PATH_ENABLED;
 import static com.facebook.presto.hive.HiveSessionProperties.getInsertExistingPartitionsBehavior;
-import static com.facebook.presto.hive.HiveSessionProperties.isPushdownFilterEnabled;
 import static com.facebook.presto.hive.HiveTableProperties.BUCKETED_BY_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.BUCKET_COUNT_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.PARTITIONED_BY_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.STORAGE_FORMAT_PROPERTY;
 import static com.facebook.presto.hive.HiveTestUtils.TYPE_MANAGER;
 import static com.facebook.presto.hive.HiveUtil.columnExtraInfo;
-import static com.facebook.presto.spi.predicate.Marker.Bound.ABOVE;
 import static com.facebook.presto.spi.predicate.Marker.Bound.EXACTLY;
 import static com.facebook.presto.spi.security.SelectedRole.Type.ROLE;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
@@ -237,17 +235,7 @@ public class TestHiveIntegrationSmokeTest
                                 new FormattedRange(
                                         new FormattedMarker(Optional.of("false"), EXACTLY),
                                         new FormattedMarker(Optional.of("false"), EXACTLY))))));
-        if (isPushdownFilterEnabled(getConnectorSession(getSession()))) {
-            expectedConstraints.add(new ColumnConstraint(
-                    "custkey",
-                    BIGINT.getTypeSignature(),
-                    new FormattedDomain(
-                            false,
-                            ImmutableSet.of(
-                                    new FormattedRange(
-                                            new FormattedMarker(Optional.empty(), ABOVE),
-                                            new FormattedMarker(Optional.of("10"), EXACTLY))))));
-        }
+
         assertEquals(
                 jsonCodec(IOPlan.class).fromJson((String) getOnlyElement(result.getOnlyColumnAsSet())),
                 new IOPlan(
@@ -271,17 +259,6 @@ public class TestHiveIntegrationSmokeTest
                                 new FormattedRange(
                                         new FormattedMarker(Optional.of("1"), EXACTLY),
                                         new FormattedMarker(Optional.of("199"), EXACTLY))))));
-        if (isPushdownFilterEnabled(getConnectorSession(getSession()))) {
-            expectedConstraints.add(new ColumnConstraint(
-                    "custkey",
-                    BIGINT.getTypeSignature(),
-                    new FormattedDomain(
-                            false,
-                            ImmutableSet.of(
-                                    new FormattedRange(
-                                            new FormattedMarker(Optional.empty(), ABOVE),
-                                            new FormattedMarker(Optional.of("10"), EXACTLY))))));
-        }
 
         result = computeActual("EXPLAIN (TYPE IO, FORMAT JSON) INSERT INTO test_orders SELECT custkey, orderkey + 10 FROM test_orders where custkey <= 10");
         assertEquals(

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -162,6 +162,11 @@ public interface Metadata
     ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle);
 
     /**
+     * Returns a TupleDomain of constraints that is suitable for ExplainIO
+     */
+    TupleDomain<ColumnHandle> toExplainIOConstraints(Session session, TableHandle tableHandle, TupleDomain<ColumnHandle> constraints);
+
+    /**
      * Gets the metadata for all columns that match the specified table prefix.
      */
     Map<QualifiedObjectName, List<ColumnMetadata>> listTableColumns(Session session, QualifiedTablePrefix prefix);

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -533,6 +533,15 @@ public class MetadataManager
     }
 
     @Override
+    public TupleDomain<ColumnHandle> toExplainIOConstraints(Session session, TableHandle tableHandle, TupleDomain<ColumnHandle> constraints)
+    {
+        ConnectorId connectorId = tableHandle.getConnectorId();
+        ConnectorMetadata metadata = getMetadata(session, connectorId);
+
+        return metadata.toExplainIOConstraints(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), constraints);
+    }
+
+    @Override
     public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
     {
         requireNonNull(prefix, "prefix is null");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
@@ -470,12 +470,14 @@ public class IOPlanPrinter
         public Void visitTableScan(TableScanNode node, IOPlanBuilder context)
         {
             TableMetadata tableMetadata = metadata.getTableMetadata(session, node.getTable());
+            TupleDomain<ColumnHandle> constraints = metadata.toExplainIOConstraints(session, node.getTable(), node.getCurrentConstraint());
+
             context.addInputTableColumnInfo(new IOPlan.TableColumnInfo(
                     new CatalogSchemaTableName(
                             tableMetadata.getConnectorId().getCatalogName(),
                             tableMetadata.getTable().getSchemaName(),
                             tableMetadata.getTable().getTableName()),
-                    parseConstraints(node.getTable(), node.getCurrentConstraint())));
+                    parseConstraints(node.getTable(), constraints)));
             return null;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -189,6 +189,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public TupleDomain<ColumnHandle> toExplainIOConstraints(Session session, TableHandle tableHandle, TupleDomain<ColumnHandle> constraints)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Map<QualifiedObjectName, List<ColumnMetadata>> listTableColumns(Session session, QualifiedTablePrefix prefix)
     {
         throw new UnsupportedOperationException();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -239,6 +239,14 @@ public interface ConnectorMetadata
     ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle);
 
     /**
+     * Returns a TupleDomain of constraints that is suitable for ExplainIO
+     */
+    default TupleDomain<ColumnHandle> toExplainIOConstraints(ConnectorSession session, ConnectorTableHandle tableHandle, TupleDomain<ColumnHandle> constraints)
+    {
+        return constraints;
+    }
+
+    /**
      * Gets the metadata for all columns that match the specified table prefix.
      */
     Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -281,6 +281,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public TupleDomain<ColumnHandle> toExplainIOConstraints(ConnectorSession session, ConnectorTableHandle tableHandle, TupleDomain<ColumnHandle> constraints)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.toExplainIOConstraints(session, tableHandle, constraints);
+        }
+    }
+
+    @Override
     public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
Allow Connectors to control column constraints in IOPlanPrinter

* Add a new metadata method . toExplainIOConstraints to the Metadata and ConnectorMetadata interfaces to optionally return only Constraint for use in IOPlanPrinter.
* Interface default method returns the current constraints
* Implement HiveConnector.toExplainIOConstraints() to filter out non-partition key columns.

Are there additional data types that Aria can return in Constraints that can also be partition columns?
* Supported:
   * VarcharType
   * TinyintType, SmallintType, IntegerType, BigintType
   * BooleanType

I need some pointer on how to test this.
```

```
