### PR TITLE
Eagerly dereference resources

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -383,7 +383,7 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
                 }
             }
         }
-
+        rowGroups = null;
         if (writeChecksumBuilder.isPresent()) {
             OrcWriteValidation.WriteChecksum actualChecksum = writeChecksumBuilder.get().build();
             validateWrite(validation -> validation.getChecksum().getTotalRowCount() == actualChecksum.getTotalRowCount(), "Invalid row count");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -38,7 +38,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
-import com.google.common.io.Closer;
 import com.google.common.primitives.Ints;
 import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
@@ -848,14 +847,6 @@ public class OrcSelectiveRecordReader
     public void close()
             throws IOException
     {
-        try (Closer closer = Closer.create()) {
-            for (SelectiveStreamReader streamReader : getStreamReaders()) {
-                if (streamReader != null) {
-                    closer.register(streamReader::close);
-                }
-            }
-        }
-
         super.close();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractDecimalSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/AbstractDecimalSelectiveStreamReader.java
@@ -322,6 +322,17 @@ public abstract class AbstractDecimalSelectiveStreamReader
     @Override
     public void close()
     {
+        values = null;
+        nulls = null;
+        outputPositions = null;
+
+        presentStream = null;
+        presentStreamSource = null;
+        dataStream = null;
+        dataStreamSource = null;
+        scaleStream = null;
+        scaleStreamSource = null;
+
         systemMemoryContext.close();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
@@ -444,6 +444,15 @@ public class BooleanSelectiveStreamReader
     @Override
     public void close()
     {
+        values = null;
+        outputPositions = null;
+        nulls = null;
+
+        presentStream = null;
+        presentStreamSource = null;
+        dataStream = null;
+        dataStreamSource = null;
+
         systemMemoryContext.close();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
@@ -445,6 +445,15 @@ public class ByteSelectiveStreamReader
     @Override
     public void close()
     {
+        values = null;
+        outputPositions = null;
+        nulls = null;
+
+        dataStream = null;
+        presentStream = null;
+        presentStreamSource = null;
+        dataStreamSource = null;
+
         systemMemoryContext.close();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleSelectiveStreamReader.java
@@ -440,6 +440,15 @@ public class DoubleSelectiveStreamReader
     @Override
     public void close()
     {
+        values = null;
+        outputPositions = null;
+        nulls = null;
+
+        presentStream = null;
+        presentStreamSource = null;
+        dataStream = null;
+        dataStreamSource = null;
+
         systemMemoryContext.close();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatSelectiveStreamReader.java
@@ -441,6 +441,15 @@ public class FloatSelectiveStreamReader
     @Override
     public void close()
     {
+        values = null;
+        outputPositions = null;
+        nulls = null;
+
+        presentStream = null;
+        presentStreamSource = null;
+        dataStream = null;
+        dataStreamSource = null;
+
         systemMemoryContext.close();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListSelectiveStreamReader.java
@@ -679,6 +679,20 @@ public class ListSelectiveStreamReader
         if (elementStreamReader != null) {
             elementStreamReader.close();
         }
+
+        outputPositions = null;
+        nulls = null;
+        offsets = null;
+        elementOffsets = null;
+        elementLengths = null;
+        elementPositions = null;
+        elementOutputPositions = null;
+        indexOutOfBounds = null;
+
+        presentStream = null;
+        presentStreamSource = null;
+        lengthStream = null;
+        lengthStreamSource = null;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
@@ -367,6 +367,16 @@ public class LongDictionarySelectiveStreamReader
     @Override
     public void close()
     {
+        values = null;
+        nulls = null;
+        outputPositions = null;
+        dictionary = null;
+        dictionaryFilterStatus = null;
+
+        dataStreamSource = null;
+        dataStream = null;
+        dictionaryDataStreamSource = null;
+
         systemMemoryContext.close();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectSelectiveStreamReader.java
@@ -370,6 +370,14 @@ public class LongDirectSelectiveStreamReader
     @Override
     public void close()
     {
+        values = null;
+        outputPositions = null;
+
+        presentStream = null;
+        presentStreamSource = null;
+        dataStream = null;
+        dataStreamSource = null;
+
         systemMemoryContext.close();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapDirectSelectiveStreamReader.java
@@ -658,6 +658,26 @@ public class MapDirectSelectiveStreamReader
     @Override
     public void close()
     {
+        if (keyReader != null) {
+            keyReader.close();
+        }
+        if (valueReader != null) {
+            valueReader.close();
+        }
+
+        nestedOffsets = null;
+        offsets = null;
+        nulls = null;
+        outputPositions = null;
+        nestedLengths = null;
+        nestedPositions = null;
+        nestedOutputPositions = null;
+
+        lengthStream = null;
+        lengthStreamSource = null;
+        presentStream = null;
+        lengthStreamSource = null;
+
         systemMemoryContext.close();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapSelectiveStreamReader.java
@@ -137,8 +137,7 @@ public class MapSelectiveStreamReader
     @Override
     public void close()
     {
-        if (currentReader != null) {
-            currentReader.close();
-        }
+        directReader.close();
+        flatReader.close();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
@@ -609,6 +609,13 @@ public class SliceDictionarySelectiveReader
     @Override
     public void close()
     {
+        dictionary = null;
+        currentDictionaryData = null;
+        rowGroupDictionaryLength = null;
+        stripeDictionaryData = null;
+        stripeDictionaryLength = null;
+        values = null;
+        outputPositions = null;
         systemMemoryContext.close();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
@@ -428,6 +428,12 @@ public class SliceDirectSelectiveStreamReader
     @Override
     public void close()
     {
+        dataAsSlice = null;
+        data = null;
+        lengthVector = null;
+        isNullVector = null;
+        offsets = null;
+        outputPositions = null;
         systemMemoryContext.close();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
@@ -609,6 +609,15 @@ public class StructSelectiveStreamReader
     @Override
     public void close()
     {
+        nestedReaders.values().stream().forEach(SelectiveStreamReader::close);
+
+        outputPositions = null;
+        nulls = null;
+        nestedOutputPositions = null;
+        nestedPositions = null;
+
+        presentStream = null;
+        presentStreamSource = null;
         systemMemoryContext.close();
     }
 
@@ -750,6 +759,7 @@ public class StructSelectiveStreamReader
         @Override
         public void close()
         {
+            outputPositions = null;
         }
 
         @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
@@ -442,6 +442,17 @@ public class TimestampSelectiveStreamReader
     @Override
     public void close()
     {
+        values = null;
+        outputPositions = null;
+        nulls = null;
+
+        presentStream = null;
+        presentStreamSource = null;
+        secondsStream = null;
+        secondsStreamSource = null;
+        nanosStream = null;
+        nanosStreamSource = null;
+
         systemMemoryContext.close();
     }
 


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```
These changes will speed up the GC process for these variables.
