### PR TITLE
Collect file stats

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveErrorCode.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveErrorCode.java
@@ -69,6 +69,7 @@ public enum HiveErrorCode
     // To be used for metadata inconsistencies and not for incorrect input from users
     HIVE_INVALID_ENCRYPTION_METADATA(42, EXTERNAL),
     HIVE_UNSUPPORTED_ENCRYPTION_OPERATION(43, USER_ERROR),
+    MALFORMED_HIVE_FILE_STATISTICS(44, INTERNAL_ERROR),
     /**/;
 
     private final ErrorCode errorCode;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -128,6 +128,8 @@ public class HiveClientModule
         binder.bind(HivePartitionManager.class).in(Scopes.SINGLETON);
         binder.bind(LocationService.class).to(HiveLocationService.class).in(Scopes.SINGLETON);
         binder.bind(TableParameterCodec.class).in(Scopes.SINGLETON);
+        binder.bind(HivePartitionStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(HivePartitionStats.class).as(generatedNameOf(HivePartitionStats.class, connectorId));
         binder.bind(HiveMetadataFactory.class).in(Scopes.SINGLETON);
         binder.bind(new TypeLiteral<Supplier<TransactionalMetadata>>() {}).to(HiveMetadataFactory.class).in(Scopes.SINGLETON);
         binder.bind(StagingFileCommitter.class).to(HiveStagingFileCommitter.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveManifestUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveManifestUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.PageBuilder;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.hive.HiveErrorCode.MALFORMED_HIVE_FILE_STATISTICS;
+import static com.facebook.presto.hive.PartitionUpdate.FileWriteInfo;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.String.format;
+
+public class HiveManifestUtils
+{
+    private static final int FILE_SIZE_CHANNEL = 0;
+    private static final int ROW_COUNT_CHANNEL = 1;
+
+    private HiveManifestUtils()
+    {
+    }
+
+    public static Page createFileStatisticsPage(long fileSize, long rowCount)
+    {
+        // FileStatistics page layout:
+        //
+        // fileSize   rowCount
+        //  X             X
+        PageBuilder statsPageBuilder = new PageBuilder(ImmutableList.of(BIGINT, BIGINT));
+        statsPageBuilder.declarePosition();
+        BIGINT.writeLong(statsPageBuilder.getBlockBuilder(FILE_SIZE_CHANNEL), fileSize);
+        BIGINT.writeLong(statsPageBuilder.getBlockBuilder(ROW_COUNT_CHANNEL), rowCount);
+
+        return statsPageBuilder.build();
+    }
+
+    public static long getFileSize(Page statisticsPage, int position)
+    {
+        // FileStatistics page layout:
+        //
+        // fileSize   rowCount
+        //  X             X
+
+        if (position < 0 || position >= statisticsPage.getPositionCount()) {
+            throw new PrestoException(MALFORMED_HIVE_FILE_STATISTICS, format("Invalid position: %d specified for FileStatistics page", position));
+        }
+        return BIGINT.getLong(statisticsPage.getBlock(FILE_SIZE_CHANNEL), position);
+    }
+
+    public static Optional<Page> createPartitionManifest(PartitionUpdate partitionUpdate)
+    {
+        // Manifest Page layout:
+        //   fileName    fileSize
+        //      X           X
+        //      X           X
+        //      X           X
+        // ....
+        PageBuilder manifestBuilder = new PageBuilder(ImmutableList.of(VARCHAR, BIGINT));
+        BlockBuilder fileNameBuilder = manifestBuilder.getBlockBuilder(0);
+        BlockBuilder fileSizeBuilder = manifestBuilder.getBlockBuilder(1);
+        for (FileWriteInfo fileWriteInfo : partitionUpdate.getFileWriteInfos()) {
+            if (!fileWriteInfo.getFileSize().isPresent()) {
+                return Optional.empty();
+            }
+            manifestBuilder.declarePosition();
+            VARCHAR.writeSlice(fileNameBuilder, utf8Slice(fileWriteInfo.getWriteFileName()));
+            BIGINT.writeLong(fileSizeBuilder, fileWriteInfo.getFileSize().get());
+        }
+        return Optional.of(manifestBuilder.build());
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -62,6 +62,7 @@ public class HiveMetadataFactory
     private final String prestoVersion;
     private final PartitionObjectBuilder partitionObjectBuilder;
     private final HiveEncryptionInformationProvider encryptionInformationProvider;
+    private final HivePartitionStats hivePartitionStats;
 
     @Inject
     @SuppressWarnings("deprecation")
@@ -84,7 +85,8 @@ public class HiveMetadataFactory
             ZeroRowFileCreator zeroRowFileCreator,
             NodeVersion nodeVersion,
             PartitionObjectBuilder partitionObjectBuilder,
-            HiveEncryptionInformationProvider encryptionInformationProvider)
+            HiveEncryptionInformationProvider encryptionInformationProvider,
+            HivePartitionStats hivePartitionStats)
     {
         this(
                 metastore,
@@ -111,7 +113,8 @@ public class HiveMetadataFactory
                 zeroRowFileCreator,
                 nodeVersion.toString(),
                 partitionObjectBuilder,
-                encryptionInformationProvider);
+                encryptionInformationProvider,
+                hivePartitionStats);
     }
 
     public HiveMetadataFactory(
@@ -139,7 +142,8 @@ public class HiveMetadataFactory
             ZeroRowFileCreator zeroRowFileCreator,
             String prestoVersion,
             PartitionObjectBuilder partitionObjectBuilder,
-            HiveEncryptionInformationProvider encryptionInformationProvider)
+            HiveEncryptionInformationProvider encryptionInformationProvider,
+            HivePartitionStats hivePartitionStats)
     {
         this.allowCorruptWritesForTesting = allowCorruptWritesForTesting;
         this.skipDeletionForAlter = skipDeletionForAlter;
@@ -167,6 +171,7 @@ public class HiveMetadataFactory
         this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
         this.partitionObjectBuilder = requireNonNull(partitionObjectBuilder, "partitionObjectBuilder is null");
         this.encryptionInformationProvider = requireNonNull(encryptionInformationProvider, "encryptionInformationProvider is null");
+        this.hivePartitionStats = requireNonNull(hivePartitionStats, "hivePartitionStats is null");
 
         if (!allowCorruptWritesForTesting && !timeZone.equals(DateTimeZone.getDefault())) {
             log.warn("Hive writes are disabled. " +
@@ -208,6 +213,7 @@ public class HiveMetadataFactory
                 stagingFileCommitter,
                 zeroRowFileCreator,
                 partitionObjectBuilder,
-                encryptionInformationProvider);
+                encryptionInformationProvider,
+                hivePartitionStats);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionStats.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionStats.java
@@ -13,27 +13,23 @@
  */
 package com.facebook.presto.hive;
 
-import com.facebook.presto.common.Page;
+import com.facebook.airlift.stats.DistributionStat;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
 
-import java.util.Optional;
-
-public interface HiveFileWriter
+public class HivePartitionStats
 {
-    long getWrittenBytes();
+    private final DistributionStat manifestSizeInBytes = new DistributionStat();
 
-    long getSystemMemoryUsage();
-
-    void appendRows(Page dataPage);
-
-    // Page returned by commit should have fileSize as first channel
-    Optional<Page> commit();
-
-    void rollback();
-
-    long getValidationCpuNanos();
-
-    default Optional<Runnable> getVerificationTask()
+    public void addManifestSizeInBytes(long bytes)
     {
-        return Optional.empty();
+        manifestSizeInBytes.add(bytes);
+    }
+
+    @Managed
+    @Nested
+    public DistributionStat getManifestSizeInBytes()
+    {
+        return manifestSizeInBytes;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriter.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import static com.facebook.presto.hive.HiveManifestUtils.getFileSize;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
@@ -37,6 +38,7 @@ public class HiveWriter
 
     private long rowCount;
     private long inputSizeInBytes;
+    private Optional<Page> fileStatistics = Optional.empty();
 
     public HiveWriter(
             HiveFileWriter fileWriter,
@@ -84,7 +86,7 @@ public class HiveWriter
 
     public void commit()
     {
-        fileWriter.commit();
+        fileStatistics = fileWriter.commit();
         onCommit.accept(this);
     }
 
@@ -110,7 +112,7 @@ public class HiveWriter
                 updateMode,
                 writePath,
                 targetPath,
-                ImmutableList.of(fileWriteInfo),
+                ImmutableList.of(new FileWriteInfo(fileWriteInfo.getWriteFileName(), fileWriteInfo.getTargetFileName(), fileStatistics.map(statisticsPage -> getFileSize(statisticsPage, 0)))),
                 rowCount,
                 inputSizeInBytes,
                 fileWriter.getWrittenBytes());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
@@ -387,7 +387,7 @@ public class HiveWriterFactory
                 hiveFileWriter,
                 partitionName,
                 writerParameters.getUpdateMode(),
-                new FileWriteInfo(writeFileName, targetFileName),
+                new FileWriteInfo(writeFileName, targetFileName, Optional.empty()),
                 writerParameters.getWriteInfo().getWritePath().toString(),
                 writerParameters.getWriteInfo().getTargetPath().toString(),
                 createCommitEventListener(path, partitionName, hiveFileWriter, writerParameters),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PartitionUpdate.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PartitionUpdate.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CONCURRENT_MODIFICATION_DETECTED;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -211,14 +212,17 @@ public class PartitionUpdate
     {
         private final String writeFileName;
         private final String targetFileName;
+        private final Optional<Long> fileSize;
 
         @JsonCreator
         public FileWriteInfo(
                 @JsonProperty("writeFileName") String writeFileName,
-                @JsonProperty("targetFileName") String targetFileName)
+                @JsonProperty("targetFileName") String targetFileName,
+                @JsonProperty("fileSize") Optional<Long> fileSize)
         {
             this.writeFileName = requireNonNull(writeFileName, "writeFileName is null");
             this.targetFileName = requireNonNull(targetFileName, "targetFileName is null");
+            this.fileSize = requireNonNull(fileSize, "fileSize is null");
         }
 
         @JsonProperty
@@ -233,6 +237,12 @@ public class PartitionUpdate
             return targetFileName;
         }
 
+        @JsonProperty
+        public Optional<Long> getFileSize()
+        {
+            return fileSize;
+        }
+
         @Override
         public boolean equals(Object o)
         {
@@ -244,13 +254,14 @@ public class PartitionUpdate
             }
             FileWriteInfo that = (FileWriteInfo) o;
             return Objects.equals(writeFileName, that.writeFileName) &&
-                    Objects.equals(targetFileName, that.targetFileName);
+                    Objects.equals(targetFileName, that.targetFileName) &&
+                    Objects.equals(fileSize, that.fileSize);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(writeFileName, targetFileName);
+            return Objects.hash(writeFileName, targetFileName, fileSize);
         }
 
         @Override
@@ -259,6 +270,7 @@ public class PartitionUpdate
             return toStringHelper(this)
                     .add("writeFileName", writeFileName)
                     .add("targetFileName", targetFileName)
+                    .add("fileSize", fileSize)
                     .toString();
         }
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RcFileFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RcFileFileWriter.java
@@ -130,7 +130,7 @@ public class RcFileFileWriter
     }
 
     @Override
-    public void commit()
+    public Optional<Page> commit()
     {
         try {
             rcFileWriter.close();
@@ -157,6 +157,7 @@ public class RcFileFileWriter
                 throw new PrestoException(HIVE_WRITE_VALIDATION_FAILED, e);
             }
         }
+        return Optional.empty();
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RecordFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RecordFileWriter.java
@@ -39,6 +39,7 @@ import org.openjdk.jol.info.ClassLayout;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
@@ -175,11 +176,12 @@ public class RecordFileWriter
     }
 
     @Override
-    public void commit()
+    public Optional<Page> commit()
     {
         try {
             recordWriter.close(false);
             committed = true;
+            return Optional.empty();
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_WRITER_CLOSE_ERROR, "Error committing write to Hive", e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SortingFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SortingFileWriter.java
@@ -124,14 +124,13 @@ public class SortingFileWriter
     }
 
     @Override
-    public void commit()
+    public Optional<Page> commit()
     {
         if (!sortBuffer.isEmpty()) {
             // skip temporary files entirely if the total output size is small
             if (tempFiles.isEmpty()) {
                 sortBuffer.flushTo(outputWriter::appendRows);
-                outputWriter.commit();
-                return;
+                return outputWriter.commit();
             }
 
             flushToTempFile();
@@ -139,7 +138,7 @@ public class SortingFileWriter
 
         try {
             writeSorted();
-            outputWriter.commit();
+            return outputWriter.commit();
         }
         catch (UncheckedIOException e) {
             throw new PrestoException(HIVE_WRITER_CLOSE_ERROR, "Error committing write to Hive", e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriter.java
@@ -24,6 +24,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
@@ -75,10 +76,11 @@ public class PageFileWriter
     }
 
     @Override
-    public void commit()
+    public Optional<Page> commit()
     {
         try {
             pageWriter.close();
+            return Optional.empty();
         }
         catch (IOException | UncheckedIOException e) {
             try {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriter.java
@@ -112,10 +112,11 @@ public class ParquetFileWriter
     }
 
     @Override
-    public void commit()
+    public Optional<Page> commit()
     {
         try {
             parquetWriter.close();
+            return Optional.empty();
         }
         catch (IOException | UncheckedIOException e) {
             try {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -943,7 +943,8 @@ public abstract class AbstractTestHiveClient
                 new HiveZeroRowFileCreator(hdfsEnvironment, new OutputStreamDataSinkFactory(), listeningDecorator(executor)),
                 TEST_SERVER_VERSION,
                 new HivePartitionObjectBuilder(),
-                new HiveEncryptionInformationProvider(ImmutableList.of()));
+                new HiveEncryptionInformationProvider(ImmutableList.of()),
+                new HivePartitionStats());
         transactionManager = new HiveTransactionManager();
         encryptionInformationProvider = new HiveEncryptionInformationProvider(ImmutableList.of());
         splitManager = new HiveSplitManager(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -206,7 +206,8 @@ public abstract class AbstractTestHiveFileSystem
                 new HiveZeroRowFileCreator(hdfsEnvironment, new OutputStreamDataSinkFactory(), listeningDecorator(executor)),
                 new NodeVersion("test_version"),
                 new HivePartitionObjectBuilder(),
-                new HiveEncryptionInformationProvider(ImmutableList.of()));
+                new HiveEncryptionInformationProvider(ImmutableList.of()),
+                new HivePartitionStats());
         transactionManager = new HiveTransactionManager();
         splitManager = new HiveSplitManager(
                 transactionManager,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveManifestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveManifestUtils.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.PageBuilder;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.common.type.StandardTypes.DOUBLE;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.hive.HiveManifestUtils.createFileStatisticsPage;
+import static com.facebook.presto.hive.HiveManifestUtils.createPartitionManifest;
+import static com.facebook.presto.hive.HiveManifestUtils.getFileSize;
+import static com.facebook.presto.hive.PartitionUpdate.FileWriteInfo;
+import static com.facebook.presto.hive.PartitionUpdate.UpdateMode.NEW;
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestHiveManifestUtils
+{
+    private static final long FILE_SIZE = 1024;
+    private static final long ROW_COUNT = 100;
+
+    @Test
+    public void testCreateFileStatisticsPage()
+    {
+        Page statisticsPage = createFileStatisticsPage(FILE_SIZE, ROW_COUNT);
+
+        assertEquals(statisticsPage.getPositionCount(), 1);
+        assertEquals(statisticsPage.getChannelCount(), 2);
+    }
+
+    @Test
+    public void testGetFileSize()
+    {
+        Page statisticsPage = createTestStatisticsPageWithOneRow(ImmutableList.of(BIGINT, BIGINT), ImmutableList.of(FILE_SIZE, ROW_COUNT));
+        assertEquals(getFileSize(statisticsPage, 0), FILE_SIZE);
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Invalid position: 2 specified for FileStatistics page")
+    public void testGetFileSizeOfInvalidStatisticsPage()
+    {
+        Page statisticsPage = createTestStatisticsPageWithOneRow(ImmutableList.of(BIGINT, BIGINT), ImmutableList.of(FILE_SIZE, ROW_COUNT));
+        getFileSize(statisticsPage, 2);
+    }
+
+    @Test
+    public void testCreatePartitionManifest()
+    {
+        PartitionUpdate partitionUpdate = new PartitionUpdate("testPartition", NEW, "/testDir", "/testDir", ImmutableList.of(new FileWriteInfo("testFileName", "testFileName", Optional.of(FILE_SIZE))), 100, 1024, 1024);
+        Optional<Page> manifestPage = createPartitionManifest(partitionUpdate);
+        assertTrue(manifestPage.isPresent());
+        assertEquals(manifestPage.get().getChannelCount(), 2);
+        assertEquals(manifestPage.get().getPositionCount(), 1);
+    }
+
+    private Page createTestStatisticsPageWithOneRow(List<Type> types, List<Object> values)
+    {
+        assertEquals(types.size(), values.size());
+        PageBuilder pageBuilder = new PageBuilder(ImmutableList.copyOf(types));
+        pageBuilder.declarePosition();
+        for (int i = 0; i < types.size(); i++) {
+            Type type = types.get(i);
+            BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(i);
+            Object value = values.get(i);
+            switch (type.getTypeSignature().getBase()) {
+                case BOOLEAN:
+                    type.writeBoolean(blockBuilder, (Boolean) value);
+                    break;
+                case StandardTypes.BIGINT:
+                    type.writeLong(blockBuilder, (Long) value);
+                    break;
+                case DOUBLE:
+                    type.writeDouble(blockBuilder, (Double) value);
+                    break;
+                case VARCHAR:
+                    type.writeSlice(blockBuilder, utf8Slice((String) value));
+                    break;
+            }
+        }
+        return pageBuilder.build();
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
@@ -125,7 +125,8 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                 new HiveZeroRowFileCreator(HDFS_ENVIRONMENT, new OutputStreamDataSinkFactory(), listeningDecorator(executor)),
                 TEST_SERVER_VERSION,
                 new HivePartitionObjectBuilder(),
-                new HiveEncryptionInformationProvider(ImmutableList.of(new TestDwrfEncryptionInformationSource())));
+                new HiveEncryptionInformationProvider(ImmutableList.of(new TestDwrfEncryptionInformationSource())),
+                new HivePartitionStats());
 
         metastore.createDatabase(Database.builder()
                 .setDatabaseName(TEST_DB_NAME)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestPartitionUpdate.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestPartitionUpdate.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
+
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static org.testng.Assert.assertEquals;
 
@@ -35,7 +37,7 @@ public class TestPartitionUpdate
                 UpdateMode.APPEND,
                 "/writePath",
                 "/targetPath",
-                ImmutableList.of(new PartitionUpdate.FileWriteInfo(".file1", "file1"), new FileWriteInfo(".file3", "file3")),
+                ImmutableList.of(new PartitionUpdate.FileWriteInfo(".file1", "file1", Optional.empty()), new FileWriteInfo(".file3", "file3", Optional.empty())),
                 123,
                 456,
                 789);
@@ -46,7 +48,7 @@ public class TestPartitionUpdate
         assertEquals(actual.getUpdateMode(), UpdateMode.APPEND);
         assertEquals(actual.getWritePath(), new Path("/writePath"));
         assertEquals(actual.getTargetPath(), new Path("/targetPath"));
-        assertEquals(actual.getFileWriteInfos(), ImmutableList.of(new FileWriteInfo(".file1", "file1"), new FileWriteInfo(".file3", "file3")));
+        assertEquals(actual.getFileWriteInfos(), ImmutableList.of(new FileWriteInfo(".file1", "file1", Optional.empty()), new FileWriteInfo(".file3", "file3", Optional.empty())));
         assertEquals(actual.getRowCount(), 123);
         assertEquals(actual.getInMemoryDataSizeInBytes(), 456);
         assertEquals(actual.getOnDiskDataSizeInBytes(), 789);


### PR DESCRIPTION
Collect the Partition - file stats (file name, size) from the HiveWriter to be stored in a TBD location and then later use it during scheduling to avoid the directory Listing call. 
In this PR we are collecting the stats, tracking the blob size and then throwing it away. 

depended by https://github.com/facebookexternal/presto-facebook/pull/1084
