### PR TITLE
Handle empty and arbitrary slices in Parquet reader

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/BinaryDictionary.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/dictionary/BinaryDictionary.java
@@ -39,9 +39,19 @@ public class BinaryDictionary
     {
         super(dictionaryPage.getEncoding());
         content = new Binary[dictionaryPage.getDictionarySize()];
+
+        byte[] dictionaryBytes;
+        int offset;
         Slice dictionarySlice = dictionaryPage.getSlice();
-        byte[] dictionaryBytes = dictionarySlice.byteArray();
-        int offset = dictionarySlice.byteArrayOffset();
+        if (dictionarySlice.hasByteArray()) {
+            dictionaryBytes = dictionarySlice.byteArray();
+            offset = dictionarySlice.byteArrayOffset();
+        }
+        else {
+            dictionaryBytes = dictionarySlice.getBytes();
+            offset = 0;
+        }
+
         if (length == null) {
             for (int i = 0; i < content.length; i++) {
                 int len = readIntLittleEndian(dictionaryBytes, offset);


### PR DESCRIPTION
Port fix for recent parquet reader optimization that would fail to handle empty `Slice` arguments from https://github.com/prestosql/presto/pull/3339

```
== NO RELEASE NOTE ==
```
