### PR TITLE
Pinot Connector Aggregation GroupBy push down when fields in group by clause is not fully presented in selection

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGenerator.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGenerator.java
@@ -151,7 +151,7 @@ public class PinotQueryGenerator
         final String table;
         final String pql;
         final List<Integer> expectedColumnIndices;
-        final int groupByClauses;
+        final List<String> groupByClauses;
         final boolean haveFilter;
         final boolean isQueryShort;
 
@@ -160,7 +160,7 @@ public class PinotQueryGenerator
                 @JsonProperty("table") String table,
                 @JsonProperty("pql") String pql,
                 @JsonProperty("expectedColumnIndices") List<Integer> expectedColumnIndices,
-                @JsonProperty("groupByClauses") int groupByClauses,
+                @JsonProperty("groupByClauses") List<String> groupByClauses,
                 @JsonProperty("haveFilter") boolean haveFilter,
                 @JsonProperty("isQueryShort") boolean isQueryShort)
         {
@@ -185,7 +185,7 @@ public class PinotQueryGenerator
         }
 
         @JsonProperty("groupByClauses")
-        public int getGroupByClauses()
+        public List<String> getGroupByClauses()
         {
             return groupByClauses;
         }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGeneratorContext.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGeneratorContext.java
@@ -24,6 +24,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -359,7 +360,16 @@ public class PinotQueryGeneratorContext
         }
 
         List<Integer> indices = getIndicesMappingFromPinotSchemaToPrestoSchema(query, getAssignments());
-        return new PinotQueryGenerator.GeneratedPql(tableName, query, indices, groupByColumns.size(), filter.isPresent(), isQueryShort);
+        return new PinotQueryGenerator.GeneratedPql(tableName, query, indices, extractGroupBy(groupByColumns), filter.isPresent(), isQueryShort);
+    }
+
+    private List<String> extractGroupBy(Set<VariableReferenceExpression> groupByExprs)
+    {
+        List<String> groupBys = new ArrayList<>();
+        for (VariableReferenceExpression expr : groupByExprs) {
+            groupBys.add(expr.getName());
+        }
+        return groupBys;
     }
 
     private List<Integer> getIndicesMappingFromPinotSchemaToPrestoSchema(String query, Map<VariableReferenceExpression, PinotColumnHandle> assignments)

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSplitManager.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSplitManager.java
@@ -84,7 +84,7 @@ public class TestPinotSplitManager
     @Test
     public void testSplitsBroker()
     {
-        PinotQueryGenerator.GeneratedPql generatedPql = new PinotQueryGenerator.GeneratedPql(realtimeOnlyTable.getTableName(), String.format("SELECT %s, COUNT(1) FROM %s GROUP BY %s TOP %d", city.getColumnName(), realtimeOnlyTable.getTableName(), city.getColumnName(), pinotConfig.getTopNLarge()), ImmutableList.of(0, 1), 1, false, true);
+        PinotQueryGenerator.GeneratedPql generatedPql = new PinotQueryGenerator.GeneratedPql(realtimeOnlyTable.getTableName(), String.format("SELECT %s, COUNT(1) FROM %s GROUP BY %s TOP %d", city.getColumnName(), realtimeOnlyTable.getTableName(), city.getColumnName(), pinotConfig.getTopNLarge()), ImmutableList.of(0, 1), ImmutableList.of(city.getColumnName()), false, true);
         PinotTableHandle pinotTableHandle = new PinotTableHandle(realtimeOnlyTable.getConnectorId(), realtimeOnlyTable.getSchemaName(), realtimeOnlyTable.getTableName(), Optional.of(true), Optional.of(generatedPql));
         List<PinotSplit> splits = getSplitsHelper(pinotTableHandle, 1, false);
         assertSplits(splits, 1, BROKER);
@@ -93,7 +93,7 @@ public class TestPinotSplitManager
     @Test(expectedExceptions = PinotSplitManager.QueryNotAdequatelyPushedDownException.class)
     public void testBrokerNonShortQuery()
     {
-        PinotQueryGenerator.GeneratedPql generatedPql = new PinotQueryGenerator.GeneratedPql(realtimeOnlyTable.getTableName(), String.format("SELECT %s FROM %s", city.getColumnName(), realtimeOnlyTable.getTableName()), ImmutableList.of(0), 0, false, false);
+        PinotQueryGenerator.GeneratedPql generatedPql = new PinotQueryGenerator.GeneratedPql(realtimeOnlyTable.getTableName(), String.format("SELECT %s FROM %s", city.getColumnName(), realtimeOnlyTable.getTableName()), ImmutableList.of(0), ImmutableList.of(), false, false);
         PinotTableHandle pinotTableHandle = new PinotTableHandle(realtimeOnlyTable.getConnectorId(), realtimeOnlyTable.getSchemaName(), realtimeOnlyTable.getTableName(), Optional.of(false), Optional.of(generatedPql));
         List<PinotSplit> splits = getSplitsHelper(pinotTableHandle, 1, true);
         assertSplits(splits, 1, BROKER);


### PR DESCRIPTION
Current Pinot can only do aggregation pushdown when full GROUP BY clause is specified in SELECT clause. And throws exception if partial of the GROUP BY clause is set.

E.g. below query works:
```
SELECT SUM(a), a FROM myTable GROUP BY a
```

But this one fails:
```
SELECT SUM(a) FROM myTable GROUP BY a
```

The change here is to make a mapping from the fields in ColumnHandle to the GroupBy results.
The results indexing follows the ordering of [GroupBy Clause] [Aggregation Clause].

E.g.  for PQL
```
SELECT SUM(a),COUNT(*), a FROM myTable GROUP BY a,b,c
```
The PQL results always contain groups [a,b,c] and values [sum(a), count(*)].

The columnHandle position index mapping would be [3,4,0] to extract PQL results values to sum(a), count(*), a

```
== NO RELEASE NOTE ==
```
