### PR TITLE
Support compression for PageFile

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCompressionCodec.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCompressionCodec.java
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 
 import static com.facebook.presto.hive.HiveStorageFormat.DWRF;
 import static com.facebook.presto.hive.HiveStorageFormat.ORC;
+import static com.facebook.presto.hive.HiveStorageFormat.PAGEFILE;
 import static java.util.Objects.requireNonNull;
 
 public enum HiveCompressionCodec
@@ -31,6 +32,7 @@ public enum HiveCompressionCodec
     NONE(null, CompressionKind.NONE, CompressionCodecName.UNCOMPRESSED, f -> true),
     SNAPPY(SnappyCodec.class, CompressionKind.SNAPPY, CompressionCodecName.SNAPPY, f -> true),
     GZIP(GzipCodec.class, CompressionKind.ZLIB, CompressionCodecName.GZIP, f -> true),
+    LZ4(null, CompressionKind.NONE, null, f -> f == PAGEFILE),
     ZSTD(null, CompressionKind.ZSTD, null, f -> f == ORC || f == DWRF);
 
     private final Optional<Class<? extends CompressionCodec>> codec;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/AirliftCompressorAdapter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/AirliftCompressorAdapter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.pagefile;
+
+import com.facebook.presto.spi.page.PageCompressor;
+import io.airlift.compress.Compressor;
+
+import java.nio.ByteBuffer;
+
+import static java.util.Objects.requireNonNull;
+
+public class AirliftCompressorAdapter
+        implements PageCompressor
+{
+    private final Compressor compressor;
+
+    public AirliftCompressorAdapter(Compressor compressor)
+    {
+        this.compressor = requireNonNull(compressor, "compressor is null");
+    }
+
+    @Override
+    public int maxCompressedLength(int uncompressedSize)
+    {
+        return compressor.maxCompressedLength(uncompressedSize);
+    }
+
+    @Override
+    public int compress(
+            byte[] input,
+            int inputOffset,
+            int inputLength,
+            byte[] output,
+            int outputOffset,
+            int maxOutputLength)
+    {
+        return compressor.compress(input, inputOffset, inputLength, output, outputOffset, maxOutputLength);
+    }
+
+    @Override
+    public void compress(ByteBuffer input, ByteBuffer output)
+    {
+        compressor.compress(input, output);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/AirliftDecompressorAdapter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/AirliftDecompressorAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.pagefile;
+
+import com.facebook.presto.spi.page.PageDecompressor;
+import io.airlift.compress.Decompressor;
+
+import java.nio.ByteBuffer;
+
+import static java.util.Objects.requireNonNull;
+
+public class AirliftDecompressorAdapter
+        implements PageDecompressor
+{
+    private final Decompressor decompressor;
+
+    public AirliftDecompressorAdapter(Decompressor decompressor)
+    {
+        this.decompressor = requireNonNull(decompressor, "decompressor is null");
+    }
+
+    @Override
+    public int decompress(
+            byte[] input,
+            int inputOffset,
+            int inputLength,
+            byte[] output,
+            int outputOffset,
+            int maxOutputLength)
+    {
+        return decompressor.decompress(input, inputOffset, inputLength, output, outputOffset, maxOutputLength);
+    }
+
+    @Override
+    public void decompress(ByteBuffer input, ByteBuffer output)
+    {
+        decompressor.decompress(input, output);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileFooterReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileFooterReader.java
@@ -13,26 +13,35 @@
  */
 package com.facebook.presto.hive.pagefile;
 
+import com.facebook.presto.hive.HiveCompressionCodec;
+import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;
-import io.airlift.slice.SliceInput;
+import io.airlift.slice.FixedLengthSliceInput;
 import io.airlift.slice.Slices;
 import org.apache.hadoop.fs.FSDataInputStream;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
+import static com.facebook.presto.hive.HiveStorageFormat.PAGEFILE;
 import static com.facebook.presto.hive.pagefile.PageFileFooterOutput.FOOTER_LENGTH_IN_BYTES;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class PageFileFooterReader
 {
     private static final int ESTIMATED_FOOTER_SIZE = 1024;
 
-    private List<Long> stripeOffsets;
-    private long footerOffset;
+    private final List<Long> stripeOffsets;
+    private final long footerOffset;
+    private final Optional<HiveCompressionCodec> compressionCodec;
 
     public PageFileFooterReader(
             FSDataInputStream inputStream,
@@ -48,8 +57,9 @@ public class PageFileFooterReader
         int footerSize = Slices.wrappedBuffer(buffer, buffer.length - FOOTER_LENGTH_IN_BYTES, FOOTER_LENGTH_IN_BYTES).getInt(0);
 
         footerOffset = fileSize - footerSize;
+        HiveCompressionCodec compression;
         if (footerOffset < 0) {
-            throw new IOException("Malformed PageFile format, incorrect footer length.");
+            throw new PrestoException(HIVE_BAD_DATA, "Malformed PageFile format, incorrect footer length.");
         }
         else if (footerOffset > 0) {
             if (footerSize > buffer.length) {
@@ -57,15 +67,38 @@ public class PageFileFooterReader
                 inputStream.readFully(footerOffset, buffer);
             }
 
-            SliceInput sliceInput = Slices.wrappedBuffer(buffer, buffer.length - footerSize, footerSize - FOOTER_LENGTH_IN_BYTES).getInput();
+            FixedLengthSliceInput sliceInput = Slices.wrappedBuffer(buffer, buffer.length - footerSize, footerSize - FOOTER_LENGTH_IN_BYTES).getInput();
+            long remainingSize = sliceInput.length();
+            // read compression
+            int compressionStringSize = sliceInput.readInt();
+            remainingSize -= SIZE_OF_INT;
+            String compressionName = sliceInput.readSlice(compressionStringSize).toStringUtf8();
+            remainingSize -= compressionStringSize;
 
-            while (sliceInput.isReadable()) {
+            try {
+                compression = HiveCompressionCodec.valueOf(compressionName);
+            }
+            catch (Exception e) {
+                throw new PrestoException(
+                        HIVE_BAD_DATA,
+                        format("%s is invalid compression method in the footer of %s", compressionName, PAGEFILE.getInputFormat()));
+            }
+
+            // read stripeOffsets
+            int stripeCount = sliceInput.readInt();
+            remainingSize -= SIZE_OF_INT;
+            if (remainingSize != SIZE_OF_LONG * stripeCount) {
+                throw new PrestoException(HIVE_BAD_DATA, "Malformed PageFile format, incorrect stripe count.");
+            }
+            for (int i = 0; i < stripeCount; ++i) {
                 stripeOffsetsBuilder.add(sliceInput.readLong());
             }
         }
         else {
             // empty page file without stripe
+            compression = null;
         }
+        compressionCodec = Optional.ofNullable(compression);
         stripeOffsets = stripeOffsetsBuilder.build();
     }
 
@@ -77,5 +110,10 @@ public class PageFileFooterReader
     public long getFooterOffset()
     {
         return footerOffset;
+    }
+
+    public Optional<HiveCompressionCodec> getCompression()
+    {
+        return compressionCodec;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSource.java
@@ -18,13 +18,14 @@ import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.Page;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.Block;
-import com.facebook.presto.spi.page.PagesSerde;
+import com.facebook.presto.spi.block.BlockEncodingSerde;
 import org.apache.hadoop.fs.FSDataInputStream;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
+import static com.facebook.presto.hive.pagefile.PageFileWriterFactory.createPagesSerdeForPageFile;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -47,7 +48,7 @@ public class PageFilePageSource
             long start,
             long splitLength,
             long fileSize,
-            PagesSerde pagesSerde,
+            BlockEncodingSerde blockEncodingSerde,
             List<HiveColumnHandle> columns)
             throws IOException
     {
@@ -64,7 +65,9 @@ public class PageFilePageSource
                 readStartAndLength.getOffset(),
                 readStartAndLength.getLength(),
                 inputStream,
-                pagesSerde);
+                createPagesSerdeForPageFile(
+                        blockEncodingSerde,
+                        pageFileFooterReader.getCompression()));
 
         int size = requireNonNull(columns, "columns is null").size();
         this.hiveColumnIndexes = new int[size];

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriter.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.pagefile;
 
+import com.facebook.presto.hive.HiveCompressionCodec;
 import com.facebook.presto.hive.HiveFileWriter;
 import com.facebook.presto.orc.DataSink;
 import com.facebook.presto.spi.Page;
@@ -35,12 +36,13 @@ public class PageFileWriter
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(PageFileWriter.class).instanceSize();
 
     private final PageWriter pageWriter;
-    private final Callable<Void> rollbackAction;
     private final PagesSerde pagesSerde;
+    private final Callable<Void> rollbackAction;
 
     public PageFileWriter(
             DataSink dataSink,
             PagesSerde pagesSerde,
+            HiveCompressionCodec compression,
             DataSize pageFileStripeMaxSize,
             Callable<Void> rollbackAction)
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriter.java
@@ -46,7 +46,7 @@ public class PageFileWriter
             DataSize pageFileStripeMaxSize,
             Callable<Void> rollbackAction)
     {
-        pageWriter = new PageWriter(dataSink, pageFileStripeMaxSize);
+        pageWriter = new PageWriter(dataSink, compression, pageFileStripeMaxSize);
         this.pagesSerde = requireNonNull(pagesSerde, "pagesSerde is null");
         this.rollbackAction = requireNonNull(rollbackAction, "rollbackAction is null");
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriterFactory.java
@@ -20,6 +20,8 @@ import com.facebook.presto.hive.HiveFileWriterFactory;
 import com.facebook.presto.hive.metastore.StorageFormat;
 import com.facebook.presto.orc.DataSink;
 import com.facebook.presto.orc.OutputStreamDataSink;
+import com.facebook.presto.orc.zlib.DeflateCompressor;
+import com.facebook.presto.orc.zlib.InflateDecompressor;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.block.BlockEncodingSerde;
@@ -137,6 +139,10 @@ public class PageFileWriterFactory
             case LZ4:
                 pageCompressor = new AirliftCompressorAdapter(new Lz4Compressor());
                 pageDecompressor = new AirliftDecompressorAdapter(new Lz4Decompressor());
+                break;
+            case GZIP:
+                pageCompressor = new AirliftCompressorAdapter(new DeflateCompressor());
+                pageDecompressor = new AirliftDecompressorAdapter(new InflateDecompressor());
                 break;
             default:
                 throw new PrestoException(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriterFactory.java
@@ -27,6 +27,8 @@ import com.facebook.presto.spi.page.PageCompressor;
 import com.facebook.presto.spi.page.PageDecompressor;
 import com.facebook.presto.spi.page.PagesSerde;
 import com.google.common.collect.ImmutableList;
+import io.airlift.compress.lz4.Lz4Compressor;
+import io.airlift.compress.lz4.Lz4Decompressor;
 import io.airlift.compress.snappy.SnappyCompressor;
 import io.airlift.compress.snappy.SnappyDecompressor;
 import org.apache.hadoop.fs.FileSystem;
@@ -131,6 +133,10 @@ public class PageFileWriterFactory
             case SNAPPY:
                 pageCompressor = new AirliftCompressorAdapter(new SnappyCompressor());
                 pageDecompressor = new AirliftDecompressorAdapter(new SnappyDecompressor());
+                break;
+            case LZ4:
+                pageCompressor = new AirliftCompressorAdapter(new Lz4Compressor());
+                pageDecompressor = new AirliftDecompressorAdapter(new Lz4Decompressor());
                 break;
             default:
                 throw new PrestoException(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/ConfigurationUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/ConfigurationUtils.java
@@ -31,6 +31,7 @@ import static org.apache.hadoop.io.SequenceFile.CompressionType.BLOCK;
 
 public final class ConfigurationUtils
 {
+    public static final String PAGE_FILE_COMPRESSION = "pagefile.output.compression";
     private static final Configuration INITIAL_CONFIGURATION;
 
     static {
@@ -116,5 +117,7 @@ public final class ConfigurationUtils
         compression.getParquetCompressionCodec().ifPresent(codec -> config.set(ParquetOutputFormat.COMPRESSION, codec.name()));
         // For SequenceFile
         config.set(FileOutputFormat.COMPRESS_TYPE, BLOCK.toString());
+        // For PageFile
+        config.set(PAGE_FILE_COMPRESSION, compression.name());
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -63,7 +63,6 @@ import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTAN
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveCompressionCodec.NONE;
 import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
-import static com.facebook.presto.hive.HiveStorageFormat.PAGEFILE;
 import static com.facebook.presto.hive.HiveTestUtils.PAGE_SORTER;
 import static com.facebook.presto.hive.HiveTestUtils.ROW_EXPRESSION_SERVICE;
 import static com.facebook.presto.hive.HiveTestUtils.TYPE_MANAGER;
@@ -121,10 +120,6 @@ public class TestHivePageSink
 
                 for (HiveCompressionCodec codec : HiveCompressionCodec.values()) {
                     if (codec == NONE || !codec.isSupportedStorageFormat(format)) {
-                        continue;
-                    }
-                    // No compression support needed for PAGEFILE
-                    if (format == PAGEFILE) {
                         continue;
                     }
                     config.setCompressionCodec(codec);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -673,6 +673,7 @@ public enum FileFormat
         {
             writer = new PageWriter(
                     new OutputStreamDataSink(new FileOutputStream(targetFile)),
+                    HiveCompressionCodec.NONE,
                     new DataSize(10, DataSize.Unit.MEGABYTE));
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
@@ -15,6 +15,7 @@ package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.checkpoint.InputStreamCheckpoint;
 import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.zlib.DeflateCompressor;
 import com.facebook.presto.orc.zstd.ZstdJniCompressor;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.compress.Compressor;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/zlib/InflateDecompressor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/zlib/InflateDecompressor.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.zlib;
+
+import io.airlift.compress.Decompressor;
+import io.airlift.compress.MalformedInputException;
+
+import java.nio.ByteBuffer;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
+
+public class InflateDecompressor
+        implements Decompressor
+{
+    @Override
+    public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+            throws MalformedInputException
+    {
+        Inflater inflater = new Inflater(true);
+        inflater.setInput(input, inputOffset, inputLength);
+        int uncompressedLength = 0;
+        try {
+            uncompressedLength = inflater.inflate(output, outputOffset, maxOutputLength);
+            if (!inflater.finished()) {
+                throw new IllegalArgumentException("maxOutputLength is incorrect, there is more data to be decompressed");
+            }
+        }
+        catch (DataFormatException e) {
+            throw new MalformedInputException(inputOffset, e.getMessage());
+        }
+        finally {
+            inflater.end();
+        }
+        return uncompressedLength;
+    }
+
+    @Override
+    public void decompress(ByteBuffer input, ByteBuffer output)
+            throws MalformedInputException
+    {
+        if (input.isDirect() || output.isDirect() || !input.hasArray() || !output.hasArray()) {
+            throw new IllegalArgumentException("Non-direct byte buffer backed by byte array required");
+        }
+        int inputOffset = input.arrayOffset() + input.position();
+        int outputOffset = output.arrayOffset() + output.position();
+
+        int written = decompress(input.array(), inputOffset, input.remaining(), output.array(), outputOffset, output.remaining());
+        output.position(output.position() + written);
+    }
+}


### PR DESCRIPTION
A pagefile footer has three parts

1. Compression

- compression string length and compression name

2. StripOffsets
- Count of stripes and offset of each stripe
3. Size of entire footer length in integer


![pagefile_compression_test](https://user-images.githubusercontent.com/6372365/80649178-86f50a00-8a3f-11ea-8120-0fa4f511b7ff.png)
```
== NO RELEASE NOTE ==
```