### PR TITLE
WIP - Optimize SliceDirectSelectiveStreamReader - part 1

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
@@ -72,6 +72,40 @@ final class ReaderUtils
         }
     }
 
+    public static void packByteArraysForPositions(byte[] values, int[] offsets, boolean[] nulls, int[] positions, int positionCount)
+    {
+        int valuesIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            int length = copyValuesRange(values, offsets, valuesIndex, position);
+
+            offsets[i + 1] = offsets[i] + length;
+            nulls[i] = nulls[position];
+        }
+    }
+
+    public static void packByteArraysForPositions(byte[] values, int[] offsets, int[] positions, int positionCount)
+    {
+        int valuesIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            int length = copyValuesRange(values, offsets, valuesIndex, position);
+
+            offsets[i + 1] = offsets[i] + length;
+        }
+    }
+
+    private static int copyValuesRange(byte[] values, int[] offsets, int valuesIndex, int position)
+    {
+        int beginIndex = offsets[position];
+        int endIndex = offsets[position + 1];
+        int length = endIndex - beginIndex;
+        System.arraycopy(values, beginIndex, values, valuesIndex, length);
+        return length;
+    }
+
     public static short[] unpackShortNulls(short[] values, boolean[] isNull)
     {
         short[] result = new short[isNull.length];
@@ -136,6 +170,29 @@ final class ReaderUtils
             int nextLength = vector[i];
             vector[i] = vector[i - 1] + currentLength;
             currentLength = nextLength;
+        }
+    }
+
+    public static void convertLengthVectorToOffsetVector(int[] offsetVector, int[] lengthVector, boolean[] isNullVector, int positionCount)
+    {
+        offsetVector[0] = 0;
+        int lengthVectorIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            if (isNullVector[i]) {
+                offsetVector[i + 1] = offsetVector[i];
+            }
+            else {
+                offsetVector[i + 1] = offsetVector[i] + lengthVector[lengthVectorIndex++];
+            }
+        }
+    }
+
+    public static void convertLengthVectorToOffsetVector(int[] offsetVector, int[] lengthVector, int positionCount)
+    {
+        offsetVector[0] = 0;
+        int lengthVectorIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            offsetVector[i + 1] = offsetVector[i] + lengthVector[lengthVectorIndex++];
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
@@ -158,14 +158,17 @@ public class SliceDirectSelectiveStreamReader
 
         int totalPositionCount = positions[positionCount - 1] + 1;
         if (totalPositionCount * (1 - BATCH_EXECUTION_FILTERRATE_THRESHOLD) <= positionCount && maxCodePointCount < 0) {
-            // unbounded, simply read all data in one shot
-            dataStream.next(data, 0, dataLength);
+            if (dataLength > 0) {
+                // unbounded, simply read all data in one shot
+                dataStream.next(data, 0, dataLength);
+            }
 
             if (presentStream == null) {
                 convertLengthVectorToOffsetVector(offsets, lengthVector, totalPositionCount);
             }
             else {
                 convertLengthVectorToOffsetVector(offsets, lengthVector, isNullVector, totalPositionCount);
+
                 if (totalPositionCount > positionCount) {
                     packByteArraysForPositions(data, offsets, isNullVector, positions, positionCount);
                 }
@@ -525,7 +528,7 @@ public class SliceDirectSelectiveStreamReader
         if (lengthStream != null) {
             int nonNullCount = totalPositions - nullCount;
             lengthVector = ensureCapacity(lengthVector, nonNullCount);
-            lengthStream.nextIntVector(nonNullCount, lengthVector, 0);
+            lengthStream.next(lengthVector, nonNullCount);
 
             //TODO calculate totalLength for only requested positions
             for (int i = 0; i < nonNullCount; i++) {


### PR DESCRIPTION
Partially resolves https://github.com/prestodb/presto/issues/13989 
This PR contains two improvements:

1) Implement the batch read for unbounded varchar and no filter (reading all rows)
2) Read the lengths using more CPU friendly batch read API next()

JMH benchmark when reading unbounded varchar for all rows:

Basline
    Benchmark                                      (withNulls)  Mode  Cnt  Score   Error  Units
    BenchmarkSelectiveStreamReaders.readAllBlocks      PARTIAL  avgt    5  0.183 ± 0.025   s/op
    BenchmarkSelectiveStreamReaders.readAllBlocks         NONE  avgt    5  0.189 ± 0.007   s/op
After
    Benchmark                                      (withNulls)  Mode  Cnt  Score   Error  Units
    BenchmarkSelectiveStreamReaders.readAllBlocks      PARTIAL  avgt    5  0.107 ± 0.015   s/op
    BenchmarkSelectiveStreamReaders.readAllBlocks         NONE  avgt    5  0.084 ± 0.005   s/op

TODO:
1) Implement batch read for readWithFilter
2) work on the unbounded case for readWithFilter(). 
3) work on the varchar bounded. For this case we need to improve string truncations. See https://github.com/prestodb/presto/issues/13990 
4) Optimize getUnsetBits in BooleanInputStream (https://github.com/prestodb/presto/issues/14539) 

```
== NO RELEASE NOTE ==
```
