### PR TITLE
Fix auto-resolution of checksum query failure 

### DIFF
--- a/presto-docs/src/main/sphinx/admin/verifier.rst
+++ b/presto-docs/src/main/sphinx/admin/verifier.rst
@@ -165,8 +165,9 @@ query failures.
 * ``EXCEEDED_TIME_LIMIT``: Resolves unconditionally.
 * ``TOO_MANY_HIVE_PARTITIONS``: Resolves if the test cluster does not have enough workers to make
   sure the number of partitions assigned to each worker stays within the limit.
-* ``COMPILER_ERROR``: Resolves if checksum fails with this error. If a control query has too many
-  columns, generated checksum query might be too large in certain cases.
+* ``COMPILER_ERROR``, ``GENERATED_BYTECODE_TOO_LARGE``: Resolves if the control checksum query
+  fails with this error. If the control query has too many columns, generated checksum queries
+  might be too large in certain cases.
 
 In cases of result mismatches, Verifier may be giving noisy signals, and we allow Verifier to
 automatically resolve certain mismatches.

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ChecksumExceededTimeLimitFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ChecksumExceededTimeLimitFailureResolver.java
@@ -16,6 +16,7 @@ package com.facebook.presto.verifier.resolver;
 import com.facebook.presto.jdbc.QueryStats;
 import com.facebook.presto.verifier.framework.QueryBundle;
 import com.facebook.presto.verifier.framework.QueryException;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Optional;
 
@@ -31,7 +32,7 @@ public class ChecksumExceededTimeLimitFailureResolver
     @Override
     public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
     {
-        return mapMatchingPrestoException(queryException, CONTROL_CHECKSUM, EXCEEDED_TIME_LIMIT,
+        return mapMatchingPrestoException(queryException, CONTROL_CHECKSUM, ImmutableSet.of(EXCEEDED_TIME_LIMIT),
                 e -> Optional.of("Time limit exceeded when running control checksum query"));
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededGlobalMemoryLimitFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededGlobalMemoryLimitFailureResolver.java
@@ -16,6 +16,7 @@ package com.facebook.presto.verifier.resolver;
 import com.facebook.presto.jdbc.QueryStats;
 import com.facebook.presto.verifier.framework.QueryBundle;
 import com.facebook.presto.verifier.framework.QueryException;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Optional;
 
@@ -31,7 +32,7 @@ public class ExceededGlobalMemoryLimitFailureResolver
     @Override
     public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
     {
-        return mapMatchingPrestoException(queryException, TEST_MAIN, EXCEEDED_GLOBAL_MEMORY_LIMIT,
+        return mapMatchingPrestoException(queryException, TEST_MAIN, ImmutableSet.of(EXCEEDED_GLOBAL_MEMORY_LIMIT),
                 e -> e.getQueryStats().isPresent() && controlQueryStats.getPeakTotalMemoryBytes() > e.getQueryStats().get().getPeakTotalMemoryBytes()
                         ? Optional.of("Control query uses more memory than the test cluster memory limit")
                         : Optional.empty());

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededTimeLimitFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededTimeLimitFailureResolver.java
@@ -16,6 +16,7 @@ package com.facebook.presto.verifier.resolver;
 import com.facebook.presto.jdbc.QueryStats;
 import com.facebook.presto.verifier.framework.QueryBundle;
 import com.facebook.presto.verifier.framework.QueryException;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Optional;
 
@@ -31,7 +32,7 @@ public class ExceededTimeLimitFailureResolver
     @Override
     public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
     {
-        return mapMatchingPrestoException(queryException, TEST_MAIN, EXCEEDED_TIME_LIMIT,
+        return mapMatchingPrestoException(queryException, TEST_MAIN, ImmutableSet.of(EXCEEDED_TIME_LIMIT),
                 e -> Optional.of("Time limit exceeded on test cluster"));
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolverUtil.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolverUtil.java
@@ -19,6 +19,7 @@ import com.facebook.presto.verifier.framework.QueryException;
 import com.facebook.presto.verifier.framework.QueryStage;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 public class FailureResolverUtil
@@ -28,14 +29,14 @@ public class FailureResolverUtil
     public static <T> Optional<T> mapMatchingPrestoException(
             QueryException queryException,
             QueryStage queryStage,
-            ErrorCodeSupplier errorCode,
+            Set<ErrorCodeSupplier> errorCodes,
             Function<PrestoQueryException, Optional<T>> mapper)
     {
         if (queryException.getQueryStage() != queryStage || !(queryException instanceof PrestoQueryException)) {
             return Optional.empty();
         }
         PrestoQueryException prestoException = (PrestoQueryException) queryException;
-        if (!prestoException.getErrorCode().equals(Optional.of(errorCode))) {
+        if (!prestoException.getErrorCode().isPresent() || !errorCodes.contains(prestoException.getErrorCode().get())) {
             return Optional.empty();
         }
         return mapper.apply(prestoException);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/TooManyOpenPartitionsFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/TooManyOpenPartitionsFailureResolver.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.tree.ShowCreate;
 import com.facebook.presto.verifier.framework.QueryBundle;
 import com.facebook.presto.verifier.framework.QueryException;
 import com.facebook.presto.verifier.prestoaction.PrestoAction;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
 
 import javax.inject.Inject;
@@ -77,7 +78,7 @@ public class TooManyOpenPartitionsFailureResolver
             return Optional.empty();
         }
 
-        return mapMatchingPrestoException(queryException, TEST_MAIN, HIVE_TOO_MANY_OPEN_PARTITIONS,
+        return mapMatchingPrestoException(queryException, TEST_MAIN, ImmutableSet.of(HIVE_TOO_MANY_OPEN_PARTITIONS),
                 e -> {
                     try {
                         ShowCreate showCreate = new ShowCreate(TABLE, test.get().getTableName());

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/VerifierLimitationFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/VerifierLimitationFailureResolver.java
@@ -16,10 +16,12 @@ package com.facebook.presto.verifier.resolver;
 import com.facebook.presto.jdbc.QueryStats;
 import com.facebook.presto.verifier.framework.QueryBundle;
 import com.facebook.presto.verifier.framework.QueryException;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardErrorCode.COMPILER_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.GENERATED_BYTECODE_TOO_LARGE;
 import static com.facebook.presto.verifier.framework.QueryStage.CONTROL_CHECKSUM;
 import static com.facebook.presto.verifier.resolver.FailureResolverUtil.mapMatchingPrestoException;
 
@@ -31,7 +33,7 @@ public class VerifierLimitationFailureResolver
     @Override
     public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryBundle> test)
     {
-        return mapMatchingPrestoException(queryException, CONTROL_CHECKSUM, COMPILER_ERROR,
+        return mapMatchingPrestoException(queryException, CONTROL_CHECKSUM, ImmutableSet.of(COMPILER_ERROR, GENERATED_BYTECODE_TOO_LARGE),
                 e -> Optional.of("Checksum query too large"));
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestVerifierLimitationFailureResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestVerifierLimitationFailureResolver.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.StandardErrorCode.COMPILER_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.GENERATED_BYTECODE_TOO_LARGE;
 import static com.facebook.presto.verifier.framework.QueryStage.CONTROL_CHECKSUM;
 import static org.testng.Assert.assertEquals;
 
@@ -41,6 +42,22 @@ public class TestVerifierLimitationFailureResolver
                                 false,
                                 CONTROL_CHECKSUM,
                                 Optional.of(COMPILER_ERROR),
+                                Optional.empty()),
+                        Optional.empty()),
+                Optional.of("Checksum query too large"));
+    }
+
+    @Test
+    public void testResolveGeneratedBytecodeTooLarge()
+    {
+        assertEquals(
+                getFailureResolver().resolveQueryFailure(
+                        CONTROL_QUERY_STATS,
+                        new PrestoQueryException(
+                                new RuntimeException(),
+                                false,
+                                CONTROL_CHECKSUM,
+                                Optional.of(GENERATED_BYTECODE_TOO_LARGE),
                                 Optional.empty()),
                         Optional.empty()),
                 Optional.of("Checksum query too large"));


### PR DESCRIPTION
Checksum queries used to fail with COMPILER_ERROR if the generated
bytecode is too large. This has been changed recently with a
dedicated error code GENERATED_BYTECODE_TOO_LARGE.

```
== RELEASE NOTES ==

Verifier Changes
* Fix auto-resolution of checksum query failure due to query complexity.
```
