### PR TITLE
Auto-resolve certain result mismatches

### DIFF
--- a/presto-docs/src/main/sphinx/admin/verifier.rst
+++ b/presto-docs/src/main/sphinx/admin/verifier.rst
@@ -168,6 +168,17 @@ query failures.
 * ``COMPILER_ERROR``: Resolves if checksum fails with this error. If a control query has too many
   columns, generated checksum query might be too large in certain cases.
 
+In cases of result mismatches, Verifier may be giving noisy signals, and we allow Verifier to
+automatically resolve certain mismatches.
+
+* **Structured-typed Columns**: If array element or map key/value contains floating point types, column checksum is unlikely to match.
+    * For an array column, resolve if the element type contains floating point types and the
+      cardinality checksum matches.
+    * For a map column, resolve the mismatch when both of the following conditions are true:
+       * The cardinality checksum matches.
+       * The checksum of the key or value that does not contains floating point types matches.
+    * Resolve a test case only when all columns are resolved.
+
 Extending Verifier
 ------------------
 
@@ -283,4 +294,6 @@ Name                                                      Description
 ``too-many-open-partitions.max-buckets-per-writer``       The maximum buckets count per writer configured on the control and the
                                                           test cluster.
 ``too-many-open-partitions.cluster-size-expiration``      The time limit of the test cluster size being cached.
+``structured-column.failure-resolver.enabled``            Whether to enable the failure resolver for column mismatches of
+                                                          structured-type columns.
 ========================================================= ======================================================================

--- a/presto-docs/src/main/sphinx/admin/verifier.rst
+++ b/presto-docs/src/main/sphinx/admin/verifier.rst
@@ -178,6 +178,8 @@ automatically resolve certain mismatches.
        * The cardinality checksum matches.
        * The checksum of the key or value that does not contains floating point types matches.
     * Resolve a test case only when all columns are resolved.
+* **Resolved Functions**: In the case of a results mismatch, if the query uses a function in a
+    specified list, the test case is marked as resolved.
 
 Extending Verifier
 ------------------
@@ -296,4 +298,8 @@ Name                                                      Description
 ``too-many-open-partitions.cluster-size-expiration``      The time limit of the test cluster size being cached.
 ``structured-column.failure-resolver.enabled``            Whether to enable the failure resolver for column mismatches of
                                                           structured-type columns.
+``ignored-functions.failure-resolver.enabled``            Whether to enable the ``IgnoredFunctions`` result mismatch failure
+                                                          resolver.
+``ignored-functions.functions``                           A comma-separated list of functions. Resolves mismatches if a query
+                                                          uses any functions in the list.
 ========================================================= ======================================================================

--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -69,7 +69,7 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-common</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-thrift-connector</artifactId>
@@ -205,6 +205,13 @@
         </dependency>
 
         <!-- for testing -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-memory</artifactId>

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ArrayColumnChecksum.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ArrayColumnChecksum.java
@@ -23,11 +23,13 @@ public class ArrayColumnChecksum
         extends StructureColumnChecksum
 {
     private final Object checksum;
+    private final Object cardinalityChecksum;
     private final long cardinalitySum;
 
-    public ArrayColumnChecksum(@Nullable Object checksum, long cardinalitySum)
+    public ArrayColumnChecksum(@Nullable Object checksum, @Nullable Object cardinalityChecksum, long cardinalitySum)
     {
         this.checksum = checksum;
+        this.cardinalityChecksum = cardinalityChecksum;
         this.cardinalitySum = cardinalitySum;
     }
 
@@ -35,6 +37,13 @@ public class ArrayColumnChecksum
     public Object getChecksum()
     {
         return checksum;
+    }
+
+    @Override
+    @Nullable
+    public Object getCardinalityChecksum()
+    {
+        return cardinalityChecksum;
     }
 
     @Override
@@ -54,18 +63,19 @@ public class ArrayColumnChecksum
         }
         ArrayColumnChecksum o = (ArrayColumnChecksum) obj;
         return Objects.equals(checksum, o.checksum) &&
+                Objects.equals(cardinalityChecksum, o.cardinalityChecksum) &&
                 Objects.equals(cardinalitySum, o.cardinalitySum);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(checksum, cardinalitySum);
+        return Objects.hash(checksum, cardinalityChecksum, cardinalitySum);
     }
 
     @Override
     public String toString()
     {
-        return format("checksum: %s, cardinality_sum: %s", checksum, cardinalitySum);
+        return format("checksum: %s, cardinality_checksum: %s, cardinality_sum: %s", checksum, cardinalityChecksum, cardinalitySum);
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ArrayColumnChecksum.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ArrayColumnChecksum.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.checksum;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+public class ArrayColumnChecksum
+        extends StructureColumnChecksum
+{
+    private final Object checksum;
+    private final long cardinalitySum;
+
+    public ArrayColumnChecksum(@Nullable Object checksum, long cardinalitySum)
+    {
+        this.checksum = checksum;
+        this.cardinalitySum = cardinalitySum;
+    }
+
+    @Nullable
+    public Object getChecksum()
+    {
+        return checksum;
+    }
+
+    @Override
+    public long getCardinalitySum()
+    {
+        return cardinalitySum;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        ArrayColumnChecksum o = (ArrayColumnChecksum) obj;
+        return Objects.equals(checksum, o.checksum) &&
+                Objects.equals(cardinalitySum, o.cardinalitySum);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(checksum, cardinalitySum);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("checksum: %s, cardinality_sum: %s", checksum, cardinalitySum);
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ChecksumValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ChecksumValidator.java
@@ -29,11 +29,9 @@ import javax.inject.Provider;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import static com.facebook.presto.sql.QueryUtil.simpleQuery;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static java.util.function.Function.identity;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class ChecksumValidator
 {
@@ -55,14 +53,11 @@ public class ChecksumValidator
         return simpleQuery(new Select(false, selectItems.build()), new Table(tableName));
     }
 
-    public Map<Column, ColumnMatchResult<?>> getMismatchedColumns(List<Column> columns, ChecksumResult controlChecksum, ChecksumResult testChecksum)
+    public List<ColumnMatchResult<?>> getMismatchedColumns(List<Column> columns, ChecksumResult controlChecksum, ChecksumResult testChecksum)
     {
         return columns.stream()
                 .flatMap(column -> columnValidators.get(column.getCategory()).get().validate(column, controlChecksum, testChecksum).stream())
-                .collect(toImmutableMap(ColumnMatchResult::getColumn, identity()))
-                .entrySet()
-                .stream()
-                .filter(entry -> !entry.getValue().isMatched())
-                .collect(toImmutableMap(Entry::getKey, Entry::getValue));
+                .filter(columnMatchResult -> !columnMatchResult.isMatched())
+                .collect(toImmutableList());
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ChecksumValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ChecksumValidator.java
@@ -55,7 +55,7 @@ public class ChecksumValidator
         return simpleQuery(new Select(false, selectItems.build()), new Table(tableName));
     }
 
-    public Map<Column, ColumnMatchResult> getMismatchedColumns(List<Column> columns, ChecksumResult controlChecksum, ChecksumResult testChecksum)
+    public Map<Column, ColumnMatchResult<?>> getMismatchedColumns(List<Column> columns, ChecksumResult controlChecksum, ChecksumResult testChecksum)
     {
         return columns.stream()
                 .flatMap(column -> columnValidators.get(column.getCategory()).get().validate(column, controlChecksum, testChecksum).stream())

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ColumnChecksum.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ColumnChecksum.java
@@ -13,14 +13,15 @@
  */
 package com.facebook.presto.verifier.checksum;
 
-import com.facebook.presto.sql.tree.SingleColumn;
-import com.facebook.presto.verifier.framework.Column;
-
-import java.util.List;
-
-public interface ColumnValidator
+public abstract class ColumnChecksum
 {
-    List<SingleColumn> generateChecksumColumns(Column column);
+    // For subclasses to implement those methods.
+    @Override
+    public abstract boolean equals(Object obj);
 
-    List<? extends ColumnMatchResult<?>> validate(Column column, ChecksumResult controlResult, ChecksumResult testResult);
+    @Override
+    public abstract int hashCode();
+
+    @Override
+    public abstract String toString();
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ColumnMatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/ColumnMatchResult.java
@@ -16,21 +16,31 @@ package com.facebook.presto.verifier.checksum;
 import com.facebook.presto.verifier.framework.Column;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
-public class ColumnMatchResult
+public class ColumnMatchResult<T extends ColumnChecksum>
 {
     private final boolean matched;
     private final Column column;
-    private final String message;
+    private final Optional<String> message;
+    private final T controlColumnChecksum;
+    private final T testColumnChecksum;
 
-    public ColumnMatchResult(boolean matched, Column column, String message)
+    public ColumnMatchResult(boolean matched, Column column, T controlColumnChecksum, T testColumnChecksum)
+    {
+        this(matched, column, Optional.empty(), controlColumnChecksum, testColumnChecksum);
+    }
+
+    public ColumnMatchResult(boolean matched, Column column, Optional<String> message, T controlColumnChecksum, T testColumnChecksum)
     {
         this.matched = matched;
         this.column = requireNonNull(column, "column is null");
         this.message = requireNonNull(message, "message is null");
+        this.controlColumnChecksum = requireNonNull(controlColumnChecksum, "controlColumnChecksum is null");
+        this.testColumnChecksum = requireNonNull(testColumnChecksum, "testColumnChecksum is null");
     }
 
     public boolean isMatched()
@@ -43,9 +53,19 @@ public class ColumnMatchResult
         return column;
     }
 
-    public String getMessage()
+    public Optional<String> getMessage()
     {
         return message;
+    }
+
+    public T getControlChecksum()
+    {
+        return controlColumnChecksum;
+    }
+
+    public T getTestChecksum()
+    {
+        return testColumnChecksum;
     }
 
     @Override
@@ -57,16 +77,17 @@ public class ColumnMatchResult
         if ((obj == null) || (getClass() != obj.getClass())) {
             return false;
         }
-        ColumnMatchResult o = (ColumnMatchResult) obj;
+        ColumnMatchResult<?> o = (ColumnMatchResult<?>) obj;
         return Objects.equals(matched, o.matched) &&
                 Objects.equals(column, o.column) &&
-                Objects.equals(message, o.message);
+                Objects.equals(controlColumnChecksum, o.controlColumnChecksum) &&
+                Objects.equals(testColumnChecksum, o.testColumnChecksum);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(matched, column, message);
+        return Objects.hash(column, controlColumnChecksum, testColumnChecksum);
     }
 
     @Override
@@ -75,7 +96,8 @@ public class ColumnMatchResult
         return toStringHelper(this)
                 .add("matched", matched)
                 .add("column", column)
-                .add("message", message)
+                .add("controlColumnChecksum", controlColumnChecksum)
+                .add("testColumnChecksum", testColumnChecksum)
                 .toString();
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/FloatingPointColumnChecksum.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/FloatingPointColumnChecksum.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.checksum;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+public class FloatingPointColumnChecksum
+        extends ColumnChecksum
+{
+    private final Object sum;
+    private final long nanCount;
+    private final long positiveInfinityCount;
+    private final long negativeInfinityCount;
+    private final long rowCount;
+
+    public FloatingPointColumnChecksum(@Nullable Object sum, long nanCount, long positiveInfinityCount, long negativeInfinityCount, long rowCount)
+    {
+        this.sum = sum;
+        this.positiveInfinityCount = positiveInfinityCount;
+        this.negativeInfinityCount = negativeInfinityCount;
+        this.nanCount = nanCount;
+        this.rowCount = rowCount;
+    }
+
+    @Nullable
+    public Object getSum()
+    {
+        return sum;
+    }
+
+    public long getNanCount()
+    {
+        return nanCount;
+    }
+
+    public long getPositiveInfinityCount()
+    {
+        return positiveInfinityCount;
+    }
+
+    public long getNegativeInfinityCount()
+    {
+        return negativeInfinityCount;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        FloatingPointColumnChecksum o = (FloatingPointColumnChecksum) obj;
+        return Objects.equals(sum, o.sum) &&
+                Objects.equals(nanCount, o.nanCount) &&
+                Objects.equals(positiveInfinityCount, o.positiveInfinityCount) &&
+                Objects.equals(negativeInfinityCount, o.negativeInfinityCount);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sum, nanCount, positiveInfinityCount, negativeInfinityCount);
+    }
+
+    @Override
+    public String toString()
+    {
+        String mean = (rowCount > 0 && sum != null) ? ", mean: " + ((double) sum / rowCount) : "";
+        return format("sum: %s, NaN: %s, +infinity: %s, -infinity: %s%s", sum, nanCount, positiveInfinityCount, negativeInfinityCount, mean);
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/FloatingPointColumnValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/FloatingPointColumnValidator.java
@@ -39,7 +39,6 @@ import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
 import static java.lang.Math.abs;
 import static java.lang.Math.min;
-import static java.lang.String.format;
 
 public class FloatingPointColumnValidator
         implements ColumnValidator
@@ -101,7 +100,7 @@ public class FloatingPointColumnValidator
     }
 
     @Override
-    public List<ColumnMatchResult> validate(Column column, ChecksumResult controlResult, ChecksumResult testResult)
+    public List<ColumnMatchResult<FloatingPointColumnChecksum>> validate(Column column, ChecksumResult controlResult, ChecksumResult testResult)
     {
         checkArgument(
                 controlResult.getRowCount() == testResult.getRowCount(),
@@ -109,72 +108,60 @@ public class FloatingPointColumnValidator
                 testResult.getRowCount(),
                 controlResult.getRowCount());
 
-        String sumColumnAlias = getSumColumnAlias(column);
-        String nanCountColumnAlias = getNanCountColumnAlias(column);
-        String positiveInfinityCountColumnAlias = getPositiveInfinityCountColumnAlias(column);
-        String negativeInfinityCountColumnAlias = getNegativeInfinityCountColumnAlias(column);
+        long rowCount = controlResult.getRowCount();
 
-        long controlNanCount = (long) controlResult.getChecksum(nanCountColumnAlias);
-        long testNanCount = (long) testResult.getChecksum(nanCountColumnAlias);
-        long controlPositiveInfinityCount = (long) controlResult.getChecksum(positiveInfinityCountColumnAlias);
-        long testPositiveInfinityCount = (long) testResult.getChecksum(positiveInfinityCountColumnAlias);
-        long controlNegativeInfinityCount = (long) controlResult.getChecksum(negativeInfinityCountColumnAlias);
-        long testNegativeInfinityCount = (long) testResult.getChecksum(negativeInfinityCountColumnAlias);
-        if (!Objects.equals(controlNanCount, testNanCount) ||
-                !Objects.equals(controlPositiveInfinityCount, testPositiveInfinityCount) ||
-                !Objects.equals(controlNegativeInfinityCount, testNegativeInfinityCount)) {
-            return ImmutableList.of(new ColumnMatchResult(
-                    false,
-                    column,
-                    format(
-                            "control(NaN: %s, +infinity: %s, -infinity: %s) test(NaN: %s, +infinity: %s, -infinity: %s)",
-                            controlNanCount,
-                            controlPositiveInfinityCount,
-                            controlNegativeInfinityCount,
-                            testNanCount,
-                            testPositiveInfinityCount,
-                            testNegativeInfinityCount)));
+        FloatingPointColumnChecksum controlChecksum = toColumnChecksum(column, controlResult, rowCount);
+        FloatingPointColumnChecksum testChecksum = toColumnChecksum(column, testResult, rowCount);
+        return ImmutableList.of(validate(column, controlChecksum, testChecksum, rowCount));
+    }
+
+    private static FloatingPointColumnChecksum toColumnChecksum(Column column, ChecksumResult checksumResult, long rowCount)
+    {
+        return new FloatingPointColumnChecksum(
+                checksumResult.getChecksum(getSumColumnAlias(column)),
+                (long) checksumResult.getChecksum(getNanCountColumnAlias(column)),
+                (long) checksumResult.getChecksum(getPositiveInfinityCountColumnAlias(column)),
+                (long) checksumResult.getChecksum(getNegativeInfinityCountColumnAlias(column)),
+                rowCount);
+    }
+
+    private ColumnMatchResult<FloatingPointColumnChecksum> validate(
+            Column column,
+            FloatingPointColumnChecksum controlChecksum,
+            FloatingPointColumnChecksum testChecksum,
+            long rowCount)
+    {
+        if (!Objects.equals(controlChecksum.getNanCount(), testChecksum.getNanCount()) ||
+                !Objects.equals(controlChecksum.getPositiveInfinityCount(), testChecksum.getPositiveInfinityCount()) ||
+                !Objects.equals(controlChecksum.getNegativeInfinityCount(), testChecksum.getNegativeInfinityCount())) {
+            return new ColumnMatchResult<>(false, column, controlChecksum, testChecksum);
         }
 
-        Object controlSumObject = controlResult.getChecksum(sumColumnAlias);
-        Object testSumObject = testResult.getChecksum(sumColumnAlias);
-        if (controlSumObject == null || testSumObject == null) {
-            return ImmutableList.of(new ColumnMatchResult(
-                    controlSumObject == null && testSumObject == null,
-                    column,
-                    format("control(sum: %s) test(sum: %s)", controlSumObject, testSumObject)));
+        if (controlChecksum.getSum() == null || testChecksum.getSum() == null) {
+            return new ColumnMatchResult<>(controlChecksum.getSum() == null && testChecksum.getSum() == null, column, controlChecksum, testChecksum);
         }
 
         // Implementation according to http://floating-point-gui.de/errors/comparison/
-        double controlSum = (double) controlSumObject;
-        double testSum = (double) testSumObject;
+        double controlSum = (double) controlChecksum.getSum();
+        double testSum = (double) testChecksum.getSum();
 
         // Fail if either sum is NaN or Infinity
         if (isNaN(controlSum) || isNaN(testSum) || isInfinite(controlSum) || isInfinite(testSum)) {
-            return ImmutableList.of(new ColumnMatchResult(
-                    false,
-                    column,
-                    format("control(sum: %s) test(sum: %s)", controlSum, testSum)));
+            return new ColumnMatchResult<>(false, column, controlChecksum, testChecksum);
         }
 
         // Use absolute error margin if either control sum or test sum is 0.
         // Row count won't be zero since otherwise controlSum and testSum will both be null, and this has already been handled above.
-        double controlMean = controlSum / controlResult.getRowCount();
-        double testMean = testSum / controlResult.getRowCount();
+        double controlMean = controlSum / rowCount;
+        double testMean = testSum / rowCount;
         if (abs(controlMean) < absoluteErrorMargin || abs(testMean) < absoluteErrorMargin) {
-            return ImmutableList.of(new ColumnMatchResult(
-                    abs(controlMean) < absoluteErrorMargin && abs(testMean) < absoluteErrorMargin,
-                    column,
-                    format("control(mean: %s) test(mean: %s)", controlMean, testMean)));
+            return new ColumnMatchResult<>(abs(controlMean) < absoluteErrorMargin && abs(testMean) < absoluteErrorMargin, column, controlChecksum, testChecksum);
         }
 
         // Use relative error margin for the common cases
         double difference = abs(controlSum - testSum);
         double relativeError = difference / min((abs(controlSum) + abs(testSum)) / 2, Double.MAX_VALUE);
-        return ImmutableList.of(new ColumnMatchResult(
-                relativeError < relativeErrorMargin,
-                column,
-                format("control(sum: %s) test(sum: %s) relative error: %s", controlSum, testSum, relativeError)));
+        return new ColumnMatchResult<>(relativeError < relativeErrorMargin, column, Optional.of("relative error: " + relativeError), controlChecksum, testChecksum);
     }
 
     private static String getSumColumnAlias(Column column)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/MapColumnChecksum.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/MapColumnChecksum.java
@@ -25,17 +25,20 @@ public class MapColumnChecksum
     private final Object checksum;
     private final Object keysChecksum;
     private final Object valuesChecksum;
+    private final Object cardinalityChecksum;
     private final long cardinalitySum;
 
     public MapColumnChecksum(
             @Nullable Object checksum,
             @Nullable Object keysChecksum,
             @Nullable Object valuesChecksum,
-            @Nullable long cardinalitySum)
+            @Nullable Object cardinalityChecksum,
+            long cardinalitySum)
     {
         this.checksum = checksum;
         this.keysChecksum = keysChecksum;
         this.valuesChecksum = valuesChecksum;
+        this.cardinalityChecksum = cardinalityChecksum;
         this.cardinalitySum = cardinalitySum;
     }
 
@@ -58,6 +61,13 @@ public class MapColumnChecksum
     }
 
     @Override
+    @Nullable
+    public Object getCardinalityChecksum()
+    {
+        return cardinalityChecksum;
+    }
+
+    @Override
     public long getCardinalitySum()
     {
         return cardinalitySum;
@@ -76,18 +86,19 @@ public class MapColumnChecksum
         return Objects.equals(checksum, o.checksum) &&
                 Objects.equals(keysChecksum, o.keysChecksum) &&
                 Objects.equals(valuesChecksum, o.valuesChecksum) &&
+                Objects.equals(cardinalityChecksum, o.cardinalityChecksum) &&
                 Objects.equals(cardinalitySum, o.cardinalitySum);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(checksum, keysChecksum, valuesChecksum, cardinalitySum);
+        return Objects.hash(checksum, keysChecksum, valuesChecksum, cardinalityChecksum, cardinalitySum);
     }
 
     @Override
     public String toString()
     {
-        return format("checksum: %s, keys_checksum: %s, values_checksum: %s, cardinality_sum: %s", checksum, keysChecksum, valuesChecksum, cardinalitySum);
+        return format("checksum: %s, keys_checksum: %s, values_checksum: %s, cardinality_checksum: %s, cardinality_sum: %s", checksum, keysChecksum, valuesChecksum, cardinalityChecksum, cardinalitySum);
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/MapColumnChecksum.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/MapColumnChecksum.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.checksum;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+public class MapColumnChecksum
+        extends StructureColumnChecksum
+{
+    private final Object checksum;
+    private final Object keysChecksum;
+    private final Object valuesChecksum;
+    private final long cardinalitySum;
+
+    public MapColumnChecksum(
+            @Nullable Object checksum,
+            @Nullable Object keysChecksum,
+            @Nullable Object valuesChecksum,
+            @Nullable long cardinalitySum)
+    {
+        this.checksum = checksum;
+        this.keysChecksum = keysChecksum;
+        this.valuesChecksum = valuesChecksum;
+        this.cardinalitySum = cardinalitySum;
+    }
+
+    @Nullable
+    public Object getChecksum()
+    {
+        return checksum;
+    }
+
+    @Nullable
+    public Object getKeysChecksum()
+    {
+        return keysChecksum;
+    }
+
+    @Nullable
+    public Object getValuesChecksum()
+    {
+        return valuesChecksum;
+    }
+
+    @Override
+    public long getCardinalitySum()
+    {
+        return cardinalitySum;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        MapColumnChecksum o = (MapColumnChecksum) obj;
+        return Objects.equals(checksum, o.checksum) &&
+                Objects.equals(keysChecksum, o.keysChecksum) &&
+                Objects.equals(valuesChecksum, o.valuesChecksum) &&
+                Objects.equals(cardinalitySum, o.cardinalitySum);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(checksum, keysChecksum, valuesChecksum, cardinalitySum);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("checksum: %s, keys_checksum: %s, values_checksum: %s, cardinality_sum: %s", checksum, keysChecksum, valuesChecksum, cardinalitySum);
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/MapColumnValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/MapColumnValidator.java
@@ -45,6 +45,7 @@ public class MapColumnValidator
         Expression checksum = functionCall("checksum", column.getExpression());
         Expression keysChecksum = generateArrayChecksum(functionCall("map_keys", column.getExpression()), new ArrayType(keyType));
         Expression valuesChecksum = generateArrayChecksum(functionCall("map_values", column.getExpression()), new ArrayType(valueType));
+        Expression mapCardinalityChecksum = functionCall("checksum", functionCall("cardinality", column.getExpression()));
         Expression mapCardinalitySum = new CoalesceExpression(
                 functionCall("sum", functionCall("cardinality", column.getExpression())),
                 new LongLiteral("0"));
@@ -53,6 +54,7 @@ public class MapColumnValidator
                 new SingleColumn(checksum, Optional.of(delimitedIdentifier(getChecksumColumnAlias(column)))),
                 new SingleColumn(keysChecksum, Optional.of(delimitedIdentifier(getKeysChecksumColumnAlias(column)))),
                 new SingleColumn(valuesChecksum, Optional.of(delimitedIdentifier(getValuesChecksumColumnAlias(column)))),
+                new SingleColumn(mapCardinalityChecksum, Optional.of(delimitedIdentifier(getCardinalityChecksumColumnAlias(column)))),
                 new SingleColumn(mapCardinalitySum, Optional.of(delimitedIdentifier(getCardinalitySumColumnAlias(column)))));
     }
 
@@ -71,6 +73,7 @@ public class MapColumnValidator
                 checksumResult.getChecksum(getChecksumColumnAlias(column)),
                 checksumResult.getChecksum(getKeysChecksumColumnAlias(column)),
                 checksumResult.getChecksum(getValuesChecksumColumnAlias(column)),
+                checksumResult.getChecksum(getCardinalityChecksumColumnAlias(column)),
                 (long) checksumResult.getChecksum(getCardinalitySumColumnAlias(column)));
     }
 
@@ -87,6 +90,11 @@ public class MapColumnValidator
     private static String getValuesChecksumColumnAlias(Column column)
     {
         return column.getName() + "$values_checksum";
+    }
+
+    private static String getCardinalityChecksumColumnAlias(Column column)
+    {
+        return column.getName() + "$cardinality_checksum";
     }
 
     private static String getCardinalitySumColumnAlias(Column column)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/RowColumnValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/RowColumnValidator.java
@@ -63,11 +63,11 @@ public class RowColumnValidator
     }
 
     @Override
-    public List<ColumnMatchResult> validate(Column column, ChecksumResult controlResult, ChecksumResult testResult)
+    public List<ColumnMatchResult<?>> validate(Column column, ChecksumResult controlResult, ChecksumResult testResult)
     {
         checkColumnType(column);
 
-        ImmutableList.Builder<ColumnMatchResult> resultsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<ColumnMatchResult<?>> resultsBuilder = ImmutableList.builder();
         List<Field> fields = getFields(column);
         for (int i = 0; i < fields.size(); i++) {
             Column fieldColumn = getFieldAsColumn(column, fields.get(i), i);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/SimpleColumnChecksum.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/SimpleColumnChecksum.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.checksum;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+public class SimpleColumnChecksum
+        extends ColumnChecksum
+{
+    private final Object checksum;
+
+    public SimpleColumnChecksum(@Nullable Object checksum)
+    {
+        this.checksum = checksum;
+    }
+
+    @Nullable
+    public Object getChecksum()
+    {
+        return checksum;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        SimpleColumnChecksum o = (SimpleColumnChecksum) obj;
+        return Objects.equals(checksum, o.checksum);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(checksum);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("%s", checksum);
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/SimpleColumnValidator.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/SimpleColumnValidator.java
@@ -24,7 +24,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.facebook.presto.verifier.framework.VerifierUtil.delimitedIdentifier;
-import static java.lang.String.format;
 
 public class SimpleColumnValidator
         implements ColumnValidator
@@ -39,15 +38,12 @@ public class SimpleColumnValidator
     }
 
     @Override
-    public List<ColumnMatchResult> validate(Column column, ChecksumResult controlResult, ChecksumResult testResult)
+    public List<ColumnMatchResult<SimpleColumnChecksum>> validate(Column column, ChecksumResult controlResult, ChecksumResult testResult)
     {
         String checksumColumnAlias = getChecksumColumnAlias(column);
-        Object controlChecksum = controlResult.getChecksum(checksumColumnAlias);
-        Object testChecksum = testResult.getChecksum(checksumColumnAlias);
-        return ImmutableList.of(new ColumnMatchResult(
-                Objects.equals(controlChecksum, testChecksum),
-                column,
-                format("control(checksum: %s) test(checksum: %s)", controlChecksum, testChecksum)));
+        SimpleColumnChecksum controlChecksum = new SimpleColumnChecksum(controlResult.getChecksum(checksumColumnAlias));
+        SimpleColumnChecksum testChecksum = new SimpleColumnChecksum(testResult.getChecksum(checksumColumnAlias));
+        return ImmutableList.of(new ColumnMatchResult<>(Objects.equals(controlChecksum, testChecksum), column, controlChecksum, testChecksum));
     }
 
     private static String getChecksumColumnAlias(Column column)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/StructureColumnChecksum.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/StructureColumnChecksum.java
@@ -13,14 +13,8 @@
  */
 package com.facebook.presto.verifier.checksum;
 
-import com.facebook.presto.sql.tree.SingleColumn;
-import com.facebook.presto.verifier.framework.Column;
-
-import java.util.List;
-
-public interface ColumnValidator
+public abstract class StructureColumnChecksum
+        extends ColumnChecksum
 {
-    List<SingleColumn> generateChecksumColumns(Column column);
-
-    List<? extends ColumnMatchResult<?>> validate(Column column, ChecksumResult controlResult, ChecksumResult testResult);
+    public abstract long getCardinalitySum();
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/StructureColumnChecksum.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/checksum/StructureColumnChecksum.java
@@ -16,5 +16,7 @@ package com.facebook.presto.verifier.checksum;
 public abstract class StructureColumnChecksum
         extends ColumnChecksum
 {
+    public abstract Object getCardinalityChecksum();
+
     public abstract long getCardinalitySum();
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
@@ -213,9 +213,13 @@ public abstract class AbstractVerification
 
         Optional<SkippedReason> skippedReason = getSkippedReason(throwable, controlQueryContext.getState(), determinismAnalysis);
         Optional<String> resolveMessage = Optional.empty();
+        if (matchResult.isPresent() && !matchResult.get().isMatched()) {
+            checkState(control.isPresent(), "control is missing");
+            resolveMessage = failureResolverManager.resolveResultMismatch(matchResult.get(), control.get());
+        }
         if (throwable.isPresent() && controlQueryContext.getState() == QueryState.SUCCEEDED) {
             checkState(controlQueryContext.getStats().isPresent(), "controlQueryStats is missing");
-            resolveMessage = failureResolverManager.resolve(controlQueryContext.getStats().get(), throwable.get(), test);
+            resolveMessage = failureResolverManager.resolveException(controlQueryContext.getStats().get(), throwable.get(), test);
         }
 
         EventStatus status;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerificationUtil.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerificationUtil.java
@@ -23,10 +23,9 @@ import com.facebook.presto.verifier.checksum.ChecksumResult;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.checksum.ColumnMatchResult;
 import com.facebook.presto.verifier.prestoaction.PrestoAction;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 
@@ -98,16 +97,16 @@ public class DataVerificationUtil
                     Optional.empty(),
                     OptionalLong.empty(),
                     OptionalLong.empty(),
-                    ImmutableMap.of());
+                    ImmutableList.of());
         }
 
         OptionalLong controlRowCount = OptionalLong.of(controlChecksum.getRowCount());
         OptionalLong testRowCount = OptionalLong.of(testChecksum.getRowCount());
 
         MatchResult.MatchType matchType;
-        Map<Column, ColumnMatchResult<?>> mismatchedColumns;
+        List<ColumnMatchResult<?>> mismatchedColumns;
         if (controlChecksum.getRowCount() != testChecksum.getRowCount()) {
-            mismatchedColumns = ImmutableMap.of();
+            mismatchedColumns = ImmutableList.of();
             matchType = ROW_COUNT_MISMATCH;
         }
         else {

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerificationUtil.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerificationUtil.java
@@ -105,7 +105,7 @@ public class DataVerificationUtil
         OptionalLong testRowCount = OptionalLong.of(testChecksum.getRowCount());
 
         MatchResult.MatchType matchType;
-        Map<Column, ColumnMatchResult> mismatchedColumns;
+        Map<Column, ColumnMatchResult<?>> mismatchedColumns;
         if (controlChecksum.getRowCount() != testChecksum.getRowCount()) {
             mismatchedColumns = ImmutableMap.of();
             matchType = ROW_COUNT_MISMATCH;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/MatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/MatchResult.java
@@ -43,14 +43,14 @@ public class MatchResult
     private final Optional<ChecksumResult> controlChecksum;
     private final OptionalLong controlRowCount;
     private final OptionalLong testRowCount;
-    private final Map<Column, ColumnMatchResult> mismatchedColumns;
+    private final Map<Column, ColumnMatchResult<?>> mismatchedColumns;
 
     public MatchResult(
             MatchType matchType,
             Optional<ChecksumResult> controlChecksum,
             OptionalLong controlRowCount,
             OptionalLong testRowCount,
-            Map<Column, ColumnMatchResult> mismatchedColumns)
+            Map<Column, ColumnMatchResult<?>> mismatchedColumns)
     {
         this.matchType = requireNonNull(matchType, "type is null");
         this.controlChecksum = requireNonNull(controlChecksum, "controlChecksum is null");
@@ -97,9 +97,14 @@ public class MatchResult
         }
 
         message.append("Mismatched Columns:\n");
-        mismatchedColumns.forEach((column, matchResult) ->
-                message.append(format("  %s (%s): %s", column.getName(), column.getType().getDisplayName(), matchResult.getMessage()))
-                        .append("\n"));
+        mismatchedColumns.forEach((column, columnMismatch) ->
+                message.append(format(
+                        "  %s (%s)%s\n    control\t(%s)\n    test\t(%s)\n",
+                        columnMismatch.getColumn().getName(),
+                        columnMismatch.getColumn().getType().getDisplayName(),
+                        columnMismatch.getMessage().map(columnMessage -> " " + columnMessage).orElse(""),
+                        columnMismatch.getControlChecksum(),
+                        columnMismatch.getTestChecksum())));
         return message.toString();
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/MatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/MatchResult.java
@@ -80,6 +80,11 @@ public class MatchResult
         return matchType == ROW_COUNT_MISMATCH || matchType == COLUMN_MISMATCH;
     }
 
+    public List<ColumnMatchResult<?>> getMismatchedColumns()
+    {
+        return mismatchedColumns;
+    }
+
     public String getResultsComparison()
     {
         StringBuilder message = new StringBuilder()

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/MatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/MatchResult.java
@@ -15,9 +15,9 @@ package com.facebook.presto.verifier.framework;
 
 import com.facebook.presto.verifier.checksum.ChecksumResult;
 import com.facebook.presto.verifier.checksum.ColumnMatchResult;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 
-import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 
@@ -43,20 +43,20 @@ public class MatchResult
     private final Optional<ChecksumResult> controlChecksum;
     private final OptionalLong controlRowCount;
     private final OptionalLong testRowCount;
-    private final Map<Column, ColumnMatchResult<?>> mismatchedColumns;
+    private final List<ColumnMatchResult<?>> mismatchedColumns;
 
     public MatchResult(
             MatchType matchType,
             Optional<ChecksumResult> controlChecksum,
             OptionalLong controlRowCount,
             OptionalLong testRowCount,
-            Map<Column, ColumnMatchResult<?>> mismatchedColumns)
+            List<ColumnMatchResult<?>> mismatchedColumns)
     {
         this.matchType = requireNonNull(matchType, "type is null");
         this.controlChecksum = requireNonNull(controlChecksum, "controlChecksum is null");
         this.controlRowCount = requireNonNull(controlRowCount, "controlRowCount is null");
         this.testRowCount = requireNonNull(testRowCount, "testRowCount is null");
-        this.mismatchedColumns = ImmutableMap.copyOf(mismatchedColumns);
+        this.mismatchedColumns = ImmutableList.copyOf(mismatchedColumns);
     }
 
     public boolean isMatched()
@@ -97,7 +97,7 @@ public class MatchResult
         }
 
         message.append("Mismatched Columns:\n");
-        mismatchedColumns.forEach((column, columnMismatch) ->
+        mismatchedColumns.forEach(columnMismatch ->
                 message.append(format(
                         "  %s (%s)%s\n    control\t(%s)\n    test\t(%s)\n",
                         columnMismatch.getColumn().getName(),

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ChecksumExceededTimeLimitFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ChecksumExceededTimeLimitFailureResolver.java
@@ -29,7 +29,7 @@ public class ChecksumExceededTimeLimitFailureResolver
     public static final String NAME = "checksum-exceeded-time-limit";
 
     @Override
-    public Optional<String> resolve(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
+    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
     {
         return mapMatchingPrestoException(queryException, CONTROL_CHECKSUM, EXCEEDED_TIME_LIMIT,
                 e -> Optional.of("Time limit exceeded when running control checksum query"));

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededGlobalMemoryLimitFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededGlobalMemoryLimitFailureResolver.java
@@ -29,7 +29,7 @@ public class ExceededGlobalMemoryLimitFailureResolver
     public static final String NAME = "exceeded-global-memory-limit";
 
     @Override
-    public Optional<String> resolve(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
+    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
     {
         return mapMatchingPrestoException(queryException, TEST_MAIN, EXCEEDED_GLOBAL_MEMORY_LIMIT,
                 e -> e.getQueryStats().isPresent() && controlQueryStats.getPeakTotalMemoryBytes() > e.getQueryStats().get().getPeakTotalMemoryBytes()

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededTimeLimitFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededTimeLimitFailureResolver.java
@@ -29,7 +29,7 @@ public class ExceededTimeLimitFailureResolver
     public static final String NAME = "exceeded-time-limit";
 
     @Override
-    public Optional<String> resolve(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
+    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
     {
         return mapMatchingPrestoException(queryException, TEST_MAIN, EXCEEDED_TIME_LIMIT,
                 e -> Optional.of("Time limit exceeded on test cluster"));

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolver.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.verifier.resolver;
 
 import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.verifier.framework.MatchResult;
 import com.facebook.presto.verifier.framework.QueryBundle;
 import com.facebook.presto.verifier.framework.QueryException;
 
@@ -21,5 +22,13 @@ import java.util.Optional;
 
 public interface FailureResolver
 {
-    Optional<String> resolve(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test);
+    default Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
+    {
+        return Optional.empty();
+    }
+
+    default Optional<String> resolveResultMismatch(MatchResult matchResult, QueryBundle control)
+    {
+        return Optional.empty();
+    }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolverModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolverModule.java
@@ -31,11 +31,14 @@ public class FailureResolverModule
         extends AbstractConfigurationAwareModule
 {
     public static final FailureResolverModule BUILT_IN = FailureResolverModule.builder()
+            // Query Failure Resolvers
             .bind(ExceededGlobalMemoryLimitFailureResolver.NAME, ExceededGlobalMemoryLimitFailureResolver.class, Optional.empty())
             .bind(ExceededTimeLimitFailureResolver.NAME, ExceededTimeLimitFailureResolver.class, Optional.empty())
             .bind(ChecksumExceededTimeLimitFailureResolver.NAME, ChecksumExceededTimeLimitFailureResolver.class, Optional.empty())
             .bind(VerifierLimitationFailureResolver.NAME, VerifierLimitationFailureResolver.class, Optional.empty())
             .bindFactory(TooManyOpenPartitionsFailureResolver.NAME, TooManyOpenPartitionsFailureResolver.Factory.class, Optional.of(TooManyOpenPartitionsFailureResolverConfig.class))
+            // Result Mismatch Resolvers
+            .bind(StructuredColumnMismatchResolver.NAME, StructuredColumnMismatchResolver.class, Optional.empty())
             .build();
 
     private final List<FailureResolverBinding> resolvers;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolverModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolverModule.java
@@ -79,8 +79,8 @@ public class FailureResolverModule
     {
         configBinder(binder).bindConfig(FailureResolverConfig.class, named(name), name);
         if (buildConfigObject(FailureResolverConfig.class, name).isEnabled()) {
-            failureResolverClass.ifPresent(clazz -> newSetBinder(binder, FailureResolver.class).addBinding().to(clazz));
-            failureResolverFactoryClass.ifPresent(clazz -> newSetBinder(binder, FailureResolverFactory.class).addBinding().to(clazz));
+            failureResolverClass.ifPresent(clazz -> newSetBinder(binder, FailureResolver.class).addBinding().to(clazz).in(SINGLETON));
+            failureResolverFactoryClass.ifPresent(clazz -> newSetBinder(binder, FailureResolverFactory.class).addBinding().to(clazz).in(SINGLETON));
             failureResolverConfigClass.ifPresent(clazz -> configBinder(binder).bindConfig(clazz, name));
         }
     }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolverModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolverModule.java
@@ -39,6 +39,7 @@ public class FailureResolverModule
             .bindFactory(TooManyOpenPartitionsFailureResolver.NAME, TooManyOpenPartitionsFailureResolver.Factory.class, Optional.of(TooManyOpenPartitionsFailureResolverConfig.class))
             // Result Mismatch Resolvers
             .bind(StructuredColumnMismatchResolver.NAME, StructuredColumnMismatchResolver.class, Optional.empty())
+            .bind(IgnoredFunctionsMismatchResolver.NAME, IgnoredFunctionsMismatchResolver.class, Optional.of(IgnoredFunctionsMismatchResolverConfig.class))
             .build();
 
     private final List<FailureResolverBinding> resolvers;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/IgnoredFunctionsMismatchResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/IgnoredFunctionsMismatchResolver.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.resolver;
+
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.sql.tree.AstVisitor;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.verifier.framework.MatchResult;
+import com.facebook.presto.verifier.framework.QueryBundle;
+import com.google.common.base.Splitter;
+
+import javax.inject.Inject;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.metadata.BuiltInFunctionNamespaceManager.DEFAULT_NAMESPACE;
+import static com.facebook.presto.verifier.framework.MatchResult.MatchType.COLUMN_MISMATCH;
+import static com.facebook.presto.verifier.framework.MatchResult.MatchType.ROW_COUNT_MISMATCH;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class IgnoredFunctionsMismatchResolver
+        implements FailureResolver
+{
+    public static final String NAME = "ignored-functions";
+
+    private final List<String> ignoredFunctions;
+
+    @Inject
+    public IgnoredFunctionsMismatchResolver(IgnoredFunctionsMismatchResolverConfig config)
+    {
+        this.ignoredFunctions = config.getFunctions().stream()
+                .map(IgnoredFunctionsMismatchResolver::normalizeFunctionName)
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public Optional<String> resolveResultMismatch(MatchResult matchResult, QueryBundle control)
+    {
+        checkArgument(!matchResult.isMatched(), "Expect not matched");
+        if (matchResult.getMatchType() != COLUMN_MISMATCH && matchResult.getMatchType() != ROW_COUNT_MISMATCH) {
+            return Optional.empty();
+        }
+
+        Set<String> ignoredFunctionsInQuery = new HashSet<>();
+        new Visitor().process(control.getQuery(), ignoredFunctionsInQuery);
+        return ignoredFunctionsInQuery.isEmpty() ? Optional.empty() : Optional.of("Query references ignored function: " + ignoredFunctionsInQuery);
+    }
+
+    private class Visitor
+            extends AstVisitor<Void, Set<String>>
+    {
+        @Override
+        protected Void visitNode(Node node, Set<String> context)
+        {
+            node.getChildren().forEach(child -> process(child, context));
+            return null;
+        }
+
+        @Override
+        protected Void visitFunctionCall(FunctionCall node, Set<String> ignoredFunctionsInQuery)
+        {
+            super.visitFunctionCall(node, ignoredFunctionsInQuery);
+            String functionName = normalizeFunctionName(node.getName());
+            if (ignoredFunctions.contains(functionName)) {
+                ignoredFunctionsInQuery.add(functionName);
+            }
+            return null;
+        }
+    }
+
+    private static String normalizeFunctionName(String name)
+    {
+        return normalizeFunctionName(QualifiedName.of(Splitter.on(".").splitToList(name)));
+    }
+
+    private static String normalizeFunctionName(QualifiedName name)
+    {
+        if (name.getParts().size() == 3 &&
+                new CatalogSchemaName(name.getParts().get(0), name.getParts().get(1)).equals(DEFAULT_NAMESPACE)) {
+            return name.getSuffix();
+        }
+        return name.toString();
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/IgnoredFunctionsMismatchResolverConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/IgnoredFunctionsMismatchResolverConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.resolver;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Locale.ENGLISH;
+
+public class IgnoredFunctionsMismatchResolverConfig
+{
+    private Set<String> functions = ImmutableSet.of();
+
+    public Set<String> getFunctions()
+    {
+        return functions;
+    }
+
+    @Config("functions")
+    @ConfigDescription("A comma-separated list of ignored functions")
+    public IgnoredFunctionsMismatchResolverConfig setFunctions(String functions)
+    {
+        if (functions != null) {
+            this.functions = Splitter.on(",").trimResults().splitToList(functions).stream()
+                    .map(catalog -> catalog.toLowerCase(ENGLISH))
+                    .collect(toImmutableSet());
+        }
+        return this;
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/StructuredColumnMismatchResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/StructuredColumnMismatchResolver.java
@@ -36,7 +36,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class StructuredColumnMismatchResolver
         implements FailureResolver
 {
-    public static final String NAME = "structure-column";
+    public static final String NAME = "structured-column";
 
     @Override
     public Optional<String> resolveResultMismatch(MatchResult matchResult, QueryBundle control)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/StructuredColumnMismatchResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/StructuredColumnMismatchResolver.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.resolver;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.verifier.checksum.ArrayColumnChecksum;
+import com.facebook.presto.verifier.checksum.ColumnMatchResult;
+import com.facebook.presto.verifier.checksum.MapColumnChecksum;
+import com.facebook.presto.verifier.checksum.StructureColumnChecksum;
+import com.facebook.presto.verifier.framework.MatchResult;
+import com.facebook.presto.verifier.framework.QueryBundle;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.RowType.Field;
+import static com.facebook.presto.verifier.framework.MatchResult.MatchType.COLUMN_MISMATCH;
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class StructuredColumnMismatchResolver
+        implements FailureResolver
+{
+    public static final String NAME = "structure-column";
+
+    @Override
+    public Optional<String> resolveResultMismatch(MatchResult matchResult, QueryBundle control)
+    {
+        checkArgument(!matchResult.isMatched(), "Expect not matched");
+        if (matchResult.getMatchType() != COLUMN_MISMATCH) {
+            return Optional.empty();
+        }
+
+        for (ColumnMatchResult<?> mismatchedColumn : matchResult.getMismatchedColumns()) {
+            Type columnType = mismatchedColumn.getColumn().getType();
+
+            if (columnType instanceof ArrayType) {
+                ArrayColumnChecksum controlChecksum = (ArrayColumnChecksum) mismatchedColumn.getControlChecksum();
+                ArrayColumnChecksum testChecksum = (ArrayColumnChecksum) mismatchedColumn.getTestChecksum();
+
+                if (!containsFloatingPointType(((ArrayType) columnType).getElementType())
+                        || !isCardinalityMatched(controlChecksum, testChecksum)) {
+                    return Optional.empty();
+                }
+            }
+            else if (columnType instanceof MapType) {
+                MapColumnChecksum controlChecksum = (MapColumnChecksum) mismatchedColumn.getControlChecksum();
+                MapColumnChecksum testChecksum = (MapColumnChecksum) mismatchedColumn.getTestChecksum();
+
+                if (!isCardinalityMatched(controlChecksum, testChecksum)) {
+                    return Optional.empty();
+                }
+
+                boolean keyContainsFloatingPoint = containsFloatingPointType(((MapType) columnType).getKeyType());
+                boolean valueContainsFloatingPoint = containsFloatingPointType(((MapType) columnType).getValueType());
+                if (!keyContainsFloatingPoint && !valueContainsFloatingPoint) {
+                    return Optional.empty();
+                }
+                if (!keyContainsFloatingPoint &&
+                        !Objects.equals(controlChecksum.getKeysChecksum(), testChecksum.getKeysChecksum())) {
+                    return Optional.empty();
+                }
+                if (!valueContainsFloatingPoint &&
+                        !Objects.equals(controlChecksum.getValuesChecksum(), testChecksum.getValuesChecksum())) {
+                    return Optional.empty();
+                }
+            }
+            else {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.of("Structured columns auto-resolved");
+    }
+
+    private static boolean containsFloatingPointType(Type type)
+    {
+        if (type instanceof DoubleType || type instanceof RealType) {
+            return true;
+        }
+        if (type instanceof ArrayType) {
+            return containsFloatingPointType(((ArrayType) type).getElementType());
+        }
+        if (type instanceof MapType) {
+            return containsFloatingPointType(((MapType) type).getKeyType()) || containsFloatingPointType(((MapType) type).getValueType());
+        }
+        if (type instanceof RowType) {
+            for (Field field : ((RowType) type).getFields()) {
+                if (containsFloatingPointType(field.getType())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return false;
+    }
+
+    private static <T extends StructureColumnChecksum> boolean isCardinalityMatched(T controlChecksum, T testChecksum)
+    {
+        return Objects.equals(controlChecksum.getCardinalityChecksum(), testChecksum.getCardinalityChecksum())
+                && Objects.equals(controlChecksum.getCardinalitySum(), testChecksum.getCardinalitySum());
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/TooManyOpenPartitionsFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/TooManyOpenPartitionsFailureResolver.java
@@ -71,7 +71,7 @@ public class TooManyOpenPartitionsFailureResolver
     }
 
     @Override
-    public Optional<String> resolve(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
+    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
     {
         if (!test.isPresent()) {
             return Optional.empty();

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/VerifierLimitationFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/VerifierLimitationFailureResolver.java
@@ -34,14 +34,4 @@ public class VerifierLimitationFailureResolver
         return mapMatchingPrestoException(queryException, CONTROL_CHECKSUM, COMPILER_ERROR,
                 e -> Optional.of("Checksum query too large"));
     }
-
-    public static class Factory
-            implements FailureResolverFactory
-    {
-        @Override
-        public FailureResolver create(FailureResolverFactoryContext context)
-        {
-            return new VerifierLimitationFailureResolver();
-        }
-    }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/VerifierLimitationFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/VerifierLimitationFailureResolver.java
@@ -29,7 +29,7 @@ public class VerifierLimitationFailureResolver
     public static final String NAME = "verifier-limitation";
 
     @Override
-    public Optional<String> resolve(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
+    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
     {
         return mapMatchingPrestoException(queryException, CONTROL_CHECKSUM, COMPILER_ERROR,
                 e -> Optional.of("Checksum query too large"));

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
@@ -19,6 +19,10 @@ import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.plugin.memory.MemoryPlugin;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.testing.mysql.MySqlOptions;
 import com.facebook.presto.testing.mysql.TestingMySqlServer;
 import com.facebook.presto.tests.StandaloneQueryRunner;
@@ -31,6 +35,7 @@ import com.facebook.presto.verifier.checksum.MapColumnValidator;
 import com.facebook.presto.verifier.checksum.RowColumnValidator;
 import com.facebook.presto.verifier.checksum.SimpleColumnValidator;
 import com.facebook.presto.verifier.framework.Column;
+import com.facebook.presto.verifier.framework.QueryBundle;
 import com.facebook.presto.verifier.framework.VerifierConfig;
 import com.facebook.presto.verifier.source.MySqlSourceQueryConfig;
 import com.facebook.presto.verifier.source.VerifierDao;
@@ -46,7 +51,11 @@ import javax.inject.Provider;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.facebook.presto.sql.parser.IdentifierSymbol.AT_SIGN;
+import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
+import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.verifier.framework.ClusterType.CONTROL;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class VerifierTestUtil
@@ -55,6 +64,15 @@ public class VerifierTestUtil
     public static final String SCHEMA = "default";
     public static final String XDB = "presto";
     public static final String VERIFIER_QUERIES_TABLE = "verifier_queries";
+
+    public static final QueryBundle TEST_BUNDLE = new QueryBundle(
+            QualifiedName.of("test"),
+            ImmutableList.of(),
+            new SqlParser(new SqlParserOptions().allowIdentifierSymbol(AT_SIGN, COLON)).createStatement(
+                    "INSERT INTO test SELECT * FROM source",
+                    ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build()),
+            ImmutableList.of(),
+            CONTROL);
 
     private static final MySqlOptions MY_SQL_OPTIONS = MySqlOptions.builder()
             .setCommandTimeout(new Duration(90, SECONDS))

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
@@ -392,7 +392,7 @@ public class TestChecksumValidator
 
     private List<ColumnMatchResult<?>> assertMismatchedColumns(List<Column> columns, ChecksumResult controlChecksum, ChecksumResult testChecksum, Column... expected)
     {
-        List<ColumnMatchResult<?>> mismatchedColumns = ImmutableList.copyOf(checksumValidator.getMismatchedColumns(columns, controlChecksum, testChecksum).values());
+        List<ColumnMatchResult<?>> mismatchedColumns = ImmutableList.copyOf(checksumValidator.getMismatchedColumns(columns, controlChecksum, testChecksum));
         List<Column> actual = mismatchedColumns.stream()
                 .map(ColumnMatchResult::getColumn)
                 .collect(toImmutableList());

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
@@ -92,12 +92,13 @@ public class TestChecksumValidator
             .put("row.d$neg_inf_count", 4L)
             .put("row.d$sum", 0.0)
             .put("row.a$checksum", new SqlVarbinary(new byte[] {0xc}))
+            .put("row.a$cardinality_checksum", new SqlVarbinary(new byte[] {0xd}))
             .put("row.a$cardinality_sum", 2L)
             .put("row.r._col1$nan_count", 2L)
             .put("row.r._col1$pos_inf_count", 3L)
             .put("row.r._col1$neg_inf_count", 4L)
             .put("row.r._col1$sum", 0.0)
-            .put("row.r.b$checksum", new SqlVarbinary(new byte[] {0xd}))
+            .put("row.r.b$checksum", new SqlVarbinary(new byte[] {0xe}))
             .build();
     private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
 
@@ -135,34 +136,40 @@ public class TestChecksumValidator
                         ", \"count\"(\"real\") FILTER (WHERE (\"real\" = \"infinity\"())) \"real$pos_inf_count\"\n" +
                         ", \"count\"(\"real\") FILTER (WHERE (\"real\" = -\"infinity\"())) \"real$neg_inf_count\"\n" +
                         ", \"checksum\"(\"array_sort\"(\"int_array\")) \"int_array$checksum\"\n" +
-                        ", COALESCE(\"sum\"(\"cardinality\"(\"int_array\")), 0) \"int_array$cardinality_sum\"" +
-                        ", COALESCE(\"checksum\"(TRY(\"array_sort\"(\"row_array\"))), \"checksum\"(\"row_array\")) \"row_array$checksum\"" +
-                        ", COALESCE(\"sum\"(\"cardinality\"(\"row_array\")), 0) \"row_array$cardinality_sum\"" +
+                        ", \"checksum\"(\"cardinality\"(\"int_array\")) \"int_array$cardinality_checksum\"\n" +
+                        ", COALESCE(\"sum\"(\"cardinality\"(\"int_array\")), 0) \"int_array$cardinality_sum\"\n" +
+                        ", COALESCE(\"checksum\"(TRY(\"array_sort\"(\"row_array\"))), \"checksum\"(\"row_array\")) \"row_array$checksum\"\n" +
+                        ", \"checksum\"(\"cardinality\"(\"row_array\")) \"row_array$cardinality_checksum\"\n" +
+                        ", COALESCE(\"sum\"(\"cardinality\"(\"row_array\")), 0) \"row_array$cardinality_sum\"\n" +
                         ", \"checksum\"(\"map_array\") \"map_array$checksum\"\n" +
-                        ", COALESCE(\"sum\"(\"cardinality\"(\"map_array\")), 0) \"map_array$cardinality_sum\"" +
+                        ", \"checksum\"(\"cardinality\"(\"map_array\")) \"map_array$cardinality_checksum\"\n" +
+                        ", COALESCE(\"sum\"(\"cardinality\"(\"map_array\")), 0) \"map_array$cardinality_sum\"\n" +
                         ", \"checksum\"(\"map\") \"map$checksum\"\n" +
                         ", \"checksum\"(\"array_sort\"(\"map_keys\"(\"map\"))) \"map$keys_checksum\"\n" +
                         ", COALESCE(\"checksum\"(TRY(\"array_sort\"(\"map_values\"(\"map\")))), \"checksum\"(\"map_values\"(\"map\"))) \"map$values_checksum\"\n" +
-                        ", COALESCE(\"sum\"(\"cardinality\"(\"map\")), 0) \"map$cardinality_sum\"" +
+                        ", \"checksum\"(\"cardinality\"(\"map\")) \"map$cardinality_checksum\"\n" +
+                        ", COALESCE(\"sum\"(\"cardinality\"(\"map\")), 0) \"map$cardinality_sum\"\n" +
                         ", \"checksum\"(\"map_non_orderable\") \"map_non_orderable$checksum\"\n" +
                         ", \"checksum\"(\"map_keys\"(\"map_non_orderable\")) \"map_non_orderable$keys_checksum\"\n" +
                         ", \"checksum\"(\"map_values\"(\"map_non_orderable\")) \"map_non_orderable$values_checksum\"\n" +
-                        ", COALESCE(\"sum\"(\"cardinality\"(\"map_non_orderable\")), 0) \"map_non_orderable$cardinality_sum\"" +
-                        ", \"checksum\"(\"row\".\"i\") \"row.i$checksum\"\n " +
-                        ", \"checksum\"(\"row\"[2]) \"row._col2$checksum\"\n " +
-                        ", \"sum\"(\"row\".\"d\") FILTER (WHERE \"is_finite\"(\"row\".\"d\")) \"row.d$sum\"" +
-                        ", \"count\"(\"row\".\"d\") FILTER (WHERE \"is_nan\"(\"row\".\"d\")) \"row.d$nan_count\"" +
-                        ", \"count\"(\"row\".\"d\") FILTER (WHERE (\"row\".\"d\" = \"infinity\"())) \"row.d$pos_inf_count\"" +
-                        ", \"count\"(\"row\".\"d\") FILTER (WHERE (\"row\".\"d\" = -\"infinity\"())) \"row.d$neg_inf_count\"" +
-                        ", \"checksum\"(\"array_sort\"(\"row\".\"a\")) \"row.a$checksum\"" +
-                        ", COALESCE(\"sum\"(\"cardinality\"(\"row\".\"a\")), 0) \"row.a$cardinality_sum\"" +
-                        ", \"sum\"(\"row\".\"r\"[1]) FILTER (WHERE \"is_finite\"(\"row\".\"r\"[1])) \"row.r._col1$sum\"" +
-                        ", \"count\"(\"row\".\"r\"[1]) FILTER (WHERE \"is_nan\"(\"row\".\"r\"[1])) \"row.r._col1$nan_count\"" +
-                        ", \"count\"(\"row\".\"r\"[1]) FILTER (WHERE (\"row\".\"r\"[1] = \"infinity\"())) \"row.r._col1$pos_inf_count\"" +
-                        ", \"count\"(\"row\".\"r\"[1]) FILTER (WHERE (\"row\".\"r\"[1] = -\"infinity\"())) \"row.r._col1$neg_inf_count\"" +
-                        ", \"checksum\"(\"row\".\"r\".\"b\") \"row.r.b$checksum\"" +
+                        ", \"checksum\"(\"cardinality\"(\"map_non_orderable\")) \"map_non_orderable$cardinality_checksum\"\n" +
+                        ", COALESCE(\"sum\"(\"cardinality\"(\"map_non_orderable\")), 0) \"map_non_orderable$cardinality_sum\"\n" +
+                        ", \"checksum\"(\"row\".\"i\") \"row.i$checksum\"\n" +
+                        ", \"checksum\"(\"row\"[2]) \"row._col2$checksum\"\n" +
+                        ", \"sum\"(\"row\".\"d\") FILTER (WHERE \"is_finite\"(\"row\".\"d\")) \"row.d$sum\"\n" +
+                        ", \"count\"(\"row\".\"d\") FILTER (WHERE \"is_nan\"(\"row\".\"d\")) \"row.d$nan_count\"\n" +
+                        ", \"count\"(\"row\".\"d\") FILTER (WHERE (\"row\".\"d\" = \"infinity\"())) \"row.d$pos_inf_count\"\n" +
+                        ", \"count\"(\"row\".\"d\") FILTER (WHERE (\"row\".\"d\" = -\"infinity\"())) \"row.d$neg_inf_count\"\n" +
+                        ", \"checksum\"(\"array_sort\"(\"row\".\"a\")) \"row.a$checksum\"\n" +
+                        ", \"checksum\"(\"cardinality\"(\"row\".\"a\")) \"row.a$cardinality_checksum\"\n" +
+                        ", COALESCE(\"sum\"(\"cardinality\"(\"row\".\"a\")), 0) \"row.a$cardinality_sum\"\n" +
+                        ", \"sum\"(\"row\".\"r\"[1]) FILTER (WHERE \"is_finite\"(\"row\".\"r\"[1])) \"row.r._col1$sum\"\n" +
+                        ", \"count\"(\"row\".\"r\"[1]) FILTER (WHERE \"is_nan\"(\"row\".\"r\"[1])) \"row.r._col1$nan_count\"\n" +
+                        ", \"count\"(\"row\".\"r\"[1]) FILTER (WHERE (\"row\".\"r\"[1] = \"infinity\"())) \"row.r._col1$pos_inf_count\"\n" +
+                        ", \"count\"(\"row\".\"r\"[1]) FILTER (WHERE (\"row\".\"r\"[1] = -\"infinity\"())) \"row.r._col1$neg_inf_count\"\n" +
+                        ", \"checksum\"(\"row\".\"r\".\"b\") \"row.r.b$checksum\"\n" +
                         "FROM\n" +
-                        "  test:di",
+                        "  \"test:di\"\n",
                 PARSING_OPTIONS);
         assertEquals(formatSql(checksumQuery, Optional.empty()), formatSql(expectedChecksumQuery, Optional.empty()));
     }
@@ -309,9 +316,11 @@ public class TestChecksumValidator
                 5,
                 ImmutableMap.<String, Object>builder()
                         .put("int_array$checksum", new SqlVarbinary(new byte[] {0xa}))
-                        .put("int_array$cardinality_sum", 3L)
-                        .put("map_array$checksum", new SqlVarbinary(new byte[] {0xb}))
-                        .put("map_array$cardinality_sum", 7L)
+                        .put("int_array$cardinality_checksum", new SqlVarbinary(new byte[] {0xb}))
+                        .put("int_array$cardinality_sum", 1L)
+                        .put("map_array$checksum", new SqlVarbinary(new byte[] {0xc}))
+                        .put("map_array$cardinality_checksum", new SqlVarbinary(new byte[] {0xd}))
+                        .put("map_array$cardinality_sum", 2L)
                         .build());
 
         // Matched
@@ -322,9 +331,24 @@ public class TestChecksumValidator
                 5,
                 ImmutableMap.<String, Object>builder()
                         .put("int_array$checksum", new SqlVarbinary(new byte[] {0x1a}))
-                        .put("int_array$cardinality_sum", 3L)
-                        .put("map_array$checksum", new SqlVarbinary(new byte[] {0x1b}))
-                        .put("map_array$cardinality_sum", 7L)
+                        .put("int_array$cardinality_checksum", new SqlVarbinary(new byte[] {0xb}))
+                        .put("int_array$cardinality_sum", 1L)
+                        .put("map_array$checksum", new SqlVarbinary(new byte[] {0x1c}))
+                        .put("map_array$cardinality_checksum", new SqlVarbinary(new byte[] {0xd}))
+                        .put("map_array$cardinality_sum", 2L)
+                        .build());
+        assertMismatchedColumns(columns, controlChecksum, testChecksum, INT_ARRAY_COLUMN, MAP_ARRAY_COLUMN);
+
+        // Mismatched different cardinality checksum
+        testChecksum = new ChecksumResult(
+                5,
+                ImmutableMap.<String, Object>builder()
+                        .put("int_array$checksum", new SqlVarbinary(new byte[] {0xa}))
+                        .put("int_array$cardinality_checksum", new SqlVarbinary(new byte[] {0x1b}))
+                        .put("int_array$cardinality_sum", 1L)
+                        .put("map_array$checksum", new SqlVarbinary(new byte[] {0xc}))
+                        .put("map_array$cardinality_checksum", new SqlVarbinary(new byte[] {0x1d}))
+                        .put("map_array$cardinality_sum", 2L)
                         .build());
         assertMismatchedColumns(columns, controlChecksum, testChecksum, INT_ARRAY_COLUMN, MAP_ARRAY_COLUMN);
 
@@ -332,10 +356,12 @@ public class TestChecksumValidator
         testChecksum = new ChecksumResult(
                 5,
                 ImmutableMap.<String, Object>builder()
-                        .put("int_array$checksum", new SqlVarbinary(new byte[] {0x1a}))
-                        .put("int_array$cardinality_sum", 2L)
-                        .put("map_array$checksum", new SqlVarbinary(new byte[] {0x1b}))
-                        .put("map_array$cardinality_sum", 5L)
+                        .put("int_array$checksum", new SqlVarbinary(new byte[] {0xa}))
+                        .put("int_array$cardinality_checksum", new SqlVarbinary(new byte[] {0xb}))
+                        .put("int_array$cardinality_sum", 3L)
+                        .put("map_array$checksum", new SqlVarbinary(new byte[] {0xc}))
+                        .put("map_array$cardinality_checksum", new SqlVarbinary(new byte[] {0xd}))
+                        .put("map_array$cardinality_sum", 4L)
                         .build());
         assertMismatchedColumns(columns, controlChecksum, testChecksum, INT_ARRAY_COLUMN, MAP_ARRAY_COLUMN);
     }
@@ -373,18 +399,68 @@ public class TestChecksumValidator
                         .put("map$keys_checksum", new SqlVarbinary(new byte[] {0xb}))
                         .put("map$values_checksum", new SqlVarbinary(new byte[] {0xc}))
                         .put("map$cardinality_sum", 3L)
+                        .put("map$cardinality_checksum", new SqlVarbinary(new byte[] {0xd}))
                         .build());
 
         // Matched
         assertTrue(checksumValidator.getMismatchedColumns(columns, controlChecksum, controlChecksum).isEmpty());
 
-        // Mismatched map checksum, keys & values checksums, cardinality sum
+        // Mismatched map checksum
         ChecksumResult testChecksum = new ChecksumResult(
                 5,
                 ImmutableMap.<String, Object>builder()
                         .put("map$checksum", new SqlVarbinary(new byte[] {0x1a}))
+                        .put("map$keys_checksum", new SqlVarbinary(new byte[] {0xb}))
+                        .put("map$values_checksum", new SqlVarbinary(new byte[] {0xc}))
+                        .put("map$cardinality_sum", 3L)
+                        .put("map$cardinality_checksum", new SqlVarbinary(new byte[] {0xd}))
+                        .build());
+        assertMismatchedColumns(columns, controlChecksum, testChecksum, MAP_COLUMN);
+
+        // Mismatched keys checksum
+        testChecksum = new ChecksumResult(
+                5,
+                ImmutableMap.<String, Object>builder()
+                        .put("map$checksum", new SqlVarbinary(new byte[] {0xa}))
                         .put("map$keys_checksum", new SqlVarbinary(new byte[] {0x1b}))
+                        .put("map$values_checksum", new SqlVarbinary(new byte[] {0xc}))
+                        .put("map$cardinality_checksum", new SqlVarbinary(new byte[] {0xd}))
+                        .put("map$cardinality_sum", 3L)
+                        .build());
+        assertMismatchedColumns(columns, controlChecksum, testChecksum, MAP_COLUMN);
+
+        // Mismatched values checksum
+        testChecksum = new ChecksumResult(
+                5,
+                ImmutableMap.<String, Object>builder()
+                        .put("map$checksum", new SqlVarbinary(new byte[] {0xa}))
+                        .put("map$keys_checksum", new SqlVarbinary(new byte[] {0xb}))
                         .put("map$values_checksum", new SqlVarbinary(new byte[] {0x1c}))
+                        .put("map$cardinality_checksum", new SqlVarbinary(new byte[] {0xd}))
+                        .put("map$cardinality_sum", 3L)
+                        .build());
+        assertMismatchedColumns(columns, controlChecksum, testChecksum, MAP_COLUMN);
+
+        // Mismatched cardinality checksum
+        testChecksum = new ChecksumResult(
+                5,
+                ImmutableMap.<String, Object>builder()
+                        .put("map$checksum", new SqlVarbinary(new byte[] {0xa}))
+                        .put("map$keys_checksum", new SqlVarbinary(new byte[] {0xb}))
+                        .put("map$values_checksum", new SqlVarbinary(new byte[] {0xc}))
+                        .put("map$cardinality_checksum", new SqlVarbinary(new byte[] {0x1d}))
+                        .put("map$cardinality_sum", 3L)
+                        .build());
+        assertMismatchedColumns(columns, controlChecksum, testChecksum, MAP_COLUMN);
+
+        // Mismatched cardinality sum
+        testChecksum = new ChecksumResult(
+                5,
+                ImmutableMap.<String, Object>builder()
+                        .put("map$checksum", new SqlVarbinary(new byte[] {0xa}))
+                        .put("map$keys_checksum", new SqlVarbinary(new byte[] {0xb}))
+                        .put("map$values_checksum", new SqlVarbinary(new byte[] {0xc}))
+                        .put("map$cardinality_checksum", new SqlVarbinary(new byte[] {0xd}))
                         .put("map$cardinality_sum", 4L)
                         .build());
         assertMismatchedColumns(columns, controlChecksum, testChecksum, MAP_COLUMN);

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -63,7 +63,6 @@ import static com.facebook.presto.verifier.framework.SkippedReason.NON_DETERMINI
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.regex.Pattern.DOTALL;
-import static java.util.regex.Pattern.MULTILINE;
 import static java.util.stream.Collectors.joining;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -195,7 +194,9 @@ public class TestDataVerification
                         "COLUMN MISMATCH\n" +
                         "Control 1 rows, Test 1 rows\n" +
                         "Mismatched Columns:\n" +
-                        "  _col0 \\(double\\): control\\(sum: 1.0\\) test\\(sum: 1.001\\) relative error: 9.995002498749525E-4\n"));
+                        "  _col0 \\(double\\) relative error: 9\\.995002498749525E-4\n" +
+                        "    control\t\\(sum: 1\\.0, NaN: 0, \\+infinity: 0, -infinity: 0, mean: 1\\.0\\)\n" +
+                        "    test\t\\(sum: 1\\.001, NaN: 0, \\+infinity: 0, -infinity: 0, mean: 1\\.001\\)\n"));
     }
 
     @Test
@@ -256,7 +257,9 @@ public class TestDataVerification
                         "COLUMN MISMATCH\n" +
                         "Control 1 rows, Test 1 rows\n" +
                         "Mismatched Columns:\n" +
-                        "  _col0 \\(double\\): control\\(sum: .*\\) test\\(sum: 2.0\\) relative error: .*\n"));
+                        "  _col0 \\(double\\) relative error: .*\n" +
+                        "    control\t\\(sum: .*, NaN: 0, \\+infinity: 0, -infinity: 0, mean: .*\\)\n" +
+                        "    test\t\\(sum: 2\\.0, NaN: 0, \\+infinity: 0, -infinity: 0, mean: 2.0\\)\n"));
 
         List<DeterminismAnalysisRun> runs = event.get().getDeterminismAnalysisDetails().getRuns();
         assertEquals(runs.size(), 1);
@@ -283,9 +286,9 @@ public class TestDataVerification
                         "COLUMN MISMATCH\n" +
                         "Control 1 rows, Test 1 rows\n" +
                         "Mismatched Columns:\n" +
-                        "  _col0 \\(array\\(row\\(integer, varchar\\(1\\)\\)\\)\\):" +
-                        " control\\(checksum: 71 b5 2f 7f 1e 9b a6 a4, cardinality_sum: 2\\)" +
-                        " test\\(checksum: b4 3c 7d 02 2b 14 77 12, cardinality_sum: 2\\)\n"));
+                        "  _col0 \\(array\\(row\\(integer, varchar\\(1\\)\\)\\)\\)\n" +
+                        "    control\t\\(checksum: 71 b5 2f 7f 1e 9b a6 a4, cardinality_sum: 2\\)\n" +
+                        "    test\t\\(checksum: b4 3c 7d 02 2b 14 77 12, cardinality_sum: 2\\)\n"));
 
         List<DeterminismAnalysisRun> runs = event.get().getDeterminismAnalysisDetails().getRuns();
         assertEquals(runs.size(), 2);
@@ -388,7 +391,7 @@ public class TestDataVerification
         }
         else {
             assertTrue(expectedErrorMessageRegex.isPresent());
-            assertTrue(Pattern.compile(expectedErrorMessageRegex.get(), MULTILINE + DOTALL).matcher(event.getErrorMessage()).matches());
+            assertTrue(Pattern.compile(expectedErrorMessageRegex.get(), DOTALL).matcher(event.getErrorMessage()).matches());
         }
     }
 

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -287,8 +287,8 @@ public class TestDataVerification
                         "Control 1 rows, Test 1 rows\n" +
                         "Mismatched Columns:\n" +
                         "  _col0 \\(array\\(row\\(integer, varchar\\(1\\)\\)\\)\\)\n" +
-                        "    control\t\\(checksum: 71 b5 2f 7f 1e 9b a6 a4, cardinality_sum: 2\\)\n" +
-                        "    test\t\\(checksum: b4 3c 7d 02 2b 14 77 12, cardinality_sum: 2\\)\n"));
+                        "    control\t\\(checksum: 71 b5 2f 7f 1e 9b a6 a4, cardinality_checksum: ad 20 38 f3 85 7c ba 56, cardinality_sum: 2\\)\n" +
+                        "    test\t\\(checksum: b4 3c 7d 02 2b 14 77 12, cardinality_checksum: ad 20 38 f3 85 7c ba 56, cardinality_sum: 2\\)\n"));
 
         List<DeterminismAnalysisRun> runs = event.get().getDeterminismAnalysisDetails().getRuns();
         assertEquals(runs.size(), 2);

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/AbstractTestPrestoQueryFailureResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/AbstractTestPrestoQueryFailureResolver.java
@@ -44,7 +44,7 @@ public class AbstractTestPrestoQueryFailureResolver
     @Test
     public void testSetupFailure()
     {
-        assertFalse(failureResolver.resolve(
+        assertFalse(failureResolver.resolveQueryFailure(
                 CONTROL_QUERY_STATS,
                 new PrestoQueryException(
                         new RuntimeException(),
@@ -59,7 +59,7 @@ public class AbstractTestPrestoQueryFailureResolver
     @Test
     public void testClusterConnectionFailure()
     {
-        assertFalse(failureResolver.resolve(
+        assertFalse(failureResolver.resolveQueryFailure(
                 CONTROL_QUERY_STATS,
                 new ClusterConnectionException(new SocketTimeoutException(), TEST_MAIN),
                 Optional.empty())
@@ -69,7 +69,7 @@ public class AbstractTestPrestoQueryFailureResolver
     @Test
     public void testNoQueryStats()
     {
-        assertFalse(failureResolver.resolve(
+        assertFalse(failureResolver.resolveQueryFailure(
                 CONTROL_QUERY_STATS,
                 new PrestoQueryException(
                         new RuntimeException(),
@@ -84,7 +84,7 @@ public class AbstractTestPrestoQueryFailureResolver
     @Test
     public void testUnrelatedErrorCode()
     {
-        assertFalse(failureResolver.resolve(
+        assertFalse(failureResolver.resolveQueryFailure(
                 CONTROL_QUERY_STATS,
                 new PrestoQueryException(
                         new RuntimeException(),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/AbstractTestResultMismatchResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/AbstractTestResultMismatchResolver.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.verifier.resolver;
 
 import com.facebook.presto.verifier.checksum.ColumnMatchResult;
+import com.facebook.presto.verifier.framework.QueryBundle;
 
 import static com.facebook.presto.verifier.VerifierTestUtil.TEST_BUNDLE;
 import static com.facebook.presto.verifier.resolver.FailureResolverTestUtil.createMatchResult;
@@ -32,11 +33,21 @@ public abstract class AbstractTestResultMismatchResolver
 
     protected void assertResolved(ColumnMatchResult<?>... mismatchedColumns)
     {
-        assertTrue(failureResolver.resolveResultMismatch(createMatchResult(mismatchedColumns), TEST_BUNDLE).isPresent());
+        assertResolved(TEST_BUNDLE, mismatchedColumns);
+    }
+
+    protected void assertResolved(QueryBundle bundle, ColumnMatchResult<?>... mismatchedColumns)
+    {
+        assertTrue(failureResolver.resolveResultMismatch(createMatchResult(mismatchedColumns), bundle).isPresent());
     }
 
     protected void assertNotResolved(ColumnMatchResult<?>... mismatchedColumns)
     {
-        assertFalse(failureResolver.resolveResultMismatch(createMatchResult(mismatchedColumns), TEST_BUNDLE).isPresent());
+        assertNotResolved(TEST_BUNDLE, mismatchedColumns);
+    }
+
+    protected void assertNotResolved(QueryBundle bundle, ColumnMatchResult<?>... mismatchedColumns)
+    {
+        assertFalse(failureResolver.resolveResultMismatch(createMatchResult(mismatchedColumns), bundle).isPresent());
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/AbstractTestResultMismatchResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/AbstractTestResultMismatchResolver.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.resolver;
+
+import com.facebook.presto.verifier.checksum.ColumnMatchResult;
+
+import static com.facebook.presto.verifier.VerifierTestUtil.TEST_BUNDLE;
+import static com.facebook.presto.verifier.resolver.FailureResolverTestUtil.createMatchResult;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public abstract class AbstractTestResultMismatchResolver
+{
+    private final FailureResolver failureResolver;
+
+    public AbstractTestResultMismatchResolver(FailureResolver failureResolver)
+    {
+        this.failureResolver = requireNonNull(failureResolver, "failureResolver is null");
+    }
+
+    protected void assertResolved(ColumnMatchResult<?>... mismatchedColumns)
+    {
+        assertTrue(failureResolver.resolveResultMismatch(createMatchResult(mismatchedColumns), TEST_BUNDLE).isPresent());
+    }
+
+    protected void assertNotResolved(ColumnMatchResult<?>... mismatchedColumns)
+    {
+        assertFalse(failureResolver.resolveResultMismatch(createMatchResult(mismatchedColumns), TEST_BUNDLE).isPresent());
+    }
+}

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/FailureResolverTestUtil.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/FailureResolverTestUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.resolver;
+
+import com.facebook.presto.common.type.SqlVarbinary;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.verifier.checksum.ColumnChecksum;
+import com.facebook.presto.verifier.checksum.ColumnMatchResult;
+import com.facebook.presto.verifier.framework.Column;
+import com.facebook.presto.verifier.framework.MatchResult;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static com.facebook.presto.verifier.framework.MatchResult.MatchType.COLUMN_MISMATCH;
+import static java.util.Arrays.asList;
+
+public class FailureResolverTestUtil
+{
+    private FailureResolverTestUtil() {}
+
+    public static <T extends ColumnChecksum> ColumnMatchResult<T> createMismatchedColumn(Type type, T controlChecksum, T testChecksum)
+    {
+        Column column = Column.create(type.getDisplayName(), new Identifier(type.getDisplayName(), true), type);
+        return new ColumnMatchResult<>(false, column, controlChecksum, testChecksum);
+    }
+
+    public static MatchResult createMatchResult(ColumnMatchResult<?>... mismatchedColumns)
+    {
+        return new MatchResult(COLUMN_MISMATCH, Optional.empty(), OptionalLong.of(1L), OptionalLong.of(1L), asList(mismatchedColumns));
+    }
+
+    public static SqlVarbinary binary(int data)
+    {
+        return new SqlVarbinary(new byte[] {(byte) data});
+    }
+}

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestChecksumExceededTimeLimitFailureResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestChecksumExceededTimeLimitFailureResolver.java
@@ -34,7 +34,7 @@ public class TestChecksumExceededTimeLimitFailureResolver
     public void testResolved()
     {
         assertEquals(
-                getFailureResolver().resolve(
+                getFailureResolver().resolveQueryFailure(
                         CONTROL_QUERY_STATS,
                         new PrestoQueryException(
                                 new RuntimeException(),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestExceededGlobalMemoryLimitFailureResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestExceededGlobalMemoryLimitFailureResolver.java
@@ -34,7 +34,7 @@ public class TestExceededGlobalMemoryLimitFailureResolver
     @Test
     public void testLowerControlMemory()
     {
-        assertFalse(getFailureResolver().resolve(
+        assertFalse(getFailureResolver().resolveQueryFailure(
                 CONTROL_QUERY_STATS,
                 new PrestoQueryException(
                         new RuntimeException(),
@@ -50,7 +50,7 @@ public class TestExceededGlobalMemoryLimitFailureResolver
     public void testResolved()
     {
         assertEquals(
-                getFailureResolver().resolve(
+                getFailureResolver().resolveQueryFailure(
                         CONTROL_QUERY_STATS,
                         new PrestoQueryException(
                                 new RuntimeException(),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestExceededTimeLimitFailureResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestExceededTimeLimitFailureResolver.java
@@ -34,7 +34,7 @@ public class TestExceededTimeLimitFailureResolver
     public void testResolved()
     {
         assertEquals(
-                getFailureResolver().resolve(
+                getFailureResolver().resolveQueryFailure(
                         CONTROL_QUERY_STATS,
                         new PrestoQueryException(
                                 new RuntimeException(),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolver.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.resolver;
+
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.verifier.checksum.ColumnMatchResult;
+import com.facebook.presto.verifier.checksum.SimpleColumnChecksum;
+import com.facebook.presto.verifier.framework.QueryBundle;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.parser.IdentifierSymbol.AT_SIGN;
+import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
+import static com.facebook.presto.verifier.framework.ClusterType.CONTROL;
+import static com.facebook.presto.verifier.framework.VerifierUtil.PARSING_OPTIONS;
+import static com.facebook.presto.verifier.resolver.FailureResolverTestUtil.binary;
+import static com.facebook.presto.verifier.resolver.FailureResolverTestUtil.createMismatchedColumn;
+
+public class TestIgnoredFunctionsMismatchResolver
+        extends AbstractTestResultMismatchResolver
+{
+    private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(AT_SIGN, COLON));
+
+    public TestIgnoredFunctionsMismatchResolver()
+    {
+        super(new IgnoredFunctionsMismatchResolver(new IgnoredFunctionsMismatchResolverConfig().setFunctions("rand,presto.default.arbitrary")));
+    }
+
+    @Test
+    public void testDefault()
+    {
+        ColumnMatchResult<?> mismatchedColumn = createMismatchedColumn(VARCHAR, new SimpleColumnChecksum(binary(0xa)), new SimpleColumnChecksum(binary(0xb)));
+
+        // resolved
+        assertResolved(createBundle("CREATE TABLE test AS SELECT rand() x FROM source"), mismatchedColumn);
+        assertResolved(createBundle("CREATE TABLE test AS SELECT presto.default.rand() x FROM source"), mismatchedColumn);
+        assertResolved(createBundle("SELECT arbitrary(x) FROM source"), mismatchedColumn);
+        assertResolved(createBundle("INSERT INTO target SELECT presto.default.arbitrary(x) FROM source"), mismatchedColumn);
+
+        assertResolved(createBundle("SELECT arbitrary(rand()) FROM source"), mismatchedColumn);
+        assertResolved(createBundle("SELECT sum(rand()) FROM source"), mismatchedColumn);
+
+        // not resolved
+        assertNotResolved(createBundle("SELECT count() FROM source"), mismatchedColumn);
+    }
+
+    private static QueryBundle createBundle(String query)
+    {
+        return new QueryBundle(
+                QualifiedName.of("test"),
+                ImmutableList.of(),
+                sqlParser.createStatement(query, PARSING_OPTIONS),
+                ImmutableList.of(),
+                CONTROL);
+    }
+}

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolverConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolverConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.resolver;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static org.testng.Assert.assertEquals;
+
+public class TestIgnoredFunctionsMismatchResolverConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(IgnoredFunctionsMismatchResolverConfig.class)
+                .setFunctions(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("functions", "rand,presto.default.arbitrary")
+                .build();
+        IgnoredFunctionsMismatchResolverConfig expected = new IgnoredFunctionsMismatchResolverConfig()
+                .setFunctions("rand,presto.default.arbitrary");
+
+        assertFullMapping(properties, expected);
+        assertEquals(expected.getFunctions(), ImmutableList.of("rand", "presto.default.arbitrary"));
+    }
+}

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestStructuredColumnMismatchResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestStructuredColumnMismatchResolver.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.resolver;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.verifier.checksum.ArrayColumnChecksum;
+import com.facebook.presto.verifier.checksum.ColumnMatchResult;
+import com.facebook.presto.verifier.checksum.FloatingPointColumnChecksum;
+import com.facebook.presto.verifier.checksum.MapColumnChecksum;
+import com.facebook.presto.verifier.checksum.SimpleColumnChecksum;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.util.StructuralTestUtil.mapType;
+import static com.facebook.presto.verifier.resolver.FailureResolverTestUtil.binary;
+import static com.facebook.presto.verifier.resolver.FailureResolverTestUtil.createMismatchedColumn;
+
+public class TestStructuredColumnMismatchResolver
+        extends AbstractTestResultMismatchResolver
+{
+    public TestStructuredColumnMismatchResolver()
+    {
+        super(new StructuredColumnMismatchResolver());
+    }
+
+    @Test
+    public void testResolveArray()
+    {
+        ArrayColumnChecksum checksum1 = new ArrayColumnChecksum(binary(0xa), binary(0xb), 1);
+        ArrayColumnChecksum checksum2 = new ArrayColumnChecksum(binary(0x1a), binary(0xb), 1);
+        ArrayColumnChecksum checksum3 = new ArrayColumnChecksum(binary(0xa), binary(0x1b), 1);
+        ArrayColumnChecksum checksum4 = new ArrayColumnChecksum(binary(0xa), binary(0xb), 2);
+
+        // resolved
+        assertResolved(createMismatchedColumn(new ArrayType(DOUBLE), checksum1, checksum2));
+        assertResolved(createMismatchedColumn(new ArrayType(REAL), checksum1, checksum2));
+        assertResolved(createMismatchedColumn(new ArrayType(new ArrayType(DOUBLE)), checksum1, checksum2));
+
+        // not resolved, contains no floating point types
+        assertNotResolved(createMismatchedColumn(new ArrayType(INTEGER), checksum1, checksum2));
+        assertNotResolved(createMismatchedColumn(new ArrayType(new ArrayType(INTEGER)), checksum1, checksum2));
+
+        // not resolved, cardinality mismatches
+        assertNotResolved(createMismatchedColumn(new ArrayType(DOUBLE), checksum1, checksum3));
+        assertNotResolved(createMismatchedColumn(new ArrayType(DOUBLE), checksum1, checksum4));
+    }
+
+    @Test
+    public void testResolveMap()
+    {
+        MapColumnChecksum checksum1 = new MapColumnChecksum(binary(0x1), binary(0xa), binary(0xa), binary(0xc), 1);
+        MapColumnChecksum checksum2 = new MapColumnChecksum(binary(0x2), binary(0xa), binary(0xb), binary(0xc), 1);
+        MapColumnChecksum checksum3 = new MapColumnChecksum(binary(0x3), binary(0xb), binary(0xa), binary(0xc), 1);
+        MapColumnChecksum checksum4 = new MapColumnChecksum(binary(0x4), binary(0xb), binary(0xb), binary(0xc), 1);
+        MapColumnChecksum checksum5 = new MapColumnChecksum(binary(0x5), binary(0xb), binary(0xb), binary(0x1c), 1);
+        MapColumnChecksum checksum6 = new MapColumnChecksum(binary(0x5), binary(0xb), binary(0xb), binary(0xc), 2);
+
+        // resolved
+        assertResolved(createMismatchedColumn(mapType(REAL, DOUBLE), checksum1, checksum4));
+        assertResolved(createMismatchedColumn(mapType(new ArrayType(REAL), RowType.anonymous(ImmutableList.of(INTEGER, DOUBLE))), checksum1, checksum4));
+
+        // not resolved, contains no floating point types
+        assertNotResolved(createMismatchedColumn(mapType(new ArrayType(VARCHAR), RowType.anonymous(ImmutableList.of(INTEGER, VARCHAR))), checksum1, checksum4));
+
+        // not resolved, cardinality mismatches
+        assertNotResolved(createMismatchedColumn(mapType(DOUBLE, DOUBLE), checksum1, checksum5));
+        assertNotResolved(createMismatchedColumn(mapType(DOUBLE, DOUBLE), checksum1, checksum6));
+
+        // Key/value checks
+        assertResolved(createMismatchedColumn(mapType(DOUBLE, INTEGER), checksum1, checksum3));
+        assertNotResolved(createMismatchedColumn(mapType(DOUBLE, INTEGER), checksum1, checksum4));
+
+        assertResolved(createMismatchedColumn(mapType(INTEGER, DOUBLE), checksum1, checksum2));
+        assertNotResolved(createMismatchedColumn(mapType(INTEGER, DOUBLE), checksum1, checksum4));
+    }
+
+    @Test
+    public void testNotResolved()
+    {
+        assertNotResolved(createMismatchedColumn(VARCHAR, new SimpleColumnChecksum(binary(0xa)), new SimpleColumnChecksum(binary(0xb))));
+        assertNotResolved(createMismatchedColumn(
+                DOUBLE,
+                new FloatingPointColumnChecksum(1.0, 0, 0, 0, 5),
+                new FloatingPointColumnChecksum(1.1, 0, 0, 0, 5)));
+    }
+
+    @Test
+    public void testMixed()
+    {
+        ColumnMatchResult<?> resolvable1 = createMismatchedColumn(
+                new ArrayType(new ArrayType(DOUBLE)),
+                new ArrayColumnChecksum(binary(0xa), binary(0xc), 1),
+                new ArrayColumnChecksum(binary(0xb), binary(0xc), 1));
+        ColumnMatchResult<?> resolvable2 = createMismatchedColumn(
+                mapType(REAL, DOUBLE),
+                new MapColumnChecksum(binary(0x1), binary(0xa), binary(0xa), binary(0xc), 1),
+                new MapColumnChecksum(binary(0x4), binary(0xb), binary(0xb), binary(0xc), 1));
+        ColumnMatchResult<?> nonResolvable = createMismatchedColumn(VARCHAR, new SimpleColumnChecksum(binary(0xa)), new SimpleColumnChecksum(binary(0xb)));
+
+        assertResolved(resolvable1, resolvable2);
+        assertNotResolved(resolvable1, nonResolvable);
+        assertNotResolved(nonResolvable, resolvable2);
+        assertNotResolved(resolvable1, nonResolvable, resolvable2);
+    }
+}

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestTooManyOpenPartitionsFailureResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestTooManyOpenPartitionsFailureResolver.java
@@ -110,25 +110,25 @@ public class TestTooManyOpenPartitionsFailureResolver
     public void testUnresolvedSufficientWorker()
     {
         createTable.set(format("CREATE TABLE %s (x varchar, ds varchar) WITH (partitioned_by = ARRAY[\"ds\"], bucket_count = 100)", TABLE_NAME));
-        getFailureResolver().resolve(CONTROL_QUERY_STATS, HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION, Optional.of(TEST_BUNDLE));
-        assertFalse(getFailureResolver().resolve(CONTROL_QUERY_STATS, HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION, Optional.of(TEST_BUNDLE)).isPresent());
+        getFailureResolver().resolveQueryFailure(CONTROL_QUERY_STATS, HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION, Optional.of(TEST_BUNDLE));
+        assertFalse(getFailureResolver().resolveQueryFailure(CONTROL_QUERY_STATS, HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION, Optional.of(TEST_BUNDLE)).isPresent());
     }
 
     @Test
     public void testUnresolvedNonBucketed()
     {
         createTable.set(format("CREATE TABLE %s (x varchar, ds varchar) WITH (partitioned_by = ARRAY[\"ds\"])", TABLE_NAME));
-        getFailureResolver().resolve(CONTROL_QUERY_STATS, HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION, Optional.of(TEST_BUNDLE));
-        assertFalse(getFailureResolver().resolve(CONTROL_QUERY_STATS, HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION, Optional.of(TEST_BUNDLE)).isPresent());
+        getFailureResolver().resolveQueryFailure(CONTROL_QUERY_STATS, HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION, Optional.of(TEST_BUNDLE));
+        assertFalse(getFailureResolver().resolveQueryFailure(CONTROL_QUERY_STATS, HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION, Optional.of(TEST_BUNDLE)).isPresent());
     }
 
     @Test
     public void testResolved()
     {
         createTable.set(format("CREATE TABLE %s (x varchar, ds varchar) WITH (partitioned_by = ARRAY[\"ds\"], bucket_count = 101)", TABLE_NAME));
-        getFailureResolver().resolve(CONTROL_QUERY_STATS, HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION, Optional.of(TEST_BUNDLE));
+        getFailureResolver().resolveQueryFailure(CONTROL_QUERY_STATS, HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION, Optional.of(TEST_BUNDLE));
         assertEquals(
-                getFailureResolver().resolve(CONTROL_QUERY_STATS, HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION, Optional.of(TEST_BUNDLE)),
+                getFailureResolver().resolveQueryFailure(CONTROL_QUERY_STATS, HIVE_TOO_MANY_OPEN_PARTITIONS_EXCEPTION, Optional.of(TEST_BUNDLE)),
                 Optional.of("Not enough workers on test cluster"));
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestVerifierLimitationFailureResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestVerifierLimitationFailureResolver.java
@@ -34,7 +34,7 @@ public class TestVerifierLimitationFailureResolver
     public void testResolveCompilerError()
     {
         assertEquals(
-                getFailureResolver().resolve(
+                getFailureResolver().resolveQueryFailure(
                         CONTROL_QUERY_STATS,
                         new PrestoQueryException(
                                 new RuntimeException(),


### PR DESCRIPTION
The PR extends `FailureResolver` to not only be able to resolve query failures, but also result mismatches. Added 2 types of result mismatch resolvers.

## StructuredColumnMismatchResolver
If array element or map key/value contains floating point types,
column checksum is unlikely to match. Hence, we can allow Verifier
to auto resolve those cases.
* For an array column, resolve if the element type contains floating
  point types and the cardinality matches.
* For a map column, resolve if either key or value contains floating
  point types, the cardinality sum matches, and the checksum of the
  key or value that does not contains floating point type matches.
* Resolve a test case only when all columns are resolved.

## IgnoredFunctionsMismatchResolver
In the case of a results mismatch, if the query uses a function in a
specified list, the test case is marked as resolved.
This is useful to mark certain FB functions that is known to produce
different results on Verifier.


```
== RELEASE NOTES ==

Verifier Changes
* Add support to auto-resolve result mismatch for structured-type columns.
* Add support to auto-resolve result mismatch in case the query uses functions to be ignored.
```
