### PR TITLE
Fix named query output does not match column list

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -140,6 +140,7 @@ import com.google.common.collect.Multimap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -892,9 +893,9 @@ class StatementAnalyzer
                         // if columns are explicitly aliased -> WITH cte(alias1, alias2 ...)
                         ImmutableList.Builder<Field> fieldBuilder = ImmutableList.builder();
 
-                        int field = 0;
+                        Iterator<Field> visibleFieldsIterator = queryDescriptor.getVisibleFields().iterator();
                         for (Identifier columnName : columnNames.get()) {
-                            Field inputField = queryDescriptor.getFieldByIndex(field);
+                            Field inputField = visibleFieldsIterator.next();
                             fieldBuilder.add(Field.newQualified(
                                     QualifiedName.of(name),
                                     Optional.of(columnName.getValue()),
@@ -903,8 +904,6 @@ class StatementAnalyzer
                                     inputField.getOriginTable(),
                                     inputField.getOriginColumnName(),
                                     inputField.isAliased()));
-
-                            field++;
                         }
 
                         fields = fieldBuilder.build();

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4224,6 +4224,7 @@ public abstract class AbstractTestQueries
                         "WITH a AS (SELECT * FROM orders) " +
                         "SELECT * FROM a",
                 "SELECT * FROM orders");
+        assertQuerySucceeds("WITH t(x, y, z) AS (TABLE region) SELECT * FROM t");
     }
 
     @Test


### PR DESCRIPTION
Resolves #14333 

```
== RELEASE NOTES ==

General Changes
* Fix VerifyException when named query is a table reference (:issue:`14333`).
```
