### PR TITLE
Reduce LazyBlock copy / wrapping in ScanFilterAndProjectOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/project/MergingPageOutput.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/MergingPageOutput.java
@@ -15,6 +15,8 @@ package com.facebook.presto.operator.project;
 
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PageBuilder;
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
 import com.google.common.collect.ImmutableList;
 import org.openjdk.jol.info.ClassLayout;
@@ -162,8 +164,10 @@ public class MergingPageOutput
         pageBuilder.declarePositions(page.getPositionCount());
         for (int channel = 0; channel < types.size(); channel++) {
             Type type = types.get(channel);
+            Block block = page.getBlock(channel);
+            BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(channel);
             for (int position = 0; position < page.getPositionCount(); position++) {
-                type.appendTo(page.getBlock(channel), position, pageBuilder.getBlockBuilder(channel));
+                type.appendTo(block, position, blockBuilder);
             }
         }
         if (pageBuilder.isFull()) {


### PR DESCRIPTION
Previously, LazyBlock instances that were already loaded would still be wrapped in a new LazyBlock that reported statistics on load. Now, only not-yet-loaded LazyBlock instances will require that wrapping. Additionally, when no changes to the Page blocks are required, the original page can be reused when recording input

```
== NO RELEASE NOTE ==
```
