### PR TITLE
Fix section labeling for KHyperLogLog documentation

### DIFF
--- a/presto-docs/src/main/sphinx/functions/khyperloglog.rst
+++ b/presto-docs/src/main/sphinx/functions/khyperloglog.rst
@@ -12,7 +12,7 @@ Data Structures
 
 KHyperLogLog is a data sketch that compactly represents the association of two
 columns. It is implemented in Presto as a two-level data structure composed of
-a MinHash structure whose entries map to :ref:`hyperloglog_type`.
+a MinHash structure whose entries map to ``HyperLogLog``.
 
 Serialization
 -------------

--- a/presto-docs/src/main/sphinx/language/types.rst
+++ b/presto-docs/src/main/sphinx/language/types.rst
@@ -282,13 +282,13 @@ Calculating the approximate distinct count can be done much more cheaply than an
 KHyperLogLog
 ------------
 
+.. _khyperloglog_type:
+
 ``KHyperLogLog``
 ^^^^^^^^^^^^^^^^
 
     A KHyperLogLog is a data sketch that can be used to compactly represents the association of two
     columns. See :doc:`/functions/khyperloglog`.
-
-.. _khyperloglog_type:
 
 Quantile Digest
 ---------------


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```
