### PR TITLE
Fix Presto Proxy for Java 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <dep.alluxio.version>2.2.0</dep.alluxio.version>
         <dep.kafka.version>2.3.1</dep.kafka.version>
         <dep.druid.version>0.17.0</dep.druid.version>
+        <dep.jaxb.version>2.3.1</dep.jaxb.version>
 
         <!--
           America/Bahia_Banderas has:
@@ -814,6 +815,18 @@
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-i18n-functions</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${dep.jaxb.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${dep.jaxb.version}</version>
             </dependency>
 
             <dependency>

--- a/presto-proxy/pom.xml
+++ b/presto-proxy/pom.xml
@@ -142,6 +142,18 @@
             <artifactId>jjwt</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
Starting from JDK9+, a Jaxb implementation is not provided by default by the JDK.  This provides the necessary dependency.

```
== NO RELEASE NOTE ==
```
