### PR TITLE
 Clean up PlanOptimizerProvider while dropping connector

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -334,6 +334,7 @@ public class ConnectorManager
         metadataManager.getSchemaPropertyManager().removeProperties(connectorId);
         metadataManager.getAnalyzePropertyManager().removeProperties(connectorId);
         metadataManager.getSessionPropertyManager().removeConnectorSessionProperties(connectorId);
+        connectorPlanOptimizerManager.removePlanOptimizerProvider(connectorId);
 
         MaterializedConnector materializedConnector = connectors.remove(connectorId);
         if (materializedConnector != null) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ConnectorPlanOptimizerManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ConnectorPlanOptimizerManager.java
@@ -45,6 +45,12 @@ public class ConnectorPlanOptimizerManager
                 "ConnectorPlanOptimizerProvider for connector '%s' is already registered", connectorId);
     }
 
+    public void removePlanOptimizerProvider(ConnectorId connectorId)
+    {
+        requireNonNull(connectorId, "connectorId is null");
+        planOptimizerProviders.remove(connectorId);
+    }
+
     public Map<ConnectorId, Set<ConnectorPlanOptimizer>> getOptimizers(PlanPhase phase)
     {
         switch (phase) {


### PR DESCRIPTION
Previously, ConnectorPlanOptimizerManager.addPlanOptimizerProvider() is invoked while adding connector, But PlanOptimizerProvider is not cleaned up while dropping connector, Dropping and adding a connector with the same name will trigger an exception like “ConnectorPlanOptimizerProvider for connector '%s' is already registered”. 

```
== NO RELEASE NOTE ==
```