### PR TITLE
[WIP] Coordinator to Worker Transportation Revamp [Task Tracking]

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -222,6 +222,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-protocol</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.teradata</groupId>
             <artifactId>re2j-td</artifactId>
         </dependency>

--- a/presto-main/src/main/java/com/facebook/presto/execution/Lifespan.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/Lifespan.java
@@ -14,6 +14,9 @@
 
 package com.facebook.presto.execution;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -23,9 +26,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Integer.parseInt;
 
+@ThriftStruct
 public class Lifespan
 {
-    private static final Lifespan TASK_WIDE = new Lifespan(false, 0);
+    private static final Lifespan TASK_WIDE = new Lifespan("TaskWide");
 
     private final boolean grouped;
     private final int groupId;
@@ -57,6 +61,20 @@ public class Lifespan
         return groupId;
     }
 
+    @ThriftConstructor
+    public Lifespan(String value)
+    {
+        if (value.equals("TaskWide")) {
+            this.grouped = false;
+            this.groupId = 0;
+        }
+        else {
+            checkArgument(value.startsWith("Group"));
+            this.grouped = true;
+            this.groupId = parseInt(value.substring("Group".length()));
+        }
+    }
+
     @JsonCreator
     public static Lifespan jsonCreator(String value)
     {
@@ -67,6 +85,7 @@ public class Lifespan
         return Lifespan.driverGroup(parseInt(value.substring("Group".length())));
     }
 
+    @ThriftField(value = 1, name = "value")
     @JsonValue
     public String toString()
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskState.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskState.java
@@ -13,11 +13,15 @@
  */
 package com.facebook.presto.execution;
 
+import com.facebook.drift.annotations.ThriftEnum;
+import com.facebook.drift.annotations.ThriftEnumValue;
+
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
+@ThriftEnum
 public enum TaskState
 {
     /**
@@ -63,5 +67,11 @@ public enum TaskState
     public boolean isDone()
     {
         return doneState;
+    }
+
+    @ThriftEnumValue
+    public int getValue()
+    {
+        return ordinal();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/BufferInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/BufferInfo.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.execution.buffer;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -23,6 +26,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class BufferInfo
 {
     private final OutputBufferId bufferId;
@@ -32,6 +36,7 @@ public class BufferInfo
     private final long pagesSent;
     private final PageBufferInfo pageBufferInfo;
 
+    @ThriftConstructor
     @JsonCreator
     public BufferInfo(
             @JsonProperty("bufferId") OutputBufferId bufferId,
@@ -50,30 +55,35 @@ public class BufferInfo
         this.bufferedPages = bufferedPages;
     }
 
+    @ThriftField(1)
     @JsonProperty
     public OutputBufferId getBufferId()
     {
         return bufferId;
     }
 
+    @ThriftField(2)
     @JsonProperty
     public boolean isFinished()
     {
         return finished;
     }
 
+    @ThriftField(3)
     @JsonProperty
     public int getBufferedPages()
     {
         return bufferedPages;
     }
 
+    @ThriftField(4)
     @JsonProperty
     public long getPagesSent()
     {
         return pagesSent;
     }
 
+    @ThriftField(5)
     @JsonProperty
     public PageBufferInfo getPageBufferInfo()
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/BufferState.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/BufferState.java
@@ -13,11 +13,15 @@
  */
 package com.facebook.presto.execution.buffer;
 
+import com.facebook.drift.annotations.ThriftEnum;
+import com.facebook.drift.annotations.ThriftEnumValue;
+
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
+@ThriftEnum
 public enum BufferState
 {
     /**
@@ -80,5 +84,11 @@ public enum BufferState
     public boolean isTerminal()
     {
         return terminal;
+    }
+
+    @ThriftEnumValue
+    public int getValue()
+    {
+        return ordinal();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBufferInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/OutputBufferInfo.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.execution.buffer;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -22,6 +25,7 @@ import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
+@ThriftStruct
 public final class OutputBufferInfo
 {
     private final String type;
@@ -34,6 +38,7 @@ public final class OutputBufferInfo
     private final long totalPagesSent;
     private final List<BufferInfo> buffers;
 
+    @ThriftConstructor
     @JsonCreator
     public OutputBufferInfo(
             @JsonProperty("type") String type,
@@ -57,58 +62,67 @@ public final class OutputBufferInfo
         this.buffers = ImmutableList.copyOf(buffers);
     }
 
+    @ThriftField(1)
     @JsonProperty
     public String getType()
     {
         return type;
     }
 
+    @ThriftField(2)
     @JsonProperty
     public BufferState getState()
     {
         return state;
     }
 
-    @JsonProperty
-    public List<BufferInfo> getBuffers()
-    {
-        return buffers;
-    }
-
+    @ThriftField(3)
     @JsonProperty
     public boolean isCanAddBuffers()
     {
         return canAddBuffers;
     }
 
+    @ThriftField(4)
     @JsonProperty
     public boolean isCanAddPages()
     {
         return canAddPages;
     }
 
+    @ThriftField(5)
     @JsonProperty
     public long getTotalBufferedBytes()
     {
         return totalBufferedBytes;
     }
 
+    @ThriftField(6)
     @JsonProperty
     public long getTotalBufferedPages()
     {
         return totalBufferedPages;
     }
 
+    @ThriftField(7)
     @JsonProperty
     public long getTotalRowsSent()
     {
         return totalRowsSent;
     }
 
+    @ThriftField(8)
     @JsonProperty
     public long getTotalPagesSent()
     {
         return totalPagesSent;
+    }
+
+    @ThriftField(9)
+    @JsonProperty
+    public List<BufferInfo> getBuffers()
+    {
+        return buffers;
     }
 
     public OutputBufferInfo summarize()

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/PageBufferInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/PageBufferInfo.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.execution.buffer;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -20,6 +23,7 @@ import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
+@ThriftStruct
 public class PageBufferInfo
 {
     private final int partition;
@@ -28,6 +32,7 @@ public class PageBufferInfo
     private final long rowsAdded;
     private final long pagesAdded;
 
+    @ThriftConstructor
     @JsonCreator
     public PageBufferInfo(
             @JsonProperty("partition") int partition,
@@ -43,30 +48,35 @@ public class PageBufferInfo
         this.pagesAdded = pagesAdded;
     }
 
+    @ThriftField(1)
     @JsonProperty
     public int getPartition()
     {
         return partition;
     }
 
+    @ThriftField(2)
     @JsonProperty
     public long getBufferedPages()
     {
         return bufferedPages;
     }
 
+    @ThriftField(3)
     @JsonProperty
     public long getBufferedBytes()
     {
         return bufferedBytes;
     }
 
+    @ThriftField(4)
     @JsonProperty
     public long getRowsAdded()
     {
         return rowsAdded;
     }
 
+    @ThriftField(5)
     @JsonProperty
     public long getPagesAdded()
     {

--- a/presto-main/src/test/java/com/facebook/presto/thrift/BenchmarkThriftTaskInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/thrift/BenchmarkThriftTaskInfo.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.thrift;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.drift.codec.internal.coercion.DefaultJavaCoercions;
+import com.facebook.drift.codec.internal.compiler.CompilerThriftCodecFactory;
+import com.facebook.drift.protocol.TBinaryProtocol;
+import com.facebook.drift.protocol.TCompactProtocol;
+import com.facebook.drift.protocol.TFacebookCompactProtocol;
+import com.facebook.drift.protocol.TMemoryBuffer;
+import com.facebook.drift.protocol.TProtocol;
+import com.facebook.drift.protocol.TTransport;
+import com.facebook.presto.execution.TaskInfo;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.function.Function;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.presto.thrift.TestTaskInfoSerDe.getTaskInfo;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 10, batchSize = 100)
+@Measurement(iterations = 10, batchSize = 100)
+@BenchmarkMode(Mode.All)
+public class BenchmarkThriftTaskInfo
+{
+    private static final JsonCodec<TaskInfo> TASK_INFO_CODEC = jsonCodec(TaskInfo.class);
+    private static final TaskInfo TASK_INFO = getTaskInfo();
+    private static final ThriftCodecManager READ_CODEC_MANAGER = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+    private static final ThriftCodecManager WRITE_CODEC_MANAGER = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+    private static final ThriftCodec<TaskInfo> READ_CODEC = READ_CODEC_MANAGER.getCodec(TaskInfo.class);
+    private static final ThriftCodec<TaskInfo> WRITE_CODEC = WRITE_CODEC_MANAGER.getCodec(TaskInfo.class);
+
+    @Benchmark
+    public void serDeJson()
+    {
+        String json = TASK_INFO_CODEC.toJson(TASK_INFO);
+        TASK_INFO_CODEC.fromJson(json);
+    }
+
+    @Benchmark
+    public void serDeTBinaryProtocol()
+            throws Throwable
+    {
+        getRoundTripSerialize(TBinaryProtocol::new);
+    }
+
+    @Benchmark
+    public void serDeTCompactProtocol()
+            throws Throwable
+    {
+        getRoundTripSerialize(TCompactProtocol::new);
+    }
+
+    @Benchmark
+    public void serDeTFacebookCompactProtocol()
+            throws Throwable
+    {
+        getRoundTripSerialize(TFacebookCompactProtocol::new);
+    }
+
+    private void getRoundTripSerialize(Function<TTransport, TProtocol> protocolFactory)
+            throws Throwable
+    {
+        TMemoryBuffer transport = new TMemoryBuffer(10 * 1024);
+        TProtocol protocol = protocolFactory.apply(transport);
+        WRITE_CODEC.write(TASK_INFO, protocol);
+        TaskInfo copy = READ_CODEC.read(protocol);
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        READ_CODEC_MANAGER.getCatalog().addDefaultCoercions(DefaultJavaCoercions.class);
+        WRITE_CODEC_MANAGER.getCatalog().addDefaultCoercions(DefaultJavaCoercions.class);
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkThriftTaskInfo.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/thrift/TestTaskInfoSerDe.java
+++ b/presto-main/src/test/java/com/facebook/presto/thrift/TestTaskInfoSerDe.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.thrift;
+
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.drift.codec.internal.coercion.DefaultJavaCoercions;
+import com.facebook.drift.codec.internal.compiler.CompilerThriftCodecFactory;
+import com.facebook.drift.codec.metadata.ThriftCatalog;
+import com.facebook.drift.codec.metadata.ThriftStructMetadata;
+import com.facebook.drift.protocol.TBinaryProtocol;
+import com.facebook.drift.protocol.TCompactProtocol;
+import com.facebook.drift.protocol.TFacebookCompactProtocol;
+import com.facebook.drift.protocol.TMemoryBuffer;
+import com.facebook.drift.protocol.TProtocol;
+import com.facebook.drift.protocol.TTransport;
+import com.facebook.presto.execution.ExecutionFailureInfo;
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.execution.TaskState;
+import com.facebook.presto.execution.TaskStatus;
+import com.facebook.presto.execution.buffer.BufferInfo;
+import com.facebook.presto.execution.buffer.BufferState;
+import com.facebook.presto.execution.buffer.OutputBufferInfo;
+import com.facebook.presto.execution.buffer.OutputBuffers;
+import com.facebook.presto.execution.buffer.PageBufferInfo;
+import com.facebook.presto.operator.TaskStats;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.joda.time.DateTime;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.function.Function;
+
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestTaskInfoSerDe
+{
+    private static final ThriftCodecManager READ_CODEC_MANAGER = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+    private static final ThriftCodecManager WRITE_CODEC_MANAGER = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+
+    @BeforeMethod
+    protected void setUp()
+    {
+        READ_CODEC_MANAGER.getCatalog().addDefaultCoercions(DefaultJavaCoercions.class);
+        WRITE_CODEC_MANAGER.getCatalog().addDefaultCoercions(DefaultJavaCoercions.class);
+    }
+
+    @Test
+    public void testLifeSpan()
+            throws Exception
+    {
+        Lifespan lifespan = Lifespan.taskWide();
+        assertEquals(lifespan, getRoundTripSerialize(lifespan, TBinaryProtocol::new));
+        assertEquals(lifespan, getRoundTripSerialize(lifespan, TCompactProtocol::new));
+        assertEquals(lifespan, getRoundTripSerialize(lifespan, TFacebookCompactProtocol::new));
+    }
+
+    @Test
+    public void testPageBufferInfo()
+            throws Exception
+    {
+        PageBufferInfo pageBufferInfo = new PageBufferInfo(0, 1, 2, 3, 4);
+        assertEquals(pageBufferInfo, getRoundTripSerialize(pageBufferInfo, TBinaryProtocol::new));
+        assertEquals(pageBufferInfo, getRoundTripSerialize(pageBufferInfo, TCompactProtocol::new));
+        assertEquals(pageBufferInfo, getRoundTripSerialize(pageBufferInfo, TFacebookCompactProtocol::new));
+    }
+
+    @Test
+    public void testBufferInfo()
+            throws Exception
+    {
+        PageBufferInfo pageBufferInfo = new PageBufferInfo(0, 1, 2, 3, 4);
+        BufferInfo bufferInfo = new BufferInfo(new OutputBuffers.OutputBufferId(10), false, 2, 3, pageBufferInfo);
+        assertEquals(bufferInfo, getRoundTripSerialize(bufferInfo, TBinaryProtocol::new));
+        assertEquals(bufferInfo, getRoundTripSerialize(bufferInfo, TCompactProtocol::new));
+        assertEquals(bufferInfo, getRoundTripSerialize(bufferInfo, TFacebookCompactProtocol::new));
+    }
+
+    @Test
+    public void testOutputBufferInfo()
+            throws Exception
+    {
+        PageBufferInfo pageBufferInfo1 = new PageBufferInfo(0, 1, 2, 3, 4);
+        BufferInfo bufferInfo1 = new BufferInfo(new OutputBuffers.OutputBufferId(1), false, 2, 3, pageBufferInfo1);
+        PageBufferInfo pageBufferInfo2 = new PageBufferInfo(5, 6, 7, 8, 9);
+        BufferInfo bufferInfo2 = new BufferInfo(new OutputBuffers.OutputBufferId(2), false, 2, 3, pageBufferInfo2);
+        OutputBufferInfo outputBufferInfo = new OutputBufferInfo("test",
+                BufferState.OPEN,
+                true,
+                false,
+                1,
+                2,
+                3,
+                4,
+                ImmutableList.of(bufferInfo1, bufferInfo2));
+        assertEquals(outputBufferInfo, getRoundTripSerialize(outputBufferInfo, TBinaryProtocol::new));
+        assertEquals(outputBufferInfo, getRoundTripSerialize(outputBufferInfo, TCompactProtocol::new));
+        assertEquals(outputBufferInfo, getRoundTripSerialize(outputBufferInfo, TFacebookCompactProtocol::new));
+    }
+
+    private static TaskStatus getTaskStatus()
+    {
+        ExecutionFailureInfo executionFailureInfo1 = new ExecutionFailureInfo("test1", "m1", null, ImmutableList.of(), ImmutableList.of(), null, null, null);
+        ExecutionFailureInfo executionFailureInfo2 = new ExecutionFailureInfo("test1", "m1", executionFailureInfo1, ImmutableList.of(executionFailureInfo1), ImmutableList.of(), null, null, null);
+        return new TaskStatus(
+                new TaskId("test", 1, 1, 1),
+                "test",
+                1,
+                TaskState.RUNNING,
+                URI.create("fake://task/" + "1"),
+                "test",
+                ImmutableSet.of(Lifespan.taskWide(), Lifespan.taskWide()),
+                ImmutableList.of(executionFailureInfo2),
+                0,
+                0,
+                0.0,
+                false,
+                new DataSize(0, BYTE),
+                new DataSize(0, BYTE),
+                new DataSize(0, BYTE),
+                0,
+                new Duration(0, MILLISECONDS));
+    }
+
+    @Test
+    public void testTaskInfo()
+            throws Exception
+    {
+        TaskInfo taskInfo = getTaskInfo();
+
+        checkTaskInfo(taskInfo, getRoundTripSerialize(taskInfo, TBinaryProtocol::new));
+        checkTaskInfo(taskInfo, getRoundTripSerialize(taskInfo, TCompactProtocol::new));
+        checkTaskInfo(taskInfo, getRoundTripSerialize(taskInfo, TFacebookCompactProtocol::new));
+    }
+
+    public static TaskInfo getTaskInfo()
+    {
+        return new TaskInfo(
+                getTaskStatus(),
+                DateTime.now(),
+                new OutputBufferInfo("test", BufferState.OPEN, true, true, 0, 0, 0, 0, ImmutableList.of()),
+                ImmutableSet.of(),
+                new TaskStats(DateTime.now(), DateTime.now()),
+                true);
+    }
+
+    private void checkTaskInfo(TaskInfo taskInfo1, TaskInfo taskInfo2)
+    {
+        assertEquals(taskInfo1.getTaskStatus().getState(), taskInfo2.getTaskStatus().getState());
+        assertEquals(taskInfo1.getTaskStatus().getTaskId(), taskInfo2.getTaskStatus().getTaskId());
+        assertEquals(taskInfo1.getTaskStatus().getSelf(), taskInfo2.getTaskStatus().getSelf());
+        assertEquals(taskInfo1.getTaskStatus().getVersion(), taskInfo2.getTaskStatus().getVersion());
+        assertEquals(taskInfo1.getTaskStatus().getTaskInstanceId(), taskInfo2.getTaskStatus().getTaskInstanceId());
+        assertEquals(taskInfo1.getTaskStatus().getMemoryReservation(), taskInfo2.getTaskStatus().getMemoryReservation());
+        assertEquals(taskInfo1.getTaskStatus().getSystemMemoryReservation(), taskInfo2.getTaskStatus().getSystemMemoryReservation());
+        assertEquals(taskInfo1.getTaskStatus().getFullGcTimeString(), taskInfo2.getTaskStatus().getFullGcTimeString());
+        assertEquals(taskInfo1.getTaskStatus().getFailures().size(), taskInfo2.getTaskStatus().getFailures().size());
+        assertEquals(taskInfo1.getStatsJson(), taskInfo2.getStatsJson());
+        assertEquals(taskInfo1.getNoMoreSplits(), taskInfo2.getNoMoreSplits());
+        assertEquals(taskInfo1.getLastHeartbeatString(), taskInfo2.getLastHeartbeatString());
+    }
+
+    public static <T> T getRoundTripSerialize(T value, Function<TTransport, TProtocol> protocolFactory)
+            throws Exception
+    {
+        ThriftCodec<T> readCodec = (ThriftCodec<T>) READ_CODEC_MANAGER.getCodec(value.getClass());
+        ThriftCodec<T> writeCodec = (ThriftCodec<T>) WRITE_CODEC_MANAGER.getCodec(value.getClass());
+
+        return getRoundTripSerialize(readCodec, writeCodec, value, protocolFactory);
+    }
+
+    private static <T> T getRoundTripSerialize(ThriftCodec<T> readCodec, ThriftCodec<T> writeCodec, T structInstance, Function<TTransport, TProtocol> protocolFactory)
+            throws Exception
+    {
+        Class<T> structClass = (Class<T>) structInstance.getClass();
+        return getRoundTripSerialize(readCodec, writeCodec, structClass, structInstance, protocolFactory);
+    }
+
+    private static <T> T getRoundTripSerialize(ThriftCodec<T> readCodec, ThriftCodec<T> writeCodec, Type structType, T structInstance, Function<TTransport, TProtocol> protocolFactory)
+            throws Exception
+    {
+        ThriftCatalog readCatalog = READ_CODEC_MANAGER.getCatalog();
+        ThriftStructMetadata readMetadata = readCatalog.getThriftStructMetadata(structType);
+        assertNotNull(readMetadata);
+
+        ThriftCatalog writeCatalog = WRITE_CODEC_MANAGER.getCatalog();
+        ThriftStructMetadata writeMetadata = writeCatalog.getThriftStructMetadata(structType);
+        assertNotNull(writeMetadata);
+
+        TMemoryBuffer transport = new TMemoryBuffer(10 * 1024);
+        TProtocol protocol = protocolFactory.apply(transport);
+        writeCodec.write(structInstance, protocol);
+
+        T copy = readCodec.read(protocol);
+        assertNotNull(copy);
+        return copy;
+    }
+}


### PR DESCRIPTION
The coordinator to worker transportation is known to be inefficient, which takes roughly 60% or more CPU time on coordinators:
    * JSON as serialization format
    * Jetty as the communication library

This PR add thrift support to TaskInfo updates. Steps:
1. Make TaskInfo ThirftStruct
2. Add Task status and Task info tracking to ThriftTaskService.




