### PR TITLE
Remove compression for creating zero row file for missing buckets

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveZeroRowFileCreator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveZeroRowFileCreator.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Properties;
 
 import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
+import static com.facebook.presto.hive.HiveCompressionCodec.NONE;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static com.facebook.presto.hive.HiveWriteUtils.initializeSerializer;
 import static com.facebook.presto.hive.util.ConfigurationUtils.configureCompression;
@@ -99,7 +100,11 @@ public class HiveZeroRowFileCreator
 
         try {
             Path target = new Path(format("file://%s/%s", tmpDirectoryPath, tmpFileName));
-            JobConf conf = configureCompression(hdfsEnvironment.getConfiguration(hdfsContext, target), compressionCodec);
+
+            //https://github.com/prestodb/presto/issues/14401 JSON Format reader does not fetch compression from source system
+            JobConf conf = configureCompression(
+                    hdfsEnvironment.getConfiguration(hdfsContext, target),
+                    outputFormatName.equals(HiveStorageFormat.JSON.getOutputFormat()) ? compressionCodec : NONE);
 
             if (outputFormatName.equals(HiveStorageFormat.PAGEFILE.getOutputFormat())) {
                 FSDataOutputStream outputStream = target.getFileSystem(conf).create(target);


### PR DESCRIPTION
Using compression for zero row files for missing buckets was running into issues with ZSTD compression as it was not supported by downstream dependencies.
Not using compression while creating zero row files is also better from efficiency and compression perspective. In my local testing I observed that for any unused bucket, it was generating 34 bytes with ZLIB, compared to 27 bytes with no compression.

```
== RELEASE NOTES ==

Hive Changes
Remove compression for creating zero row file for missing buckets
```
