### PR TITLE
Add support for Druid's basic and kerberos authentication

### DIFF
--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidConfig.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidConfig.java
@@ -31,14 +31,14 @@ public class DruidConfig
     private boolean pushdown;
     private List<String> hadoopConfiguration = ImmutableList.of();
     private DruidAuthenticationType druidAuthenticationType = DruidAuthenticationType.NONE;
-    private String username;
-    private String password;
+    private String basicAuthenticationUsername;
+    private String basicAuthenticationPassword;
 
     public enum DruidAuthenticationType
     {
         NONE,
         BASIC,
-        KERBEROS,
+        KERBEROS
     }
 
     @NotNull
@@ -135,28 +135,28 @@ public class DruidConfig
     }
 
     @Nullable
-    public String getUsername()
+    public String getBasicAuthenticationUsername()
     {
-        return username;
+        return basicAuthenticationUsername;
     }
 
-    @Config("druid.authentication.username")
-    public DruidConfig setUsername(String username)
+    @Config("druid.basic.authentication.username")
+    public DruidConfig setBasicAuthenticationUsername(String basicAuthenticationUsername)
     {
-        this.username = username;
+        this.basicAuthenticationUsername = basicAuthenticationUsername;
         return this;
     }
 
     @Nullable
-    public String getPassword()
+    public String getBasicAuthenticationPassword()
     {
-        return password;
+        return basicAuthenticationPassword;
     }
 
-    @Config("druid.authentication.password")
-    public DruidConfig setPassword(String password)
+    @Config("druid.basic.authentication.password")
+    public DruidConfig setBasicAuthenticationPassword(String basicAuthenticationPassword)
     {
-        this.password = password;
+        this.basicAuthenticationPassword = basicAuthenticationPassword;
         return this;
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidConfig.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidConfig.java
@@ -29,6 +29,14 @@ public class DruidConfig
     private String schema = "druid";
     private boolean pushdown;
     private List<String> hadoopConfiguration = ImmutableList.of();
+    private DruidAuthenticationType druidAuthenticationType = DruidAuthenticationType.NONE;
+
+    public enum DruidAuthenticationType
+    {
+        NONE,
+        BASIC,
+        KERBEROS,
+    }
 
     @NotNull
     public String getDruidCoordinatorUrl()
@@ -104,6 +112,21 @@ public class DruidConfig
     {
         if (files != null) {
             this.hadoopConfiguration = ImmutableList.copyOf(files);
+        }
+        return this;
+    }
+
+    @NotNull
+    public DruidAuthenticationType getDruidAuthenticationType()
+    {
+        return druidAuthenticationType;
+    }
+
+    @Config("druid.authentication.type")
+    public DruidConfig setDruidAuthenticationType(DruidAuthenticationType druidAuthenticationType)
+    {
+        if (druidAuthenticationType != null) {
+            this.druidAuthenticationType = druidAuthenticationType;
         }
         return this;
     }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidConfig.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidConfig.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.configuration.ConfigDescription;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
 import java.util.List;
@@ -30,6 +31,8 @@ public class DruidConfig
     private boolean pushdown;
     private List<String> hadoopConfiguration = ImmutableList.of();
     private DruidAuthenticationType druidAuthenticationType = DruidAuthenticationType.NONE;
+    private String username;
+    private String password;
 
     public enum DruidAuthenticationType
     {
@@ -128,6 +131,32 @@ public class DruidConfig
         if (druidAuthenticationType != null) {
             this.druidAuthenticationType = druidAuthenticationType;
         }
+        return this;
+    }
+
+    @Nullable
+    public String getUsername()
+    {
+        return username;
+    }
+
+    @Config("druid.authentication.username")
+    public DruidConfig setUsername(String username)
+    {
+        this.username = username;
+        return this;
+    }
+
+    @Nullable
+    public String getPassword()
+    {
+        return password;
+    }
+
+    @Config("druid.authentication.password")
+    public DruidConfig setPassword(String password)
+    {
+        this.password = password;
         return this;
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidConnectorFactory.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidConnectorFactory.java
@@ -16,6 +16,7 @@ package com.facebook.presto.druid;
 import com.facebook.airlift.bootstrap.Bootstrap;
 import com.facebook.airlift.json.JsonModule;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.druid.authentication.DruidAuthenticationModule;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
@@ -54,6 +55,7 @@ public class DruidConnectorFactory
             Bootstrap app = new Bootstrap(
                     new JsonModule(),
                     new DruidModule(),
+                    new DruidAuthenticationModule(),
                     binder -> {
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());
                         binder.bind(FunctionMetadataManager.class).toInstance(context.getFunctionMetadataManager());

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidModule.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidModule.java
@@ -18,7 +18,6 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
-import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
 
 public class DruidModule
         implements Module
@@ -40,7 +39,5 @@ public class DruidModule
         binder.bind(DruidPageSourceProvider.class).in(Scopes.SINGLETON);
         binder.bind(DruidQueryGenerator.class).in(Scopes.SINGLETON);
         binder.bind(DruidSessionProperties.class).in(Scopes.SINGLETON);
-
-        httpClientBinder(binder).bindHttpClient("druid-client", ForDruidClient.class);
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/authentication/DruidAuthenticationModule.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/authentication/DruidAuthenticationModule.java
@@ -23,6 +23,9 @@ import java.util.function.Predicate;
 
 import static com.facebook.airlift.configuration.ConditionalModule.installModuleIf;
 import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static com.facebook.presto.druid.DruidConfig.DruidAuthenticationType.BASIC;
+import static com.facebook.presto.druid.DruidConfig.DruidAuthenticationType.KERBEROS;
+import static com.facebook.presto.druid.DruidConfig.DruidAuthenticationType.NONE;
 
 public class DruidAuthenticationModule
         extends AbstractConfigurationAwareModule
@@ -31,15 +34,15 @@ public class DruidAuthenticationModule
     protected void setup(Binder binder)
     {
         bindAuthenticationModule(
-                config -> config.getDruidAuthenticationType() == DruidConfig.DruidAuthenticationType.NONE,
+                config -> config.getDruidAuthenticationType() == NONE,
                 noneAuthenticationModule());
 
         bindAuthenticationModule(
-                config -> config.getDruidAuthenticationType() == DruidConfig.DruidAuthenticationType.BASIC,
+                config -> config.getDruidAuthenticationType() == BASIC,
                 basicAuthenticationModule());
 
         bindAuthenticationModule(
-                config -> config.getDruidAuthenticationType() == DruidConfig.DruidAuthenticationType.KERBEROS,
+                config -> config.getDruidAuthenticationType() == KERBEROS,
                 kerberosbAuthenticationModule());
     }
 

--- a/presto-druid/src/main/java/com/facebook/presto/druid/authentication/DruidAuthenticationModule.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/authentication/DruidAuthenticationModule.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.druid.authentication;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.druid.DruidConfig;
+import com.facebook.presto.druid.ForDruidClient;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import java.util.function.Predicate;
+
+import static com.facebook.airlift.configuration.ConditionalModule.installModuleIf;
+import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
+
+public class DruidAuthenticationModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        bindAuthenticationModule(
+                config -> config.getDruidAuthenticationType() == DruidConfig.DruidAuthenticationType.NONE,
+                noneAuthenticationModule());
+
+        bindAuthenticationModule(
+                config -> config.getDruidAuthenticationType() == DruidConfig.DruidAuthenticationType.BASIC,
+                basicAuthenticationModule());
+    }
+
+    private void bindAuthenticationModule(Predicate<DruidConfig> predicate, Module module)
+    {
+        install(installModuleIf(DruidConfig.class, predicate, module));
+    }
+
+    private static Module noneAuthenticationModule()
+    {
+        return binder -> httpClientBinder(binder).bindHttpClient("druid-client", ForDruidClient.class);
+    }
+
+    private static Module basicAuthenticationModule()
+    {
+        return binder -> httpClientBinder(binder).bindHttpClient("druid-client", ForDruidClient.class)
+                .withConfigDefaults(
+                        config -> config.setAuthenticationEnabled(false) //disable Kerberos auth
+                ).withFilter(
+                        DruidBasicAuthHttpRequestFilter.class);
+    }
+}

--- a/presto-druid/src/main/java/com/facebook/presto/druid/authentication/DruidAuthenticationModule.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/authentication/DruidAuthenticationModule.java
@@ -37,6 +37,10 @@ public class DruidAuthenticationModule
         bindAuthenticationModule(
                 config -> config.getDruidAuthenticationType() == DruidConfig.DruidAuthenticationType.BASIC,
                 basicAuthenticationModule());
+
+        bindAuthenticationModule(
+                config -> config.getDruidAuthenticationType() == DruidConfig.DruidAuthenticationType.KERBEROS,
+                kerberosbAuthenticationModule());
     }
 
     private void bindAuthenticationModule(Predicate<DruidConfig> predicate, Module module)
@@ -56,5 +60,12 @@ public class DruidAuthenticationModule
                         config -> config.setAuthenticationEnabled(false) //disable Kerberos auth
                 ).withFilter(
                         DruidBasicAuthHttpRequestFilter.class);
+    }
+
+    private static Module kerberosbAuthenticationModule()
+    {
+        return binder -> httpClientBinder(binder).bindHttpClient("druid-client", ForDruidClient.class)
+                .withConfigDefaults(
+                        config -> config.setAuthenticationEnabled(true));
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/authentication/DruidBasicAuthHttpRequestFilter.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/authentication/DruidBasicAuthHttpRequestFilter.java
@@ -30,8 +30,8 @@ public class DruidBasicAuthHttpRequestFilter
     @Inject
     public DruidBasicAuthHttpRequestFilter(DruidConfig config)
     {
-        String username = requireNonNull(config.getUsername(), "username cannot be null when using basic authentication");
-        String password = requireNonNull(config.getPassword(), "password cannot be null when using basic authentication");
+        String username = requireNonNull(config.getBasicAuthenticationUsername(), "username cannot be null when using basic authentication");
+        String password = requireNonNull(config.getBasicAuthenticationPassword(), "password cannot be null when using basic authentication");
         this.filter = new BasicAuthRequestFilter(username, password);
     }
 

--- a/presto-druid/src/main/java/com/facebook/presto/druid/authentication/DruidBasicAuthHttpRequestFilter.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/authentication/DruidBasicAuthHttpRequestFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.druid.authentication;
+
+import com.facebook.airlift.http.client.BasicAuthRequestFilter;
+import com.facebook.airlift.http.client.HttpRequestFilter;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.presto.druid.DruidConfig;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class DruidBasicAuthHttpRequestFilter
+        implements HttpRequestFilter
+{
+    private final BasicAuthRequestFilter filter;
+
+    @Inject
+    public DruidBasicAuthHttpRequestFilter(DruidConfig config)
+    {
+        String username = requireNonNull(config.getUsername(), "username cannot be null when using basic authentication");
+        String password = requireNonNull(config.getPassword(), "password cannot be null when using basic authentication");
+        this.filter = new BasicAuthRequestFilter(username, password);
+    }
+
+    @Override
+    public Request filterRequest(Request request)
+    {
+        return filter.filterRequest(request);
+    }
+}

--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidConfig.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidConfig.java
@@ -34,7 +34,9 @@ public class TestDruidConfig
                 .setDruidSchema("druid")
                 .setComputePushdownEnabled(false)
                 .setHadoopConfiguration("")
-                .setDruidAuthenticationType(null));
+                .setDruidAuthenticationType(null)
+                .setUsername(null)
+                .setPassword(null));
     }
 
     @Test
@@ -47,6 +49,8 @@ public class TestDruidConfig
                 .put("druid.compute-pushdown-enabled", "true")
                 .put("druid.hadoop.config.resources", "/etc/core-site.xml,/etc/hdfs-site.xml")
                 .put("druid.authentication.type", "BASIC")
+                .put("druid.authentication.username", "http_basic_username")
+                .put("druid.authentication.password", "http_basic_password")
                 .build();
 
         DruidConfig expected = new DruidConfig()
@@ -55,7 +59,9 @@ public class TestDruidConfig
                 .setDruidSchema("test")
                 .setComputePushdownEnabled(true)
                 .setHadoopConfiguration(ImmutableList.of("/etc/core-site.xml", "/etc/hdfs-site.xml"))
-                .setDruidAuthenticationType(DruidConfig.DruidAuthenticationType.BASIC);
+                .setDruidAuthenticationType(DruidConfig.DruidAuthenticationType.BASIC)
+                .setUsername("http_basic_username")
+                .setPassword("http_basic_password");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidConfig.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidConfig.java
@@ -22,6 +22,8 @@ import java.util.Map;
 
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static com.facebook.presto.druid.DruidConfig.DruidAuthenticationType.BASIC;
+import static com.facebook.presto.druid.DruidConfig.DruidAuthenticationType.NONE;
 
 public class TestDruidConfig
 {
@@ -34,9 +36,9 @@ public class TestDruidConfig
                 .setDruidSchema("druid")
                 .setComputePushdownEnabled(false)
                 .setHadoopConfiguration("")
-                .setDruidAuthenticationType(null)
-                .setUsername(null)
-                .setPassword(null));
+                .setDruidAuthenticationType(NONE)
+                .setBasicAuthenticationUsername(null)
+                .setBasicAuthenticationPassword(null));
     }
 
     @Test
@@ -49,8 +51,8 @@ public class TestDruidConfig
                 .put("druid.compute-pushdown-enabled", "true")
                 .put("druid.hadoop.config.resources", "/etc/core-site.xml,/etc/hdfs-site.xml")
                 .put("druid.authentication.type", "BASIC")
-                .put("druid.authentication.username", "http_basic_username")
-                .put("druid.authentication.password", "http_basic_password")
+                .put("druid.basic.authentication.username", "http_basic_username")
+                .put("druid.basic.authentication.password", "http_basic_password")
                 .build();
 
         DruidConfig expected = new DruidConfig()
@@ -59,9 +61,9 @@ public class TestDruidConfig
                 .setDruidSchema("test")
                 .setComputePushdownEnabled(true)
                 .setHadoopConfiguration(ImmutableList.of("/etc/core-site.xml", "/etc/hdfs-site.xml"))
-                .setDruidAuthenticationType(DruidConfig.DruidAuthenticationType.BASIC)
-                .setUsername("http_basic_username")
-                .setPassword("http_basic_password");
+                .setDruidAuthenticationType(BASIC)
+                .setBasicAuthenticationUsername("http_basic_username")
+                .setBasicAuthenticationPassword("http_basic_password");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidConfig.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidConfig.java
@@ -33,7 +33,8 @@ public class TestDruidConfig
                 .setDruidCoordinatorUrl(null)
                 .setDruidSchema("druid")
                 .setComputePushdownEnabled(false)
-                .setHadoopConfiguration(""));
+                .setHadoopConfiguration("")
+                .setDruidAuthenticationType(null));
     }
 
     @Test
@@ -45,6 +46,7 @@ public class TestDruidConfig
                 .put("druid.schema-name", "test")
                 .put("druid.compute-pushdown-enabled", "true")
                 .put("druid.hadoop.config.resources", "/etc/core-site.xml,/etc/hdfs-site.xml")
+                .put("druid.authentication.type", "BASIC")
                 .build();
 
         DruidConfig expected = new DruidConfig()
@@ -52,7 +54,8 @@ public class TestDruidConfig
                 .setDruidCoordinatorUrl("http://druid.coordinator:4321")
                 .setDruidSchema("test")
                 .setComputePushdownEnabled(true)
-                .setHadoopConfiguration(ImmutableList.of("/etc/core-site.xml", "/etc/hdfs-site.xml"));
+                .setHadoopConfiguration(ImmutableList.of("/etc/core-site.xml", "/etc/hdfs-site.xml"))
+                .setDruidAuthenticationType(DruidConfig.DruidAuthenticationType.BASIC);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Basic authentication is supported by airlift's BasicAuthRequestFilter
Kerberos authentication is supported by the embedded SpnegoAuthentication in airlift's http-client

```
== RELEASE NOTES ==

General Changes
* Add support for Druid's basic and kerberos authentication
```

