### PR TITLE
Filtering nulls from left and right in inner join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -156,6 +156,7 @@ public final class SystemSessionProperties
     public static final String OPTIMIZE_COMMON_SUB_EXPRESSIONS = "optimize_common_sub_expressions";
     public static final String PREFER_DISTRIBUTED_UNION = "prefer_distributed_union";
     public static final String WARNING_HANDLING = "warning_handling";
+    public static final String OPTIMIZE_NULLS_IN_JOINS = "optimize_nulls_in_join";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -800,7 +801,12 @@ public final class SystemSessionProperties
                         warningCollectorConfig.getWarningHandlingLevel(),
                         false,
                         value -> WarningHandlingLevel.valueOf(((String) value).toUpperCase()),
-                        WarningHandlingLevel::name));
+                        WarningHandlingLevel::name),
+                booleanProperty(
+                        OPTIMIZE_NULLS_IN_JOINS,
+                        "Filter nulls from inner side of join",
+                        featuresConfig.isOptimizeNullsInJoin(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -1350,5 +1356,10 @@ public final class SystemSessionProperties
     public static WarningHandlingLevel getWarningHandlingLevel(Session session)
     {
         return session.getSystemProperty(WARNING_HANDLING, WarningHandlingLevel.class);
+    }
+
+    public static boolean isOptimizeNullsInJoin(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZE_NULLS_IN_JOINS, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -153,6 +153,7 @@ public class FeaturesConfig
     private boolean useLegacyScheduler = true;
     private boolean optimizeCommonSubExpressions = true;
     private boolean preferDistributedUnion = true;
+    private boolean optimizeNullsInJoin;
 
     private PartitioningPrecisionStrategy partitioningPrecisionStrategy = PartitioningPrecisionStrategy.AUTOMATIC;
 
@@ -1262,6 +1263,18 @@ public class FeaturesConfig
     public FeaturesConfig setPreferDistributedUnion(boolean preferDistributedUnion)
     {
         this.preferDistributedUnion = preferDistributedUnion;
+        return this;
+    }
+
+    public boolean isOptimizeNullsInJoin()
+    {
+        return optimizeNullsInJoin;
+    }
+
+    @Config("optimize-nulls-in-join")
+    public FeaturesConfig setOptimizeNullsInJoin(boolean optimizeNullsInJoin)
+    {
+        this.optimizeNullsInJoin = optimizeNullsInJoin;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -59,6 +59,7 @@ import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.Intersect;
+import com.facebook.presto.sql.tree.IsNotNullPredicate;
 import com.facebook.presto.sql.tree.Join;
 import com.facebook.presto.sql.tree.JoinUsing;
 import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
@@ -290,11 +291,13 @@ class RelationPlanner
                     if (firstDependencies.stream().allMatch(left::canResolve) && secondDependencies.stream().allMatch(right::canResolve)) {
                         leftComparisonExpressions.add(firstExpression);
                         rightComparisonExpressions.add(secondExpression);
+                        addNullFilters(complexJoinExpressions, node.getType(), firstExpression, secondExpression);
                         joinConditionComparisonOperators.add(comparisonOperator);
                     }
                     else if (firstDependencies.stream().allMatch(right::canResolve) && secondDependencies.stream().allMatch(left::canResolve)) {
                         leftComparisonExpressions.add(secondExpression);
                         rightComparisonExpressions.add(firstExpression);
+                        addNullFilters(complexJoinExpressions, node.getType(), secondExpression, firstExpression);
                         joinConditionComparisonOperators.add(comparisonOperator.flip());
                     }
                     else {
@@ -398,6 +401,32 @@ class RelationPlanner
         }
 
         return new RelationPlan(root, analysis.getScope(node), outputs);
+    }
+
+    private void addNullFilters(List<Expression> conditions, Join.Type joinType, Expression left, Expression right)
+    {
+        if (SystemSessionProperties.isOptimizeNullsInJoin(session)) {
+            switch (joinType) {
+                case INNER:
+                    addNullFilterIfSupported(conditions, left);
+                    addNullFilterIfSupported(conditions, right);
+                    break;
+                case LEFT:
+                    addNullFilterIfSupported(conditions, right);
+                    break;
+                case RIGHT:
+                    addNullFilterIfSupported(conditions, left);
+                    break;
+            }
+        }
+    }
+
+    private void addNullFilterIfSupported(List<Expression> conditions, Expression incoming)
+    {
+        if (!(incoming instanceof InPredicate)) {
+            // (A.x IN (1,2,3)) IS NOT NULL is not supported as a join condition as of today.
+            conditions.add(new IsNotNullPredicate(incoming));
+        }
     }
 
     private RelationPlan planJoinUsing(Join node, RelationPlan left, RelationPlan right)

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -134,7 +134,8 @@ public class TestFeaturesConfig
                 .setExperimentalFunctionsEnabled(false)
                 .setUseLegacyScheduler(true)
                 .setOptimizeCommonSubExpressions(true)
-                .setPreferDistributedUnion(true));
+                .setPreferDistributedUnion(true)
+                .setOptimizeNullsInJoin(false));
     }
 
     @Test
@@ -225,6 +226,7 @@ public class TestFeaturesConfig
                 .put("use-legacy-scheduler", "false")
                 .put("optimize-common-sub-expressions", "false")
                 .put("prefer-distributed-union", "false")
+                .put("optimize-nulls-in-join", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -311,7 +313,8 @@ public class TestFeaturesConfig
                 .setExperimentalFunctionsEnabled(true)
                 .setUseLegacyScheduler(false)
                 .setOptimizeCommonSubExpressions(false)
-                .setPreferDistributedUnion(false);
+                .setPreferDistributedUnion(false)
+                .setOptimizeNullsInJoin(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -56,6 +56,7 @@ import java.util.stream.IntStream;
 import static com.facebook.presto.SystemSessionProperties.DISTRIBUTED_SORT;
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_NULLS_IN_JOINS;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DecimalType.createDecimalType;
@@ -8200,6 +8201,46 @@ public abstract class AbstractTestQueries
         assertQueryFails(
                 "SELECT * FROM (VALUES array[2, 2]) a(x) FULL OUTER JOIN LATERAL(VALUES x) ON true",
                 "line .*: LATERAL on other than the right side of CROSS JOIN is not supported");
+    }
+
+    @Test
+    public void testJoinsWithNulls()
+    {
+        Session sessionWithOptNulls = Session.builder(getSession())
+                .setSystemProperty(OPTIMIZE_NULLS_IN_JOINS, "true")
+                .build();
+        testJoinsWithNullsInternal(getSession());
+        testJoinsWithNullsInternal(sessionWithOptNulls);
+    }
+
+    private void testJoinsWithNullsInternal(Session session)
+    {
+        assertQuery(
+                session,
+                "SELECT * FROM (VALUES 2, 3, null) a(x) INNER JOIN (VALUES 3, 4, null) b(x) ON a.x = b.x",
+                "SELECT * FROM VALUES (3, 3)");
+
+        assertQuery(
+                session,
+                "SELECT * FROM (VALUES 2, 3, null) a(x) LEFT JOIN (VALUES 3, 4, null) b(x) ON a.x = b.x",
+                "SELECT * FROM VALUES (3, 3), (2, NULL), (NULL, NULL)");
+
+        assertQuery(
+                session,
+                "SELECT * FROM (VALUES 2, 3, null) a(x) RIGHT JOIN (VALUES 3, 4, null) b(x) ON a.x = b.x",
+                "SELECT * FROM VALUES (3, 3), (NULL, 4), (NULL, NULL)");
+
+        assertQuery(
+                session,
+                "SELECT * FROM (VALUES 2, 3, null) a(x) " +
+                        "FULL OUTER JOIN (VALUES 3, 4, null) b(x) ON a.x = b.x",
+                "SELECT * FROM VALUES (3, 3), (NULL, 4), (2, NULL), (NULL, NULL), (NULL, NULL)");
+
+        assertQuery(
+                session,
+                "SELECT * FROM (VALUES 2, 3, null) a(x) " +
+                        "FULL OUTER JOIN (VALUES 3, 4, null) b(x) ON a.x = b.x WHERE a.x IS NULL",
+                "SELECT * FROM VALUES (NULL, 4), (NULL, NULL), (NULL, NULL)");
     }
 
     @Test


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Add new INNER JOIN optimisation, to filters rows from left and right side of inner join, which have NULL values on join key.
```
