### PR TITLE
Add release notes for 0.236

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.236
     release/release-0.235.1
     release/release-0.235
     release/release-0.234.3

--- a/presto-docs/src/main/sphinx/release/release-0.236.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.236.rst
@@ -1,0 +1,26 @@
+=============
+Release 0.236
+=============
+
+General Changes
+_______________
+* Fix query failure for case expression with large number of cases.
+* Add warning about inefficient use of ``UNION DISTINCT``.
+
+JDBC Changes
+____________
+* Add support for ``PreparedStatement#getMetaData``.
+
+Hive Changes
+____________
+* Fix ``ANALYZE`` query failure for tables with structure-typed columns. (:issue:`14494`).
+* Fix Parquet schema mismatch when type is upgraded from ``int32`` to ``int64``.
+* Improve planning time for queries that scan large number of partitions across multiple partition columns.
+* Add local data caching support with `Alluxio <https://www.alluxio.io/>`_ cache library. This can be enabled by setting the configuration property ``cache.enabled`` to ``true`` and ``cache.type`` to ``ALLUXIO``.
+* Improve Hive file caching by introducing Parquet metadata caching.
+
+Verifier Changes
+________________
+* Add ``ErrorType`` of query failures to verification outputs.
+* Add support for auto-resolving result mismatches for array, map, and row columns.
+* Add support for auto-resolving result mismatches for queries that use certain functions. The list of functions can be configured by setting the configuration property ``ignored-functions.functions``.


### PR DESCRIPTION
# Missing Release Notes
## Rongrong Zhong
- [x] https://github.com/prestodb/presto/pull/14491 Change common sub-expression functions to return check flags and return result (Merged by: Rongrong Zhong)
- [x] 46993651d8c2e19c07c11598c5dc41575f7ccaeb Fix NPE in CommonSubExpressionRewriter triggered by CASE-WHEN expression

## Ryan Rupp
- [x] https://github.com/prestodb/presto/pull/14526 Allow cached reads on the non-offset version of readFully (Merged by: Zhenxiao Luo)

# Extracted Release Notes
- #14460 (Author: Adam J. Shook): Implement JDBC PreparedStatement.getMetaData
  - Adds PreparedStatement support for getMetaData.
- #14471 (Author: Sreeni Viswanadha): Simplify searched case translation
  - Fixed translation of searched case expressions to be flat.
- #14477 (Author: Shixuan Fan): Optimize createPredicate in getTableLayout
  - Improve planning time for queries that scan large number of partitions across multiple partition columns.
- #14499 (Author: Rohit Jain): Add Alluxio based data caching
  - Add local data caching support with `Alluxio <https://www.alluxio.io/>`_ cache library. To enable it, set config `cache.enabled=true` and `cache.type=ALLUXIO`.
- #14506 (Author: Leiqing Cai): Auto-resolve certain result mismatches
  - Add support to auto-resolve result mismatch for structured-type columns.
  - Add support to auto-resolve result mismatch in case the query uses functions to be ignored.
- #14532 (Author: Sujay Jain): Analyze table fails for tables with struct columns
  - Fix  ANALYZE table_name failure for tables with map, list or struct columns (:issue:`14494`).
- #14533 (Author: Leiqing Cai): Expose ErrorType in VerifierQueryEvent
  - Add ``ErrorType`` of query failures to verification outputs.
- #14538 (Author: Gregory Nazario): Warn when using expensive UNION DISTINCT queries
  - Improve experience by warning user of poorly performant UNION DISTINCT usage.
- #14548 (Author: Venki Korukanti): Fix Parquet schema mismatch for type upgrade (int32 -> int64)
  - Fix Parquet schema mismatch when type is upgraded (int32 -> int64).

# All Commits
- 46993651d8c2e19c07c11598c5dc41575f7ccaeb Fix NPE in CommonSubExpressionRewriter triggered by CASE-WHEN expression (Rongrong Zhong)
- 081de9638fb5db5f04151d03d7586187cea75a7f Add additional logging to resource group scheduler (Mayank Garg)
- de43c1522fe4ef4aa81d7a0a962bafdc99e57375 Check for all Throwables while get query results (Mayank Garg)
- b90ad7766311006042b2551ca8ff5d36d67f1d6d Simplify searched case translation. (Sreeni Viswanadha)
- c89a8e3579689fa3ad15cbed245702cc917a169c Filter out non primitive columns when creating metastore column statictics (Sujay Jain)
- 1229e1fd5f3f1b3733d7a7678afbc086b59b2206 Warn when using expensive UNION DISTINCT queries (Gregory Nazario)
- b6985d3a5da63710bf95732ffa526232f223d02d Bind classes as singleton in FailureResolverModule (Leiqing Cai)
- a10adac975888c5465926f5b369a29caa18808a9 Auto-resolve queries referencing certain functions (Leiqing Cai)
- eeab40c3fcc7b5999b3b1f95322e355e17dcebac Auto-resolve mismatched structured-type columns (Leiqing Cai)
- ba67a8d536c3215927e3416ca202b912cf197976 Compute cardinality checksum for array and map columns (Leiqing Cai)
- bf0db246ce4c3966ad866d1081d35edfef803b98 Convert MatchResult.mismatchedColumns to a list (Leiqing Cai)
- 0f2bf8e1269f01c337efa17baa6d72e1efbc76dc Return checksum objects in column validator (Leiqing Cai)
- cf64512600a19242dcc3ec8638be990aa5e0a021 Remove unused class in VerifierLimitationFailureResolver (Leiqing Cai)
- f43e4441f46e56e6816bca0cfc8b66473a9c3b21 Parquet schema mismatch for type upgrade (int32 -> int64) (Venki Korukanti)
- e58c3511c692698160968affe5f95922f462da37 Allow cached reads on the non-offset version of readFully (Ryan Rupp)
- bb2e6160dbb3730cf733fa3b09e7fc1b2e9a2f78 Expose ErrorType in VerifierQueryEvent (Leiqing Cai)
- 0221e24b54bf710997d9f421834b6af087ef6859 Add OutputStreamDataSinkFactory (Vic Zhang)
- 1d9d967f1af238d31aa9af84f768b9fc230d2509 Upgrade Drift to version 1.24 (Nikhil Collooru)
- 561e977f3b39c056ef76ea00ff826f0148039b93 Implement JDBC PreparedStatement getMetaData (Adam J. Shook)
- e2a5010472caec495a893185f7ab6fdf653068c2 Fix DruidRequestBody JSON serialization error and add unit test cases (Beinan Wang)
- b9865182d9b6c58853c43bf00fb62f739b5f9087 Fix null config issue for caching filesystem (Rohit Jain)
- 00dd95161d528e148765efc4e4d72a33aede190f Fix Presto Proxy for Java 10 (Tim Meehan)
- e5226228051da204ac5d8b62f11317d47dc898c8 Refactoring and fixing code review issues (Beinan Wang)
- 4803f79484efb4baa51272327971405e2814ffae Add unit test case for druid.hadoop.config.resources (Beinan Wang)
- 5b2397565265ec08b00e2e39e9550c409e2faff8 Exclude transitive dependency to fix build error (Beinan Wang)
- 448ca8b70e8c98851e9e8891e4dcbdbb2391136e Add presto-druid into presto-product-test config properties (Beinan Wang)
- b7acf134f314e94604fb9ade07ee777380db3767 Add the problematical file path to the presto exception message (Beinan Wang)
- eeb990760b5ae37319cba936d699a3f9ede517a0 Support query columns with 'Other' type (Beinan Wang)
- 52a87c70c561eec4663530042e4f2c5f53a8bcc8 Add dependency of fastutil for Druid HDFS file parsing (Beinan Wang)
- e628b4d792719301b901f19bcf75035012ac7aab Add configuration for hdfs config resources (Beinan Wang)
- 86a6e586bdeff8f5723851814a7ca9389d855756 Refactoring and fix code reivew issue (Beinan Wang)
- 028ba0083f1ae100b62418e0781a3d36c995a1cd Escaping variable name and the column name inside distinct count. (Beinan Wang)
- 4d3e19d3eb1257f089deb357c7fb6731e80102b5 Improve JSON serialization for the http requests to Druid (Beinan Wang)
- 9898dba7ced3e4411d21fc5f53e5d2a7baee81a8 Fix the exception of 'Internal file \"column_name\" doesn't exist' (Beinan Wang)
- 880928aaee68faca26ff333c13e54e96c216ab1c Escaping special characters in druid table name and column name. (Beinan Wang)
- 5166a2ebf8811fc9169111eb277884e022f5ed17 Fix json type deserialization issue on DruidSegmentInfo (Beinan Wang)
- 37aa1b1465d968e6c6650440a108dfa30055208b Support cachable flag in CachingDirectoryLister (Shixuan Fan)
- adb411680d35c776761c90d15ac1e439235f8508 Use functional style for Optional handling (Shixuan Fan)
- a1367571e8aad24a1f2f604c2e980daf57030937 Remove redundant requireNonNull (Shixuan Fan)
- 69eacc0513d5f35c76e2fb1bdb6b89a6bb03865a Use java util Supplier in BackgroundHiveSplitLoader (Shixuan Fan)
- fac749a71afe65cbf07e9e3e73145b7171ab93ec Implement broadcast join (Andrii Rosa)
- 973e7de41a79a203a8d266f39d63025ed3777d13 Increase visibility of BlockUtil (Andrii Rosa)
- f3735f9d738dbc3e43ac85f68958122ae000766b Refactor PrestoSparkTaskInputs (Andrii Rosa)
- d7cecad12faa8761eaccf3f3943438f898e83056 Refactor PrestoSparkRemoteSourceOperator (Andrii Rosa)
- 01590935deefddbce0c4dc2a418324c1a9c091b8 Improve rollback handling in PrestoSparkQueryExecutionFactory (Andrii Rosa)
- 71d6280c3ba422f4f5cb7143bd7f22e636cbedcc Refactor PrestoSparkRddFactory (Andrii Rosa)
- a6ea2487ad2aaf3006caa037017402053ac4f092 Update task limit state without delay for testing (Vic Zhang)
- 83882e0c29fb1316a020ad01464927174680fff6 Ensure only single SparkContext exist per jvm (Andrii Rosa)
- e565e3d0bc3744e95c9800ecdda002973b70399a Run presto-spark-base tests in a separate travis job (Andrii Rosa)
- 19d6f0a2f56dc09803517317f99eca2c2c826a48 Decrease logging in PrestoSparkQueryRunner (Andrii Rosa)
- 510a1e84b8ad86334f3280d96228a50b66eb4241 Use Hive connector in PrestoSparkQueryRunner (Andrii Rosa)
- bcab682907a6884e959de7adf3738489926a573b Improve PrestoSparkQueryRunner (Andrii Rosa)
- 40a3bac47f8e57841b67b1b9742d56026f24571c Register system catalog for Presto on Spark (Andrii Rosa)
- 75187c6979c7a93ca7d66a24f61636c45e439e72 Fix PrestoSparkOutputOperator (Andrii Rosa)
- 472538a02722c5409649533f9a602b5b76d9dd2d Add Alluxio based data caching (Rohit Jain)
- 5699056e4c0ca44f4d98e2e0dc4bebc872ce28fb Upgrade Drift to version 1.23 (Ajay George)
- 2e38dd471b5b48fe9d08740a4ddc266cef412e8f Change common sub-expression methods to return result (Rongrong Zhong)
- 5618ebd4f2d8579f8d31a0e13c20b70a1241981c Partition projections into subsets that depend on same common sub-expressions (Rongrong Zhong)
- 10a8cb56c5a93ae8a8497ffc7dda9ecb83a07faa Add extracted common sub-expression to debug level logging (Rongrong Zhong)
- cc312861c9df16c95a693949f710712c36ed606b Drop presto-orc usage of NOT_SUPPORTED PrestoException (Nikhil Collooru)
- 20b4db7136187d959ee12ea233412b6391ef6369 Drop presto-orc usage of GENERIC_INTERNAL_ERROR PrestoException (Nikhil Collooru)
- 04daeb45f6d2ba2abd9e3cf59a8a755256b4da1a Drop presto-orc usage of INVALID_FUNCTION_ARGUMENT PrestoException (Nikhil Collooru)
- 007891b015623d378fd56b05e11917a6120b5986 Do not prune partitions with recoverable failures in filter evaluation (Bhavani Hari)
- e4fbf228981ab834f065a8d70ea6a98b0dffae1c FastutilSetHelper ObjectStrategy equals result can be null. (Sujay Jain)
- b70fcf3e077916b3c975cb4af0f465ee01a1796b Add release notes collection script (Leiqing Cai)
- 9057aea31af2d9f01b439580da22b415793e6c5d Handle NotSupportedException from RowType, MapType, ArrayType (Nikhil Collooru)
- e7a2cb0ed589a852d743cf9780dd9fc39ef8d490 Handle NotSupportedException from SingleMapBlock, TimeZoneKey (Nikhil Collooru)
- 76d18ba99ad036a891ebcdf7df744c952ed6f84b Catch InvalidFunctionArgumentException and rethrow as PrestoException (Nikhil Collooru)
- efe29ef9d4ac84ca31675b97caa7603bb3ee8950 Remove unused OutOfRangeException (Nikhil Collooru)
- 29acdbaff128fff2de185c28fb26031be1d88019 Refactor predicate package into presto-common (Nikhil Collooru)
- 04138bc26a4fc801630fe936463d89d071d00c0a Move Type,Block,SqlFunctionProperties to presto-common (Nikhil Collooru)
- e5710cddd85d70f739c4877f692b73cae1a61aa0 Move Subfield to presto-common (Nikhil Collooru)
- b5f7eea32cfcf5a490458baae789c76f211d7255 Refactor function package of presto-spi into presto-common (Nikhil Collooru)
- c4635ef9bd65a5a8be3817737379039021c5fac8 Add types of Exceptions to presto-common (Nikhil Collooru)
- 1a15abad6eee705bdd3da7a15f6946883fc6727d Add new presto-common module (Nikhil Collooru)
- 56117346d6b2f2154e4d37af02efa7a25b90e5a5 Optimize createPredicate in getTableLayout (Shixuan Fan)
- 8886f79944f347ed58108f01ed402d2e31f89cd0 Remove unused field in HiveMetadata (Shixuan Fan)
- 46d18342378d93283f592127def1d39ee27e2c31 Disable memory allocation tracking by default (Masha Basmanova)
- 5bd40c56a06b8bc48d7d0a361c506f456dc68e86 Fix integer overflow when creating a BigIntValues Filter (Bhavani Hari)
- 516aba5b59ad138c72666ddad42d988a379ea5d6 Add PageFile compression in HiveFileFormatBenchmark (Vic Zhang)
- cd2a34bd2320872814698ed2e228c6ea1c0edf37 Support reading compressed PageFile format (Vic Zhang)
- f297b39d95a67c7501026ed3eb9ad9ce66bdedc4 Add compression information in PageFile footer (Vic Zhang)
- f7cfca440852e00deebd16349a18d53993adebb5 Implement Decompressor using zlib (Vic Zhang)
- f2cef22ed2c03d5dbe3bb30c77e87a6d23fa0d57 Add LZ4 compression in HiveCompressionCodec (Vic Zhang)
- e03790e14dd0b71903440e421b4283de22642791 Support page compression in PageFileWriter (Vic Zhang)
- 491bab7752f5c697669cb25d14c18cf0d0463abc Add adapters for PageCompressor and PageDecompressor (Vic Zhang)
- 3dd9704fc8bc8be4014876631aaaed55ad3c7cc5 Fix getBlockView to use positionCount instead of outputPositionCount (Bhavani Hari)
- 659c0c2ca62d780bc638045b9eed2a53102d7378 Lower startup-grace-period for TestRaptorIntegrationSmokeTestMySql (James Sun)
- dbf3a80c504efc569fb59e969ca60ac8739a8560 Handle pruned columns in a pushed down pinot table scan (Devesh Agrawal)
- 6eb0d35a718c8695f292d3f0991b1c680ca6bf3c Add stats and cost rule for IntersectNode (Saumitra Shahapure)