### PR TITLE
Fix estimatedSerializedSizeInBytes calculation in ColumnarXXX

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarArray.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarArray.java
@@ -103,7 +103,7 @@ public class ColumnarArray
                 // 2) nulls array size: Byte.BYTES * positionCount
                 // 3) the estimated serialized size for the elementsBlock which was just constructed as a new DictionaryBlock:
                 //     the average row size: elementsBlock.getSizeInBytes() / (double) elementsBlock.getPositionCount() * the number of rows: offsets[positionCount]
-                (Integer.BYTES + Byte.BYTES) * positionCount + (long) (elementsBlock.getSizeInBytes() / (double) elementsBlock.getPositionCount() * offsets[positionCount]));
+                (Integer.BYTES + Byte.BYTES) * positionCount + elementsBlock.getPositionCount() == 0 ? 0 : (long) (elementsBlock.getSizeInBytes() / (double) elementsBlock.getPositionCount() * offsets[positionCount]));
     }
 
     private static ColumnarArray toColumnarArray(RunLengthEncodedBlock rleBlock)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarMap.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarMap.java
@@ -114,7 +114,8 @@ public class ColumnarMap
                 // 2) nulls array size: Byte.BYTES * positionCount
                 // 3) the estimated serialized size for the keysBlock and valuesBlock which were just constructed as new DictionaryBlocks:
                 //     the average row size: keysBlock.getSizeInBytes() / (double) keysBlock.getPositionCount() + valuesBlock.getSizeInBytes() / (double) valuesBlock.getPositionCount() * the number of rows: offsets[positionCount]
-                (Integer.BYTES + Byte.BYTES) * positionCount + (long) ((keysBlock.getSizeInBytes() / (double) keysBlock.getPositionCount() + valuesBlock.getSizeInBytes() / (double) valuesBlock.getPositionCount()) * offsets[positionCount]));
+                (Integer.BYTES + Byte.BYTES) * positionCount +
+                         (long) ((keysBlock.getPositionCount() == 0 ? 0 : keysBlock.getSizeInBytes() / (double) keysBlock.getPositionCount() + valuesBlock.getPositionCount() == 0 ? 0 : valuesBlock.getSizeInBytes() / (double) valuesBlock.getPositionCount()) * offsets[positionCount]));
     }
 
     private static ColumnarMap toColumnarMap(RunLengthEncodedBlock rleBlock)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarRow.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/block/ColumnarRow.java
@@ -86,7 +86,7 @@ public final class ColumnarRow
         for (int i = 0; i < columnarRow.getFieldCount(); i++) {
             Block field = columnarRow.getField(i);
             fields[i] = new DictionaryBlock(nonNullPositionCount, field, dictionaryIds);
-            averageRowSize += field.getSizeInBytes() / field.getPositionCount();
+            averageRowSize += field.getPositionCount() == 0 ? 0 : field.getSizeInBytes() / field.getPositionCount();
         }
         return new ColumnarRow(
                 dictionaryBlock,


### PR DESCRIPTION
Fix TestUnnestOperator broken by https://github.com/prestodb/presto/pull/13746

```
== NO RELEASE NOTE ==
```
