### PR TITLE
Warn when using expensive UNION DISTINCT queries

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/StandardWarningCode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/StandardWarningCode.java
@@ -18,6 +18,7 @@ public enum StandardWarningCode
 {
     TOO_MANY_STAGES(0x0000_0001),
     PARSER_WARNING(0x0000_0002),
+    PERFORMANCE_WARNING(0x0000_0003)
     /**/;
     private final WarningCode warningCode;
 


### PR DESCRIPTION
UNION DISTINCT can be expensive, when there is a lot of data involved.
We are sending a warning when there there are many visible fields, and
some may be expensive to process. The current criteria are, that there
are greater than 3 visible fields, and that one is a complex type.

```
== RELEASE NOTES ==

General Changes
* Improve experience by warning user of poorly performant UNION DISTINCT usage.
```