### PR TITLE
Update default storage directory in /etc/raptor.properties to support…

### DIFF
--- a/presto-main/etc/catalog/raptor.properties
+++ b/presto-main/etc/catalog/raptor.properties
@@ -10,4 +10,4 @@ metadata.db.type=h2
 metadata.db.filename=mem:raptor;DB_CLOSE_DELAY=-1
 #metadata.db.type=mysql
 #metadata.db.connections.max=500
-storage.data-directory=file:///var/data
+storage.data-directory=file:///tmp/raptor


### PR DESCRIPTION
… OSX development

PrestoServer attempts to create directories in "storage.data-directory" for
Raptor. This is configured in etc/raptor.properties by default as "/var/data".
In OSX, this is not a writable directory, so PrestoServer fails to start. This
change fixes the issue by setting storage.data-directory to /tmp/raptor.

```
== NO RELEASE NOTE ==
```
