### PR TITLE
Allow cached reads on the non-offset version of readFully

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCachingInputStream.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCachingInputStream.java
@@ -46,6 +46,13 @@ public final class FileMergeCachingInputStream
     }
 
     @Override
+    public void readFully(long position, byte[] buffer)
+            throws IOException
+    {
+        readFully(position, buffer, 0, buffer.length);
+    }
+
+    @Override
     public void readFully(long position, byte[] buffer, int offset, int length)
             throws IOException
     {


### PR DESCRIPTION
Missing override caused reads the don't use the full overloaded version of the method to not be cached such as Parquet metadata reads.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==
Hive Changes
Allow Hive file caching to cache Parquet metadata reads
```
