### PR TITLE
Add Native Parquet Writer in Hive Module and Misc fixes

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -27,6 +27,7 @@ import com.facebook.presto.hive.orc.OrcSelectivePageSourceFactory;
 import com.facebook.presto.hive.orc.TupleDomainFilterCache;
 import com.facebook.presto.hive.pagefile.PageFilePageSourceFactory;
 import com.facebook.presto.hive.pagefile.PageFileWriterFactory;
+import com.facebook.presto.hive.parquet.ParquetFileWriterFactory;
 import com.facebook.presto.hive.parquet.ParquetPageSourceFactory;
 import com.facebook.presto.hive.rcfile.RcFilePageSourceFactory;
 import com.facebook.presto.hive.rule.HivePlanOptimizerProvider;
@@ -171,6 +172,7 @@ public class HiveClientModule
         fileWriterFactoryBinder.addBinding().to(PageFileWriterFactory.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(ParquetFileWriterConfig.class);
+        fileWriterFactoryBinder.addBinding().to(ParquetFileWriterFactory.class).in(Scopes.SINGLETON);
         binder.install(new MetastoreClientModule());
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -73,6 +73,7 @@ public final class HiveSessionProperties
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
+    private static final String PARQUET_OPTIMIZED_WRITER_ENABLED = "parquet_optimized_writer_enabled";
     private static final String MAX_SPLIT_SIZE = "max_split_size";
     private static final String MAX_INITIAL_SPLIT_SIZE = "max_initial_split_size";
     public static final String RCFILE_OPTIMIZED_WRITER_ENABLED = "rcfile_optimized_writer_enabled";
@@ -450,6 +451,11 @@ public final class HiveSessionProperties
                         USE_LIST_DIRECTORY_CACHE,
                         "Use list directory cache if available when set to true",
                         !hiveClientConfig.getFileStatusCacheTables().isEmpty(),
+                        false),
+                booleanProperty(
+                        PARQUET_OPTIMIZED_WRITER_ENABLED,
+                        "Experimental: Enable optimized writer",
+                        parquetFileWriterConfig.isParquetOptimizedWriterEnabled(),
                         false));
     }
 
@@ -784,5 +790,10 @@ public final class HiveSessionProperties
     public static boolean isUseListDirectoryCache(ConnectorSession session)
     {
         return session.getProperty(USE_LIST_DIRECTORY_CACHE, Boolean.class);
+    }
+
+    public static boolean isParquetOptimizedWriterEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_OPTIMIZED_WRITER_ENABLED, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ParquetFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ParquetFileWriterConfig.java
@@ -21,6 +21,8 @@ import static io.airlift.units.DataSize.Unit.BYTE;
 
 public class ParquetFileWriterConfig
 {
+    private boolean parquetOptimizedWriterEnabled;
+
     private DataSize blockSize = new DataSize(ParquetWriter.DEFAULT_BLOCK_SIZE, BYTE);
     private DataSize pageSize = new DataSize(ParquetWriter.DEFAULT_PAGE_SIZE, BYTE);
 
@@ -45,6 +47,18 @@ public class ParquetFileWriterConfig
     public ParquetFileWriterConfig setPageSize(DataSize pageSize)
     {
         this.pageSize = pageSize;
+        return this;
+    }
+
+    public boolean isParquetOptimizedWriterEnabled()
+    {
+        return parquetOptimizedWriterEnabled;
+    }
+
+    @Config("hive.parquet.optimized-writer.enabled")
+    public ParquetFileWriterConfig setParquetOptimizedWriterEnabled(boolean parquetOptimizedWriterEnabled)
+    {
+        this.parquetOptimizedWriterEnabled = parquetOptimizedWriterEnabled;
         return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriter.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.RunLengthEncodedBlock;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.hive.HiveFileWriter;
+import com.facebook.presto.parquet.writer.ParquetWriter;
+import com.facebook.presto.parquet.writer.ParquetWriterOptions;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import org.openjdk.jol.info.ClassLayout;
+import parquet.hadoop.metadata.CompressionCodecName;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
+import static java.util.Objects.requireNonNull;
+
+public class ParquetFileWriter
+        implements HiveFileWriter
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ParquetFileWriter.class).instanceSize();
+
+    private final ParquetWriter parquetWriter;
+    private final Callable<Void> rollbackAction;
+    private final int[] fileInputColumnIndexes;
+    private final List<Block> nullBlocks;
+
+    public ParquetFileWriter(
+            OutputStream outputStream,
+            Callable<Void> rollbackAction,
+            List<String> columnNames,
+            List<Type> fileColumnTypes,
+            ParquetWriterOptions parquetWriterOptions,
+            int[] fileInputColumnIndexes,
+            CompressionCodecName compressionCodecName)
+    {
+        requireNonNull(outputStream, "outputStream is null");
+
+        this.parquetWriter = new ParquetWriter(
+                outputStream,
+                columnNames,
+                fileColumnTypes,
+                parquetWriterOptions,
+                compressionCodecName.getHadoopCompressionCodecClassName());
+
+        this.rollbackAction = requireNonNull(rollbackAction, "rollbackAction is null");
+        this.fileInputColumnIndexes = requireNonNull(fileInputColumnIndexes, "fileInputColumnIndexes is null");
+
+        ImmutableList.Builder<Block> nullBlocks = ImmutableList.builder();
+        for (Type fileColumnType : fileColumnTypes) {
+            BlockBuilder blockBuilder = fileColumnType.createBlockBuilder(null, 1, 0);
+            blockBuilder.appendNull();
+            nullBlocks.add(blockBuilder.build());
+        }
+        this.nullBlocks = nullBlocks.build();
+    }
+
+    @Override
+    public long getWrittenBytes()
+    {
+        return parquetWriter.getWrittenBytes();
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return INSTANCE_SIZE + parquetWriter.getRetainedBytes();
+    }
+
+    @Override
+    public void appendRows(Page dataPage)
+    {
+        Block[] blocks = new Block[fileInputColumnIndexes.length];
+        for (int i = 0; i < fileInputColumnIndexes.length; i++) {
+            int inputColumnIndex = fileInputColumnIndexes[i];
+            if (inputColumnIndex < 0) {
+                blocks[i] = new RunLengthEncodedBlock(nullBlocks.get(i), dataPage.getPositionCount());
+            }
+            else {
+                blocks[i] = dataPage.getBlock(inputColumnIndex);
+            }
+        }
+        Page page = new Page(dataPage.getPositionCount(), blocks);
+        try {
+            parquetWriter.write(page);
+        }
+        catch (IOException | UncheckedIOException e) {
+            throw new PrestoException(HIVE_WRITER_DATA_ERROR, e);
+        }
+    }
+
+    @Override
+    public void commit()
+    {
+        try {
+            parquetWriter.close();
+        }
+        catch (IOException | UncheckedIOException e) {
+            try {
+                rollbackAction.call();
+            }
+            catch (Exception ignored) {
+            }
+            throw new PrestoException(HIVE_WRITER_CLOSE_ERROR, "Error committing writing parquet to Hive", e);
+        }
+    }
+
+    @Override
+    public void rollback()
+    {
+        try {
+            try {
+                parquetWriter.close();
+            }
+            finally {
+                rollbackAction.call();
+            }
+        }
+        catch (Exception e) {
+            throw new PrestoException(HIVE_WRITER_CLOSE_ERROR, "Error rolling back write parquet to Hive", e);
+        }
+    }
+
+    @Override
+    public long getValidationCpuNanos()
+    {
+        return 0;
+    }
+
+    @Override
+    public Optional<Runnable> getVerificationTask()
+    {
+        return Optional.empty();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriterFactory.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveFileWriter;
+import com.facebook.presto.hive.HiveFileWriterFactory;
+import com.facebook.presto.hive.NodeVersion;
+import com.facebook.presto.hive.metastore.StorageFormat;
+import com.facebook.presto.parquet.writer.ParquetWriterOptions;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.base.Splitter;
+import com.google.inject.Inject;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
+import org.apache.hadoop.mapred.JobConf;
+import org.joda.time.DateTimeZone;
+import parquet.hadoop.metadata.CompressionCodecName;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
+import static com.facebook.presto.hive.HiveSessionProperties.getParquetWriterBlockSize;
+import static com.facebook.presto.hive.HiveSessionProperties.getParquetWriterPageSize;
+import static com.facebook.presto.hive.HiveSessionProperties.isParquetOptimizedWriterEnabled;
+import static com.facebook.presto.hive.HiveType.toHiveTypes;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_COLUMNS;
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_COLUMN_TYPES;
+
+public class ParquetFileWriterFactory
+        implements HiveFileWriterFactory
+{
+    private final HdfsEnvironment hdfsEnvironment;
+    private final TypeManager typeManager;
+    private final ParquetWriterOptions parquetWriterOptions;
+
+    @Inject
+    public ParquetFileWriterFactory(
+            HdfsEnvironment hdfsEnvironment,
+            TypeManager typeManager,
+            NodeVersion nodeVersion,
+            HiveClientConfig hiveConfig)
+    {
+        this(
+                hdfsEnvironment,
+                typeManager,
+                nodeVersion,
+                requireNonNull(hiveConfig, "hiveConfig is null").getDateTimeZone(),
+                ParquetWriterOptions.builder().build());
+    }
+
+    public ParquetFileWriterFactory(
+            HdfsEnvironment hdfsEnvironment,
+            TypeManager typeManager,
+            NodeVersion nodeVersion,
+            DateTimeZone hiveStorageTimeZone,
+            ParquetWriterOptions parquetWriterOptions)
+    {
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.parquetWriterOptions = requireNonNull(parquetWriterOptions, "parquetWriterOptions is null");
+    }
+
+    @Override
+    public Optional<HiveFileWriter> createFileWriter(Path path, List<String> inputColumnNames, StorageFormat storageFormat, Properties schema, JobConf conf, ConnectorSession session)
+    {
+        if (!isParquetOptimizedWriterEnabled(session)) {
+            return Optional.empty();
+        }
+
+        if (!MapredParquetOutputFormat.class.getName().equals(storageFormat.getOutputFormat())) {
+            return Optional.empty();
+        }
+
+        List<String> fileColumnNames = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(schema.getProperty(META_TABLE_COLUMNS, ""));
+        List<Type> fileColumnTypes = toHiveTypes(schema.getProperty(META_TABLE_COLUMN_TYPES, "")).stream()
+                .map(hiveType -> hiveType.getType(typeManager))
+                .collect(toList());
+
+        int[] fileInputColumnIndexes = fileColumnNames.stream()
+                .mapToInt(inputColumnNames::indexOf)
+                .toArray();
+
+        try {
+            FileSystem fileSystem = hdfsEnvironment.getFileSystem(session.getUser(), path, conf);
+
+            Callable<Void> rollbackAction = () -> {
+                fileSystem.delete(path, false);
+                return null;
+            };
+
+            return Optional.of(new ParquetFileWriter(
+                    fileSystem.create(path),
+                    rollbackAction,
+                    fileColumnNames,
+                    fileColumnTypes,
+                    parquetWriterOptions,
+                    fileInputColumnIndexes,
+                    CompressionCodecName.SNAPPY));
+        }
+        catch (IOException e) {
+            throw new PrestoException(HIVE_WRITER_OPEN_ERROR, "Error creating Parquet file", e);
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriterFactory.java
@@ -55,7 +55,6 @@ public class ParquetFileWriterFactory
 {
     private final HdfsEnvironment hdfsEnvironment;
     private final TypeManager typeManager;
-    private final ParquetWriterOptions parquetWriterOptions;
 
     @Inject
     public ParquetFileWriterFactory(
@@ -68,20 +67,17 @@ public class ParquetFileWriterFactory
                 hdfsEnvironment,
                 typeManager,
                 nodeVersion,
-                requireNonNull(hiveConfig, "hiveConfig is null").getDateTimeZone(),
-                ParquetWriterOptions.builder().build());
+                requireNonNull(hiveConfig, "hiveConfig is null").getDateTimeZone());
     }
 
     public ParquetFileWriterFactory(
             HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager,
             NodeVersion nodeVersion,
-            DateTimeZone hiveStorageTimeZone,
-            ParquetWriterOptions parquetWriterOptions)
+            DateTimeZone hiveStorageTimeZone)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
-        this.parquetWriterOptions = requireNonNull(parquetWriterOptions, "parquetWriterOptions is null");
     }
 
     @Override
@@ -94,6 +90,11 @@ public class ParquetFileWriterFactory
         if (!MapredParquetOutputFormat.class.getName().equals(storageFormat.getOutputFormat())) {
             return Optional.empty();
         }
+
+        ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
+                .setMaxPageSize(getParquetWriterPageSize(session))
+                .setMaxBlockSize(getParquetWriterBlockSize(session))
+                .build();
 
         CompressionCodecName compressionCodecName = getCompression(conf);
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
@@ -28,7 +28,6 @@ import com.facebook.presto.hive.rcfile.RcFilePageSourceFactory;
 import com.facebook.presto.orc.OrcWriterOptions;
 import com.facebook.presto.orc.StorageStripeMetadataSource;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
-import com.facebook.presto.parquet.writer.ParquetWriterOptions;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ErrorCodeSupplier;
@@ -342,7 +341,7 @@ public class TestHiveFileFormats
                 .withSession(session)
                 .withColumns(testColumns)
                 .withRowsCount(rowCount)
-                .withFileWriterFactory(new ParquetFileWriterFactory(HDFS_ENVIRONMENT, TYPE_MANAGER, new NodeVersion("test"), HIVE_STORAGE_TIME_ZONE, ParquetWriterOptions.builder().build()))
+                .withFileWriterFactory(new ParquetFileWriterFactory(HDFS_ENVIRONMENT, TYPE_MANAGER, new NodeVersion("test"), HIVE_STORAGE_TIME_ZONE))
                 .isReadableByPageSource(new ParquetPageSourceFactory(TYPE_MANAGER, HDFS_ENVIRONMENT, STATS));
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestParquetFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestParquetFileWriterConfig.java
@@ -32,6 +32,7 @@ public class TestParquetFileWriterConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(ParquetFileWriterConfig.class)
+                .setParquetOptimizedWriterEnabled(false)
                 .setBlockSize(new DataSize(ParquetWriter.DEFAULT_BLOCK_SIZE, BYTE))
                 .setPageSize(new DataSize(ParquetWriter.DEFAULT_PAGE_SIZE, BYTE)));
     }
@@ -40,11 +41,13 @@ public class TestParquetFileWriterConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("hive.parquet.optimized-writer.enabled", "true")
                 .put("hive.parquet.writer.block-size", "234MB")
                 .put("hive.parquet.writer.page-size", "11MB")
                 .build();
 
         ParquetFileWriterConfig expected = new ParquetFileWriterConfig()
+                .setParquetOptimizedWriterEnabled(true)
                 .setBlockSize(new DataSize(234, MEGABYTE))
                 .setPageSize(new DataSize(11, MEGABYTE));
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -703,7 +703,10 @@ public class ParquetTester
                 new FileOutputStream(outputFile),
                 columnNames,
                 types,
-                ParquetWriterOptions.builder().build(),
+                ParquetWriterOptions.builder()
+                        .setMaxPageSize(DataSize.succinctBytes(100))
+                        .setMaxBlockSize(DataSize.succinctBytes(100000))
+                        .build(),
                 compressionCodecName.getHadoopCompressionCodecClassName());
 
         PageBuilder pageBuilder = new PageBuilder(types);

--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -128,6 +128,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>com.facebook.airlift</groupId>

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ArrayColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ArrayColumnWriter.java
@@ -19,6 +19,7 @@ import com.facebook.presto.parquet.writer.levels.DefinitionLevelIterables;
 import com.facebook.presto.parquet.writer.levels.RepetitionLevelIterable;
 import com.facebook.presto.parquet.writer.levels.RepetitionLevelIterables;
 import com.google.common.collect.ImmutableList;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.List;
@@ -28,6 +29,8 @@ import static java.util.Objects.requireNonNull;
 public class ArrayColumnWriter
         implements ColumnWriter
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ArrayColumnWriter.class).instanceSize();
+
     private final ColumnWriter elementWriter;
     private final int maxDefinitionLevel;
     private final int maxRepetitionLevel;
@@ -73,6 +76,12 @@ public class ArrayColumnWriter
     public long getBufferedBytes()
     {
         return elementWriter.getBufferedBytes();
+    }
+
+    @Override
+    public long getRetainedBytes()
+    {
+        return INSTANCE_SIZE + elementWriter.getRetainedBytes();
     }
 
     @Override

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ColumnWriter.java
@@ -32,6 +32,8 @@ public interface ColumnWriter
 
     long getBufferedBytes();
 
+    long getRetainedBytes();
+
     void reset();
 
     class BufferData

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/MapColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/MapColumnWriter.java
@@ -19,6 +19,7 @@ import com.facebook.presto.parquet.writer.levels.DefinitionLevelIterables;
 import com.facebook.presto.parquet.writer.levels.RepetitionLevelIterable;
 import com.facebook.presto.parquet.writer.levels.RepetitionLevelIterables;
 import com.google.common.collect.ImmutableList;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.List;
@@ -28,6 +29,8 @@ import static java.util.Objects.requireNonNull;
 public class MapColumnWriter
         implements ColumnWriter
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapColumnWriter.class).instanceSize();
+
     private final ColumnWriter keyWriter;
     private final ColumnWriter valueWriter;
     private final int maxDefinitionLevel;
@@ -77,6 +80,12 @@ public class MapColumnWriter
     public long getBufferedBytes()
     {
         return keyWriter.getBufferedBytes() + valueWriter.getBufferedBytes();
+    }
+
+    @Override
+    public long getRetainedBytes()
+    {
+        return INSTANCE_SIZE + keyWriter.getRetainedBytes() + valueWriter.getRetainedBytes();
     }
 
     @Override

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
@@ -21,6 +21,7 @@ import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.OutputStreamSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.format.ColumnMetaData;
 import org.apache.parquet.format.FileMetaData;
@@ -43,6 +44,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
 import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
@@ -58,6 +60,9 @@ public class ParquetWriter
         implements Closeable
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ParquetWriter.class).instanceSize();
+
+    private static final int CHUNK_MAX_BYTES = toIntExact(DataSize.valueOf("128MB").toBytes());
+    private static final int DEFAULT_ROW_GROUP_MAX_ROW_COUNT = 10_000;
 
     private final List<ColumnWriter> columnWriters;
     private final OutputStreamSliceOutput outputStream;
@@ -88,11 +93,14 @@ public class ParquetWriter
         ParquetSchemaConverter parquetSchemaConverter = new ParquetSchemaConverter(types, columnNames);
         this.messageType = parquetSchemaConverter.getMessageType();
 
-        ParquetProperties parquetProperties = ParquetProperties.builder().withWriterVersion(PARQUET_2_0).build();
+        ParquetProperties parquetProperties = ParquetProperties.builder()
+                .withWriterVersion(PARQUET_2_0)
+                .withPageSize(writerOption.getMaxPageSize())
+                .build();
         CompressionCodecName compressionCodecName = getCompressionCodecName(compressionCodecClass);
         this.columnWriters = ParquetWriters.getColumnWriters(messageType, parquetSchemaConverter.getPrimitiveTypes(), parquetProperties, compressionCodecName);
 
-        this.chunkMaxLogicalBytes = max(1, writerOption.getMaxBlockSize() / 2);
+        this.chunkMaxLogicalBytes = max(1, CHUNK_MAX_BYTES / 2);
     }
 
     public long getWrittenBytes()
@@ -124,7 +132,7 @@ public class ParquetWriter
         checkArgument(page.getChannelCount() == columnWriters.size());
 
         while (page != null) {
-            int chunkRows = min(page.getPositionCount(), writerOption.getRowGroupMaxRowCount());
+            int chunkRows = min(page.getPositionCount(), DEFAULT_ROW_GROUP_MAX_ROW_COUNT);
             Page chunk = page.getRegion(0, chunkRows);
 
             // avoid chunk with huge logical size
@@ -156,7 +164,7 @@ public class ParquetWriter
         }
         rows += page.getPositionCount();
 
-        if (bufferedBytes >= writerOption.getMaxBlockSize()) {
+        if (bufferedBytes >= writerOption.getMaxRowGroupSize()) {
             columnWriters.forEach(ColumnWriter::close);
             flush();
             columnWriters.forEach(ColumnWriter::reset);

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
@@ -266,7 +266,9 @@ public class ParquetWriter
         ImmutableList.Builder<ColumnMetaData> builder = ImmutableList.builder();
         long currentOffset = offset;
         for (ColumnMetaData column : columns) {
-            builder.add(new ColumnMetaData(column.type, column.encodings, column.path_in_schema, column.codec, column.num_values, column.total_uncompressed_size, column.total_compressed_size, currentOffset));
+            ColumnMetaData columnMetaData = new ColumnMetaData(column.type, column.encodings, column.path_in_schema, column.codec, column.num_values, column.total_uncompressed_size, column.total_compressed_size, currentOffset);
+            columnMetaData.setStatistics(column.getStatistics());
+            builder.add(columnMetaData);
             currentOffset += column.getTotal_compressed_size();
         }
         return builder.build();

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
@@ -23,7 +23,6 @@ public class ParquetWriterOptions
     private static final DataSize DEFAULT_MAX_ROW_GROUP_SIZE = DataSize.valueOf("128MB");
     private static final DataSize DEFAULT_MAX_PAGE_SIZE = DataSize.valueOf("1MB");
 
-
     public static ParquetWriterOptions.Builder builder()
     {
         return new ParquetWriterOptions.Builder();

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriterOptions.java
@@ -20,37 +20,38 @@ import static java.util.Objects.requireNonNull;
 
 public class ParquetWriterOptions
 {
-    private static final DataSize DEFAULT_BLOCK_SIZE = DataSize.valueOf("128MB");
-    private static final int DEFAULT_ROW_GROUP_MAX_ROW_COUNT = 10_000;
+    private static final DataSize DEFAULT_MAX_ROW_GROUP_SIZE = DataSize.valueOf("128MB");
+    private static final DataSize DEFAULT_MAX_PAGE_SIZE = DataSize.valueOf("1MB");
+
 
     public static ParquetWriterOptions.Builder builder()
     {
         return new ParquetWriterOptions.Builder();
     }
 
-    private final int maxBlockSize;
-    private final int rowGroupMaxRowCount;
+    private final int maxRowGroupSize;
+    private final int maxPageSize;
 
-    private ParquetWriterOptions(DataSize maxBlockSize, int rowGroupMaxRowCount)
+    private ParquetWriterOptions(DataSize maxRowGroupSize, DataSize maxPageSize)
     {
-        this.maxBlockSize = toIntExact(requireNonNull(maxBlockSize, "maxBlockSize is null").toBytes());
-        this.rowGroupMaxRowCount = rowGroupMaxRowCount;
+        this.maxRowGroupSize = toIntExact(requireNonNull(maxRowGroupSize, "maxRowGroupSize is null").toBytes());
+        this.maxPageSize = toIntExact(requireNonNull(maxPageSize, "maxPageSize is null").toBytes());
     }
 
-    public int getMaxBlockSize()
+    public int getMaxRowGroupSize()
     {
-        return maxBlockSize;
+        return maxRowGroupSize;
     }
 
-    public int getRowGroupMaxRowCount()
+    public int getMaxPageSize()
     {
-        return rowGroupMaxRowCount;
+        return maxPageSize;
     }
 
     public static class Builder
     {
-        private DataSize maxBlockSize = DEFAULT_BLOCK_SIZE;
-        private int rowGroupMaxRowCount = DEFAULT_ROW_GROUP_MAX_ROW_COUNT;
+        private DataSize maxBlockSize = DEFAULT_MAX_ROW_GROUP_SIZE;
+        private DataSize maxPageSize = DEFAULT_MAX_PAGE_SIZE;
 
         public Builder setMaxBlockSize(DataSize maxBlockSize)
         {
@@ -58,15 +59,15 @@ public class ParquetWriterOptions
             return this;
         }
 
-        public Builder setRowGroupMaxRowCount(int rowGroupMaxRowCount)
+        public Builder setMaxPageSize(DataSize maxPageSize)
         {
-            this.rowGroupMaxRowCount = rowGroupMaxRowCount;
+            this.maxPageSize = maxPageSize;
             return this;
         }
 
         public ParquetWriterOptions build()
         {
-            return new ParquetWriterOptions(maxBlockSize, rowGroupMaxRowCount);
+            return new ParquetWriterOptions(maxBlockSize, maxPageSize);
         }
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriter.java
@@ -281,6 +281,8 @@ public class PrimitiveColumnWriter
             dictPage.add(pageData);
             totalCompressedSize += pageHeader.size() + compressedSize;
             totalUnCompressedSize += pageHeader.size() + uncompressedSize;
+
+            primitiveValueWriter.resetDictionary();
         }
         getDataStreamsCalled = true;
 
@@ -308,9 +310,6 @@ public class PrimitiveColumnWriter
     @Override
     public void reset()
     {
-        primitiveValueWriter.reset();
-        primitiveValueWriter.resetDictionary();
-
         pageBuffer.clear();
         closed = false;
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriter.java
@@ -286,7 +286,16 @@ public class PrimitiveColumnWriter
     @Override
     public long getBufferedBytes()
     {
-        return pageBuffer.stream().mapToLong(ParquetDataOutput::size).sum() + definitionLevelEncoder.getBufferedSize() + repetitionLevelEncoder.getBufferedSize();
+        return pageBuffer.stream().mapToLong(ParquetDataOutput::size).sum() +
+                definitionLevelEncoder.getBufferedSize() +
+                repetitionLevelEncoder.getBufferedSize() +
+                primitiveValueWriter.getBufferedSize();
+    }
+
+    @Override
+    public long getRetainedBytes()
+    {
+        return 0;
     }
 
     @Override

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/PrimitiveColumnWriter.java
@@ -122,7 +122,6 @@ public class PrimitiveColumnWriter
 
         // write values
         primitiveValueWriter.write(columnChunk.getBlock());
-        encodings.add(primitiveValueWriter.getEncoding());
 
         // write definition levels
         Iterator<Integer> defIterator = DefinitionLevelIterables.getIterator(current.getDefinitionLevelIterables());
@@ -194,6 +193,9 @@ public class PrimitiveColumnWriter
         BytesInput bytes = primitiveValueWriter.getBytes();
         ParquetDataOutput repetitions = createDataOutput(copy(repetitionLevelEncoder.toBytes()));
         ParquetDataOutput definitions = createDataOutput(copy(definitionLevelEncoder.toBytes()));
+
+        // Add encoding should be called after primitiveValueWriter.getBytes() and before primitiveValueWriter.reset()
+        encodings.add(primitiveValueWriter.getEncoding());
 
         long uncompressedSize = bytes.size() + repetitions.size() + definitions.size();
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/StructColumnWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/StructColumnWriter.java
@@ -20,6 +20,7 @@ import com.facebook.presto.parquet.writer.levels.DefinitionLevelIterables;
 import com.facebook.presto.parquet.writer.levels.RepetitionLevelIterable;
 import com.facebook.presto.parquet.writer.levels.RepetitionLevelIterables;
 import com.google.common.collect.ImmutableList;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.util.List;
@@ -31,6 +32,8 @@ import static org.apache.parquet.Preconditions.checkArgument;
 public class StructColumnWriter
         implements ColumnWriter
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(StructColumnWriter.class).instanceSize();
+
     private final List<ColumnWriter> columnWriters;
     private final int maxDefinitionLevel;
     private final int maxRepetitionLevel;
@@ -86,6 +89,13 @@ public class StructColumnWriter
     public long getBufferedBytes()
     {
         return columnWriters.stream().mapToLong(ColumnWriter::getBufferedBytes).sum();
+    }
+
+    @Override
+    public long getRetainedBytes()
+    {
+        return INSTANCE_SIZE +
+                columnWriters.stream().mapToLong(ColumnWriter::getRetainedBytes).sum();
     }
 
     @Override


### PR DESCRIPTION
Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
N/A

Hive Changes
Add native parquet writer, can be turned on by "parquet_optimized_writer_enabled" session property.
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
