### PR TITLE
align snappy-java version 1.1.2.6, 1.1.1.7, 1.1.7.1 to 1.1.7.1

### DIFF
--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.2.6</version>
+            <version>1.1.7.1</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.1.7</version>
+            <version>1.1.7.1</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
align inconsistent snappy-java dependency version to unified version 1.1.7.1, to avoid inconsistent API behaviors across modules.