### PR TITLE
Pre-calculate nested positions array size in BlockEncodingBuffer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
@@ -252,10 +252,13 @@ public abstract class AbstractBlockEncodingBuffer
         return decodedBlockNode;
     }
 
+    protected void ensurePositionsCapacity(int capacity)
+    {
+        positions = ensureCapacity(positions, capacity, SMALL, NONE, bufferAllocator);
+    }
+
     protected void appendPositionRange(int offset, int length)
     {
-        positions = ensureCapacity(positions, positionCount + length, LARGE, PRESERVE, bufferAllocator);
-
         for (int i = 0; i < length; i++) {
             positions[positionCount++] = offset + i;
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
@@ -259,17 +259,13 @@ public class ArrayBlockEncodingBuffer
         int[] positions = getPositions();
 
         for (int i = 0; i < positionCount; i++) {
-            int position = positions[i];
-            int beginOffset = columnarArray.getOffset(position);
-            int endOffset = columnarArray.getOffset(position + 1);
-            int length = endOffset - beginOffset;
+            offsets[i + 1] = offsets[i] + columnarArray.getLength(positions[i]);
+        }
 
-            offsets[i + 1] = offsets[i] + length;
+        valuesBuffers.ensurePositionsCapacity(offsets[positionCount]);
 
-            if (length > 0) {
-                // beginOffset is the absolute position in the nested block. We need to subtract the base offset from it to get the logical position.
-                valuesBuffers.appendPositionRange(beginOffset, length);
-            }
+        for (int i = 0; i < positionCount; i++) {
+            valuesBuffers.appendPositionRange(columnarArray.getOffset(positions[i]), offsets[i + 1] - offsets[i]);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
@@ -345,16 +345,17 @@ public class MapBlockEncodingBuffer
 
         for (int i = 0; i < positionCount; i++) {
             int position = positions[i];
-            int beginOffset = columnarMap.getOffset(position);
-            int endOffset = columnarMap.getOffset(position + 1);
-            int currentRowSize = endOffset - beginOffset;
+            offsets[i + 1] = offsets[i] + columnarMap.getOffset(position + 1) - columnarMap.getOffset(position);
+        }
 
-            offsets[i + 1] = offsets[i] + currentRowSize;
+        keyBuffers.ensurePositionsCapacity(offsets[positionCount]);
+        valueBuffers.ensurePositionsCapacity(offsets[positionCount]);
 
-            if (currentRowSize > 0) {
-                keyBuffers.appendPositionRange(beginOffset, currentRowSize);
-                valueBuffers.appendPositionRange(beginOffset, currentRowSize);
-            }
+        for (int i = 0; i < positionCount; i++) {
+            int beginOffset = columnarMap.getOffset(positions[i]);
+            int currentRowSize = offsets[i + 1] - offsets[i];
+            keyBuffers.appendPositionRange(beginOffset, currentRowSize);
+            valueBuffers.appendPositionRange(beginOffset, currentRowSize);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
@@ -312,10 +312,16 @@ public class RowBlockEncodingBuffer
         int columnarRowBaseOffset = columnarRow.getOffset(0);
         for (int i = 0; i < positionCount; i++) {
             int position = positions[i];
-            int beginOffset = columnarRow.getOffset(position);
-            int endOffset = columnarRow.getOffset(position + 1);  // if the row is null, endOffsetInBlock == beginOffsetInBlock
-            int currentRowSize = endOffset - beginOffset;
-            offsets[i + 1] = offsets[i] + currentRowSize;
+            offsets[i + 1] = offsets[i] + columnarRow.getOffset(position + 1) - columnarRow.getOffset(position);
+        }
+
+        for (int j = 0; j < fieldBuffers.length; j++) {
+            fieldBuffers[j].ensurePositionsCapacity(offsets[positionCount]);
+        }
+
+        for (int i = 0; i < positionCount; i++) {
+            int beginOffset = columnarRow.getOffset(positions[i]);
+            int currentRowSize = offsets[i + 1] - offsets[i];
 
             if (currentRowSize > 0) {
                 for (int j = 0; j < fieldBuffers.length; j++) {


### PR DESCRIPTION
Resolves https://github.com/prestodb/presto/issues/14433

The positions array for nested BlockEncodingBuffer used to be grown on
the fly. This uses extra CPU and makes the positions array larger than
required because the growth factor was 2.0. This commit pre-calculates
the nested positions array size, allocate the memory in one shot, then
populate the positions.


```
== NO RELEASE NOTE ==
```
