### PR TITLE
Skip escaping columnnames for table-scan on hdfs

### DIFF
--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidQueryGeneratorContext.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidQueryGeneratorContext.java
@@ -198,6 +198,7 @@ public class DruidQueryGeneratorContext
     {
         return "\"" + identifier + "\"";
     }
+
     public DruidQueryGeneratorContext withVariablesInAggregation(Set<VariableReferenceExpression> newVariablesInAggregation)
     {
         return new DruidQueryGeneratorContext(
@@ -290,7 +291,7 @@ public class DruidQueryGeneratorContext
             VariableReferenceExpression variable = entry.getKey();
             Selection selection = entry.getValue();
             DruidColumnHandle handle = selection.getOrigin() == Origin.TABLE_COLUMN ?
-                    new DruidColumnHandle(selection.getEscapedDefinition(), variable.getType(), DruidColumnHandle.DruidColumnType.REGULAR) :
+                    new DruidColumnHandle(selection.getDefinition(), variable.getType(), DruidColumnHandle.DruidColumnType.REGULAR) :
                     new DruidColumnHandle(variable, DruidColumnHandle.DruidColumnType.DERIVED);
             result.put(variable, handle);
         });


### PR DESCRIPTION
Remove the escaping logic in getAssignments, because during the scanning on hdfs files, we don't need escape column names.  
This change won't break the current dql generation,  we have unit tests cover that.

```
== NO RELEASE NOTE ==
```
