### PR TITLE
Fixing broken Test due to Reliable Resource Group changes

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -464,7 +464,7 @@ public class TestQueuesDb
 
         QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, secondDashboardQuery, FAILED);
-        assertEquals(queryRunner.getQueryInfo(secondDashboardQuery).getErrorCode(), INVALID_RESOURCE_GROUP.toErrorCode());
+        assertEquals(queryRunner.getCoordinator().getDispatchManager().getFullQueryInfo(secondDashboardQuery).getErrorCode(), INVALID_RESOURCE_GROUP.toErrorCode());
     }
 
     @Test


### PR DESCRIPTION
Fixing broken test where we look for failed query in queryRunner.

```
== NO RELEASE NOTE ==
```
