### PR TITLE
Fix query client timeout

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
@@ -285,6 +285,11 @@ public class DispatchManager
                 });
     }
 
+    public boolean isQueryPresent(QueryId queryId)
+    {
+        return queryTracker.tryGetQuery(queryId).isPresent();
+    }
+
     public void failQuery(QueryId queryId, Throwable cause)
     {
         requireNonNull(cause, "cause is null");

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/QueuedStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/QueuedStatementResource.java
@@ -118,7 +118,7 @@ public class QueuedStatementResource
                             }
 
                             // forget about this query if the query manager is no longer tracking it
-                            if (!dispatchManager.getDispatchInfo(entry.getKey()).isPresent()) {
+                            if (!dispatchManager.isQueryPresent(entry.getKey())) {
                                 queries.remove(entry.getKey());
                             }
                         }


### PR DESCRIPTION
The `queryPurger` in `QueuedStatementResource` was inadvertently triggering a heartbeat when checking if the query was expired, preventing expiration.

```
== NO RELEASE NOTE ==
```
