### PR TITLE
Simplify searched case translation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
@@ -15,9 +15,12 @@ package com.facebook.presto.sql.analyzer;
 
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.DefaultExpressionTraversalVisitor;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.InListExpression;
+import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.google.common.collect.ImmutableList;
@@ -95,5 +98,15 @@ public final class ExpressionTreeUtils
             }
         }.process(node, null);
         return nodes.build();
+    }
+
+    public static boolean isEqualComparisonExpression(Expression expression)
+    {
+        return expression instanceof ComparisonExpression && ((ComparisonExpression) expression).getOperator() == ComparisonExpression.Operator.EQUAL;
+    }
+
+    public static boolean isInValuesComparisonExpression(Expression expression)
+    {
+        return expression instanceof InPredicate && ((InPredicate) expression).getValueList() instanceof InListExpression;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -94,6 +94,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.spi.plan.AggregationNode.singleGroupingSet;
+import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.isEqualComparisonExpression;
 import static com.facebook.presto.sql.analyzer.SemanticExceptions.notSupportedException;
 import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identitiesAsSymbolReferences;
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.asSymbolReference;
@@ -551,11 +552,6 @@ class RelationPlanner
                 .addAll(rightPlan.getRoot().getOutputVariables())
                 .build();
         return new RelationPlan(planBuilder.getRoot(), analysis.getScope(join), outputVariables);
-    }
-
-    private static boolean isEqualComparisonExpression(Expression conjunct)
-    {
-        return conjunct instanceof ComparisonExpression && ((ComparisonExpression) conjunct).getOperator() == ComparisonExpression.Operator.EQUAL;
     }
 
     private RelationPlan planCrossJoinUnnest(RelationPlan leftPlan, Join joinNode, Unnest node)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -323,21 +323,20 @@ public class RowExpressionInterpreter
                 case IF: {
                     checkArgument(node.getArguments().size() == 3);
                     Object condition = processWithExceptionHandling(node.getArguments().get(0), context);
-                    Object trueValue = processWithExceptionHandling(node.getArguments().get(1), context);
-                    Object falseValue = processWithExceptionHandling(node.getArguments().get(2), context);
 
                     if (condition instanceof RowExpression) {
                         return new SpecialFormExpression(
                                 IF,
                                 node.getType(),
                                 toRowExpression(condition, node.getArguments().get(0)),
-                                toRowExpression(trueValue, node.getArguments().get(1)),
-                                toRowExpression(falseValue, node.getArguments().get(2)));
+                                toRowExpression(processWithExceptionHandling(node.getArguments().get(1), context), node.getArguments().get(1)),
+                                toRowExpression(processWithExceptionHandling(node.getArguments().get(2), context), node.getArguments().get(2)));
                     }
                     else if (Boolean.TRUE.equals(condition)) {
-                        return trueValue;
+                        return processWithExceptionHandling(node.getArguments().get(1), context);
                     }
-                    return falseValue;
+
+                    return processWithExceptionHandling(node.getArguments().get(2), context);
                 }
                 case NULL_IF: {
                     checkArgument(node.getArguments().size() == 2);

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestExpressionInterpreter.java
@@ -889,9 +889,6 @@ public class TestExpressionInterpreter
                         "else 1 " +
                         "end");
 
-        assertOptimizedMatches("case when 0 / 0 = 0 then 1 end",
-                "case when cast(fail(8, 'ignored failure message') as boolean) then 1 end");
-
         assertOptimizedMatches("if(false, 1, 0 / 0)", "cast(fail(8, 'ignored failure message') as integer)");
 
         assertOptimizedEquals("case " +

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -8301,7 +8301,7 @@ public abstract class AbstractTestQueries
     @Test
     public void testLargeBytecode()
     {
-        StringBuilder stringBuilder = new StringBuilder("SELECT x FROM (SELECT orderkey x, custkey y from orders limit 10) WHERE CASE");
+        StringBuilder stringBuilder = new StringBuilder("SELECT x FROM (SELECT orderkey x, custkey y from orders limit 10) WHERE CASE true ");
         // Generate 100 cases.
         for (int i = 0; i < 100; i++) {
             stringBuilder.append(" when x in (");
@@ -8334,6 +8334,18 @@ public abstract class AbstractTestQueries
         query.append("ROW(32)) ");
         query.append("FROM (values(null)) as t (null_value)");
         assertQuery(query.toString(), "SELECT NULL");
+    }
+
+    @Test
+    public void testRowExpressionInterpreterStackOverflow()
+    {
+        StringBuilder stringBuilder = new StringBuilder("SELECT  CASE");
+        for (int i = 1; i <= 500; i++) {
+            stringBuilder.append(" when x = random(" + i + ") then " + i);
+        }
+
+        stringBuilder.append(" else x end from (select -1 x)");
+        assertQuery(stringBuilder.toString(), "values -1");
     }
 
     protected Session noJoinReordering()


### PR DESCRIPTION
Currently, SearchedCase is translated as nested IF expressions and even with 500 cases, we generate a complicated expression potentially causing stack overflows. So the fix is to translate searched case as:

CASE TRUE WHEN p1 THEN r1 WHEN p2 THEN r2.. ELSE r_else END

which will result in SWITCH operator which is flatter.

Also, fixed RowExpressionInterpreter to not call then part and else part unconditionally in interpreting IF.

```
== RELEASE NOTES ==

General Changes
* Fixed translation of searched case expressions to be flat

```
