### PR TITLE
Fix null config issue for caching filesystem

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/CachingFileSystem.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/CachingFileSystem.java
@@ -84,6 +84,12 @@ public abstract class CachingFileSystem
     }
 
     @Override
+    public Configuration getConf()
+    {
+        return dataTier.getConf();
+    }
+
+    @Override
     public Path getWorkingDirectory()
     {
         return dataTier.getWorkingDirectory();


### PR DESCRIPTION
When using caching filesystems, in few cases, configuration was found to be null. Which was resulting into null pointer exception.