### PR TITLE
Beinan/druid hdfs bug fixing

### DIFF
--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -168,6 +168,12 @@
         </dependency>
 
         <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
@@ -189,12 +195,12 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <artifactId>jackson-core</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <!-- Presto SPI -->

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -68,6 +68,26 @@
                     <groupId>org.jruby.jcodings</groupId>
                     <artifactId>jcodings</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-artifact</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -122,6 +142,26 @@
                 <exclusion>
                     <groupId>org.jruby.jcodings</groupId>
                     <artifactId>jcodings</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-artifact</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidConfig.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidConfig.java
@@ -94,13 +94,17 @@ public class DruidConfig
     @Config("druid.hadoop.config.resources")
     public DruidConfig setHadoopResourceConfigFiles(String files)
     {
-        this.hadoopResourceConfigFiles = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(files);
+        if (files != null) {
+            this.hadoopResourceConfigFiles = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(files);
+        }
         return this;
     }
 
     public DruidConfig setHadoopResourceConfigFiles(List<String> files)
     {
-        this.hadoopResourceConfigFiles = ImmutableList.copyOf(files);
+        if (files != null) {
+            this.hadoopResourceConfigFiles = ImmutableList.copyOf(files);
+        }
         return this;
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidConfig.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidConfig.java
@@ -28,7 +28,7 @@ public class DruidConfig
     private String brokerUrl;
     private String schema = "druid";
     private boolean pushdown;
-    private List<String> hadoopResourceConfigFiles = ImmutableList.of();
+    private List<String> hadoopConfiguration = ImmutableList.of();
 
     @NotNull
     public String getDruidCoordinatorUrl()
@@ -86,24 +86,24 @@ public class DruidConfig
     }
 
     @NotNull
-    public List<String> getHadoopResourceConfigFiles()
+    public List<String> getHadoopConfiguration()
     {
-        return hadoopResourceConfigFiles;
+        return hadoopConfiguration;
     }
 
     @Config("druid.hadoop.config.resources")
-    public DruidConfig setHadoopResourceConfigFiles(String files)
+    public DruidConfig setHadoopConfiguration(String files)
     {
         if (files != null) {
-            this.hadoopResourceConfigFiles = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(files);
+            this.hadoopConfiguration = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(files);
         }
         return this;
     }
 
-    public DruidConfig setHadoopResourceConfigFiles(List<String> files)
+    public DruidConfig setHadoopConfiguration(List<String> files)
     {
         if (files != null) {
-            this.hadoopResourceConfigFiles = ImmutableList.copyOf(files);
+            this.hadoopConfiguration = ImmutableList.copyOf(files);
         }
         return this;
     }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidConfig.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidConfig.java
@@ -15,8 +15,12 @@ package com.facebook.presto.druid;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 
 import javax.validation.constraints.NotNull;
+
+import java.util.List;
 
 public class DruidConfig
 {
@@ -24,6 +28,7 @@ public class DruidConfig
     private String brokerUrl;
     private String schema = "druid";
     private boolean pushdown;
+    private List<String> hadoopResourceConfigFiles = ImmutableList.of();
 
     @NotNull
     public String getDruidCoordinatorUrl()
@@ -77,6 +82,25 @@ public class DruidConfig
     public DruidConfig setComputePushdownEnabled(boolean pushdown)
     {
         this.pushdown = pushdown;
+        return this;
+    }
+
+    @NotNull
+    public List<String> getHadoopResourceConfigFiles()
+    {
+        return hadoopResourceConfigFiles;
+    }
+
+    @Config("druid.hadoop.config.resources")
+    public DruidConfig setHadoopResourceConfigFiles(String files)
+    {
+        this.hadoopResourceConfigFiles = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(files);
+        return this;
+    }
+
+    public DruidConfig setHadoopResourceConfigFiles(List<String> files)
+    {
+        this.hadoopResourceConfigFiles = ImmutableList.copyOf(files);
         return this;
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
@@ -147,6 +147,7 @@ public class DruidMetadata
     {
         switch (type.toUpperCase()) {
             case "VARCHAR":
+            case "OTHER":
                 return VARCHAR;
             case "BIGINT":
                 return BIGINT;

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
@@ -148,6 +148,7 @@ public class DruidMetadata
         switch (type.toUpperCase()) {
             case "VARCHAR":
             case "OTHER":
+                //hyperUnique, approxHistogram Druid column types
                 return VARCHAR;
             case "BIGINT":
                 return BIGINT;

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidPageSourceProvider.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidPageSourceProvider.java
@@ -91,7 +91,7 @@ public class DruidPageSourceProvider
                     new DruidSegmentReader(segmentIndexSource, columns));
         }
         catch (IOException e) {
-            throw new PrestoException(DRUID_DEEP_STORAGE_ERROR, e);
+            throw new PrestoException(DRUID_DEEP_STORAGE_ERROR, "Failed to create page source on " + segmentInfo.getDeepStoragePath(), e);
         }
     }
 

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidPageSourceProvider.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidPageSourceProvider.java
@@ -39,6 +39,7 @@ import javax.inject.Inject;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static com.facebook.presto.druid.DruidErrorCode.DRUID_DEEP_STORAGE_ERROR;
 import static com.facebook.presto.druid.DruidSplit.SplitType.BROKER;
@@ -48,11 +49,13 @@ public class DruidPageSourceProvider
         implements ConnectorPageSourceProvider
 {
     private final DruidClient druidClient;
+    private final Configuration hadoopConfiguration;
 
     @Inject
-    public DruidPageSourceProvider(DruidClient druidClient)
+    public DruidPageSourceProvider(DruidClient druidClient, DruidConfig config)
     {
         this.druidClient = requireNonNull(druidClient, "druid client is null");
+        this.hadoopConfiguration = readConfiguration(config.getHadoopResourceConfigFiles());
     }
 
     @Override
@@ -73,7 +76,7 @@ public class DruidPageSourceProvider
         DruidSegmentInfo segmentInfo = druidSplit.getSegmentInfo().get();
         try {
             Path hdfsPath = new Path(segmentInfo.getDeepStoragePath());
-            FileSystem fileSystem = hdfsPath.getFileSystem(new Configuration());
+            FileSystem fileSystem = hdfsPath.getFileSystem(hadoopConfiguration);
             long fileSize = fileSystem.getFileStatus(hdfsPath).getLen();
             FSDataInputStream inputStream = fileSystem.open(hdfsPath);
             DataInputSourceId dataInputSourceId = new DataInputSourceId(hdfsPath.toString());
@@ -90,5 +93,19 @@ public class DruidPageSourceProvider
         catch (IOException e) {
             throw new PrestoException(DRUID_DEEP_STORAGE_ERROR, e);
         }
+    }
+
+    private static Configuration readConfiguration(List<String> resourcePaths)
+    {
+        Configuration configuration = new Configuration(false);
+
+        for (String resourcePath : resourcePaths) {
+            Configuration resourceProperties = new Configuration(false);
+            resourceProperties.addResource(new Path(resourcePath));
+            for (Map.Entry<String, String> entry : resourceProperties) {
+                configuration.set(entry.getKey(), entry.getValue());
+            }
+        }
+        return configuration;
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidPageSourceProvider.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidPageSourceProvider.java
@@ -55,7 +55,7 @@ public class DruidPageSourceProvider
     public DruidPageSourceProvider(DruidClient druidClient, DruidConfig config)
     {
         this.druidClient = requireNonNull(druidClient, "druid client is null");
-        this.hadoopConfiguration = readConfiguration(config.getHadoopResourceConfigFiles());
+        this.hadoopConfiguration = readConfiguration(config.getHadoopConfiguration());
     }
 
     @Override

--- a/presto-druid/src/main/java/com/facebook/presto/druid/column/StringColumnReader.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/column/StringColumnReader.java
@@ -39,7 +39,7 @@ public class StringColumnReader
         checkArgument(type == VARCHAR);
         BlockBuilder builder = type.createBlockBuilder(null, batchSize);
         for (int i = 0; i < batchSize; i++) {
-            String value = valueSelector.getObject();
+            String value = String.valueOf(valueSelector.getObject());
             if (value != null) {
                 type.writeSlice(builder, Slices.utf8Slice(value));
             }

--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidConfig.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.druid;
 
 import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
@@ -28,10 +29,11 @@ public class TestDruidConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(DruidConfig.class)
-                    .setDruidBrokerUrl(null)
-                    .setDruidCoordinatorUrl(null)
-                    .setDruidSchema("druid")
-                    .setComputePushdownEnabled(false));
+                .setDruidBrokerUrl(null)
+                .setDruidCoordinatorUrl(null)
+                .setDruidSchema("druid")
+                .setComputePushdownEnabled(false)
+                .setHadoopResourceConfigFiles((String) null));
     }
 
     @Test
@@ -42,13 +44,15 @@ public class TestDruidConfig
                 .put("druid.coordinator-url", "http://druid.coordinator:4321")
                 .put("druid.schema-name", "test")
                 .put("druid.compute-pushdown-enabled", "true")
+                .put("druid.hadoop.config.resources", "/etc/core-site.xml,/etc/hdfs-site.xml")
                 .build();
 
         DruidConfig expected = new DruidConfig()
                 .setDruidBrokerUrl("http://druid.broker:1234")
                 .setDruidCoordinatorUrl("http://druid.coordinator:4321")
                 .setDruidSchema("test")
-                .setComputePushdownEnabled(true);
+                .setComputePushdownEnabled(true)
+                .setHadoopResourceConfigFiles(ImmutableList.of("/etc/core-site.xml", "/etc/hdfs-site.xml"));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidConfig.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidConfig.java
@@ -33,7 +33,7 @@ public class TestDruidConfig
                 .setDruidCoordinatorUrl(null)
                 .setDruidSchema("druid")
                 .setComputePushdownEnabled(false)
-                .setHadoopResourceConfigFiles((String) null));
+                .setHadoopConfiguration(""));
     }
 
     @Test
@@ -52,7 +52,7 @@ public class TestDruidConfig
                 .setDruidCoordinatorUrl("http://druid.coordinator:4321")
                 .setDruidSchema("test")
                 .setComputePushdownEnabled(true)
-                .setHadoopResourceConfigFiles(ImmutableList.of("/etc/core-site.xml", "/etc/hdfs-site.xml"));
+                .setHadoopConfiguration(ImmutableList.of("/etc/core-site.xml", "/etc/hdfs-site.xml"));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-product-tests/conf/presto/etc/config.properties
+++ b/presto-product-tests/conf/presto/etc/config.properties
@@ -33,6 +33,7 @@ plugin.bundles=\
   ../../../presto-tpch/pom.xml,\
   ../../../presto-blackhole/pom.xml,\
   ../../../presto-cassandra/pom.xml,\
+  ../../../presto-druid/pom.xml,\
   ../../../presto-mysql/pom.xml,\
   ../../../presto-postgresql/pom.xml,\
   ../../../presto-sqlserver/pom.xml,\


### PR DESCRIPTION
1 Add configuration for hdfs config resources.  
2 Add dependency of fastutil for Druid HDFS file parsing
3 Support query columns with 'Other' type
4 Add the problematical file path to the presto exception message
5 Add presto-druid into presto-product-test config properties
6 Exclude transitive dependency to fix build error

Tested on viewfs.
```
== NO RELEASE NOTE ==
```
