### PR TITLE
Do not return MapBlock's hashtables in Optional

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
@@ -121,7 +121,7 @@ public abstract class AbstractMapBlock
             newPosition++;
         }
 
-        int[] rawHashTables = getHashTables().get().orElse(null);
+        int[] rawHashTables = getHashTables().get();
         int[] newRawHashTables = null;
         int newHashTableEntries = newOffsets[newOffsets.length - 1] * HASH_MULTIPLIER;
         if (rawHashTables != null) {
@@ -237,7 +237,7 @@ public abstract class AbstractMapBlock
         boolean[] mapIsNull = getMapIsNull();
         boolean[] newMapIsNull = mapIsNull == null ? null : compactArray(mapIsNull, position + getOffsetBase(), length);
 
-        int[] rawHashTables = getHashTables().get().orElse(null);
+        int[] rawHashTables = getHashTables().get();
         int[] newRawHashTables = null;
         int expectedNewHashTableEntries = (endValueOffset - startValueOffset) * HASH_MULTIPLIER;
         if (rawHashTables != null) {
@@ -314,7 +314,7 @@ public abstract class AbstractMapBlock
         Block newKeys = getRawKeyBlock().copyRegion(startValueOffset, valueLength);
         Block newValues = getRawValueBlock().copyRegion(startValueOffset, valueLength);
 
-        int[] rawHashTables = getHashTables().get().orElse(null);
+        int[] rawHashTables = getHashTables().get();
         int[] newRawHashTables = null;
         int expectedNewHashTableEntries = (endValueOffset - startValueOffset) * HASH_MULTIPLIER;
         if (rawHashTables != null) {
@@ -373,7 +373,7 @@ public abstract class AbstractMapBlock
 
     public boolean isHashTablesPresent()
     {
-        return getHashTables().get().isPresent();
+        return getHashTables().get() != null;
     }
 
     private void checkReadablePosition(int position)
@@ -410,9 +410,10 @@ public abstract class AbstractMapBlock
             this.expectedHashTableCount = expectedHashTableCount;
         }
 
-        Optional<int[]> get()
+        @Nullable
+        int[] get()
         {
-            return Optional.ofNullable(hashTables);
+            return hashTables;
         }
 
         void set(int[] hashTables)

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
@@ -180,7 +180,7 @@ public class MapBlock
     {
         super(keyType, keyNativeHashCode, keyBlockNativeEquals, keyBlockHashCode);
 
-        int[] rawHashTables = hashTables.get().orElse(null);
+        int[] rawHashTables = hashTables.get();
         if (rawHashTables != null && rawHashTables.length < keyBlock.getPositionCount() * HASH_MULTIPLIER) {
             throw new IllegalArgumentException(format("keyBlock/valueBlock size does not match hash table size: %s %s", keyBlock.getPositionCount(), rawHashTables.length));
         }
@@ -324,13 +324,13 @@ public class MapBlock
     @Override
     protected void ensureHashTableLoaded()
     {
-        if (this.hashTables.get().isPresent()) {
+        if (isHashTablesPresent()) {
             return;
         }
 
         // We need to synchronize access to the hashTables field as it may be shared by multiple MapBlock instances.
         synchronized (hashTables) {
-            if (this.hashTables.get().isPresent()) {
+            if (isHashTablesPresent()) {
                 return;
             }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
@@ -203,14 +203,14 @@ public class MapBlockBuilder
         int previousAggregatedEntryCount = offsets[positionCount - 1];
         int aggregatedEntryCount = offsets[positionCount];
         int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
-        Optional<int[]> rawHashTables = hashTables.get();
-        verify(rawHashTables.isPresent(), "rawHashTables is empty");
+        int[] rawHashTables = hashTables.get();
+        verify(rawHashTables != null, "rawHashTables is null");
         buildHashTable(
                 keyBlockBuilder,
                 previousAggregatedEntryCount,
                 entryCount,
                 keyBlockHashCode,
-                rawHashTables.get(),
+                rawHashTables,
                 previousAggregatedEntryCount * HASH_MULTIPLIER,
                 entryCount * HASH_MULTIPLIER);
         return this;
@@ -237,15 +237,15 @@ public class MapBlockBuilder
         int previousAggregatedEntryCount = offsets[positionCount - 1];
         int aggregatedEntryCount = offsets[positionCount];
         int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
-        Optional<int[]> rawHashTables = hashTables.get();
-        verify(rawHashTables.isPresent(), "rawHashTables is empty");
+        int[] rawHashTables = hashTables.get();
+        verify(rawHashTables != null, "rawHashTables is null");
         buildHashTableStrict(
                 keyBlockBuilder,
                 previousAggregatedEntryCount,
                 entryCount,
                 keyBlockEquals,
                 keyBlockHashCode,
-                rawHashTables.get(),
+                rawHashTables,
                 previousAggregatedEntryCount * HASH_MULTIPLIER,
                 entryCount * HASH_MULTIPLIER);
         return this;
@@ -264,14 +264,14 @@ public class MapBlockBuilder
         int previousAggregatedEntryCount = offsets[positionCount - 1];
         int aggregatedEntryCount = offsets[positionCount];
 
-        Optional<int[]> rawHashTables = hashTables.get();
-        verify(rawHashTables.isPresent(), "rawHashTables is empty");
+        int[] rawHashTables = hashTables.get();
+        verify(rawHashTables != null, "rawHashTables is null");
         if (providedHashTable != null) {
             // Directly copy instead of building hashtable if providedHashTable is not null
             int hashTableOffset = previousAggregatedEntryCount * HASH_MULTIPLIER;
             int hashTableSize = (aggregatedEntryCount - previousAggregatedEntryCount) * HASH_MULTIPLIER;
             for (int i = 0; i < hashTableSize; i++) {
-                rawHashTables.get()[hashTableOffset + i] = providedHashTable[providedHashTableOffset + i];
+                rawHashTables[hashTableOffset + i] = providedHashTable[providedHashTableOffset + i];
             }
         }
         else {
@@ -282,7 +282,7 @@ public class MapBlockBuilder
                     previousAggregatedEntryCount,
                     entryCount,
                     keyBlockHashCode,
-                    rawHashTables.get(),
+                    rawHashTables,
                     previousAggregatedEntryCount * HASH_MULTIPLIER,
                     entryCount * HASH_MULTIPLIER);
         }
@@ -322,12 +322,12 @@ public class MapBlockBuilder
 
     private void ensureHashTableSize()
     {
-        Optional<int[]> rawHashTables = hashTables.get();
-        verify(rawHashTables.isPresent(), "rawHashTables is empty");
-        if (rawHashTables.get().length < offsets[positionCount] * HASH_MULTIPLIER) {
+        int[] rawHashTables = hashTables.get();
+        verify(rawHashTables != null, "rawHashTables is null");
+        if (rawHashTables.length < offsets[positionCount] * HASH_MULTIPLIER) {
             int newSize = BlockUtil.calculateNewArraySize(offsets[positionCount] * HASH_MULTIPLIER);
-            int[] newRawHashTables = Arrays.copyOf(rawHashTables.get(), newSize);
-            Arrays.fill(newRawHashTables, rawHashTables.get().length, newSize, -1);
+            int[] newRawHashTables = Arrays.copyOf(rawHashTables, newSize);
+            Arrays.fill(newRawHashTables, rawHashTables.length, newSize, -1);
             hashTables.set(newRawHashTables);
         }
     }
@@ -358,8 +358,8 @@ public class MapBlockBuilder
             throw new IllegalStateException("Current entry must be closed before the block can be built");
         }
 
-        Optional<int[]> rawHashTables = hashTables.get();
-        verify(rawHashTables.isPresent(), "rawHashTables is empty");
+        int[] rawHashTables = hashTables.get();
+        verify(rawHashTables != null, "rawHashTables is null");
         int hashTablesEntries = offsets[positionCount] * HASH_MULTIPLIER;
         return createMapBlockInternal(
                 0,
@@ -368,7 +368,7 @@ public class MapBlockBuilder
                 offsets,
                 keyBlockBuilder.build(),
                 valueBlockBuilder.build(),
-                new HashTables(Optional.of(Arrays.copyOf(rawHashTables.get(), hashTablesEntries)), positionCount, hashTablesEntries),
+                new HashTables(Optional.of(Arrays.copyOf(rawHashTables, hashTablesEntries)), positionCount, hashTablesEntries),
                 keyType,
                 keyBlockNativeEquals,
                 keyNativeHashCode,
@@ -447,7 +447,7 @@ public class MapBlockBuilder
             }
         }
 
-        closeEntry(mapBlock.getHashTables().get().orElse(null), startValueOffset * HASH_MULTIPLIER);
+        closeEntry(mapBlock.getHashTables().get(), startValueOffset * HASH_MULTIPLIER);
         return this;
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockEncoding.java
@@ -55,7 +55,7 @@ public class MapBlockEncoding
 
         int offsetBase = mapBlock.getOffsetBase();
         int[] offsets = mapBlock.getOffsets();
-        int[] hashTable = mapBlock.getHashTables().get().orElse(null);
+        int[] hashTable = mapBlock.getHashTables().get();
 
         int entriesStartOffset = offsets[offsetBase];
         int entriesEndOffset = offsets[offsetBase + positionCount];

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
@@ -134,7 +134,7 @@ public class SingleMapBlock
     @Nullable
     int[] getHashTable()
     {
-        return mapBlock.getHashTables().get().orElse(null);
+        return mapBlock.getHashTables().get();
     }
 
     Type getKeyType()
@@ -152,7 +152,7 @@ public class SingleMapBlock
         }
 
         mapBlock.ensureHashTableLoaded();
-        int[] hashTable = mapBlock.getHashTables().get().get();
+        int[] hashTable = mapBlock.getHashTables().get();
 
         long hashCode;
         try {
@@ -199,7 +199,7 @@ public class SingleMapBlock
         }
 
         mapBlock.ensureHashTableLoaded();
-        int[] hashTable = mapBlock.getHashTables().get().get();
+        int[] hashTable = mapBlock.getHashTables().get();
 
         long hashCode;
         try {
@@ -243,7 +243,7 @@ public class SingleMapBlock
         }
 
         mapBlock.ensureHashTableLoaded();
-        int[] hashTable = mapBlock.getHashTables().get().get();
+        int[] hashTable = mapBlock.getHashTables().get();
 
         long hashCode;
         try {
@@ -287,7 +287,7 @@ public class SingleMapBlock
         }
 
         mapBlock.ensureHashTableLoaded();
-        int[] hashTable = mapBlock.getHashTables().get().get();
+        int[] hashTable = mapBlock.getHashTables().get();
 
         long hashCode;
         try {
@@ -331,7 +331,7 @@ public class SingleMapBlock
         }
 
         mapBlock.ensureHashTableLoaded();
-        int[] hashTable = mapBlock.getHashTables().get().get();
+        int[] hashTable = mapBlock.getHashTables().get();
 
         long hashCode;
         try {
@@ -375,7 +375,7 @@ public class SingleMapBlock
         }
 
         mapBlock.ensureHashTableLoaded();
-        int[] hashTable = mapBlock.getHashTables().get().get();
+        int[] hashTable = mapBlock.getHashTables().get();
 
         long hashCode;
         try {

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
@@ -34,8 +34,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
-import java.util.Optional;
-
 import static com.facebook.presto.array.Arrays.ExpansionFactor.LARGE;
 import static com.facebook.presto.array.Arrays.ExpansionFactor.SMALL;
 import static com.facebook.presto.array.Arrays.ExpansionOption.NONE;
@@ -276,8 +274,8 @@ public class MapBlockEncodingBuffer
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
 
-        if (!noHashTables && columnarMap.getHashTables().isPresent()) {
-            estimatedHashTableBufferMaxCapacity = (int) (targetBufferSize * columnarMap.getHashTables().get().length / columnarMap.getRetainedSizeInBytes());
+        if (!noHashTables && columnarMap.getHashTables() != null) {
+            estimatedHashTableBufferMaxCapacity = (int) (targetBufferSize * columnarMap.getHashTables().length / columnarMap.getRetainedSizeInBytes());
             targetBufferSize -= estimatedHashTableBufferMaxCapacity;
         }
         else {
@@ -378,8 +376,8 @@ public class MapBlockEncodingBuffer
             return;
         }
 
-        Optional<int[]> hashTables = columnarMap.getHashTables();
-        if (!hashTables.isPresent()) {
+        int[] hashTables = columnarMap.getHashTables();
+        if (hashTables == null) {
             noHashTables = true;
             hashTableBufferIndex = 0;
             return;
@@ -399,7 +397,7 @@ public class MapBlockEncodingBuffer
             hashTableBufferIndex = setInts(
                     hashTablesBuffer,
                     hashTableBufferIndex,
-                    hashTables.get(),
+                    hashTables,
                     beginOffset * HASH_MULTIPLIER,
                     (endOffset - beginOffset) * HASH_MULTIPLIER);
         }


### PR DESCRIPTION
In recent production workload we observed large amount of memory
allocation on the Optional objects when getting a MapBlock's hashtables,
and it resulted in high GC activities that could lead to reliability
issues. This commit directly returns the hashtables in raw int array
without wrapping it up with Optional.


```
== NO RELEASE NOTE ==
```
