### PR TITLE
Fix timeout of testQueuingWhenTaskLimitExceeds

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -318,6 +318,9 @@ public final class InternalResourceGroupManager<C>
     public void setTaskLimitExceeded(boolean exceeded)
     {
         taskLimitExceeded.set(exceeded);
+        for (RootInternalResourceGroup group : rootGroups) {
+            group.setTaskLimitExceeded(exceeded);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryTaskLimit.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryTaskLimit.java
@@ -28,10 +28,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
-import static com.facebook.presto.execution.QueryState.FAILED;
 import static com.facebook.presto.execution.QueryState.QUEUED;
 import static com.facebook.presto.execution.QueryState.RUNNING;
-import static com.facebook.presto.execution.TestQueryRunnerUtil.cancelQuery;
 import static com.facebook.presto.execution.TestQueryRunnerUtil.createQuery;
 import static com.facebook.presto.execution.TestQueryRunnerUtil.waitForQueryState;
 import static com.facebook.presto.execution.TestQueues.LONG_LASTING_QUERY;
@@ -89,7 +87,7 @@ public class TestQueryTaskLimit
     }
 
     @Test(timeOut = 30_000)
-    public void testQueuingdWhenTaskLimitExceeds()
+    public void testQueuingWhenTaskLimitExceeds()
             throws Exception
     {
         try (DistributedQueryRunner queryRunner = createQueryRunner(defaultSession, ImmutableMap.of())) {
@@ -103,12 +101,6 @@ public class TestQueryTaskLimit
 
             queryRunner.getCoordinator().getResourceGroupManager().get().setTaskLimitExceeded(false);
             waitForQueryState(queryRunner, secondQuery, RUNNING);
-
-            cancelQuery(queryRunner, firstQuery);
-            cancelQuery(queryRunner, secondQuery);
-
-            waitForQueryState(queryRunner, firstQuery, FAILED);
-            waitForQueryState(queryRunner, secondQuery, FAILED);
         }
     }
 


### PR DESCRIPTION
 When `InternalResourceGroupManager::taskLimitExceeded` is updated by testing method `setTaskLimitExceeded`, there is a delay in updating root resource group's state (each resource group could have its own limit and this is updated asynchronously).

This flaw exists only in testing method.

Before this fix:
 One failure out of 30 running of test `testQueuingWhenTaskLimitExceeds` on average.
After the fix:
 No failure after 100 runs.

```
== NO RELEASE NOTE ==
```
