### PR TITLE
Make TaskStatus Leaner

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
@@ -471,7 +471,7 @@ public class TestHiveRecoverableExecution
 
     private static void cancelAllTasks(TestingPrestoServer server)
     {
-        server.getTaskManager().getAllTaskInfo().forEach(task -> server.getTaskManager().cancelTask(task.getTaskStatus().getTaskId()));
+        server.getTaskManager().getAllTaskInfo().forEach(task -> server.getTaskManager().cancelTask(task.getTaskId()));
     }
 
     private static Session createRecoverableSession(int writerConcurrency)

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/TaskSystemTable.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/TaskSystemTable.java
@@ -111,10 +111,10 @@ public class TaskSystemTable
             table.addRow(
                     nodeId,
 
-                    taskStatus.getTaskId().toString(),
-                    taskStatus.getTaskId().getStageExecutionId().toString(),
-                    taskStatus.getTaskId().getStageExecutionId().getStageId().toString(),
-                    taskStatus.getTaskId().getQueryId().toString(),
+                    taskInfo.getTaskId().toString(),
+                    taskInfo.getTaskId().getStageExecutionId().toString(),
+                    taskInfo.getTaskId().getStageExecutionId().getStageId().toString(),
+                    taskInfo.getTaskId().getQueryId().toString(),
                     taskStatus.getState().toString(),
 
                     (long) stats.getTotalDrivers(),

--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -386,7 +386,7 @@ public class QueryMonitor
                 failureInfo.getErrorCode(),
                 Optional.ofNullable(failureInfo.getType()),
                 Optional.ofNullable(failureInfo.getMessage()),
-                failedTask.map(task -> task.getTaskStatus().getTaskId().toString()),
+                failedTask.map(task -> task.getTaskId().toString()),
                 failedTask.map(task -> task.getTaskStatus().getSelf().getHost()),
                 executionFailureInfoCodec.toJson(failureInfo)));
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -413,8 +413,7 @@ public class QueryStateMachine
                     .flatMap(stageInfo -> Streams.concat(ImmutableList.of(stageInfo.getLatestAttemptExecutionInfo()).stream(), stageInfo.getPreviousAttemptsExecutionInfos().stream()))
                     .flatMap(execution -> execution.getTasks().stream())
                     .filter(taskInfo -> taskInfo.getTaskStatus().getState() == TaskState.FAILED)
-                    .map(TaskInfo::getTaskStatus)
-                    .map(TaskStatus::getTaskId)
+                    .map(TaskInfo::getTaskId)
                     .collect(toImmutableList()));
         }
         else {

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -284,23 +284,21 @@ public class SqlTask
         }
 
         return new TaskStatus(
-                taskStateMachine.getTaskId(),
                 taskInstanceId,
                 versionNumber,
                 state,
                 location,
-                nodeId,
                 completedDriverGroups,
                 failures,
                 queuedPartitionedDrivers,
                 runningPartitionedDrivers,
                 outputBuffer.getUtilization(),
                 isOutputBufferOverutilized(),
-                physicalWrittenDataSize,
-                userMemoryReservation,
-                systemMemoryReservation,
+                physicalWrittenDataSize.toBytes(),
+                userMemoryReservation.toBytes(),
+                systemMemoryReservation.toBytes(),
                 fullGcCount,
-                fullGcTime);
+                fullGcTime.toMillis());
     }
 
     private TaskStats getTaskStats(TaskHolder taskHolder)
@@ -338,6 +336,7 @@ public class SqlTask
 
         TaskStatus taskStatus = createTaskStatus(taskHolder);
         return new TaskInfo(
+                taskStateMachine.getTaskId(),
                 taskStatus,
                 lastHeartbeat.get(),
                 outputBuffer.getInfo(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -449,7 +449,7 @@ public class SqlTaskManager
     {
         DateTime oldestAllowedTask = DateTime.now().minus(infoCacheTime.toMillis());
         for (TaskInfo taskInfo : filter(transform(tasks.asMap().values(), SqlTask::getTaskInfo), notNull())) {
-            TaskId taskId = taskInfo.getTaskStatus().getTaskId();
+            TaskId taskId = taskInfo.getTaskId();
             try {
                 DateTime endTime = taskInfo.getStats().getEndTime();
                 if (endTime != null && endTime.isBefore(oldestAllowedTask)) {
@@ -475,8 +475,8 @@ public class SqlTaskManager
                 }
                 DateTime lastHeartbeat = taskInfo.getLastHeartbeat();
                 if (lastHeartbeat != null && lastHeartbeat.isBefore(oldestAllowedHeartbeat)) {
-                    log.info("Failing abandoned task %s", taskStatus.getTaskId());
-                    sqlTask.failed(new PrestoException(ABANDONED_TASK, format("Task %s has not been accessed since %s: currentTime %s", taskStatus.getTaskId(), lastHeartbeat, now)));
+                    log.info("Failing abandoned task %s", taskInfo.getTaskId());
+                    sqlTask.failed(new PrestoException(ABANDONED_TASK, format("Task %s has not been accessed since %s: currentTime %s", taskInfo.getTaskId(), lastHeartbeat, now)));
                 }
             }
             catch (RuntimeException e) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
@@ -17,8 +17,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import io.airlift.units.DataSize;
-import io.airlift.units.Duration;
 
 import java.net.URI;
 import java.util.List;
@@ -28,9 +26,7 @@ import static com.facebook.presto.execution.TaskState.PLANNED;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class TaskStatus
 {
@@ -51,12 +47,10 @@ public class TaskStatus
      */
     private static final long MAX_VERSION = Long.MAX_VALUE;
 
-    private final TaskId taskId;
     private final String taskInstanceId;
     private final long version;
     private final TaskState state;
     private final URI self;
-    private final String nodeId;
     private final Set<Lifespan> completedDriverGroups;
 
     private final int queuedPartitionedDrivers;
@@ -65,43 +59,39 @@ public class TaskStatus
     private final double outputBufferUtilization;
     private final boolean outputBufferOverutilized;
 
-    private final DataSize physicalWrittenDataSize;
-    private final DataSize memoryReservation;
-    private final DataSize systemMemoryReservation;
+    private final long physicalWrittenDataSizeInBytes;
+    private final long memoryReservationInBytes;
+    private final long systemMemoryReservationInBytes;
 
     private final long fullGcCount;
-    private final Duration fullGcTime;
+    private final long fullGcTimeInMillis;
 
     private final List<ExecutionFailureInfo> failures;
 
     @JsonCreator
     public TaskStatus(
-            @JsonProperty("taskId") TaskId taskId,
             @JsonProperty("taskInstanceId") String taskInstanceId,
             @JsonProperty("version") long version,
             @JsonProperty("state") TaskState state,
             @JsonProperty("self") URI self,
-            @JsonProperty("nodeId") String nodeId,
             @JsonProperty("completedDriverGroups") Set<Lifespan> completedDriverGroups,
             @JsonProperty("failures") List<ExecutionFailureInfo> failures,
             @JsonProperty("queuedPartitionedDrivers") int queuedPartitionedDrivers,
             @JsonProperty("runningPartitionedDrivers") int runningPartitionedDrivers,
             @JsonProperty("outputBufferUtilization") double outputBufferUtilization,
             @JsonProperty("outputBufferOverutilized") boolean outputBufferOverutilized,
-            @JsonProperty("physicalWrittenDataSize") DataSize physicalWrittenDataSize,
-            @JsonProperty("memoryReservation") DataSize memoryReservation,
-            @JsonProperty("systemMemoryReservation") DataSize systemMemoryReservation,
+            @JsonProperty("physicalWrittenDataSizeInBytes") long physicalWrittenDataSizeInBytes,
+            @JsonProperty("memoryReservationInBytes") long memoryReservationInBytes,
+            @JsonProperty("systemMemoryReservationInBytes") long systemMemoryReservationInBytes,
             @JsonProperty("fullGcCount") long fullGcCount,
-            @JsonProperty("fullGcTime") Duration fullGcTime)
+            @JsonProperty("fullGcTimeInMillis") long fullGcTimeInMillis)
     {
-        this.taskId = requireNonNull(taskId, "taskId is null");
         this.taskInstanceId = requireNonNull(taskInstanceId, "taskInstanceId is null");
 
         checkState(version >= MIN_VERSION, "version must be >= MIN_VERSION");
         this.version = version;
         this.state = requireNonNull(state, "state is null");
         this.self = requireNonNull(self, "self is null");
-        this.nodeId = requireNonNull(nodeId, "nodeId is null");
         this.completedDriverGroups = requireNonNull(completedDriverGroups, "completedDriverGroups is null");
 
         checkArgument(queuedPartitionedDrivers >= 0, "queuedPartitionedDrivers must be positive");
@@ -113,21 +103,15 @@ public class TaskStatus
         this.outputBufferUtilization = outputBufferUtilization;
         this.outputBufferOverutilized = outputBufferOverutilized;
 
-        this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "physicalWrittenDataSize is null");
+        this.physicalWrittenDataSizeInBytes = physicalWrittenDataSizeInBytes;
 
-        this.memoryReservation = requireNonNull(memoryReservation, "memoryReservation is null");
-        this.systemMemoryReservation = requireNonNull(systemMemoryReservation, "systemMemoryReservation is null");
+        this.memoryReservationInBytes = memoryReservationInBytes;
+        this.systemMemoryReservationInBytes = systemMemoryReservationInBytes;
         this.failures = ImmutableList.copyOf(requireNonNull(failures, "failures is null"));
 
         checkArgument(fullGcCount >= 0, "fullGcCount is negative");
         this.fullGcCount = fullGcCount;
-        this.fullGcTime = requireNonNull(fullGcTime, "fullGcTime is null");
-    }
-
-    @JsonProperty
-    public TaskId getTaskId()
-    {
-        return taskId;
+        this.fullGcTimeInMillis = fullGcTimeInMillis;
     }
 
     @JsonProperty
@@ -155,12 +139,6 @@ public class TaskStatus
     }
 
     @JsonProperty
-    public String getNodeId()
-    {
-        return nodeId;
-    }
-
-    @JsonProperty
     public Set<Lifespan> getCompletedDriverGroups()
     {
         return completedDriverGroups;
@@ -185,12 +163,6 @@ public class TaskStatus
     }
 
     @JsonProperty
-    public DataSize getPhysicalWrittenDataSize()
-    {
-        return physicalWrittenDataSize;
-    }
-
-    @JsonProperty
     public double getOutputBufferUtilization()
     {
         return outputBufferUtilization;
@@ -203,15 +175,21 @@ public class TaskStatus
     }
 
     @JsonProperty
-    public DataSize getMemoryReservation()
+    public long getPhysicalWrittenDataSizeInBytes()
     {
-        return memoryReservation;
+        return physicalWrittenDataSizeInBytes;
     }
 
     @JsonProperty
-    public DataSize getSystemMemoryReservation()
+    public long getMemoryReservationInBytes()
     {
-        return systemMemoryReservation;
+        return memoryReservationInBytes;
+    }
+
+    @JsonProperty
+    public long getSystemMemoryReservationInBytes()
+    {
+        return systemMemoryReservationInBytes;
     }
 
     @JsonProperty
@@ -221,61 +199,56 @@ public class TaskStatus
     }
 
     @JsonProperty
-    public Duration getFullGcTime()
+    public long getFullGcTimeInMillis()
     {
-        return fullGcTime;
+        return fullGcTimeInMillis;
     }
 
     @Override
     public String toString()
     {
         return toStringHelper(this)
-                .add("taskId", taskId)
                 .add("state", state)
                 .toString();
     }
 
-    public static TaskStatus initialTaskStatus(TaskId taskId, URI location, String nodeId)
+    public static TaskStatus initialTaskStatus(URI location)
     {
         return new TaskStatus(
-                taskId,
                 "",
                 MIN_VERSION,
                 PLANNED,
                 location,
-                nodeId,
                 ImmutableSet.of(),
                 ImmutableList.of(),
                 0,
                 0,
                 0.0,
                 false,
-                new DataSize(0, BYTE),
-                new DataSize(0, BYTE),
-                new DataSize(0, BYTE),
                 0,
-                new Duration(0, MILLISECONDS));
+                0,
+                0,
+                0,
+                0);
     }
 
     public static TaskStatus failWith(TaskStatus taskStatus, TaskState state, List<ExecutionFailureInfo> exceptions)
     {
         return new TaskStatus(
-                taskStatus.getTaskId(),
                 taskStatus.getTaskInstanceId(),
                 MAX_VERSION,
                 state,
                 taskStatus.getSelf(),
-                taskStatus.getNodeId(),
                 taskStatus.getCompletedDriverGroups(),
                 exceptions,
                 taskStatus.getQueuedPartitionedDrivers(),
                 taskStatus.getRunningPartitionedDrivers(),
                 taskStatus.getOutputBufferUtilization(),
                 taskStatus.isOutputBufferOverutilized(),
-                taskStatus.getPhysicalWrittenDataSize(),
-                taskStatus.getMemoryReservation(),
-                taskStatus.getSystemMemoryReservation(),
+                taskStatus.getPhysicalWrittenDataSizeInBytes(),
+                taskStatus.getMemoryReservationInBytes(),
+                taskStatus.getSystemMemoryReservationInBytes(),
                 taskStatus.getFullGcCount(),
-                taskStatus.getFullGcTime());
+                taskStatus.getFullGcTimeInMillis());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/TrackingRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TrackingRemoteTaskFactory.java
@@ -82,8 +82,8 @@ public class TrackingRemoteTaskFactory
         @Override
         public synchronized void stateChanged(TaskStatus newStatus)
         {
-            long currentUserMemory = newStatus.getMemoryReservation().toBytes();
-            long currentSystemMemory = newStatus.getSystemMemoryReservation().toBytes();
+            long currentUserMemory = newStatus.getMemoryReservationInBytes();
+            long currentSystemMemory = newStatus.getSystemMemoryReservationInBytes();
             long currentTotalMemory = currentUserMemory + currentSystemMemory;
             long deltaUserMemoryInBytes = currentUserMemory - previousUserMemory;
             long deltaTotalMemoryInBytes = currentTotalMemory - (previousUserMemory + previousSystemMemory);

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScaledWriterScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScaledWriterScheduler.java
@@ -103,8 +103,7 @@ public class ScaledWriterScheduler
                 .average().orElse(0.0);
 
         long writtenBytes = writerTasksProvider.get().stream()
-                .map(TaskStatus::getPhysicalWrittenDataSize)
-                .mapToLong(DataSize::toBytes)
+                .mapToLong(TaskStatus::getPhysicalWrittenDataSizeInBytes)
                 .sum();
 
         if ((fullTasks >= 0.5) && (writtenBytes >= (writerMinSizeBytes * scheduledNodes.size()))) {

--- a/presto-main/src/main/java/com/facebook/presto/server/GracefulShutdownHandler.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/GracefulShutdownHandler.java
@@ -91,7 +91,7 @@ public class GracefulShutdownHandler
                 CountDownLatch countDownLatch = new CountDownLatch(activeTasks.size());
 
                 for (TaskInfo taskInfo : activeTasks) {
-                    sqlTaskManager.addStateChangeListener(taskInfo.getTaskStatus().getTaskId(), newState -> {
+                    sqlTaskManager.addStateChangeListener(taskInfo.getTaskId(), newState -> {
                         if (newState.isDone()) {
                             countDownLatch.countDown();
                         }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
@@ -80,6 +80,7 @@ class ContinuousTaskStatusFetcher
 
     public ContinuousTaskStatusFetcher(
             Consumer<Throwable> onFail,
+            TaskId taskId,
             TaskStatus initialTaskStatus,
             Duration refreshMaxWait,
             Codec<TaskStatus> taskStatusCodec,
@@ -92,7 +93,7 @@ class ContinuousTaskStatusFetcher
     {
         requireNonNull(initialTaskStatus, "initialTaskStatus is null");
 
-        this.taskId = initialTaskStatus.getTaskId();
+        this.taskId = requireNonNull(taskId, "taskId is null");
         this.onFail = requireNonNull(onFail, "onFail is null");
         this.taskStatus = new StateMachine<>("task-" + taskId, executor, initialTaskStatus);
 

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -276,10 +276,11 @@ public final class HttpRemoteTask
                     .map(outputId -> new BufferInfo(outputId, false, 0, 0, PageBufferInfo.empty()))
                     .collect(toImmutableList());
 
-            TaskInfo initialTask = createInitialTask(taskId, location, nodeId, bufferStates, new TaskStats(DateTime.now(), null));
+            TaskInfo initialTask = createInitialTask(taskId, location, bufferStates, new TaskStats(DateTime.now(), null));
 
             this.taskStatusFetcher = new ContinuousTaskStatusFetcher(
                     this::failTask,
+                    taskId,
                     initialTask.getTaskStatus(),
                     taskStatusRefreshMaxWait,
                     taskStatusCodec,

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
@@ -108,7 +108,7 @@ public class TaskInfoFetcher
         requireNonNull(initialTask, "initialTask is null");
         requireNonNull(errorScheduledExecutor, "errorScheduledExecutor is null");
 
-        this.taskId = initialTask.getTaskStatus().getTaskId();
+        this.taskId = initialTask.getTaskId();
         this.onFail = requireNonNull(onFail, "onFail is null");
         this.taskInfo = new StateMachine<>("task " + taskId, executor, initialTask);
         this.finalTaskInfo = new StateMachine<>("task-" + taskId, executor, Optional.empty());

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -55,7 +55,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.DataSize;
-import io.airlift.units.Duration;
 import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -89,7 +88,6 @@ import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class MockRemoteTaskFactory
         implements RemoteTaskFactory
@@ -246,24 +244,23 @@ public class MockRemoteTaskFactory
             }
 
             return new TaskInfo(
+                    taskStateMachine.getTaskId(),
                     new TaskStatus(
-                            taskStateMachine.getTaskId(),
                             TASK_INSTANCE_ID,
                             nextTaskInfoVersion.getAndIncrement(),
                             state,
                             location,
-                            nodeId,
                             ImmutableSet.of(),
                             failures,
                             0,
                             0,
                             0.0,
                             false,
-                            new DataSize(0, BYTE),
-                            new DataSize(0, BYTE),
-                            new DataSize(0, BYTE),
                             0,
-                            new Duration(0, MILLISECONDS)),
+                            0,
+                            0,
+                            0,
+                            0),
                     DateTime.now(),
                     outputBuffer.getInfo(),
                     ImmutableSet.of(),
@@ -281,23 +278,21 @@ public class MockRemoteTaskFactory
         public TaskStatus getTaskStatus()
         {
             TaskStats stats = taskContext.getTaskStats();
-            return new TaskStatus(taskStateMachine.getTaskId(),
-                    TASK_INSTANCE_ID,
+            return new TaskStatus(TASK_INSTANCE_ID,
                     nextTaskInfoVersion.get(),
                     taskStateMachine.getState(),
                     location,
-                    nodeId,
                     ImmutableSet.of(),
                     ImmutableList.of(),
                     stats.getQueuedPartitionedDrivers(),
                     stats.getRunningPartitionedDrivers(),
                     0.0,
                     false,
-                    stats.getPhysicalWrittenDataSize(),
-                    stats.getUserMemoryReservation(),
-                    stats.getSystemMemoryReservation(),
+                    stats.getPhysicalWrittenDataSize().toBytes(),
+                    stats.getUserMemoryReservation().toBytes(),
+                    stats.getSystemMemoryReservation().toBytes(),
                     0,
-                    new Duration(0, MILLISECONDS));
+                    0);
         }
 
         private synchronized void updateSplitQueueSpace()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -230,7 +230,7 @@ public class TestSqlTaskManager
             sqlTaskManager.removeOldTasks();
 
             for (TaskInfo info : sqlTaskManager.getAllTaskInfo()) {
-                assertNotEquals(info.getTaskStatus().getTaskId(), taskId);
+                assertNotEquals(info.getTaskId(), taskId);
             }
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -463,6 +463,7 @@ public class TestHttpRemoteTask
         private TaskInfo buildTaskInfo()
         {
             return new TaskInfo(
+                    initialTaskInfo.getTaskId(),
                     buildTaskStatus(),
                     initialTaskInfo.getLastHeartbeat(),
                     initialTaskInfo.getOutputBuffers(),
@@ -496,23 +497,21 @@ public class TestHttpRemoteTask
             }
 
             return new TaskStatus(
-                    initialTaskStatus.getTaskId(),
                     taskInstanceId,
                     ++version,
                     taskState,
                     initialTaskStatus.getSelf(),
-                    "fake",
                     ImmutableSet.of(),
                     initialTaskStatus.getFailures(),
                     initialTaskStatus.getQueuedPartitionedDrivers(),
                     initialTaskStatus.getRunningPartitionedDrivers(),
                     initialTaskStatus.getOutputBufferUtilization(),
                     initialTaskStatus.isOutputBufferOverutilized(),
-                    initialTaskStatus.getPhysicalWrittenDataSize(),
-                    initialTaskStatus.getMemoryReservation(),
-                    initialTaskStatus.getSystemMemoryReservation(),
+                    initialTaskStatus.getPhysicalWrittenDataSizeInBytes(),
+                    initialTaskStatus.getMemoryReservationInBytes(),
+                    initialTaskStatus.getSystemMemoryReservationInBytes(),
                     initialTaskStatus.getFullGcCount(),
-                    initialTaskStatus.getFullGcTime());
+                    initialTaskStatus.getFullGcTimeInMillis());
         }
     }
 }


### PR DESCRIPTION
The coordinator to worker transportation is known to be inefficient, which takes roughly 60% or more CPU time on coordinators. We are planning revamp the coordinator - worker communication.

This PR is part of the general effort. TaskStatus is transported heavily from workers to coordinator. Decoding of  TaskStatus  contributes to 9-10% of the coordinator CPU.

TaskStatus JSON decoding improved about 15% by making it leaner. 

Before:
![Screen Shot 2020-05-19 at 6 13 10 PM](https://user-images.githubusercontent.com/16330476/82394062-d4d8ae80-99fc-11ea-9268-4cabe1796b63.png)

After:
![Screen Shot 2020-05-19 at 6 06 08 PM](https://user-images.githubusercontent.com/16330476/82394068-d73b0880-99fc-11ea-9733-fa8cb07a4947.png)
