### PR TITLE
Fix NPE when reading structs with a newly added subfield

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -885,6 +885,8 @@ public class TestHivePushdownFilterQueries
         Path newDirectoryPath = getOnlyPath("test_struct_add_column").getParent();
         Files.move(oldFilePath, Paths.get(newDirectoryPath.toString(), "old_file"), ATOMIC_MOVE);
         assertQuery("SELECT * FROM test_struct_add_column", "SELECT (1, 2, 3) UNION ALL SELECT (1, 2, null)");
+        assertQuery("SELECT x.a FROM test_struct_add_column", "SELECT 1 UNION ALL SELECT 1");
+        assertQuery("SELECT count(*) FROM test_struct_add_column where x.c = 1", "SELECT 0");
     }
 
     @Test


### PR DESCRIPTION
If a nestedStream is missing for a field in the schema create a MissingFieldStreamReader
Fixes #14358 
```
== NO RELEASE NOTE ==
```
