### PR TITLE
fix PruneUnreferencedOutputs filter no output column, druid source still read the column, then cause exception

### DIFF
--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -270,5 +270,11 @@
             <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidAggregationColumnNode.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidAggregationColumnNode.java
@@ -72,11 +72,13 @@ public abstract class DruidAggregationColumnNode
             extends DruidAggregationColumnNode
     {
         private final CallExpression callExpression;
+        private final String alias;
 
-        public AggregationFunctionColumnNode(VariableReferenceExpression output, CallExpression callExpression)
+        public AggregationFunctionColumnNode(VariableReferenceExpression output, CallExpression callExpression, String alias)
         {
             super(ExpressionType.AGGREGATE, output);
             this.callExpression = requireNonNull(callExpression, "callExpression is null");
+            this.alias = requireNonNull(alias, "alias is null");
         }
 
         public CallExpression getCallExpression()
@@ -84,10 +86,15 @@ public abstract class DruidAggregationColumnNode
             return callExpression;
         }
 
+        public String getAlias()
+        {
+            return alias;
+        }
+
         @Override
         public String toString()
         {
-            return callExpression.toString();
+            return callExpression.toString() + ", " + alias;
         }
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidBrokerPageSource.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidBrokerPageSource.java
@@ -122,12 +122,11 @@ public class DruidBrokerPageSource
                 Iterator<JsonNode> iterator = arrayNode.elements();
                 while (iterator.hasNext()) {
                     JsonNode node = iterator.next();
-                    Iterator<String> fieldNamesIterator = node.fieldNames();
-                    for (int i = 0; i < columnHandles.size(); i++) {
+                    for (int i = 0; i < handles.size(); i++) {
                         Type type = columnTypes.get(i);
                         BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(i);
 
-                        String fieldName = fieldNamesIterator.next();
+                        String fieldName = handles.get(i).getColumnName();
                         JsonNode value = node.get(fieldName);
                         if (value == null) {
                             blockBuilder.appendNull();

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidFilterExpressionConverter.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidFilterExpressionConverter.java
@@ -185,7 +185,7 @@ public class DruidFilterExpressionConverter
                 throw new PrestoException(DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION, "Invalid Timestamp literal in Druid filter: " + argument.toString());
             }
             SqlTimestamp value = new SqlTimestamp((long) ((ConstantExpression) argument).getValue(), session.getTimeZoneKey());
-            return new DruidExpression("'" + value.toString() + "'", Origin.LITERAL);
+            return new DruidExpression("TIMESTAMP '" + value.toString() + "'", Origin.LITERAL);
         }
 
         throw new PrestoException(DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION, "Function " + call + " not supported in Druid filter");

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidPushdownUtils.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidPushdownUtils.java
@@ -30,6 +30,7 @@ import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -62,7 +63,7 @@ public class DruidPushdownUtils
                         || aggregation.getMask().isPresent()) {
                     throw new PrestoException(DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION, "Unsupported aggregation node " + aggregationNode);
                 }
-                nodeBuilder.add(new AggregationFunctionColumnNode(outputColumn, aggregation.getCall()));
+                nodeBuilder.add(new AggregationFunctionColumnNode(outputColumn, aggregation.getCall(), RandomStringUtils.randomAlphabetic(10)));
             }
             else {
                 // group by output

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidQueryGeneratorContext.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidQueryGeneratorContext.java
@@ -252,7 +252,9 @@ public class DruidQueryGeneratorContext
         selections.entrySet().stream().filter(e -> !hiddenColumnSet.contains(e.getKey())).forEach(entry -> {
             VariableReferenceExpression variable = entry.getKey();
             Selection selection = entry.getValue();
-            DruidColumnHandle handle = selection.getOrigin() == Origin.TABLE_COLUMN ? new DruidColumnHandle(selection.getDefinition(), variable.getType(), DruidColumnHandle.DruidColumnType.REGULAR) : new DruidColumnHandle(variable, DruidColumnHandle.DruidColumnType.DERIVED);
+            String alias = selection.getAlias();
+            VariableReferenceExpression derivedVariable = alias == null ? variable : new VariableReferenceExpression(alias, variable.getType());
+            DruidColumnHandle handle = selection.getOrigin() == Origin.TABLE_COLUMN ? new DruidColumnHandle(selection.getDefinition(), variable.getType(), DruidColumnHandle.DruidColumnType.REGULAR) : new DruidColumnHandle(derivedVariable, DruidColumnHandle.DruidColumnType.DERIVED);
             result.put(variable, handle);
         });
         return result;
@@ -287,11 +289,20 @@ public class DruidQueryGeneratorContext
     {
         private final String definition;
         private final Origin origin;
+        private final String alias;
 
         public Selection(String definition, Origin origin)
         {
             this.definition = definition;
             this.origin = origin;
+            this.alias = null;
+        }
+
+        public Selection(String definition, Origin origin, String alias)
+        {
+            this.definition = definition;
+            this.origin = origin;
+            this.alias = alias;
         }
 
         public String getDefinition()
@@ -302,6 +313,11 @@ public class DruidQueryGeneratorContext
         public Origin getOrigin()
         {
             return origin;
+        }
+
+        public String getAlias()
+        {
+            return alias;
         }
 
         @Override


### PR DESCRIPTION
== NO RELEASE NOTE ==