### PR TITLE
Fix NegativeArraySizeException in REPLACE

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -81,6 +81,9 @@ String Functions
 
     Replaces all instances of ``search`` with ``replace`` in ``string``.
 
+    If ``search`` is an empty string, inserts ``replace`` in front of every
+    character and at the end of the ``string``.
+
 .. function:: reverse(string) -> varchar
 
     Returns ``string`` with the characters in reverse order.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -122,8 +122,15 @@ public final class StringFunctions
     {
         // Empty search?
         if (search.length() == 0) {
-            // With empty `search` we insert `replace` in front of every character and and the end
-            Slice buffer = Slices.allocate((countCodePoints(str) + 1) * replace.length() + str.length());
+            // With empty `search` we insert `replace` in front of every character and at the end
+            int resultLength;
+            try {
+                resultLength = Math.addExact(Math.multiplyExact(countCodePoints(str) + 1, replace.length()), str.length());
+            }
+            catch (ArithmeticException e) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "inputs to \"replace\" function are too large: when \"search\" parameter is empty, length of \"string\" times length of \"replace\" must not exceed " + Integer.MAX_VALUE);
+            }
+            Slice buffer = Slices.allocate(resultLength);
             // Always start with replace
             buffer.setBytes(0, replace);
             int indexBuffer = replace.length();

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -248,6 +248,9 @@ public class TestStringFunctions
         assertFunction("CAST(REPLACE('abc' || utf8(from_hex('CE')) || 'xyz', '', 'X') AS VARBINARY)",
                 VARBINARY,
                 new SqlVarbinary(new byte[] {'X', 'a', 'X', 'b', 'X', 'c', 'X', (byte) 0xCE, 'X', 'x', 'X', 'y', 'X', 'z', 'X'}));
+
+        String longString = new String(new char[1_000_000]);
+        assertInvalidFunction(String.format("replace('%s', '', '%s')", longString, longString), "inputs to \"replace\" function are too large: when \"search\" parameter is empty, length of \"string\" times length of \"replace\" must not exceed 2147483647");
     }
 
     @Test


### PR DESCRIPTION
Update "replace" function to check for integer overflow and throw INVALID_FUNCTION_ARGUMENT with explanation instead of java.lang.NegativeArraySizeException.

Fixes #14592

```
== NO RELEASE NOTE ==
```
