### PR TITLE
Add subfield pruning to StripeReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -23,6 +23,7 @@ import com.facebook.presto.orc.metadata.statistics.StripeStatistics;
 import com.facebook.presto.orc.reader.StreamReader;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.Subfield;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.FixedWidthType;
 import com.facebook.presto.spi.type.Type;
@@ -111,6 +112,7 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
 
     public AbstractOrcRecordReader(
             Map<Integer, Type> includedColumns,
+            Map<Integer, List<Subfield>> requiredSubfields,
             T[] streamReaders,
             OrcPredicate predicate,
             long numberOfRows,
@@ -221,6 +223,7 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
                 decompressor,
                 types,
                 this.presentColumns,
+                requiredSubfields,
                 rowsInRowGroup,
                 predicate,
                 hiveWriterVersion,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
 import org.joda.time.DateTimeZone;
@@ -71,6 +72,7 @@ public class OrcBatchRecordReader
 
     {
         super(includedColumns,
+                ImmutableMap.of(),
                 // The streamReadersSystemMemoryContext covers the StreamReader local buffer sizes, plus leaf node StreamReaders'
                 // instance sizes who use local buffers. SliceDirectStreamReader's instance size is not counted, because it
                 // doesn't have a local buffer. All non-leaf level StreamReaders' (e.g. MapStreamReader, LongStreamReader,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -173,6 +173,7 @@ public class OrcSelectiveRecordReader
             boolean cacheable)
     {
         super(includedColumns,
+                requiredSubfields,
                 createStreamReaders(
                         orcDataSource,
                         types,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
@@ -35,6 +35,7 @@ import com.facebook.presto.orc.stream.OrcInputStream;
 import com.facebook.presto.orc.stream.ValueInputStream;
 import com.facebook.presto.orc.stream.ValueInputStreamSource;
 import com.facebook.presto.orc.stream.ValueStreams;
+import com.facebook.presto.spi.Subfield;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -48,6 +49,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -59,6 +61,7 @@ import static com.facebook.presto.orc.checkpoint.Checkpoints.getDictionaryStream
 import static com.facebook.presto.orc.checkpoint.Checkpoints.getStreamCheckpoints;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY_V2;
+import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.STRUCT;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.BLOOM_FILTER;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.BLOOM_FILTER_UTF8;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_COUNT;
@@ -93,6 +96,7 @@ public class StripeReader
             Optional<OrcDecompressor> decompressor,
             List<OrcType> types,
             Set<Integer> includedColumns,
+            Map<Integer, List<Subfield>> requiredSubfields,
             int rowsInRowGroup,
             OrcPredicate predicate,
             HiveWriterVersion hiveWriterVersion,
@@ -104,7 +108,7 @@ public class StripeReader
         this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
         this.decompressor = requireNonNull(decompressor, "decompressor is null");
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
-        this.includedOrcColumns = getIncludedOrcColumns(types, requireNonNull(includedColumns, "includedColumns is null"));
+        this.includedOrcColumns = getIncludedOrcColumns(types, requireNonNull(includedColumns, "includedColumns is null"), requireNonNull(requiredSubfields, "requiredSubfields is null"));
         this.rowsInRowGroup = rowsInRowGroup;
         this.predicate = requireNonNull(predicate, "predicate is null");
         this.hiveWriterVersion = requireNonNull(hiveWriterVersion, "hiveWriterVersion is null");
@@ -456,14 +460,16 @@ public class StripeReader
     private static Map<Integer, ColumnStatistics> getRowGroupStatistics(OrcType rootStructType, Map<StreamId, List<RowGroupIndex>> columnIndexes, int rowGroup)
     {
         requireNonNull(rootStructType, "rootStructType is null");
-        checkArgument(rootStructType.getOrcTypeKind() == OrcTypeKind.STRUCT);
+        checkArgument(rootStructType.getOrcTypeKind() == STRUCT);
         requireNonNull(columnIndexes, "columnIndexes is null");
         checkArgument(rowGroup >= 0, "rowGroup is negative");
 
         Map<Integer, List<ColumnStatistics>> groupedColumnStatistics = new HashMap<>();
         for (Entry<StreamId, List<RowGroupIndex>> entry : columnIndexes.entrySet()) {
-            groupedColumnStatistics.computeIfAbsent(entry.getKey().getColumn(), key -> new ArrayList<>())
-                    .add(entry.getValue().get(rowGroup).getColumnStatistics());
+            if (!entry.getValue().isEmpty() && entry.getValue().get(rowGroup) != null) {
+                groupedColumnStatistics.computeIfAbsent(entry.getKey().getColumn(), key -> new ArrayList<>())
+                        .add(entry.getValue().get(rowGroup).getColumnStatistics());
+            }
         }
 
         ImmutableMap.Builder<Integer, ColumnStatistics> statistics = ImmutableMap.builder();
@@ -503,26 +509,61 @@ public class StripeReader
         return streamDiskRanges.build();
     }
 
-    private static Set<Integer> getIncludedOrcColumns(List<OrcType> types, Set<Integer> includedColumns)
+    private static Set<Integer> getIncludedOrcColumns(List<OrcType> types, Set<Integer> includedColumns, Map<Integer, List<Subfield>> requiredSubfields)
     {
         Set<Integer> includes = new LinkedHashSet<>();
 
         OrcType root = types.get(0);
         for (int includedColumn : includedColumns) {
-            includeOrcColumnsRecursive(types, includes, root.getFieldTypeIndex(includedColumn));
+            List<Subfield> subfields = Optional.ofNullable(requiredSubfields.get(includedColumn)).orElse(ImmutableList.of());
+            includeOrcColumnsRecursive(types, includes, root.getFieldTypeIndex(includedColumn), subfields);
         }
 
         return includes;
     }
 
-    private static void includeOrcColumnsRecursive(List<OrcType> types, Set<Integer> result, int typeId)
+    private static void includeOrcColumnsRecursive(List<OrcType> types, Set<Integer> result, int typeId, List<Subfield> requiredSubfields)
     {
         result.add(typeId);
         OrcType type = types.get(typeId);
+
+        Optional<Map<String, List<Subfield>>> requiredFields = Optional.empty();
+        if (type.getOrcTypeKind() == STRUCT) {
+            requiredFields = getRequiredFields(requiredSubfields);
+        }
+
         int children = type.getFieldCount();
         for (int i = 0; i < children; ++i) {
-            includeOrcColumnsRecursive(types, result, type.getFieldTypeIndex(i));
+            List<Subfield> subfields = ImmutableList.of();
+            if (requiredFields.isPresent()) {
+                String fieldName = type.getFieldNames().get(i);
+                if (!requiredFields.get().containsKey(fieldName)) {
+                    continue;
+                }
+                subfields = requiredFields.get().get(fieldName);
+            }
+
+            includeOrcColumnsRecursive(types, result, type.getFieldTypeIndex(i), subfields);
         }
+    }
+
+    private static Optional<Map<String, List<Subfield>>> getRequiredFields(List<Subfield> requiredSubfields)
+    {
+        if (requiredSubfields.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Map<String, List<Subfield>> fields = new HashMap<>();
+        for (Subfield subfield : requiredSubfields) {
+            List<Subfield.PathElement> path = subfield.getPath();
+            String name = ((Subfield.NestedField) path.get(0)).getName().toLowerCase(Locale.ENGLISH);
+            fields.computeIfAbsent(name, k -> new ArrayList<>());
+            if (path.size() > 1) {
+                fields.get(name).add(new Subfield("c", path.subList(1, path.size())));
+            }
+        }
+
+        return Optional.of(ImmutableMap.copyOf(fields));
     }
 
     /**


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```
While processing a struct column, we used to read all the nested streams even though a single nested field was required or accessed.
Eg. consider a column `col row(a bigint, b bigint, c row(...))`
For sql query` SELECT col.a` we will end up reading metadata for columns b, c,  all nested columns for c.  This increases the InputBytes processed, processing time, which can be improved by pruning the read for non-required subfields.