### PR TITLE
Cast MongoDB ObjectID as VARCHAR

### DIFF
--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -187,6 +187,13 @@
         </dependency>
     </dependencies>
 
+    <!-- used by tests but also needed transitively -->
+    <dependency>
+        <groupId>io.airlift</groupId>
+        <artifactId>log-manager</artifactId>
+        <scope>runtime</scope>
+    </dependency>
+
     <profiles>
         <profile>
             <id>default</id>


### PR DESCRIPTION
Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
*  Cast MongoDB ObjectID as VARCHAR:
           CAST( _id AS VARCHAR)

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
#14338