### PR TITLE
Analyze table fails for tables with struct columns

### DIFF
--- a/presto-docs/src/main/sphinx/sql/analyze.rst
+++ b/presto-docs/src/main/sphinx/sql/analyze.rst
@@ -13,6 +13,7 @@ Description
 -----------
 
 Collects table and column statistics for a given table.
+Currently column statistics are only collected for primitive types.
 
 The optional ``WITH`` clause can be used to provide
 connector-specific properties. To list all available properties, run the following query::

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -107,6 +107,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.apache.hadoop.hive.common.FileUtils.makePartName;
 import static org.apache.hadoop.hive.metastore.api.HiveObjectType.TABLE;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.PRIMITIVE;
 
 @ThreadSafe
 public class ThriftHiveMetastore
@@ -412,6 +413,7 @@ public class ThriftHiveMetastore
         com.facebook.presto.hive.metastore.Table table = fromMetastoreApiTable(modifiedTable);
         OptionalLong rowCount = basicStatistics.getRowCount();
         List<ColumnStatisticsObj> metastoreColumnStatistics = updatedStatistics.getColumnStatistics().entrySet().stream()
+                .filter(entry -> table.getColumn(entry.getKey()).get().getType().getTypeInfo().getCategory() == PRIMITIVE)
                 .map(entry -> createMetastoreColumnStatistics(entry.getKey(), table.getColumn(entry.getKey()).get().getType(), entry.getValue(), rowCount))
                 .collect(toImmutableList());
         if (!metastoreColumnStatistics.isEmpty()) {

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveTableStatistics.java
@@ -682,6 +682,24 @@ public class TestHiveTableStatistics
     }
 
     @Test
+    public void testAnalyzeForTableWithNonPrimitiveTypes()
+    {
+        String tableName = "test_analyze_table_complex_types";
+        String showStatsTable = "SHOW STATS FOR " + tableName;
+
+        query("DROP TABLE IF EXISTS " + tableName);
+        query("CREATE TABLE " + tableName + "(c_row row(c1 int, c2 int), c_char char, c_int int)");
+        query("INSERT INTO " + tableName + " VALUES (row(1,2), 'a', 3)");
+
+        assertThat(query("ANALYZE " + tableName)).containsExactly(row(1));
+        assertThat(query(showStatsTable)).containsOnly(
+                row("c_row", null, null, null, null, null, null),
+                row("c_char", 1.0, 1.0, 0.0, null, null, null),
+                row("c_int", null, 1.0, 0.0, null, "3", "3"),
+                row(null, null, null, null, 1.0, null, null));
+    }
+
+    @Test
     @Requires(NationPartitionedByBigintTable.class)
     public void testAnalyzeForTablePartitionedByBigint()
     {


### PR DESCRIPTION
This PR filters out non-primitive column types when creating metastore column statistics. This fixes the issue of ```ANALYZE``` failing on tables due to the check [here](https://github.com/prestodb/presto/blob/master/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java#L694)

Fixes #14494
```
== RELEASE NOTES ==

Hive Changes
* Fix  ANALYZE table_name failure for tables with map, list or struct columns (:issue:`14494`).
```