### PR TITLE
Bump up Cassandra driver version to 3.6.0-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1648,7 +1648,7 @@
             <dependency>
                 <groupId>com.facebook.presto.cassandra</groupId>
                 <artifactId>cassandra-driver</artifactId>
-                <version>3.1.4-1</version>
+                <version>3.6.0-1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>io.netty</groupId>


### PR DESCRIPTION
```
== RELEASE NOTES ==

Cassandra Changes
* Fix missing Netty library introduced in version 0.229
```
