### PR TITLE
Support verifying SELECT queries with certain non-storable columns

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.verifier.rewrite;
 
 import com.facebook.presto.spi.type.ArrayType;
+import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.MapType;
 import com.facebook.presto.spi.type.RowType;
 import com.facebook.presto.spi.type.Type;
@@ -59,9 +60,13 @@ import java.util.stream.Stream;
 
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.DateType.DATE;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.RowType.Field;
 import static com.facebook.presto.spi.type.StandardTypes.MAP;
+import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.tree.LikeClause.PropertiesOption.INCLUDING;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.verifier.framework.QueryStage.REWRITE;
@@ -275,11 +280,17 @@ public class QueryRewriter
 
     private Optional<Type> getColumnTypeRewrite(Type type)
     {
-        if (type.equals(DATE)) {
+        if (type.equals(DATE) || type.equals(TIME)) {
             return Optional.of(TIMESTAMP);
+        }
+        if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
+            return Optional.of(VARCHAR);
         }
         if (type.equals(UNKNOWN)) {
             return Optional.of(BIGINT);
+        }
+        if (type instanceof DecimalType) {
+            return Optional.of(DOUBLE);
         }
         if (type instanceof ArrayType) {
             return getColumnTypeRewrite(((ArrayType) type).getElementType()).map(ArrayType::new);

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -302,9 +302,36 @@ public class TestDataVerification
     }
 
     @Test
+    public void testSelectTime()
+    {
+        String query = "SELECT time '12:34:56'";
+        Optional<VerifierQueryEvent> event = runVerification(query, query);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    @Test
+    public void testSelectTimestampWithTimeZone()
+    {
+        String query = "SELECT cast(timestamp '2020-04-01 12:34:56' AS timestamp with time zone)";
+        Optional<VerifierQueryEvent> event = runVerification(query, query);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    @Test
     public void testSelectUnknown()
     {
         Optional<VerifierQueryEvent> event = runVerification("SELECT null, null unknown", "SELECT null, null unknown");
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    @Test
+    public void testSelectDecimal()
+    {
+        String query = "SELECT decimal '1.2'";
+        Optional<VerifierQueryEvent> event = runVerification(query, query);
         assertTrue(event.isPresent());
         assertEvent(event.get(), SUCCEEDED, Optional.empty(), Optional.empty(), Optional.empty());
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
@@ -218,12 +218,39 @@ public class TestQueryRewriter
     }
 
     @Test
+    public void testRewriteTime()
+    {
+        QueryBundle queryBundle = getQueryRewriter().rewriteQuery("SELECT time '12:34:56', time '12:34:56' now", CONTROL);
+        assertCreateTableAs(queryBundle.getQuery(), "SELECT\n" +
+                "  CAST(time '12:34:56' AS timestamp)\n" +
+                ", CAST(time '12:34:56' AS timestamp) now");
+    }
+
+    @Test
+    public void testRewriteTimestampWithTimeZone()
+    {
+        QueryBundle queryBundle = getQueryRewriter().rewriteQuery("SELECT now(), now() now", CONTROL);
+        assertCreateTableAs(queryBundle.getQuery(), "SELECT\n" +
+                "  CAST(now() AS varchar)\n" +
+                ", CAST(now() AS varchar) now");
+    }
+
+    @Test
     public void testRewriteUnknown()
     {
         QueryBundle queryBundle = getQueryRewriter().rewriteQuery("SELECT null, null unknown", CONTROL);
         assertCreateTableAs(queryBundle.getQuery(), "SELECT\n" +
                 "  CAST(null AS bigint)\n" +
                 ", CAST(null AS bigint) unknown");
+    }
+
+    @Test
+    public void testRewriteDecimal()
+    {
+        QueryBundle queryBundle = getQueryRewriter().rewriteQuery("SELECT decimal '1.2', decimal '1.2' d", CONTROL);
+        assertCreateTableAs(queryBundle.getQuery(), "SELECT\n" +
+                "  CAST(decimal '1.2' AS double)\n" +
+                ", CAST(decimal '1.2' AS double) d");
     }
 
     @Test


### PR DESCRIPTION
Support verifying SELECT queries with certain non-storable columns
    
When verifying SELECT queries
- Cast Time columns to Timestamp
- Cast Timestamp With Time Zone columns to Varchar
- Cast Decimal columns to Double


```
== RELEASE NOTES ==

Verifier Changes
* Add support for verifying ``SELECT`` queries that produce columns of ``TIME``,
  ``TIMESTAMP WITH TIME ZONE``, or ``DECIMAL`` types, or columns of structured types
  with those types.
```
