### PR TITLE
Make PageFile format splittable

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveZeroRowFileCreator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveZeroRowFileCreator.java
@@ -20,7 +20,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
 import org.apache.hadoop.mapred.JobConf;
@@ -39,6 +38,7 @@ import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
 import static com.facebook.presto.hive.HiveCompressionCodec.NONE;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static com.facebook.presto.hive.HiveWriteUtils.initializeSerializer;
+import static com.facebook.presto.hive.pagefile.PageFileWriterFactory.createEmptyPageFile;
 import static com.facebook.presto.hive.util.ConfigurationUtils.configureCompression;
 import static com.google.common.util.concurrent.Futures.whenAllSucceed;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -107,8 +107,7 @@ public class HiveZeroRowFileCreator
                     outputFormatName.equals(HiveStorageFormat.JSON.getOutputFormat()) ? compressionCodec : NONE);
 
             if (outputFormatName.equals(HiveStorageFormat.PAGEFILE.getOutputFormat())) {
-                FSDataOutputStream outputStream = target.getFileSystem(conf).create(target);
-                outputStream.close();
+                createEmptyPageFile(target.getFileSystem(conf), target);
                 return readAllBytes(tmpFilePath);
             }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileFooterOutput.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileFooterOutput.java
@@ -49,4 +49,9 @@ public class PageFileFooterOutput
         }
         sliceOutput.writeInt(toIntExact(size()));
     }
+
+    public static PageFileFooterOutput createEmptyPageFileFooterOutput()
+    {
+        return new PageFileFooterOutput(ImmutableList.of());
+    }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileFooterOutput.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileFooterOutput.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.pagefile;
+
+import com.facebook.presto.orc.stream.DataOutput;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.SliceOutput;
+
+import java.util.List;
+
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class PageFileFooterOutput
+        implements DataOutput
+{
+    public static final int FOOTER_LENGTH_IN_BYTES = SIZE_OF_INT;
+    private final List<Long> stripeOffsets;
+
+    public PageFileFooterOutput(List<Long> stripeOffsets)
+    {
+        this.stripeOffsets = ImmutableList.copyOf(requireNonNull(stripeOffsets, "stripeOffsets is null"));
+    }
+
+    @Override
+    public long size()
+    {
+        return SIZE_OF_LONG * stripeOffsets.size() + FOOTER_LENGTH_IN_BYTES;
+    }
+
+    @Override
+    public void writeData(SliceOutput sliceOutput)
+    {
+        for (long offset : stripeOffsets) {
+            sliceOutput.writeLong(offset);
+        }
+        sliceOutput.writeInt(toIntExact(size()));
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileFooterReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileFooterReader.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.pagefile;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.Slices;
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.facebook.presto.hive.pagefile.PageFileFooterOutput.FOOTER_LENGTH_IN_BYTES;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class PageFileFooterReader
+{
+    private static final int ESTIMATED_FOOTER_SIZE = 1024;
+
+    private List<Long> stripeOffsets;
+    private long footerOffset;
+
+    public PageFileFooterReader(
+            FSDataInputStream inputStream,
+            long fileSize)
+            throws IOException
+    {
+        checkArgument(fileSize >= FOOTER_LENGTH_IN_BYTES, "Malformed PageFile format, footer length is missing.");
+        requireNonNull(inputStream, "inputStream is null");
+        ImmutableList.Builder<Long> stripeOffsetsBuilder = ImmutableList.builder();
+
+        byte[] buffer = new byte[toIntExact(min(fileSize, ESTIMATED_FOOTER_SIZE))];
+        inputStream.readFully(fileSize - buffer.length, buffer);
+        int footerSize = Slices.wrappedBuffer(buffer, buffer.length - FOOTER_LENGTH_IN_BYTES, FOOTER_LENGTH_IN_BYTES).getInt(0);
+
+        footerOffset = fileSize - footerSize;
+        if (footerOffset < 0) {
+            throw new IOException("Malformed PageFile format, incorrect footer length.");
+        }
+        else if (footerOffset > 0) {
+            if (footerSize > buffer.length) {
+                buffer = new byte[footerSize];
+                inputStream.readFully(footerOffset, buffer);
+            }
+
+            SliceInput sliceInput = Slices.wrappedBuffer(buffer, buffer.length - footerSize, footerSize - FOOTER_LENGTH_IN_BYTES).getInput();
+
+            while (sliceInput.isReadable()) {
+                stripeOffsetsBuilder.add(sliceInput.readLong());
+            }
+        }
+        else {
+            // empty page file without stripe
+        }
+        stripeOffsets = stripeOffsetsBuilder.build();
+    }
+
+    public List<Long> getStripeOffsets()
+    {
+        return stripeOffsets;
+    }
+
+    public long getFooterOffset()
+    {
+        return footerOffset;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageReader.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.pagefile;
+
+import com.facebook.presto.spi.Page;
+import com.facebook.presto.spi.page.PagesSerde;
+import com.facebook.presto.spi.page.SerializedPage;
+import io.airlift.slice.InputStreamSliceInput;
+import io.airlift.slice.SliceInput;
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static com.facebook.presto.spi.page.PagesSerdeUtil.readSerializedPage;
+import static java.util.Objects.requireNonNull;
+
+public class PageFilePageReader
+        implements Iterator<Page>
+{
+    private final PagesSerde pagesSerde;
+    private final SliceInput input;
+    private final long readLength;
+
+    public PageFilePageReader(
+            long readStart,
+            long readLength,
+            FSDataInputStream inputStream,
+            PagesSerde pagesSerde)
+            throws IOException
+    {
+        this.pagesSerde = requireNonNull(pagesSerde, "pagesSerde is null");
+        this.readLength = readLength;
+        requireNonNull(inputStream, "inputStream is null");
+        inputStream.seek(readStart);
+        this.input = new InputStreamSliceInput(inputStream);
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        return input.position() < readLength && input.isReadable();
+    }
+
+    @Override
+    public Page next()
+    {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        SerializedPage serializedPage = readSerializedPage(input);
+        return pagesSerde.deserialize(serializedPage);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSource.java
@@ -19,7 +19,6 @@ import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.page.PagesSerde;
-import io.airlift.slice.InputStreamSliceInput;
 import org.apache.hadoop.fs.FSDataInputStream;
 
 import java.io.IOException;
@@ -27,7 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
-import static com.facebook.presto.spi.page.PagesSerdeUtil.readPages;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class PageFilePageSource
@@ -45,13 +44,27 @@ public class PageFilePageSource
 
     public PageFilePageSource(
             FSDataInputStream inputStream,
+            long start,
+            long splitLength,
+            long fileSize,
             PagesSerde pagesSerde,
             List<HiveColumnHandle> columns)
+            throws IOException
     {
         this.inputStream = requireNonNull(inputStream, "inputStream is null");
-        pageReader = readPages(
-                requireNonNull(pagesSerde, "pagesSerde is null"),
-                new InputStreamSliceInput(inputStream));
+        PageFileFooterReader pageFileFooterReader = new PageFileFooterReader(inputStream, fileSize);
+
+        OffsetAndLength readStartAndLength = getReadStartAndLength(
+                start,
+                splitLength,
+                pageFileFooterReader.getFooterOffset(),
+                pageFileFooterReader.getStripeOffsets());
+
+        pageReader = new PageFilePageReader(
+                readStartAndLength.getOffset(),
+                readStartAndLength.getLength(),
+                inputStream,
+                pagesSerde);
 
         int size = requireNonNull(columns, "columns is null").size();
         this.hiveColumnIndexes = new int[size];
@@ -126,5 +139,62 @@ public class PageFilePageSource
     {
         inputStream.close();
         closed = true;
+    }
+
+    private static OffsetAndLength getReadStartAndLength(
+            long splitStart,
+            long splitLength,
+            long lastStripeEnd,
+            List<Long> stripeOffsets)
+    {
+        checkArgument(stripeOffsets != null, "stripeOffsets is null, failed to read page file footer.");
+        if (stripeOffsets.isEmpty()) {
+            return new OffsetAndLength(0, 0);
+        }
+
+        long readStart = 0;
+        long readEnd = 0;
+        boolean stripeFound = false;
+        for (int i = 0; i < stripeOffsets.size(); ++i) {
+            if (splitContainsStripe(splitStart, splitLength, stripeOffsets.get(i))) {
+                if (!stripeFound) {
+                    readStart = stripeOffsets.get(i);
+                    stripeFound = true;
+                }
+                readEnd = i == stripeOffsets.size() - 1 ? lastStripeEnd : stripeOffsets.get(i + 1);
+            }
+            else if (stripeFound) {
+                break;
+            }
+        }
+
+        return new OffsetAndLength(readStart, readEnd - readStart);
+    }
+
+    private static boolean splitContainsStripe(long splitStart, long splitLength, long stripeOffset)
+    {
+        return splitStart <= stripeOffset && stripeOffset < splitStart + splitLength;
+    }
+
+    private static class OffsetAndLength
+    {
+        private final long offset;
+        private final long length;
+
+        OffsetAndLength(long offset, long length)
+        {
+            this.offset = offset;
+            this.length = length;
+        }
+
+        private long getOffset()
+        {
+            return offset;
+        }
+
+        private long getLength()
+        {
+            return length;
+        }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSourceFactory.java
@@ -80,8 +80,10 @@ public class PageFilePageSourceFactory
         }
 
         FSDataInputStream inputStream;
+        PageFilePageSource pageFilePageSource;
         try {
             inputStream = hdfsEnvironment.getFileSystem(session.getUser(), path, configuration).openFile(path, hiveFileContext);
+            pageFilePageSource = new PageFilePageSource(inputStream, start, length, fileSize, pagesSerde, columns);
         }
         catch (Exception e) {
             if (nullToEmpty(e.getMessage()).trim().equals("Filesystem closed") ||
@@ -91,7 +93,7 @@ public class PageFilePageSourceFactory
             throw new PrestoException(HIVE_CANNOT_OPEN_SPLIT, splitError(e, path, start, length), e);
         }
 
-        return Optional.of(new PageFilePageSource(inputStream, pagesSerde, columns));
+        return Optional.of(pageFilePageSource);
     }
 
     private static String splitError(Throwable t, Path path, long start, long length)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageInputFormat.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageInputFormat.java
@@ -33,6 +33,6 @@ public class PageInputFormat
 
     protected boolean isSplitable(FileSystem fs, Path file)
     {
-        return false;
+        return true;
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -4753,6 +4753,33 @@ public class TestHiveIntegrationSmokeTest
         assertUpdate("DROP TABLE test_pagefile_orders");
     }
 
+    @Test
+    public void testPageFileFormatSmallSplitSize()
+    {
+        Session testSession = Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty(catalog, "pagefile_writer_max_stripe_size", "100B")
+                .setCatalogSessionProperty(catalog, "max_split_size", "1kB")
+                .setCatalogSessionProperty(catalog, "max_initial_split_size", "1kB")
+                .build();
+
+        assertUpdate(
+                testSession,
+                "CREATE TABLE test_pagefile_orders\n" +
+                        "WITH (\n" +
+                        "format = 'PAGEFILE'\n" +
+                        ") AS\n" +
+                        "SELECT\n" +
+                        "*\n" +
+                        "FROM tpch.orders",
+                "SELECT count(*) FROM orders");
+
+        assertQuery(testSession, "SELECT count(*) FROM test_pagefile_orders", "SELECT count(*) FROM orders");
+
+        assertQuery(testSession, "SELECT sum(custkey) FROM test_pagefile_orders", "SELECT sum(custkey) FROM orders");
+
+        assertUpdate("DROP TABLE test_pagefile_orders");
+    }
+
     private static Consumer<Plan> assertTableWriterMergeNodeIsPresent()
     {
         return plan -> assertTrue(searchFrom(plan.getRoot())

--- a/presto-spi/src/main/java/com/facebook/presto/spi/page/PagesSerdeUtil.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/page/PagesSerdeUtil.java
@@ -63,7 +63,7 @@ public class PagesSerdeUtil
         output.writeBytes(page.getSlice());
     }
 
-    private static SerializedPage readSerializedPage(SliceInput sliceInput)
+    public static SerializedPage readSerializedPage(SliceInput sliceInput)
     {
         int positionCount = sliceInput.readInt();
         byte codecMarker = sliceInput.readByte();


### PR DESCRIPTION
A pagefile footer has two parts

- Offset of each stripe,  the first stripe always starts at offset 0
- Size of entire footer in Integer

For example, for a file with 3 stripes (100 bytes each),  footer will be
- Long integer array [0, 100, 200] 
- size = SIZE_OF_LONG * 3 + SIZE_OF_INT = 28 bytes

```
== NO RELEASE NOTE ==
```
