### PR TITLE
Create quantile_at_value function for QDigest type

### DIFF
--- a/presto-docs/src/main/sphinx/functions/qdigest.rst
+++ b/presto-docs/src/main/sphinx/functions/qdigest.rst
@@ -30,6 +30,12 @@ Functions
     Returns the approximate percentile values from the quantile digest given
     the number ``quantile`` between 0 and 1.
 
+.. function:: quantile_at_value(qdigest(T), T) -> quantile
+
+    Returns the approximate ``quantile`` number between 0 and 1 from the
+    quantile digest given an input value. Null is returned if the quantile digest
+    is empty or the input value is outside of the range of the quantile digest.
+
 .. function:: scale_qdigest(qdigest(T), scale_factor) -> qdigest(T)
 
     Returns a ``qdigest`` whose distribution has been scaled by a factor


### PR DESCRIPTION
This commit fixes #14423. It creates a quantile_at_value function for QDigest type. When given an input value X, `quantile_at_value(qdigest(T), X)` will return an approximate quantile of X.

```
== NO RELEASE NOTE ==
```
