### PR TITLE
Add release notes for 0.235

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.235
     release/release-0.234.2
     release/release-0.234.1
     release/release-0.234

--- a/presto-docs/src/main/sphinx/release/release-0.235.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.235.rst
@@ -1,0 +1,56 @@
+=============
+Release 0.235
+=============
+
+General Changes
+_______________
+* Fix named queries where its output does not match its column list (:issue:`14333`).
+* Fix issue where queries with large filters in the where clause would cause excessive memory usage.  Now such queries will fail quickly with ``GENERATED_BYTECODE_TOO_LARGE``.
+* Improve performance of ``UNNEST``.
+* Improve ``CREATE FUNCTION`` to allow parameter type list and return type to have a length up to 30k characters.
+* Add optimization for filters and projections to extract common subexpressions and evaluate them only once.  This optimization can be turned off by the session property ``optimize_common_sub_expressions``.
+* Add support for ``SHOW CREATE FUNCTION``.
+* Add soft memory limit configuration properties. Soft memory limits are default memory limits given to each query that can be overridden using session properties up to the hard limit set by the existing configuration properties. Available soft memory limit configuration properties are ``query.soft-max-memory-per-node``, ``query.soft-max-total-memory-per-node``, ``query.soft-max-total-memory``, and ``query.soft-max-memory``.
+* Add check to disallow invoking SQL functions in SQL function body.
+* Add support for limiting the total number of buffers per optimized repartitioning operator. The limit can be set by the configuration property ``driver.max-page-partitioning-buffer-count``.
+* Add peak task total memory to query stats.
+* Add :func:`scale_qdigest` function to scale a ``qdigest`` to a new weight.
+* Add :func:`myanmar_font_encoding` and :func:`myanmar_normalize_unicode` to support working with Burmese text
+* Add support for :func:`ST_AsText` to accept Spherical Geographies.
+* Add support for :func:`ST_Centroid` to accept Spherical Geography Points and MultiPoints.
+
+Pinot Connector Changes
+_______________________
+* Add support for mapping Pinot ``BYTES`` data type to Presto ``VARBINARY`` type.
+* Add support for mapping Pinot time fields with days since epoch value to Presto ``DATE`` type via the system property ``pinot.infer-date-type-in-schema``.
+* Add support for mapping Pinot time fields with milliseconds since epoch value to Presto ``TIMESTAMP`` type via the system prpoerty ``pinot.infer-timestamp-type-in-schema``.
+* Add Pinot Field type in to column comment field shown as ``DIMENSION``, ``METRIC``, ``TIME``, ``DATETIME``, to provide more information.
+* Add support for pushing down distinct count query to Pinot on a best-effort basis.
+* Add support for new Pinot Routing Table APIs.
+
+Hive Connector Changes
+______________________
+* Fix a bug in Hive split calculation which affects Parquet reader in few corner cases.
+* Fix ZSTD compression issue with zero row file for missing buckets.
+* Fix AWS client metric reporting when using S3 select.
+* Add AWS client retry pause time metrics to ``PrestoS3FileSystemStats``.
+* Add table property ``preferred_ordering_columns`` to support writing sorted files for unbucketed table.
+* Add native Parquet Writer for Presto.
+* Add support for impersonation access by using HMS delegation token.
+* Add support for multi-HMS instances load balancing and breakdown metrics by HMS hosts.
+* Add support in file status cache to cache all tables. This could be enabled by setting the configuration property ``hive.file-status-cache-tables`` to ``*``.
+* Add configuration property ``hive.orc-compression-codec`` to override ``hive.compression-codec`` for ORC and DWRF formats. If specified, ORC and DWRF files are compressed using this codec. RC, Parquet, and other files are compressed using hive.compression-codec.
+
+Druid Connector Changes
+_______________________
+* Fix druid connector segment scan.
+* Fix an issue where distinct is not respected in count aggregation.
+* Add support for query processing pushdown via the ``druid.compute-pushdown-enabled`` configuration property.
+
+Verifier Changes
+________________
+* Fix an issue where resubmitted queries always fail.
+* Add support for verifying ``SELECT`` queries that produce columns of ``TIME``, ``TIMESTAMP WITH TIME ZONE``, or ``DECIMAL`` types, or columns of structured types with those types.
+* Add support for specifying table properties override for temporary Verifier tables, through configuration property ``control.table-properties`` and ``test.table-properties``.
+* Add support to output verification results for failures due to Verifier internal errors.
+* Add support to skip teardown queries in case control and test queries succeeds but verification fails. This can be enabled by configuration property ``smart-teardown``, which replaces ``run-teardown-on-result-mismatch``.


### PR DESCRIPTION
# Missing Release Notes
## Andrii Rosa
- [x] https://github.com/prestodb/presto/pull/14451 Fix interruption handling in Driver (Merged by: Andrii Rosa)
- [x] https://github.com/prestodb/presto/pull/14452 Refactor presto spark launcher (Merged by: Andrii Rosa)
- [x] https://github.com/prestodb/presto/pull/14356 Revert #13699 (Merged by: Andrii Rosa)

## John Roll
- [x] https://github.com/prestodb/presto/pull/14331 EXPLAIN (TYPE IO) support for Aria (Merged by: Maria Basmanova)

## Nick LaGrow
- [x] https://github.com/prestodb/presto/pull/14352 Add Internationalization (i18n) plugin and Myanmar UDFs (Merged by: Rongrong Zhong)

## Rohit Jain
- [x] https://github.com/prestodb/presto/pull/14407 Add config for orc compression codec (Merged by: Maria Basmanova)
- [x] https://github.com/prestodb/presto/pull/14396 Remove compression for creating zero row file for missing buckets (Merged by: Maria Basmanova)
- [x] https://github.com/prestodb/presto/pull/14244 Add ExtendedFileSystem (Merged by: James Sun)

## Tim Meehan
- [x] https://github.com/prestodb/presto/pull/14443 Add function scale_qdigest (Merged by: Leiqing Cai)

## Vic Zhang
- [x] https://github.com/prestodb/presto/pull/14329 Simple PageFile format (Merged by: Andrii Rosa)

## Wenlei Xie
- [x] https://github.com/prestodb/presto/pull/13854 Support table write commit in Presto on Spark (Merged by: Andrii Rosa)

## miller
- [x] https://github.com/prestodb/presto/pull/14458 read druid query response stream by page (Merged by: Zhenxiao Luo)
- [x] https://github.com/prestodb/presto/pull/14438 presto-druid changed (Merged by: Zhenxiao Luo)

# Extracted Release Notes
- #13699 (Author: Curt): HMS Impersonation Access and breakdown metrics by hosts
  - Impersonation Access by using HMS delegation token.
  - Enable multi HMS instances load balancing and breakdown metrics by HMS hosts.
- #13746 (Author: Ying Su): Optimize UNNEST
  - Improve performance of UnnestOperator.
- #14214 (Author: Leiqing Cai): Verifier fixes and improvements
  - Fix an issue where resubmitted queries always fail.
  - Add support to output verification results for failures due to Verifier internal errors.
  - Add support to skip teardown queries in case control and test queries succeeds but verification fails. This can be enabled by configuration property ``smart-teardown``, which replaces ``run-teardown-on-result-mismatch``.
- #14255 (Author: Leiqing Cai): Relax length limit of parameter type list and return type
  - Improve ``CREATE FUNCTION`` to allow parameter type list and return type to have a length up to 30k characters.
- #14275 (Author: Xiang Fu): Upgrade presto pinot connector to be compatible with new Broker routing and time boundary APIs in Pinot 0.3.0 release
  - Adding support for new Pinot Routing Table APIs.
- #14302 (Author: David Taieb): Add ST_Centroid for points, multi-points on a sphere
  - Add support for :func:`ST_AsText` to accept Spherical Geographies.
  - Add support for :func:`ST_Centroid` to accept Spherical Geography Points and MultiPoints.
- #14303 (Author: Rongrong Zhong): Extract common subexpression in page projection at codegen
  - Add optimization for page projection by extract and compute common subexpressions among all projections first. This optimization can be turned off by session property ``optimize_common_sub_expressions``.
- #14320 (Author: Ying Su): Add max buffer count config property for optimized repartitioning
  - Add config property driver.max-page-partitioning-buffer-count, to limit the total number of buffers per optimized repartitioning operator. The default value is 1,000,000.
- #14322 (Author: Xiang Fu): Adding more support for  Pinot types to Presto type conversion
  - Support mapping Pinot `BYTES` data type to Presto `VARBINARY` type.
  - Support mapping Pinot time fields with days since epoch value to Presto `DATE` type.
  - Support mapping Pinot time fields with milliseconds since epoch value to Presto `TIMESTAMP` type.
  - Put Pinot Field type in to column comment field shown as DIMENSTION, METRIC, TIME, DATETIME, to provide more information.
  - Adding configs 'pinot.infer-date-type-in-schema' and 'pinot.infer-timestamp-type-in-schema' to switch on/off the type conversion. Default is OFF.
- #14324 (Author: Ariel Weisberg): Add peak [task] total memory to returned stats 
  - Add peak [task] total memory to returned stats.
- #14326 (Author: Shixuan Fan): Support caching all tables in file status cache
  - Added support in file status cache to cache all tables. This could be enabled by setting ``hive.file-status-cache-tables`` to ``*``.
- #14332 (Author: Leiqing Cai): Make table properties a config property
  - Add support for specifying table properties override for temporary Verifier tables, through configuration property ``control.table-properties`` and ``test.table-properties``.
- #14334 (Author: Rongrong Zhong): Fix named query output does not match column list
  - Fix VerifyException when named query is a table reference (:issue:`14333`).
- #14335 (Author: Zhenxiao Luo): Add native parquet writer
  - Native Parquet Writer for Presto.
- #14340 (Author: Rongrong Zhong): Fix NullPointerExpression in ExpressionInterpreter::visitBindExpression
  - Fix potential `NullPointerException` in `ExpressionInterpreter::visitBindExpression` when processed values contain `null`.
- #14341 (Author: Xiang Fu): Best effort push down distinct count to pinot
  - Add capability to push down distinct count query to Pinot with best effort.
- #14354 (Author: Leiqing Cai): Support verifying SELECT queries with certain non-storable columns
  - Add support for verifying ``SELECT`` queries that produce columns of ``TIME``, ``TIMESTAMP WITH TIME ZONE``, or ``DECIMAL`` types, or columns of structured types with those types.
- #14355 (Author: Venki Korukanti): Pass the correct value for fileSize in Hive internal split factory
  - Fix a bug in Hive split calculation which affects Parquet reader in few corner cases.
- #14365 (Author: Leiqing Cai): Disallow invoking SQL functions in SQL function body
  - Add check to disallow invoking SQL functions in SQL function body.
- #14366 (Author: Leiqing Cai): Support SHOW CREATE FUNCTION
  - Add support for SHOW CREATE FUNCTION.
- #14372 (Author: Zhenxiao Luo): count distinct pushdown for druid connector
  - Count distinct pushdown for druid connector.
  - Fix druid connector segment scan.
- #14383 (Author: Shixuan Fan): Add preferred ordering columns for unbucketed table
  - Added table property preferred_ordering_columns to support writing sorted files for unbucketed table. The list of ordering columns could be specified using the preferred_ordering_columns table property.
- #14386 (Author: Ariel Weisberg): Add soft memory limit configuration properties
  - Add soft memory limit configuration properties. Soft memory limits are default memory limits given to each query that can be overridden using session properties up to the hard limit set by the existing configuration properties. Available soft memory limit configuration properties are ``query.soft-max-memory-per-node``, ``query.soft-max-total-memory-per-node``, ``query.soft-max-total-memory``, and ``query.soft-max-memory``.
- #14393 (Author: James Petty): Refactor AWS SDK client metrics collection
  - Add AWS client retry pause time metrics to PrestoS3FileSystemStats.
  - Fix AWS client metric reporting when using S3 select.
- #14435 (Author: Zhenxiao Luo): Add session property for druid connector
  - Session property, druid.pushdown, it added, to control whether to pushdown all query processing to druid.
- #14449 (Author: Rongrong Zhong): Cse filter
  - Enable `optimize_common_sub_expressions` for filter.
- #14463 (Author: Sreeni Viswanadha): Error on excessively large code generation
  - Call the ASM's simple ClassWriter with COMPUTE_MAXS flag to flush out things like code size too big before we do the expensive COMPUTE_FRAMES call which can result in worker GC storms.

# All Commits
- c609bf9cf4c497eb11f2f933269063238df52899 Prevent ASM library causing worker GC storms. (Sreeni Viswanadha)
- b13f60bd4d27395d059756dce944b86b6b419694 Pre-calculate nested positions array size in BlockEncodingBuffer (Ying Su)
- a75114b306232a7565075da4f53cb83a9157ca62 Enable common sub expression optimization in PageFunctionCompiler filter (Rongrong Zhong)
- f9f9d83c84dbb35fc49e5b4c70326024d8ff3d1e Support SHOW CREATE FUNCTION (Leiqing Cai)
- ecfe63ece55cf63e49cd9da00bdd55c691faf77b Unify QualifiedName to QualifiedFunctionName conversion (Leiqing Cai)
- b6659dac0d67ff8dc80561b97fb0794a9a7eb0f8 Performance benchmark for common sub expression projection (Rongrong Zhong)
- c096a8e9a913939e632bf86bc1c3fb34fd8d9e02 Generate projection bytecode based on common sub expression (Rongrong Zhong)
- bc8e55724705f209977ac368ab9815a4da7e0a44 Change PageFunctionCompiler to compile a list of projections (Rongrong Zhong)
- a95a5bf3eb305992e6cd45ffd1cea83549e6e465 Remove PageProjection::getType (Rongrong Zhong)
- ee1f00442f315024c1d1e8703f7c66a0587050b2 Add API in PageFunctionCompiler to compile a list of projections (Rongrong Zhong)
- 555df6a06ceda5a8bc43928486bd12820eb71b72 Change PageProjection to produce List<Block> (Rongrong Zhong)
- 1361d6df2052191e7997f2104f59f11c4e59456d Fix named query output does not match column list (Rongrong Zhong)
- a5a04929e51756cac167c14cf73399a0df74f4c5 Fix invalid quantile to be a user error (Tim Meehan)
- 34500b106c5309ac5c6e2b9af71e114da60fd838 Add function scale_qdigest (Tim Meehan)
- 52eaac51fbc9a3e15857266ca06b4ec5db64ded4 Fix interruption handling in Driver (Andrii Rosa)
- 84451771c18eed5c81a6c8a4e077c8f87de9a1d2 read druid query response stream by page (miller)
- c9f3fb634808508c3245ef88fe54745bc76f358b Refactor presto spark launcher (Andrii Rosa)
- 22d97dde8c213eeb345ca3a9ac62aac6ce567bbb Fix duplicated table name in TestHiveIntegrationSmokeTest (Vic Zhang)
- aaeaa5ba217dc5af865e624b388823be86d8f03b Remove positionCount check in createRandomLongDecimalsBlock (Ying Su)
- ca3f93f2597303657dd9a07a5affd6547d6a171c Fix "bound must be positive" exception when creating DictionaryBlock (Ying Su)
- 0a0c6ff04654b61140ae9a0aef2a04ac735c6a2a Support splittable read of PageFile (Vic Zhang)
- f8fac992cdcb0c1a74f660e30f7c422a1f00491a Create zero row file for PageFile format (Vic Zhang)
- 1cc59eb4d01692f8ec43810c46b59a58820b29d8 Add footer to PageFile format (Vic Zhang)
- 2bfddd03187f5e81da333fe31fbf5ece21607d68 Support table write commit in Presto on Spark (Wenlei Xie)
- c93c8ce8dcd3763b79eeb3f947f17058345ce54f Introduce PageSinkCommitStrategy (Wenlei Xie)
- 8df52544dbda9aa23d0379c39ca84df3673c565e Rename partition / lifespan commit into page sink commit (Andrii Rosa)
- 2c9385a1f03e75d30e9cd5070138740d5ec1f10d Rename PageSinkProperties#isPartitionCommitRequired (Wenlei Xie)
- b4f826e1f6a7f1ce33d4d4a3da68826e79a099cc Refactor HiveWriterFactory (Wenlei Xie)
- 0e6c5ffd1df775e5da562fa1f0a809ccdbf94939 Fix query client timeout (Tim Meehan)
- 34b3f6a75b333d5c072bd81e0638ee7711bb68a1 Add session property for druid connector (Zhenxiao Luo)
- a20247b1e77890381faa068b5564af8066031feb escape keyword for druid column name (miller)
- 7a988d5657d537516317c362be2d015dd5ff8417 Fix float value for druid connector (miller)
- 353853bde9f528441c8fa4f70f1d9a5d31acc497 add presto-druid connector to server tarball (miller)
- 4405e0cbc7af572d4457b5d6331fa59912a68af4 Allow queued queries to be preempted and canceled (Tim Meehan)
- 25fe380c3305b0d744abe252dbebaa6e5405382e Fix QueryResource for queued queries (Tim Meehan)
- 90e74057d960665351529af8e2bc582947f2884e Display built-in functions first in SHOW FUNCTIONS (Leiqing Cai)
- b61e0b698a0722a312e36eedba6a120c3c5d6e1f Use shared metrics collector in PestoS3ClientFactory (James Petty)
- ab241b8443c7ba6102f93de836fde9c43724f37d Refactor AWS SDK Client Metrics Collection (James Petty)
- 22a421bb426ca9fc848c8b37ecc37bdfe8872ca0 Remove unused code from TestRowBasedSerialization#testRandomBlocks (Ying Su)
- fc81c05a26cec5d8f532c613161d6709bd478db7 Refactor flattenCollection to GeometryUtils (James A. Gill)
- 8f7edbd6b2d491b6c124cbdd0e27c3015a98f728 Add config for orc compression codec (Rohit Jain)
- f220d7f47f0fa0f8f9dc5bc446903f0cbffe170b Add soft memory limit configuration properties (Ariel Weisberg)
- 6aac57fee4b1f177330e4c164b703209da5934ee Clean up PlanOptimizerProvider while dropping connector (Yubin Li)
- 7a01f2be75286cc3ba2cfe15939f5d5773d95822 Make parquet's schema check more tolerant for adding and removing sub-field in struct (Beinan Wang)
- 746c290a0374c987fc8935ff7e3eb1df34a46d9b add unit test for parquet schema mismatch checker and fix code review issues (Beinan Wang)
- 5368a56d78ed72ad5e1ccf2d025083ec98f5935c Use field name for Parquet schema mismatch checking (Beinan Wang)
- e1ddc0e2cdfd3ed5089e55b7c1c20d84bc491381 Fix writing tables with preferred ordering using temp path (Shixuan Fan)
- 957ee09d43ca50bd1902f019a82cb251824420bc Drop presto-orc's dependency on presto-array (Nikhil Collooru)
- 8f12b44d803a5fd1d47fff358d6cd69eaeb6d161 Fix estimatedSerializedSizeInBytes calculation in ColumnarXXX (Ying Su)
- 96c6da60bbe9df7031d75ab88e82b5a31dcbdc61 Improve BenchmarkUnnestOperator (Ying Su)
- 6e09add9d0ad7968c7644065cef15efc7f259845 Optimize Unnest (Ying Su)
- aa240aa73d114081d254abf7e86a225b46cec7ef Refactor Unnester (Ying Su)
- 36df11f11116cc0a5f66ca0d9d49bd76aa7b3968 Refactor UnnestOperator (Ying Su)
- 78225ade5d59640fff8ca3362bf77c56a4d6315a Add appendNull() to Block interface (Ying Su)
- e64bb52f1f4585979c3b00d521ab11dae46644ee Add support for generating blocks and pages with specified percentage of nulls (Ying Su)
- 01d9ef470f3ef81c444fcf3a66affbd19a70551b Add benchmark for copying blocks (Ying Su)
- 3e4f18232ef791188f3388377fc0889922f23333 Add preferred ordering columns for unbucketed table (Shixuan Fan)
- 77530ba5863c1ff3952555e51844c1ae6802058d Move sorting column string conversion methods into SortingColumn (Shixuan Fan)
- bf4485f24780320a2194e7bb2c5676f2bd85b39c Replace comma string with static constant COMMA (Shixuan Fan)
- c8dbd9a149229d1912f0280fbcd340beee7ea7f1 Fix WarningsCollector (Tim Meehan)
- dd0a82f449b5d5088a443c5284c1fd7f140cb65f Remove deprecated functions from ConnectorSession (Nikhil Collooru)
- 0e916c680aae4339ed8ec788184183866251d283 Update discovery-server to 1.31. (Sujay Jain)
- 6bab32ac4639256314ead93d8d970cb056f1c1f2 Drop presto-orc dependency on ConnectorSession (Nikhil Collooru)
- a2a4c46aaf5163fdd07960e764a3610619be82be Send SqlFunctionProperties to operators (Nikhil Collooru)
- 42d5f118fdda6ded6b637c3d53b2a93f7624e3ff Add sessionStartTime,sessionLocale,sessionUser to SqlFunctionProperties (Nikhil Collooru)
- 8c469bda0657f41c146796ea2ccaaea6dfa552e6 Fix bug in IS_SUBNET_OF function (Nikhil Collooru)
- 3384c20a24c7118cde3f6eefd4d7c4fa7e3058e7 Remove compression for creating zero row file (Rohit Jain)
- 669cf6ea45945d61d90784dfc65be2804a5f81b2 Add Internationalization (i18n) plugin and Myanmar UDFs (Nick LaGrow)
- 60fbdb065db0d7f4e0d34a7da638f812842629e2 Fix EXPLAIN (TYPE IO) when Aria scan is ON (John Roll)
- 24be9ab8acc63ee0a3c188a2d7d53b40bf3250d0 Use NO_NODES_AVAILABLE Exception for affinity scheduler (Ke Wang)
- 29afd77004af88c4f13702893ff75e90ccec854f Add test coverage for MySqlConnectionModule (Leiqing Cai)
- d8c6b8f62eaa6720e6e3f0582f3d8a31c9a8763c Fix ClusterStatsResource (Tim Meehan)
- 319aff3694d9c22ab3f625951a28599e92e5924e Fix failing SQL functions test (Leiqing Cai)
- f62b73b33bb670db98b25bc7f318d1c25b9f21c0 Add subfield pruning to StripeReader (Bhavani Hari)
- eb60ad9301dee48da99d1f3d9ed83bbcdf0bfba4 Add status endpoint for HTTP HEAD requests (James Petty)
- a48650226a9d917a4ea47ff7ae9cda000da4105c Reduce LazyBlock copy / wrapping in ScanFilterAndProjectOperator (James Petty)
- bcabbdf933076c5a82428d15a9792f10fcf337de Disallow invoking SQL functions in SQL function body (Leiqing Cai)
- 80b03de610e306851e64a55ffde7e0740549d729 Support function namespace in integration tests (Leiqing Cai)
- 0d3235a41d1b9c7ce57ed96deb36b45444e10d6c Update h2 to 1.4.199 (Leiqing Cai)
- 9e5eb477b8b5741bb2e482d1beb7d20751324ecd Speed up GC of MapFlatSelectiveReader by clearing member variables in close() (Bhavani Hari)
- ab52a1a58763575a713b240a407a3d7b52a3b944 Speed up GC of DecimalStreamReader by clearing member variables in close() (Bhavani Hari)
- 34841afb54a2d5bea0f3731b790592d080a0caa7 Speed up GC of StructStreamReader by clearing member variables in close() (Bhavani Hari)
- 25faa639cbda56ae53d5326d8dd2a8ecf27b2fec Speed up GC of ListStreamReader by clearing member variables in close() (Bhavani Hari)
- dc60bb22f5d640289c062750b65a1afbcbef4525 Speed up GC of TimestampSelectiveReader by clearing member variables in close() (Bhavani Hari)
- 615879039567b1afc9dfe8b5f67a626c052052a0 Speed up GC of DoubleSelectiveReader by clearing member variables in close() (Bhavani Hari)
- 3a78b32bdc0d835807020b57c01a42e3e03c2b5a Speed up GC of FloatSelectiveReader by clearing member variables in close() (Bhavani Hari)
- 13738ff96fe65a30252bd1870a099ad5daa7b26a Speed up GC of BooleanSelectiveReader by clearing member variables in close() (Bhavani Hari)
- 3d66fde80b47676618ab030aa3debc557b31f184 Speed up GC of ByteSelectiveReader by clearing member variables in close() (Bhavani Hari)
- c5c58158a6973ea36a62d107922d6fb334b1b808 Speed up GC of OrcReader by clearing member variables in close() (Bhavani Hari)
- 3559e8823df01e47af51ff67b40a3aec7764d245 Speed up GC of MapSelectiveReader by clearing member variables in close() (Bhavani Hari)
- 924c584f737c445009c8d58047fbf31d7bbc056c Speed up GC of LongSelectiveReaders by clearing member variables in close() (Bhavani Hari)
- 4ac5783f84360c25615723b14afa55398fe7e70a Speed up GC of SliceSelectiveReader by clearing member variables in close() (Bhavani Hari)
- d9d839837afa086c600b5493f23544e70085cc6d Add PageFile format in HiveFileFormatBenchmark (Vic Zhang)
- 777ff920abaa6f26a036e4668100903e1abe3b72 Disable unnecessary test for PageFile format (Vic Zhang)
- 7f329aab533b1af8602b2e10f188fad82204953f Add control property for PageFile stripe max size (Vic Zhang)
- efdeb1274a1907782bcc54d78ae4608315facdfb Create PageFilePageSource to read PageFile (Vic Zhang)
- 7f1138dfbf7c36014f6eed7eff50221fd9e33827 Support write serialized pages to PageFile format (Vic Zhang)
- 191979c7b75d7483cfad14d2afca85ad84e561fc Add BlockEncodingSerde to ConnectorContext (Vic Zhang)
- cf42f75855174b26fd5199b683de3ddee1ad59f0 Add ST_Centroid for points and multipoints on a sphere (David Taieb)
- 5a969b2739dc41aabb2a1d67ac99ad74c83ebc94 Enforce buffer size limits for BlockEncodingBuffer (Ying Su)
- ef718277394f712ad07c8387a1f565aef4cab8b1 Introduce estimatedSerializedSizeInBytes in DecodedBlockNode (Ying Su)
- d1f21b5d17cdfe755b4fd45eed7dc7f9bbaef67f Introduce estimatedSerializedSizeInBytes in ColumnarXXX (Ying Su)
- e83844e06373c6ebfd921b816dadcdcb4b3627c3 Rename pageSize to partitionBufferCapacity (Ying Su)
- 6ec48b2a2b50442640d0b095f3d72397ada11aae Refactor getRetainedSizeInBytes in DecodedBlockNode (Ying Su)
- 61679f4f0778d700402001226240c46543c87fde Change nested buffers to AbstractBlockEncodingBuffer (Ying Su)
- d90e533ff9e9ba34c50286e00e63bb983522172a Rename OrcDataSink to DataSink (Vic Zhang)
- 8c65a959e526b95d61e6a6350987e4ab09a23abb Rename OutputStreamOrcDataSink to OutputStreamDataSink (Vic Zhang)
- eaa0c57c7a5e00b83f2bc8c74a4e81d77c6300c2 Rename OrcDataOutput to DataOutput (Vic Zhang)
- ad004b74fd3412f4c9fb94d820e8a012b6450c14 Remove unused methods in TestDruidQueryBase (Zhenxiao Luo)
- 5f89b532e12ef653ad2a5acc577bd5acdf5f8eb6 Fix druid connector segment scan (Zhenxiao Luo)
- 1e51f2f2d52b1f7ce0719330eea597bb274d077b count distinct pushdown for druid connector (Zhenxiao Luo)
- b7a0941b8cf6211c4d0ad1246fcdc0e7c2d48435 Fix section labeling for KHyperLogLog documentation (Leiqing Cai)
- e3386889222438453aac2bf448777c943a507321 Fix NPE when reading structs with a newly added subfield (Bhavani Hari)
- 61681cfe20c37d0a2252d9417ae9a67032af79f7 Best effort to push down distinct count function to pinot (Xiang Fu)
- 99653c6e1989b2bb8cd5e20c59027950482a577d fixing date type in pinot-connector (Xiang Fu)
- 3c2d9d80e4aba2c7fcba2a8b1df28c4c66875221 Handle empty and arbitrary slices in Parquet reader (James Petty)
- fdfd5dfdc8090c56eac750f02e914596b8f8e1e0 Optimize metastore communication when writing to partitioned table (Andrii Rosa)
- d699f4687bec616344054c3a27806e23a2e4c863 Add smoke test for insert into immutable partition (Andrii Rosa)
- 0366472937d460808550fa883c6da9e4e7bc2104 Refactor TestHiveIntegrationSmokeTest (Andrii Rosa)
- f7ecf0e720914f7a53d73789a08de0eb14526a17 Refactor HiveWriterFactory#getWriterParameters (Andrii Rosa)
- 701c24aefddbd1dbb45fc6428c1c9ad53dc6771d Refactor HiveWriterFactory#createWriter (Andrii Rosa)
- 4c4307526af2185a8b494d29d59f654d48d51773 Make timestamp columns nullable (Leiqing Cai)
- 030052bd17d519cc0b8a8662704f646ef905b066 Relax length limit of parameter type list and return type (Leiqing Cai)
- a8de10f13138f4d9ee3746db83f503eabd09cd6e Improve TestMySqlFunctionNamespaceManager (Leiqing Cai)
- d4fc345d1bd1cfe5403e6fc332da29a27f13f456 Support verifying SELECT queries with certain non-storable columns (Leiqing Cai)
- 10c3bd02db21e19d89ed01986c8a22adabaf82d0 Add Alluxio Catalog in Cache documentation (Haoyuan Li)
- 95bcb3947cad1570e19a0adaebc58009aa362ada Drop presto-orc's dependency on presto-memory-context (Nikhil Collooru)
- d9fc4620e554cb97b4c6fffd538b40c3f790b3e1 Add ExtendedFileSystem (Rohit Jain)
- 2d9e768a03b5c9d804825c9a489383465f373801 Fix bug AddExchanges dropping filter when pushdown is enabled (Saksham Sachdev)
- 726e18ae85e583b8493c39f97761e9f2976e2298 Add max buffer count config property for optimized repartitioning (Ying Su)
- 36141ed8ea368117d30a3f0abb9f3d2ebd452dd1 Add peak [task] total memory to returned stats (Ariel Weisberg)
- 5c296b93e07cb923ff8fcf3a31a85379d0fc155b Fix minor typo in error message (Shixuan Fan)
- 11b8d41c866eebd8c46e8a7d691c0979aa27cee8 Report failure to compile pushed down filter as COMPILE_ERROR (Sujay Jain)
- 30c0c9a3c33b764a1163b60e554d5707dc974b22 Reduce instance size and block copies in Page class (James Petty)
- 5812d786c14d6d194d82ac6a5c549d27907e906e Pass the correct value for fileSize in Hive internal split factory (Venki Korukanti)
- 824f282594be1b8135938e46d3a1d201793e96d0 Revert "Hive Meta Store impersonation access" (Andrii Rosa)
- fa769f73f0fce1d6cfce52b04a3eaa6382b038bb Revert "HMS multiple instance metrics" (Andrii Rosa)
- 88f304cca162c8d8e1e95b7401ca0a997f2ec253 Revert "refactoring to use HMS Authentication Module" (Andrii Rosa)
- 4b2e750abdaee7ced9b0ab555065bbd52fa1b7a4 Revert "add Config for multiple hms instances" (Andrii Rosa)
- 837f6a0afee5f7a474cca323927084b47f88c0a7 Revert "Update HMS memory settings" (Andrii Rosa)
- a82d63caf226f293c3e1d69fbe294f2f9b2615f1 Revert "address review comments" (Andrii Rosa)
- c615632b9d2fe0332097a4c0a043fdd68fee6e23 Use full name for Parquet classes (Zhenxiao Luo)
- d041bdeca2867551b6a3ba2b5e29bbee247ddb04 Add native parquet writer (qqibrow)
- 824fbc2f5f30cfdb04bb0484269378803873334c address review comments (Curt)
- 358f72724121a32bfce58d902e3359c54de87bda Update HMS memory settings (Curt)
- ff9ae918ecf9f0bec7aa9f9f401d70160e231bea add Config for multiple hms instances (Curt)
- a5321125a6ce49f4b9bd22bb8435b436c49b3551 refactoring to use HMS Authentication Module (Curt)
- 4d144f0474854377c9acf430f7926280c6da9739 HMS multiple instance metrics (Curt)
- bb21a83c200ed6a3dc336587c29623693a785069 Hive Meta Store impersonation access (Zhongting Hu)
- 719823f92aea236bd7f7627014e5c384ef969e22 Add documentation for KHyperLogLog (Tim Meehan)
- 05e03901374b809347d79b2aeb486dcb1429adc6 Fix NullPointerExpression in ExpressionInterpreter::visitBindExpression (Rongrong Zhong)
- b9eab4443caa0d2a5a1f09083f7cd4173e786862 Make table properties a config property instead of hard-coded (Leiqing Cai)
- 0bed384af9ae769b0d5096a75ca6bcc833ed52b0 Drop presto-orc's dependency on presto-hive-common (Nikhil Collooru)
- abf9a5bf37b70a4c05f3dfa8b4528bd310074837 Move MarkDistinctNode to SPI (Xiang Fu)
- c3334ebe99ec8aa9931de0934c20736bd967f2a3 Add a page on caching (Bin Fan)
- fcb7e4180ec4b816c6d89f68ddf7a7d5008ed05f Upgrade aircompressor to 0.15 (Zhenxiao Luo)
- bf9b5261805a8c654c9e630fa18ac8e13a8cba11 Support caching all tables in file status cache (Shixuan Fan)
- a1d0999c83b193f305a15cb5a5127dd17496c197 Update Presto schema example in pinot connector doc (Xiang Fu)
- 30584d20ed02832e1f0087b5a23264f186e0c655 Address comments (Xiang Fu)
- c1412c7636f13572d7de0cf62efa617e730ac7d0 Adding config to swtich on/off date type and timestamp type inferral (Xiang Fu)
- cd439c500db4e13513263c9b69b550d39e52d6f9 Adding support for Date and Timestamp data type support for Pinot (Xiang Fu)
- 68a0632bed80a896df3b41fa74080c83c963ccd4 Fix bugs in Druid connector aggregation pushdown (Zhenxiao Luo)
- 3facc7374a17755cc979235ee242a13265cc5a7c Fix getRetainedSizeInBytes for ColumnarXXX (Ying Su)
- 3f03c2c31986da23ec2b91772da2d6dc961c5246 change variable errMsgSplits to errorMessageSplits (Xiang Fu)
- 175cddb830f87836a3b01fcea6dc2075318d01eb Address comments (Xiang Fu)
- 0ebc22050b6e93e2f1dd0d3e5fdc2dbe3c01333a Upgrade presto pinot connector to be compatible with new Pinot Broker routingTable and time boundary APIs in Pinot 0.3.0 release. (Xiang Fu)
- 3e64b8a863757727eca224645e523284da4f5803 Fix memory allocation for nestedPositions in the map reader (Masha Basmanova)
- 489c233a86eb89eb3ae0410b6e8c83892e558333 Reduce memory allocations in OrcInputStream (Masha Basmanova)
- 37a9750fa82507f2ac980f1c723915faf5dfd851 Reduce memory allocations in SliceDirectSelectiveStreamReader (Masha Basmanova)
- 7eb85a22e35f782387d0cdcb78abe79eee4cd645 Add SqlBaseParser initializer hook and refreshable ATN caches (James Petty)
- da2cc5620075d12abb19f3860a5459615f515cb4 Restart verification if checksum queries fail with table already exists (Leiqing Cai)
- b65fc7c4cdb2aac7de3dc84e7834957da63a03bb Improve teardown skipping (Leiqing Cai)
- 2df407bd7b64d95ea8450e7f6a116de75818497e Fix AbstractTestVerifierIntegrationSmokeTest (Leiqing Cai)
- 7f833d0b27ac96b5d8f8d7c76e5c426992409dfe Expose unexpected exceptions in Verifier (Leiqing Cai)
- 7e74c269a29598c66c6434db6f455a2523f19109 Improve readability in AbstractVerification (Leiqing Cai)
- aa4c4ff1879f23308b5920bd65d98f1e3483f256 Fix verification resubmission (Leiqing Cai)
- cfe1d3dc79c5f6cf028202cf1a8701c0f49dae1d Improve VerificationContext (Leiqing Cai)
- 3ffdf85861030f520da7e35c6c99e0f5d8dccdde Move PagesSerde and PagesSerdeUtil to SPI (Vic Zhang)
- 0afbdb36b6b2f1d4e9fb0169061c5b2f1a067b35 Add PageCompressor in SPI (Vic Zhang)
- f98d7adc65e356c610fe1f0050e939ef4f8d3403 Move SpillCipher to SPI (Vic Zhang)
- f98e644d18937f2eb38e55b0ff16c26e153d985e Remove guava dependency from PagesSerdeUtil (Vic Zhang)
- 2bba1ccf3dfe2a83c59402fbddd387b4d74def51 Remove data copy from InMemoryRecordSet (James Petty)
- 5c52eeaebee5ec61479e585dbf27dcc09fcf2155 Optimize Slice functions to avoid Slice.getBytes() (James Petty)
- af1f416328bac2f130130bf473be667349209e48 Use JSON generator Base64 conversion in BlockJsonSerde (James Petty)
- 778b5a8bd3cc190373716656bf605f7b6f449b95 Avoid Slice copies in parquet reader (James Petty)