### PR TITLE
Check for all Throwables while get query results

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
@@ -271,7 +271,7 @@ public class LocalDispatchQuery
         try {
             return tryGetFutureValue(queryExecutionFuture);
         }
-        catch (Exception ignored) {
+        catch (Throwable ignored) {
             return Optional.empty();
         }
     }


### PR DESCRIPTION
There are situations where in `AssertionError`s are thrown in the code and that cannot be caught with `Exception`. Changing this to catch `Throwable`

```
== NO RELEASE NOTE ==
```
