### PR TITLE
Move cache max size config

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/CacheConfig.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/CacheConfig.java
@@ -15,8 +15,11 @@ package com.facebook.presto.cache;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
 
 import java.net.URI;
+
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
 
 public class CacheConfig
 {
@@ -24,6 +27,7 @@ public class CacheConfig
     private CacheType cacheType;
     private URI baseDirectory;
     private boolean validationEnabled;
+    private DataSize maxCacheSize = new DataSize(2, GIGABYTE);
 
     public URI getBaseDirectory()
     {
@@ -75,5 +79,18 @@ public class CacheConfig
     public CacheType getCacheType()
     {
         return cacheType;
+    }
+
+    public DataSize getMaxCacheSize()
+    {
+        return maxCacheSize;
+    }
+
+    @Config("cache.max-cache-size")
+    @ConfigDescription("The maximum cache size")
+    public CacheConfig setMaxCacheSize(DataSize maxCacheSize)
+    {
+        this.maxCacheSize = maxCacheSize;
+        return this;
     }
 }

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheConfig.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheConfig.java
@@ -14,10 +14,6 @@
 package com.facebook.presto.cache.alluxio;
 
 import com.facebook.airlift.configuration.Config;
-import com.facebook.airlift.configuration.ConfigDescription;
-import io.airlift.units.DataSize;
-
-import static io.airlift.units.DataSize.Unit.GIGABYTE;
 
 public class AlluxioCacheConfig
 {
@@ -25,7 +21,6 @@ public class AlluxioCacheConfig
     private boolean asyncWriteEnabled;
     private String jmxClass = "alluxio.metrics.sink.JmxSink";
     private String metricsDomain = "com.facebook.alluxio";
-    private DataSize maxCacheSize = new DataSize(2, GIGABYTE);
 
     public boolean isMetricsCollectionEnabled()
     {
@@ -72,19 +67,6 @@ public class AlluxioCacheConfig
     public AlluxioCacheConfig setAsyncWriteEnabled(boolean asyncWriteEnabled)
     {
         this.asyncWriteEnabled = asyncWriteEnabled;
-        return this;
-    }
-
-    public DataSize getMaxCacheSize()
-    {
-        return maxCacheSize;
-    }
-
-    @Config("cache.alluxio.max-cache-size")
-    @ConfigDescription("The maximum cache size")
-    public AlluxioCacheConfig setMaxCacheSize(DataSize maxCacheSize)
-    {
-        this.maxCacheSize = maxCacheSize;
         return this;
     }
 }

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
@@ -43,7 +43,7 @@ public class AlluxioCachingConfigurationProvider
         if (cacheConfig.isCachingEnabled() && cacheConfig.getCacheType() == ALLUXIO) {
             configuration.set("alluxio.user.local.cache.enabled", String.valueOf(cacheConfig.isCachingEnabled()));
             configuration.set("alluxio.user.client.cache.dir", cacheConfig.getBaseDirectory().getPath());
-            configuration.set("alluxio.user.client.cache.size", alluxioCacheConfig.getMaxCacheSize().toString());
+            configuration.set("alluxio.user.client.cache.size", cacheConfig.getMaxCacheSize().toString());
             configuration.set("alluxio.user.client.cache.async.write.enabled", String.valueOf(alluxioCacheConfig.isAsyncWriteEnabled()));
             configuration.set("alluxio.user.metrics.collection.enabled", String.valueOf(alluxioCacheConfig.isMetricsCollectionEnabled()));
             configuration.set("sink.jmx.class", alluxioCacheConfig.getJmxClass());

--- a/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCacheConfig.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCacheConfig.java
@@ -15,20 +15,17 @@ package com.facebook.presto.cache.filemerge;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
-import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
 import javax.validation.constraints.Min;
 
-import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static java.util.concurrent.TimeUnit.DAYS;
 
 public class FileMergeCacheConfig
 {
     private int maxCachedEntries = 1_000;
     private Duration cacheTtl = new Duration(2, DAYS);
-    private DataSize maxInMemoryCacheSize = new DataSize(2, GIGABYTE);
 
     @Min(1)
     public int getMaxCachedEntries()
@@ -41,19 +38,6 @@ public class FileMergeCacheConfig
     public FileMergeCacheConfig setMaxCachedEntries(int maxCachedEntries)
     {
         this.maxCachedEntries = maxCachedEntries;
-        return this;
-    }
-
-    public DataSize getMaxInMemoryCacheSize()
-    {
-        return maxInMemoryCacheSize;
-    }
-
-    @Config("cache.max-in-memory-cache-size")
-    @ConfigDescription("The maximum cache size allowed in memory")
-    public FileMergeCacheConfig setMaxInMemoryCacheSize(DataSize maxInMemoryCacheSize)
-    {
-        this.maxInMemoryCacheSize = maxInMemoryCacheSize;
         return this;
     }
 

--- a/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCacheManager.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCacheManager.java
@@ -113,8 +113,8 @@ public class FileMergeCacheManager
                 .build();
         this.stats = requireNonNull(stats, "stats is null");
         this.baseDirectory = new Path(cacheConfig.getBaseDirectory());
-        checkArgument(fileMergeCacheConfig.getMaxInMemoryCacheSize().toBytes() >= 0, "maxInflightBytes is negative");
-        this.maxInflightBytes = fileMergeCacheConfig.getMaxInMemoryCacheSize().toBytes();
+        checkArgument(cacheConfig.getMaxCacheSize().toBytes() >= 0, "maxInflightBytes is negative");
+        this.maxInflightBytes = cacheConfig.getMaxCacheSize().toBytes();
 
         File target = new File(baseDirectory.toUri());
         if (!target.exists()) {

--- a/presto-cache/src/test/java/com/facebook/presto/cache/TestCacheConfig.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/TestCacheConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.cache;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
 import java.net.URI;
@@ -23,6 +24,8 @@ import static com.facebook.airlift.configuration.testing.ConfigAssertions.assert
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static com.facebook.presto.cache.CacheType.FILE_MERGE;
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class TestCacheConfig
 {
@@ -32,6 +35,7 @@ public class TestCacheConfig
         assertRecordedDefaults(recordDefaults(CacheConfig.class)
                 .setCachingEnabled(false)
                 .setCacheType(null)
+                .setMaxCacheSize(new DataSize(2, GIGABYTE))
                 .setBaseDirectory(null)
                 .setValidationEnabled(false));
     }
@@ -43,6 +47,7 @@ public class TestCacheConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("cache.enabled", "true")
                 .put("cache.type", "FILE_MERGE")
+                .put("cache.max-cache-size", "42MB")
                 .put("cache.base-directory", "tcp://abc")
                 .put("cache.validation-enabled", "true")
                 .build();
@@ -50,6 +55,7 @@ public class TestCacheConfig
         CacheConfig expected = new CacheConfig()
                 .setCachingEnabled(true)
                 .setCacheType(FILE_MERGE)
+                .setMaxCacheSize(new DataSize(42, MEGABYTE))
                 .setBaseDirectory(new URI("tcp://abc"))
                 .setValidationEnabled(true);
 

--- a/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCacheConfig.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCacheConfig.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.cache.alluxio;
 
 import com.google.common.collect.ImmutableMap;
-import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -22,8 +21,6 @@ import java.util.Map;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
-import static io.airlift.units.DataSize.Unit.GIGABYTE;
-import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class TestAlluxioCacheConfig
 {
@@ -32,7 +29,6 @@ public class TestAlluxioCacheConfig
     {
         assertRecordedDefaults(recordDefaults(AlluxioCacheConfig.class)
                 .setAsyncWriteEnabled(false)
-                .setMaxCacheSize(new DataSize(2, GIGABYTE))
                 .setMetricsCollectionEnabled(true)
                 .setMetricsDomain("com.facebook.alluxio")
                 .setJmxClass("alluxio.metrics.sink.JmxSink"));
@@ -43,7 +39,6 @@ public class TestAlluxioCacheConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("cache.alluxio.async-write.enabled", "true")
-                .put("cache.alluxio.max-cache-size", "42MB")
                 .put("cache.alluxio.metrics.enabled", "false")
                 .put("cache.alluxio.metrics.domain", "test.alluxio")
                 .put("cache.alluxio.jmx.class", "test.TestJmxSink")
@@ -51,7 +46,6 @@ public class TestAlluxioCacheConfig
 
         AlluxioCacheConfig expected = new AlluxioCacheConfig()
                 .setAsyncWriteEnabled(true)
-                .setMaxCacheSize(new DataSize(42, MEGABYTE))
                 .setMetricsCollectionEnabled(false)
                 .setMetricsDomain("test.alluxio")
                 .setJmxClass("test.TestJmxSink");

--- a/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
@@ -158,9 +158,9 @@ public class TestAlluxioCachingFileSystem
         CacheConfig cacheConfig = new CacheConfig()
                 .setCacheType(ALLUXIO)
                 .setCachingEnabled(true)
-                .setBaseDirectory(cacheDirectory);
-        AlluxioCacheConfig alluxioCacheConfig = new AlluxioCacheConfig()
+                .setBaseDirectory(cacheDirectory)
                 .setMaxCacheSize(new DataSize(10, KILOBYTE));
+        AlluxioCacheConfig alluxioCacheConfig = new AlluxioCacheConfig();
 
         AlluxioCachingFileSystem cachingFileSystem = cachingFileSystem(cacheConfig, alluxioCacheConfig);
         stressTest(data, (position, buffer, offset, length) -> {
@@ -209,7 +209,7 @@ public class TestAlluxioCachingFileSystem
         if (cacheConfig.isCachingEnabled() && cacheConfig.getCacheType() == ALLUXIO) {
             configuration.set("alluxio.user.local.cache.enabled", String.valueOf(cacheConfig.isCachingEnabled()));
             configuration.set("alluxio.user.client.cache.dir", cacheConfig.getBaseDirectory().getPath());
-            configuration.set("alluxio.user.client.cache.size", alluxioCacheConfig.getMaxCacheSize().toString());
+            configuration.set("alluxio.user.client.cache.size", cacheConfig.getMaxCacheSize().toString());
             configuration.set("alluxio.user.client.cache.page.size", Integer.toString(PAGE_SIZE));
             configuration.set("alluxio.user.metrics.collection.enabled", String.valueOf(alluxioCacheConfig.isMetricsCollectionEnabled()));
             configuration.set("alluxio.user.client.cache.async.write.enabled", String.valueOf(alluxioCacheConfig.isAsyncWriteEnabled()));

--- a/presto-cache/src/test/java/com/facebook/presto/cache/filemerge/TestFileMergeCacheConfig.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/filemerge/TestFileMergeCacheConfig.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.cache.filemerge;
 
 import com.google.common.collect.ImmutableMap;
-import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
@@ -23,8 +22,6 @@ import java.util.Map;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
-import static io.airlift.units.DataSize.Unit.GIGABYTE;
-import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -35,7 +32,6 @@ public class TestFileMergeCacheConfig
     {
         assertRecordedDefaults(recordDefaults(FileMergeCacheConfig.class)
                 .setMaxCachedEntries(1_000)
-                .setMaxInMemoryCacheSize(new DataSize(2, GIGABYTE))
                 .setCacheTtl(new Duration(2, DAYS)));
     }
 
@@ -44,13 +40,11 @@ public class TestFileMergeCacheConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("cache.max-cached-entries", "5")
-                .put("cache.max-in-memory-cache-size", "42MB")
                 .put("cache.ttl", "10s")
                 .build();
 
         FileMergeCacheConfig expected = new FileMergeCacheConfig()
                 .setMaxCachedEntries(5)
-                .setMaxInMemoryCacheSize(new DataSize(42, MEGABYTE))
                 .setCacheTtl(new Duration(10, SECONDS));
         assertFullMapping(properties, expected);
     }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/RaptorQueryRunner.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/RaptorQueryRunner.java
@@ -80,7 +80,7 @@ public final class RaptorQueryRunner
         if (useHdfs) {
             builder.put("storage.file-system", "hdfs")
                     .put("cache.base-directory", "file://" + new File(baseDir, "cache").getAbsolutePath())
-                    .put("cache.max-in-memory-cache-size", "100MB")
+                    .put("cache.max-cache-size", "100MB")
                     .put("cache.validation-enabled", "true")
                     .put("storage.data-directory", queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data").toFile().toURI().toString());
         }


### PR DESCRIPTION
Moving cache max size config from Alluxio specific configuration
to generic cache configuration.

```
== RELEASE NOTES ==

Hive Changes
Move cache max size config from Alluxio specific configuration to generic cache configuration.

```

depended by https://github.com/facebookexternal/presto-facebook/pull/987