### PR TITLE
Update etc/raptor.properties

### DIFF
--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -109,7 +109,8 @@ statement
     | SHOW ROLE GRANTS ((FROM | IN) identifier)?                       #showRoleGrants
     | DESCRIBE qualifiedName                                           #showColumns
     | DESC qualifiedName                                               #showColumns
-    | SHOW FUNCTIONS                                                   #showFunctions
+    | SHOW FUNCTIONS
+        (LIKE pattern=string (ESCAPE escape=string)?)?                 #showFunctions
     | SHOW SESSION                                                     #showSession
     | SET SESSION qualifiedName EQ expression                          #setSession
     | RESET SESSION qualifiedName                                      #resetSession

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -761,6 +761,14 @@ public final class SqlFormatter
         {
             builder.append("SHOW FUNCTIONS");
 
+            node.getLikePattern().ifPresent((value) ->
+                    builder.append(" LIKE ")
+                            .append(formatStringLiteral(value)));
+
+            node.getEscape().ifPresent((value) ->
+                    builder.append(" ESCAPE ")
+                            .append(formatStringLiteral(value)));
+
             return null;
         }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -877,7 +877,12 @@ class AstBuilder
     @Override
     public Node visitShowFunctions(SqlBaseParser.ShowFunctionsContext context)
     {
-        return new ShowFunctions(getLocation(context));
+        return new ShowFunctions(
+                getLocation(context),
+                getTextIfPresent(context.pattern)
+                        .map(AstBuilder::unquote),
+                getTextIfPresent(context.escape)
+                        .map(AstBuilder::unquote));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowFunctions.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowFunctions.java
@@ -16,26 +16,43 @@ package com.facebook.presto.sql.tree;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
 
 public class ShowFunctions
         extends Statement
 {
-    public ShowFunctions()
+    private final Optional<String> likePattern;
+    private final Optional<String> escape;
+
+    public ShowFunctions(Optional<String> likePattern, Optional<String> escape)
     {
-        this(Optional.empty());
+        this(Optional.empty(), likePattern, escape);
     }
 
-    public ShowFunctions(NodeLocation location)
+    public ShowFunctions(NodeLocation location, Optional<String> likePattern, Optional<String> escape)
     {
-        this(Optional.of(location));
+        this(Optional.of(location), likePattern, escape);
     }
 
-    private ShowFunctions(Optional<NodeLocation> location)
+    public ShowFunctions(Optional<NodeLocation> location, Optional<String> likePattern, Optional<String> escape)
     {
         super(location);
+        this.likePattern = requireNonNull(likePattern, "likePattern is null");
+        this.escape = requireNonNull(escape, "escape is null");
+    }
+
+    public Optional<String> getLikePattern()
+    {
+        return likePattern;
+    }
+
+    public Optional<String> getEscape()
+    {
+        return escape;
     }
 
     @Override
@@ -53,7 +70,7 @@ public class ShowFunctions
     @Override
     public int hashCode()
     {
-        return 0;
+        return Objects.hash(likePattern, escape);
     }
 
     @Override
@@ -62,12 +79,20 @@ public class ShowFunctions
         if (this == obj) {
             return true;
         }
-        return (obj != null) && (getClass() == obj.getClass());
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        ShowFunctions o = (ShowFunctions) obj;
+        return Objects.equals(likePattern, o.likePattern) &&
+                Objects.equals(escape, o.escape);
     }
 
     @Override
     public String toString()
     {
-        return toStringHelper(this).toString();
+        return toStringHelper(this)
+                .add("likePattern", likePattern)
+                .add("escape", escape)
+                .toString();
     }
 }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -116,6 +116,7 @@ import com.facebook.presto.sql.tree.SetSession;
 import com.facebook.presto.sql.tree.ShowCatalogs;
 import com.facebook.presto.sql.tree.ShowColumns;
 import com.facebook.presto.sql.tree.ShowCreateFunction;
+import com.facebook.presto.sql.tree.ShowFunctions;
 import com.facebook.presto.sql.tree.ShowGrants;
 import com.facebook.presto.sql.tree.ShowRoleGrants;
 import com.facebook.presto.sql.tree.ShowRoles;
@@ -723,6 +724,14 @@ public class TestSqlParser
         assertStatement("SHOW COLUMNS FROM a.b", new ShowColumns(QualifiedName.of("a", "b")));
         assertStatement("SHOW COLUMNS FROM \"awesome table\"", new ShowColumns(QualifiedName.of("awesome table")));
         assertStatement("SHOW COLUMNS FROM \"awesome schema\".\"awesome table\"", new ShowColumns(QualifiedName.of("awesome schema", "awesome table")));
+    }
+
+    @Test
+    public void testShowFunctions()
+    {
+        assertStatement("SHOW FUNCTIONS", new ShowFunctions(Optional.empty(), Optional.empty()));
+        assertStatement("SHOW FUNCTIONS LIKE '%'", new ShowFunctions(Optional.of("%"), Optional.empty()));
+        assertStatement("SHOW FUNCTIONS LIKE '%$_%' ESCAPE '$'", new ShowFunctions(Optional.of("%$_%"), Optional.of("$")));
     }
 
     @Test


### PR DESCRIPTION
PrestoServer attempts to create directories in "storage.data-directory" for
Raptor. This is configured in etc/raptor.properties by default as "/var/data".
In OSX, this is not a writable directory, so PrestoServer fails to start. This
change fixes the issue by setting storage.data-directory to /tmp/raptor.

```
== NO RELEASE NOTE ==
```
