### PR TITLE
Change common sub-expression functions to return check flags and return result

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/PageFunctionCompiler.java
@@ -428,7 +428,7 @@ public class PageFunctionCompiler
                     MethodDefinition method = classDefinition.declareMethod(
                             a(PRIVATE),
                             "get" + cseVariable.getName(),
-                            type(void.class),
+                            type(cseFields.resultType),
                             ImmutableList.<Parameter>builder()
                                     .add(properties)
                                     .add(page)
@@ -452,13 +452,19 @@ public class PageFunctionCompiler
                             metadata,
                             sqlFunctionProperties,
                             compiledLambdaMap);
+                    IfStatement ifStatement = new IfStatement()
+                            .condition(thisVariable.getField(cseFields.evaluatedField))
+                            .ifFalse(new BytecodeBlock()
+                                    .append(thisVariable)
+                                    .append(cseCompiler.compile(cse, scope, Optional.empty()))
+                                    .append(boxPrimitiveIfNecessary(scope, type))
+                                    .putField(cseFields.resultField)
+                                    .append(thisVariable.setField(cseFields.evaluatedField, constantBoolean(true))));
 
-                    body.append(thisVariable)
-                            .append(cseCompiler.compile(cse, scope, Optional.empty()))
-                            .append(boxPrimitiveIfNecessary(scope, type))
-                            .putField(cseFields.resultField)
-                            .append(thisVariable.setField(cseFields.evaluatedField, constantBoolean(true)))
-                            .ret();
+                    body.append(ifStatement)
+                            .append(thisVariable)
+                            .getField(cseFields.resultField)
+                            .retObject();
 
                     methods.add(method);
                     cseMap.put(cseVariable, cseFields);
@@ -839,13 +845,8 @@ public class PageFunctionCompiler
         public BytecodeNode visitVariableReference(VariableReferenceExpression reference, Scope context)
         {
             CommonSubExpressionFields fields = variableMap.get(reference);
-            IfStatement ifStatement = new IfStatement()
-                    .condition(thisVariable.getField(fields.evaluatedField))
-                    .ifFalse(new BytecodeBlock()
-                            .append(thisVariable.invoke(fields.methodName, void.class, context.getVariable("properties"), context.getVariable("page"), context.getVariable("position"))));
             return new BytecodeBlock()
-                    .append(ifStatement)
-                    .append(thisVariable.getField(fields.resultField))
+                    .append(thisVariable.invoke(fields.methodName, fields.resultType, context.getVariable("properties"), context.getVariable("page"), context.getVariable("position")))
                     .append(unboxPrimitiveIfNecessary(context, Primitives.wrap(reference.getType().getJavaType())));
         }
 


### PR DESCRIPTION
The way we do common sub-expressions is to create 2 variables for each cse, 1 boolean flag to indicate whether the cse has been computed, another to store the computed results. So the logic for using cse is `if(!computed) compute; return computed_result;`. There are two ways to generate these:
1. wrap cse computation in a function, and when cse is used, check the flag, if flag is false, invoke function, otherwise load the result
2. wrap the flag check and computation in a function, which will return the result, so when cse is used, invoke the function.

We did some benchmarking with Facebook workload and found that approach 2 gives better performance. This is probably due to jit being able to better inline and predict the branch. Currently the implementation is approach 1, switching to approach 2 with this PR.