### PR TITLE
Rename ORC related classes

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriter.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.hive;
 
-import com.facebook.presto.orc.OrcDataSink;
+import com.facebook.presto.orc.DataSink;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcEncoding;
 import com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode;
@@ -62,7 +62,7 @@ public class OrcFileWriter
     private long validationCpuNanos;
 
     public OrcFileWriter(
-            OrcDataSink orcDataSink,
+            DataSink dataSink,
             Callable<Void> rollbackAction,
             OrcEncoding orcEncoding,
             List<String> columnNames,
@@ -76,10 +76,10 @@ public class OrcFileWriter
             OrcWriteValidationMode validationMode,
             OrcWriterStats stats)
     {
-        requireNonNull(orcDataSink, "orcDataSink is null");
+        requireNonNull(dataSink, "dataSink is null");
 
         orcWriter = new OrcWriter(
-                orcDataSink,
+                dataSink,
                 columnNames,
                 fileColumnTypes,
                 orcEncoding,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
@@ -22,7 +22,7 @@ import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.OrcEncoding;
 import com.facebook.presto.orc.OrcWriterOptions;
 import com.facebook.presto.orc.OrcWriterStats;
-import com.facebook.presto.orc.OutputStreamOrcDataSink;
+import com.facebook.presto.orc.OutputStreamDataSink;
 import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
@@ -221,7 +221,7 @@ public class OrcFileWriterFactory
     protected OrcDataSink createOrcDataSink(ConnectorSession session, FileSystem fileSystem, Path path)
             throws IOException
     {
-        return new OutputStreamOrcDataSink(fileSystem.create(path));
+        return new OutputStreamDataSink(fileSystem.create(path));
     }
 
     private static CompressionKind getCompression(Properties schema, JobConf configuration, OrcEncoding orcEncoding)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
@@ -16,7 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.hive.metastore.MetastoreUtil;
 import com.facebook.presto.hive.metastore.StorageFormat;
 import com.facebook.presto.hive.orc.HdfsOrcDataSource;
-import com.facebook.presto.orc.OrcDataSink;
+import com.facebook.presto.orc.DataSink;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.OrcEncoding;
@@ -160,7 +160,7 @@ public class OrcFileWriterFactory
 
         try {
             FileSystem fileSystem = hdfsEnvironment.getFileSystem(session.getUser(), path, configuration);
-            OrcDataSink orcDataSink = createOrcDataSink(session, fileSystem, path);
+            DataSink dataSink = createDataSink(session, fileSystem, path);
 
             Optional<Supplier<OrcDataSource>> validationInputFactory = Optional.empty();
             if (HiveSessionProperties.isOrcOptimizedWriterValidate(session)) {
@@ -188,7 +188,7 @@ public class OrcFileWriterFactory
             };
 
             return Optional.of(new OrcFileWriter(
-                    orcDataSink,
+                    dataSink,
                     rollbackAction,
                     orcEncoding,
                     fileColumnNames,
@@ -218,7 +218,7 @@ public class OrcFileWriterFactory
     /**
      * Allow subclass to replace data sink implementation.
      */
-    protected OrcDataSink createOrcDataSink(ConnectorSession session, FileSystem fileSystem, Path path)
+    protected DataSink createDataSink(ConnectorSession session, FileSystem fileSystem, Path path)
             throws IOException
     {
         return new OutputStreamDataSink(fileSystem.create(path));

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SortingFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SortingFileWriter.java
@@ -19,7 +19,7 @@ import com.facebook.presto.hive.util.MergingPageIterator;
 import com.facebook.presto.hive.util.SortBuffer;
 import com.facebook.presto.hive.util.TempFileReader;
 import com.facebook.presto.hive.util.TempFileWriter;
-import com.facebook.presto.orc.OrcDataSink;
+import com.facebook.presto.orc.DataSink;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.spi.Page;
@@ -312,7 +312,7 @@ public class SortingFileWriter
 
     public interface TempFileSinkFactory
     {
-        OrcDataSink createSink(FileSystem fileSystem, Path path)
+        DataSink createSink(FileSystem fileSystem, Path path)
                 throws IOException;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SortingFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SortingFileWriterFactory.java
@@ -102,7 +102,7 @@ public class SortingFileWriterFactory
                 sortFields,
                 sortOrders,
                 pageSorter,
-                (fs, p) -> orcFileWriterFactory.createOrcDataSink(session, fs, p),
+                (fs, p) -> orcFileWriterFactory.createDataSink(session, fs, p),
                 sortedWriteToTempPathEnabled);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileWriter.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.hive.util;
 
-import com.facebook.presto.orc.OrcDataSink;
+import com.facebook.presto.orc.DataSink;
 import com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode;
 import com.facebook.presto.orc.OrcWriter;
 import com.facebook.presto.orc.OrcWriterOptions;
@@ -41,7 +41,7 @@ public class TempFileWriter
 {
     private final OrcWriter orcWriter;
 
-    public TempFileWriter(List<Type> types, OrcDataSink sink)
+    public TempFileWriter(List<Type> types, DataSink sink)
     {
         this.orcWriter = createOrcFileWriter(sink, types);
     }
@@ -68,7 +68,7 @@ public class TempFileWriter
         return orcWriter.getWrittenBytes();
     }
 
-    private static OrcWriter createOrcFileWriter(OrcDataSink sink, List<Type> types)
+    private static OrcWriter createOrcFileWriter(DataSink sink, List<Type> types)
     {
         List<String> columnNames = IntStream.range(0, types.size())
                 .mapToObj(String::valueOf)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -36,7 +36,7 @@ import com.facebook.presto.hive.rcfile.RcFilePageSourceFactory;
 import com.facebook.presto.orc.OrcWriter;
 import com.facebook.presto.orc.OrcWriterOptions;
 import com.facebook.presto.orc.OrcWriterStats;
-import com.facebook.presto.orc.OutputStreamOrcDataSink;
+import com.facebook.presto.orc.OutputStreamDataSink;
 import com.facebook.presto.orc.StorageStripeMetadataSource;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.parquet.writer.ParquetWriter;
@@ -527,7 +527,7 @@ public enum FileFormat
                 throws IOException
         {
             writer = new OrcWriter(
-                    new OutputStreamOrcDataSink(new FileOutputStream(targetFile)),
+                    new OutputStreamDataSink(new FileOutputStream(targetFile)),
                     columnNames,
                     types,
                     ORC,
@@ -564,7 +564,7 @@ public enum FileFormat
                 throws IOException
         {
             writer = new OrcWriter(
-                    new OutputStreamOrcDataSink(new FileOutputStream(targetFile)),
+                    new OutputStreamDataSink(new FileOutputStream(targetFile)),
                     columnNames,
                     types,
                     DWRF,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/DataSink.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DataSink.java
@@ -18,7 +18,7 @@ import com.facebook.presto.orc.stream.DataOutput;
 import java.io.IOException;
 import java.util.List;
 
-public interface OrcDataSink
+public interface DataSink
 {
     /**
      * Number of bytes written to this sink so far.

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcDataSink.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcDataSink.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.orc;
 
-import com.facebook.presto.orc.stream.OrcDataOutput;
+import com.facebook.presto.orc.stream.DataOutput;
 
 import java.io.IOException;
 import java.util.List;
@@ -33,7 +33,7 @@ public interface OrcDataSink
     /**
      * Write a stripe and optionally header and footer data
      */
-    void write(List<OrcDataOutput> outputData)
+    void write(List<DataOutput> outputData)
             throws IOException;
 
     /**

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -28,7 +28,7 @@ import com.facebook.presto.orc.metadata.StripeFooter;
 import com.facebook.presto.orc.metadata.StripeInformation;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.metadata.statistics.StripeStatistics;
-import com.facebook.presto.orc.stream.OrcDataOutput;
+import com.facebook.presto.orc.stream.DataOutput;
 import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.orc.writer.ColumnWriter;
 import com.facebook.presto.orc.writer.SliceDictionaryColumnWriter;
@@ -63,7 +63,7 @@ import static com.facebook.presto.orc.OrcWriterStats.FlushReason.MAX_BYTES;
 import static com.facebook.presto.orc.OrcWriterStats.FlushReason.MAX_ROWS;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static com.facebook.presto.orc.metadata.PostScript.MAGIC;
-import static com.facebook.presto.orc.stream.OrcDataOutput.createDataOutput;
+import static com.facebook.presto.orc.stream.DataOutput.createDataOutput;
 import static com.facebook.presto.orc.writer.ColumnWriters.createColumnWriter;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -323,7 +323,7 @@ public class OrcWriter
     private void flushStripe(FlushReason flushReason)
             throws IOException
     {
-        List<OrcDataOutput> outputData = new ArrayList<>();
+        List<DataOutput> outputData = new ArrayList<>();
         long stripeStartOffset = orcDataSink.size();
         // add header to first stripe (this is not required but nice to have)
         if (closedStripes.isEmpty()) {
@@ -356,7 +356,7 @@ public class OrcWriter
      * Collect the data for for the stripe.  This is not the actual data, but
      * instead are functions that know how to write the data.
      */
-    private List<OrcDataOutput> bufferStripeData(long stripeStartOffset, FlushReason flushReason)
+    private List<DataOutput> bufferStripeData(long stripeStartOffset, FlushReason flushReason)
             throws IOException
     {
         if (stripeRowCount == 0) {
@@ -375,7 +375,7 @@ public class OrcWriter
 
         columnWriters.forEach(ColumnWriter::close);
 
-        List<OrcDataOutput> outputData = new ArrayList<>();
+        List<DataOutput> outputData = new ArrayList<>();
         List<Stream> allStreams = new ArrayList<>(columnWriters.size() * 3);
 
         // get index streams
@@ -456,10 +456,10 @@ public class OrcWriter
      * Collect the data for for the file footer.  This is not the actual data, but
      * instead are functions that know how to write the data.
      */
-    private List<OrcDataOutput> bufferFileFooter()
+    private List<DataOutput> bufferFileFooter()
             throws IOException
     {
-        List<OrcDataOutput> outputData = new ArrayList<>();
+        List<DataOutput> outputData = new ArrayList<>();
 
         Metadata metadata = new Metadata(closedStripes.stream()
                 .map(ClosedStripe::getStatistics)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OutputStreamDataSink.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OutputStreamDataSink.java
@@ -23,14 +23,14 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
-public class OutputStreamOrcDataSink
+public class OutputStreamDataSink
         implements OrcDataSink
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(OutputStreamOrcDataSink.class).instanceSize();
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(OutputStreamDataSink.class).instanceSize();
 
     private final OutputStreamSliceOutput output;
 
-    public OutputStreamOrcDataSink(OutputStream outputStream)
+    public OutputStreamDataSink(OutputStream outputStream)
     {
         this.output = new OutputStreamSliceOutput(requireNonNull(outputStream, "outputStream is null"));
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OutputStreamDataSink.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OutputStreamDataSink.java
@@ -24,7 +24,7 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 
 public class OutputStreamDataSink
-        implements OrcDataSink
+        implements DataSink
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(OutputStreamDataSink.class).instanceSize();
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OutputStreamOrcDataSink.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OutputStreamOrcDataSink.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.orc;
 
-import com.facebook.presto.orc.stream.OrcDataOutput;
+import com.facebook.presto.orc.stream.DataOutput;
 import io.airlift.slice.OutputStreamSliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -48,7 +48,7 @@ public class OutputStreamOrcDataSink
     }
 
     @Override
-    public void write(List<OrcDataOutput> outputData)
+    public void write(List<DataOutput> outputData)
     {
         outputData.forEach(data -> data.writeData(output));
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DataOutput.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DataOutput.java
@@ -18,12 +18,12 @@ import io.airlift.slice.SliceOutput;
 
 import static java.util.Objects.requireNonNull;
 
-public interface OrcDataOutput
+public interface DataOutput
 {
-    static OrcDataOutput createDataOutput(Slice slice)
+    static DataOutput createDataOutput(Slice slice)
     {
         requireNonNull(slice, "slice is null");
-        return new OrcDataOutput()
+        return new DataOutput()
         {
             @Override
             public long size()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/StreamDataOutput.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/StreamDataOutput.java
@@ -23,7 +23,7 @@ import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
 public final class StreamDataOutput
-        implements OrcDataOutput, Comparable<StreamDataOutput>
+        implements DataOutput, Comparable<StreamDataOutput>
 {
     private final ToLongFunction<SliceOutput> writer;
     private final Stream stream;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1340,7 +1340,7 @@ public class OrcTester
         metadata.put("columns.types", createSettableStructObjectInspector(types).getTypeName());
 
         OrcWriter writer = new OrcWriter(
-                new OutputStreamOrcDataSink(new FileOutputStream(outputFile)),
+                new OutputStreamDataSink(new FileOutputStream(outputFile)),
                 columnNames,
                 types,
                 format.getOrcEncoding(),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -19,7 +19,7 @@ import com.facebook.presto.orc.metadata.Footer;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.StripeFooter;
 import com.facebook.presto.orc.metadata.StripeInformation;
-import com.facebook.presto.orc.stream.OrcDataOutput;
+import com.facebook.presto.orc.stream.DataOutput;
 import com.facebook.presto.orc.stream.OrcInputStream;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
@@ -198,7 +198,7 @@ public class TestOrcWriter
         }
 
         @Override
-        public void write(List<OrcDataOutput> outputData)
+        public void write(List<DataOutput> outputData)
                 throws IOException
         {
             throw new IOException("Dummy exception from mocked instance");

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -141,7 +141,7 @@ public class TestOrcWriter
             throws IOException
     {
         OrcWriter writer = new OrcWriter(
-                new MockOrcDataSink(),
+                new MockDataSink(),
                 ImmutableList.of("test1"),
                 ImmutableList.of(VARCHAR),
                 ORC,
@@ -178,10 +178,10 @@ public class TestOrcWriter
         }
     }
 
-    public static class MockOrcDataSink
-            implements OrcDataSink
+    public static class MockDataSink
+            implements DataSink
     {
-        public MockOrcDataSink()
+        public MockDataSink()
         {
         }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -58,7 +58,7 @@ public class TestOrcWriter
         for (OrcWriteValidationMode validationMode : OrcWriteValidationMode.values()) {
             TempFile tempFile = new TempFile();
             OrcWriter writer = new OrcWriter(
-                    new OutputStreamOrcDataSink(new FileOutputStream(tempFile.getFile())),
+                    new OutputStreamDataSink(new FileOutputStream(tempFile.getFile())),
                     ImmutableList.of("test1", "test2", "test3", "test4", "test5"),
                     ImmutableList.of(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR),
                     ORC,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
@@ -220,7 +220,7 @@ public class TestStructBatchStreamReader
             throws IOException
     {
         OrcWriter writer = new OrcWriter(
-                new OutputStreamOrcDataSink(new FileOutputStream(tempFile.getFile())),
+                new OutputStreamDataSink(new FileOutputStream(tempFile.getFile())),
                 ImmutableList.of(STRUCT_COL_NAME),
                 ImmutableList.of(writerType),
                 ORC,

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/HdfsOrcDataEnvironment.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/HdfsOrcDataEnvironment.java
@@ -16,7 +16,7 @@ package com.facebook.presto.raptor.filesystem;
 import com.facebook.presto.orc.OrcDataSink;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcDataSourceId;
-import com.facebook.presto.orc.OutputStreamOrcDataSink;
+import com.facebook.presto.orc.OutputStreamDataSink;
 import com.facebook.presto.raptor.storage.OrcDataEnvironment;
 import com.facebook.presto.raptor.storage.ReaderAttributes;
 import com.facebook.presto.spi.PrestoException;
@@ -72,6 +72,6 @@ public class HdfsOrcDataEnvironment
     public OrcDataSink createOrcDataSink(FileSystem fileSystem, Path path)
             throws IOException
     {
-        return new OutputStreamOrcDataSink(fileSystem.create(path));
+        return new OutputStreamDataSink(fileSystem.create(path));
     }
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/HdfsOrcDataEnvironment.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/HdfsOrcDataEnvironment.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.raptor.filesystem;
 
-import com.facebook.presto.orc.OrcDataSink;
+import com.facebook.presto.orc.DataSink;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.OutputStreamDataSink;
@@ -69,7 +69,7 @@ public class HdfsOrcDataEnvironment
     }
 
     @Override
-    public OrcDataSink createOrcDataSink(FileSystem fileSystem, Path path)
+    public DataSink createOrcDataSink(FileSystem fileSystem, Path path)
             throws IOException
     {
         return new OutputStreamDataSink(fileSystem.create(path));

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/LocalOrcDataEnvironment.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/LocalOrcDataEnvironment.java
@@ -16,7 +16,7 @@ package com.facebook.presto.raptor.filesystem;
 import com.facebook.presto.orc.FileOrcDataSource;
 import com.facebook.presto.orc.OrcDataSink;
 import com.facebook.presto.orc.OrcDataSource;
-import com.facebook.presto.orc.OutputStreamOrcDataSink;
+import com.facebook.presto.orc.OutputStreamDataSink;
 import com.facebook.presto.raptor.storage.OrcDataEnvironment;
 import com.facebook.presto.raptor.storage.ReaderAttributes;
 import com.facebook.presto.spi.PrestoException;
@@ -77,7 +77,7 @@ public class LocalOrcDataEnvironment
     public OrcDataSink createOrcDataSink(FileSystem fileSystem, Path path)
             throws IOException
     {
-        return new OutputStreamOrcDataSink(new FileOutputStream(localFileSystem.pathToFile(path)));
+        return new OutputStreamDataSink(new FileOutputStream(localFileSystem.pathToFile(path)));
     }
 
     public static Optional<RawLocalFileSystem> tryGetLocalFileSystem(OrcDataEnvironment environment)

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/LocalOrcDataEnvironment.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/LocalOrcDataEnvironment.java
@@ -13,8 +13,8 @@
  */
 package com.facebook.presto.raptor.filesystem;
 
+import com.facebook.presto.orc.DataSink;
 import com.facebook.presto.orc.FileOrcDataSource;
-import com.facebook.presto.orc.OrcDataSink;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OutputStreamDataSink;
 import com.facebook.presto.raptor.storage.OrcDataEnvironment;
@@ -74,7 +74,7 @@ public class LocalOrcDataEnvironment
     }
 
     @Override
-    public OrcDataSink createOrcDataSink(FileSystem fileSystem, Path path)
+    public DataSink createOrcDataSink(FileSystem fileSystem, Path path)
             throws IOException
     {
         return new OutputStreamDataSink(new FileOutputStream(localFileSystem.pathToFile(path)));

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcDataEnvironment.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcDataEnvironment.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.raptor.storage;
 
-import com.facebook.presto.orc.OrcDataSink;
+import com.facebook.presto.orc.DataSink;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.raptor.filesystem.FileSystemContext;
 import org.apache.hadoop.fs.FileSystem;
@@ -28,6 +28,6 @@ public interface OrcDataEnvironment
     OrcDataSource createOrcDataSource(FileSystem fileSystem, Path path, ReaderAttributes readerAttributes)
             throws IOException;
 
-    OrcDataSink createOrcDataSink(FileSystem fileSystem, Path path)
+    DataSink createOrcDataSink(FileSystem fileSystem, Path path)
             throws IOException;
 }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.raptor.storage;
 
 import com.facebook.airlift.json.JsonCodec;
-import com.facebook.presto.orc.OrcDataSink;
+import com.facebook.presto.orc.DataSink;
 import com.facebook.presto.orc.OrcWriter;
 import com.facebook.presto.orc.OrcWriterOptions;
 import com.facebook.presto.orc.OrcWriterStats;
@@ -55,7 +55,7 @@ public class OrcFileWriter
     private long rowCount;
     private long uncompressedSize;
 
-    public OrcFileWriter(List<Long> columnIds, List<Type> columnTypes, OrcDataSink target, boolean validate, OrcWriterStats stats, TypeManager typeManager, CompressionKind compression)
+    public OrcFileWriter(List<Long> columnIds, List<Type> columnTypes, DataSink target, boolean validate, OrcWriterStats stats, TypeManager typeManager, CompressionKind compression)
     {
         this(columnIds, columnTypes, target, true, validate, stats, typeManager, compression);
     }
@@ -64,7 +64,7 @@ public class OrcFileWriter
     OrcFileWriter(
             List<Long> columnIds,
             List<Type> columnTypes,
-            OrcDataSink target,
+            DataSink target,
             boolean writeMetadata,
             boolean validate,
             OrcWriterStats stats,

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -15,9 +15,9 @@ package com.facebook.presto.raptor.storage;
 
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.hive.HiveFileContext;
+import com.facebook.presto.orc.DataSink;
 import com.facebook.presto.orc.OrcAggregatedMemoryContext;
 import com.facebook.presto.orc.OrcBatchRecordReader;
-import com.facebook.presto.orc.OrcDataSink;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcPredicate;
 import com.facebook.presto.orc.OrcReader;
@@ -841,7 +841,7 @@ public class OrcStorageManager
                 Path stagingFile = storageService.getStagingFile(shardUuid);
                 storageService.createParents(stagingFile);
                 stagingFiles.add(stagingFile);
-                OrcDataSink sink;
+                DataSink sink;
                 try {
                     sink = orcDataEnvironment.createOrcDataSink(fileSystem, stagingFile);
                 }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
@@ -25,7 +25,7 @@ import com.facebook.presto.orc.OrcPredicate;
 import com.facebook.presto.orc.OrcReader;
 import com.facebook.presto.orc.OrcReaderOptions;
 import com.facebook.presto.orc.OrcWriterStats;
-import com.facebook.presto.orc.OutputStreamOrcDataSink;
+import com.facebook.presto.orc.OutputStreamDataSink;
 import com.facebook.presto.orc.StorageStripeMetadataSource;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.raptor.RaptorOrcAggregatedMemoryContext;
@@ -123,7 +123,7 @@ final class OrcTestingUtil
     {
         TypeRegistry typeManager = new TypeRegistry();
         new FunctionManager(typeManager, new BlockEncodingManager(typeManager), new FeaturesConfig());
-        return new OrcFileWriter(columnIds, columnTypes, new OutputStreamOrcDataSink(new FileOutputStream(file)), true, true, new OrcWriterStats(), typeManager, ZSTD);
+        return new OrcFileWriter(columnIds, columnTypes, new OutputStreamDataSink(new FileOutputStream(file)), true, true, new OrcWriterStats(), typeManager, ZSTD);
     }
 
     public static OrcReaderOptions createDefaultTestConfig()

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
@@ -20,7 +20,7 @@ import com.facebook.presto.orc.OrcBatchRecordReader;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcReader;
 import com.facebook.presto.orc.OrcWriterStats;
-import com.facebook.presto.orc.OutputStreamOrcDataSink;
+import com.facebook.presto.orc.OutputStreamDataSink;
 import com.facebook.presto.orc.StorageStripeMetadataSource;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.raptor.RaptorOrcAggregatedMemoryContext;
@@ -708,7 +708,7 @@ public class TestOrcFileRewriter
         return new OrcFileWriter(
                 columnIds,
                 columnTypes,
-                new OutputStreamOrcDataSink(new FileOutputStream(file)),
+                new OutputStreamDataSink(new FileOutputStream(file)),
                 writeMetadata,
                 true,
                 new OrcWriterStats(),


### PR DESCRIPTION
These classes have no dependency on ORC format, rename to make them reusable.

```
== NO RELEASE NOTE ==
```
