### PR TITLE
Fix bug in IS_SUBNET_OF function

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/IpPrefixFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/IpPrefixFunctions.java
@@ -134,7 +134,7 @@ public final class IpPrefixFunctions
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean isPrefixSubnetOf(@SqlType(StandardTypes.IPPREFIX) Slice first, @SqlType(StandardTypes.IPPREFIX) Slice second)
     {
-        return between(ipSubnetMin(second), ipSubnetMin(first), ipSubnetMax(first));
+        return between(ipSubnetMin(second), ipSubnetMin(first), ipSubnetMax(first)) && between(ipSubnetMax(second), ipSubnetMin(first), ipSubnetMax(first));
     }
 
     private static InetAddress toInetAddress(Slice ipAddress)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestIpPrefixFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestIpPrefixFunctions.java
@@ -113,5 +113,9 @@ public class TestIpPrefixFunctions
         assertFunction("IS_SUBNET_OF(IPPREFIX '1.2.3.128/26', IPPREFIX '1.2.3.128/26')", BOOLEAN, true);
         assertFunction("IS_SUBNET_OF(IPPREFIX '64:ff9b::17/64', IPPREFIX '64:ff9b::ff:25/80')", BOOLEAN, true);
         assertFunction("IS_SUBNET_OF(IPPREFIX '64:ff9b::17/64', IPPREFIX '64:ffff::17/64')", BOOLEAN, false);
+        assertFunction("IS_SUBNET_OF(IPPREFIX '2804:431:b000::/37', IPPREFIX '2804:431:b000::/38')", BOOLEAN, true);
+        assertFunction("IS_SUBNET_OF(IPPREFIX '2804:431:b000::/38', IPPREFIX '2804:431:b000::/37')", BOOLEAN, false);
+        assertFunction("IS_SUBNET_OF(IPPREFIX '170.0.52.0/22', IPPREFIX '170.0.52.0/24')", BOOLEAN, true);
+        assertFunction("IS_SUBNET_OF(IPPREFIX '170.0.52.0/24', IPPREFIX '170.0.52.0/22')", BOOLEAN, false);
     }
 }


### PR DESCRIPTION
    is_subnet_of (IPPREFIX '2804:431:b000::/37', IPPREFIX '2804:431:b000::/38') -- True
    is_subnet_of (IPPREFIX '2804:431:b000::/38', IPPREFIX '2804:431:b000::/37') -- False

We need to check that both MAX and MIN of ipprefix2 lies in the subnet of ipprefix1. Otherwise both the above statements will return True. 

```
== NO RELEASE NOTE ==
```
