### PR TITLE
Expose ErrorType in VerifierQueryEvent

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/event/QueryFailure.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/event/QueryFailure.java
@@ -15,6 +15,7 @@ package com.facebook.presto.verifier.event;
 
 import com.facebook.airlift.event.client.EventField;
 import com.facebook.airlift.event.client.EventType;
+import com.facebook.presto.spi.ErrorType;
 import com.facebook.presto.verifier.framework.QueryStage;
 
 import javax.annotation.concurrent.Immutable;
@@ -30,6 +31,7 @@ public class QueryFailure
     private final String clusterType;
     private final String queryStage;
     private final String errorCode;
+    private final String errorType;
     private final boolean retryable;
     private final String prestoQueryId;
     private final String stacktrace;
@@ -37,6 +39,7 @@ public class QueryFailure
     public QueryFailure(
             QueryStage queryStage,
             String errorCode,
+            Optional<ErrorType> errorType,
             boolean retryable,
             Optional<String> prestoQueryId,
             String stacktrace)
@@ -44,6 +47,7 @@ public class QueryFailure
         this.queryStage = requireNonNull(queryStage.name(), "queryStage is null");
         this.clusterType = requireNonNull(queryStage.getTargetCluster().name(), "cluster is null");
         this.errorCode = requireNonNull(errorCode, "errorCode is null");
+        this.errorType = errorType.map(ErrorType::name).orElse(null);
         this.retryable = retryable;
         this.prestoQueryId = prestoQueryId.orElse(null);
         this.stacktrace = requireNonNull(stacktrace, "stacktrace is null");
@@ -65,6 +69,12 @@ public class QueryFailure
     public String getErrorCode()
     {
         return errorCode;
+    }
+
+    @EventField
+    public String getErrorType()
+    {
+        return errorType;
     }
 
     @EventField

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryException.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryException.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.verifier.framework;
 
 import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.spi.ErrorCode;
+import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.verifier.event.QueryFailure;
 
 import java.util.Optional;
@@ -51,6 +53,9 @@ public abstract class QueryException
         return new QueryFailure(
                 queryStage,
                 getErrorCodeName(),
+                this instanceof PrestoQueryException
+                        ? ((PrestoQueryException) this).getErrorCode().map(ErrorCodeSupplier::toErrorCode).map(ErrorCode::getType)
+                        : Optional.empty(),
                 retryable,
                 this instanceof PrestoQueryException
                         ? ((PrestoQueryException) this).getQueryStats().map(QueryStats::getQueryId)


### PR DESCRIPTION
This will help us categorize high vs low signals from verification failure.

```
== RELEASE NOTES ==

Verifier Changes
* Add ``ErrorType`` of query failures to verification outputs.
```
