### PR TITLE
Add flatten_geometry_collections function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -412,6 +412,17 @@ Accessors
    ``GEOMETRYCOLLECTION(MULTIPOINT(0 0, 1 1), GEOMETRYCOLLECTION(MULTILINESTRING((2 2, 3 3))))``
    would produce ``array[MULTIPOINT(0 0, 1 1), GEOMETRYCOLLECTION(MULTILINESTRING((2 2, 3 3)))]``.
 
+.. function:: flatten_geometry_collections(Geometry) -> array(Geometry)
+
+    Recursively flattens any GeometryCollections in Geometry, returning an array
+    of constituent non-GeometryCollection geometries.  The order of the array is
+    arbitrary and should not be relied upon.  Examples:
+
+    ``POINT (0 0) -> [POINT (0 0)]``,
+    ``MULTIPOINT (0 0, 1 1) -> [MULTIPOINT (0 0, 1 1)]``,
+    ``GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (POINT (1 1))) -> [POINT (0 0), POINT (1 1)]``,
+    ``GEOMETRYCOLLECTION EMPTY -> []``.
+
 .. function:: ST_NumPoints(Geometry) -> bigint
 
     Returns the number of points in a geometry. This is an extension to the SQL/MM

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -1190,6 +1190,27 @@ public class TestGeoFunctions
     }
 
     @Test
+    public void testFlattenGeometryCollections()
+    {
+        assertFlattenGeometryCollections("POINT (0 0)", "POINT (0 0)");
+        assertFlattenGeometryCollections("MULTIPOINT ((0 0), (1 1))", "MULTIPOINT ((0 0), (1 1))");
+        assertFlattenGeometryCollections("GEOMETRYCOLLECTION EMPTY");
+        assertFlattenGeometryCollections("GEOMETRYCOLLECTION (POINT EMPTY)", "POINT EMPTY");
+        assertFlattenGeometryCollections("GEOMETRYCOLLECTION (MULTIPOLYGON EMPTY)", "MULTIPOLYGON EMPTY");
+        assertFlattenGeometryCollections("GEOMETRYCOLLECTION (POINT (0 0))", "POINT (0 0)");
+        assertFlattenGeometryCollections(
+                "GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (POINT (1 1)))",
+                "POINT (1 1)", "POINT (0 0)");
+    }
+
+    private void assertFlattenGeometryCollections(String wkt, String... expected)
+    {
+        assertFunction(
+                String.format("transform(flatten_geometry_collections(ST_GeometryFromText('%s')), x -> ST_ASText(x))", wkt),
+                new ArrayType(VARCHAR), ImmutableList.copyOf(expected));
+    }
+
+    @Test
     public void testSTGeometryFromText()
     {
         assertInvalidFunction("ST_GeometryFromText('xyz')", "Invalid WKT: Unknown geometry type: XYZ (line 1)");


### PR DESCRIPTION
GeometryCollections are often problematic for geometry computations.
First, some standard functions perform non-intuitively for them, or may
throw an exception.  Second, they can be arbitrarily nested, so ensuring
that you've flattened a geometry to contain no GeometryCollections is
challenging in SQL.  A common request is to recursively flatten any
encountered GeometryCollections, which is what this function does.

Non-GeometryCollections transform to a singleton array:
`MULTIPOINT(0 0, 1 1)` goes to `[MULTIPOINT(0 0, 1 1)]`.

GeometryCollections are recursively flattened to an array of their
(leaf) constituents:
`GEOMETRYCOLLECTION(POINT(0 0), GEOMETRYCOLLECTION(POINT(1 1)))`
goes to `[POINT(0 0), POINT(1 1)]`.  The order of the array is
implementation-dependent and not guaranteed.

```
== RELEASE NOTES ==
GeoSpatial Changes
* Add `flatten_geometry_collections` function to recursively flatten `GeometryCollection`s.
```
