### PR TITLE
Support built-in SQL scalar functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -35,6 +35,11 @@ Array Functions
     array is empty); ``NULL`` if the predicate function returns ``NULL`` for one or more elements and ``false``
     for all other elements.
 
+.. function:: array_average(array(double)) -> double
+
+    Returns the average of all non-null elements of the ``array``. If there is no non-null elements, returns
+    ``null``.
+
 .. function:: array_distinct(x) -> array
 
     Remove duplicate values from the array ``x``.
@@ -101,6 +106,14 @@ Array Functions
                           (x, y) -> IF(cardinality(x) < cardinality(y),
                                        -1,
                                        IF(cardinality(x) = cardinality(y), 0, 1))); -- [[1, 2], [2, 3, 1], [4, 2, 1, 4]]
+
+.. function:: array_sum(array(T)) -> bigint/double
+
+    Returns the sum of all non-null elements of the ``array``. If there is no non-null elements, returns ``0``.
+    The behavior is similar to aggregation function :func:`sum`.
+
+    ``T`` must be coercible to ``double``.
+    Returns ``bigint`` if T is coercible to ``bigint``. Otherwise, returns ``double``.
 
 .. function:: arrays_overlap(x, y) -> boolean
 

--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -71,6 +71,11 @@ Map Functions
 
     Returns all the keys in the map ``x``.
 
+.. function:: map_normalize(x(varchar,double)) -> array(varchar,double)
+
+    Returns the map with the same keys but all non-null values are scaled proportionally so that the sum of values becomes 1.
+    Map entries with null values remain unchanged.
+
 .. function:: map_values(x(K,V)) -> array(V)
 
     Returns all the values in the map ``x``.

--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/TranslatorAnnotationParser.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/TranslatorAnnotationParser.java
@@ -88,6 +88,7 @@ class TranslatorAnnotationParser
         return new FunctionMetadata(
                 metadata.getName(),
                 argumentsBuilder.build(),
+                Optional.empty(),
                 metadata.getReturnType(),
                 metadata.getFunctionKind(),
                 metadata.getImplementationType(),
@@ -161,7 +162,7 @@ class TranslatorAnnotationParser
         if (header.getOperatorType().isPresent()) {
             return new FunctionMetadata(header.getOperatorType().get(), argumentTypes.build(), returnType, SCALAR, BUILTIN, header.isDeterministic(), header.isCalledOnNullInput());
         }
-        return new FunctionMetadata(header.getName(), argumentTypes.build(), returnType, SCALAR, BUILTIN, header.isDeterministic(), header.isCalledOnNullInput());
+        return new FunctionMetadata(header.getName(), argumentTypes.build(), Optional.empty(), returnType, SCALAR, BUILTIN, header.isDeterministic(), header.isCalledOnNullInput());
     }
 
     @SafeVarargs

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.FunctionNamespaceManager;
 import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
+import com.facebook.presto.spi.function.Parameter;
 import com.facebook.presto.spi.function.ScalarFunctionImplementation;
 import com.facebook.presto.spi.function.Signature;
 import com.facebook.presto.spi.function.SqlFunction;
@@ -26,7 +27,6 @@ import com.facebook.presto.spi.function.SqlFunctionHandle;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.function.SqlInvokedScalarFunctionImplementation;
-import com.facebook.presto.spi.function.SqlParameter;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -201,7 +201,7 @@ public abstract class AbstractSqlInvokedFunctionNamespaceManager
                 function.getSignature().getName(),
                 function.getSignature().getArgumentTypes(),
                 function.getParameters().stream()
-                        .map(SqlParameter::getName)
+                        .map(Parameter::getName)
                         .collect(toImmutableList()),
                 function.getSignature().getReturnType(),
                 SCALAR,

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
@@ -200,9 +200,9 @@ public abstract class AbstractSqlInvokedFunctionNamespaceManager
         return new FunctionMetadata(
                 function.getSignature().getName(),
                 function.getSignature().getArgumentTypes(),
-                function.getParameters().stream()
+                Optional.of(function.getParameters().stream()
                         .map(Parameter::getName)
-                        .collect(toImmutableList()),
+                        .collect(toImmutableList())),
                 function.getSignature().getReturnType(),
                 SCALAR,
                 function.getFunctionImplementationType(),

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/FunctionNamespaceDao.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/FunctionNamespaceDao.java
@@ -14,10 +14,10 @@
 package com.facebook.presto.functionNamespace.mysql;
 
 import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.spi.function.Parameter;
 import com.facebook.presto.spi.function.RoutineCharacteristics;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
-import com.facebook.presto.spi.function.SqlParameter;
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactories;
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
@@ -263,7 +263,7 @@ public interface FunctionNamespaceDao
             @Bind("catalog_name") String catalogName,
             @Bind("schema_name") String schemaName,
             @Bind("function_name") String functionName,
-            @Bind("parameters") List<SqlParameter> parameters,
+            @Bind("parameters") List<Parameter> parameters,
             @Bind("return_type") TypeSignature returnType,
             @Bind("description") String description,
             @Bind("routine_characteristics") RoutineCharacteristics routineCharacteristics,

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManager.java
@@ -23,6 +23,7 @@ import com.facebook.presto.functionNamespace.SqlInvokedFunctionNamespaceManagerC
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.AlterRoutineCharacteristics;
 import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.Parameter;
 import com.facebook.presto.spi.function.RoutineCharacteristics;
 import com.facebook.presto.spi.function.ScalarFunctionImplementation;
 import com.facebook.presto.spi.function.Signature;
@@ -30,7 +31,6 @@ import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.function.SqlFunctionHandle;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
-import com.facebook.presto.spi.function.SqlParameter;
 import org.jdbi.v3.core.Jdbi;
 
 import javax.annotation.PostConstruct;
@@ -145,7 +145,7 @@ public class MySqlFunctionNamespaceManager
         if (function.getParameters().size() > MAX_PARAMETER_COUNT) {
             throw new PrestoException(GENERIC_USER_ERROR, format("Function has more than %s parameters: %s", MAX_PARAMETER_COUNT, function.getParameters().size()));
         }
-        for (SqlParameter parameter : function.getParameters()) {
+        for (Parameter parameter : function.getParameters()) {
             checkFieldLength("Parameter name", parameter.getName(), MAX_PARAMETER_NAME_LENGTH);
         }
 

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlInvokedFunctionRowMapper.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlInvokedFunctionRowMapper.java
@@ -16,9 +16,9 @@ package com.facebook.presto.functionNamespace.mysql;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.function.QualifiedFunctionName;
+import com.facebook.presto.spi.function.Parameter;
 import com.facebook.presto.spi.function.RoutineCharacteristics;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
-import com.facebook.presto.spi.function.SqlParameter;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -34,7 +34,7 @@ import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 public class SqlInvokedFunctionRowMapper
         implements RowMapper<SqlInvokedFunction>
 {
-    private static final JsonCodec<List<SqlParameter>> SQL_PARAMETERS_CODEC = listJsonCodec(SqlParameter.class);
+    private static final JsonCodec<List<Parameter>> PARAMETERS_CODEC = listJsonCodec(Parameter.class);
     private static final JsonCodec<RoutineCharacteristics> ROUTINE_CHARACTERISTICS_CODEC = jsonCodec(RoutineCharacteristics.class);
 
     @Override
@@ -44,7 +44,7 @@ public class SqlInvokedFunctionRowMapper
         String catalog = rs.getString("catalog_name");
         String schema = rs.getString("schema_name");
         String functionName = rs.getString("function_name");
-        List<SqlParameter> parameters = SQL_PARAMETERS_CODEC.fromJson(rs.getString("parameters"));
+        List<Parameter> parameters = PARAMETERS_CODEC.fromJson(rs.getString("parameters"));
         String returnType = rs.getString("return_type");
         String description = rs.getString("description");
         RoutineCharacteristics routineCharacteristics = ROUTINE_CHARACTERISTICS_CODEC.fromJson(rs.getString("routine_characteristics"));

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlParametersArgumentFactory.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/SqlParametersArgumentFactory.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.functionNamespace.mysql;
 
 import com.facebook.airlift.json.JsonCodec;
-import com.facebook.presto.spi.function.SqlParameter;
+import com.facebook.presto.spi.function.Parameter;
 import org.jdbi.v3.core.argument.AbstractArgumentFactory;
 import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.core.argument.ObjectArgument;
@@ -26,9 +26,9 @@ import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
 import static java.sql.Types.VARCHAR;
 
 public class SqlParametersArgumentFactory
-        extends AbstractArgumentFactory<List<SqlParameter>>
+        extends AbstractArgumentFactory<List<Parameter>>
 {
-    private static final JsonCodec<List<SqlParameter>> CODEC = listJsonCodec(SqlParameter.class);
+    private static final JsonCodec<List<Parameter>> CODEC = listJsonCodec(Parameter.class);
 
     public SqlParametersArgumentFactory()
     {
@@ -36,7 +36,7 @@ public class SqlParametersArgumentFactory
     }
 
     @Override
-    public Argument build(List<SqlParameter> parameters, ConfigRegistry config)
+    public Argument build(List<Parameter> parameters, ConfigRegistry config)
     {
         return new ObjectArgument(CODEC.toJson(parameters), VARCHAR);
     }

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/SqlInvokedFunctionTestUtils.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/SqlInvokedFunctionTestUtils.java
@@ -15,9 +15,9 @@ package com.facebook.presto.functionNamespace.testing;
 
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.function.QualifiedFunctionName;
+import com.facebook.presto.spi.function.Parameter;
 import com.facebook.presto.spi.function.RoutineCharacteristics;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
-import com.facebook.presto.spi.function.SqlParameter;
 import com.google.common.collect.ImmutableList;
 
 import java.util.Optional;
@@ -42,7 +42,7 @@ public class SqlInvokedFunctionTestUtils
 
     public static final SqlInvokedFunction FUNCTION_POWER_TOWER_DOUBLE = new SqlInvokedFunction(
             POWER_TOWER,
-            ImmutableList.of(new SqlParameter("x", parseTypeSignature(DOUBLE))),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(DOUBLE))),
             parseTypeSignature(DOUBLE),
             "power tower",
             RoutineCharacteristics.builder().setDeterminism(DETERMINISTIC).build(),
@@ -51,7 +51,7 @@ public class SqlInvokedFunctionTestUtils
 
     public static final SqlInvokedFunction FUNCTION_POWER_TOWER_DOUBLE_UPDATED = new SqlInvokedFunction(
             POWER_TOWER,
-            ImmutableList.of(new SqlParameter("x", parseTypeSignature(DOUBLE))),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(DOUBLE))),
             parseTypeSignature(DOUBLE),
             "power tower",
             RoutineCharacteristics.builder().setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
@@ -60,7 +60,7 @@ public class SqlInvokedFunctionTestUtils
 
     public static final SqlInvokedFunction FUNCTION_POWER_TOWER_INT = new SqlInvokedFunction(
             POWER_TOWER,
-            ImmutableList.of(new SqlParameter("x", parseTypeSignature(INTEGER))),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(INTEGER))),
             parseTypeSignature(INTEGER),
             "power tower",
             RoutineCharacteristics.builder().setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
@@ -69,7 +69,7 @@ public class SqlInvokedFunctionTestUtils
 
     public static final SqlInvokedFunction FUNCTION_TANGENT = new SqlInvokedFunction(
             TANGENT,
-            ImmutableList.of(new SqlParameter("x", parseTypeSignature(DOUBLE))),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(DOUBLE))),
             parseTypeSignature(DOUBLE),
             "tangent",
             RoutineCharacteristics.builder()

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManager.java
@@ -24,11 +24,11 @@ import com.facebook.presto.spi.function.AlterRoutineCharacteristics;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
+import com.facebook.presto.spi.function.Parameter;
 import com.facebook.presto.spi.function.RoutineCharacteristics;
 import com.facebook.presto.spi.function.SqlFunctionHandle;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
-import com.facebook.presto.spi.function.SqlParameter;
 import com.facebook.presto.testing.mysql.TestingMySqlServer;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -217,39 +217,39 @@ public class TestMySqlFunctionNamespaceManager
     @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Function has more than 100 parameters: 101")
     public void testTooManyParameters()
     {
-        List<SqlParameter> parameters = nCopies(101, new SqlParameter("x", parseTypeSignature(DOUBLE)));
+        List<Parameter> parameters = nCopies(101, new Parameter("x", parseTypeSignature(DOUBLE)));
         createFunction(createFunctionTangent(parameters), false);
     }
 
     public void testLargeParameterCount()
     {
-        List<SqlParameter> parameters = nCopies(100, new SqlParameter("x", parseTypeSignature(DOUBLE)));
+        List<Parameter> parameters = nCopies(100, new Parameter("x", parseTypeSignature(DOUBLE)));
         createFunction(createFunctionTangent(parameters), false);
     }
 
     @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Parameter name exceeds max length of 100.*")
     public void testParameterNameTooLong()
     {
-        List<SqlParameter> parameters = ImmutableList.of(new SqlParameter(dummyString(101), parseTypeSignature(DOUBLE)));
+        List<Parameter> parameters = ImmutableList.of(new Parameter(dummyString(101), parseTypeSignature(DOUBLE)));
         createFunction(createFunctionTangent(parameters), false);
     }
 
     public void testLongParameterName()
     {
-        List<SqlParameter> parameters = ImmutableList.of(new SqlParameter(dummyString(100), parseTypeSignature(DOUBLE)));
+        List<Parameter> parameters = ImmutableList.of(new Parameter(dummyString(100), parseTypeSignature(DOUBLE)));
         createFunction(createFunctionTangent(parameters), false);
     }
 
     @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Parameter type list exceeds max length of 30000.*")
     public void testParameterTypeListTooLong()
     {
-        List<SqlParameter> parameters = ImmutableList.of(new SqlParameter("x", createLargeRowType(4286)));
+        List<Parameter> parameters = ImmutableList.of(new Parameter("x", createLargeRowType(4286)));
         createFunction(createFunctionTangent(parameters), false);
     }
 
     public void testLongParameterTypeList()
     {
-        List<SqlParameter> parameters = ImmutableList.of(new SqlParameter("x", createLargeRowType(4285)));
+        List<Parameter> parameters = ImmutableList.of(new Parameter("x", createLargeRowType(4285)));
         createFunction(createFunctionTangent(parameters), false);
     }
 
@@ -280,7 +280,7 @@ public class TestMySqlFunctionNamespaceManager
                 FUNCTION_POWER_TOWER_INT.withVersion(1L),
                 new SqlInvokedFunction(
                         POWER_TOWER,
-                        ImmutableList.of(new SqlParameter("x", parseTypeSignature(DOUBLE))),
+                        ImmutableList.of(new Parameter("x", parseTypeSignature(DOUBLE))),
                         parseTypeSignature(DOUBLE),
                         "power tower",
                         RoutineCharacteristics.builder().setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
@@ -484,7 +484,7 @@ public class TestMySqlFunctionNamespaceManager
     {
         return new SqlInvokedFunction(
                 functionName,
-                ImmutableList.of(new SqlParameter("x", parseTypeSignature(DOUBLE))),
+                ImmutableList.of(new Parameter("x", parseTypeSignature(DOUBLE))),
                 parseTypeSignature(DOUBLE),
                 "power tower",
                 RoutineCharacteristics.builder().setDeterminism(DETERMINISTIC).build(),
@@ -504,7 +504,7 @@ public class TestMySqlFunctionNamespaceManager
                 Optional.empty());
     }
 
-    private static SqlInvokedFunction createFunctionTangent(List<SqlParameter> parameters)
+    private static SqlInvokedFunction createFunctionTangent(List<Parameter> parameters)
     {
         return new SqlInvokedFunction(
                 FUNCTION_TANGENT.getFunctionId().getFunctionName(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateFunctionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateFunctionTask.java
@@ -18,10 +18,10 @@ import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.Parameter;
 import com.facebook.presto.spi.function.RoutineCharacteristics;
 import com.facebook.presto.spi.function.SqlFunctionHandle;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
-import com.facebook.presto.spi.function.SqlParameter;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Analyzer;
 import com.facebook.presto.sql.parser.SqlParser;
@@ -84,8 +84,8 @@ public class CreateFunctionTask
     private SqlInvokedFunction createSqlInvokedFunction(CreateFunction statement)
     {
         QualifiedFunctionName functionName = qualifyFunctionName(statement.getFunctionName());
-        List<SqlParameter> parameters = statement.getParameters().stream()
-                .map(parameter -> new SqlParameter(parameter.getName().toString().toLowerCase(ENGLISH), parseTypeSignature(parameter.getType())))
+        List<Parameter> parameters = statement.getParameters().stream()
+                .map(parameter -> new Parameter(parameter.getName().toString().toLowerCase(ENGLISH), parseTypeSignature(parameter.getType())))
                 .collect(toImmutableList());
         TypeSignature returnType = parseTypeSignature(statement.getReturnType());
         String description = statement.getComment().orElse("");

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
@@ -802,6 +802,7 @@ public class BuiltInFunctionNamespaceManager
             return new FunctionMetadata(
                     signature.getName(),
                     signature.getArgumentTypes(),
+                    Optional.empty(),
                     signature.getReturnType(),
                     signature.getKind(),
                     BUILTIN,

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionExtractor.java
@@ -14,16 +14,20 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.operator.scalar.annotations.ScalarFromAnnotationsParser;
+import com.facebook.presto.operator.scalar.annotations.SqlInvokedScalarFromAnnotationsParser;
 import com.facebook.presto.operator.window.WindowAnnotationsParser;
 import com.facebook.presto.spi.function.AggregationFunction;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlFunction;
+import com.facebook.presto.spi.function.SqlInvokedScalarFunction;
 import com.facebook.presto.spi.function.WindowFunction;
+import com.google.common.collect.ImmutableList;
 
 import java.util.Collection;
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public final class FunctionExtractor
@@ -55,6 +59,15 @@ public final class FunctionExtractor
             return ScalarFromAnnotationsParser.parseFunctionDefinition(clazz);
         }
 
-        return ScalarFromAnnotationsParser.parseFunctionDefinitions(clazz);
+        if (clazz.isAnnotationPresent(SqlInvokedScalarFunction.class)) {
+            return SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinition(clazz);
+        }
+
+        List<SqlFunction> scalarFunctions = ImmutableList.<SqlFunction>builder()
+                .addAll(ScalarFromAnnotationsParser.parseFunctionDefinitions(clazz))
+                .addAll(SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinitions(clazz))
+                .build();
+        checkArgument(!scalarFunctions.isEmpty(), "Class [%s] does not define any scalar functions", clazz.getName());
+        return scalarFunctions;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionExtractor.java
@@ -18,6 +18,7 @@ import com.facebook.presto.operator.window.WindowAnnotationsParser;
 import com.facebook.presto.spi.function.AggregationFunction;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.function.WindowFunction;
 
 import java.util.Collection;
@@ -29,7 +30,7 @@ public final class FunctionExtractor
 {
     private FunctionExtractor() {}
 
-    public static List<BuiltInFunction> extractFunctions(Collection<Class<?>> classes)
+    public static List<SqlFunction> extractFunctions(Collection<Class<?>> classes)
     {
         return classes.stream()
                 .map(FunctionExtractor::extractFunctions)
@@ -37,7 +38,7 @@ public final class FunctionExtractor
                 .collect(toImmutableList());
     }
 
-    public static List<? extends BuiltInFunction> extractFunctions(Class<?> clazz)
+    public static List<? extends SqlFunction> extractFunctions(Class<?> clazz)
     {
         if (WindowFunction.class.isAssignableFrom(clazz)) {
             @SuppressWarnings("unchecked")

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
@@ -15,6 +15,7 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.operator.scalar.annotations.ScalarFromAnnotationsParser;
 import com.facebook.presto.operator.window.WindowAnnotationsParser;
+import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.function.WindowFunction;
 import com.google.common.collect.ImmutableList;
 
@@ -25,7 +26,7 @@ import static java.util.Objects.requireNonNull;
 
 public class FunctionListBuilder
 {
-    private final List<BuiltInFunction> functions = new ArrayList<>();
+    private final List<SqlFunction> functions = new ArrayList<>();
 
     public FunctionListBuilder window(Class<? extends WindowFunction> clazz)
     {
@@ -72,7 +73,7 @@ public class FunctionListBuilder
         return this;
     }
 
-    public List<BuiltInFunction> getFunctions()
+    public List<SqlFunction> getFunctions()
     {
         return ImmutableList.copyOf(functions);
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.operator.scalar.annotations.ScalarFromAnnotationsParser;
+import com.facebook.presto.operator.scalar.annotations.SqlInvokedScalarFromAnnotationsParser;
 import com.facebook.presto.operator.window.WindowAnnotationsParser;
 import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.function.WindowFunction;
@@ -55,6 +56,18 @@ public class FunctionListBuilder
     public FunctionListBuilder scalars(Class<?> clazz)
     {
         functions.addAll(ScalarFromAnnotationsParser.parseFunctionDefinitions(clazz));
+        return this;
+    }
+
+    public FunctionListBuilder sqlInvokedScalar(Class<?> clazz)
+    {
+        functions.addAll(SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinition(clazz));
+        return this;
+    }
+
+    public FunctionListBuilder sqlInvokedScalars(Class<?> clazz)
+    {
+        functions.addAll(SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinitions(clazz));
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
@@ -182,7 +182,7 @@ public class FunctionManager
         handleResolver.addFunctionNamespace(factory.getName(), factory.getHandleResolver());
     }
 
-    public void registerBuiltInFunctions(List<? extends BuiltInFunction> functions)
+    public void registerBuiltInFunctions(List<? extends SqlFunction> functions)
     {
         builtInFunctionNamespaceManager.registerBuiltInFunctions(functions);
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -60,7 +60,7 @@ public interface Metadata
 
     List<SqlFunction> listFunctions(Session session);
 
-    void registerBuiltInFunctions(List<? extends BuiltInFunction> functions);
+    void registerBuiltInFunctions(List<? extends SqlFunction> functions);
 
     boolean schemaExists(Session session, CatalogSchemaName schema);
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -270,7 +270,7 @@ public class MetadataManager
     }
 
     @Override
-    public void registerBuiltInFunctions(List<? extends BuiltInFunction> functionInfos)
+    public void registerBuiltInFunctions(List<? extends SqlFunction> functionInfos)
     {
         functions.registerBuiltInFunctions(functionInfos);
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SpecializedFunctionKey.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SpecializedFunctionKey.java
@@ -13,24 +13,26 @@
  */
 package com.facebook.presto.metadata;
 
+import com.facebook.presto.spi.function.SqlFunction;
+
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
 public class SpecializedFunctionKey
 {
-    private final BuiltInFunction function;
+    private final SqlFunction function;
     private final BoundVariables boundVariables;
     private final int arity;
 
-    public SpecializedFunctionKey(BuiltInFunction function, BoundVariables boundVariables, int arity)
+    public SpecializedFunctionKey(SqlFunction function, BoundVariables boundVariables, int arity)
     {
         this.function = requireNonNull(function, "function is null");
         this.boundVariables = requireNonNull(boundVariables, "boundVariables is null");
         this.arity = arity;
     }
 
-    public BuiltInFunction getFunction()
+    public SqlFunction getFunction()
     {
         return function;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationFromAnnotationsParser.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationFromAnnotationsParser.java
@@ -110,7 +110,7 @@ public class AggregationFromAnnotationsParser
     private static Optional<Method> getAggregationStateSerializerFactory(Class<?> aggregationDefinition, Class<?> stateClass)
     {
         // Only include methods that match this state class
-        List<Method> stateSerializerFactories = FunctionsParserHelper.findPublicStaticMethodsWithAnnotation(aggregationDefinition, AggregationStateSerializerFactory.class).stream()
+        List<Method> stateSerializerFactories = FunctionsParserHelper.findPublicStaticMethods(aggregationDefinition, AggregationStateSerializerFactory.class).stream()
                 .filter(method -> ((AggregationStateSerializerFactory) method.getAnnotation(AggregationStateSerializerFactory.class)).value().equals(stateClass))
                 .collect(toImmutableList());
 
@@ -174,7 +174,7 @@ public class AggregationFromAnnotationsParser
     public static Method getCombineFunction(Class<?> clazz, Class<?> stateClass)
     {
         // Only include methods that match this state class
-        List<Method> combineFunctions = FunctionsParserHelper.findPublicStaticMethodsWithAnnotation(clazz, CombineFunction.class).stream()
+        List<Method> combineFunctions = FunctionsParserHelper.findPublicStaticMethods(clazz, CombineFunction.class).stream()
                 .filter(method -> method.getParameterTypes()[AggregationImplementation.Parser.findAggregationStateParamId(method, 0)] == stateClass)
                 .filter(method -> method.getParameterTypes()[AggregationImplementation.Parser.findAggregationStateParamId(method, 1)] == stateClass)
                 .collect(toImmutableList());
@@ -186,7 +186,7 @@ public class AggregationFromAnnotationsParser
     private static List<Method> getOutputFunctions(Class<?> clazz, Class<?> stateClass)
     {
         // Only include methods that match this state class
-        List<Method> outputFunctions = FunctionsParserHelper.findPublicStaticMethodsWithAnnotation(clazz, OutputFunction.class).stream()
+        List<Method> outputFunctions = FunctionsParserHelper.findPublicStaticMethods(clazz, OutputFunction.class).stream()
                 .filter(method -> method.getParameterTypes()[AggregationImplementation.Parser.findAggregationStateParamId(method)] == stateClass)
                 .collect(toImmutableList());
 
@@ -197,7 +197,7 @@ public class AggregationFromAnnotationsParser
     private static List<Method> getInputFunctions(Class<?> clazz, Class<?> stateClass)
     {
         // Only include methods that match this state class
-        List<Method> inputFunctions = FunctionsParserHelper.findPublicStaticMethodsWithAnnotation(clazz, InputFunction.class).stream()
+        List<Method> inputFunctions = FunctionsParserHelper.findPublicStaticMethods(clazz, InputFunction.class).stream()
                 .filter(method -> (method.getParameterTypes()[AggregationImplementation.Parser.findAggregationStateParamId(method)] == stateClass))
                 .collect(toImmutableList());
 
@@ -208,7 +208,7 @@ public class AggregationFromAnnotationsParser
     private static Set<Class<?>> getStateClasses(Class<?> clazz)
     {
         ImmutableSet.Builder<Class<?>> builder = ImmutableSet.builder();
-        for (Method inputFunction : FunctionsParserHelper.findPublicStaticMethodsWithAnnotation(clazz, InputFunction.class)) {
+        for (Method inputFunction : FunctionsParserHelper.findPublicStaticMethods(clazz, InputFunction.class)) {
             checkArgument(inputFunction.getParameterTypes().length > 0, "Input function has no parameters");
             Class<?> stateClass = AggregationImplementation.Parser.findAggregationStateParamType(inputFunction);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/SqlInvokedScalarFromAnnotationsParser.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/SqlInvokedScalarFromAnnotationsParser.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.annotations;
+
+import com.facebook.presto.common.function.QualifiedFunctionName;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.Parameter;
+import com.facebook.presto.spi.function.RoutineCharacteristics;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.function.SqlInvokedScalarFunction;
+import com.facebook.presto.spi.function.SqlParameter;
+import com.facebook.presto.spi.function.SqlParameters;
+import com.facebook.presto.spi.function.SqlType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.metadata.BuiltInFunctionNamespaceManager.DEFAULT_NAMESPACE;
+import static com.facebook.presto.operator.annotations.FunctionsParserHelper.findPublicStaticMethods;
+import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.Determinism.DETERMINISTIC;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.Determinism.NOT_DETERMINISTIC;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.NullCallClause.CALLED_ON_NULL_INPUT;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.NullCallClause.RETURNS_NULL_ON_NULL_INPUT;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+import static java.util.Arrays.stream;
+
+public final class SqlInvokedScalarFromAnnotationsParser
+{
+    private SqlInvokedScalarFromAnnotationsParser() {}
+
+    public static List<SqlInvokedFunction> parseFunctionDefinition(Class<?> clazz)
+    {
+        checkArgument(clazz.isAnnotationPresent(SqlInvokedScalarFunction.class), "Class is not annotated with SqlInvokedScalarFunction: %s", clazz.getName());
+
+        SqlInvokedScalarFunction header = clazz.getAnnotation(SqlInvokedScalarFunction.class);
+        Optional<String> description = Optional.ofNullable(clazz.getAnnotation(Description.class)).map(Description::value);
+
+        return findScalarsInFunctionDefinitionClass(clazz).stream()
+                .map(method -> createSqlInvokedFunctions(method, Optional.of(header), description))
+                .flatMap(List::stream)
+                .collect(toImmutableList());
+    }
+
+    public static List<SqlInvokedFunction> parseFunctionDefinitions(Class<?> clazz)
+    {
+        return findScalarsInFunctionSetClass(clazz).stream()
+                .map(method -> createSqlInvokedFunctions(method, Optional.empty(), Optional.empty()))
+                .flatMap(List::stream)
+                .collect(toImmutableList());
+    }
+
+    private static List<Method> findScalarsInFunctionDefinitionClass(Class<?> clazz)
+    {
+        Set<Method> methods = findPublicStaticMethods(
+                clazz,
+                ImmutableSet.of(SqlInvokedScalarFunction.class, SqlType.class, SqlParameter.class, SqlParameters.class, Description.class),
+                ImmutableSet.of(ScalarFunction.class, ScalarOperator.class));
+        for (Method method : methods) {
+            checkCondition(
+                    !method.isAnnotationPresent(SqlInvokedScalarFunction.class) && !method.isAnnotationPresent(Description.class),
+                    FUNCTION_IMPLEMENTATION_ERROR,
+                    "Function-defining method [%s] cannot have @SqlInvokedScalarFunction",
+                    method);
+            checkCondition(
+                    method.isAnnotationPresent(SqlType.class),
+                    FUNCTION_IMPLEMENTATION_ERROR,
+                    "Function-defining method [%s] is missing @SqlType",
+                    method);
+            checkReturnString(method);
+        }
+
+        return ImmutableList.copyOf(methods);
+    }
+
+    private static List<Method> findScalarsInFunctionSetClass(Class<?> clazz)
+    {
+        Set<Method> methods = findPublicStaticMethods(
+                clazz,
+                ImmutableSet.of(SqlInvokedScalarFunction.class, SqlType.class, SqlParameter.class, SqlParameters.class, Description.class),
+                ImmutableSet.of(ScalarFunction.class, ScalarOperator.class));
+        for (Method method : methods) {
+            checkCondition(
+                    method.isAnnotationPresent(SqlInvokedScalarFunction.class) && method.isAnnotationPresent(SqlType.class),
+                    FUNCTION_IMPLEMENTATION_ERROR,
+                    "Function-defining method [%s] is missing @SqlInvokedScalarFunction or @SqlType",
+                    method);
+            checkReturnString(method);
+        }
+        return ImmutableList.copyOf(methods);
+    }
+
+    private static List<SqlInvokedFunction> createSqlInvokedFunctions(Method method, Optional<SqlInvokedScalarFunction> header, Optional<String> description)
+    {
+        SqlInvokedScalarFunction functionHeader = header.orElse(method.getAnnotation(SqlInvokedScalarFunction.class));
+        String functionDescription = description.orElse(method.isAnnotationPresent(Description.class) ? method.getAnnotation(Description.class).value() : "");
+        TypeSignature returnType = parseTypeSignature(method.getAnnotation(SqlType.class).value());
+
+        // Parameter
+        checkCondition(
+                !method.isAnnotationPresent(SqlParameter.class) || !method.isAnnotationPresent(SqlParameters.class),
+                FUNCTION_IMPLEMENTATION_ERROR,
+                "Function-defining method [%s] is annotated with both @SqlParameter and @SqlParameters",
+                method);
+        List<Parameter> parameters;
+        if (method.isAnnotationPresent(SqlParameter.class)) {
+            parameters = ImmutableList.of(getParameterFromAnnotation(method.getAnnotation(SqlParameter.class)));
+        }
+        else if (method.isAnnotationPresent(SqlParameters.class)) {
+            parameters = stream(method.getAnnotation(SqlParameters.class).value())
+                    .map(SqlInvokedScalarFromAnnotationsParser::getParameterFromAnnotation)
+                    .collect(toImmutableList());
+        }
+        else {
+            parameters = ImmutableList.of();
+        }
+
+        // Routine characteristics
+        RoutineCharacteristics routineCharacteristics = RoutineCharacteristics.builder()
+                .setLanguage(RoutineCharacteristics.Language.SQL)
+                .setDeterminism(functionHeader.deterministic() ? DETERMINISTIC : NOT_DETERMINISTIC)
+                .setNullCallClause(functionHeader.calledOnNullInput() ? CALLED_ON_NULL_INPUT : RETURNS_NULL_ON_NULL_INPUT)
+                .build();
+
+        String body;
+        try {
+            body = (String) method.invoke(null);
+        }
+        catch (ReflectiveOperationException e) {
+            throw new PrestoException(FUNCTION_IMPLEMENTATION_ERROR, format("Failed to get function body for method [%s]", method), e);
+        }
+
+        return Stream.concat(Stream.of(functionHeader.value()), stream(functionHeader.alias()))
+                .map(name -> new SqlInvokedFunction(
+                        QualifiedFunctionName.of(DEFAULT_NAMESPACE, name),
+                        parameters,
+                        returnType,
+                        functionDescription,
+                        routineCharacteristics,
+                        body,
+                        Optional.of(1L)))
+                .collect(toImmutableList());
+    }
+
+    private static Parameter getParameterFromAnnotation(SqlParameter sqlParameter)
+    {
+        return new Parameter(sqlParameter.name(), parseTypeSignature(sqlParameter.type()));
+    }
+
+    private static void checkReturnString(Method method)
+    {
+        checkCondition(method.getReturnType().equals(String.class), FUNCTION_IMPLEMENTATION_ERROR, "Function-defining method [%s] must return String");
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArrayArithmeticFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArrayArithmeticFunctions.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.SqlInvokedScalarFunction;
+import com.facebook.presto.spi.function.SqlParameter;
+import com.facebook.presto.spi.function.SqlType;
+
+public class ArrayArithmeticFunctions
+{
+    private ArrayArithmeticFunctions() {}
+
+    @SqlInvokedScalarFunction(value = "array_sum", deterministic = true, calledOnNullInput = false)
+    @Description("Returns the sum of all array elements, or 0 if the array is empty. Ignores null elements.")
+    @SqlParameter(name = "input", type = "array<bigint>")
+    @SqlType("bigint")
+    public static String arraySumBigint()
+    {
+        return "RETURN reduce(input, BIGINT '0', (s, x) -> s + coalesce(x, BIGINT '0'), s -> s)";
+    }
+
+    @SqlInvokedScalarFunction(value = "array_sum", deterministic = true, calledOnNullInput = false)
+    @Description("Returns the sum of all array elements, or 0 if the array is empty. Ignores null elements.")
+    @SqlParameter(name = "input", type = "array<double>")
+    @SqlType("double")
+    public static String arraySumDouble()
+    {
+        return "RETURN reduce(input, DOUBLE '0', (s, x) -> s + coalesce(x, DOUBLE '0'), s -> s)";
+    }
+
+    @SqlInvokedScalarFunction(value = "array_average", deterministic = true, calledOnNullInput = false)
+    @Description("Returns the average of all array elements, or null if the array is empty. Ignores null elements.")
+    @SqlParameter(name = "input", type = "array<double>")
+    @SqlType("double")
+    public static String arrayAverage()
+    {
+        return "RETURN reduce(" +
+                "input, " +
+                "(double '0.0', 0), " +
+                "(s, x) -> IF(x IS NOT NULL, (s[1] + x, s[2] + 1), s), " +
+                "s -> if(s[2] = 0, cast(null as double), s[1] / cast(s[2] as double)))";
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/MapNormalizeFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/MapNormalizeFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.SqlInvokedScalarFunction;
+import com.facebook.presto.spi.function.SqlParameter;
+import com.facebook.presto.spi.function.SqlType;
+
+@SqlInvokedScalarFunction(value = "map_normalize", deterministic = true, calledOnNullInput = false)
+@Description("Returns the map with the same keys but all non-null values are scaled proportionally so that the sum of values becomes 1.")
+public class MapNormalizeFunction
+{
+    private MapNormalizeFunction() {}
+
+    @SqlParameter(name = "input", type = "map<varchar, double>")
+    @SqlType("map<varchar, double>")
+    public static String arraySumDouble()
+    {
+        return "RETURN transform_values(input, (k, v) -> (v / reduce(map_values(input), double '0.0', (s, x) -> (s + coalesce(x, double '0.0')), (s) -> s)))";
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlFunctionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlFunctionUtils.java
@@ -61,6 +61,7 @@ public final class SqlFunctionUtils
     public static Expression getSqlFunctionExpression(FunctionMetadata functionMetadata, SqlInvokedScalarFunctionImplementation implementation, SqlFunctionProperties sqlFunctionProperties, List<Expression> arguments)
     {
         checkArgument(functionMetadata.getImplementationType().equals(SQL), format("Expect SQL function, get %s", functionMetadata.getImplementationType()));
+        checkArgument(functionMetadata.getArgumentNames().isPresent(), "Argument name is missing");
         Expression expression = parseSqlFunctionExpression(implementation, sqlFunctionProperties);
         return SqlFunctionArgumentBinder.bindFunctionArguments(expression, functionMetadata.getArgumentNames().get(), arguments);
     }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -75,7 +75,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public void registerBuiltInFunctions(List<? extends BuiltInFunction> functions)
+    public void registerBuiltInFunctions(List<? extends SqlFunction> functions)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionManager.java
@@ -124,7 +124,7 @@ public class TestFunctionManager
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "\\QFunction already registered: presto.default.custom_add(bigint,bigint):bigint\\E")
     public void testDuplicateFunctions()
     {
-        List<BuiltInFunction> functions = new FunctionListBuilder()
+        List<SqlFunction> functions = new FunctionListBuilder()
                 .scalars(CustomFunctions.class)
                 .getFunctions()
                 .stream()
@@ -140,7 +140,7 @@ public class TestFunctionManager
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "'presto.default.sum' is both an aggregation and a scalar function")
     public void testConflictingScalarAggregation()
     {
-        List<BuiltInFunction> functions = new FunctionListBuilder()
+        List<SqlFunction> functions = new FunctionListBuilder()
                 .scalars(ScalarSum.class)
                 .getFunctions();
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -19,7 +19,6 @@ import com.facebook.presto.common.type.DecimalParseResult;
 import com.facebook.presto.common.type.Decimals;
 import com.facebook.presto.common.type.SqlDecimal;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.metadata.BuiltInFunction;
 import com.facebook.presto.metadata.FunctionListBuilder;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.SqlScalarFunction;
@@ -27,6 +26,7 @@ import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.StandardErrorCode;
+import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.SemanticErrorCode;
 import com.google.common.collect.ImmutableList;
@@ -192,7 +192,7 @@ public abstract class AbstractTestFunctions
     protected void registerScalar(Class<?> clazz)
     {
         Metadata metadata = functionAssertions.getMetadata();
-        List<BuiltInFunction> functions = new FunctionListBuilder()
+        List<SqlFunction> functions = new FunctionListBuilder()
                 .scalars(clazz)
                 .getFunctions();
         metadata.getFunctionManager().registerBuiltInFunctions(functions);
@@ -201,7 +201,7 @@ public abstract class AbstractTestFunctions
     protected void registerParametricScalar(Class<?> clazz)
     {
         Metadata metadata = functionAssertions.getMetadata();
-        List<BuiltInFunction> functions = new FunctionListBuilder()
+        List<SqlFunction> functions = new FunctionListBuilder()
                 .scalar(clazz)
                 .getFunctions();
         metadata.getFunctionManager().registerBuiltInFunctions(functions);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestFunctions.java
@@ -52,6 +52,8 @@ import static org.testng.Assert.fail;
 
 public abstract class AbstractTestFunctions
 {
+    private static final double DELTA = 1e-5;
+
     protected final Session session;
     private final FeaturesConfig config;
     protected FunctionAssertions functionAssertions;
@@ -93,6 +95,16 @@ public abstract class AbstractTestFunctions
     protected void assertFunction(String projection, Type expectedType, Object expected)
     {
         functionAssertions.assertFunction(projection, expectedType, expected);
+    }
+
+    protected void assertFunctionWithError(String projection, Type expectedType, double expected)
+    {
+        assertFunctionWithError(projection, expectedType, expected, DELTA);
+    }
+
+    protected void assertFunctionWithError(String projection, Type expectedType, double expected, double delta)
+    {
+        functionAssertions.assertFunctionWithError(projection, expectedType, expected, delta);
     }
 
     protected void assertOperator(OperatorType operator, String value, Type expectedType, Object expected)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -23,7 +23,6 @@ import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.execution.warnings.WarningCollector;
-import com.facebook.presto.metadata.BuiltInFunction;
 import com.facebook.presto.metadata.FunctionListBuilder;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.Split;
@@ -53,6 +52,7 @@ import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -233,7 +233,7 @@ public final class FunctionAssertions
         return metadata;
     }
 
-    public FunctionAssertions addFunctions(List<? extends BuiltInFunction> functionInfos)
+    public FunctionAssertions addFunctions(List<? extends SqlFunction> functionInfos)
     {
         metadata.registerBuiltInFunctions(functionInfos);
         return this;

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestScalarValidation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestScalarValidation.java
@@ -159,7 +159,7 @@ public class TestScalarValidation
         }
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Method .* annotated with @ScalarFunction must be public")
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Annotated method \\[.*\\] must be public")
     public void testNonPublicAnnnotatedMethod()
     {
         extractScalars(NonPublicAnnnotatedMethod.class);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestArrayArithmeticFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestArrayArithmeticFunctions.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+
+public class TestArrayArithmeticFunctions
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testArraySum()
+    {
+        assertFunction("array_sum(array[BIGINT '1', BIGINT '2'])", BIGINT, 3L);
+        assertFunction("array_sum(array[INTEGER '1', INTEGER '2'])", BIGINT, 3L);
+        assertFunction("array_sum(array[SMALLINT '1', SMALLINT '2'])", BIGINT, 3L);
+        assertFunction("array_sum(array[TINYINT '1', TINYINT '2'])", BIGINT, 3L);
+
+        assertFunction("array_sum(array[BIGINT '1', INTEGER '2'])", BIGINT, 3L);
+        assertFunction("array_sum(array[INTEGER '1', SMALLINT '2'])", BIGINT, 3L);
+        assertFunction("array_sum(array[SMALLINT '1', TINYINT '2'])", BIGINT, 3L);
+
+        assertFunctionWithError("array_sum(array[DOUBLE '-2.0', DOUBLE '5.3'])", DOUBLE, 3.3);
+        assertFunctionWithError("array_sum(array[DOUBLE '-2.0', REAL '5.3'])", DOUBLE, 3.3);
+        assertFunctionWithError("array_sum(array[DOUBLE '-2.0', DECIMAL '5.3'])", DOUBLE, 3.3);
+        assertFunctionWithError("array_sum(array[REAL '-2.0', DECIMAL '5.3'])", DOUBLE, 3.3);
+
+        assertFunctionWithError("array_sum(array[BIGINT '-2', DOUBLE '5.3'])", DOUBLE, 3.3);
+        assertFunctionWithError("array_sum(array[INTEGER '-2', REAL '5.3'])", DOUBLE, 3.3);
+        assertFunctionWithError("array_sum(array[SMALLINT '-2', DECIMAL '5.3'])", DOUBLE, 3.3);
+        assertFunctionWithError("array_sum(array[TINYINT '-2', DOUBLE '5.3'])", DOUBLE, 3.3);
+
+        assertFunction("array_sum(null)", BIGINT, null);
+        assertFunction("array_sum(array[])", BIGINT, 0L);
+        assertFunction("array_sum(array[NULL])", BIGINT, 0L);
+        assertFunction("array_sum(array[NULL, NULL, NULL])", BIGINT, 0L);
+        assertFunction("array_sum(array[3, NULL, 5])", BIGINT, 8L);
+        assertFunctionWithError("array_sum(array[NULL, double '1.2', double '2.3', NULL, -3])", DOUBLE, 0.5);
+    }
+
+    @Test
+    public void testArrayAverage()
+    {
+        assertFunctionWithError("array_average(array[1, 2])", DOUBLE, 1.5);
+        assertFunctionWithError("array_average(array[1, bigint '2', smallint '3', tinyint '4', 5.0])", DOUBLE, 3.0);
+
+        assertFunctionWithError("array_average(array[1, null, 2, null])", DOUBLE, 1.5);
+        assertFunctionWithError("array_average(array[null, null, 1])", DOUBLE, 1.0);
+
+        assertFunction("array_average(array[null])", DOUBLE, null);
+        assertFunction("array_average(array[null, null])", DOUBLE, null);
+        assertFunction("array_average(null)", DOUBLE, null);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapNormalize.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapNormalize.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.util.StructuralTestUtil.mapType;
+
+public class TestMapNormalize
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testMapNormalize()
+    {
+        assertFunction(
+                "map_normalize(map(array['w', 'x', 'y', 'z'], array[1, 1, 1, 1]))",
+                mapType(VARCHAR, DOUBLE),
+                ImmutableMap.of("w", 0.25, "x", 0.25, "y", 0.25, "z", 0.25));
+        assertFunction(
+                "map_normalize(map(array['w', 'x', 'y', 'z'], array[1.0, 2, 3.0, 4]))",
+                mapType(VARCHAR, DOUBLE),
+                ImmutableMap.of("w", 0.1, "x", 0.2, "y", 0.3, "z", 0.4));
+        assertFunction(
+                "map_normalize(map(array['w', 'x', 'y', 'z'], array[1, 2, -3, -4]))",
+                mapType(VARCHAR, DOUBLE),
+                ImmutableMap.of("w", -0.25, "x", -0.5, "y", 0.75, "z", 1.0));
+
+        Map<String, Double> expectedWithNull = new HashMap<>();
+        expectedWithNull.put("w", 1.0 / 7);
+        expectedWithNull.put("x", 2.0 / 7);
+        expectedWithNull.put("y", null);
+        expectedWithNull.put("z", 4.0 / 7);
+        assertFunction("map_normalize(map(array['w', 'x', 'y', 'z'], array[1, 2, null, 4.0]))", mapType(VARCHAR, DOUBLE), expectedWithNull);
+
+        Map<String, Double> expectedNullOnly = new HashMap<>();
+        expectedNullOnly.put("w", null);
+        assertFunction("map_normalize(map(array['w'], array[null]))", mapType(VARCHAR, DOUBLE), expectedNullOnly);
+
+        assertFunction("map_normalize(map(array[], array[]))", mapType(VARCHAR, DOUBLE), ImmutableMap.of());
+        assertFunction("map_normalize(null)", mapType(VARCHAR, DOUBLE), null);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionMetadata.java
@@ -40,26 +40,14 @@ public class FunctionMetadata
     public FunctionMetadata(
             QualifiedFunctionName name,
             List<TypeSignature> argumentTypes,
+            Optional<List<String>> argumentNames,
             TypeSignature returnType,
             FunctionKind functionKind,
             FunctionImplementationType implementationType,
             boolean deterministic,
             boolean calledOnNullInput)
     {
-        this(name, Optional.empty(), argumentTypes, Optional.empty(), returnType, functionKind, implementationType, deterministic, calledOnNullInput);
-    }
-
-    public FunctionMetadata(
-            QualifiedFunctionName name,
-            List<TypeSignature> argumentTypes,
-            List<String> argumentNames,
-            TypeSignature returnType,
-            FunctionKind functionKind,
-            FunctionImplementationType implementationType,
-            boolean deterministic,
-            boolean calledOnNullInput)
-    {
-        this(name, Optional.empty(), argumentTypes, Optional.of(argumentNames), returnType, functionKind, implementationType, deterministic, calledOnNullInput);
+        this(name, Optional.empty(), argumentTypes, argumentNames, returnType, functionKind, implementationType, deterministic, calledOnNullInput);
     }
 
     public FunctionMetadata(

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/Parameter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/Parameter.java
@@ -21,13 +21,13 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
-public class SqlParameter
+public class Parameter
 {
     private final String name;
     private final TypeSignature type;
 
     @JsonCreator
-    public SqlParameter(
+    public Parameter(
             @JsonProperty("name") String name,
             @JsonProperty("type") TypeSignature type)
     {
@@ -56,7 +56,7 @@ public class SqlParameter
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        SqlParameter o = (SqlParameter) obj;
+        Parameter o = (Parameter) obj;
         return Objects.equals(name, o.name)
                 && Objects.equals(type, o.type);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedFunction.java
@@ -34,7 +34,7 @@ import static java.util.stream.Collectors.toList;
 public class SqlInvokedFunction
         implements SqlFunction
 {
-    private final List<SqlParameter> parameters;
+    private final List<Parameter> parameters;
     private final String description;
     private final RoutineCharacteristics routineCharacteristics;
     private final String body;
@@ -45,7 +45,7 @@ public class SqlInvokedFunction
 
     public SqlInvokedFunction(
             QualifiedFunctionName functionName,
-            List<SqlParameter> parameters,
+            List<Parameter> parameters,
             TypeSignature returnType,
             String description,
             RoutineCharacteristics routineCharacteristics,
@@ -58,7 +58,7 @@ public class SqlInvokedFunction
         this.body = requireNonNull(body, "body is null");
 
         List<TypeSignature> argumentTypes = parameters.stream()
-                .map(SqlParameter::getType)
+                .map(Parameter::getType)
                 .collect(collectingAndThen(toList(), Collections::unmodifiableList));
         this.signature = new Signature(functionName, SCALAR, returnType, argumentTypes);
         this.functionId = new SqlFunctionId(functionName, argumentTypes);
@@ -110,7 +110,7 @@ public class SqlInvokedFunction
         return description;
     }
 
-    public List<SqlParameter> getParameters()
+    public List<Parameter> getParameters()
     {
         return parameters;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedScalarFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedScalarFunction.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.function;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface SqlInvokedScalarFunction
+{
+    String value() default "";
+
+    String[] alias() default {};
+
+    boolean deterministic();
+
+    boolean calledOnNullInput();
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlParameter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlParameter.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.function;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface SqlParameter
+{
+    String name() default "";
+
+    String type() default "";
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlParameters.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlParameters.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.function;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface SqlParameters
+{
+    SqlParameter[] value() default {};
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -18,9 +18,9 @@ import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.common.type.Decimals;
 import com.facebook.presto.common.type.SqlTimestampWithTimeZone;
 import com.facebook.presto.common.type.VarcharType;
-import com.facebook.presto.metadata.BuiltInFunction;
 import com.facebook.presto.metadata.FunctionListBuilder;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy;
@@ -103,7 +103,7 @@ public abstract class AbstractTestQueries
         extends AbstractTestQueryFramework
 {
     // We can just use the default type registry, since we don't use any parametric types
-    public static final List<BuiltInFunction> CUSTOM_FUNCTIONS = new FunctionListBuilder()
+    public static final List<SqlFunction> CUSTOM_FUNCTIONS = new FunctionListBuilder()
             .aggregates(CustomSum.class)
             .window(CustomRank.class)
             .scalars(CustomAdd.class)


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Add support for defining SQL-invoked functions in plugins.
* Add functions :func:`array_sum` and :func:`map_normalize`.
```
