### PR TITLE
Set an upper limit on number of projections per PageProjection

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CommonSubExpressionRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CommonSubExpressionRewriter.java
@@ -147,6 +147,7 @@ public class CommonSubExpressionRewriter
                     newList.add(expression);
                     dependencies.addAll(second);
                     merged[j] = true;
+                    j = i + 1;
                 }
                 else {
                     j++;

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CommonSubExpressionRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CommonSubExpressionRewriter.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -85,7 +86,7 @@ public class CommonSubExpressionRewriter
         return collectCSEByLevel(ImmutableList.of(expression));
     }
 
-    public static Map<List<RowExpression>, Boolean> getExpressionsPartitionedByCSE(Collection<? extends RowExpression> expressions)
+    public static Map<List<RowExpression>, Boolean> getExpressionsPartitionedByCSE(Collection<? extends RowExpression> expressions, int expressionGroupSize)
     {
         if (expressions.isEmpty()) {
             return ImmutableMap.of();
@@ -128,13 +129,13 @@ public class CommonSubExpressionRewriter
                 break;
             }
             merged[i] = true;
-            ImmutableList.Builder<RowExpression> newList = ImmutableList.builder();
+            List<RowExpression> newList = new ArrayList<>();
             newList.add(expressionsWithCse.get(i));
             Set<RowExpression> dependencies = new HashSet<>();
             Set<RowExpression> first = cseDependency.get(i);
             dependencies.addAll(first);
             int j = i + 1;
-            while (j < merged.length) {
+            while (j < merged.length && newList.size() < expressionGroupSize) {
                 while (j < merged.length && merged[j]) {
                     j++;
                 }
@@ -153,7 +154,7 @@ public class CommonSubExpressionRewriter
                     j++;
                 }
             }
-            expressionsPartitionedByCse.put(newList.build(), true);
+            expressionsPartitionedByCse.put(ImmutableList.copyOf(newList), true);
         }
 
         return expressionsPartitionedByCse.build();

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestCommonSubExpressionRewritter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestCommonSubExpressionRewritter.java
@@ -65,7 +65,7 @@ public class TestCommonSubExpressionRewritter
                         ImmutableList.of(rowExpression("x + y"), rowExpression("(x + y) * 2")), true,
                         ImmutableList.of(rowExpression("x + 2"), rowExpression("y * (x + 2)")), true,
                         ImmutableList.of(rowExpression("x * y")), false));
-        expressions = ImmutableList.of(rowExpression("x + y"), rowExpression("x + y + x * 2"), rowExpression("y * 2"), rowExpression("x * 2"), rowExpression("x + y * 2"));
+        expressions = ImmutableList.of(rowExpression("x + y"), rowExpression("x * 2"), rowExpression("x + y + x * 2"), rowExpression("y * 2"), rowExpression("x + y * 2"));
         expressionsWithCSE = getExpressionsPartitionedByCSE(expressions);
         assertEquals(
                 expressionsWithCSE,

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestCommonSubExpressionRewritter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestCommonSubExpressionRewritter.java
@@ -58,7 +58,7 @@ public class TestCommonSubExpressionRewritter
     void testGetExpressionsWithCSE()
     {
         List<RowExpression> expressions = ImmutableList.of(rowExpression("x + y"), rowExpression("(x + y) * 2"), rowExpression("x + 2"), rowExpression("y * (x + 2)"), rowExpression("x * y"));
-        Map<List<RowExpression>, Boolean> expressionsWithCSE = getExpressionsPartitionedByCSE(expressions);
+        Map<List<RowExpression>, Boolean> expressionsWithCSE = getExpressionsPartitionedByCSE(expressions, 3);
         assertEquals(
                 expressionsWithCSE,
                 ImmutableMap.of(
@@ -66,12 +66,20 @@ public class TestCommonSubExpressionRewritter
                         ImmutableList.of(rowExpression("x + 2"), rowExpression("y * (x + 2)")), true,
                         ImmutableList.of(rowExpression("x * y")), false));
         expressions = ImmutableList.of(rowExpression("x + y"), rowExpression("x * 2"), rowExpression("x + y + x * 2"), rowExpression("y * 2"), rowExpression("x + y * 2"));
-        expressionsWithCSE = getExpressionsPartitionedByCSE(expressions);
+        expressionsWithCSE = getExpressionsPartitionedByCSE(expressions, 3);
         assertEquals(
                 expressionsWithCSE,
                 ImmutableMap.of(
                         ImmutableList.of(rowExpression("x + y"), rowExpression("x + y + x * 2"), rowExpression("x * 2")), true,
                         ImmutableList.of(rowExpression("y * 2"), rowExpression("x + y * 2")), true));
+
+        expressionsWithCSE = getExpressionsPartitionedByCSE(expressions, 2);
+        assertEquals(
+                expressionsWithCSE,
+                ImmutableMap.of(
+                        ImmutableList.of(rowExpression("x + y"), rowExpression("x + y + x * 2")), true,
+                        ImmutableList.of(rowExpression("y * 2"), rowExpression("x + y * 2")), true,
+                        ImmutableList.of(rowExpression("x * 2")), true));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestPageFunctionCompiler.java
@@ -25,6 +25,7 @@ import com.facebook.presto.operator.project.PageProjectionWithOutputs;
 import com.facebook.presto.operator.project.SelectedPositions;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
@@ -32,6 +33,7 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.common.function.OperatorType.ADD;
 import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
@@ -41,11 +43,13 @@ import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IF;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.field;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
@@ -194,6 +198,27 @@ public class TestPageFunctionCompiler
     }
 
     @Test
+    public void testCommonSubExpressionLongProjectionList()
+    {
+        PageFunctionCompiler functionCompiler = new PageFunctionCompiler(createTestMetadataManager(), 0);
+
+        List<Supplier<PageProjectionWithOutputs>> pageProjections = functionCompiler.compileProjections(SESSION.getSqlFunctionProperties(), createIfProjectionList(5), true, Optional.empty());
+        assertEquals(pageProjections.size(), 1);
+
+        pageProjections = functionCompiler.compileProjections(SESSION.getSqlFunctionProperties(), createIfProjectionList(10), true, Optional.empty());
+        assertEquals(pageProjections.size(), 1);
+
+        pageProjections = functionCompiler.compileProjections(SESSION.getSqlFunctionProperties(), createIfProjectionList(11), true, Optional.empty());
+        assertEquals(pageProjections.size(), 2);
+
+        pageProjections = functionCompiler.compileProjections(SESSION.getSqlFunctionProperties(), createIfProjectionList(20), true, Optional.empty());
+        assertEquals(pageProjections.size(), 2);
+
+        pageProjections = functionCompiler.compileProjections(SESSION.getSqlFunctionProperties(), createIfProjectionList(101), true, Optional.empty());
+        assertEquals(pageProjections.size(), 11);
+    }
+
+    @Test
     public void testCommonSubExpressionInFilter()
     {
         PageFunctionCompiler functionCompiler = new PageFunctionCompiler(createTestMetadataManager(), 0);
@@ -237,5 +262,22 @@ public class TestPageFunctionCompiler
             blocks[i] = builder.build();
         }
         return new Page(blocks);
+    }
+
+    private List<? extends RowExpression> createIfProjectionList(int projectionCount)
+    {
+        return IntStream.range(0, projectionCount)
+                .mapToObj(i -> new SpecialFormExpression(
+                        IF,
+                        BIGINT,
+                        call(
+                                GREATER_THAN.name(),
+                                FUNCTION_MANAGER.resolveOperator(GREATER_THAN, fromTypes(BIGINT, BIGINT)),
+                                BOOLEAN,
+                                field(0, BIGINT),
+                                constant(10L, BIGINT)),
+                        constant((long) i, BIGINT),
+                        constant((long) i + 1, BIGINT)))
+                .collect(toImmutableList());
     }
 }


### PR DESCRIPTION
This is to address performance regressions when too many projections are compiled into one class.

```
== NO RELEASE NOTE ==
```
