### PR TITLE
Fix interruption handling in Driver

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/MoreUninterruptibles.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/MoreUninterruptibles.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class MoreUninterruptibles
+{
+    private MoreUninterruptibles() {}
+
+    /**
+     * Migrate to https://github.com/google/guava/pull/3880 once merged and released
+     */
+    public static boolean tryLockUninterruptibly(Lock lock, long timeout, TimeUnit unit)
+    {
+        boolean interrupted = false;
+        try {
+            long remainingNanos = unit.toNanos(timeout);
+            long end = System.nanoTime() + remainingNanos;
+
+            while (true) {
+                try {
+                    return lock.tryLock(remainingNanos, NANOSECONDS);
+                }
+                catch (InterruptedException e) {
+                    interrupted = true;
+                    remainingNanos = end - System.nanoTime();
+                }
+            }
+        }
+        finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}


### PR DESCRIPTION
The issue was discovered when testing Presto on Spark.

Spark emits the `interrupt` signal to cancel the task.

If the interrupt signal is emitted when the Driver is about to finish (before
the `isFinished` method is called) the execution never finishes.

The `finish` method tries to ackquire the lock that alwayws returns `false`
when the interrupted flag is set. Since the `false` is interpreted as a failure
to aquire the lock, the finish is called again and again as it never succeeds.

Since the timeout for aquiring the lock is tiny (<=100ms) it is fine to try
to aquire the lock in a non interruptible manner to avoid taking care of non
trivial semantics of interrupting.
