### PR TITLE
Improve the web UI by providing a production mode for build

### DIFF
--- a/presto-main/src/main/resources/webapp/src/package.json
+++ b/presto-main/src/main/resources/webapp/src/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "install": "webpack --config webpack.config.js",
-    "package": "webpack --config webpack.config.js",
+    "package": "webpack -p --config webpack.config.js",
     "watch": "webpack --config webpack.config.js --watch"
   }
 }

--- a/presto-main/src/main/resources/webapp/src/webpack.config.js
+++ b/presto-main/src/main/resources/webapp/src/webpack.config.js
@@ -1,5 +1,9 @@
 /* global __dirname */
 
+const process = require('process');
+
+const mode = process.argv.includes('-p') ? 'production' : 'development';
+
 module.exports = {
     entry: {
         'index': `${__dirname}/index.jsx`,
@@ -9,7 +13,7 @@ module.exports = {
         'stage': `${__dirname}/stage.jsx`,
         'worker': `${__dirname}/worker.jsx`,
     },
-    mode: 'development',
+    mode,
     module: {
         rules: [
             {

--- a/presto-main/src/main/resources/webapp/src/webpack.config.js
+++ b/presto-main/src/main/resources/webapp/src/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
         'stage': `${__dirname}/stage.jsx`,
         'worker': `${__dirname}/worker.jsx`,
     },
-    mode: "development",
+    mode: 'development',
     module: {
         rules: [
             {

--- a/presto-main/src/main/resources/webapp/src/webpack.config.js
+++ b/presto-main/src/main/resources/webapp/src/webpack.config.js
@@ -1,11 +1,13 @@
+/* global __dirname */
+
 module.exports = {
     entry: {
-        'index': __dirname +'/index.jsx',
-        'query': __dirname +'/query.jsx',
-        'plan': __dirname +'/plan.jsx',
-        'embedded_plan': __dirname +'/embedded_plan.jsx',
-        'stage': __dirname +'/stage.jsx',
-        'worker': __dirname +'/worker.jsx',
+        'index': `${__dirname}/index.jsx`,
+        'query': `${__dirname}/query.jsx`,
+        'plan': `${__dirname}/plan.jsx`,
+        'embedded_plan': `${__dirname}/embedded_plan.jsx`,
+        'stage': `${__dirname}/stage.jsx`,
+        'worker': `${__dirname}/worker.jsx`,
     },
     mode: "development",
     module: {


### PR DESCRIPTION
This PR provides an option to build the web UI dist with a production mode, concentrating on smaller JS bundles.

The size of the original web UI built package is **~33 MB**. After enabling the production mode, the size will be reduced to **~5.9 MB**. This can improve the page loading time of Presto Web UI.

```
== NO RELEASE NOTE ==
```
