### PR TITLE
FastutilSetHelper ObjectStrategy#equals result can be null.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/FastutilSetHelper.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/FastutilSetHelper.java
@@ -204,8 +204,6 @@ public final class FastutilSetHelper
         {
             try {
                 Boolean result = (Boolean) equalsHandle.invokeExact(a, b);
-                // FastutilHashSet is not intended be used for indeterminate values lookup
-                verify(result != null, "result is null");
                 return TRUE.equals(result);
             }
             catch (Throwable t) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -8316,6 +8316,26 @@ public abstract class AbstractTestQueries
         assertQueryFails(stringBuilder.toString(), "Query results in large bytecode exceeding the limits imposed by JVM|Compiler failed");
     }
 
+    @Test
+    public void testInComplexTypes()
+    {
+        //test cases to trigger the SET_CONTAINS path of InCodeGenerator.java with complex types
+        StringBuilder query = new StringBuilder("select * from (values('a'), (null)) as t (name) where ROW('1', name) IN ( ");
+        for (int i = 2; i < 32; i++) {
+            query.append(String.format("ROW('1','%s'), ", i));
+        }
+        query.append("ROW('1', name), ROW('2',name), ROW('3',name))");
+        assertQuerySucceeds(query.toString());
+
+        query = new StringBuilder("select ROW(null_value) IN ( ");
+        for (int i = 0; i < 32; i++) {
+            query.append(String.format("ROW(%s), ", i));
+        }
+        query.append("ROW(32)) ");
+        query.append("FROM (values(null)) as t (null_value)");
+        assertQuery(query.toString(), "SELECT NULL");
+    }
+
     protected Session noJoinReordering()
     {
         return Session.builder(getSession())


### PR DESCRIPTION
We're seeing some queries fail due to this [verify](https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/util/FastutilSetHelper.java#L208) check. The assumption here seems to be that ```SET_CONTAINS``` would be used only for non-complex types, but it reality can also be used for complex types - eg: the test case included in [TestHivePushdownFilterQueries](presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java)  

```
== NO RELEASE NOTE ==
```