### PR TITLE
Add alluxio config validation flag

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheConfig.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheConfig.java
@@ -26,13 +26,15 @@ public class AlluxioCacheConfig
     private String jmxClass = "alluxio.metrics.sink.JmxSink";
     private String metricsDomain = "com.facebook.alluxio";
     private DataSize maxCacheSize = new DataSize(2, GIGABYTE);
+    private boolean configValidationEnabled;
 
     public boolean isMetricsCollectionEnabled()
     {
         return metricsCollectionEnabled;
     }
 
-    @Config("cache.alluxio.metrics.enabled")
+    @Config("cache.alluxio.metrics-enabled")
+    @ConfigDescription("If metrics for alluxio caching are enabled")
     public AlluxioCacheConfig setMetricsCollectionEnabled(boolean metricsCollectionEnabled)
     {
         this.metricsCollectionEnabled = metricsCollectionEnabled;
@@ -44,7 +46,8 @@ public class AlluxioCacheConfig
         return jmxClass;
     }
 
-    @Config("cache.alluxio.jmx.class")
+    @Config("cache.alluxio.jmx-class")
+    @ConfigDescription("JMX class name used by the alluxio caching for metrics")
     public AlluxioCacheConfig setJmxClass(String jmxClass)
     {
         this.jmxClass = jmxClass;
@@ -56,7 +59,8 @@ public class AlluxioCacheConfig
         return metricsDomain;
     }
 
-    @Config("cache.alluxio.metrics.domain")
+    @Config("cache.alluxio.metrics-domain")
+    @ConfigDescription("Metrics domain name used by the alluxio caching")
     public AlluxioCacheConfig setMetricsDomain(String metricsDomain)
     {
         this.metricsDomain = metricsDomain;
@@ -68,7 +72,8 @@ public class AlluxioCacheConfig
         return asyncWriteEnabled;
     }
 
-    @Config("cache.alluxio.async-write.enabled")
+    @Config("cache.alluxio.async-write-enabled")
+    @ConfigDescription("If alluxio caching should write to cache asynchronously")
     public AlluxioCacheConfig setAsyncWriteEnabled(boolean asyncWriteEnabled)
     {
         this.asyncWriteEnabled = asyncWriteEnabled;
@@ -81,10 +86,23 @@ public class AlluxioCacheConfig
     }
 
     @Config("cache.alluxio.max-cache-size")
-    @ConfigDescription("The maximum cache size")
+    @ConfigDescription("The maximum cache size available for alluxio cache")
     public AlluxioCacheConfig setMaxCacheSize(DataSize maxCacheSize)
     {
         this.maxCacheSize = maxCacheSize;
         return this;
+    }
+
+    @Config("cache.alluxio.config-validation-enabled")
+    @ConfigDescription("If the alluxio caching should validate the provided configuration")
+    public AlluxioCacheConfig setConfigValidationEnabled(boolean configValidationEnabled)
+    {
+        this.configValidationEnabled = configValidationEnabled;
+        return this;
+    }
+
+    public boolean isConfigValidationEnabled()
+    {
+        return configValidationEnabled;
     }
 }

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
@@ -48,6 +48,7 @@ public class AlluxioCachingConfigurationProvider
             configuration.set("alluxio.user.metrics.collection.enabled", String.valueOf(alluxioCacheConfig.isMetricsCollectionEnabled()));
             configuration.set("sink.jmx.class", alluxioCacheConfig.getJmxClass());
             configuration.set("sink.jmx.domain", alluxioCacheConfig.getMetricsDomain());
+            configuration.set("alluxio.conf.validation.enabled", String.valueOf(alluxioCacheConfig.isConfigValidationEnabled()));
         }
     }
 }

--- a/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCacheConfig.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCacheConfig.java
@@ -35,18 +35,20 @@ public class TestAlluxioCacheConfig
                 .setMaxCacheSize(new DataSize(2, GIGABYTE))
                 .setMetricsCollectionEnabled(true)
                 .setMetricsDomain("com.facebook.alluxio")
-                .setJmxClass("alluxio.metrics.sink.JmxSink"));
+                .setJmxClass("alluxio.metrics.sink.JmxSink")
+                .setConfigValidationEnabled(false));
     }
 
     @Test
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("cache.alluxio.async-write.enabled", "true")
+                .put("cache.alluxio.async-write-enabled", "true")
                 .put("cache.alluxio.max-cache-size", "42MB")
-                .put("cache.alluxio.metrics.enabled", "false")
-                .put("cache.alluxio.metrics.domain", "test.alluxio")
-                .put("cache.alluxio.jmx.class", "test.TestJmxSink")
+                .put("cache.alluxio.metrics-enabled", "false")
+                .put("cache.alluxio.metrics-domain", "test.alluxio")
+                .put("cache.alluxio.jmx-class", "test.TestJmxSink")
+                .put("cache.alluxio.config-validation-enabled", "true")
                 .build();
 
         AlluxioCacheConfig expected = new AlluxioCacheConfig()
@@ -54,7 +56,8 @@ public class TestAlluxioCacheConfig
                 .setMaxCacheSize(new DataSize(42, MEGABYTE))
                 .setMetricsCollectionEnabled(false)
                 .setMetricsDomain("test.alluxio")
-                .setJmxClass("test.TestJmxSink");
+                .setJmxClass("test.TestJmxSink")
+                .setConfigValidationEnabled(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Adding alluxio config validation flag, it can be used to disable the cache configuration validation. Cache configuration validation is a costly operation.


```
== NO RELEASE NOTE ==
```
