### PR TITLE
Support cachable flag in CachingDirectoryLister

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -29,7 +29,6 @@ import com.facebook.presto.hive.util.ResumableTasks;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
@@ -65,6 +64,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.IntPredicate;
+import java.util.function.Supplier;
 
 import static com.facebook.presto.hive.HiveBucketing.getVirtualBucketNumber;
 import static com.facebook.presto.hive.HiveColumnHandle.pathColumnHandle;
@@ -165,7 +165,7 @@ public class BackgroundHiveSplitLoader
         this.partitions = new ConcurrentLazyQueue<>(requireNonNull(partitions, "partitions is null"));
         this.hdfsContext = new HdfsContext(session, table.getDatabaseName(), table.getTableName());
         this.schedulerUsesHostAddresses = schedulerUsesHostAddresses;
-        this.hoodiePathFilterSupplier = Suppliers.memoize(HoodieROTablePathFilter::new);
+        this.hoodiePathFilterSupplier = Suppliers.memoize(HoodieROTablePathFilter::new)::get;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -155,7 +155,7 @@ public class BackgroundHiveSplitLoader
         this.table = requireNonNull(table, "table is null");
         this.pathDomain = requireNonNull(pathDomain, "pathDomain is null");
         this.tableBucketInfo = requireNonNull(tableBucketInfo, "tableBucketInfo is null");
-        this.loaderConcurrency = requireNonNull(loaderConcurrency, "loaderConcurrency is null");
+        this.loaderConcurrency = loaderConcurrency;
         this.session = requireNonNull(session, "session is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.namenodeStats = requireNonNull(namenodeStats, "namenodeStats is null");

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -449,7 +449,7 @@ public class BackgroundHiveSplitLoader
     {
         int readBucketCount = bucketSplitInfo.getReadBucketCount();
         int tableBucketCount = bucketSplitInfo.getTableBucketCount();
-        int partitionBucketCount = bucketConversion.isPresent() ? bucketConversion.get().getPartitionBucketCount() : tableBucketCount;
+        int partitionBucketCount = bucketConversion.map(BucketConversion::getPartitionBucketCount).orElse(tableBucketCount);
 
         checkState(readBucketCount <= tableBucketCount, "readBucketCount(%s) should be less than or equal to tableBucketCount(%s)", readBucketCount, tableBucketCount);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -75,6 +75,7 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_PARTITION_VALUE;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNKNOWN_ERROR;
 import static com.facebook.presto.hive.HiveSessionProperties.getNodeSelectionStrategy;
+import static com.facebook.presto.hive.HiveSessionProperties.isUseListDirectoryCache;
 import static com.facebook.presto.hive.HiveUtil.getFooterCount;
 import static com.facebook.presto.hive.HiveUtil.getHeaderCount;
 import static com.facebook.presto.hive.HiveUtil.getInputFormat;
@@ -430,7 +431,8 @@ public class BackgroundHiveSplitLoader
 
     private Iterator<InternalHiveSplit> createInternalHiveSplitIterator(Path path, ExtendedFileSystem fileSystem, InternalHiveSplitFactory splitFactory, boolean splittable, PathFilter pathFilter)
     {
-        return stream(directoryLister.list(fileSystem, table, path, namenodeStats, recursiveDirWalkerEnabled ? RECURSE : IGNORED, pathFilter))
+        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, isUseListDirectoryCache(session));
+        return stream(directoryLister.list(fileSystem, table, path, namenodeStats, pathFilter, hiveDirectoryContext))
                 .map(status -> splitFactory.createInternalHiveSplit(status, splittable))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
@@ -456,7 +458,7 @@ public class BackgroundHiveSplitLoader
         // list all files in the partition
         List<HiveFileInfo> fileInfos = new ArrayList<>(partitionBucketCount);
         try {
-            Iterators.addAll(fileInfos, directoryLister.list(fileSystem, table, path, namenodeStats, FAIL, pathFilter));
+            Iterators.addAll(fileInfos, directoryLister.list(fileSystem, table, path, namenodeStats, pathFilter, new HiveDirectoryContext(FAIL, isUseListDirectoryCache(session))));
         }
         catch (NestedDirectoryNotAllowedException e) {
             // Fail here to be on the safe side. This seems to be the same as what Hive does
@@ -524,7 +526,8 @@ public class BackgroundHiveSplitLoader
     private List<InternalHiveSplit> getVirtuallyBucketedSplits(Path path, ExtendedFileSystem fileSystem, InternalHiveSplitFactory splitFactory, int bucketCount, boolean splittable, PathFilter pathFilter)
     {
         // List all files recursively in the partition and assign virtual bucket number to each of them
-        return stream(directoryLister.list(fileSystem, table, path, namenodeStats, recursiveDirWalkerEnabled ? RECURSE : IGNORED, pathFilter))
+        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, isUseListDirectoryCache(session));
+        return stream(directoryLister.list(fileSystem, table, path, namenodeStats, pathFilter, hiveDirectoryContext))
                 .map(fileInfo -> {
                     int virtualBucketNumber = getVirtualBucketNumber(bucketCount, fileInfo.getPath());
                     return splitFactory.createInternalHiveSplit(fileInfo, virtualBucketNumber, virtualBucketNumber, splittable);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/CachingDirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/CachingDirectoryLister.java
@@ -81,8 +81,8 @@ public class CachingDirectoryLister
             Table table,
             Path path,
             NamenodeStats namenodeStats,
-            NestedDirectoryPolicy nestedDirectoryPolicy,
-            PathFilter pathFilter)
+            PathFilter pathFilter,
+            HiveDirectoryContext hiveDirectoryContext)
     {
         SchemaTableName schemaTableName = new SchemaTableName(table.getDatabaseName(), table.getTableName());
 
@@ -91,8 +91,8 @@ public class CachingDirectoryLister
             return files.iterator();
         }
 
-        Iterator<HiveFileInfo> iterator = delegate.list(fileSystem, table, path, namenodeStats, nestedDirectoryPolicy, pathFilter);
-        if (cachedTableChecker.isCachedTable(schemaTableName)) {
+        Iterator<HiveFileInfo> iterator = delegate.list(fileSystem, table, path, namenodeStats, pathFilter, hiveDirectoryContext);
+        if (hiveDirectoryContext.isCacheable() && cachedTableChecker.isCachedTable(schemaTableName)) {
             return cachingIterator(iterator, path);
         }
         return iterator;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/DirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/DirectoryLister.java
@@ -27,6 +27,6 @@ public interface DirectoryLister
             Table table,
             Path path,
             NamenodeStats namenodeStats,
-            NestedDirectoryPolicy nestedDirectoryPolicy,
-            PathFilter pathFilter);
+            PathFilter pathFilter,
+            HiveDirectoryContext hiveDirectoryContext);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HadoopDirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HadoopDirectoryLister.java
@@ -37,10 +37,15 @@ public class HadoopDirectoryLister
             Table table,
             Path path,
             NamenodeStats namenodeStats,
-            NestedDirectoryPolicy nestedDirectoryPolicy,
-            PathFilter pathFilter)
+            PathFilter pathFilter,
+            HiveDirectoryContext hiveDirectoryContext)
     {
-        return new HiveFileIterator(path, p -> new HadoopFileInfoIterator(fileSystem.listLocatedStatus(p)), namenodeStats, nestedDirectoryPolicy, pathFilter);
+        return new HiveFileIterator(
+                path,
+                p -> new HadoopFileInfoIterator(fileSystem.listLocatedStatus(p)),
+                namenodeStats,
+                hiveDirectoryContext.getNestedDirectoryPolicy(),
+                pathFilter);
     }
 
     public static class HadoopFileInfoIterator

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveDirectoryContext.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveDirectoryContext.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import static java.util.Objects.requireNonNull;
+
+public class HiveDirectoryContext
+{
+    private final NestedDirectoryPolicy nestedDirectoryPolicy;
+    private final boolean cacheable;
+
+    public HiveDirectoryContext(NestedDirectoryPolicy nestedDirectoryPolicy, boolean cacheable)
+    {
+        this.nestedDirectoryPolicy = requireNonNull(nestedDirectoryPolicy, "nestedDirectoryPolicy is null");
+        this.cacheable = cacheable;
+    }
+
+    public NestedDirectoryPolicy getNestedDirectoryPolicy()
+    {
+        return nestedDirectoryPolicy;
+    }
+
+    public boolean isCacheable()
+    {
+        return cacheable;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -99,6 +99,7 @@ public final class HiveSessionProperties
     public static final String MAX_BUCKETS_FOR_GROUPED_EXECUTION = "max_buckets_for_grouped_execution";
     public static final String OFFLINE_DATA_DEBUG_MODE_ENABLED = "offline_data_debug_mode_enabled";
     public static final String FAIL_FAST_ON_INSERT_INTO_IMMUTABLE_PARTITIONS_ENABLED = "fail_fast_on_insert_into_immutable_partitions_enabled";
+    public static final String USE_LIST_DIRECTORY_CACHE = "use_list_directory_cache";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -444,6 +445,11 @@ public final class HiveSessionProperties
                         FAIL_FAST_ON_INSERT_INTO_IMMUTABLE_PARTITIONS_ENABLED,
                         "Fail fast when trying to insert into an immutable partition. Increases load on the metastore",
                         hiveClientConfig.isFailFastOnInsertIntoImmutablePartitionsEnabled(),
+                        false),
+                booleanProperty(
+                        USE_LIST_DIRECTORY_CACHE,
+                        "Use list directory cache if available when set to true",
+                        !hiveClientConfig.getFileStatusCacheTables().isEmpty(),
                         false));
     }
 
@@ -773,5 +779,10 @@ public final class HiveSessionProperties
     public static boolean isFailFastOnInsertIntoImmutablePartitionsEnabled(ConnectorSession session)
     {
         return session.getProperty(FAIL_FAST_ON_INSERT_INTO_IMMUTABLE_PARTITIONS_ENABLED, Boolean.class);
+    }
+
+    public static boolean isUseListDirectoryCache(ConnectorSession session)
+    {
+        return session.getProperty(USE_LIST_DIRECTORY_CACHE, Boolean.class);
     }
 }


### PR DESCRIPTION
This could provide more flexibility on whether a query should use
cache or not. For example, we might not want ingestion query to
pollute cache, and only want cache to serve latency sensitive
queries.

```
== NO RELEASE NOTE ==
```

Depended by https://github.com/facebookexternal/presto-facebook/pull/986