### PR TITLE
Add Internationalization (i18n) plugin and Myanmar UDFs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <module>presto-hive-common</module>
         <module>presto-hive-hadoop2</module>
         <module>presto-hive-metastore</module>
+        <module>presto-i18n-functions</module>
         <module>presto-teradata-functions</module>
         <module>presto-example-http</module>
         <module>presto-local-file</module>
@@ -787,6 +788,12 @@
                         <artifactId>annotations</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-i18n-functions</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -1585,6 +1592,12 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.myanmartools</groupId>
+                <artifactId>myanmar-tools</artifactId>
+                <version>1.1.3</version>
             </dependency>
 
             <dependency>

--- a/presto-docs/src/main/sphinx/functions.rst
+++ b/presto-docs/src/main/sphinx/functions.rst
@@ -31,3 +31,4 @@ Functions and Operators
     functions/color
     functions/session
     functions/teradata
+    functions/internationalization

--- a/presto-docs/src/main/sphinx/functions/internationalization.rst
+++ b/presto-docs/src/main/sphinx/functions/internationalization.rst
@@ -1,0 +1,23 @@
+==============================
+Internationalization Functions
+==============================
+
+Myanmar Functions
+-----------------
+
+.. note::
+
+    Text written in Myanmar uses primarily the Zawgyi font encoding,
+    which is not compatible with Unicode. These functions provide
+    some utilities for comparing content in Myanmar despite the font
+    encoding.
+
+    See http://www.unicode.org/faq/myanmar.html for more information.
+
+.. function:: myanmar_font_encoding(text) -> varchar
+
+    Returns the font encoding of the text. Returns ``zawgyi`` if the content is Zawgyi encoded and ``unicode`` otherwise.
+
+.. function:: myanmar_normalize_unicode(text) -> varchar
+
+    Returns the text normalized as Unicode. Zawgyi text is converted to Unicode and Unicode text is left unchanged.

--- a/presto-i18n-functions/pom.xml
+++ b/presto-i18n-functions/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.235-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-i18n-functions</artifactId>
+    <description>Internationalization functions for Presto</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.myanmartools</groupId>
+            <artifactId>myanmar-tools</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>joda-to-java-time-bridge</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+
+        <!-- Presto SPI -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/presto-i18n-functions/src/main/java/com/facebook/presto/i18n/functions/I18nFunctionsPlugin.java
+++ b/presto-i18n-functions/src/main/java/com/facebook/presto/i18n/functions/I18nFunctionsPlugin.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.i18n.functions;
+
+import com.facebook.presto.spi.Plugin;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+public class I18nFunctionsPlugin
+        implements Plugin
+{
+    @Override
+    public Set<Class<?>> getFunctions()
+    {
+        return ImmutableSet.<Class<?>>builder()
+                .add(I18nMyanmarFunctions.class)
+                .build();
+    }
+}

--- a/presto-i18n-functions/src/main/java/com/facebook/presto/i18n/functions/I18nMyanmarFunctions.java
+++ b/presto-i18n-functions/src/main/java/com/facebook/presto/i18n/functions/I18nMyanmarFunctions.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.i18n.functions;
+
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.type.StandardTypes;
+import com.google.myanmartools.TransliterateZ2U;
+import com.google.myanmartools.ZawgyiDetector;
+import io.airlift.slice.Slice;
+
+import static io.airlift.slice.Slices.utf8Slice;
+
+public final class I18nMyanmarFunctions
+{
+    /**
+     * ZawgyiDetector returns a confidence score that a given string is Zawgyi encoded.
+     * This constant defines the default confidence at which a string is treated as Zawgyi.
+     */
+    private static final double ZAWGYI_PROBABILITY_THRESHOLD = 0.9;
+
+    private static final ZawgyiDetector detector = new ZawgyiDetector();
+    private static final TransliterateZ2U z2uTransliterator = new TransliterateZ2U("Zawgyi to Unicode");
+
+    private I18nMyanmarFunctions() {}
+
+    @Description("labels whether input strings use Unicode or Zawgyi font encoding")
+    @ScalarFunction
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice myanmarFontEncoding(@SqlType(StandardTypes.VARCHAR) Slice slice)
+    {
+        if (detector.getZawgyiProbability(slice.toStringUtf8()) > ZAWGYI_PROBABILITY_THRESHOLD) {
+            return utf8Slice("zawgyi");
+        }
+        else {
+            return utf8Slice("unicode");
+        }
+    }
+
+    @Description("transforms strings using Myanmar characters to a normalized Unicode form")
+    @ScalarFunction
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice myanmarNormalizeUnicode(@SqlType(StandardTypes.VARCHAR) Slice slice)
+    {
+        String[] rawInputPieces = slice.toStringUtf8().split("\n");
+        String[] normalizedPieces = new String[rawInputPieces.length];
+        for (int i = 0; i < rawInputPieces.length; i++) {
+            if (detector.getZawgyiProbability(rawInputPieces[i]) > ZAWGYI_PROBABILITY_THRESHOLD) {
+                normalizedPieces[i] = z2uTransliterator.convert(rawInputPieces[i]);
+            }
+            else {
+                normalizedPieces[i] = rawInputPieces[i];
+            }
+        }
+        return utf8Slice(String.join("\n", normalizedPieces));
+    }
+}

--- a/presto-i18n-functions/src/test/java/com/facebook/presto/i18n/functions/TestMyanmarFunctions.java
+++ b/presto-i18n-functions/src/test/java/com/facebook/presto/i18n/functions/TestMyanmarFunctions.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.i18n.functions;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.metadata.FunctionExtractor.extractFunctions;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
+
+public class TestMyanmarFunctions
+        extends AbstractTestFunctions
+{
+    @BeforeClass
+    public void setUp()
+    {
+        functionAssertions.addFunctions(extractFunctions(new I18nFunctionsPlugin().getFunctions()));
+    }
+
+    @Test
+    public void testMyanmarFontEncoding()
+    {
+        assertFunction("myanmar_font_encoding(NULL)", VARCHAR, null);
+        assertFunction("myanmar_font_encoding('english string')", VARCHAR, "unicode");
+        assertFunction("myanmar_font_encoding('\u1095')", VARCHAR, "zawgyi");
+        assertFunction("myanmar_font_encoding('\u1021\u101E\u1004\u1039\u1038\u1019\u103D')", VARCHAR, "zawgyi");
+        assertFunction("myanmar_font_encoding('\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A')", VARCHAR, "unicode");
+    }
+
+    @Test
+    public void testMyanmarNormalizeUnicode()
+    {
+        assertFunction("myanmar_normalize_unicode(NULL)", VARCHAR, null);
+        assertFunction("myanmar_normalize_unicode('english string')", VARCHAR, "english string");
+        assertFunction("myanmar_normalize_unicode('\u1021\u101E\u1004\u1039\u1038\u1019\u103D')", VARCHAR, "\u1021\u101E\u1004\u103A\u1038\u1019\u103E");
+        assertFunction("myanmar_normalize_unicode('\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A')", VARCHAR, "\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A");
+        assertFunction("myanmar_normalize_unicode('\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A\n\u1021\u101E\u1004\u1039\u1038\u1019\u103D')", VARCHAR, "\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A\n\u1021\u101E\u1004\u103A\u1038\u1019\u103E");
+    }
+}

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -40,6 +40,7 @@ plugin.bundles=\
   ../presto-sqlserver/pom.xml, \
   ../presto-postgresql/pom.xml, \
   ../presto-tpcds/pom.xml, \
+  ../presto-i18n-functions/pom.xml,\
   ../presto-function-namespace-managers/pom.xml
 
 presto.version=testversion


### PR DESCRIPTION
## RELEASE NOTES

### Context 
Text entered in Myanmar is often entered in non-Unicode-compliant Zawgyi. These are rendered differently based on the font encoding of devices in Myanmar. This means if someone entered Burmese-script text on a Zawgyi device, someone on a Unicode device could not read it, and vice versa.

Example:
* Unicode: နင် အခုဘယ်မှာလဲ? (readable)
* Zawgyi: နင္ အခုဘယ္မွာလဲ? (unreadable)

You can learn more about the overall issue at http://www.unicode.org/faq/myanmar.html

So if you query a search term in a Myanmar script in Presto, you'll only match text entered with the same font encoding.

These changes propose to functions to help resolve this:

* `MYANMAR_FONT_ENCODING(text)` which simply returns whether the encoding is Zawgyi or Unicode
* `MYANMAR_NORMALIZE_UNICODE(text)` which leaves Unicode as is and converts Zawgyi to Unicode using Google's Myanmar Tools algorithm: https://github.com/google/myanmar-tools

This change also adds an `Internationalization` or `i18n` plugin to cover other cases unique to certain languages