### PR TITLE
Fix DruidRequestBody JSON serialization error and add unit test case

### DIFF
--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidClient.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidClient.java
@@ -185,7 +185,7 @@ public class DruidClient
             }
         }
     }
-    private static class DruidRequestBody
+    public static class DruidRequestBody
     {
         private String query;
         private String resultFormat;

--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidClient.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidClient.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.druid;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestDruidClient
+{
+    @Test
+    public void testDruidRequestBodyToJson()
+    {
+        DruidClient.DruidRequestBody requestBody = new DruidClient.DruidRequestBody(
+                "select \"city.name\" from \"geo-location\"",
+                "arrayLines",
+                false);
+        assertEquals("{\n" +
+                "  \"query\" : \"select \\\"city.name\\\" from \\\"geo-location\\\"\",\n" +
+                "  \"resultFormat\" : \"arrayLines\",\n" +
+                "  \"queryHeader\" : false\n" +
+                "}",
+                requestBody.toJson());
+    }
+}


### PR DESCRIPTION
The static inner class DruidRequestBody has to be public, otherwise we will get a json serialization exception when sending the request to druid.

```
== NO RELEASE NOTE ==
```
