### PR TITLE
Disallow invoking SQL functions in SQL function body

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -816,7 +816,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.197</version>
+                <version>1.4.199</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -580,6 +580,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-function-namespace-managers</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.facebook.hive</groupId>
                 <artifactId>hive-dwrf</artifactId>
                 <version>0.8.3</version>

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManagerModule.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManagerModule.java
@@ -17,11 +17,7 @@ import com.facebook.presto.functionNamespace.ServingCatalog;
 import com.facebook.presto.functionNamespace.SqlInvokedFunctionNamespaceManagerConfig;
 import com.google.inject.Binder;
 import com.google.inject.Module;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
-import org.jdbi.v3.core.Jdbi;
-import org.jdbi.v3.core.statement.SqlStatements;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.google.inject.Scopes.SINGLETON;
@@ -45,13 +41,5 @@ public class MySqlFunctionNamespaceManagerModule
         configBinder(binder).bindConfig(SqlInvokedFunctionNamespaceManagerConfig.class);
         configBinder(binder).bindConfig(MySqlFunctionNamespaceManagerConfig.class);
         binder.bind(MySqlFunctionNamespaceManager.class).in(SINGLETON);
-    }
-
-    @Provides
-    @Singleton
-    public FunctionNamespaceDao provideFunctionNamespaceDao(Jdbi jdbi)
-    {
-        SqlStatements config = jdbi.getConfig(SqlStatements.class);
-        return jdbi.onDemand(FunctionNamespaceDao.class);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -76,7 +76,7 @@ public class TestHivePushdownFilterQueries
             "   CASE WHEN orderkey % 43 = 0 THEN null ELSE (CAST(discount AS DECIMAL(20, 8)), CAST(tax AS DECIMAL(20, 8))) END AS long_decimals, " +
             "   CASE WHEN orderkey % 11 = 0 THEN null ELSE (orderkey, partkey, suppkey) END AS keys, \n" +
             "   CASE WHEN orderkey % 41 = 0 THEN null ELSE (extendedprice, discount, tax) END AS doubles, \n" +
-            "   CASE WHEN orderkey % 13 = 0 THEN null ELSE ((orderkey, partkey), (suppkey,), CASE WHEN orderkey % 17 = 0 THEN null ELSE (orderkey, partkey) END) END AS nested_keys, \n" +
+            "   CASE WHEN orderkey % 13 = 0 THEN null ELSE ARRAY[ARRAY[orderkey, partkey], ARRAY[suppkey], CASE WHEN orderkey % 17 = 0 THEN null ELSE ARRAY[orderkey, partkey] END] END AS nested_keys, \n" +
             "   CASE WHEN orderkey % 17 = 0 THEN null ELSE (shipmode = 'AIR', returnflag = 'R') END as flags, \n" +
             "   CASE WHEN orderkey % 19 = 0 THEN null ELSE (CAST(discount AS REAL), CAST(tax AS REAL)) END as reals, \n" +
             "   CASE WHEN orderkey % 23 = 0 THEN null ELSE (orderkey, linenumber, (CAST(day(shipdate) as TINYINT), CAST(month(shipdate) AS TINYINT), CAST(year(shipdate) AS INTEGER))) END AS info, \n" +

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -601,6 +601,12 @@ public class LocalQueryRunner
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public void loadFunctionNamespaceManager(String functionNamespaceManagerName, String catalogName, Map<String, String> properties)
+    {
+        metadata.getFunctionManager().loadFunctionNamespaceManager(functionNamespaceManagerName, catalogName, properties);
+    }
+
     public LocalQueryRunner printPlan()
     {
         printPlan = true;

--- a/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
@@ -80,6 +80,8 @@ public interface QueryRunner
 
     void createCatalog(String catalogName, String connectorName, Map<String, String> properties);
 
+    void loadFunctionNamespaceManager(String catalogName, String connectorName, Map<String, String> properties);
+
     Lock getExclusiveLock();
 
     class MaterializedResultWithPlan

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbResourceGroupConfigurationManager.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.testng.annotations.Test;
 
@@ -141,7 +142,7 @@ public class TestDbResourceGroupConfigurationManager
         }
         catch (RuntimeException ex) {
             assertTrue(ex instanceof UnableToExecuteStatementException);
-            assertTrue(ex.getCause() instanceof org.h2.jdbc.JdbcSQLException);
+            assertTrue(ex.getCause() instanceof JdbcSQLIntegrityConstraintViolationException);
             assertTrue(ex.getCause().getMessage().startsWith("Unique index or primary key violation"));
         }
         dao.insertSelector(1, 1, null, null, null, null, null);
@@ -157,7 +158,7 @@ public class TestDbResourceGroupConfigurationManager
         }
         catch (RuntimeException ex) {
             assertTrue(ex instanceof UnableToExecuteStatementException);
-            assertTrue(ex.getCause() instanceof org.h2.jdbc.JdbcSQLException);
+            assertTrue(ex.getCause() instanceof JdbcSQLIntegrityConstraintViolationException);
             assertTrue(ex.getCause().getMessage().startsWith("Unique index or primary key violation"));
         }
 

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
@@ -21,7 +21,7 @@ import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import org.h2.jdbc.JdbcSQLException;
+import org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.testng.annotations.Test;
 
@@ -244,14 +244,14 @@ public class TestResourceGroupsDao
             dao.insertResourceGroupsGlobalProperties("invalid_property", "1h");
         }
         catch (UnableToExecuteStatementException ex) {
-            assertTrue(ex.getCause() instanceof JdbcSQLException);
+            assertTrue(ex.getCause() instanceof JdbcSQLIntegrityConstraintViolationException);
             assertTrue(ex.getCause().getMessage().startsWith("Check constraint violation:"));
         }
         try {
             dao.updateResourceGroupsGlobalProperties("invalid_property_name");
         }
         catch (UnableToExecuteStatementException ex) {
-            assertTrue(ex.getCause() instanceof JdbcSQLException);
+            assertTrue(ex.getCause() instanceof JdbcSQLIntegrityConstraintViolationException);
             assertTrue(ex.getCause().getMessage().startsWith("Check constraint violation:"));
         }
     }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -312,6 +312,12 @@ public class PrestoSparkQueryRunner
     }
 
     @Override
+    public void loadFunctionNamespaceManager(String functionNamespaceManagerName, String catalogName, Map<String, String> properties)
+    {
+        metadata.getFunctionManager().loadFunctionNamespaceManager(functionNamespaceManagerName, catalogName, properties);
+    }
+
+    @Override
     public Lock getExclusiveLock()
     {
         throw new UnsupportedOperationException();

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -48,6 +48,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-function-namespace-managers</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>
@@ -113,6 +118,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
@@ -140,6 +150,11 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-sqlobject</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7043,9 +7043,9 @@ public abstract class AbstractTestQueries
     @Test
     public void testNonReservedTimeWords()
     {
-        assertQuery("" +
-                "SELECT TIME, TIMESTAMP, DATE, INTERVAL\n" +
-                "FROM (SELECT 1 TIME, 2 TIMESTAMP, 3 DATE, 4 INTERVAL)");
+        assertQuery(
+                "SELECT TIME, TIMESTAMP, DATE, INTERVAL FROM (SELECT 1 TIME, 2 TIMESTAMP, 3 DATE, 4 INTERVAL)",
+                "SELECT 1, 2, 3, 4");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -48,6 +48,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Closer;
 import io.airlift.units.Duration;
 import org.intellij.lang.annotations.Language;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -59,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -68,9 +71,11 @@ import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
 import static com.facebook.presto.testing.TestingSession.createBogusTestingCatalog;
 import static com.facebook.presto.tests.AbstractTestQueries.TEST_CATALOG_PROPERTIES;
 import static com.facebook.presto.tests.AbstractTestQueries.TEST_SYSTEM_PROPERTIES;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.units.Duration.nanosSince;
+import static java.lang.System.nanoTime;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -91,6 +96,8 @@ public class DistributedQueryRunner
     private final TestingPrestoClient prestoClient;
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    private final AtomicReference<Handle> testFunctionNamespacesHandle = new AtomicReference<>();
 
     @Deprecated
     public DistributedQueryRunner(Session defaultSession, int nodeCount)
@@ -124,7 +131,7 @@ public class DistributedQueryRunner
         requireNonNull(defaultSession, "defaultSession is null");
 
         try {
-            long start = System.nanoTime();
+            long start = nanoTime();
             discoveryServer = new TestingDiscoveryServer(environment);
             closer.register(() -> closeUnchecked(discoveryServer));
             log.info("Created TestingDiscoveryServer in %s", nanosSince(start).convertToMostSuccinctTimeUnit());
@@ -158,14 +165,14 @@ public class DistributedQueryRunner
         defaultSession = defaultSession.toSessionRepresentation().toSession(coordinator.getMetadata().getSessionPropertyManager());
         this.prestoClient = closer.register(new TestingPrestoClient(coordinator, defaultSession));
 
-        long start = System.nanoTime();
+        long start = nanoTime();
         while (!allNodesGloballyVisible()) {
             Assertions.assertLessThan(nanosSince(start), new Duration(10, SECONDS));
             MILLISECONDS.sleep(10);
         }
         log.info("Announced servers in %s", nanosSince(start).convertToMostSuccinctTimeUnit());
 
-        start = System.nanoTime();
+        start = nanoTime();
         for (TestingPrestoServer server : servers) {
             server.getMetadata().registerBuiltInFunctions(AbstractTestQueries.CUSTOM_FUNCTIONS);
         }
@@ -185,7 +192,7 @@ public class DistributedQueryRunner
     private static TestingPrestoServer createTestingPrestoServer(URI discoveryUri, boolean coordinator, Map<String, String> extraProperties, SqlParserOptions parserOptions, String environment, Optional<Path> baseDataDir)
             throws Exception
     {
-        long start = System.nanoTime();
+        long start = nanoTime();
         ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.<String, String>builder()
                 .put("query.client.timeout", "10m")
                 .put("exchange.http-client.idle-timeout", "1h")
@@ -297,7 +304,7 @@ public class DistributedQueryRunner
     @Override
     public void installPlugin(Plugin plugin)
     {
-        long start = System.nanoTime();
+        long start = nanoTime();
         for (TestingPrestoServer server : servers) {
             server.installPlugin(plugin);
         }
@@ -312,7 +319,7 @@ public class DistributedQueryRunner
     @Override
     public void createCatalog(String catalogName, String connectorName, Map<String, String> properties)
     {
-        long start = System.nanoTime();
+        long start = nanoTime();
         Set<ConnectorId> connectorIds = new HashSet<>();
         for (TestingPrestoServer server : servers) {
             connectorIds.add(server.createCatalog(catalogName, connectorName, properties));
@@ -321,7 +328,7 @@ public class DistributedQueryRunner
         log.info("Created catalog %s (%s) in %s", catalogName, connectorId, nanosSince(start));
 
         // wait for all nodes to announce the new catalog
-        start = System.nanoTime();
+        start = nanoTime();
         while (!isConnectionVisibleToAllNodes(connectorId)) {
             Assertions.assertLessThan(nanosSince(start), new Duration(100, SECONDS), "waiting for connector " + connectorId + " to be initialized in every node");
             try {
@@ -335,11 +342,42 @@ public class DistributedQueryRunner
         log.info("Announced catalog %s (%s) in %s", catalogName, connectorId, nanosSince(start));
     }
 
+    @Override
     public void loadFunctionNamespaceManager(String functionNamespaceManagerName, String catalogName, Map<String, String> properties)
     {
         for (TestingPrestoServer server : servers) {
             server.getMetadata().getFunctionManager().loadFunctionNamespaceManager(functionNamespaceManagerName, catalogName, properties);
         }
+    }
+
+    /**
+     * This method exists only because it is currently impossible to create a function namespace from the query engine,
+     * and therefore the query runner needs to be aware of the H2 handle in order to create function namespaces when
+     * required by the tests.
+     * <p>
+     * TODO: Remove when there is a generic way of creating function namespaces as if creating schemas.
+     */
+    public void enableTestFunctionNamespaces(List<String> catalogNames)
+    {
+        checkState(testFunctionNamespacesHandle.get() == null, "Test function namespaces already enabled");
+
+        String databaseName = String.valueOf(nanoTime());
+        Map<String, String> properties = ImmutableMap.of("database-name", databaseName);
+        installPlugin(new H2FunctionNamespaceManagerPlugin());
+        for (String catalogName : catalogNames) {
+            loadFunctionNamespaceManager("h2", catalogName, properties);
+        }
+
+        Handle handle = Jdbi.open(H2ConnectionModule.getJdbcUrl(databaseName));
+        testFunctionNamespacesHandle.set(handle);
+        closer.register(handle);
+    }
+
+    public void createTestFunctionNamespace(String catalogName, String schemaName)
+    {
+        checkState(testFunctionNamespacesHandle.get() != null, "Test function namespaces not enabled");
+
+        testFunctionNamespacesHandle.get().execute("INSERT INTO function_namespaces SELECT ?, ?", catalogName, schemaName);
     }
 
     private boolean isConnectionVisibleToAllNodes(ConnectorId connectorId)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2ConnectionConfig.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2ConnectionConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.airlift.configuration.Config;
+
+public class H2ConnectionConfig
+{
+    private String databaseName;
+
+    public String getDatabaseName()
+    {
+        return databaseName;
+    }
+
+    @Config("database-name")
+    public H2ConnectionConfig setDatabaseName(String databaseName)
+    {
+        this.databaseName = databaseName;
+        return this;
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2ConnectionModule.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2ConnectionModule.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.functionNamespace.mysql.FunctionNamespaceDao;
+import com.facebook.presto.functionNamespace.mysql.MySqlFunctionNamespaceManagerConfig;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.sql.DriverManager;
+
+import static com.facebook.presto.functionNamespace.mysql.MySqlConnectionModule.createJdbi;
+import static com.google.inject.Scopes.SINGLETON;
+import static java.lang.String.format;
+
+public class H2ConnectionModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        String databaseName = buildConfigObject(H2ConnectionConfig.class).getDatabaseName();
+        Jdbi jdbi = createJdbi(
+                () -> DriverManager.getConnection(getJdbcUrl(databaseName)),
+                buildConfigObject(MySqlFunctionNamespaceManagerConfig.class));
+        binder.bind(Jdbi.class).toInstance(jdbi);
+        binder.bind(HandleLifecycleManager.class).in(SINGLETON);
+        binder.bind(FunctionNamespaceDao.class).toProvider(new FunctionNamespaceDaoProvider()).in(SINGLETON);
+        binder.bind(new TypeLiteral<Class<? extends FunctionNamespaceDao>>() {}).toInstance(H2FunctionNamespaceDao.class);
+    }
+
+    private static class HandleLifecycleManager
+    {
+        private final Handle handle;
+
+        @Inject
+        public HandleLifecycleManager(Jdbi jdbi)
+        {
+            this.handle = jdbi.open();
+        }
+
+        public Handle getHandle()
+        {
+            return handle;
+        }
+
+        @PreDestroy
+        public void destroy()
+        {
+            handle.close();
+        }
+    }
+
+    private static class FunctionNamespaceDaoProvider
+            implements Provider<FunctionNamespaceDao>
+    {
+        private Injector injector;
+
+        @Inject
+        public void setInjector(Injector injector)
+        {
+            this.injector = injector;
+        }
+
+        @Override
+        public FunctionNamespaceDao get()
+        {
+            return injector.getInstance(HandleLifecycleManager.class).getHandle().attach(H2FunctionNamespaceDao.class);
+        }
+    }
+
+    public static String getJdbcUrl(String databaseName)
+    {
+        return format("jdbc:h2:mem:test%s;MODE=MySQL;DATABASE_TO_LOWER=TRUE", databaseName);
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2FunctionNamespaceDao.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2FunctionNamespaceDao.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.functionNamespace.mysql.FunctionNamespaceDao;
+import com.facebook.presto.spi.function.SqlFunctionId;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+public interface H2FunctionNamespaceDao
+        extends FunctionNamespaceDao
+{
+    @SqlUpdate("UPDATE\n" +
+            "    <sql_functions_table>\n" +
+            "SET\n" +
+            "    deleted = :deleted\n," +
+            "    delete_time = CASEWHEN(:deleted, NOW(), null)\n" +
+            "WHERE\n" +
+            "    function_id_hash = :function_id_hash\n" +
+            "    AND function_id = :function_id\n" +
+            "    AND version = :version")
+    @Override
+    int setDeletionStatus(
+            @Bind("function_id_hash") String functionIdHash,
+            @Bind("function_id") SqlFunctionId functionId,
+            @Bind("version") long version,
+            @Bind("deleted") boolean deleted);
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2FunctionNamespaceManagerFactory.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2FunctionNamespaceManagerFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.presto.functionNamespace.mysql.MySqlFunctionNamespaceManager;
+import com.facebook.presto.functionNamespace.mysql.MySqlFunctionNamespaceManagerModule;
+import com.facebook.presto.spi.function.FunctionHandleResolver;
+import com.facebook.presto.spi.function.FunctionNamespaceManager;
+import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
+import com.facebook.presto.spi.function.SqlFunctionHandle;
+import com.google.inject.Injector;
+
+import java.util.Map;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+
+public class H2FunctionNamespaceManagerFactory
+        implements FunctionNamespaceManagerFactory
+{
+    public static final String NAME = "h2";
+
+    private static final SqlFunctionHandle.Resolver HANDLE_RESOLVER = new SqlFunctionHandle.Resolver();
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public FunctionHandleResolver getHandleResolver()
+    {
+        return HANDLE_RESOLVER;
+    }
+
+    @Override
+    public FunctionNamespaceManager<?> create(String catalogName, Map<String, String> config)
+    {
+        try {
+            Bootstrap app = new Bootstrap(
+                    new MySqlFunctionNamespaceManagerModule(catalogName),
+                    new H2ConnectionModule());
+
+            Injector injector = app
+                    .strictConfig()
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+            return injector.getInstance(MySqlFunctionNamespaceManager.class);
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2FunctionNamespaceManagerPlugin.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2FunctionNamespaceManagerPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
+import com.google.common.collect.ImmutableList;
+
+public class H2FunctionNamespaceManagerPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<FunctionNamespaceManagerFactory> getFunctionNamespaceManagerFactories()
+    {
+        return ImmutableList.of(new H2FunctionNamespaceManagerFactory());
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -230,6 +230,12 @@ public final class StandaloneQueryRunner
     }
 
     @Override
+    public void loadFunctionNamespaceManager(String functionNamespaceManagerName, String catalogName, Map<String, String> properties)
+    {
+        server.getMetadata().getFunctionManager().loadFunctionNamespaceManager(functionNamespaceManagerName, catalogName, properties);
+    }
+
+    @Override
     public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
     {
         lock.readLock().lock();

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestSqlFunctions.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestSqlFunctions.java
@@ -120,6 +120,15 @@ public class TestSqlFunctions
     }
 
     @Test
+    public void testNestedSqlFunctions()
+    {
+        assertQuerySucceeds("CREATE FUNCTION testing.common.a() RETURNS int RETURN 1");
+        assertQueryFails(
+                "CREATE FUNCTION testing.common.b() RETURNS int RETURN testing.common.a()",
+                "Invoking a SQL function in SQL function body is not yet supported");
+    }
+
+    @Test
     public void testSqlFunctions()
     {
         assertQuerySucceeds("CREATE FUNCTION testing.common.array_append(a array<int>, x int)\n" +

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/ThriftQueryRunner.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/ThriftQueryRunner.java
@@ -276,6 +276,12 @@ public final class ThriftQueryRunner
         }
 
         @Override
+        public void loadFunctionNamespaceManager(String catalogName, String connectorName, Map<String, String> properties)
+        {
+            source.loadFunctionNamespaceManager(catalogName, connectorName, properties);
+        }
+
+        @Override
         public Lock getExclusiveLock()
         {
             return source.getExclusiveLock();


### PR DESCRIPTION
Current, executing a SQL function that calls another SQL function
throws internal error with "compiler failed" error message.

If the fix the compiling issue, we'll then have to properly handle
possible recursion.

Therefore, we should disallow such function body meanwhile.

Depended by https://github.com/facebookexternal/presto-facebook/pull/940

```
== RELEASE NOTES ==

General Changes
* Add check to disallow invoking SQL functions in SQL function body.
```
