### PR TITLE
Do not prune partition columns which fail expression evaluation

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
@@ -457,6 +457,7 @@ public class HiveFilterPushdown
             }
             catch (PrestoException e) {
                 propagateIfUnhandled(e);
+                return true;
             }
 
             // If any conjuncts evaluate to FALSE or null, then the whole predicate will never be true and so the partition should be pruned

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -4633,6 +4633,10 @@ public class TestHiveIntegrationSmokeTest
                 "SELECT * FROM test_prune_failure\n" +
                 "WHERE x < 0 AND cast(p AS int) > 0");
 
+        assertQueryFails("" +
+                "SELECT * FROM test_prune_failure\n" +
+                "WHERE x > 0 AND cast(p AS int) > 0", "Cannot cast 'abc' to INT");
+
         assertUpdate("DROP TABLE test_prune_failure");
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -791,26 +791,28 @@ public class TestHivePushdownFilterQueries
     @Test
     public void testPartitionColumns()
     {
-        assertUpdate("CREATE TABLE test_partition_columns WITH (partitioned_by = ARRAY['p', 'q']) AS\n" +
-                "SELECT * FROM (VALUES (1, 'abc', 'cba'), (2, 'abc', 'def')) as t(x, p, q)", 2);
+        assertUpdate("CREATE TABLE test_partition_columns WITH (partitioned_by = ARRAY['p', 'q', 'ds']) AS\n" +
+                "SELECT * FROM (VALUES (1, 'abc', 'cba', '2020-01-01'), (2, 'abc', 'def', '2020-01-01')) as t(x, p, q, ds)", 2);
 
-        assertQuery("SELECT * FROM test_partition_columns", "SELECT 1, 'abc', 'cba' UNION ALL SELECT 2, 'abc', 'def'");
+        assertQuery("SELECT * FROM test_partition_columns", "SELECT 1, 'abc', 'cba', '2020-01-01' UNION ALL SELECT 2, 'abc', 'def', '2020-01-01'");
 
         assertQuery("SELECT x FROM test_partition_columns", "SELECT 1 UNION ALL SELECT 2");
 
-        assertQuery("SELECT * FROM test_partition_columns WHERE p = 'abc'", "SELECT 1, 'abc', 'cba' UNION ALL SELECT 2, 'abc', 'def'");
+        assertQuery("SELECT * FROM test_partition_columns WHERE p = 'abc'", "SELECT 1, 'abc', 'cba', '2020-01-01' UNION ALL SELECT 2, 'abc', 'def', '2020-01-01'");
 
-        assertQuery("SELECT * FROM test_partition_columns WHERE p LIKE 'a%'", "SELECT 1, 'abc', 'cba' UNION ALL SELECT 2, 'abc', 'def'");
+        assertQuery("SELECT * FROM test_partition_columns WHERE p LIKE 'a%'", "SELECT 1, 'abc', 'cba', '2020-01-01' UNION ALL SELECT 2, 'abc', 'def', '2020-01-01'");
 
-        assertQuery("SELECT * FROM test_partition_columns WHERE substr(p, x, 1) = 'a' and substr(q, 1, 1) = 'c'", "SELECT 1, 'abc', 'cba'");
+        assertQuery("SELECT * FROM test_partition_columns WHERE substr(p, x, 1) = 'a' and substr(q, 1, 1) = 'c'", "SELECT 1, 'abc', 'cba', '2020-01-01'");
 
         assertQueryReturnsEmptyResult("SELECT * FROM test_partition_columns WHERE p = 'xxx'");
 
         assertQueryReturnsEmptyResult("SELECT * FROM test_partition_columns WHERE p = 'abc' and p='def'");
 
-        assertUpdate("INSERT into test_partition_columns values (3, 'abc', NULL)", 1);
+        assertUpdate("INSERT into test_partition_columns values (3, 'abc', NULL, '2020-01-01')", 1);
 
         assertQuerySucceeds(getSession(), "select * from test_partition_columns");
+
+        assertQueryFails("SELECT * FROM test_partition_columns WHERE DATE_DIFF( 'day', PARSE_DATETIME( '2020-01-08', 'YYYY-MM-dd' ), PARSE_DATETIME( ds, 'yyyy-MM-dd HH:mm:ss.SSS' ) ) = 7", "Invalid format: \"2020-01-01\" is too short");
 
         assertUpdate("DROP TABLE test_partition_columns");
     }


### PR DESCRIPTION
During the Query Plan phase, we optimize the partition expression and check if it can be pruned.
In case the partition expression throws an exception during evaluation we need to include it in the list of partitions to be scanned instead of pruning, as existing filters might evaluate to `false` which makes this expression not evaluate.

Currently with the pushdown filter path we have a bug where when the partition expression eval fails, we are pruning the partition.

```
presto:tpch> show create table test_prune_failure;
                Create Table
---------------------------------------------
 CREATE TABLE hive.tpch.test_prune_failure (
    x integer,
    p varchar(3)
 )
 WITH (
    format = 'ORC',
    partitioned_by = ARRAY['p']
 )
(1 row)



presto:tpch> select * from test_prune_failure ;
  x  |  p
-----+-----
 123 | abc

presto:tpch> SELECT * FROM test_prune_failure WHERE x>0 and cast(p AS int) > 0;
 x | p
---+---
(0 rows)
```
Without this fix the query returns 0 rows, but it should fail with. `failed: Cannot cast 'abc' to INT`.

Fixes #14492 
```
== NO RELEASE NOTE ==
```
