### PR TITLE
Use local private credentials (json key file) to refresh GCS access token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1170,6 +1170,7 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+
             <dependency>
                 <groupId>com.google.cloud.bigdataoss</groupId>
                 <artifactId>gcsio</artifactId>
@@ -1185,6 +1186,7 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+
             <dependency>
                 <groupId>com.google.cloud.bigdataoss</groupId>
                 <artifactId>util-hadoop</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1140,6 +1140,18 @@
             </dependency>
 
             <dependency>
+                <groupId>com.google.auth</groupId>
+                <artifactId>google-auth-library-oauth2-http</artifactId>
+                <version>0.12.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>com.google.cloud.bigdataoss</groupId>
                 <artifactId>util</artifactId>
                 <version>${dep.gcs.version}</version>
@@ -1158,7 +1170,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
             <dependency>
                 <groupId>com.google.cloud.bigdataoss</groupId>
                 <artifactId>gcsio</artifactId>
@@ -1174,7 +1185,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
             <dependency>
                 <groupId>com.google.cloud.bigdataoss</groupId>
                 <artifactId>util-hadoop</artifactId>
@@ -1345,6 +1355,24 @@
                         <artifactId>slf4j-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.5</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>4.4.9</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.10</version>
             </dependency>
 
             <dependency>

--- a/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
@@ -26,8 +26,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static com.facebook.presto.client.ClientSession.stripTransactionId;
+import static com.facebook.presto.client.GCSOAuthInterceptor.GCS_CREDENTIALS_PATH_KEY;
 import static com.facebook.presto.client.OkHttpUtil.basicAuth;
 import static com.facebook.presto.client.OkHttpUtil.setupCookieJar;
+import static com.facebook.presto.client.OkHttpUtil.setupGCSOauth;
 import static com.facebook.presto.client.OkHttpUtil.setupHttpProxy;
 import static com.facebook.presto.client.OkHttpUtil.setupKerberos;
 import static com.facebook.presto.client.OkHttpUtil.setupSocksProxy;
@@ -94,6 +96,9 @@ public class QueryRunner
                     kerberosKeytabPath.map(File::new),
                     kerberosCredentialCachePath.map(File::new));
         }
+
+        Optional.ofNullable(session.getExtraCredentials().get(GCS_CREDENTIALS_PATH_KEY))
+                .ifPresent(credentialPath -> setupGCSOauth(builder, credentialPath));
 
         this.httpClient = builder.build();
     }

--- a/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/QueryRunner.java
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 
 import static com.facebook.presto.client.ClientSession.stripTransactionId;
 import static com.facebook.presto.client.GCSOAuthInterceptor.GCS_CREDENTIALS_PATH_KEY;
+import static com.facebook.presto.client.GCSOAuthInterceptor.GCS_OAUTH_SCOPES_KEY;
 import static com.facebook.presto.client.OkHttpUtil.basicAuth;
 import static com.facebook.presto.client.OkHttpUtil.setupCookieJar;
 import static com.facebook.presto.client.OkHttpUtil.setupGCSOauth;
@@ -98,7 +99,7 @@ public class QueryRunner
         }
 
         Optional.ofNullable(session.getExtraCredentials().get(GCS_CREDENTIALS_PATH_KEY))
-                .ifPresent(credentialPath -> setupGCSOauth(builder, credentialPath));
+                .ifPresent(credentialPath -> setupGCSOauth(builder, credentialPath, Optional.ofNullable(session.getExtraCredentials().get(GCS_OAUTH_SCOPES_KEY))));
 
         this.httpClient = builder.build();
     }

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -69,33 +69,6 @@
         <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
-            <version>0.20.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.j2objc</groupId>
-                    <artifactId>j2objc-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpcore</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.auto.value</groupId>
-                    <artifactId>auto-value-annotations</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -67,6 +67,38 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-oauth2-http</artifactId>
+            <version>0.20.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.auto.value</groupId>
+                    <artifactId>auto-value-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>

--- a/presto-client/src/main/java/com/facebook/presto/client/GCSOAuthHandler.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/GCSOAuthHandler.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import okhttp3.Authenticator;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
+
+import javax.annotation.Nullable;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Collections;
+
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_EXTRA_CREDENTIAL;
+import static java.util.Objects.requireNonNull;
+
+public class GCSOAuthHandler
+        implements Interceptor, Authenticator
+{
+
+    public static final String GCS_CREDENTIALS_PATH_KEY = "hive.gcs.credentials.path";
+    private static final String GCS_CREDENTIALS_OAUTH_TOKEN_KEY = "hive.gcs.oauth";
+    private final ClientSession session;
+
+    private String credentialsFilePath;
+
+    private GoogleCredentials credentials;
+
+    public GCSOAuthHandler(ClientSession session)
+    {
+        this.session = requireNonNull(session);
+        this.credentialsFilePath = session.getExtraCredentials().get(GCS_CREDENTIALS_PATH_KEY);
+    }
+
+    @Nullable
+    @Override
+    public Request authenticate(Route route, Response response)
+            throws IOException
+    {
+        return attachGCSAccessToken(response.request());
+    }
+
+    @Override
+    public Response intercept(Chain chain)
+            throws IOException
+    {
+        try {
+            return chain.proceed(attachGCSAccessToken(chain.request()));
+        }
+        catch (ClientException ignored) {
+            return chain.proceed(chain.request());
+        }
+    }
+
+    private Request attachGCSAccessToken(Request request)
+    {
+        AccessToken token = getCredentials().getAccessToken();
+        return request.newBuilder()
+                .addHeader(PRESTO_EXTRA_CREDENTIAL, GCS_CREDENTIALS_OAUTH_TOKEN_KEY + "=" + token.getTokenValue())
+                .build();
+    }
+
+    private synchronized GoogleCredentials getCredentials()
+    {
+        if (credentials == null) {
+            credentials = createCredentials();
+        }
+        try {
+            credentials.refreshIfExpired();
+        }
+        catch (IOException e) {
+            throw new ClientException("Google credential refreshing error", e);
+        }
+        return credentials;
+    }
+
+    private GoogleCredentials createCredentials()
+    {
+        try {
+            return GoogleCredentials.fromStream(new FileInputStream(credentialsFilePath)).createScoped(Collections.singleton("https://www.googleapis.com/auth/devstorage.read_only"));
+        }
+        catch (IOException e) {
+            throw new ClientException("Google credential loading error", e);
+        }
+    }
+}

--- a/presto-client/src/main/java/com/facebook/presto/client/GCSOAuthScope.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/GCSOAuthScope.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import static java.util.Objects.requireNonNull;
+
+public enum GCSOAuthScope
+{
+    CLOUD_PLATFORM("https://www.googleapis.com/auth/cloud-platform"),
+    CLOUD_PLATFORM_READ_ONLY("https://www.googleapis.com/auth/cloud-platform.read-only"),
+    DEVSTORAGE_FULL_CONTROL("https://www.googleapis.com/auth/devstorage.full_control"),
+    DEVSTORAGE_READ_ONLY("https://www.googleapis.com/auth/devstorage.read_only"),
+    DEVSTORAGE_READ_WRITE("https://www.googleapis.com/auth/devstorage.read_write");
+
+    private final String scopeURL;
+
+    GCSOAuthScope(String scopeURL)
+    {
+        this.scopeURL = requireNonNull(scopeURL);
+    }
+
+    public String getScopeURL()
+    {
+        return scopeURL;
+    }
+}

--- a/presto-client/src/main/java/com/facebook/presto/client/OkHttpUtil.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/OkHttpUtil.java
@@ -271,4 +271,10 @@ public final class OkHttpUtil
         clientBuilder.addInterceptor(handler);
         clientBuilder.authenticator(handler);
     }
+
+    public static void setupGCSOauth(OkHttpClient.Builder clientBuilder, ClientSession session)
+    {
+        GCSOAuthHandler handler = new GCSOAuthHandler(session);
+        clientBuilder.addInterceptor(handler);
+    }
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/OkHttpUtil.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/OkHttpUtil.java
@@ -272,9 +272,9 @@ public final class OkHttpUtil
         clientBuilder.authenticator(handler);
     }
 
-    public static void setupGCSOauth(OkHttpClient.Builder clientBuilder, ClientSession session)
+    public static void setupGCSOauth(OkHttpClient.Builder clientBuilder, String credentialPath)
     {
-        GCSOAuthHandler handler = new GCSOAuthHandler(session);
+        GCSOAuthInterceptor handler = new GCSOAuthInterceptor(credentialPath);
         clientBuilder.addInterceptor(handler);
     }
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/OkHttpUtil.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/OkHttpUtil.java
@@ -272,9 +272,9 @@ public final class OkHttpUtil
         clientBuilder.authenticator(handler);
     }
 
-    public static void setupGCSOauth(OkHttpClient.Builder clientBuilder, String credentialPath)
+    public static void setupGCSOauth(OkHttpClient.Builder clientBuilder, String credentialPath, Optional<String> gcsOAuthScopesString)
     {
-        GCSOAuthInterceptor handler = new GCSOAuthInterceptor(credentialPath);
+        GCSOAuthInterceptor handler = new GCSOAuthInterceptor(credentialPath, gcsOAuthScopesString);
         clientBuilder.addInterceptor(handler);
     }
 }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.jdbc;
 
 import com.facebook.presto.client.ClientException;
-import com.facebook.presto.client.GCSOAuthInterceptor;
 import com.facebook.presto.client.OkHttpUtil;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
@@ -33,6 +32,8 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Properties;
 
+import static com.facebook.presto.client.GCSOAuthInterceptor.GCS_CREDENTIALS_PATH_KEY;
+import static com.facebook.presto.client.GCSOAuthInterceptor.GCS_OAUTH_SCOPES_KEY;
 import static com.facebook.presto.client.KerberosUtil.defaultCredentialCachePath;
 import static com.facebook.presto.client.OkHttpUtil.basicAuth;
 import static com.facebook.presto.client.OkHttpUtil.setupCookieJar;
@@ -196,8 +197,8 @@ final class PrestoDriverUri
             }
 
             Map<String, String> extraCredentials = EXTRA_CREDENTIALS.getValue(properties).orElse(ImmutableMap.of());
-            Optional.ofNullable(extraCredentials.get(GCSOAuthInterceptor.GCS_CREDENTIALS_PATH_KEY))
-                    .ifPresent(credentialPath -> OkHttpUtil.setupGCSOauth(builder, credentialPath));
+            Optional.ofNullable(extraCredentials.get(GCS_CREDENTIALS_PATH_KEY))
+                    .ifPresent(credentialPath -> OkHttpUtil.setupGCSOauth(builder, credentialPath, Optional.ofNullable(extraCredentials.get(GCS_OAUTH_SCOPES_KEY))));
 
             if (ACCESS_TOKEN.getValue(properties).isPresent()) {
                 if (!useSecureConnection) {

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.jdbc;
 
 import com.facebook.presto.client.ClientException;
+import com.facebook.presto.client.GCSOAuthInterceptor;
+import com.facebook.presto.client.OkHttpUtil;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -192,6 +194,10 @@ final class PrestoDriverUri
                         Optional.ofNullable(KERBEROS_CREDENTIAL_CACHE_PATH.getValue(properties)
                                 .orElseGet(() -> defaultCredentialCachePath().map(File::new).orElse(null))));
             }
+
+            Map<String, String> extraCredentials = EXTRA_CREDENTIALS.getValue(properties).orElse(ImmutableMap.of());
+            Optional.ofNullable(extraCredentials.get(GCSOAuthInterceptor.GCS_CREDENTIALS_PATH_KEY))
+                    .ifPresent(credentialPath -> OkHttpUtil.setupGCSOauth(builder, credentialPath));
 
             if (ACCESS_TOKEN.getValue(properties).isPresent()) {
                 if (!useSecureConnection) {

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
@@ -15,7 +15,10 @@ package com.facebook.presto.jdbc;
 
 import org.testng.annotations.Test;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Properties;
 
@@ -231,10 +234,11 @@ public class TestPrestoDriverUri
 
     @Test
     public void testUriWithExtraCredentials()
-            throws SQLException
+            throws SQLException, UnsupportedEncodingException
     {
-        String extraCredentials = "test.token.foo:bar;test.token.abc:xyz";
-        PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?extraCredentials=" + extraCredentials);
+        String extraCredentials = "test.token.foo:bar;test.token.abc:xyz;test.scopes:read_only|read_write";
+        String encodedExtraCredentials = URLEncoder.encode(extraCredentials, StandardCharsets.UTF_8.toString());
+        PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?extraCredentials=" + encodedExtraCredentials);
         Properties properties = parameters.getProperties();
         assertEquals(properties.getProperty(EXTRA_CREDENTIALS.getKey()), extraCredentials);
     }


### PR DESCRIPTION
Generating and refresh GCS access token by the local private credentials (json key file)
Support the credentials of either "service_account" or "authorized_user" type
Added to both presto-cli and presto-jdbc

```
== RELEASE NOTES ==

General Changes
* Use local private credentials (json key file) to refresh GCS access token
presto-cli --extra-credential hive.gcs.credentials.path="${PRIVATE_KEY_JSON_PATH}"
```


