### PR TITLE
Enforce memory limits on broadcasted tables for lookup join

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
@@ -273,6 +273,7 @@ public abstract class AbstractOperatorBenchmark
                 new QueryId("test"),
                 new DataSize(256, MEGABYTE),
                 new DataSize(512, MEGABYTE),
+                new DataSize(256, MEGABYTE),
                 memoryPool,
                 new TestingGcMonitor(),
                 localQueryRunner.getExecutor(),

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
@@ -112,7 +112,8 @@ public class HashBuildAndJoinBenchmark
                 1_500_000,
                 new PagesIndex.TestingFactory(false),
                 false,
-                SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory());
+                SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory(),
+                false);
         driversBuilder.add(hashBuilder);
         DriverFactory hashBuildDriverFactory = new DriverFactory(0, true, false, driversBuilder.build(), OptionalInt.empty(), UNGROUPED_EXECUTION);
 

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
@@ -83,7 +83,8 @@ public class HashBuildBenchmark
                 1_500_000,
                 new PagesIndex.TestingFactory(false),
                 false,
-                SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory());
+                SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory(),
+                false);
         DriverFactory hashBuildDriverFactory = new DriverFactory(0, true, true, ImmutableList.of(ordersTableScan, hashBuilder), OptionalInt.empty(), UNGROUPED_EXECUTION);
 
         // empty join so build finishes

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
@@ -92,7 +92,8 @@ public class HashJoinBenchmark
                     1_500_000,
                     new PagesIndex.TestingFactory(false),
                     false,
-                    SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory());
+                    SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory(),
+                    false);
 
             DriverContext driverContext = taskContext.addPipelineContext(0, false, false, false).addDriverContext();
             DriverFactory buildDriverFactory = new DriverFactory(0, false, false, ImmutableList.of(ordersTableScan, hashBuilder), OptionalInt.empty(), UNGROUPED_EXECUTION);

--- a/presto-benchmark/src/test/java/com/facebook/presto/benchmark/MemoryLocalQueryRunner.java
+++ b/presto-benchmark/src/test/java/com/facebook/presto/benchmark/MemoryLocalQueryRunner.java
@@ -79,6 +79,7 @@ public class MemoryLocalQueryRunner
                 new QueryId("test"),
                 new DataSize(1, GIGABYTE),
                 new DataSize(2, GIGABYTE),
+                new DataSize(1, GIGABYTE),
                 memoryPool,
                 new TestingGcMonitor(),
                 localQueryRunner.getExecutor(),

--- a/presto-main/src/main/java/com/facebook/presto/ExceededMemoryLimitException.java
+++ b/presto-main/src/main/java/com/facebook/presto/ExceededMemoryLimitException.java
@@ -40,6 +40,12 @@ public class ExceededMemoryLimitException
                 format("Query exceeded per-node user memory limit of %s [%s]", maxMemory, additionalFailureInfo));
     }
 
+    public static ExceededMemoryLimitException exceededLocalBroadcastMemoryLimit(DataSize maxMemory, String additionalFailureInfo)
+    {
+        return new ExceededMemoryLimitException(EXCEEDED_LOCAL_MEMORY_LIMIT,
+                format("Query exceeded per-node broadcast memory limit of %s [%s]", maxMemory, additionalFailureInfo));
+    }
+
     public static ExceededMemoryLimitException exceededLocalTotalMemoryLimit(DataSize maxMemory, String additionalFailureInfo)
     {
         return new ExceededMemoryLimitException(EXCEEDED_LOCAL_MEMORY_LIMIT,

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -82,6 +82,7 @@ public final class SystemSessionProperties
     public static final String TASK_SHARE_INDEX_LOADING = "task_share_index_loading";
     public static final String QUERY_MAX_MEMORY = "query_max_memory";
     public static final String QUERY_MAX_MEMORY_PER_NODE = "query_max_memory_per_node";
+    public static final String QUERY_MAX_BROADCAST_MEMORY = "query_max_broadcast_memory";
     public static final String QUERY_MAX_TOTAL_MEMORY = "query_max_total_memory";
     public static final String QUERY_MAX_TOTAL_MEMORY_PER_NODE = "query_max_total_memory_per_node";
     public static final String QUERY_MAX_EXECUTION_TIME = "query_max_execution_time";
@@ -378,6 +379,15 @@ public final class SystemSessionProperties
                         VARCHAR,
                         DataSize.class,
                         nodeMemoryConfig.getSoftMaxQueryMemoryPerNode(),
+                        true,
+                        value -> DataSize.valueOf((String) value),
+                        DataSize::toString),
+                new PropertyMetadata<>(
+                        QUERY_MAX_BROADCAST_MEMORY,
+                        "Maximum amount of memory a query can use for broadcast join",
+                        VARCHAR,
+                        DataSize.class,
+                        nodeMemoryConfig.getMaxQueryBroadcastMemory(),
                         true,
                         value -> DataSize.valueOf((String) value),
                         DataSize::toString),
@@ -948,6 +958,11 @@ public final class SystemSessionProperties
     public static DataSize getQueryMaxMemoryPerNode(Session session)
     {
         return session.getSystemProperty(QUERY_MAX_MEMORY_PER_NODE, DataSize.class);
+    }
+
+    public static DataSize getQueryMaxBroadcastMemory(Session session)
+    {
+        return session.getSystemProperty(QUERY_MAX_BROADCAST_MEMORY, DataSize.class);
     }
 
     public static DataSize getQueryMaxTotalMemory(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/memory/NodeMemoryConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/NodeMemoryConfig.java
@@ -25,6 +25,7 @@ import static io.airlift.units.DataSize.Unit.BYTE;
 public class NodeMemoryConfig
 {
     public static final long AVAILABLE_HEAP_MEMORY = Runtime.getRuntime().maxMemory();
+    public static final String QUERY_MAX_BROADCAST_MEMORY_CONFIG = "query.max-broadcast-memory";
     public static final String QUERY_MAX_MEMORY_PER_NODE_CONFIG = "query.max-memory-per-node";
     public static final String QUERY_SOFT_MAX_MEMORY_PER_NODE_CONFIG = "query.soft-max-memory-per-node";
     public static final String QUERY_MAX_TOTAL_MEMORY_PER_NODE_CONFIG = "query.max-total-memory-per-node";
@@ -32,6 +33,7 @@ public class NodeMemoryConfig
 
     private boolean isReservedPoolEnabled = true;
 
+    private DataSize maxQueryBroadcastMemory;
     private DataSize maxQueryMemoryPerNode = new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE);
     private DataSize softMaxQueryMemoryPerNode;
 
@@ -39,6 +41,24 @@ public class NodeMemoryConfig
     private DataSize maxQueryTotalMemoryPerNode = new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE);
     private DataSize softMaxQueryTotalMemoryPerNode;
     private DataSize heapHeadroom = new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE);
+
+    @NotNull
+    public DataSize getMaxQueryBroadcastMemory()
+    {
+        if (maxQueryBroadcastMemory == null) {
+            return getMaxQueryMemoryPerNode();
+        }
+        return maxQueryBroadcastMemory;
+    }
+
+    @Config(QUERY_MAX_BROADCAST_MEMORY_CONFIG)
+    public NodeMemoryConfig setMaxQueryBroadcastMemory(DataSize maxQueryBroadcastMemory)
+    {
+        if (maxQueryBroadcastMemory.toBytes() < getMaxQueryMemoryPerNode().toBytes()) {
+            this.maxQueryBroadcastMemory = maxQueryBroadcastMemory;
+        }
+        return this;
+    }
 
     @NotNull
     public DataSize getMaxQueryMemoryPerNode()

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -72,6 +72,7 @@ public class HashBuilderOperator
         private final Map<Lifespan, Integer> partitionIndexManager = new HashMap<>();
 
         private boolean closed;
+        private boolean enforceBroadcastMemoryLimit;
 
         public HashBuilderOperatorFactory(
                 int operatorId,
@@ -86,7 +87,8 @@ public class HashBuilderOperator
                 int expectedPositions,
                 PagesIndex.Factory pagesIndexFactory,
                 boolean spillEnabled,
-                SingleStreamSpillerFactory singleStreamSpillerFactory)
+                SingleStreamSpillerFactory singleStreamSpillerFactory,
+                boolean enforceBroadcastMemoryLimit)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
@@ -106,6 +108,7 @@ public class HashBuilderOperator
             this.singleStreamSpillerFactory = requireNonNull(singleStreamSpillerFactory, "singleStreamSpillerFactory is null");
 
             this.expectedPositions = expectedPositions;
+            this.enforceBroadcastMemoryLimit = enforceBroadcastMemoryLimit;
         }
 
         @Override
@@ -130,7 +133,8 @@ public class HashBuilderOperator
                     expectedPositions,
                     pagesIndexFactory,
                     spillEnabled,
-                    singleStreamSpillerFactory);
+                    singleStreamSpillerFactory,
+                    enforceBroadcastMemoryLimit);
         }
 
         @Override
@@ -225,6 +229,8 @@ public class HashBuilderOperator
 
     private Optional<Runnable> finishMemoryRevoke = Optional.empty();
 
+    private final boolean enforceBroadcastMemoryLimit;
+
     public HashBuilderOperator(
             OperatorContext operatorContext,
             PartitionedLookupSourceFactory lookupSourceFactory,
@@ -238,7 +244,8 @@ public class HashBuilderOperator
             int expectedPositions,
             PagesIndex.Factory pagesIndexFactory,
             boolean spillEnabled,
-            SingleStreamSpillerFactory singleStreamSpillerFactory)
+            SingleStreamSpillerFactory singleStreamSpillerFactory,
+            boolean enforceBroadcastMemoryLimit)
     {
         requireNonNull(pagesIndexFactory, "pagesIndexFactory is null");
 
@@ -263,6 +270,7 @@ public class HashBuilderOperator
 
         this.spillEnabled = spillEnabled;
         this.singleStreamSpillerFactory = requireNonNull(singleStreamSpillerFactory, "singleStreamSpillerFactory is null");
+        this.enforceBroadcastMemoryLimit = enforceBroadcastMemoryLimit;
     }
 
     @Override
@@ -341,9 +349,9 @@ public class HashBuilderOperator
             localRevocableMemoryContext.setBytes(index.getEstimatedSize().toBytes());
         }
         else {
-            if (!localUserMemoryContext.trySetBytes(index.getEstimatedSize().toBytes())) {
+            if (!localUserMemoryContext.trySetBytes(index.getEstimatedSize().toBytes(), enforceBroadcastMemoryLimit)) {
                 index.compact();
-                localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes());
+                localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes(), enforceBroadcastMemoryLimit);
             }
         }
         operatorContext.recordOutput(page.getSizeInBytes(), page.getPositionCount());
@@ -372,7 +380,7 @@ public class HashBuilderOperator
 
             finishMemoryRevoke = Optional.of(() -> {
                 index.clear();
-                localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes());
+                localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes(), enforceBroadcastMemoryLimit);
                 localRevocableMemoryContext.setBytes(0);
                 lookupSourceFactory.setPartitionSpilledLookupSourceHandle(partitionIndex, spilledLookupSourceHandle);
                 state = State.SPILLING_INPUT;
@@ -384,7 +392,7 @@ public class HashBuilderOperator
                 lookupSourceFactory.setPartitionSpilledLookupSourceHandle(partitionIndex, spilledLookupSourceHandle);
                 lookupSourceNotNeeded = Optional.empty();
                 index.clear();
-                localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes());
+                localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes(), enforceBroadcastMemoryLimit);
                 localRevocableMemoryContext.setBytes(0);
                 lookupSourceChecksum = OptionalLong.of(lookupSourceSupplier.checksum());
                 lookupSourceSupplier = null;
@@ -488,7 +496,7 @@ public class HashBuilderOperator
             localRevocableMemoryContext.setBytes(partition.get().getInMemorySizeInBytes());
         }
         else {
-            localUserMemoryContext.setBytes(partition.get().getInMemorySizeInBytes());
+            localUserMemoryContext.setBytes(partition.get().getInMemorySizeInBytes(), enforceBroadcastMemoryLimit);
         }
         lookupSourceNotNeeded = Optional.of(lookupSourceFactory.lendPartitionLookupSource(partitionIndex, partition));
 
@@ -505,7 +513,7 @@ public class HashBuilderOperator
 
         index.clear();
         localRevocableMemoryContext.setBytes(0);
-        localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes());
+        localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes(), enforceBroadcastMemoryLimit);
         lookupSourceSupplier = null;
         close();
     }
@@ -532,7 +540,7 @@ public class HashBuilderOperator
         verify(spiller.isPresent());
         verify(!unspillInProgress.isPresent());
 
-        localUserMemoryContext.setBytes(getSpiller().getSpilledPagesInMemorySize() + index.getEstimatedSize().toBytes());
+        localUserMemoryContext.setBytes(getSpiller().getSpilledPagesInMemorySize() + index.getEstimatedSize().toBytes(), enforceBroadcastMemoryLimit);
         unspillInProgress = Optional.of(getSpiller().getAllSpilledPages());
 
         state = State.INPUT_UNSPILLING;
@@ -551,20 +559,20 @@ public class HashBuilderOperator
         long memoryRetainedByRemainingPages = pages.stream()
                 .mapToLong(Page::getRetainedSizeInBytes)
                 .sum();
-        localUserMemoryContext.setBytes(memoryRetainedByRemainingPages + index.getEstimatedSize().toBytes());
+        localUserMemoryContext.setBytes(memoryRetainedByRemainingPages + index.getEstimatedSize().toBytes(), enforceBroadcastMemoryLimit);
 
         while (!pages.isEmpty()) {
             Page next = pages.remove();
             index.addPage(next);
             // There is no attempt to compact index, since unspilled pages are unlikely to have blocks with retained size > logical size.
             memoryRetainedByRemainingPages -= next.getRetainedSizeInBytes();
-            localUserMemoryContext.setBytes(memoryRetainedByRemainingPages + index.getEstimatedSize().toBytes());
+            localUserMemoryContext.setBytes(memoryRetainedByRemainingPages + index.getEstimatedSize().toBytes(), enforceBroadcastMemoryLimit);
         }
 
         LookupSourceSupplier partition = buildLookupSource();
         lookupSourceChecksum.ifPresent(checksum ->
                 checkState(partition.checksum() == checksum, "Unspilled lookupSource checksum does not match original one"));
-        localUserMemoryContext.setBytes(partition.get().getInMemorySizeInBytes());
+        localUserMemoryContext.setBytes(partition.get().getInMemorySizeInBytes(), enforceBroadcastMemoryLimit);
 
         spilledLookupSourceHandle.setLookupSource(partition);
 
@@ -579,7 +587,7 @@ public class HashBuilderOperator
         }
 
         index.clear();
-        localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes());
+        localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes(), enforceBroadcastMemoryLimit);
 
         close();
     }
@@ -625,7 +633,7 @@ public class HashBuilderOperator
         try (Closer closer = Closer.create()) {
             closer.register(index::clear);
             spiller.ifPresent(closer::register);
-            closer.register(() -> localUserMemoryContext.setBytes(0));
+            closer.register(() -> localUserMemoryContext.setBytes(0, enforceBroadcastMemoryLimit));
             closer.register(() -> localRevocableMemoryContext.setBytes(0));
         }
         catch (IOException e) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -603,7 +603,13 @@ public class OperatorContext
         @Override
         public ListenableFuture<?> setBytes(long bytes)
         {
-            ListenableFuture<?> blocked = delegate.setBytes(bytes);
+            return setBytes(bytes, false);
+        }
+
+        @Override
+        public ListenableFuture<?> setBytes(long bytes, boolean enforceBroadcastMemoryLimit)
+        {
+            ListenableFuture<?> blocked = delegate.setBytes(bytes, enforceBroadcastMemoryLimit);
             updateMemoryFuture(blocked, memoryFuture);
             allocationListener.run();
             return blocked;
@@ -612,7 +618,13 @@ public class OperatorContext
         @Override
         public boolean trySetBytes(long bytes)
         {
-            if (delegate.trySetBytes(bytes)) {
+            return trySetBytes(bytes, false);
+        }
+
+        @Override
+        public boolean trySetBytes(long bytes, boolean enforceBroadcastMemoryLimit)
+        {
+            if (delegate.trySetBytes(bytes, enforceBroadcastMemoryLimit)) {
                 allocationListener.run();
                 return true;
             }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingTaskContext.java
@@ -151,6 +151,7 @@ public final class TestingTaskContext
                     queryId,
                     queryMaxMemory,
                     queryMaxTotalMemory,
+                    queryMaxMemory,
                     memoryPool,
                     GC_MONITOR,
                     notificationExecutor,

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -197,6 +197,7 @@ public class MockRemoteTaskFactory
             QueryContext queryContext = new QueryContext(taskId.getQueryId(),
                     new DataSize(1, MEGABYTE),
                     new DataSize(2, MEGABYTE),
+                    new DataSize(1, MEGABYTE),
                     memoryPool,
                     new TestingGcMonitor(),
                     executor,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
@@ -302,6 +302,7 @@ public class TestMemoryRevokingScheduler
                 new QueryContext(new QueryId("query"),
                         new DataSize(1, MEGABYTE),
                         new DataSize(2, MEGABYTE),
+                        new DataSize(1, MEGABYTE),
                         memoryPool,
                         new TestingGcMonitor(),
                         executor,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -311,6 +311,7 @@ public class TestSqlTask
         QueryContext queryContext = new QueryContext(new QueryId("query"),
                 new DataSize(1, MEGABYTE),
                 new DataSize(2, MEGABYTE),
+                new DataSize(1, MEGABYTE),
                 new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE)),
                 new TestingGcMonitor(),
                 taskNotificationExecutor,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -614,6 +614,7 @@ public class TestSqlTaskExecution
                 new QueryId("queryid"),
                 new DataSize(1, MEGABYTE),
                 new DataSize(2, MEGABYTE),
+                new DataSize(1, MEGABYTE),
                 new MemoryPool(new MemoryPoolId("test"), new DataSize(1, GIGABYTE)),
                 new TestingGcMonitor(),
                 taskNotificationExecutor,

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
@@ -1062,13 +1062,13 @@ public class TestBroadcastOutputBuffer
         }
 
         @Override
-        public ListenableFuture<?> reserveMemory(String allocationTag, long delta)
+        public ListenableFuture<?> reserveMemory(String allocationTag, long delta, boolean enforceBroadcastMemoryLimit)
         {
             return blockedFuture;
         }
 
         @Override
-        public boolean tryReserveMemory(String allocationTag, long delta)
+        public boolean tryReserveMemory(String allocationTag, long delta, boolean enforceBroadcastMemoryLimit)
         {
             return true;
         }

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
@@ -96,6 +96,7 @@ public class TestMemoryPools
         QueryContext queryContext = new QueryContext(new QueryId("query"),
                 TEN_MEGABYTES,
                 new DataSize(20, MEGABYTE),
+                TEN_MEGABYTES,
                 userPool,
                 new TestingGcMonitor(),
                 localQueryRunner.getExecutor(),

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
@@ -100,6 +100,7 @@ public class TestMemoryTracking
                 new QueryId("test_query"),
                 queryMaxMemory,
                 queryMaxTotalMemory,
+                queryMaxMemory,
                 memoryPool,
                 new TestingGcMonitor(),
                 notificationExecutor,

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestNodeMemoryConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestNodeMemoryConfig.java
@@ -33,6 +33,7 @@ public class TestNodeMemoryConfig
     public void testDefaults()
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(NodeMemoryConfig.class)
+                .setMaxQueryBroadcastMemory(new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE))
                 .setMaxQueryMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE))
                 .setSoftMaxQueryMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE))
                 .setMaxQueryTotalMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE))
@@ -46,6 +47,32 @@ public class TestNodeMemoryConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("query.max-memory-per-node", "1GB")
+                .put("query.max-broadcast-memory", "512MB")
+                .put("query.soft-max-memory-per-node", "512MB")
+                .put("query.max-total-memory-per-node", "3GB")
+                .put("query.soft-max-total-memory-per-node", "2GB")
+                .put("memory.heap-headroom-per-node", "1GB")
+                .put("experimental.reserved-pool-enabled", "false")
+                .build();
+
+        NodeMemoryConfig expected = new NodeMemoryConfig()
+                .setMaxQueryBroadcastMemory(new DataSize(512, MEGABYTE))
+                .setMaxQueryMemoryPerNode(new DataSize(1, GIGABYTE))
+                .setSoftMaxQueryMemoryPerNode(new DataSize(512, MEGABYTE))
+                .setMaxQueryTotalMemoryPerNode(new DataSize(3, GIGABYTE))
+                .setSoftMaxQueryTotalMemoryPerNode(new DataSize(2, GIGABYTE))
+                .setHeapHeadroom(new DataSize(1, GIGABYTE))
+                .setReservedPoolEnabled(false);
+
+        assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testOutOfRangeBroadcastMemoryLimit()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("query.max-memory-per-node", "1GB")
+                .put("query.max-broadcast-memory", "5GB")
                 .put("query.soft-max-memory-per-node", "512MB")
                 .put("query.max-total-memory-per-node", "3GB")
                 .put("query.soft-max-total-memory-per-node", "2GB")
@@ -55,6 +82,7 @@ public class TestNodeMemoryConfig
 
         NodeMemoryConfig expected = new NodeMemoryConfig()
                 .setMaxQueryMemoryPerNode(new DataSize(1, GIGABYTE))
+                .setMaxQueryBroadcastMemory(new DataSize(1, GIGABYTE))
                 .setSoftMaxQueryMemoryPerNode(new DataSize(512, MEGABYTE))
                 .setMaxQueryTotalMemoryPerNode(new DataSize(3, GIGABYTE))
                 .setSoftMaxQueryTotalMemoryPerNode(new DataSize(2, GIGABYTE))

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestQueryContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestQueryContext.java
@@ -77,6 +77,7 @@ public class TestQueryContext
                     new QueryId("query"),
                     new DataSize(10, BYTE),
                     new DataSize(20, BYTE),
+                    new DataSize(10, BYTE),
                     new MemoryPool(GENERAL_POOL, new DataSize(10, BYTE)),
                     new TestingGcMonitor(),
                     localQueryRunner.getExecutor(),
@@ -140,6 +141,7 @@ public class TestQueryContext
     private static QueryContext createQueryContext(QueryId queryId, MemoryPool generalPool)
     {
         return new QueryContext(queryId,
+                new DataSize(10_000, BYTE),
                 new DataSize(10_000, BYTE),
                 new DataSize(10_000, BYTE),
                 generalPool,

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -308,7 +308,8 @@ public class BenchmarkHashBuildAndJoinOperators
                 10_000,
                 new PagesIndex.TestingFactory(false),
                 false,
-                SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory());
+                SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory(),
+                false);
 
         Operator operator = hashBuilderOperatorFactory.createOperator(driverContext);
         for (Page page : buildContext.getBuildPages()) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/GroupByHashYieldAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/GroupByHashYieldAssertion.java
@@ -83,6 +83,7 @@ public final class GroupByHashYieldAssertion
                 queryId,
                 new DataSize(512, MEGABYTE),
                 new DataSize(1024, MEGABYTE),
+                new DataSize(512, MEGABYTE),
                 memoryPool,
                 new TestingGcMonitor(),
                 EXECUTOR,

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/LocalMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/LocalMemoryContext.java
@@ -31,6 +31,12 @@ public interface LocalMemoryContext
     ListenableFuture<?> setBytes(long bytes);
 
     /**
+     * This method will eventually call {@code setBytes(long bytes)} function, after conditionally check against
+     * broadcast memory usage limit based on the value of {@code enforceBroadcastMemoryLimit}.
+     */
+    ListenableFuture<?> setBytes(long bytes, boolean enforceBroadcastMemoryLimit);
+
+    /**
      * This method can return false when there is not enough memory available to satisfy a positive delta allocation
      * ({@code bytes} is greater than the bytes tracked by this LocalMemoryContext).
      * <p/>
@@ -38,6 +44,12 @@ public interface LocalMemoryContext
      * @return true if the bytes tracked by this LocalMemoryContext can be set to {@code bytes}.
      */
     boolean trySetBytes(long bytes);
+
+    /**
+     * This method will eventually call {@code trySetBytes(long bytes)} function, after conditionally check against
+     * broadcast memory usage limit based on the value of {@code enforceBroadcastMemoryLimit}.
+     */
+    boolean trySetBytes(long bytes, boolean enforceBroadcastMemoryLimit);
 
     /**
      * Closes this LocalMemoryContext. Once closed the bytes tracked by this LocalMemoryContext will be set to 0, and

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/MemoryReservationHandler.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/MemoryReservationHandler.java
@@ -20,12 +20,12 @@ public interface MemoryReservationHandler
     /**
      * @return a future that signals the caller to block before reserving more memory.
      */
-    ListenableFuture<?> reserveMemory(String allocationTag, long delta);
+    ListenableFuture<?> reserveMemory(String allocationTag, long delta, boolean enforceBroadcastMemoryLimit);
 
     /**
      * Try reserving the given number of bytes.
      *
      * @return true if reservation is successful, false otherwise.
      */
-    boolean tryReserveMemory(String allocationTag, long delta);
+    boolean tryReserveMemory(String allocationTag, long delta, boolean enforceBroadcastMemoryLimit);
 }

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/RootAggregatedMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/RootAggregatedMemoryContext.java
@@ -31,11 +31,12 @@ class RootAggregatedMemoryContext
     }
 
     @Override
-    synchronized ListenableFuture<?> updateBytes(String allocationTag, long bytes)
+    synchronized ListenableFuture<?> updateBytes(String allocationTag, long bytes, boolean enforceBroadcastMemoryLimit)
     {
         checkState(!isClosed(), "RootAggregatedMemoryContext is already closed");
-        ListenableFuture<?> future = reservationHandler.reserveMemory(allocationTag, bytes);
+        ListenableFuture<?> future = reservationHandler.reserveMemory(allocationTag, bytes, enforceBroadcastMemoryLimit);
         addBytes(bytes);
+        addBroadcastBytes(bytes);
         // make sure we never block queries below guaranteedMemory
         if (getBytes() < guaranteedMemory) {
             future = NOT_BLOCKED;
@@ -44,10 +45,11 @@ class RootAggregatedMemoryContext
     }
 
     @Override
-    synchronized boolean tryUpdateBytes(String allocationTag, long delta)
+    synchronized boolean tryUpdateBytes(String allocationTag, long delta, boolean enforceBroadcastMemoryLimit)
     {
-        if (reservationHandler.tryReserveMemory(allocationTag, delta)) {
+        if (reservationHandler.tryReserveMemory(allocationTag, delta, enforceBroadcastMemoryLimit)) {
             addBytes(delta);
+            addBroadcastBytes(delta);
             return true;
         }
         return false;
@@ -62,6 +64,6 @@ class RootAggregatedMemoryContext
     @Override
     void closeContext()
     {
-        reservationHandler.reserveMemory(FORCE_FREE_TAG, -getBytes());
+        reservationHandler.reserveMemory(FORCE_FREE_TAG, -getBytes(), false);
     }
 }

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/SimpleAggregatedMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/SimpleAggregatedMemoryContext.java
@@ -24,7 +24,7 @@ class SimpleAggregatedMemoryContext
         extends AbstractAggregatedMemoryContext
 {
     @Override
-    synchronized ListenableFuture<?> updateBytes(String allocationTag, long bytes)
+    synchronized ListenableFuture<?> updateBytes(String allocationTag, long bytes, boolean enforceBroadcastMemoryLimit)
     {
         checkState(!isClosed(), "SimpleAggregatedMemoryContext is already closed");
         addBytes(bytes);
@@ -32,7 +32,7 @@ class SimpleAggregatedMemoryContext
     }
 
     @Override
-    synchronized boolean tryUpdateBytes(String allocationTag, long delta)
+    synchronized boolean tryUpdateBytes(String allocationTag, long delta, boolean enforceBroadcastMemoryLimit)
     {
         addBytes(delta);
         return true;

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -242,6 +242,7 @@ public class PrestoSparkTaskExecutorFactory
                 session.getQueryId(),
                 maxUserMemory,
                 maxTotalMemory,
+                maxUserMemory,
                 memoryPool,
                 new TestingGcMonitor(),
                 notificationExecutor,


### PR DESCRIPTION
**Background**: we want to prevent people from exceeding the lower local memory limits supported by certain types of hardware even if they are running on hardware that is configured with a higher local memory limit while doing broadcast join.

If the build side of the broadcast join exceeds the memory limits it will generate an `ExceededMemoryLimitException` that terminates the query.


== RELEASE NOTES ==

General Changes
* a new session property `query_max_broadcast_memory` that allows for specifying the maximum amount of memory a query can use for broadcast join.

