### PR TITLE
Warn when using expensive UNION DISTINCT queries

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -18,7 +18,9 @@ import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RealType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.execution.warnings.WarningCollector;
@@ -34,6 +36,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.security.AccessDeniedException;
@@ -121,6 +124,7 @@ import com.facebook.presto.sql.tree.StartTransaction;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.TableSubquery;
+import com.facebook.presto.sql.tree.Union;
 import com.facebook.presto.sql.tree.Unnest;
 import com.facebook.presto.sql.tree.Use;
 import com.facebook.presto.sql.tree.Values;
@@ -156,6 +160,7 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static com.facebook.presto.spi.StandardWarningCode.PERFORMANCE_WARNING;
 import static com.facebook.presto.spi.function.FunctionKind.AGGREGATE;
 import static com.facebook.presto.spi.function.FunctionKind.WINDOW;
 import static com.facebook.presto.sql.NodeUtils.getSortItemsFromOrderBy;
@@ -229,6 +234,7 @@ import static java.util.stream.Collectors.groupingBy;
 
 class StatementAnalyzer
 {
+    private static final int UNION_DISTINCT_FIELDS_WARNING_THRESHOLD = 3;
     private final Analysis analysis;
     private final Metadata metadata;
     private final Session session;
@@ -1159,8 +1165,8 @@ class StatementAnalyzer
             Type[] outputFieldTypes = relationScopes.get(0).getRelationType().getVisibleFields().stream()
                     .map(Field::getType)
                     .toArray(Type[]::new);
+            int outputFieldSize = outputFieldTypes.length;
             for (Scope relationScope : relationScopes) {
-                int outputFieldSize = outputFieldTypes.length;
                 RelationType relationType = relationScope.getRelationType();
                 int descFieldSize = relationType.getVisibleFields().size();
                 String setOperationName = node.getClass().getSimpleName().toUpperCase(ENGLISH);
@@ -1187,6 +1193,15 @@ class StatementAnalyzer
                                 descFieldType.getDisplayName());
                     }
                     outputFieldTypes[i] = commonSuperType.get();
+
+                    if (isExpensiveDistinctUnion(node, outputFieldSize, outputFieldTypes[i])) {
+                        warningCollector.add(new PrestoWarning(
+                                PERFORMANCE_WARNING,
+                                format("%s query uses UNION DISTINCT and should consider reducing the number of visible fields (%d) to %d or less",
+                                        setOperationName,
+                                        outputFieldSize,
+                                        UNION_DISTINCT_FIELDS_WARNING_THRESHOLD)));
+                    }
                 }
             }
 
@@ -1218,6 +1233,16 @@ class StatementAnalyzer
                 }
             }
             return createAndAssignScope(node, scope, outputDescriptorFields);
+        }
+
+        private boolean isExpensiveDistinctUnion(SetOperation setOperation, int numOutputFields, Type outputType)
+        {
+            return setOperation instanceof Union && setOperation.isDistinct() && numOutputFields > UNION_DISTINCT_FIELDS_WARNING_THRESHOLD && isComplexType(outputType);
+        }
+
+        private boolean isComplexType(Type type)
+        {
+            return type instanceof RealType || type instanceof DoubleType || type instanceof MapType || type instanceof ArrayType;
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -18,12 +18,14 @@ import com.facebook.presto.Session;
 import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RealType;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.connector.informationSchema.InformationSchemaConnector;
 import com.facebook.presto.connector.system.SystemConnector;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.execution.warnings.WarningCollector;
+import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.metadata.AnalyzePropertyManager;
@@ -44,6 +46,7 @@ import com.facebook.presto.security.AllowAllAccessControl;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
@@ -55,6 +58,8 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.tree.NodeLocation;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.testing.TestingMetadata;
+import com.facebook.presto.testing.TestingWarningCollector;
+import com.facebook.presto.testing.TestingWarningCollectorConfig;
 import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
@@ -73,6 +78,7 @@ import static com.facebook.presto.metadata.ViewDefinition.ViewColumn;
 import static com.facebook.presto.operator.scalar.ApplyFunction.APPLY_FUNCTION;
 import static com.facebook.presto.spi.ConnectorId.createInformationSchemaConnectorId;
 import static com.facebook.presto.spi.ConnectorId.createSystemTablesConnectorId;
+import static com.facebook.presto.spi.StandardWarningCode.PERFORMANCE_WARNING;
 import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.AMBIGUOUS_ATTRIBUTE;
@@ -124,6 +130,8 @@ import static com.facebook.presto.transaction.InMemoryTransactionManager.createT
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 @Test(singleThreaded = true)
@@ -1052,6 +1060,29 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testUnionDistinctPerformanceWarning()
+    {
+        WarningCollector warningCollector = analyzeWithWarnings("SELECT a,b,c,d FROM t8 UNION DISTINCT SELECT a,b,c,d FROM t9");
+        List<PrestoWarning> warnings = warningCollector.getWarnings();
+        assertEquals(warnings.size(), 1);
+        assertEquals(warnings.get(0), PERFORMANCE_WARNING);
+    }
+
+    @Test
+    public void testUnionNoPerformanceWarning()
+    {
+        // <= 3 fields
+        WarningCollector warningCollector = analyzeWithWarnings("SELECT a,b,c FROM t8 UNION DISTINCT SELECT a,b,c FROM t9");
+        assertTrue(warningCollector.getWarnings().isEmpty());
+        // > 3 fields, no expensive types
+        //warningCollector = analyzeWithWarnings("SELECT a,b,c,d FROM t1 UNION DISTINCT SELECT a,b,c,d FROM t1");
+        assertTrue(warningCollector.getWarnings().isEmpty());
+        // > 3 fields, expensive types, not distinct
+        warningCollector = analyzeWithWarnings("SELECT a,b,c,d FROM t8 UNION ALL SELECT a,b,c,d FROM t9");
+        assertTrue(warningCollector.getWarnings().isEmpty());
+    }
+
+    @Test
     public void testMismatchedUnionQueries()
     {
         assertFails(TYPE_MISMATCH, "SELECT 1 UNION SELECT 'a'");
@@ -1631,6 +1662,26 @@ public class TestAnalyzer
                         new ColumnMetadata("d", new ArrayType(DOUBLE)))),
                 false));
 
+        // table with three doubles
+        SchemaTableName table8 = new SchemaTableName("s1", "t8");
+        inSetupTransaction(session -> metadata.createTable(session, TPCH_CATALOG,
+                new ConnectorTableMetadata(table8, ImmutableList.of(
+                        new ColumnMetadata("a", DOUBLE),
+                        new ColumnMetadata("b", new ArrayType(BIGINT)),
+                        new ColumnMetadata("c", RealType.REAL),
+                        new ColumnMetadata("d", BIGINT))),
+                false));
+
+        // table with three doubles
+        SchemaTableName table9 = new SchemaTableName("s1", "t9");
+        inSetupTransaction(session -> metadata.createTable(session, TPCH_CATALOG,
+                new ConnectorTableMetadata(table9, ImmutableList.of(
+                        new ColumnMetadata("a", DOUBLE),
+                        new ColumnMetadata("b", new ArrayType(BIGINT)),
+                        new ColumnMetadata("c", RealType.REAL),
+                        new ColumnMetadata("d", BIGINT))),
+                false));
+
         // valid view referencing table in same schema
         String viewData1 = JsonCodec.jsonCodec(ViewDefinition.class).toJson(
                 new ViewDefinition(
@@ -1705,7 +1756,7 @@ public class TestAnalyzer
                 .execute(SETUP_SESSION, consumer);
     }
 
-    private static Analyzer createAnalyzer(Session session, Metadata metadata)
+    private static Analyzer createAnalyzer(Session session, Metadata metadata, WarningCollector warningCollector)
     {
         return new Analyzer(
                 session,
@@ -1714,7 +1765,7 @@ public class TestAnalyzer
                 new AllowAllAccessControl(),
                 Optional.empty(),
                 emptyList(),
-                WarningCollector.NOOP);
+                warningCollector);
     }
 
     private void analyze(@Language("SQL") String query)
@@ -1722,14 +1773,26 @@ public class TestAnalyzer
         analyze(CLIENT_SESSION, query);
     }
 
+    private WarningCollector analyzeWithWarnings(@Language("SQL") String query)
+    {
+        WarningCollector warningCollector = new TestingWarningCollector(new WarningCollectorConfig(), new TestingWarningCollectorConfig());
+        analyze(CLIENT_SESSION, warningCollector, query);
+        return warningCollector;
+    }
+
     private void analyze(Session clientSession, @Language("SQL") String query)
+    {
+        analyze(clientSession, WarningCollector.NOOP, query);
+    }
+
+    private void analyze(Session clientSession, WarningCollector warningCollector, @Language("SQL") String query)
     {
         transaction(transactionManager, accessControl)
                 .singleStatement()
                 .readUncommitted()
                 .readOnly()
                 .execute(clientSession, session -> {
-                    Analyzer analyzer = createAnalyzer(session, metadata);
+                    Analyzer analyzer = createAnalyzer(session, metadata, warningCollector);
                     Statement statement = SQL_PARSER.createStatement(query);
                     analyzer.analyze(statement);
                 });

--- a/presto-spi/src/main/java/com/facebook/presto/spi/StandardWarningCode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/StandardWarningCode.java
@@ -18,6 +18,7 @@ public enum StandardWarningCode
 {
     TOO_MANY_STAGES(0x0000_0001),
     PARSER_WARNING(0x0000_0002),
+    PERFORMANCE_WARNING(0x0000_0003)
     /**/;
     private final WarningCode warningCode;
 


### PR DESCRIPTION
UNION DISTINCT can be expensive, when there is a lot of data involved.
We are sending a warning when there there are many visible fields, and
some may be expensive to process.  The current criteria are, that there
are greater than 3 visible fields, and that one is a complex type.

```
== RELEASE NOTES ==

General Changes
* Improve experience by warning user of poorly performant UNION DISTINCT usage.
```