### PR TITLE
Add support for column names with ampersand or pipe to SubfieldTokenizer

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/SubfieldTokenizer.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/SubfieldTokenizer.java
@@ -147,7 +147,7 @@ class SubfieldTokenizer
 
     private static boolean isUnquotedPathCharacter(char c)
     {
-        return c == ':' || c == '$' || c == '-' || c == '/' || isUnquotedSubscriptCharacter(c);
+        return c == ':' || c == '$' || c == '-' || c == '/' || c == '@' || c == '|' || isUnquotedSubscriptCharacter(c);
     }
 
     private Subfield.PathElement matchUnquotedSubscript()

--- a/presto-common/src/test/java/com/facebook/presto/common/TestSubfieldTokenizer.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/TestSubfieldTokenizer.java
@@ -76,6 +76,8 @@ public class TestSubfieldTokenizer
         assertPath(new Subfield("$bucket", ImmutableList.of()));
         assertPath(new Subfield("apollo-11", ImmutableList.of()));
         assertPath(new Subfield("a/b/c:12", ImmutableList.of()));
+        assertPath(new Subfield("@basis", ImmutableList.of()));
+        assertPath(new Subfield("@basis|city_id", ImmutableList.of()));
     }
 
     @Test


### PR DESCRIPTION

```
== NO RELEASE NOTE ==
```
