### PR TITLE
Support all types for temporary hive table

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveType.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveType.java
@@ -199,11 +199,22 @@ public final class HiveType
         return new HiveType(typeInfo);
     }
 
-    public static HiveType toHiveType(TypeTranslator typeTranslator, Type type)
+    public static HiveType toHiveType(
+            TypeTranslator typeTranslator,
+            Type type)
+    {
+        return toHiveType(typeTranslator, type, Optional.empty());
+    }
+
+    public static HiveType toHiveType(
+            TypeTranslator typeTranslator,
+            Type type,
+            Optional<HiveType> defaultHiveType)
     {
         requireNonNull(typeTranslator, "typeTranslator is null");
         requireNonNull(type, "type is null");
-        return new HiveType(typeTranslator.translate(type));
+        requireNonNull(defaultHiveType, "defaultHiveType is null");
+        return new HiveType(typeTranslator.translate(type, defaultHiveType));
     }
 
     private static TypeSignature getTypeSignature(TypeInfo typeInfo)

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/TypeTranslator.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/TypeTranslator.java
@@ -16,7 +16,19 @@ package com.facebook.presto.hive;
 import com.facebook.presto.common.type.Type;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 
+import java.util.Optional;
+
 public interface TypeTranslator
 {
-    TypeInfo translate(Type type);
+    default TypeInfo translate(Type type)
+    {
+        return translate(type, Optional.empty());
+    }
+
+    /**
+     * When there is no mapping type in hive to translate {@code type},
+     * use provided {@code }defaultHiveType} when necessary. For example,
+     * explicit type is not needed for PageFile format.
+     */
+    TypeInfo translate(Type type, Optional<HiveType> defaultHiveType);
 }


### PR DESCRIPTION
- Unit test will fail before the code change.
- Unit test will fail if `temporary_table_storage_format `is not `PAGEFILE`

```
== NO RELEASE NOTE ==
```
