### PR TITLE
Reduce instance size and block copies in Page class

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/PageBuilder.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/PageBuilder.java
@@ -169,7 +169,7 @@ public class PageBuilder
             }
         }
 
-        return new Page(blocks);
+        return Page.wrapBlocksWithoutCopy(declaredPositions, blocks);
     }
 
     private static void checkArgument(boolean expression, String errorMessage)


### PR DESCRIPTION
Refactors Page class to avoid extra allocations and copies. Fields didn't require `AtomicLong` semantics and simple volatile fields are now used instead. Additionally, trusted methods can avoid copying `Block[]` in the page constructor by using a new static helper method. Finally, no valid reason should exist for `Page` subclassing, so the class is now final.

Cross contribution of https://github.com/prestosql/presto/pull/2975

```
== NO RELEASE NOTE ==
```
