### PR TITLE
Pass the correct value for fileSize in Hive internal split factory

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
@@ -176,7 +176,7 @@ public class InternalHiveSplitFactory
                 relativePath.toString(),
                 start,
                 start + length,
-                length,
+                fileSize,
                 blocks,
                 readBucketNumber,
                 tableBucketNumber,


### PR DESCRIPTION
We are passing the split length as `fileSize` to `InternalSplit`
which was used by Parquet reader when trying to find the last few bytes
that contain the Parquet file magic code to verify the file is a Parquet
file. PR #12780 accidentally modified this. It looks like Parquet is the
only reader which is using the filed `fileSize and this reproes only
if `InputFormat.getSplits()` is used which is not the most common.

```
== RELEASE NOTES ==
Hive Changes
* Fix a bug in Hive split calculation which affects Parquet reader in few corner cases
```