### PR TITLE
Update README to fix VM options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ After opening the project in IntelliJ, double check that the Java SDK is properl
 Presto comes with sample configuration that should work out-of-the-box for development. Use the following options to create a run configuration:
 
 * Main Class: `com.facebook.presto.server.PrestoServer`
-* VM Options: `-ea -XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -Xmx2G -Dconfig=etc/config.properties -Dlog.levels-file=etc/log.properties`
+* VM Options: `-ea -XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -Xmx2G -Dconfig=etc/config.properties -Dlog.levels-file=etc/log.properties -Dstorage.data-directory=file:///${HOME}/raptor`
 * Working directory: `$MODULE_DIR$`
 * Use classpath of module: `presto-main`
 


### PR DESCRIPTION
PrestoServer attempts to create directories in "storage.data-directory" for Raptor. This is configured in etc/raptor.properties by default as "/var/data". In OSX, this is not a writable directory, so PrestoServer fails to start. This change adds a VM option that overrides etc/raptor.properties and creates raptor's data directories in $HOME.

```
== NO RELEASE NOTE ==
```
