### PR TITLE
Fix integer overflow when creating a BigIntValues Filter

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilterUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilterUtils.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Type;
 import io.airlift.slice.Slice;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
 
@@ -347,7 +348,10 @@ public class TupleDomainFilterUtils
         // slots in a hash table), e.g. up to 192 bits per value.
         // Filter based on a bitmap uses (max - min) / num-values bits per value.
         // Choose the filter that uses less bits per value.
-        if ((max - min + 1) > Integer.MAX_VALUE || ((max - min + 1) / values.length) > 192) {
+        BigInteger range = BigInteger.valueOf(max)
+                .subtract(BigInteger.valueOf(min))
+                .add(BigInteger.valueOf(1));
+        if (range.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) == 1 || (range.intValueExact() / values.length) > 192) {
             return BigintValuesUsingHashTable.of(min, max, values, nullAllowed);
         }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilterUtils.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainFilterUtils.java
@@ -230,6 +230,8 @@ public class TestTupleDomainFilterUtils
         assertEquals(toFilter(not(greaterThanOrEqual(C_BIGINT, bigintLiteral(2L)))), BigintRange.of(Long.MIN_VALUE, 1L, false));
 
         assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(1, 10, 100_000))), BigintValuesUsingHashTable.of(1, 100_000, new long[] {1, 10, 100_000}, false));
+        assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(Long.MIN_VALUE, 10, 100_000))), BigintValuesUsingHashTable.of(Long.MIN_VALUE, 100_000, new long[] {Long.MIN_VALUE, 10, 100_000}, false));
+        assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(Long.MIN_VALUE, Long.MAX_VALUE, 0))), BigintValuesUsingHashTable.of(Long.MIN_VALUE, Long.MAX_VALUE, new long[] {Long.MIN_VALUE, 0, Long.MAX_VALUE}, false));
         assertEquals(toFilter(in(C_BIGINT, ImmutableList.of(1, 10, 100))), BigintValuesUsingBitmask.of(1, 100, new long[] {1, 10, 100}, false));
         assertEquals(toFilter(not(in(C_BIGINT, ImmutableList.of(1, 10, 100)))), BigintMultiRange.of(ImmutableList.of(
                 BigintRange.of(Long.MIN_VALUE, 0L, false),


### PR DESCRIPTION
Fix Int overflow exception which is caused when calculating (max - min + 1 ) because of long wrap around. 

Fixes #14469 
```
== NO RELEASE NOTE ==
```
