### PR TITLE
Make table properties a config property

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/PrestoVerifyCommand.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/PrestoVerifyCommand.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.verifier;
 
 import com.facebook.presto.sql.parser.SqlParserOptions;
-import com.facebook.presto.sql.tree.Property;
 import com.facebook.presto.verifier.framework.AbstractVerifyCommand;
 import com.facebook.presto.verifier.framework.SourceQuery;
 import com.facebook.presto.verifier.prestoaction.PrestoExceptionClassifier;
@@ -66,11 +65,5 @@ public class PrestoVerifyCommand
     public SqlExceptionClassifier getSqlExceptionClassifier()
     {
         return PrestoExceptionClassifier.createDefault();
-    }
-
-    @Override
-    public List<Property> getTablePropertyOverrides()
-    {
-        return ImmutableList.of();
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerifyCommand.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerifyCommand.java
@@ -44,8 +44,7 @@ public abstract class AbstractVerifyCommand
                 .add(new VerifierModule(
                         getSqlParserOptions(),
                         getCustomQueryFilterClasses(),
-                        getSqlExceptionClassifier(),
-                        getTablePropertyOverrides()))
+                        getSqlExceptionClassifier()))
                 .add(new SourceQueryModule(getCustomSourceQuerySupplierTypes()))
                 .add(new EventClientModule(getCustomEventClientTypes()))
                 .addAll(getAdditionalModules())

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
@@ -25,7 +25,6 @@ import com.facebook.presto.spi.type.TypeManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
-import com.facebook.presto.sql.tree.Property;
 import com.facebook.presto.transaction.ForTransactionManager;
 import com.facebook.presto.transaction.InMemoryTransactionManager;
 import com.facebook.presto.transaction.TransactionManager;
@@ -85,18 +84,15 @@ public class VerifierModule
     private final SqlParserOptions sqlParserOptions;
     private final List<Class<? extends Predicate<SourceQuery>>> customQueryFilterClasses;
     private final SqlExceptionClassifier exceptionClassifier;
-    private final List<Property> tablePropertyOverrides;
 
     public VerifierModule(
             SqlParserOptions sqlParserOptions,
             List<Class<? extends Predicate<SourceQuery>>> customQueryFilterClasses,
-            SqlExceptionClassifier exceptionClassifier,
-            List<Property> tablePropertyOverrides)
+            SqlExceptionClassifier exceptionClassifier)
     {
         this.sqlParserOptions = requireNonNull(sqlParserOptions, "sqlParserOptions is null");
         this.customQueryFilterClasses = ImmutableList.copyOf(customQueryFilterClasses);
         this.exceptionClassifier = requireNonNull(exceptionClassifier, "exceptionClassifier is null");
-        this.tablePropertyOverrides = requireNonNull(tablePropertyOverrides, "tablePropertyOverrides is null");
     }
 
     protected final void setup(Binder binder)
@@ -154,7 +150,6 @@ public class VerifierModule
         columnValidatorBinder.addBinding(ROW).to(RowColumnValidator.class).in(SINGLETON);
         columnValidatorBinder.addBinding(MAP).to(MapColumnValidator.class).in(SINGLETON);
         binder.bind(new TypeLiteral<List<Predicate<SourceQuery>>>() {}).toProvider(new CustomQueryFilterProvider(customQueryFilterClasses));
-        binder.bind(new TypeLiteral<List<Property>>() {}).toInstance(tablePropertyOverrides);
     }
 
     private static class CustomQueryFilterProvider

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifyCommand.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifyCommand.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.verifier.framework;
 
 import com.facebook.presto.sql.parser.SqlParserOptions;
-import com.facebook.presto.sql.tree.Property;
 import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
 import com.google.inject.Module;
 
@@ -36,6 +35,4 @@ public interface VerifyCommand
     List<Class<? extends Predicate<SourceQuery>>> getCustomQueryFilterClasses();
 
     SqlExceptionClassifier getSqlExceptionClassifier();
-
-    List<Property> getTablePropertyOverrides();
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriteConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriteConfig.java
@@ -16,13 +16,20 @@ package com.facebook.presto.verifier.rewrite;
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
 import com.facebook.presto.sql.tree.QualifiedName;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
 
 import javax.validation.constraints.NotNull;
+
+import java.io.IOException;
+import java.util.Map;
 
 public class QueryRewriteConfig
 {
     private QualifiedName tablePrefix = QualifiedName.of("tmp_verifier");
+    private Map<String, Object> tableProperties = ImmutableMap.of();
 
     @NotNull
     public QualifiedName getTablePrefix()
@@ -37,6 +44,28 @@ public class QueryRewriteConfig
         this.tablePrefix = tablePrefix == null ?
                 null :
                 QualifiedName.of(Splitter.on(".").splitToList(tablePrefix));
+        return this;
+    }
+
+    @NotNull
+    public Map<String, Object> getTableProperties()
+    {
+        return tableProperties;
+    }
+
+    @ConfigDescription("A json map representing the table properties of the temporary tables")
+    @Config("table-properties")
+    public QueryRewriteConfig setTableProperties(String tableProperties)
+    {
+        if (tableProperties == null) {
+            return this;
+        }
+        try {
+            this.tableProperties = new ObjectMapper().readValue(tableProperties, new TypeReference<Map<String, Object>>() {});
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         return this;
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDeterminismAnalyzer.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDeterminismAnalyzer.java
@@ -25,7 +25,6 @@ import com.facebook.presto.verifier.prestoaction.PrestoClusterConfig;
 import com.facebook.presto.verifier.prestoaction.PrestoExceptionClassifier;
 import com.facebook.presto.verifier.retry.RetryConfig;
 import com.facebook.presto.verifier.rewrite.QueryRewriter;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
@@ -77,8 +76,8 @@ public class TestDeterminismAnalyzer
                 sqlParser,
                 typeManager,
                 prestoAction,
-                ImmutableList.of(),
-                ImmutableMap.of(CONTROL, QualifiedName.of("tmp_verifier_c"), TEST, QualifiedName.of("tmp_verifier_t")));
+                ImmutableMap.of(CONTROL, QualifiedName.of("tmp_verifier_c"), TEST, QualifiedName.of("tmp_verifier_t")),
+                ImmutableMap.of());
         ChecksumValidator checksumValidator = createChecksumValidator(verifierConfig);
         SourceQuery sourceQuery = new SourceQuery("test", "", "", "", configuration, configuration);
 

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
@@ -217,7 +217,7 @@ public class TestVerificationManager
                 new VerificationFactory(
                         SQL_PARSER,
                         (sourceQuery, verificationContext) -> prestoAction,
-                        presto -> new QueryRewriter(SQL_PARSER, createTypeManager(), presto, ImmutableList.of(), ImmutableMap.of(CONTROL, TABLE_PREFIX, TEST, TABLE_PREFIX)),
+                        presto -> new QueryRewriter(SQL_PARSER, createTypeManager(), presto, ImmutableMap.of(CONTROL, TABLE_PREFIX, TEST, TABLE_PREFIX), ImmutableMap.of()),
                         new FailureResolverManagerFactory(ImmutableSet.of(), ImmutableSet.of()),
                         new MockNodeResourceClient(),
                         createChecksumValidator(verifierConfig),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriteConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriteConfig.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static org.testng.Assert.assertEquals;
 
 public class TestQueryRewriteConfig
 {
@@ -28,7 +29,8 @@ public class TestQueryRewriteConfig
     public void testDefault()
     {
         assertRecordedDefaults(recordDefaults(QueryRewriteConfig.class)
-                .setTablePrefix("tmp_verifier"));
+                .setTablePrefix("tmp_verifier")
+                .setTableProperties(null));
     }
 
     @Test
@@ -36,10 +38,13 @@ public class TestQueryRewriteConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("table-prefix", "local.tmp")
+                .put("table-properties", "{\"retention\":21}")
                 .build();
         QueryRewriteConfig expected = new QueryRewriteConfig()
-                .setTablePrefix("local.tmp");
+                .setTablePrefix("local.tmp")
+                .setTableProperties("{\"retention\":21}");
 
         assertFullMapping(properties, expected);
+        assertEquals(expected.getTableProperties(), ImmutableMap.of("retention", 21));
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
@@ -17,10 +17,6 @@ import com.facebook.presto.sql.parser.ParsingOptions;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
-import com.facebook.presto.sql.tree.Identifier;
-import com.facebook.presto.sql.tree.LongLiteral;
-import com.facebook.presto.sql.tree.Property;
-import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.tests.StandaloneQueryRunner;
@@ -29,11 +25,11 @@ import com.facebook.presto.verifier.framework.QueryBundle;
 import com.facebook.presto.verifier.framework.QueryConfiguration;
 import com.facebook.presto.verifier.framework.VerificationContext;
 import com.facebook.presto.verifier.prestoaction.JdbcPrestoAction;
+import com.facebook.presto.verifier.prestoaction.PrestoAction;
 import com.facebook.presto.verifier.prestoaction.PrestoClusterConfig;
 import com.facebook.presto.verifier.prestoaction.PrestoExceptionClassifier;
 import com.facebook.presto.verifier.retry.RetryConfig;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -51,7 +47,6 @@ import static com.facebook.presto.verifier.VerifierTestUtil.SCHEMA;
 import static com.facebook.presto.verifier.VerifierTestUtil.createTypeManager;
 import static com.facebook.presto.verifier.VerifierTestUtil.setupPresto;
 import static com.facebook.presto.verifier.framework.ClusterType.CONTROL;
-import static com.facebook.presto.verifier.framework.ClusterType.TEST;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
@@ -60,13 +55,15 @@ import static org.testng.Assert.assertTrue;
 @Test
 public class TestQueryRewriter
 {
-    private static final QualifiedName DEFAULT_PREFIX = QualifiedName.of("local", "tmp");
     private static final QueryConfiguration CONFIGURATION = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty());
-    private static final List<Property> TABLE_PROPERTIES_OVERRIDE = ImmutableList.of(new Property(new Identifier("test_property"), new LongLiteral("21")));
     private static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build();
+    private static final QueryRewriteConfig QUERY_REWRITE_CONFIG = new QueryRewriteConfig()
+            .setTablePrefix("local.tmp")
+            .setTableProperties("{\"p_int\": 30, \"p_long\": 4294967297, \"p_double\": 1.5, \"p_varchar\": \"test\", \"p_bool\": true}");
     private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
 
     private static StandaloneQueryRunner queryRunner;
+    private static PrestoAction prestoAction;
 
     @BeforeClass
     public void setup()
@@ -74,6 +71,15 @@ public class TestQueryRewriter
     {
         queryRunner = setupPresto();
         queryRunner.execute("CREATE TABLE test_table (a bigint, b varchar)");
+        prestoAction = new JdbcPrestoAction(
+                PrestoExceptionClassifier.createDefault(),
+                CONFIGURATION,
+                VerificationContext.create(),
+                new PrestoClusterConfig()
+                        .setHost(queryRunner.getServer().getAddress().getHost())
+                        .setJdbcPort(queryRunner.getServer().getAddress().getPort()),
+                new RetryConfig(),
+                new RetryConfig());
     }
 
     @AfterClass
@@ -86,7 +92,7 @@ public class TestQueryRewriter
     public void testRewriteSelect()
     {
         assertShadowed(
-                getQueryRewriter(DEFAULT_PREFIX),
+                getQueryRewriter(),
                 "SELECT " +
                         "1 x, " +
                         "2 y, " +
@@ -98,27 +104,41 @@ public class TestQueryRewriter
                         "FROM test_table",
                 "local.tmp",
                 ImmutableList.of(),
-                "CREATE TABLE %s " +
-                        "(\"x\", \"y\", \"x_p_7\", \"x__1\", \"x_p_7__1\", \"a\", \"a__1\", \"b\") WITH (test_property = 21) AS " +
-                        "SELECT " +
-                        "1 x, " +
-                        "2 y, " +
-                        "3 \"X?p$7\", " +
-                        "4 \"x\", " +
-                        "5 x_p_7, " +
-                        "6 a, " +
-                        "* " +
-                        "FROM test_table",
+                "CREATE TABLE %s( \"x\", \"y\", \"x_p_7\", \"x__1\", \"x_p_7__1\", \"a\", \"a__1\", \"b\" )\n" +
+                        "WITH (\n" +
+                        "   p_int = 30,\n" +
+                        "   p_long = 4294967297,\n" +
+                        "   p_double = 1.5E0,\n" +
+                        "   p_varchar = 'test',\n" +
+                        "   p_bool = true\n" +
+                        ") AS SELECT\n" +
+                        "  1 x\n" +
+                        ", 2 y\n" +
+                        ", 3 \"X?p$7\"\n" +
+                        ", 4 \"x\"\n" +
+                        ", 5 x_p_7\n" +
+                        ", 6 a\n" +
+                        ", *\n" +
+                        "FROM\n" +
+                        "  test_table",
                 ImmutableList.of("DROP TABLE IF EXISTS %s"));
 
         assertShadowed(
-                getQueryRewriter(DEFAULT_PREFIX),
+                getQueryRewriter(),
                 "SELECT * FROM test_table a CROSS JOIN test_table b",
                 "local.tmp",
                 ImmutableList.of(),
-                "CREATE TABLE %s " +
-                        "(\"a\", \"b\", \"a__1\", \"b__1\") WITH (test_property = 21) AS " +
-                        "SELECT * FROM test_table a CROSS JOIN test_table b",
+                "CREATE TABLE %s( \"a\", \"b\", \"a__1\", \"b__1\" )\n" +
+                        "WITH (\n" +
+                        "   p_int = 30,\n" +
+                        "   p_long = 4294967297,\n" +
+                        "   p_double = 1.5E0,\n" +
+                        "   p_varchar = 'test',\n" +
+                        "   p_bool = true\n" +
+                        ") AS SELECT *\n" +
+                        "FROM\n" +
+                        "  (test_table a\n" +
+                        "CROSS JOIN test_table b)",
                 ImmutableList.of("DROP TABLE IF EXISTS %s"));
     }
 
@@ -126,10 +146,19 @@ public class TestQueryRewriter
     public void testRewriteInsert()
     {
         assertShadowed(
-                getQueryRewriter(DEFAULT_PREFIX),
+                getQueryRewriter(),
                 "INSERT INTO dest_table SELECT * FROM test_table",
                 "local.tmp",
-                ImmutableList.of("CREATE TABLE %s (LIKE dest_table INCLUDING PROPERTIES) WITH (test_property = 21)"),
+                ImmutableList.of("CREATE TABLE %s (\n" +
+                        "   LIKE dest_table INCLUDING PROPERTIES\n" +
+                        ")\n" +
+                        "WITH (\n" +
+                        "   p_int = 30,\n" +
+                        "   p_long = 4294967297,\n" +
+                        "   p_double = 1.5E0,\n" +
+                        "   p_varchar = 'test',\n" +
+                        "   p_bool = true\n" +
+                        ")"),
                 "INSERT INTO %s SELECT * FROM test_table",
                 ImmutableList.of("DROP TABLE IF EXISTS %s"));
     }
@@ -138,20 +167,30 @@ public class TestQueryRewriter
     public void testRewriteCreateTableAsSelect()
     {
         assertShadowed(
-                getQueryRewriter(DEFAULT_PREFIX),
+                getQueryRewriter(),
                 "CREATE TABLE dest_table WITH (test_property = 90) AS SELECT * FROM test_table",
                 "local.tmp",
                 ImmutableList.of(),
-                "CREATE TABLE %s WITH (test_property = 21) AS SELECT * FROM test_table",
+                "CREATE TABLE %s\n" +
+                        "WITH (\n" +
+                        "   p_varchar = 'test',\n" +
+                        "   p_long = 4294967297,\n" +
+                        "   p_int = 30,\n" +
+                        "   test_property = 90,\n" +
+                        "   p_double = 1.5E0,\n" +
+                        "   p_bool = true\n" +
+                        ") AS SELECT *\n" +
+                        "FROM\n" +
+                        "  test_table",
                 ImmutableList.of("DROP TABLE IF EXISTS %s"));
     }
 
     @Test
     public void testTemporaryTableName()
     {
-        QueryRewriter tableNameRewriter = getQueryRewriter(QualifiedName.of("tmp"));
-        QueryRewriter schemaRewriter = getQueryRewriter(QualifiedName.of("local", "tmp"));
-        QueryRewriter catalogRewriter = getQueryRewriter(QualifiedName.of("verifier_batch", "local", "tmp"));
+        QueryRewriter tableNameRewriter = getQueryRewriter(new QueryRewriteConfig().setTablePrefix("tmp"));
+        QueryRewriter schemaRewriter = getQueryRewriter(new QueryRewriteConfig().setTablePrefix("local.tmp"));
+        QueryRewriter catalogRewriter = getQueryRewriter(new QueryRewriteConfig().setTablePrefix("verifier_batch.local.tmp"));
 
         @Language("SQL") String query = "INSERT INTO dest_table SELECT * FROM test_table";
         assertTableName(tableNameRewriter, query, "tmp_");
@@ -172,7 +211,7 @@ public class TestQueryRewriter
     @Test
     public void testRewriteDate()
     {
-        QueryBundle queryBundle = getQueryRewriter(DEFAULT_PREFIX).rewriteQuery("SELECT date '2020-01-01', date(now()) today", CONTROL);
+        QueryBundle queryBundle = getQueryRewriter().rewriteQuery("SELECT date '2020-01-01', date(now()) today", CONTROL);
         assertCreateTableAs(queryBundle.getQuery(), "SELECT\n" +
                 "  CAST(date '2020-01-01' AS timestamp)\n" +
                 ", CAST(date(now()) AS timestamp) today");
@@ -181,7 +220,7 @@ public class TestQueryRewriter
     @Test
     public void testRewriteUnknown()
     {
-        QueryBundle queryBundle = getQueryRewriter(DEFAULT_PREFIX).rewriteQuery("SELECT null, null unknown", CONTROL);
+        QueryBundle queryBundle = getQueryRewriter().rewriteQuery("SELECT null, null unknown", CONTROL);
         assertCreateTableAs(queryBundle.getQuery(), "SELECT\n" +
                 "  CAST(null AS bigint)\n" +
                 ", CAST(null AS bigint) unknown");
@@ -190,7 +229,7 @@ public class TestQueryRewriter
     @Test
     public void testRewriteNonStorableStructuredTypes()
     {
-        QueryBundle queryBundle = getQueryRewriter(DEFAULT_PREFIX).rewriteQuery(
+        QueryBundle queryBundle = getQueryRewriter().rewriteQuery(
                 "SELECT\n" +
                         "    ARRAY[DATE '2020-01-01'],\n" +
                         "    ARRAY[NULL],\n" +
@@ -231,26 +270,26 @@ public class TestQueryRewriter
             String tableName = bundle.getTableName().toString();
             assertTrue(tableName.startsWith(prefix + "_"));
 
-            assertEquals(bundle.getSetupQueries(), templateToStatements(expectedSetupTemplates, tableName));
-            assertEquals(ImmutableList.of(bundle.getQuery()), templateToStatements(ImmutableList.of(expectedTemplates), tableName));
-            assertEquals(bundle.getTeardownQueries(), templateToStatements(expectedTeardownTemplates, tableName));
+            assertStatements(bundle.getSetupQueries(), templateToStatements(expectedSetupTemplates, tableName));
+            assertStatements(ImmutableList.of(bundle.getQuery()), templateToStatements(ImmutableList.of(expectedTemplates), tableName));
+            assertStatements(bundle.getTeardownQueries(), templateToStatements(expectedTeardownTemplates, tableName));
         }
     }
 
-    private void assertTableName(QueryRewriter queryRewriter, @Language("SQL") String query, String expectedPrefix)
+    private static void assertTableName(QueryRewriter queryRewriter, @Language("SQL") String query, String expectedPrefix)
     {
         QueryBundle bundle = queryRewriter.rewriteQuery(query, CONTROL);
         assertTrue(bundle.getTableName().toString().startsWith(expectedPrefix));
     }
 
-    private void assertCreateTableAs(Statement statement, String selectQuery)
+    private static void assertCreateTableAs(Statement statement, String selectQuery)
     {
         assertTrue(statement instanceof CreateTableAsSelect);
         Query query = ((CreateTableAsSelect) statement).getQuery();
         assertEquals(formatSql(query, Optional.empty()), formatSql(sqlParser.createStatement(selectQuery, PARSING_OPTIONS), Optional.empty()));
     }
 
-    private List<Statement> templateToStatements(List<String> templates, String tableName)
+    private static List<Statement> templateToStatements(List<String> templates, String tableName)
     {
         return templates.stream()
                 .map(template -> format(template, tableName))
@@ -258,21 +297,24 @@ public class TestQueryRewriter
                 .collect(toImmutableList());
     }
 
-    private QueryRewriter getQueryRewriter(QualifiedName prefix)
+    private static void assertStatements(List<Statement> actual, List<Statement> expected)
     {
-        return new QueryRewriter(
-                sqlParser,
-                createTypeManager(),
-                new JdbcPrestoAction(
-                        PrestoExceptionClassifier.createDefault(),
-                        CONFIGURATION,
-                        VerificationContext.create(),
-                        new PrestoClusterConfig()
-                                .setHost(queryRunner.getServer().getAddress().getHost())
-                                .setJdbcPort(queryRunner.getServer().getAddress().getPort()),
-                        new RetryConfig(),
-                        new RetryConfig()),
-                TABLE_PROPERTIES_OVERRIDE,
-                ImmutableMap.of(CONTROL, prefix, TEST, prefix));
+        List<String> actualQueries = actual.stream()
+                .map(statement -> formatSql(statement, Optional.empty()))
+                .collect(toImmutableList());
+        List<String> expectedQueries = expected.stream()
+                .map(statement -> formatSql(statement, Optional.empty()))
+                .collect(toImmutableList());
+        assertEquals(actualQueries, expectedQueries);
+    }
+
+    private QueryRewriter getQueryRewriter()
+    {
+        return getQueryRewriter(QUERY_REWRITE_CONFIG);
+    }
+
+    private QueryRewriter getQueryRewriter(QueryRewriteConfig config)
+    {
+        return new VerificationQueryRewriterFactory(sqlParser, createTypeManager(), config, config).create(prestoAction);
     }
 }


### PR DESCRIPTION
Depended by https://github.com/facebookexternal/presto-facebook/pull/936

Instead of harding coding table properties, making it a configuration property.

```
== RELEASE NOTES ==

Verifier Changes
* Add support for specifying table properties override for temporary Verifier tables, through configuration property ``control.table-properties`` and ``test.table-properties``.
```
