### PR TITLE
Introduce table cache quota to HiveConnector

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/CacheConfig.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/CacheConfig.java
@@ -15,8 +15,13 @@ package com.facebook.presto.cache;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.presto.hive.CacheQuotaScope;
+import io.airlift.units.DataSize;
 
 import java.net.URI;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.CacheQuotaScope.GLOBAL;
 
 public class CacheConfig
 {
@@ -24,6 +29,8 @@ public class CacheConfig
     private CacheType cacheType;
     private URI baseDirectory;
     private boolean validationEnabled;
+    private CacheQuotaScope cacheQuotaScope = GLOBAL;
+    private Optional<DataSize> defaultCacheQuota = Optional.empty();
 
     public URI getBaseDirectory()
     {
@@ -75,5 +82,31 @@ public class CacheConfig
     public CacheType getCacheType()
     {
         return cacheType;
+    }
+
+    public CacheQuotaScope getCacheQuotaScope()
+    {
+        return cacheQuotaScope;
+    }
+
+    @Config("cache.cache-quota-scope")
+    public CacheConfig setCacheQuotaScope(CacheQuotaScope cacheQuotaScope)
+    {
+        this.cacheQuotaScope = cacheQuotaScope;
+        return this;
+    }
+
+    public Optional<DataSize> getDefaultCacheQuota()
+    {
+        return defaultCacheQuota;
+    }
+
+    @Config("cache.default-cache-quota")
+    public CacheConfig setDefaultCacheQuota(DataSize defaultCacheQuota)
+    {
+        if (defaultCacheQuota != null) {
+            this.defaultCacheQuota = Optional.of(defaultCacheQuota);
+        }
+        return this;
     }
 }

--- a/presto-cache/src/main/java/com/facebook/presto/cache/CacheManager.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/CacheManager.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.cache;
 
+import com.facebook.presto.hive.CacheQuota;
 import io.airlift.slice.Slice;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -22,13 +23,16 @@ public interface CacheManager
 {
     /**
      * Given {@param request}, check if the data is in cache.
-     * If it is not in cache, return false.
-     * Otherwise, save the data in {@param buffer} starting at {@param offset} and return true.
+     * If it is in cache, save the data in {@param buffer} starting at {@param offset} and return HIT.
+     * If it is not in cache:
+     *      1. If there is still cache quota for this table, return MISS
+     *      2. Otherwise, return CACHE_QUOTA_EXCEED
+     * @return CacheResult
      */
-    boolean get(FileReadRequest request, byte[] buffer, int offset);
+    CacheResult get(FileReadRequest request, byte[] buffer, int offset, CacheQuota cacheQuota);
 
     /**
      * Save data in cache
      */
-    void put(FileReadRequest request, Slice data);
+    void put(FileReadRequest request, Slice data, CacheQuota cacheQuota);
 }

--- a/presto-cache/src/main/java/com/facebook/presto/cache/CacheResult.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/CacheResult.java
@@ -13,23 +13,18 @@
  */
 package com.facebook.presto.cache;
 
-import com.facebook.presto.hive.CacheQuota;
-import io.airlift.slice.Slice;
-
-import static com.facebook.presto.cache.CacheResult.MISS;
-
-public class NoOpCacheManager
-        implements CacheManager
+public enum CacheResult
 {
-    @Override
-    public CacheResult get(FileReadRequest request, byte[] buffer, int offset, CacheQuota cacheQuota)
-    {
-        return MISS;
-    }
-
-    @Override
-    public void put(FileReadRequest request, Slice data, CacheQuota cacheQuota)
-    {
-        // no op
-    }
+    /**
+     * The data we're reading is in cache
+     */
+    HIT,
+    /**
+     * The data we're reading is not in cache and we have quota to write them to cache
+     */
+    MISS,
+    /**
+     * The data we're reading is not in cache and we don't have quota to write them to cache
+     */
+    CACHE_QUOTA_EXCEED
 }

--- a/presto-cache/src/main/java/com/facebook/presto/cache/CacheStats.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/CacheStats.java
@@ -25,6 +25,7 @@ public class CacheStats
     private final AtomicLong inMemoryRetainedBytes = new AtomicLong();
     private final AtomicLong hit = new AtomicLong();
     private final AtomicLong miss = new AtomicLong();
+    private final AtomicLong quotaExceed = new AtomicLong();
 
     public void incrementCacheHit()
     {
@@ -34,6 +35,11 @@ public class CacheStats
     public void incrementCacheMiss()
     {
         miss.getAndIncrement();
+    }
+
+    public void incrementQuotaExceed()
+    {
+        quotaExceed.getAndIncrement();
     }
 
     public void addInMemoryRetainedBytes(long bytes)
@@ -57,5 +63,11 @@ public class CacheStats
     public long getCacheMiss()
     {
         return miss.get();
+    }
+
+    @Managed
+    public long getQuotaExceed()
+    {
+        return quotaExceed.get();
     }
 }

--- a/presto-cache/src/main/java/com/facebook/presto/cache/CachingModule.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/CachingModule.java
@@ -60,7 +60,8 @@ public class CachingModule
                     fileMergeCacheConfig,
                     cacheStats,
                     newScheduledThreadPool(5, daemonThreadsNamed("hive-cache-flusher-%s")),
-                    newScheduledThreadPool(1, daemonThreadsNamed("hive-cache-remover-%s")));
+                    newScheduledThreadPool(1, daemonThreadsNamed("hive-cache-remover-%s")),
+                    newScheduledThreadPool(1, daemonThreadsNamed("hive-cache-size-calculator-%s")));
         }
         return new NoOpCacheManager();
     }

--- a/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCachingFileSystem.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCachingFileSystem.java
@@ -53,7 +53,7 @@ public final class FileMergeCachingFileSystem
             throws Exception
     {
         if (hiveFileContext.isCacheable()) {
-            return new FileMergeCachingInputStream(dataTier.openFile(path, hiveFileContext), cacheManager, path, cacheValidationEnabled);
+            return new FileMergeCachingInputStream(dataTier.openFile(path, hiveFileContext), cacheManager, path, hiveFileContext.getCacheQuota(), cacheValidationEnabled);
         }
 
         return dataTier.openFile(path, hiveFileContext);

--- a/presto-cache/src/test/java/com/facebook/presto/cache/TestCacheConfig.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/TestCacheConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.cache;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
 import java.net.URI;
@@ -23,6 +24,8 @@ import static com.facebook.airlift.configuration.testing.ConfigAssertions.assert
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static com.facebook.presto.cache.CacheType.FILE_MERGE;
+import static com.facebook.presto.hive.CacheQuotaScope.GLOBAL;
+import static com.facebook.presto.hive.CacheQuotaScope.TABLE;
 
 public class TestCacheConfig
 {
@@ -33,7 +36,9 @@ public class TestCacheConfig
                 .setCachingEnabled(false)
                 .setCacheType(null)
                 .setBaseDirectory(null)
-                .setValidationEnabled(false));
+                .setValidationEnabled(false)
+                .setCacheQuotaScope(GLOBAL)
+                .setDefaultCacheQuota(null));
     }
 
     @Test
@@ -45,13 +50,17 @@ public class TestCacheConfig
                 .put("cache.type", "FILE_MERGE")
                 .put("cache.base-directory", "tcp://abc")
                 .put("cache.validation-enabled", "true")
+                .put("cache.cache-quota-scope", "TABLE")
+                .put("cache.default-cache-quota", "1GB")
                 .build();
 
         CacheConfig expected = new CacheConfig()
                 .setCachingEnabled(true)
                 .setCacheType(FILE_MERGE)
                 .setBaseDirectory(new URI("tcp://abc"))
-                .setValidationEnabled(true);
+                .setValidationEnabled(true)
+                .setCacheQuotaScope(TABLE)
+                .setDefaultCacheQuota(DataSize.succinctDataSize(1, DataSize.Unit.GIGABYTE));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
@@ -50,6 +50,7 @@ import java.util.concurrent.ExecutionException;
 import static com.facebook.presto.cache.CacheType.ALLUXIO;
 import static com.facebook.presto.cache.TestingCacheUtils.stressTest;
 import static com.facebook.presto.cache.TestingCacheUtils.validateBuffer;
+import static com.facebook.presto.hive.CacheQuota.NO_CACHE_CONSTRAINTS;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static java.nio.file.Files.createTempDirectory;
@@ -222,7 +223,7 @@ public class TestAlluxioCachingFileSystem
     private int readFully(AlluxioCachingFileSystem fileSystem, long position, byte[] buffer, int offset, int length)
             throws Exception
     {
-        try (FSDataInputStream stream = fileSystem.openFile(new Path(testFilePath), new HiveFileContext(true, Optional.empty()))) {
+        try (FSDataInputStream stream = fileSystem.openFile(new Path(testFilePath), new HiveFileContext(true, NO_CACHE_CONSTRAINTS, Optional.empty()))) {
             return stream.read(position, buffer, offset, length);
         }
     }

--- a/presto-hive-common/pom.xml
+++ b/presto-hive-common/pom.xml
@@ -28,5 +28,15 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/CacheQuota.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/CacheQuota.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import io.airlift.units.DataSize;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.hash.Hashing.md5;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class CacheQuota
+{
+    public static final CacheQuota NO_CACHE_CONSTRAINTS = new CacheQuota("NO_IDENTITY", Optional.empty());
+
+    private final long identifier;
+    private final Optional<DataSize> quota;
+
+    public CacheQuota(String identity, Optional<DataSize> quota)
+    {
+        this.identifier = md5().hashString(identity, UTF_8).asLong();
+        this.quota = requireNonNull(quota, "quota is null");
+    }
+
+    public long getIdentifier()
+    {
+        return identifier;
+    }
+
+    public Optional<DataSize> getQuota()
+    {
+        return quota;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CacheQuota that = (CacheQuota) o;
+        return identifier == that.identifier && Objects.equals(quota, that.quota);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(identifier, quota);
+    }
+}

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/CacheQuotaRequirement.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/CacheQuotaRequirement.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.units.DataSize;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.CacheQuotaScope.GLOBAL;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class CacheQuotaRequirement
+{
+    public static final CacheQuotaRequirement NO_CACHE_REQUIREMENT = new CacheQuotaRequirement(GLOBAL, Optional.empty());
+
+    private final CacheQuotaScope cacheQuotaScope;
+    private final Optional<DataSize> quota;
+
+    @JsonCreator
+    public CacheQuotaRequirement(
+            @JsonProperty("cacheQuotaScope") CacheQuotaScope cacheQuotaScope,
+            @JsonProperty("quota") Optional<DataSize> quota)
+    {
+        this.cacheQuotaScope = requireNonNull(cacheQuotaScope, "cacheQuotaScope");
+        this.quota = quota;
+    }
+
+    @JsonProperty
+    public CacheQuotaScope getCacheQuotaScope()
+    {
+        return cacheQuotaScope;
+    }
+
+    @JsonProperty
+    public Optional<DataSize> getQuota()
+    {
+        return quota;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CacheQuotaRequirement that = (CacheQuotaRequirement) o;
+        return Objects.equals(cacheQuotaScope, that.cacheQuotaScope) && Objects.equals(quota, that.quota);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(cacheQuotaScope, quota);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("cacheQuotaScope", cacheQuotaScope)
+                .add("quota", quota)
+                .toString();
+    }
+}

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/CacheQuotaScope.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/CacheQuotaScope.java
@@ -11,25 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.cache;
+package com.facebook.presto.hive;
 
-import com.facebook.presto.hive.CacheQuota;
-import io.airlift.slice.Slice;
-
-import static com.facebook.presto.cache.CacheResult.MISS;
-
-public class NoOpCacheManager
-        implements CacheManager
+public enum CacheQuotaScope
 {
-    @Override
-    public CacheResult get(FileReadRequest request, byte[] buffer, int offset, CacheQuota cacheQuota)
-    {
-        return MISS;
-    }
-
-    @Override
-    public void put(FileReadRequest request, Slice data, CacheQuota cacheQuota)
-    {
-        // no op
-    }
+    GLOBAL, SCHEMA, TABLE, PARTITION
 }

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileContext.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileContext.java
@@ -15,18 +15,21 @@ package com.facebook.presto.hive;
 
 import java.util.Optional;
 
+import static com.facebook.presto.hive.CacheQuota.NO_CACHE_CONSTRAINTS;
 import static java.util.Objects.requireNonNull;
 
 public class HiveFileContext
 {
-    public static final HiveFileContext DEFAULT_HIVE_FILE_CONTEXT = new HiveFileContext(false, Optional.empty());
+    public static final HiveFileContext DEFAULT_HIVE_FILE_CONTEXT = new HiveFileContext(true, NO_CACHE_CONSTRAINTS, Optional.empty());
 
     private final boolean cacheable;
+    private final CacheQuota cacheQuota;
     private final Optional<ExtraHiveFileInfo<?>> extraFileInfo;
 
-    public HiveFileContext(boolean cacheable, Optional<ExtraHiveFileInfo<?>> extraFileInfo)
+    public HiveFileContext(boolean cacheable, CacheQuota cacheQuota, Optional<ExtraHiveFileInfo<?>> extraFileInfo)
     {
         this.cacheable = cacheable;
+        this.cacheQuota = requireNonNull(cacheQuota, "cacheQuota is null");
         this.extraFileInfo = requireNonNull(extraFileInfo, "extraFileInfo is null");
     }
 
@@ -36,6 +39,11 @@ public class HiveFileContext
     public boolean isCacheable()
     {
         return cacheable;
+    }
+
+    public CacheQuota getCacheQuota()
+    {
+        return cacheQuota;
     }
 
     /**

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
@@ -57,6 +57,7 @@ public class HiveSplit
     private final Optional<BucketConversion> bucketConversion;
     private final boolean s3SelectPushdownEnabled;
     private final Optional<byte[]> extraFileInfo;
+    private final CacheQuotaRequirement cacheQuotaRequirement;
 
     @JsonCreator
     public HiveSplit(
@@ -77,7 +78,8 @@ public class HiveSplit
             @JsonProperty("partitionSchemaDifference") Map<Integer, Column> partitionSchemaDifference,
             @JsonProperty("bucketConversion") Optional<BucketConversion> bucketConversion,
             @JsonProperty("s3SelectPushdownEnabled") boolean s3SelectPushdownEnabled,
-            @JsonProperty("extraFileInfo") Optional<byte[]> extraFileInfo)
+            @JsonProperty("extraFileInfo") Optional<byte[]> extraFileInfo,
+            @JsonProperty("cacheQuota") CacheQuotaRequirement cacheQuotaRequirement)
     {
         checkArgument(start >= 0, "start must be positive");
         checkArgument(length >= 0, "length must be positive");
@@ -95,6 +97,7 @@ public class HiveSplit
         requireNonNull(partitionSchemaDifference, "partitionSchemaDifference is null");
         requireNonNull(bucketConversion, "bucketConversion is null");
         requireNonNull(extraFileInfo, "extraFileInfo is null");
+        requireNonNull(cacheQuotaRequirement, "cacheQuotaRequirement is null");
 
         this.database = database;
         this.table = table;
@@ -114,6 +117,7 @@ public class HiveSplit
         this.bucketConversion = bucketConversion;
         this.s3SelectPushdownEnabled = s3SelectPushdownEnabled;
         this.extraFileInfo = extraFileInfo;
+        this.cacheQuotaRequirement = cacheQuotaRequirement;
     }
 
     @JsonProperty
@@ -244,6 +248,12 @@ public class HiveSplit
         return extraFileInfo;
     }
 
+    @JsonProperty
+    public CacheQuotaRequirement getCacheQuotaRequirement()
+    {
+        return cacheQuotaRequirement;
+    }
+
     @Override
     public Object getInfo()
     {
@@ -258,6 +268,7 @@ public class HiveSplit
                 .put("nodeSelectionStrategy", nodeSelectionStrategy)
                 .put("partitionName", partitionName)
                 .put("s3SelectPushdownEnabled", s3SelectPushdownEnabled)
+                .put("cacheQuotaRequirement", cacheQuotaRequirement)
                 .build();
     }
 
@@ -270,6 +281,7 @@ public class HiveSplit
                 .addValue(length)
                 .addValue(fileSize)
                 .addValue(s3SelectPushdownEnabled)
+                .addValue(cacheQuotaRequirement)
                 .toString();
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientLocal.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClientLocal.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.cache.CacheConfig;
 import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.spi.ConnectorTableHandle;
@@ -68,7 +69,7 @@ public abstract class AbstractTestHiveClientLocal
                 .setTimeZone("America/Los_Angeles");
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
 
-        setup(testDbName, hiveConfig, metastoreClientConfig, metastore);
+        setup(testDbName, hiveConfig, new CacheConfig(), metastoreClientConfig, metastore);
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.concurrent.BoundedExecutor;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.GroupByHashPageIndexerFactory;
+import com.facebook.presto.cache.CacheConfig;
 import com.facebook.presto.hive.AbstractTestHiveClient.HiveTransaction;
 import com.facebook.presto.hive.AbstractTestHiveClient.Transaction;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
@@ -133,6 +134,7 @@ public abstract class AbstractTestHiveFileSystem
 
     private ExecutorService executor;
     private HiveClientConfig config;
+    private CacheConfig cacheConfig;
     private MetastoreClientConfig metastoreClientConfig;
 
     @BeforeClass
@@ -161,6 +163,7 @@ public abstract class AbstractTestHiveFileSystem
         temporaryCreateTable = new SchemaTableName(database, "tmp_presto_test_create_" + random);
 
         config = new HiveClientConfig().setS3SelectPushdownEnabled(s3SelectPushdownEnabled);
+        cacheConfig = new CacheConfig();
         metastoreClientConfig = new MetastoreClientConfig();
 
         String proxy = System.getProperty("hive.metastore.thrift.client.socks-proxy");
@@ -217,7 +220,9 @@ public abstract class AbstractTestHiveFileSystem
                 config.getMaxPartitionBatchSize(),
                 config.getMaxInitialSplits(),
                 config.getSplitLoaderConcurrency(),
-                config.getRecursiveDirWalkerEnabled());
+                config.getRecursiveDirWalkerEnabled(),
+                cacheConfig.getCacheQuotaScope(),
+                cacheConfig.getDefaultCacheQuota());
         pageSinkProvider = new HivePageSinkProvider(
                 getDefaultHiveFileWriterFactories(config, metastoreClientConfig),
                 hdfsEnvironment,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -58,6 +58,7 @@ import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.hive.BackgroundHiveSplitLoader.BucketSplitInfo.createBucketSplitInfo;
+import static com.facebook.presto.hive.CacheQuotaScope.GLOBAL;
 import static com.facebook.presto.hive.HiveTestUtils.SESSION;
 import static com.facebook.presto.hive.HiveType.HIVE_INT;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
@@ -438,6 +439,8 @@ public class TestBackgroundHiveSplitLoader
                 SESSION,
                 SIMPLE_TABLE.getDatabaseName(),
                 SIMPLE_TABLE.getTableName(),
+                GLOBAL,
+                Optional.empty(),
                 1,
                 1,
                 new DataSize(32, MEGABYTE),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -65,6 +65,7 @@ import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
+import static com.facebook.presto.hive.CacheQuotaRequirement.NO_CACHE_REQUIREMENT;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveCompressionCodec.NONE;
 import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
@@ -243,7 +244,8 @@ public class TestHivePageSink
                 ImmutableMap.of(),
                 Optional.empty(),
                 false,
-                Optional.empty());
+                Optional.empty(),
+                NO_CACHE_REQUIREMENT);
         TableHandle tableHandle = new TableHandle(
                 new ConnectorId(HIVE_CATALOG),
                 new HiveTableHandle(SCHEMA_NAME, TABLE_NAME),
@@ -312,7 +314,7 @@ public class TestHivePageSink
         return new TestingConnectorSession(new HiveSessionProperties(config, new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties());
     }
 
-    private static List<HiveColumnHandle> getColumnHandles()
+    public static List<HiveColumnHandle> getColumnHandles()
     {
         ImmutableList.Builder<HiveColumnHandle> handles = ImmutableList.builder();
         List<LineItemColumn> columns = getTestColumns();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.metastore.StorageFormat;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.facebook.presto.hive.CacheQuotaRequirement.NO_CACHE_REQUIREMENT;
+import static com.facebook.presto.hive.CacheQuotaScope.PARTITION;
+import static com.facebook.presto.hive.TestHivePageSink.getColumnHandles;
+import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+
+public class TestHivePageSourceProvider
+{
+    private static final String SCHEMA_NAME = "schema";
+    private static final String TABLE_NAME = "table";
+    private static final String PARTITION_NAME = "partition";
+
+    @Test
+    public void testGenerateCacheQuota()
+    {
+        HiveClientConfig config = new HiveClientConfig();
+
+        HiveSplit split = new HiveSplit(
+                SCHEMA_NAME,
+                TABLE_NAME,
+                PARTITION_NAME,
+                "file://test",
+                0,
+                10,
+                10,
+                new Storage(
+                        StorageFormat.create(config.getHiveStorageFormat().getSerDe(), config.getHiveStorageFormat().getInputFormat(), config.getHiveStorageFormat().getOutputFormat()),
+                        "location",
+                        Optional.empty(),
+                        false,
+                        ImmutableMap.of(),
+                        ImmutableMap.of()),
+                ImmutableList.of(),
+                ImmutableList.of(),
+                OptionalInt.empty(),
+                OptionalInt.empty(),
+                NO_PREFERENCE,
+                getColumnHandles().size(),
+                ImmutableMap.of(),
+                Optional.empty(),
+                false,
+                Optional.empty(),
+                NO_CACHE_REQUIREMENT);
+
+        CacheQuota cacheQuota = HivePageSourceProvider.generateCacheQuota(split);
+        CacheQuota expectedCacheQuota = new CacheQuota(".", Optional.empty());
+        assertEquals(cacheQuota, expectedCacheQuota);
+
+        split = new HiveSplit(
+                SCHEMA_NAME,
+                TABLE_NAME,
+                PARTITION_NAME,
+                "file://test",
+                0,
+                10,
+                10,
+                new Storage(
+                        StorageFormat.create(config.getHiveStorageFormat().getSerDe(), config.getHiveStorageFormat().getInputFormat(), config.getHiveStorageFormat().getOutputFormat()),
+                        "location",
+                        Optional.empty(),
+                        false,
+                        ImmutableMap.of(),
+                        ImmutableMap.of()),
+                ImmutableList.of(),
+                ImmutableList.of(),
+                OptionalInt.empty(),
+                OptionalInt.empty(),
+                NO_PREFERENCE,
+                getColumnHandles().size(),
+                ImmutableMap.of(),
+                Optional.empty(),
+                false,
+                Optional.empty(),
+                new CacheQuotaRequirement(PARTITION, Optional.of(DataSize.succinctDataSize(1, DataSize.Unit.MEGABYTE))));
+
+        cacheQuota = HivePageSourceProvider.generateCacheQuota(split);
+        expectedCacheQuota = new CacheQuota(SCHEMA_NAME + "." + TABLE_NAME + "." + PARTITION_NAME, Optional.of(DataSize.succinctDataSize(1, DataSize.Unit.MEGABYTE)));
+        assertEquals(cacheQuota, expectedCacheQuota);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
@@ -48,6 +48,7 @@ import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.json.JsonBinder.jsonBinder;
 import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.hive.CacheQuotaRequirement.NO_CACHE_REQUIREMENT;
 import static com.facebook.presto.hive.HiveType.HIVE_LONG;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
@@ -89,7 +90,8 @@ public class TestHiveSplit
                         16,
                         ImmutableList.of(new HiveColumnHandle("col", HIVE_LONG, BIGINT.getTypeSignature(), 5, ColumnType.REGULAR, Optional.of("comment"))))),
                 false,
-                Optional.empty());
+                Optional.empty(),
+                NO_CACHE_REQUIREMENT);
 
         JsonCodec<HiveSplit> codec = getJsonCodec();
         String json = codec.toJson(expected);
@@ -110,6 +112,7 @@ public class TestHiveSplit
         assertEquals(actual.getBucketConversion(), expected.getBucketConversion());
         assertEquals(actual.getNodeSelectionStrategy(), expected.getNodeSelectionStrategy());
         assertEquals(actual.isS3SelectPushdownEnabled(), expected.isS3SelectPushdownEnabled());
+        assertEquals(actual.getCacheQuotaRequirement(), expected.getCacheQuotaRequirement());
     }
 
     private JsonCodec<HiveSplit> getJsonCodec()

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorPageSourceProvider.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorPageSourceProvider.java
@@ -38,6 +38,7 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.UUID;
 
+import static com.facebook.presto.hive.HiveFileContext.DEFAULT_HIVE_FILE_CONTEXT;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -61,7 +62,6 @@ public class RaptorPageSourceProvider
             SplitContext splitContext)
     {
         RaptorSplit raptorSplit = (RaptorSplit) split;
-        HiveFileContext hiveFileContext = new HiveFileContext(splitContext.isCacheable(), Optional.empty());
         OptionalInt bucketNumber = raptorSplit.getBucketNumber();
         TupleDomain<RaptorColumnHandle> predicate = raptorSplit.getEffectivePredicate();
         ReaderAttributes attributes = ReaderAttributes.from(session);
@@ -76,7 +76,7 @@ public class RaptorPageSourceProvider
             UUID shardUuid = raptorSplit.getShardUuids().iterator().next();
             return createPageSource(
                     context,
-                    hiveFileContext,
+                    DEFAULT_HIVE_FILE_CONTEXT,
                     shardUuid,
                     Optional.ofNullable(shardDeltaMap.get(shardUuid)),
                     tableSupportsDeltaDelete,
@@ -91,7 +91,7 @@ public class RaptorPageSourceProvider
         Iterator<ConnectorPageSource> iterator = raptorSplit.getShardUuids().stream()
                 .map(shardUuid -> createPageSource(
                         context,
-                        hiveFileContext,
+                        DEFAULT_HIVE_FILE_CONTEXT,
                         shardUuid,
                         Optional.ofNullable(shardDeltaMap.get(shardUuid)),
                         tableSupportsDeltaDelete,

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/HdfsModule.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/HdfsModule.java
@@ -75,7 +75,8 @@ public class HdfsModule
                     fileMergeCacheConfig,
                     cacheStats,
                     newScheduledThreadPool(5, daemonThreadsNamed("raptor-cache-flusher-%s")),
-                    newScheduledThreadPool(1, daemonThreadsNamed("raptor-cache-remover-%s")));
+                    newScheduledThreadPool(1, daemonThreadsNamed("raptor-cache-remover-%s")),
+                    newScheduledThreadPool(1, daemonThreadsNamed("hive-cache-size-calculator-%s")));
         }
         return new NoOpCacheManager();
     }


### PR DESCRIPTION
```
== RELEASE NOTES ==

Hive Changes
* Introduced cache quota with respect to a scope. A scope could be at global, schema, table, or partition level. Cache quota prevents queries scanning too much data to disrupt cache locality. Such queries can only use the cache within their own scopes. Cache quota now only works with `FILE_MERGE` cache. Turn it on with config `cache.cache-quota-scope` and `cache.default-cache-quota`.
```

For further potential steps (as following PR)
1. Read the table quota and whitelist from FB internal configuration system
2. Break the dependency between presto-hive and presto-cache
3. Add support for CATALOG level quota if needed


Project doc: https://docs.google.com/document/d/1FDcPG3okhs4tfQ3ABF-5yAJSkV4PaSmIHytfn1JNft0/edit?usp=sharing
