### PR TITLE
Handle pruned columns in a pushed down pinot table scan

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotClusterInfoFetcher.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotClusterInfoFetcher.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.facebook.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static com.facebook.presto.pinot.PinotErrorCode.PINOT_HTTP_ERROR;
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_INVALID_CONFIGURATION;
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_UNABLE_TO_FIND_BROKER;
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_UNEXPECTED_RESPONSE;
@@ -160,7 +161,7 @@ public class PinotClusterInfoFetcher
         }
         else {
             throw new PinotException(
-                    PinotErrorCode.PINOT_HTTP_ERROR,
+                    PINOT_HTTP_ERROR,
                     Optional.empty(),
                     String.format(
                             "Unexpected response status: %d for request %s to url %s, with headers %s, full response %s",

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConnection.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConnection.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
+import static com.facebook.presto.pinot.PinotErrorCode.PINOT_UNCLASSIFIED_ERROR;
 import static com.google.common.cache.CacheLoader.asyncReloading;
 import static java.util.Objects.requireNonNull;
 
@@ -80,7 +81,7 @@ public class PinotConnection
             return cache.get(key);
         }
         catch (ExecutionException e) {
-            throw new PinotException(PinotErrorCode.PINOT_UNCLASSIFIED_ERROR, Optional.empty(), "Cannot fetch from cache " + key, e.getCause());
+            throw new PinotException(PINOT_UNCLASSIFIED_ERROR, Optional.empty(), "Cannot fetch from cache " + key, e.getCause());
         }
     }
 

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotMetadata.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotMetadata.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.pinot.PinotColumnHandle.PinotColumnType.REGULAR;
+import static com.facebook.presto.pinot.PinotErrorCode.PINOT_UNCLASSIFIED_ERROR;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -69,7 +70,7 @@ public class PinotMetadata
                 return pinotTableName;
             }
         }
-        throw new PinotException(PinotErrorCode.PINOT_UNCLASSIFIED_ERROR, Optional.empty(), "Unable to find the presto table " + prestoTableName + " in " + allTables);
+        throw new PinotException(PINOT_UNCLASSIFIED_ERROR, Optional.empty(), "Unable to find the presto table " + prestoTableName + " in " + allTables);
     }
 
     @Override

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPageSourceProvider.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPageSourceProvider.java
@@ -93,6 +93,7 @@ public class PinotPageSourceProvider
                         session,
                         pinotSplit.getBrokerPql().get(),
                         handles,
+                        pinotSplit.getExpectedColumnHandles(),
                         clusterInfoFetcher,
                         objectMapper);
             default:

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPlanOptimizer.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPlanOptimizer.java
@@ -172,7 +172,13 @@ public class PinotPlanOptimizer
             boolean isQueryShort = pql.get().getGeneratedPql().isQueryShort();
             TableHandle newTableHandle = new TableHandle(
                     oldTableHandle.getConnectorId(),
-                    new PinotTableHandle(pinotTableHandle.getConnectorId(), pinotTableHandle.getSchemaName(), pinotTableHandle.getTableName(), Optional.of(isQueryShort), Optional.of(pql.get().getGeneratedPql())),
+                    new PinotTableHandle(
+                            pinotTableHandle.getConnectorId(),
+                            pinotTableHandle.getSchemaName(),
+                            pinotTableHandle.getTableName(),
+                            Optional.of(isQueryShort),
+                            Optional.of(ImmutableList.copyOf(assignments.values())),
+                            Optional.of(pql.get().getGeneratedPql())),
                     oldTableHandle.getTransaction(),
                     oldTableHandle.getLayout());
             return Optional.of(

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPushdownUtils.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPushdownUtils.java
@@ -119,7 +119,7 @@ public class PinotPushdownUtils
     public static void checkSupported(boolean condition, String errorMessage, Object... errorMessageArgs)
     {
         if (!condition) {
-            throw new PinotException(PinotErrorCode.PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), String.format(errorMessage, errorMessageArgs));
+            throw new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), String.format(errorMessage, errorMessageArgs));
         }
     }
 

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSplit.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSplit.java
@@ -34,6 +34,7 @@ public class PinotSplit
 {
     private final String connectorId;
     private final SplitType splitType;
+    private final List<PinotColumnHandle> expectedColumnHandles;
 
     // Properties needed for broker split type
     private final Optional<PinotQueryGenerator.GeneratedPql> brokerPql;
@@ -47,6 +48,7 @@ public class PinotSplit
     public PinotSplit(
             @JsonProperty("connectorId") String connectorId,
             @JsonProperty("splitType") SplitType splitType,
+            @JsonProperty("expectedColumnHandles") List<PinotColumnHandle> expectedColumnHandles,
             @JsonProperty("brokerPql") Optional<PinotQueryGenerator.GeneratedPql> brokerPql,
             @JsonProperty("segmentPql") Optional<String> segmentPql,
             @JsonProperty("segments") List<String> segments,
@@ -54,6 +56,7 @@ public class PinotSplit
     {
         this.connectorId = requireNonNull(connectorId, "connector id is null");
         this.splitType = requireNonNull(splitType, "splitType id is null");
+        this.expectedColumnHandles = requireNonNull(expectedColumnHandles, "expected column handles is null");
         this.brokerPql = requireNonNull(brokerPql, "brokerPql is null");
         this.segmentPql = requireNonNull(segmentPql, "table name is null");
         this.segments = ImmutableList.copyOf(requireNonNull(segments, "segment is null"));
@@ -70,22 +73,24 @@ public class PinotSplit
         }
     }
 
-    public static PinotSplit createBrokerSplit(String connectorId, PinotQueryGenerator.GeneratedPql brokerPql)
+    public static PinotSplit createBrokerSplit(String connectorId, List<PinotColumnHandle> expectedColumnHandles, PinotQueryGenerator.GeneratedPql brokerPql)
     {
         return new PinotSplit(
                 requireNonNull(connectorId, "connector id is null"),
                 SplitType.BROKER,
+                expectedColumnHandles,
                 Optional.of(requireNonNull(brokerPql, "brokerPql is null")),
                 Optional.empty(),
                 ImmutableList.of(),
                 Optional.empty());
     }
 
-    public static PinotSplit createSegmentSplit(String connectorId, String pql, List<String> segments, String segmentHost)
+    public static PinotSplit createSegmentSplit(String connectorId, String pql, List<PinotColumnHandle> expectedColumnHandles, List<String> segments, String segmentHost)
     {
         return new PinotSplit(
                 requireNonNull(connectorId, "connector id is null"),
                 SplitType.SEGMENT,
+                expectedColumnHandles,
                 Optional.empty(),
                 Optional.of(requireNonNull(pql, "pql is null")),
                 requireNonNull(segments, "segments are null"),
@@ -134,11 +139,18 @@ public class PinotSplit
         return toStringHelper(this)
                 .add("connectorId", connectorId)
                 .add("splitType", splitType)
+                .add("columnHandle", expectedColumnHandles)
                 .add("segmentPql", segmentPql)
                 .add("brokerPql", brokerPql)
                 .add("segments", segments)
                 .add("segmentHost", segmentHost)
                 .toString();
+    }
+
+    @JsonProperty
+    public List<PinotColumnHandle> getExpectedColumnHandles()
+    {
+        return expectedColumnHandles;
     }
 
     @Override

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotTableHandle.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotTableHandle.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -33,13 +34,14 @@ public final class PinotTableHandle
     private final String tableName;
     private final Optional<Boolean> isQueryShort;
     private final Optional<PinotQueryGenerator.GeneratedPql> pql;
+    private final Optional<List<PinotColumnHandle>> expectedColumnHandles;
 
     public PinotTableHandle(
             String connectorId,
             String schemaName,
             String tableName)
     {
-        this(connectorId, schemaName, tableName, Optional.empty(), Optional.empty());
+        this(connectorId, schemaName, tableName, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     @JsonCreator
@@ -48,6 +50,7 @@ public final class PinotTableHandle
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
             @JsonProperty("isQueryShort") Optional<Boolean> isQueryShort,
+            @JsonProperty("expectedColumnHandles") Optional<List<PinotColumnHandle>> expectedColumnHandles,
             @JsonProperty("pql") Optional<PinotQueryGenerator.GeneratedPql> pql)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
@@ -55,6 +58,7 @@ public final class PinotTableHandle
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.isQueryShort = requireNonNull(isQueryShort, "safe to execute is null");
         this.pql = requireNonNull(pql, "broker pql is null");
+        this.expectedColumnHandles = requireNonNull(expectedColumnHandles, "expected column handles is null");
     }
 
     @JsonProperty
@@ -87,6 +91,12 @@ public final class PinotTableHandle
         return isQueryShort;
     }
 
+    @JsonProperty
+    public Optional<List<PinotColumnHandle>> getExpectedColumnHandles()
+    {
+        return expectedColumnHandles;
+    }
+
     public SchemaTableName toSchemaTableName()
     {
         return new SchemaTableName(schemaName, tableName);
@@ -106,13 +116,14 @@ public final class PinotTableHandle
                 Objects.equals(schemaName, that.schemaName) &&
                 Objects.equals(tableName, that.tableName) &&
                 Objects.equals(isQueryShort, that.isQueryShort) &&
+                Objects.equals(expectedColumnHandles, that.expectedColumnHandles) &&
                 Objects.equals(pql, that.pql);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(connectorId, schemaName, tableName, isQueryShort, pql);
+        return Objects.hash(connectorId, schemaName, tableName, isQueryShort, expectedColumnHandles, pql);
     }
 
     @Override
@@ -123,6 +134,7 @@ public final class PinotTableHandle
                 .add("schemaName", schemaName)
                 .add("tableName", tableName)
                 .add("isQueryShort", isQueryShort)
+                .add("expectedColumnHandles", expectedColumnHandles)
                 .add("pql", pql)
                 .toString();
     }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotUtils.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotUtils.java
@@ -13,10 +13,9 @@
  */
 package com.facebook.presto.pinot;
 
-import com.google.common.base.Preconditions;
-
 import java.util.function.Function;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.net.HttpURLConnection.HTTP_MULT_CHOICE;
 import static java.net.HttpURLConnection.HTTP_OK;
 
@@ -34,7 +33,7 @@ public class PinotUtils
     public static <T> T doWithRetries(int retries, Function<Integer, T> caller)
     {
         PinotException firstError = null;
-        Preconditions.checkState(retries > 0, "Invalid num of retries %d", retries);
+        checkState(retries > 0, "Invalid num of retries %d", retries);
         for (int i = 0; i < retries; ++i) {
             try {
                 return caller.apply(i);

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGeneratorContext.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGeneratorContext.java
@@ -358,7 +358,8 @@ public class PinotQueryGeneratorContext
             query += " " + limitKeyWord + " " + queryLimit;
         }
 
-        List<Integer> indices = getIndicesMappingFromPinotSchemaToPrestoSchema(query, getAssignments());
+        LinkedHashMap<VariableReferenceExpression, PinotColumnHandle> assignments = getAssignments();
+        List<Integer> indices = getIndicesMappingFromPinotSchemaToPrestoSchema(query, assignments);
         return new PinotQueryGenerator.GeneratedPql(tableName, query, indices, groupByColumns.size(), filter.isPresent(), isQueryShort);
     }
 

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotBrokerPageSource.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotBrokerPageSource.java
@@ -15,7 +15,6 @@ package com.facebook.presto.pinot;
 
 import com.facebook.airlift.json.ObjectMapperProvider;
 import com.facebook.presto.pinot.query.PinotQueryGenerator;
-import com.facebook.presto.spi.PageBuilder;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.type.Type;
@@ -34,7 +33,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.spi.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.testng.Assert.assertEquals;
@@ -45,6 +43,7 @@ public class TestPinotBrokerPageSource
 {
     private static PinotTableHandle pinotTable = new PinotTableHandle("connId", "schema", "tbl");
     private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private static PinotColumnHandle jobState = new PinotColumnHandle("jobState", VARCHAR, PinotColumnHandle.PinotColumnType.REGULAR);
 
     private static class PqlParsedInfo
     {
@@ -113,37 +112,67 @@ public class TestPinotBrokerPageSource
         return new Object[][] {
                 {"SELECT count(*), sum(regionId) FROM eats_job_state GROUP BY jobState TOP 1000000",
                         "{\"aggregationResults\":[{\"groupByResult\":[{\"value\":\"10646777\",\"group\":[\"CREATED\"]},{\"value\":\"9441201\",\"group\":[\"ASSIGNED\"]},{\"value\":\"5329962\",\"group\":[\"SUBMITTED_TO_BILLING\"]},{\"value\":\"5281666\",\"group\":[\"PICKUP_COMPLETED\"]},{\"value\":\"5225839\",\"group\":[\"OFFERED\"]},{\"value\":\"5088568\",\"group\":[\"READY\"]},{\"value\":\"5027369\",\"group\":[\"COMPLETED\"]},{\"value\":\"3677267\",\"group\":[\"SUBMITTED_TO_MANIFEST\"]},{\"value\":\"1559953\",\"group\":[\"SCHEDULED\"]},{\"value\":\"1532913\",\"group\":[\"ACCEPTED\"]},{\"value\":\"1532891\",\"group\":[\"RELEASED\"]},{\"value\":\"531719\",\"group\":[\"UNASSIGNED\"]},{\"value\":\"252977\",\"group\":[\"PREP_TIME_UPDATED\"]},{\"value\":\"243463\",\"group\":[\"CANCELED\"]},{\"value\":\"211553\",\"group\":[\"PAYMENT_PENDING\"]},{\"value\":\"148548\",\"group\":[\"PAYMENT_CONFIRMED\"]},{\"value\":\"108057\",\"group\":[\"UNFULFILLED_WARNED\"]},{\"value\":\"47043\",\"group\":[\"DELIVERY_FAILED\"]},{\"value\":\"30832\",\"group\":[\"UNFULFILLED\"]},{\"value\":\"18009\",\"group\":[\"SCHEDULE_ORDER_CREATED\"]},{\"value\":\"16459\",\"group\":[\"SCHEDULE_ORDER_ACCEPTED\"]},{\"value\":\"11086\",\"group\":[\"FAILED\"]},{\"value\":\"9976\",\"group\":[\"SCHEDULE_ORDER_OFFERED\"]},{\"value\":\"3094\",\"group\":[\"PAYMENT_FAILED\"]}],\"function\":\"count_star\",\"groupByColumns\":[\"jobState\"]},{\"groupByResult\":[{\"value\":\"3274799599.00000\",\"group\":[\"CREATED\"]},{\"value\":\"2926585674.00000\",\"group\":[\"ASSIGNED\"]},{\"value\":\"1645707788.00000\",\"group\":[\"SUBMITTED_TO_BILLING\"]},{\"value\":\"1614715326.00000\",\"group\":[\"OFFERED\"]},{\"value\":\"1608041994.00000\",\"group\":[\"PICKUP_COMPLETED\"]},{\"value\":\"1568036720.00000\",\"group\":[\"READY\"]},{\"value\":\"1541977381.00000\",\"group\":[\"COMPLETED\"]},{\"value\":\"1190457213.00000\",\"group\":[\"SUBMITTED_TO_MANIFEST\"]},{\"value\":\"430246171.00000\",\"group\":[\"SCHEDULED\"]},{\"value\":\"422020881.00000\",\"group\":[\"RELEASED\"]},{\"value\":\"421937782.00000\",\"group\":[\"ACCEPTED\"]},{\"value\":\"147557783.00000\",\"group\":[\"UNASSIGNED\"]},{\"value\":\"94882088.00000\",\"group\":[\"PREP_TIME_UPDATED\"]},{\"value\":\"86447788.00000\",\"group\":[\"CANCELED\"]},{\"value\":\"77505566.00000\",\"group\":[\"PAYMENT_PENDING\"]},{\"value\":\"53955037.00000\",\"group\":[\"PAYMENT_CONFIRMED\"]},{\"value\":\"36026660.00000\",\"group\":[\"UNFULFILLED_WARNED\"]},{\"value\":\"15306755.00000\",\"group\":[\"DELIVERY_FAILED\"]},{\"value\":\"8811788.00000\",\"group\":[\"UNFULFILLED\"]},{\"value\":\"5301567.00000\",\"group\":[\"SCHEDULE_ORDER_CREATED\"]},{\"value\":\"4855342.00000\",\"group\":[\"SCHEDULE_ORDER_ACCEPTED\"]},{\"value\":\"3113490.00000\",\"group\":[\"FAILED\"]},{\"value\":\"2811789.00000\",\"group\":[\"SCHEDULE_ORDER_OFFERED\"]},{\"value\":\"1053944.00000\",\"group\":[\"PAYMENT_FAILED\"]}],\"function\":\"sum_regionId\",\"groupByColumns\":[\"jobState\"]}],\"exceptions\":[],\"numServersQueried\":7,\"numServersResponded\":7,\"numDocsScanned\":55977222,\"numEntriesScannedInFilter\":0,\"numEntriesScannedPostFilter\":111954444,\"totalDocs\":55977222,\"numGroupsLimitReached\":false,\"timeUsedMs\":775,\"segmentStatistics\":[],\"traceInfo\":{}}",
-                        ImmutableList.of(VARCHAR, BIGINT, BIGINT), Optional.empty()},
+                        ImmutableList.of(derived("count"), derived("sum"), jobState),
+                        ImmutableList.of(2, 0, 1),
+                        ImmutableList.of(derived("count"), derived("sum"), jobState),
+                        Optional.empty()},
+                {"SELECT count(*) FROM eats_job_state GROUP BY jobState TOP 1000000", // projecting group-by by without aggregate
+                        "{\"traceInfo\":{},\"numEntriesScannedPostFilter\":55979949,\"numDocsScanned\":55979949,\"numServersResponded\":7,\"numGroupsLimitReached\":false,\"aggregationResults\":[{\"groupByResult\":[{\"value\":\"10647363\",\"group\":[\"CREATED\"]},{\"value\":\"9441638\",\"group\":[\"ASSIGNED\"]},{\"value\":\"5330203\",\"group\":[\"SUBMITTED_TO_BILLING\"]},{\"value\":\"5281905\",\"group\":[\"PICKUP_COMPLETED\"]},{\"value\":\"5226090\",\"group\":[\"OFFERED\"]},{\"value\":\"5088813\",\"group\":[\"READY\"]},{\"value\":\"5027589\",\"group\":[\"COMPLETED\"]},{\"value\":\"3677424\",\"group\":[\"SUBMITTED_TO_MANIFEST\"]},{\"value\":\"1560029\",\"group\":[\"SCHEDULED\"]},{\"value\":\"1533006\",\"group\":[\"ACCEPTED\"]},{\"value\":\"1532980\",\"group\":[\"RELEASED\"]},{\"value\":\"531745\",\"group\":[\"UNASSIGNED\"]},{\"value\":\"252989\",\"group\":[\"PREP_TIME_UPDATED\"]},{\"value\":\"243477\",\"group\":[\"CANCELED\"]},{\"value\":\"211571\",\"group\":[\"PAYMENT_PENDING\"]},{\"value\":\"148557\",\"group\":[\"PAYMENT_CONFIRMED\"]},{\"value\":\"108062\",\"group\":[\"UNFULFILLED_WARNED\"]},{\"value\":\"47048\",\"group\":[\"DELIVERY_FAILED\"]},{\"value\":\"30832\",\"group\":[\"UNFULFILLED\"]},{\"value\":\"18009\",\"group\":[\"SCHEDULE_ORDER_CREATED\"]},{\"value\":\"16461\",\"group\":[\"SCHEDULE_ORDER_ACCEPTED\"]},{\"value\":\"11086\",\"group\":[\"FAILED\"]},{\"value\":\"9978\",\"group\":[\"SCHEDULE_ORDER_OFFERED\"]},{\"value\":\"3094\",\"group\":[\"PAYMENT_FAILED\"]}],\"function\":\"count_star\",\"groupByColumns\":[\"jobState\"]}],\"exceptions\":[],\"numEntriesScannedInFilter\":0,\"timeUsedMs\":402,\"segmentStatistics\":[],\"numServersQueried\":7,\"totalDocs\":55979949}",
+                        ImmutableList.of(jobState),
+                        ImmutableList.of(0, -1),
+                        ImmutableList.of(jobState, derived("hidden_count")),
+                        Optional.empty()},
+                {"SELECT count(*) FROM eats_job_state GROUP BY jobState TOP 1000000", // projecting aggregate without group-by
+                        "{\"traceInfo\":{},\"numEntriesScannedPostFilter\":55979949,\"numDocsScanned\":55979949,\"numServersResponded\":7,\"numGroupsLimitReached\":false,\"aggregationResults\":[{\"groupByResult\":[{\"value\":\"10647363\",\"group\":[\"CREATED\"]},{\"value\":\"9441638\",\"group\":[\"ASSIGNED\"]},{\"value\":\"5330203\",\"group\":[\"SUBMITTED_TO_BILLING\"]},{\"value\":\"5281905\",\"group\":[\"PICKUP_COMPLETED\"]},{\"value\":\"5226090\",\"group\":[\"OFFERED\"]},{\"value\":\"5088813\",\"group\":[\"READY\"]},{\"value\":\"5027589\",\"group\":[\"COMPLETED\"]},{\"value\":\"3677424\",\"group\":[\"SUBMITTED_TO_MANIFEST\"]},{\"value\":\"1560029\",\"group\":[\"SCHEDULED\"]},{\"value\":\"1533006\",\"group\":[\"ACCEPTED\"]},{\"value\":\"1532980\",\"group\":[\"RELEASED\"]},{\"value\":\"531745\",\"group\":[\"UNASSIGNED\"]},{\"value\":\"252989\",\"group\":[\"PREP_TIME_UPDATED\"]},{\"value\":\"243477\",\"group\":[\"CANCELED\"]},{\"value\":\"211571\",\"group\":[\"PAYMENT_PENDING\"]},{\"value\":\"148557\",\"group\":[\"PAYMENT_CONFIRMED\"]},{\"value\":\"108062\",\"group\":[\"UNFULFILLED_WARNED\"]},{\"value\":\"47048\",\"group\":[\"DELIVERY_FAILED\"]},{\"value\":\"30832\",\"group\":[\"UNFULFILLED\"]},{\"value\":\"18009\",\"group\":[\"SCHEDULE_ORDER_CREATED\"]},{\"value\":\"16461\",\"group\":[\"SCHEDULE_ORDER_ACCEPTED\"]},{\"value\":\"11086\",\"group\":[\"FAILED\"]},{\"value\":\"9978\",\"group\":[\"SCHEDULE_ORDER_OFFERED\"]},{\"value\":\"3094\",\"group\":[\"PAYMENT_FAILED\"]}],\"function\":\"count_star\",\"groupByColumns\":[\"jobState\"]}],\"exceptions\":[],\"numEntriesScannedInFilter\":0,\"timeUsedMs\":402,\"segmentStatistics\":[],\"numServersQueried\":7,\"totalDocs\":55979949}",
+                        ImmutableList.of(derived("count")),
+                        ImmutableList.of(1, 0),
+                        ImmutableList.of(derived("count"), jobState),
+                        Optional.empty()},
                 {"SELECT count(*) FROM eats_job_state GROUP BY jobState TOP 1000000",
                         "{\"traceInfo\":{},\"numEntriesScannedPostFilter\":55979949,\"numDocsScanned\":55979949,\"numServersResponded\":7,\"numGroupsLimitReached\":false,\"aggregationResults\":[{\"groupByResult\":[{\"value\":\"10647363\",\"group\":[\"CREATED\"]},{\"value\":\"9441638\",\"group\":[\"ASSIGNED\"]},{\"value\":\"5330203\",\"group\":[\"SUBMITTED_TO_BILLING\"]},{\"value\":\"5281905\",\"group\":[\"PICKUP_COMPLETED\"]},{\"value\":\"5226090\",\"group\":[\"OFFERED\"]},{\"value\":\"5088813\",\"group\":[\"READY\"]},{\"value\":\"5027589\",\"group\":[\"COMPLETED\"]},{\"value\":\"3677424\",\"group\":[\"SUBMITTED_TO_MANIFEST\"]},{\"value\":\"1560029\",\"group\":[\"SCHEDULED\"]},{\"value\":\"1533006\",\"group\":[\"ACCEPTED\"]},{\"value\":\"1532980\",\"group\":[\"RELEASED\"]},{\"value\":\"531745\",\"group\":[\"UNASSIGNED\"]},{\"value\":\"252989\",\"group\":[\"PREP_TIME_UPDATED\"]},{\"value\":\"243477\",\"group\":[\"CANCELED\"]},{\"value\":\"211571\",\"group\":[\"PAYMENT_PENDING\"]},{\"value\":\"148557\",\"group\":[\"PAYMENT_CONFIRMED\"]},{\"value\":\"108062\",\"group\":[\"UNFULFILLED_WARNED\"]},{\"value\":\"47048\",\"group\":[\"DELIVERY_FAILED\"]},{\"value\":\"30832\",\"group\":[\"UNFULFILLED\"]},{\"value\":\"18009\",\"group\":[\"SCHEDULE_ORDER_CREATED\"]},{\"value\":\"16461\",\"group\":[\"SCHEDULE_ORDER_ACCEPTED\"]},{\"value\":\"11086\",\"group\":[\"FAILED\"]},{\"value\":\"9978\",\"group\":[\"SCHEDULE_ORDER_OFFERED\"]},{\"value\":\"3094\",\"group\":[\"PAYMENT_FAILED\"]}],\"function\":\"count_star\",\"groupByColumns\":[\"jobState\"]}],\"exceptions\":[],\"numEntriesScannedInFilter\":0,\"timeUsedMs\":402,\"segmentStatistics\":[],\"numServersQueried\":7,\"totalDocs\":55979949}",
-                        ImmutableList.of(VARCHAR, BIGINT), Optional.empty()},
+                        ImmutableList.of(derived("count"), jobState),
+                        ImmutableList.of(1, 0),
+                        ImmutableList.of(derived("count"), jobState),
+                        Optional.empty()},
                 {"SELECT count(*) FROM eats_job_state",
                         "{\"traceInfo\":{},\"numEntriesScannedPostFilter\":0,\"numDocsScanned\":55981101,\"numServersResponded\":7,\"numGroupsLimitReached\":false,\"aggregationResults\":[{\"function\":\"count_star\",\"value\":\"55981101\"}],\"exceptions\":[],\"numEntriesScannedInFilter\":0,\"timeUsedMs\":7,\"segmentStatistics\":[],\"numServersQueried\":7,\"totalDocs\":55981101}",
-                        ImmutableList.of(BIGINT), Optional.empty()},
+                        ImmutableList.of(derived("count")),
+                        ImmutableList.of(0),
+                        ImmutableList.of(derived("count")),
+                        Optional.empty()},
                 {"SELECT sum(regionId), count(*) FROM eats_job_state",
                         "{\"traceInfo\":{},\"numEntriesScannedPostFilter\":55981641,\"numDocsScanned\":55981641,\"numServersResponded\":7,\"numGroupsLimitReached\":false,\"aggregationResults\":[{\"function\":\"sum_regionId\",\"value\":\"17183585871.00000\"},{\"function\":\"count_star\",\"value\":\"55981641\"}],\"exceptions\":[],\"numEntriesScannedInFilter\":0,\"timeUsedMs\":549,\"segmentStatistics\":[],\"numServersQueried\":7,\"totalDocs\":55981641}",
-                        ImmutableList.of(BIGINT, BIGINT), Optional.empty()},
+                        ImmutableList.of(derived("sum"), derived("count")),
+                        ImmutableList.of(0, 1),
+                        ImmutableList.of(derived("sum"), derived("count")),
+                        Optional.empty()},
                 {"SELECT jobState, regionId FROM eats_job_state LIMIT 10",
                         "{\"selectionResults\":{\"columns\":[\"jobState\",\"regionId\"],\"results\":[[\"CREATED\",\"197\"],[\"SUBMITTED_TO_BILLING\",\"227\"],[\"ASSIGNED\",\"188\"],[\"SCHEDULED\",\"1479\"],[\"CANCELED\",\"1708\"],[\"CREATED\",\"134\"],[\"CREATED\",\"12\"],[\"OFFERED\",\"30\"],[\"COMPLETED\",\"215\"],[\"CREATED\",\"7\"]]},\"exceptions\":[],\"numServersQueried\":7,\"numServersResponded\":7,\"numDocsScanned\":380,\"numEntriesScannedInFilter\":0,\"numEntriesScannedPostFilter\":760,\"totalDocs\":55988817,\"numGroupsLimitReached\":false,\"timeUsedMs\":2,\"segmentStatistics\":[],\"traceInfo\":{}}",
-                        ImmutableList.of(VARCHAR, BIGINT), Optional.empty()},
+                        ImmutableList.of(jobState, regionId),
+                        ImmutableList.of(0, 1),
+                        ImmutableList.of(jobState, regionId),
+                        Optional.empty()},
                 {"SELECT shoppingCartUUID, $validUntil, $validFrom, jobState, tenancy, accountUUID, vehicleViewId, $partition, clientUUID, orderJobUUID, productTypeUUID, demandJobUUID, regionId, workflowUUID, jobType, kafkaOffset, productUUID, timestamp, flowType, ts FROM eats_job_state LIMIT 10",
                         "{\"selectionResults\":{\"columns\":[\"shoppingCartUUID\",\"$validUntil\",\"$validFrom\",\"jobState\",\"tenancy\",\"accountUUID\",\"vehicleViewId\",\"$partition\",\"clientUUID\",\"orderJobUUID\",\"productTypeUUID\",\"demandJobUUID\",\"regionId\",\"workflowUUID\",\"jobType\",\"kafkaOffset\",\"productUUID\",\"timestamp\",\"flowType\",\"ts\"],\"results\":[]},\"traceInfo\":{},\"numEntriesScannedPostFilter\":0,\"numDocsScanned\":0,\"numServersResponded\":7,\"numGroupsLimitReached\":false,\"exceptions\":[{\"errorCode\":200,\"message\":\"QueryExecutionError:\\njava.lang.NullPointerException\\n\\tat java.lang.Class.forName0(Native Method\\n\\tat\"}],\"numEntriesScannedInFilter\":0,\"timeUsedMs\":3,\"segmentStatistics\":[],\"numServersQueried\":7,\"totalDocs\":0}",
-                        ImmutableList.of(), Optional.of(PinotException.class)},
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        Optional.of(PinotException.class)},
                 {"SELECT * from eats_utilization_summarized",
                         "{\n" +
                                 "    \"selectionResults\": {\n" +
                                 "        \"columns\": [\"activeTrips\", \"numDrivers\", \"region\", \"rowtime\", \"secondsSinceEpoch\", \"utilization\", \"utilizedDrivers\", \"vehicleViewId\", \"windowEnd\", \"windowStart\"],\n" +
                                 "        \"results\": [\n" +
-                                "            [\"0\", \"0\", \"foobar\", \"null\", \"4588780800\", \"-∞\", \"0\", \"20017545\", \"4588780740000\", \"4588780725000\"],\n" +
-                                "            [\"8699\", \"11452\", \"doobar\", \"null\", \"4588780800\", \"0.730701685\", \"8368\", \"0\", \"4588780740000\", \"4588780725000\"],\n" +
-                                "            [\"0\", \"14\", \"zoobar\", \"null\", \"4588780800\", \"0.5\", \"7\", \"20014789\", \"4588780740000\", \"4588780725000\"],\n" +
-                                "            [\"0\", \"23\", \"moobar\", \"null\", \"4588780800\", \"0.4336180091\", \"10\", \"20009983\", \"4588780740000\", \"4588780725000\"],\n" +
-                                "            [\"0\", \"840\", \"koobar\", \"null\", \"4588780800\", \"0.6597985029\", \"554\", \"20006875\", \"4588780740000\", \"4588780725000\"],\n" +
-                                "            [\"0\", \"0\", \"loobar\", \"null\", \"4588780800\", \"-∞\", \"0\", \"20006291\", \"4588780740000\", \"4588780725000\"],\n" +
-                                "            [\"15\", \"1832\", \"monkeybar\", \"null\", \"4588780800\", \"0.8792306185\", \"1610\", \"20004007\", \"4588780740000\", \"4588780725000\"],\n" +
-                                "            [\"0\", \"0\", \"donkeybar\", \"null\", \"4588780800\", \"-∞\", \"0\", \"0\", \"4588780740000\", \"4588780725000\"],\n" +
-                                "            [\"1\", \"7\", \"horseybar\", \"null\", \"4588780800\", \"0.2857142985\", \"2\", \"20016753\", \"4588780740000\", \"4588780725000\"],\n" +
-                                "            [\"0\", \"130\", \"ginbar\", \"null\", \"4588780800\", \"0.8052611947\", \"105\", \"10000942\", \"4588780740000\", \"4588780725000\"]\n" +
+                                "            [\"0\", \"0\", \"foobar\", null, \"4588780800\", \"-∞\", \"0\", \"20017545\", \"4588780740000\", \"4588780725000\"],\n" +
+                                "            [\"8699\", \"11452\", \"doobar\", null, \"4588780800\", \"0.730701685\", \"8368\", \"0\", \"4588780740000\", \"4588780725000\"],\n" +
+                                "            [\"0\", \"14\", \"zoobar\", null, \"4588780800\", \"0.5\", \"7\", \"20014789\", \"4588780740000\", \"4588780725000\"],\n" +
+                                "            [\"0\", \"23\", \"moobar\", null, \"4588780800\", \"0.4336180091\", \"10\", \"20009983\", \"4588780740000\", \"4588780725000\"],\n" +
+                                "            [\"0\", \"840\", \"koobar\", null, \"4588780800\", \"0.6597985029\", \"554\", \"20006875\", \"4588780740000\", \"4588780725000\"],\n" +
+                                "            [\"0\", \"0\", \"loobar\", null, \"4588780800\", \"-∞\", \"0\", \"20006291\", \"4588780740000\", \"4588780725000\"],\n" +
+                                "            [\"15\", \"1832\", \"monkeybar\", null, \"4588780800\", \"0.8792306185\", \"1610\", \"20004007\", \"4588780740000\", \"4588780725000\"],\n" +
+                                "            [\"0\", \"0\", \"donkeybar\", null, \"4588780800\", \"-∞\", \"0\", \"0\", \"4588780740000\", \"4588780725000\"],\n" +
+                                "            [\"1\", \"7\", \"horseybar\", null, \"4588780800\", \"0.2857142985\", \"2\", \"20016753\", \"4588780740000\", \"4588780725000\"],\n" +
+                                "            [\"0\", \"130\", \"ginbar\", null, \"4588780800\", \"0.8052611947\", \"105\", \"10000942\", \"4588780740000\", \"4588780725000\"]\n" +
                                 "        ]\n" +
                                 "    },\n" +
                                 "    \"exceptions\": [],\n" +
@@ -161,26 +190,64 @@ public class TestPinotBrokerPageSource
                                 "    \"segmentStatistics\": [],\n" +
                                 "    \"traceInfo\": {}\n" +
                                 "}",
-                        ImmutableList.of(BIGINT, BIGINT, VARCHAR, VARCHAR, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT), Optional.empty()}
+                        ImmutableList.of(bigint("activeTrips"), bigint("numDrivers"), varchar("region"), bigint("rowtime"), secondsSinceEpoch, fraction("utilization"), bigint("utilizedDrivers"), bigint("vehicleViewId"), bigint("windowEnd"), bigint("windowStart")),
+                        ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+                        ImmutableList.of(bigint("activeTrips"), bigint("numDrivers"), varchar("region"), bigint("rowtime"), secondsSinceEpoch, fraction("utilization"), bigint("utilizedDrivers"), bigint("vehicleViewId"), bigint("windowEnd"), bigint("windowStart")),
+                        Optional.empty()}
         };
     }
 
     @Test(dataProvider = "pqlResponses")
-    public void testPopulateFromPql(String pql, String pqlResponse, List<Type> types, Optional<Class<? extends PrestoException>> expectedError)
+    public void testPopulateFromPql(String pql, String pqlResponse, List<PinotColumnHandle> actualHandles,
+            List<Integer> expectedColumnIndices,
+            List<PinotColumnHandle> expectedColumnHandles,
+            Optional<Class<? extends PrestoException>> expectedError)
             throws IOException
     {
         PqlParsedInfo pqlParsedInfo = getBasicInfoFromPql(pqlResponse);
-        ImmutableList.Builder<BlockBuilder> blockBuilders = ImmutableList.builder();
-        PageBuilder pageBuilder = new PageBuilder(types);
-        PinotBrokerPageSource pageSource = getPinotBrokerPageSource();
-        for (int i = 0; i < types.size(); i++) {
-            blockBuilders.add(pageBuilder.getBlockBuilder(i));
+        PinotQueryGenerator.GeneratedPql generatedPql = new PinotQueryGenerator.GeneratedPql(
+                pinotTable.getTableName(),
+                pql,
+                expectedColumnIndices,
+                pqlParsedInfo.groupByColumns,
+                false,
+                false);
+        PinotBrokerPageSource pageSource = new PinotBrokerPageSource(
+                pinotConfig,
+                new TestingConnectorSession(ImmutableList.of()),
+                generatedPql,
+                actualHandles,
+                expectedColumnHandles,
+                new MockPinotClusterInfoFetcher(pinotConfig),
+                objectMapper);
+        PinotBrokerPageSource.BlockAndTypeBuilder blockAndTypeBuilder = new PinotBrokerPageSource.BlockAndTypeBuilder(actualHandles, generatedPql, expectedColumnHandles);
+
+        validateExpectedColumnIndices(expectedColumnIndices, expectedColumnHandles);
+        List<BlockBuilder> columnBlockBuilders = blockAndTypeBuilder.getColumnBlockBuilders();
+        List<Type> columnTypes = blockAndTypeBuilder.getColumnTypes();
+
+        assertEquals(columnTypes.size(), columnBlockBuilders.size());
+
+        int numNonNullTypes = 0;
+        for (int i = 0; i < columnTypes.size(); i++) {
+            Type type = columnTypes.get(i);
+            BlockBuilder builder = columnBlockBuilders.get(i);
+            assertEquals(type == null, builder == null);
+            if (type != null) {
+                numNonNullTypes++;
+            }
         }
+        assertEquals(numNonNullTypes, actualHandles.size());
 
         Optional<? extends PrestoException> thrown = Optional.empty();
         int rows = -1;
         try {
-            rows = pageSource.populateFromPqlResults(pql, pqlParsedInfo.groupByColumns, blockBuilders.build(), types, pqlResponse);
+            rows = pageSource.populateFromPqlResults(
+                    pql,
+                    pqlParsedInfo.groupByColumns,
+                    columnBlockBuilders,
+                    columnTypes,
+                    pqlResponse);
         }
         catch (PrestoException e) {
             thrown = Optional.of(e);
@@ -190,16 +257,22 @@ public class TestPinotBrokerPageSource
         Optional<String> errorString = thrown.map(e -> Throwables.getStackTraceAsString(e));
         assertEquals(thrownType, expectedError, String.format("Expected error %s, but got error of type %s: %s", expectedError, thrownType, errorString));
         if (!expectedError.isPresent()) {
-            assertEquals(types.size(), pqlParsedInfo.columns);
+            assertEquals(expectedColumnIndices.size(), pqlParsedInfo.columns);
             assertEquals(rows, pqlParsedInfo.rows);
         }
     }
 
-    private PinotBrokerPageSource getPinotBrokerPageSource()
+    private void validateExpectedColumnIndices(List<Integer> expectedColumnIndices, List<PinotColumnHandle> expectedColumnHandles)
     {
-        List<PinotColumnHandle> pinotColumnHandles = ImmutableList.of(regionId, fare, city, fare, secondsSinceEpoch);
-        PinotConfig pinotConfig = new PinotConfig();
-        PinotQueryGenerator.GeneratedPql generatedPql = new PinotQueryGenerator.GeneratedPql(pinotTable.getTableName(), String.format("SELECT %s, %s FROM %s LIMIT %d", city.getColumnName(), regionId.getColumnName(), pinotTable.getTableName(), pinotConfig.getLimitLargeForSegment()), ImmutableList.of(0, 1), 0, false, true);
-        return new PinotBrokerPageSource(pinotConfig, new TestingConnectorSession(ImmutableList.of()), generatedPql, pinotColumnHandles, new MockPinotClusterInfoFetcher(pinotConfig), objectMapper);
+        int numValid = 0;
+        Set<Integer> uniqueIndices = new HashSet<>();
+        for (int expectedColumnIndex : expectedColumnIndices) {
+            assertTrue(expectedColumnIndex == -1 || expectedColumnIndex >= 0 && expectedColumnIndex < expectedColumnHandles.size());
+            if (expectedColumnIndex >= 0) {
+                numValid++;
+                uniqueIndices.add(expectedColumnIndex);
+            }
+        }
+        assertEquals(numValid, uniqueIndices.size());
     }
 }

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
@@ -232,4 +232,24 @@ public class TestPinotQueryBase
     {
         return new PlanBuilder(sessionHolder.getSession(), new PlanNodeIdAllocator(), metadata);
     }
+
+    protected static PinotColumnHandle derived(String name)
+    {
+        return new PinotColumnHandle(name, BIGINT, PinotColumnHandle.PinotColumnType.DERIVED);
+    }
+
+    protected static PinotColumnHandle bigint(String name)
+    {
+        return new PinotColumnHandle(name, BIGINT, PinotColumnHandle.PinotColumnType.REGULAR);
+    }
+
+    protected static PinotColumnHandle fraction(String name)
+    {
+        return new PinotColumnHandle(name, DOUBLE, PinotColumnHandle.PinotColumnType.REGULAR);
+    }
+
+    protected static PinotColumnHandle varchar(String name)
+    {
+        return new PinotColumnHandle(name, VARCHAR, PinotColumnHandle.PinotColumnType.REGULAR);
+    }
 }


### PR DESCRIPTION
## Problem: _PruneUnreferencedOptimizer_ can prune columns after pushdown has been done.

_PruneUnreferencedOptimizer_ runs after the connector pushdown optimizer and prunes away columns it thinks are not used in the table scan node. This creates a mismatch between the generated PQL and the columns expected during actual scan. This can happen in both broker and segment pinot scan codepaths.

As an example, consider this query:
```
select count(*) from baseballstats group by teamid limit 10
```

In this query, the pinot connector sees the plan: 
```
Project (count) -> Limit 10 -> Aggregation (teamid, count(*)) -> Scan baseballstats.
```

Since projections cannot currently be pushed on top of aggregations, so only the plan until the limit is pushed down. The resulting plan looks like:
```
Project(count) -> Pushed table scan node with PQL: "select count(*) from baseballstats group by teamid".
```
Note that the pushed table scan will emit "teamid" and "count(*)". 

PruneUnreferencedOptimizer runs next and removes the "teamid" from the scan node. This creates a problem: we are emitting an extra column teamid in the PinotBrokerPageSource which the scan does not need. 

## Solution: Remember the original column handles that corresponded to the generated PQL

This PR attempts to handle this scenario: both in the broker and segment codepaths. It does so with a lot of plumbing: It remembers the original column handles when the PQL was generated in the _PinotTableHandle_. These are passed eventually to the page sources via the _PinotSplit_. 

The page source then checks which columns can be ignored or have been re-ordered. The broker page source already had some support for this (necessitated by the _hiddenColumnSet_ for handling group-by without aggregations) and I have merely generalized this support. It was also trivial to add this support to the segment page source.

Added unit tests for these conditions in the pinot broker and segment page sources.


```
== NO RELEASE NOTE ==
```
