### PR TITLE
Optimize shuffle efficiency for Presto on Spark

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkBufferedResult.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkBufferedResult.java
@@ -11,16 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.spark.classloader_interface;
+package com.facebook.presto.spark.execution;
 
-import org.apache.spark.api.java.function.Function;
-
-public class PrestoSparkToMaterializedRowFunction
-        implements Function<PrestoSparkMutableRow, PrestoSparkMaterializedRow>
+public interface PrestoSparkBufferedResult
 {
-    @Override
-    public PrestoSparkMaterializedRow call(PrestoSparkMutableRow row)
-    {
-        return row.toMaterializedRow();
-    }
+    long getRetainedSizeInBytes();
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkBufferedSerializedPage.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkBufferedSerializedPage.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.spi.page.SerializedPage;
+import org.openjdk.jol.info.ClassLayout;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkBufferedSerializedPage
+        implements PrestoSparkBufferedResult
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(PrestoSparkBufferedSerializedPage.class).instanceSize();
+
+    private final SerializedPage serializedPage;
+
+    public PrestoSparkBufferedSerializedPage(SerializedPage serializedPage)
+    {
+        this.serializedPage = requireNonNull(serializedPage, "serializedPage is null");
+    }
+
+    public SerializedPage getSerializedPage()
+    {
+        return serializedPage;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + serializedPage.getRetainedSizeInBytes();
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkMutableRowPageInput.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkMutableRowPageInput.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.PageBuilder;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.List;
+
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkMutableRowPageInput
+        implements PrestoSparkPageInput
+{
+    private static final int TARGET_SIZE = 1024 * 1024;
+    private static final int BUFFER_SIZE = (int) (TARGET_SIZE * 1.2f);
+    private static final int MAX_ROWS_PER_ZERO_COLUMN_PAGE = 10_000;
+
+    private final List<Type> types;
+    private final Iterator<PrestoSparkMutableRow> rowsIterator;
+
+    public PrestoSparkMutableRowPageInput(List<Type> types, Iterator<PrestoSparkMutableRow> rowsIterator)
+    {
+        this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+        this.rowsIterator = requireNonNull(rowsIterator, "rowsIterator is null");
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        // zero columns page
+        if (types.isEmpty()) {
+            int rowsCount = 0;
+            synchronized (rowsIterator) {
+                if (!rowsIterator.hasNext()) {
+                    return null;
+                }
+                while (rowsIterator.hasNext() && rowsCount < MAX_ROWS_PER_ZERO_COLUMN_PAGE) {
+                    rowsIterator.next();
+                    rowsCount++;
+                }
+            }
+            return new Page(rowsCount);
+        }
+
+        SliceOutput output = new DynamicSliceOutput(BUFFER_SIZE);
+        int rowCount = 0;
+        synchronized (rowsIterator) {
+            if (!rowsIterator.hasNext()) {
+                return null;
+            }
+            while (rowsIterator.hasNext() && output.size() < TARGET_SIZE) {
+                PrestoSparkMutableRow row = rowsIterator.next();
+                ByteBuffer buffer = row.getBuffer();
+                output.writeBytes(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+                rowCount++;
+            }
+        }
+        SliceInput sliceInput = output.slice().getInput();
+        PageBuilder pageBuilder = new PageBuilder(types);
+        while (sliceInput.isReadable()) {
+            pageBuilder.declarePosition();
+            for (int channel = 0; channel < types.size(); channel++) {
+                BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(channel);
+                blockBuilder.readPositionFrom(sliceInput);
+            }
+        }
+        Page page = pageBuilder.build();
+        verify(page.getPositionCount() == rowCount, "unexpected row count: %s != %s", page.getPositionCount(), rowCount);
+        return page;
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkOutputBuffer.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkOutputBuffer.java
@@ -23,17 +23,17 @@ import java.util.Queue;
 
 import static java.util.Objects.requireNonNull;
 
-public class PrestoSparkRowBuffer
+public class PrestoSparkOutputBuffer<T extends PrestoSparkBufferedResult>
 {
     private final OutputBufferMemoryManager memoryManager;
 
     private final Object monitor = new Object();
     @GuardedBy("monitor")
-    private final Queue<PrestoSparkRowBatch> buffer = new ArrayDeque<>();
+    private final Queue<T> buffer = new ArrayDeque<>();
     @GuardedBy("monitor")
     private boolean finished;
 
-    public PrestoSparkRowBuffer(OutputBufferMemoryManager memoryManager)
+    public PrestoSparkOutputBuffer(OutputBufferMemoryManager memoryManager)
     {
         this.memoryManager = requireNonNull(memoryManager, "memoryManager is null");
     }
@@ -43,7 +43,7 @@ public class PrestoSparkRowBuffer
         return memoryManager.getBufferBlockedFuture();
     }
 
-    public void enqueue(PrestoSparkRowBatch rows)
+    public void enqueue(T rows)
     {
         requireNonNull(rows, "rows is null");
         synchronized (monitor) {
@@ -62,10 +62,10 @@ public class PrestoSparkRowBuffer
         }
     }
 
-    public PrestoSparkRowBatch get()
+    public T get()
             throws InterruptedException
     {
-        PrestoSparkRowBatch rowBatch = null;
+        T rowBatch = null;
         synchronized (monitor) {
             while (buffer.isEmpty() && !finished) {
                 monitor.wait();

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkPageInput.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkPageInput.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.common.Page;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Implementation of this interface is expected to be thread safe
+ */
+@ThreadSafe
+public interface PrestoSparkPageInput
+{
+    @Nullable
+    Page getNextPage();
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkPageOutputOperator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkPageOutputOperator.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.execution.buffer.PagesSerdeFactory;
+import com.facebook.presto.operator.DriverContext;
+import com.facebook.presto.operator.Operator;
+import com.facebook.presto.operator.OperatorContext;
+import com.facebook.presto.operator.OperatorFactory;
+import com.facebook.presto.operator.OutputFactory;
+import com.facebook.presto.spi.page.PagesSerde;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.sql.planner.OutputPartitioning;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.facebook.presto.common.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+import static com.facebook.presto.execution.buffer.PageSplitterUtil.splitPage;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkPageOutputOperator
+        implements Operator
+{
+    public static class PrestoSparkPageOutputFactory
+            implements OutputFactory
+    {
+        private final PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer;
+        private final PagesSerde pagesSerde;
+
+        public PrestoSparkPageOutputFactory(
+                PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer,
+                PagesSerde pagesSerde)
+        {
+            this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
+            this.pagesSerde = requireNonNull(pagesSerde, "pagesSerde is null");
+        }
+
+        @Override
+        public OperatorFactory createOutputOperator(
+                int operatorId,
+                PlanNodeId planNodeId,
+                List<Type> types,
+                Function<Page, Page> pagePreprocessor,
+                Optional<OutputPartitioning> outputPartitioning,
+                PagesSerdeFactory serdeFactory)
+        {
+            checkArgument(!outputPartitioning.isPresent(), "output partitioning is not expected to be present");
+            return new PrestoSparkOutputOperatorFactory(
+                    operatorId,
+                    planNodeId,
+                    outputBuffer,
+                    pagePreprocessor, pagesSerde);
+        }
+    }
+
+    public static class PrestoSparkOutputOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+        private final PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer;
+        private final Function<Page, Page> pagePreprocessor;
+        private final PagesSerde pagesSerde;
+
+        public PrestoSparkOutputOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer,
+                Function<Page, Page> pagePreprocessor,
+                PagesSerde pagesSerde)
+        {
+            this.operatorId = operatorId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
+            this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
+            this.pagesSerde = requireNonNull(pagesSerde, "pagesSerde is null");
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, PrestoSparkPageOutputOperator.class.getSimpleName());
+            return new PrestoSparkPageOutputOperator(
+                    operatorContext,
+                    outputBuffer,
+                    pagePreprocessor,
+                    pagesSerde);
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            return new PrestoSparkOutputOperatorFactory(
+                    operatorId,
+                    planNodeId,
+                    outputBuffer,
+                    pagePreprocessor, pagesSerde);
+        }
+    }
+
+    private final OperatorContext operatorContext;
+    private final PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer;
+    private final Function<Page, Page> pagePreprocessor;
+    private final PagesSerde pagesSerde;
+
+    private boolean finished;
+
+    public PrestoSparkPageOutputOperator(
+            OperatorContext operatorContext,
+            PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer,
+            Function<Page, Page> pagePreprocessor, PagesSerde pagesSerde)
+    {
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
+        this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
+        this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
+        this.pagesSerde = requireNonNull(pagesSerde, "pagesSerde is null");
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public ListenableFuture<?> isBlocked()
+    {
+        return outputBuffer.isFull();
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return !finished && isBlocked().isDone();
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        page = pagePreprocessor.apply(page);
+
+        int positionCount = page.getPositionCount();
+        if (positionCount == 0) {
+            return;
+        }
+
+        List<PrestoSparkBufferedSerializedPage> serializedPages = splitPage(page, DEFAULT_MAX_PAGE_SIZE_IN_BYTES).stream()
+                .map(pagesSerde::serialize)
+                .map(PrestoSparkBufferedSerializedPage::new)
+                .collect(toImmutableList());
+
+        serializedPages.forEach(outputBuffer::enqueue);
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        return null;
+    }
+
+    @Override
+    public void finish()
+    {
+        finished = true;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finished && isBlocked().isDone();
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRemoteSourceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRemoteSourceFactory.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.spark.util.PrestoSparkUtils.toSerializedPage;
-import static com.facebook.presto.spark.util.PrestoSparkUtils.transformRowsToPages;
+import static com.facebook.presto.spark.util.PrestoSparkUtils.transformMutableRowsToPages;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterators.transform;
 import static java.util.Objects.requireNonNull;
@@ -70,7 +70,7 @@ public class PrestoSparkRemoteSourceFactory
         return new SparkRemoteSourceOperatorFactory(
                 operatorId,
                 planNodeId,
-                transformRowsToPages(shuffleInput, types));
+                transformMutableRowsToPages(shuffleInput, types));
     }
 
     @Override

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRemoteSourceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRemoteSourceFactory.java
@@ -29,10 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static com.facebook.presto.spark.util.PrestoSparkUtils.toSerializedPage;
-import static com.facebook.presto.spark.util.PrestoSparkUtils.transformMutableRowsToPages;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Iterators.transform;
 import static java.util.Objects.requireNonNull;
 
 public class PrestoSparkRemoteSourceFactory
@@ -64,13 +61,13 @@ public class PrestoSparkRemoteSourceFactory
             return new SparkRemoteSourceOperatorFactory(
                     operatorId,
                     planNodeId,
-                    transform(broadcastInput, sparkSerializedPage -> pagesSerde.deserialize(toSerializedPage(sparkSerializedPage))));
+                    new PrestoSparkSerializedPageInput(pagesSerde, broadcastInput));
         }
 
         return new SparkRemoteSourceOperatorFactory(
                 operatorId,
                 planNodeId,
-                transformMutableRowsToPages(shuffleInput, types));
+                new PrestoSparkMutableRowPageInput(types, shuffleInput));
     }
 
     @Override

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRemoteSourceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRemoteSourceFactory.java
@@ -17,7 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.operator.OperatorFactory;
-import com.facebook.presto.spark.classloader_interface.PrestoSparkRow;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
 import com.facebook.presto.spark.execution.PrestoSparkRemoteSourceOperator.SparkRemoteSourceOperatorFactory;
 import com.facebook.presto.spi.page.PagesSerde;
@@ -39,12 +39,12 @@ public class PrestoSparkRemoteSourceFactory
         implements RemoteSourceFactory
 {
     private final PagesSerde pagesSerde;
-    private final Map<PlanNodeId, Iterator<PrestoSparkRow>> shuffleInputs;
+    private final Map<PlanNodeId, Iterator<PrestoSparkMutableRow>> shuffleInputs;
     private final Map<PlanNodeId, Iterator<PrestoSparkSerializedPage>> broadcastInputs;
 
     public PrestoSparkRemoteSourceFactory(
             PagesSerde pagesSerde,
-            Map<PlanNodeId, Iterator<PrestoSparkRow>> shuffleInputs,
+            Map<PlanNodeId, Iterator<PrestoSparkMutableRow>> shuffleInputs,
             Map<PlanNodeId, Iterator<PrestoSparkSerializedPage>> broadcastInputs)
     {
         this.pagesSerde = requireNonNull(pagesSerde, "pagesSerde is null");
@@ -55,7 +55,7 @@ public class PrestoSparkRemoteSourceFactory
     @Override
     public OperatorFactory createRemoteSource(Session session, int operatorId, PlanNodeId planNodeId, List<Type> types)
     {
-        Iterator<PrestoSparkRow> shuffleInput = shuffleInputs.get(planNodeId);
+        Iterator<PrestoSparkMutableRow> shuffleInput = shuffleInputs.get(planNodeId);
         Iterator<PrestoSparkSerializedPage> broadcastInput = broadcastInputs.get(planNodeId);
         checkArgument(shuffleInput != null || broadcastInput != null, "input not found for plan node with id %s", planNodeId);
         checkArgument(shuffleInput == null || broadcastInput == null, "single remote source cannot accept both, broadcast and shuffle inputs");

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowBatch.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowBatch.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
+import com.google.common.collect.AbstractIterator;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceOutput;
+import org.openjdk.jol.info.ClassLayout;
+import scala.Tuple2;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkRowBatch
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(PrestoSparkRowBatch.class).instanceSize();
+
+    private static final int DEFAULT_TARGET_SIZE = 1024 * 1024;
+    private static final int DEFAULT_EXPECTED_ROWS_COUNT = 10000;
+    private static final int REPLICATED_ROW_PARTITION_ID = -1;
+
+    private final int partitionCount;
+    private final int rowCount;
+    private final byte[] rowData;
+    private final int[] rowPartitions;
+    private final int[] rowSizes;
+    private final long retainedSizeInBytes;
+
+    private PrestoSparkRowBatch(int partitionCount, int rowCount, byte[] rowData, int[] rowPartitions, int[] rowSizes)
+    {
+        this.partitionCount = partitionCount;
+        this.rowCount = rowCount;
+        this.rowData = requireNonNull(rowData, "rowData is null");
+        this.rowPartitions = requireNonNull(rowPartitions, "rowPartitions is null");
+        this.rowSizes = requireNonNull(rowSizes, "rowSizes is null");
+        this.retainedSizeInBytes = INSTANCE_SIZE
+                + sizeOf(rowData)
+                + sizeOf(rowPartitions)
+                + sizeOf(rowSizes);
+    }
+
+    public Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> createRowTupleIterator()
+    {
+        return new RowTupleIterator(partitionCount, rowCount, rowData, rowPartitions, rowSizes);
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    public static PrestoSparkRowBatchBuilder builder(int partitionCount)
+    {
+        return new PrestoSparkRowBatchBuilder(partitionCount, DEFAULT_TARGET_SIZE, DEFAULT_EXPECTED_ROWS_COUNT);
+    }
+
+    public static PrestoSparkRowBatchBuilder builder(int partitionCount, int targetSizeInBytes, int expectedRowsCount)
+    {
+        return new PrestoSparkRowBatchBuilder(partitionCount, targetSizeInBytes, expectedRowsCount);
+    }
+
+    public static class PrestoSparkRowBatchBuilder
+    {
+        private static final int BUILDER_INSTANCE_SIZE = ClassLayout.parseClass(PrestoSparkRowBatchBuilder.class).instanceSize();
+
+        private final int partitionCount;
+        private final int targetSizeInBytes;
+        private final DynamicSliceOutput sliceOutput;
+        private int[] rowSizes;
+        private int[] rowPartitions;
+        private int rowCount;
+
+        private int currentRowOffset;
+        private boolean openEntry;
+
+        private PrestoSparkRowBatchBuilder(int partitionCount, int targetSizeInBytes, int expectedRowsCount)
+        {
+            checkArgument(partitionCount > 0, "partitionCount must be greater then zero: %s", partitionCount);
+            this.partitionCount = partitionCount;
+            this.targetSizeInBytes = targetSizeInBytes;
+            sliceOutput = new DynamicSliceOutput((int) (targetSizeInBytes * 1.2f));
+            rowSizes = new int[expectedRowsCount];
+            rowPartitions = new int[expectedRowsCount];
+        }
+
+        public long getRetainedSizeInBytes()
+        {
+            return BUILDER_INSTANCE_SIZE + sliceOutput.getRetainedSize() + sizeOf(rowSizes) + sizeOf(rowPartitions);
+        }
+
+        public boolean isFull()
+        {
+            return sliceOutput.size() >= targetSizeInBytes;
+        }
+
+        public boolean isEmpty()
+        {
+            return rowCount == 0;
+        }
+
+        public SliceOutput beginRowEntry()
+        {
+            checkState(!openEntry, "previous entry must be closed before creating a new entry");
+            openEntry = true;
+            currentRowOffset = sliceOutput.size();
+            return sliceOutput;
+        }
+
+        public void closeEntryForNonReplicatedRow(int partition)
+        {
+            closeEntry(partition);
+        }
+
+        public void closeEntryForReplicatedRow()
+        {
+            closeEntry(REPLICATED_ROW_PARTITION_ID);
+        }
+
+        private void closeEntry(int partitionId)
+        {
+            checkState(openEntry, "entry must be opened first");
+            openEntry = false;
+
+            rowSizes = ensureCapacity(rowSizes, rowCount + 1);
+            rowSizes[rowCount] = sliceOutput.size() - currentRowOffset;
+
+            rowPartitions = ensureCapacity(rowPartitions, rowCount + 1);
+            rowPartitions[rowCount] = partitionId;
+
+            rowCount++;
+        }
+
+        private static int[] ensureCapacity(int[] array, int capacity)
+        {
+            if (array.length >= capacity) {
+                return array;
+            }
+            return Arrays.copyOf(array, capacity * 2);
+        }
+
+        public PrestoSparkRowBatch build()
+        {
+            checkState(!openEntry, "entry must be closed before creating a row batch");
+            return new PrestoSparkRowBatch(partitionCount, rowCount, sliceOutput.getUnderlyingSlice().byteArray(), rowPartitions, rowSizes);
+        }
+    }
+
+    private static class RowTupleIterator
+            extends AbstractIterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>
+    {
+        private final int partitionCount;
+        private final int rowCount;
+        private final int[] rowPartitions;
+        private final int[] rowSizes;
+
+        private int remainingReplicasCount;
+        private int currentRow;
+        private int currentOffset;
+        private final ByteBuffer rowData;
+        private final MutablePartitionId mutablePartitionId;
+        private final Tuple2<MutablePartitionId, PrestoSparkMutableRow> tuple;
+
+        private RowTupleIterator(int partitionCount, int rowCount, byte[] rowData, int[] rowPartitions, int[] rowSizes)
+        {
+            this.partitionCount = partitionCount;
+            this.rowCount = rowCount;
+            this.rowPartitions = requireNonNull(rowPartitions, "rowPartitions is null");
+            this.rowSizes = requireNonNull(rowSizes, "rowSizes is null");
+
+            this.rowData = ByteBuffer.wrap(requireNonNull(rowData, "rowData is null"));
+            mutablePartitionId = new MutablePartitionId();
+            PrestoSparkMutableRow row = new PrestoSparkMutableRow();
+            row.setBuffer(this.rowData);
+            tuple = new Tuple2<>(mutablePartitionId, row);
+        }
+
+        @Override
+        protected Tuple2<MutablePartitionId, PrestoSparkMutableRow> computeNext()
+        {
+            if (currentRow >= rowCount) {
+                return endOfData();
+            }
+
+            int rowSize = rowSizes[currentRow];
+            rowData.limit(currentOffset + rowSize);
+            rowData.position(currentOffset);
+
+            int partition = rowPartitions[currentRow];
+            if (partition == REPLICATED_ROW_PARTITION_ID) {
+                if (remainingReplicasCount == 0) {
+                    remainingReplicasCount = partitionCount;
+                }
+                mutablePartitionId.setPartition(remainingReplicasCount - 1);
+                remainingReplicasCount--;
+                if (remainingReplicasCount == 0) {
+                    currentRow++;
+                    currentOffset += rowSize;
+                }
+            }
+            else {
+                mutablePartitionId.setPartition(partition);
+                currentRow++;
+                currentOffset += rowSize;
+            }
+            return tuple;
+        }
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowBatch.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowBatch.java
@@ -31,6 +31,7 @@ import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
 public class PrestoSparkRowBatch
+        implements PrestoSparkBufferedResult
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(PrestoSparkRowBatch.class).instanceSize();
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowBuffer.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowBuffer.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.spark.execution;
 
 import com.facebook.presto.execution.buffer.OutputBufferMemoryManager;
-import com.facebook.presto.spark.classloader_interface.PrestoSparkRow;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.openjdk.jol.info.ClassLayout;
@@ -66,7 +66,7 @@ public class PrestoSparkRowBuffer
         }
     }
 
-    public List<PrestoSparkRow> get()
+    public List<PrestoSparkMutableRow> get()
             throws InterruptedException
     {
         BufferedRows bufferedRows = null;
@@ -91,16 +91,16 @@ public class PrestoSparkRowBuffer
     {
         private static final int INSTANCE_SIZE = ClassLayout.parseClass(BufferedRows.class).instanceSize();
 
-        private final List<PrestoSparkRow> rowsList;
+        private final List<PrestoSparkMutableRow> rowsList;
         private final int rowsListRetainedSize;
 
-        public BufferedRows(List<PrestoSparkRow> rowsList, int rowsListRetainedSize)
+        public BufferedRows(List<PrestoSparkMutableRow> rowsList, int rowsListRetainedSize)
         {
             this.rowsList = ImmutableList.copyOf(requireNonNull(rowsList, "rowsList is null"));
             this.rowsListRetainedSize = rowsListRetainedSize;
         }
 
-        public List<PrestoSparkRow> getRows()
+        public List<PrestoSparkMutableRow> getRows()
         {
             return rowsList;
         }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowOutputOperator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowOutputOperator.java
@@ -41,10 +41,10 @@ import java.util.function.Function;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
-public class PrestoSparkOutputOperator
+public class PrestoSparkRowOutputOperator
         implements Operator
 {
-    public static class PrestoSparkOutputFactory
+    public static class PrestoSparkRowOutputFactory
             implements OutputFactory
     {
         private static final OutputPartitioning SINGLE_PARTITION = new OutputPartitioning(
@@ -54,11 +54,11 @@ public class PrestoSparkOutputOperator
                 false,
                 OptionalInt.empty());
 
-        private final PrestoSparkRowBuffer rowBuffer;
+        private final PrestoSparkOutputBuffer<PrestoSparkRowBatch> outputBuffer;
 
-        public PrestoSparkOutputFactory(PrestoSparkRowBuffer rowBuffer)
+        public PrestoSparkRowOutputFactory(PrestoSparkOutputBuffer<PrestoSparkRowBatch> outputBuffer)
         {
-            this.rowBuffer = requireNonNull(rowBuffer, "rowBuffer is null");
+            this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
         }
 
         @Override
@@ -71,10 +71,10 @@ public class PrestoSparkOutputOperator
                 PagesSerdeFactory serdeFactory)
         {
             OutputPartitioning partitioning = outputPartitioning.orElse(SINGLE_PARTITION);
-            return new PrestoSparkOutputOperatorFactory(
+            return new PrestoSparkRowOutputOperatorFactory(
                     operatorId,
                     planNodeId,
-                    rowBuffer,
+                    outputBuffer,
                     pagePreprocessor,
                     partitioning.getPartitionFunction(),
                     partitioning.getPartitionChannels(),
@@ -102,12 +102,12 @@ public class PrestoSparkOutputOperator
         }
     }
 
-    public static class PrestoSparkOutputOperatorFactory
+    public static class PrestoSparkRowOutputOperatorFactory
             implements OperatorFactory
     {
         private final int operatorId;
         private final PlanNodeId planNodeId;
-        private final PrestoSparkRowBuffer rowBuffer;
+        private final PrestoSparkOutputBuffer<PrestoSparkRowBatch> outputBuffer;
         private final Function<Page, Page> pagePreprocessor;
         private final PartitionFunction partitionFunction;
         private final List<Integer> partitionChannels;
@@ -115,10 +115,10 @@ public class PrestoSparkOutputOperator
         private final boolean replicateNullsAndAny;
         private final OptionalInt nullChannel;
 
-        public PrestoSparkOutputOperatorFactory(
+        public PrestoSparkRowOutputOperatorFactory(
                 int operatorId,
                 PlanNodeId planNodeId,
-                PrestoSparkRowBuffer rowBuffer,
+                PrestoSparkOutputBuffer<PrestoSparkRowBatch> outputBuffer,
                 Function<Page, Page> pagePreprocessor,
                 PartitionFunction partitionFunction,
                 List<Integer> partitionChannels,
@@ -128,7 +128,7 @@ public class PrestoSparkOutputOperator
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
-            this.rowBuffer = requireNonNull(rowBuffer, "rowBuffer is null");
+            this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
             this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
             this.partitionFunction = requireNonNull(partitionFunction, "partitionFunction is null");
             this.partitionChannels = requireNonNull(partitionChannels, "partitionChannels is null");
@@ -140,11 +140,11 @@ public class PrestoSparkOutputOperator
         @Override
         public Operator createOperator(DriverContext driverContext)
         {
-            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, PrestoSparkOutputOperator.class.getSimpleName());
-            return new PrestoSparkOutputOperator(
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, PrestoSparkRowOutputOperator.class.getSimpleName());
+            return new PrestoSparkRowOutputOperator(
                     operatorContext,
-                    operatorContext.newLocalSystemMemoryContext(PrestoSparkOutputOperator.class.getSimpleName()),
-                    rowBuffer,
+                    operatorContext.newLocalSystemMemoryContext(PrestoSparkRowOutputOperator.class.getSimpleName()),
+                    outputBuffer,
                     pagePreprocessor,
                     partitionFunction,
                     partitionChannels,
@@ -161,10 +161,10 @@ public class PrestoSparkOutputOperator
         @Override
         public OperatorFactory duplicate()
         {
-            return new PrestoSparkOutputOperatorFactory(
+            return new PrestoSparkRowOutputOperatorFactory(
                     operatorId,
                     planNodeId,
-                    rowBuffer,
+                    outputBuffer,
                     pagePreprocessor,
                     partitionFunction,
                     partitionChannels,
@@ -176,7 +176,7 @@ public class PrestoSparkOutputOperator
 
     private final OperatorContext operatorContext;
     private final LocalMemoryContext systemMemoryContext;
-    private final PrestoSparkRowBuffer rowBuffer;
+    private final PrestoSparkOutputBuffer<PrestoSparkRowBatch> outputBuffer;
     private final Function<Page, Page> pagePreprocessor;
     private final PartitionFunction partitionFunction;
     private final List<Integer> partitionChannels;
@@ -189,10 +189,10 @@ public class PrestoSparkOutputOperator
     private boolean finished;
     private boolean hasAnyRowBeenReplicated;
 
-    public PrestoSparkOutputOperator(
+    public PrestoSparkRowOutputOperator(
             OperatorContext operatorContext,
             LocalMemoryContext systemMemoryContext,
-            PrestoSparkRowBuffer rowBuffer,
+            PrestoSparkOutputBuffer<PrestoSparkRowBatch> outputBuffer,
             Function<Page, Page> pagePreprocessor,
             PartitionFunction partitionFunction,
             List<Integer> partitionChannels,
@@ -202,7 +202,7 @@ public class PrestoSparkOutputOperator
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
-        this.rowBuffer = requireNonNull(rowBuffer, "rowBuffer is null");
+        this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
         this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
         this.partitionFunction = requireNonNull(partitionFunction, "partitionFunction is null");
         this.partitionChannels = ImmutableList.copyOf(requireNonNull(partitionChannels, "partitionChannels is null"));
@@ -220,7 +220,7 @@ public class PrestoSparkOutputOperator
     @Override
     public ListenableFuture<?> isBlocked()
     {
-        return rowBuffer.isFull();
+        return outputBuffer.isFull();
     }
 
     @Override
@@ -249,7 +249,7 @@ public class PrestoSparkOutputOperator
         Page partitionFunctionArguments = getPartitionFunctionArguments(page);
         for (int position = 0; position < positionCount; position++) {
             if (rowBatchBuilder.isFull()) {
-                rowBuffer.enqueue(rowBatchBuilder.build());
+                outputBuffer.enqueue(rowBatchBuilder.build());
                 rowBatchBuilder = PrestoSparkRowBatch.builder(partitionCount);
             }
 
@@ -302,7 +302,7 @@ public class PrestoSparkOutputOperator
     public void finish()
     {
         if (rowBatchBuilder != null && !rowBatchBuilder.isEmpty()) {
-            rowBuffer.enqueue(rowBatchBuilder.build());
+            outputBuffer.enqueue(rowBatchBuilder.build());
             rowBatchBuilder = null;
         }
         updateMemoryContext();

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkSerializedPageInput.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkSerializedPageInput.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
+import com.facebook.presto.spi.page.PagesSerde;
+
+import java.util.Iterator;
+
+import static com.facebook.presto.spark.util.PrestoSparkUtils.toSerializedPage;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkSerializedPageInput
+        implements PrestoSparkPageInput
+{
+    private final PagesSerde pagesSerde;
+    private final Iterator<PrestoSparkSerializedPage> serializedPageIterator;
+
+    public PrestoSparkSerializedPageInput(PagesSerde pagesSerde, Iterator<PrestoSparkSerializedPage> serializedPageIterator)
+    {
+        this.pagesSerde = requireNonNull(pagesSerde, "pagesSerde is null");
+        this.serializedPageIterator = requireNonNull(serializedPageIterator, "serializedPageIterator is null");
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        PrestoSparkSerializedPage prestoSparkSerializedPage;
+        synchronized (serializedPageIterator) {
+            if (!serializedPageIterator.hasNext()) {
+                return null;
+            }
+            prestoSparkSerializedPage = serializedPageIterator.next();
+        }
+        return pagesSerde.deserialize(toSerializedPage(prestoSparkSerializedPage));
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -32,6 +32,7 @@ import com.facebook.presto.memory.MemoryPool;
 import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.operator.OutputFactory;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.spark.PrestoSparkAuthenticatorProvider;
@@ -42,10 +43,12 @@ import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskInputs;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskOutput;
 import com.facebook.presto.spark.classloader_interface.SerializedPrestoSparkTaskDescriptor;
 import com.facebook.presto.spark.classloader_interface.SerializedPrestoSparkTaskSource;
 import com.facebook.presto.spark.classloader_interface.SerializedTaskStats;
-import com.facebook.presto.spark.execution.PrestoSparkOutputOperator.PrestoSparkOutputFactory;
+import com.facebook.presto.spark.execution.PrestoSparkPageOutputOperator.PrestoSparkPageOutputFactory;
+import com.facebook.presto.spark.execution.PrestoSparkRowOutputOperator.PrestoSparkRowOutputFactory;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.page.PagesSerde;
 import com.facebook.presto.spi.plan.PlanNodeId;
@@ -77,6 +80,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static com.facebook.presto.spark.util.PrestoSparkUtils.toPrestoSparkSerializedPage;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.propagateIfPossible;
@@ -204,29 +208,31 @@ public class PrestoSparkTaskExecutorFactory
     }
 
     @Override
-    public IPrestoSparkTaskExecutor create(
+    public <T extends PrestoSparkTaskOutput> IPrestoSparkTaskExecutor<T> create(
             int partitionId,
             int attemptNumber,
             SerializedPrestoSparkTaskDescriptor serializedTaskDescriptor,
             Iterator<SerializedPrestoSparkTaskSource> serializedTaskSources,
             PrestoSparkTaskInputs inputs,
-            CollectionAccumulator<SerializedTaskStats> taskStatsCollector)
+            CollectionAccumulator<SerializedTaskStats> taskStatsCollector,
+            Class<T> outputType)
     {
         try {
-            return doCreate(partitionId, attemptNumber, serializedTaskDescriptor, serializedTaskSources, inputs, taskStatsCollector);
+            return doCreate(partitionId, attemptNumber, serializedTaskDescriptor, serializedTaskSources, inputs, taskStatsCollector, outputType);
         }
         catch (RuntimeException e) {
             throw executionExceptionFactory.toPrestoSparkExecutionException(e);
         }
     }
 
-    public IPrestoSparkTaskExecutor doCreate(
+    public <T extends PrestoSparkTaskOutput> IPrestoSparkTaskExecutor<T> doCreate(
             int partitionId,
             int attemptNumber,
             SerializedPrestoSparkTaskDescriptor serializedTaskDescriptor,
             Iterator<SerializedPrestoSparkTaskSource> serializedTaskSources,
             PrestoSparkTaskInputs inputs,
-            CollectionAccumulator<SerializedTaskStats> taskStatsCollector)
+            CollectionAccumulator<SerializedTaskStats> taskStatsCollector,
+            Class<T> outputType)
     {
         PrestoSparkTaskDescriptor taskDescriptor = taskDescriptorJsonCodec.fromJson(serializedTaskDescriptor.getBytes());
         ImmutableMap.Builder<String, TokenAuthenticator> extraAuthenticators = ImmutableMap.builder();
@@ -276,40 +282,55 @@ public class PrestoSparkTaskExecutorFactory
                 allocationTrackingEnabled,
                 false);
 
+        ImmutableMap.Builder<PlanNodeId, Iterator<PrestoSparkMutableRow>> rowInputs = ImmutableMap.builder();
+        ImmutableMap.Builder<PlanNodeId, Iterator<PrestoSparkSerializedPage>> pageInputs = ImmutableMap.builder();
+        for (RemoteSourceNode remoteSource : fragment.getRemoteSourceNodes()) {
+            List<Iterator<PrestoSparkMutableRow>> remoteSourceRowInputs = new ArrayList<>();
+            List<Iterator<PrestoSparkSerializedPage>> remoteSourcePageInputs = new ArrayList<>();
+            for (PlanFragmentId sourceFragmentId : remoteSource.getSourceFragmentIds()) {
+                Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> shuffleInput = inputs.getShuffleInputs().get(sourceFragmentId.toString());
+                Broadcast<List<PrestoSparkSerializedPage>> broadcastInput = inputs.getBroadcastInputs().get(sourceFragmentId.toString());
+                List<PrestoSparkSerializedPage> inMemoryInput = inputs.getInMemoryInputs().get(sourceFragmentId.toString());
+
+                if (shuffleInput != null) {
+                    checkArgument(broadcastInput == null, "single remote source is not expected to accept different kind of inputs");
+                    checkArgument(inMemoryInput == null, "single remote source is not expected to accept different kind of inputs");
+                    remoteSourceRowInputs.add(Iterators.transform(shuffleInput, tuple -> tuple._2));
+                    continue;
+                }
+
+                if (broadcastInput != null) {
+                    checkArgument(inMemoryInput == null, "single remote source is not expected to accept different kind of inputs");
+                    // TODO: Enable NullifyingIterator once migrated to one task per JVM model
+                    // NullifyingIterator removes element from the list upon return
+                    // This allows GC to gradually reclaim memory
+                    // remoteSourcePageInputs.add(getNullifyingIterator(broadcastInput.value()));
+                    remoteSourcePageInputs.add(broadcastInput.value().iterator());
+                    continue;
+                }
+
+                if (inMemoryInput != null) {
+                    remoteSourcePageInputs.add(inMemoryInput.iterator());
+                    continue;
+                }
+
+                throw new IllegalArgumentException("Input not found for sourceFragmentId: " + sourceFragmentId);
+            }
+            if (!remoteSourceRowInputs.isEmpty()) {
+                rowInputs.put(remoteSource.getId(), Iterators.concat(remoteSourceRowInputs.iterator()));
+            }
+            if (!remoteSourcePageInputs.isEmpty()) {
+                pageInputs.put(remoteSource.getId(), Iterators.concat(remoteSourcePageInputs.iterator()));
+            }
+        }
+
         OutputBufferMemoryManager memoryManager = new OutputBufferMemoryManager(
                 sinkMaxBufferSize.toBytes(),
                 () -> queryContext.getTaskContextByTaskId(taskId).localSystemMemoryContext(),
                 notificationExecutor);
-        PrestoSparkRowBuffer rowBuffer = new PrestoSparkRowBuffer(memoryManager);
-
-        ImmutableMap.Builder<PlanNodeId, Iterator<PrestoSparkMutableRow>> shuffleInputs = ImmutableMap.builder();
-        ImmutableMap.Builder<PlanNodeId, Iterator<PrestoSparkSerializedPage>> broadcastInputs = ImmutableMap.builder();
-        for (RemoteSourceNode remoteSource : fragment.getRemoteSourceNodes()) {
-            List<Iterator<PrestoSparkMutableRow>> shuffleRemoteSourceInputs = new ArrayList<>();
-            List<Iterator<PrestoSparkSerializedPage>> broadcastRemoteSourceInputs = new ArrayList<>();
-            for (PlanFragmentId sourceFragmentId : remoteSource.getSourceFragmentIds()) {
-                Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> shuffleInput = inputs.getShuffleInputs().get(sourceFragmentId.toString());
-                Broadcast<List<PrestoSparkSerializedPage>> broadcastInput = inputs.getBroadcastInputs().get(sourceFragmentId.toString());
-                checkArgument(shuffleInput != null || broadcastInput != null, "Input not found for sourceFragmentId: %s", sourceFragmentId);
-                checkArgument(shuffleInput == null || broadcastInput == null, "Single remote source cannot accept both, broadcast and shuffle inputs");
-                if (shuffleInput != null) {
-                    shuffleRemoteSourceInputs.add(Iterators.transform(shuffleInput, tuple -> tuple._2));
-                }
-                if (broadcastInput != null) {
-                    // TODO: Enable NullifyingIterator once migrated to one task per JVM model
-                    // NullifyingIterator removes element from the list upon return
-                    // This allows GC to gradually reclaim memory
-                    // broadcastRemoteSourceInputs.add(getNullifyingIterator(broadcastInput.value()));
-                    broadcastRemoteSourceInputs.add(broadcastInput.value().iterator());
-                }
-            }
-            if (!shuffleRemoteSourceInputs.isEmpty()) {
-                shuffleInputs.put(remoteSource.getId(), Iterators.concat(shuffleRemoteSourceInputs.iterator()));
-            }
-            if (!broadcastRemoteSourceInputs.isEmpty()) {
-                broadcastInputs.put(remoteSource.getId(), Iterators.concat(broadcastRemoteSourceInputs.iterator()));
-            }
-        }
+        PagesSerde pagesSerde = new PagesSerde(blockEncodingManager, Optional.empty(), Optional.empty(), Optional.empty());
+        Output<T> output = configureOutput(outputType, pagesSerde, memoryManager);
+        PrestoSparkOutputBuffer<?> outputBuffer = output.getOutputBuffer();
 
         LocalExecutionPlan localExecutionPlan = localExecutionPlanner.plan(
                 taskContext,
@@ -317,18 +338,18 @@ public class PrestoSparkTaskExecutorFactory
                 fragment.getPartitioningScheme(),
                 fragment.getStageExecutionDescriptor(),
                 fragment.getTableScanSchedulingOrder(),
-                new PrestoSparkOutputFactory(rowBuffer),
+                output.getOutputFactory(),
                 new PrestoSparkRemoteSourceFactory(
-                        new PagesSerde(blockEncodingManager, Optional.empty(), Optional.empty(), Optional.empty()),
-                        shuffleInputs.build(),
-                        broadcastInputs.build()),
+                        pagesSerde,
+                        rowInputs.build(),
+                        pageInputs.build()),
                 taskDescriptor.getTableWriteInfo(),
                 true);
 
         TaskStateMachine taskStateMachine = new TaskStateMachine(taskId, notificationExecutor);
         taskStateMachine.addStateChangeListener(state -> {
             if (state.isDone()) {
-                rowBuffer.setNoMoreRows();
+                outputBuffer.setNoMoreRows();
             }
         });
 
@@ -342,46 +363,67 @@ public class PrestoSparkTaskExecutorFactory
 
         taskExecution.start(taskSources);
 
-        return new PrestoSparkTaskExecutor(
+        return new PrestoSparkTaskExecutor<>(
                 taskContext,
                 taskStateMachine,
-                rowBuffer,
+                output.getOutputSupplier(),
                 taskStatsJsonCodec,
                 taskStatsCollector,
                 executionExceptionFactory);
     }
 
-    private static class PrestoSparkTaskExecutor
-            extends AbstractIterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>
-            implements IPrestoSparkTaskExecutor
+    @SuppressWarnings("unchecked")
+    private static <T extends PrestoSparkTaskOutput> Output<T> configureOutput(
+            Class<T> outputType,
+            PagesSerde pagesSerde,
+            OutputBufferMemoryManager memoryManager)
+    {
+        if (outputType.equals(PrestoSparkMutableRow.class)) {
+            PrestoSparkOutputBuffer<PrestoSparkRowBatch> outputBuffer = new PrestoSparkOutputBuffer<>(memoryManager);
+            OutputFactory outputFactory = new PrestoSparkRowOutputFactory(outputBuffer);
+            OutputSupplier<T> outputSupplier = (OutputSupplier<T>) new RowOutputSupplier(outputBuffer);
+            return new Output<>(outputBuffer, outputFactory, outputSupplier);
+        }
+        else if (outputType.equals(PrestoSparkSerializedPage.class)) {
+            PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer = new PrestoSparkOutputBuffer<>(memoryManager);
+            OutputFactory outputFactory = new PrestoSparkPageOutputFactory(outputBuffer, pagesSerde);
+            OutputSupplier<T> outputSupplier = (OutputSupplier<T>) new PageOutputSupplier(outputBuffer);
+            return new Output<>(outputBuffer, outputFactory, outputSupplier);
+        }
+        else {
+            throw new IllegalArgumentException("Unexpected output type: " + outputType.getName());
+        }
+    }
+
+    private static class PrestoSparkTaskExecutor<T extends PrestoSparkTaskOutput>
+            extends AbstractIterator<Tuple2<MutablePartitionId, T>>
+            implements IPrestoSparkTaskExecutor<T>
     {
         private final TaskContext taskContext;
         private final TaskStateMachine taskStateMachine;
-        private final PrestoSparkRowBuffer rowBuffer;
+        private final OutputSupplier<T> outputSupplier;
         private final JsonCodec<TaskStats> taskStatsJsonCodec;
         private final CollectionAccumulator<SerializedTaskStats> taskStatsCollector;
         private final PrestoSparkExecutionExceptionFactory executionExceptionFactory;
 
-        private Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> currentRowBatchIterator;
-
         private PrestoSparkTaskExecutor(
                 TaskContext taskContext,
                 TaskStateMachine taskStateMachine,
-                PrestoSparkRowBuffer rowBuffer,
+                OutputSupplier<T> outputSupplier,
                 JsonCodec<TaskStats> taskStatsJsonCodec,
                 CollectionAccumulator<SerializedTaskStats> taskStatsCollector,
                 PrestoSparkExecutionExceptionFactory executionExceptionFactory)
         {
             this.taskContext = requireNonNull(taskContext, "taskContext is null");
             this.taskStateMachine = requireNonNull(taskStateMachine, "taskStateMachine is null");
-            this.rowBuffer = requireNonNull(rowBuffer, "rowBuffer is null");
+            this.outputSupplier = requireNonNull(outputSupplier, "outputSupplier is null");
             this.taskStatsJsonCodec = requireNonNull(taskStatsJsonCodec, "taskStatsJsonCodec is null");
             this.taskStatsCollector = requireNonNull(taskStatsCollector, "taskStatsCollector is null");
             this.executionExceptionFactory = requireNonNull(executionExceptionFactory, "executionExceptionFactory is null");
         }
 
         @Override
-        protected Tuple2<MutablePartitionId, PrestoSparkMutableRow> computeNext()
+        protected Tuple2<MutablePartitionId, T> computeNext()
         {
             try {
                 return doComputeNext();
@@ -396,12 +438,12 @@ public class PrestoSparkTaskExecutorFactory
             }
         }
 
-        private Tuple2<MutablePartitionId, PrestoSparkMutableRow> doComputeNext()
+        private Tuple2<MutablePartitionId, T> doComputeNext()
                 throws InterruptedException
         {
-            Tuple2<MutablePartitionId, PrestoSparkMutableRow> row = getNextRow();
-            if (row != null) {
-                return row;
+            Tuple2<MutablePartitionId, T> output = outputSupplier.getNext();
+            if (output != null) {
+                return output;
             }
 
             //  TODO: Implement task stats collection
@@ -423,21 +465,96 @@ public class PrestoSparkTaskExecutorFactory
             propagateIfPossible(failure, InterruptedException.class);
             throw new RuntimeException(failure);
         }
+    }
 
-        private Tuple2<MutablePartitionId, PrestoSparkMutableRow> getNextRow()
+    private static class Output<T extends PrestoSparkTaskOutput>
+    {
+        private final PrestoSparkOutputBuffer<?> outputBuffer;
+        private final OutputFactory outputFactory;
+        private final OutputSupplier<T> outputSupplier;
+
+        private Output(
+                PrestoSparkOutputBuffer<?> outputBuffer,
+                OutputFactory outputFactory,
+                OutputSupplier<T> outputSupplier)
+        {
+            this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
+            this.outputFactory = requireNonNull(outputFactory, "outputFactory is null");
+            this.outputSupplier = requireNonNull(outputSupplier, "outputSupplier is null");
+        }
+
+        public PrestoSparkOutputBuffer<?> getOutputBuffer()
+        {
+            return outputBuffer;
+        }
+
+        public OutputFactory getOutputFactory()
+        {
+            return outputFactory;
+        }
+
+        public OutputSupplier<T> getOutputSupplier()
+        {
+            return outputSupplier;
+        }
+    }
+
+    private interface OutputSupplier<T extends PrestoSparkTaskOutput>
+    {
+        Tuple2<MutablePartitionId, T> getNext()
+                throws InterruptedException;
+    }
+
+    private static class RowOutputSupplier
+            implements OutputSupplier<PrestoSparkMutableRow>
+    {
+        private final PrestoSparkOutputBuffer<PrestoSparkRowBatch> outputBuffer;
+        private Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> rowBatchIterator;
+
+        private RowOutputSupplier(PrestoSparkOutputBuffer<PrestoSparkRowBatch> outputBuffer)
+        {
+            this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
+        }
+
+        @Override
+        public Tuple2<MutablePartitionId, PrestoSparkMutableRow> getNext()
                 throws InterruptedException
         {
-            if (currentRowBatchIterator == null || !currentRowBatchIterator.hasNext()) {
-                PrestoSparkRowBatch rowBatch = rowBuffer.get();
+            if (rowBatchIterator == null || !rowBatchIterator.hasNext()) {
+                PrestoSparkRowBatch rowBatch = outputBuffer.get();
                 if (rowBatch == null) {
                     return null;
                 }
-                this.currentRowBatchIterator = rowBatch.createRowTupleIterator();
-                if (!currentRowBatchIterator.hasNext()) {
+                this.rowBatchIterator = rowBatch.createRowTupleIterator();
+                if (!rowBatchIterator.hasNext()) {
                     return null;
                 }
             }
-            return currentRowBatchIterator.next();
+            return rowBatchIterator.next();
+        }
+    }
+
+    private static class PageOutputSupplier
+            implements OutputSupplier<PrestoSparkSerializedPage>
+    {
+        private static final MutablePartitionId DEFAULT_PARTITION = new MutablePartitionId();
+
+        private final PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer;
+
+        private PageOutputSupplier(PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer)
+        {
+            this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
+        }
+
+        @Override
+        public Tuple2<MutablePartitionId, PrestoSparkSerializedPage> getNext()
+                throws InterruptedException
+        {
+            PrestoSparkBufferedSerializedPage page = outputBuffer.get();
+            if (page == null) {
+                return null;
+            }
+            return new Tuple2<>(DEFAULT_PARTITION, toPrestoSparkSerializedPage(page.getSerializedPage()));
         }
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkPartitioner;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleSerializer;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskExecutorFactoryProvider;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskProcessor;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskRdd;
@@ -55,6 +56,7 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.rdd.RDD;
+import org.apache.spark.rdd.ShuffledRDD;
 import org.apache.spark.util.CollectionAccumulator;
 import scala.Tuple2;
 import scala.reflect.ClassTag;
@@ -175,7 +177,7 @@ public class PrestoSparkRddFactory
             }
 
             Map<PlanFragmentId, JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow>> partitionedInputs = rddInputs.entrySet().stream()
-                    .collect(toImmutableMap(Entry::getKey, entry -> entry.getValue().partitionBy(createPartitioner(session, partitioning))));
+                    .collect(toImmutableMap(Entry::getKey, entry -> partitionBy(entry.getValue(), createPartitioner(session, partitioning))));
 
             return createRdd(
                     sparkContext,
@@ -204,6 +206,17 @@ public class PrestoSparkRddFactory
             return fragment.withBucketToPartition(Optional.of(IntStream.range(0, connectorPartitionCount).toArray()));
         }
         return fragment;
+    }
+
+    private static JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow> partitionBy(JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow> rdd, Partitioner partitioner)
+    {
+        JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow> javaPairRdd = rdd.partitionBy(partitioner);
+        ShuffledRDD<MutablePartitionId, PrestoSparkMutableRow, PrestoSparkMutableRow> shuffledRdd = (ShuffledRDD<MutablePartitionId, PrestoSparkMutableRow, PrestoSparkMutableRow>) javaPairRdd.rdd();
+        shuffledRdd.setSerializer(new PrestoSparkShuffleSerializer());
+        return JavaPairRDD.fromRDD(
+                shuffledRdd,
+                classTag(MutablePartitionId.class),
+                classTag(PrestoSparkMutableRow.class));
     }
 
     private Partitioner createPartitioner(Session session, PartitioningHandle partitioning)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
@@ -17,7 +17,7 @@ import com.facebook.presto.common.Page;
 import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.spark.classloader_interface.PrestoSparkRow;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
 import com.facebook.presto.spi.page.SerializedPage;
 import com.google.common.collect.AbstractIterator;
@@ -38,7 +38,7 @@ public class PrestoSparkUtils
 {
     private PrestoSparkUtils() {}
 
-    public static Iterator<Page> transformRowsToPages(Iterator<PrestoSparkRow> rows, List<Type> types)
+    public static Iterator<Page> transformRowsToPages(Iterator<PrestoSparkMutableRow> rows, List<Type> types)
     {
         return new AbstractIterator<Page>()
         {
@@ -50,7 +50,7 @@ public class PrestoSparkUtils
                 }
                 PageBuilder pageBuilder = new PageBuilder(types);
                 while (rows.hasNext() && !pageBuilder.isFull()) {
-                    PrestoSparkRow row = rows.next();
+                    PrestoSparkMutableRow row = rows.next();
                     SliceInput sliceInput = new BasicSliceInput(wrappedBuffer(row.getBytes(), 0, row.getLength()));
                     pageBuilder.declarePosition();
                     for (int channel = 0; channel < types.size(); channel++) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
@@ -18,7 +18,6 @@ import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMaterializedRow;
-import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
 import com.facebook.presto.spi.page.SerializedPage;
 import com.google.common.collect.AbstractIterator;
@@ -51,36 +50,6 @@ public class PrestoSparkUtils
                 while (rows.hasNext() && !pageBuilder.isFull()) {
                     PrestoSparkMaterializedRow row = rows.next();
                     SliceInput sliceInput = Slices.wrappedBuffer(row.getData()).getInput();
-                    pageBuilder.declarePosition();
-                    for (int channel = 0; channel < types.size(); channel++) {
-                        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(channel);
-                        blockBuilder.readPositionFrom(sliceInput);
-                    }
-                    sliceInput.close();
-                }
-                verify(!pageBuilder.isEmpty());
-                return pageBuilder.build();
-            }
-        };
-    }
-
-    /**
-     * TODO: Transitional method. Will be removed in the next commit.
-     */
-    public static Iterator<Page> transformMutableRowsToPages(Iterator<PrestoSparkMutableRow> rows, List<Type> types)
-    {
-        return new AbstractIterator<Page>()
-        {
-            @Override
-            protected Page computeNext()
-            {
-                if (!rows.hasNext()) {
-                    return endOfData();
-                }
-                PageBuilder pageBuilder = new PageBuilder(types);
-                while (rows.hasNext() && !pageBuilder.isFull()) {
-                    PrestoSparkMutableRow row = rows.next();
-                    SliceInput sliceInput = Slices.wrappedBuffer(row.getBuffer()).getInput();
                     pageBuilder.declarePosition();
                     for (int channel = 0; channel < types.size(); channel++) {
                         BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(channel);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -13,8 +13,11 @@
  */
 package com.facebook.presto.spark;
 
+import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import org.testng.annotations.Test;
+
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 
 public class TestPrestoSparkQueryRunner
         extends AbstractTestQueryFramework
@@ -302,6 +305,15 @@ public class TestPrestoSparkQueryRunner
         assertQuery(
                 "SELECT count(*) FROM (SELECT orderkey, count(*) FROM hive.hive_test.empty_orders_bucketed GROUP BY orderkey)",
                 "SELECT 0");
+    }
+
+    @Test
+    public void testLimit()
+    {
+        MaterializedResult actual = computeActual("SELECT * FROM orders LIMIT 10");
+        assertEquals(actual.getRowCount(), 10);
+        actual = computeActual("SELECT 'a' FROM orders LIMIT 10");
+        assertEquals(actual.getRowCount(), 10);
     }
 
     private void assertBucketedQuery(String sql)

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestPrestoSparkRowBatch.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestPrestoSparkRowBatch.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
+import com.facebook.presto.spark.execution.PrestoSparkRowBatch.PrestoSparkRowBatchBuilder;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.SliceOutput;
+import org.testng.annotations.Test;
+import scala.Tuple2;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Streams.stream;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestPrestoSparkRowBatch
+{
+    @Test
+    public void testRoundTrip()
+    {
+        assertRoundTrip(ImmutableList.of());
+        assertRoundTrip(ImmutableList.of(createTuple(1, "row_data_1")));
+        assertRoundTrip(ImmutableList.of(createTuple(1, "")));
+        assertRoundTrip(ImmutableList.of(createTuple(1, ""), createTuple(1, "")));
+        assertRoundTrip(ImmutableList.of(createTuple(1, ""), createTuple(1, ""), createTuple(1, "")));
+        assertRoundTrip(ImmutableList.of(createTuple(1, "row_data_1"), createTuple(1, "row_data_2")));
+        assertRoundTrip(ImmutableList.of(createTuple(1, "row_data_1"), createTuple(2, "row_data_2")));
+        assertRoundTrip(ImmutableList.of(createTuple(1, "row_data_1"), createTuple(2, "row_data_2")));
+        assertRoundTrip(IntStream.range(0, 4)
+                .mapToObj(i -> createTuple(i, "row_data_" + i))
+                .collect(toImmutableList()));
+        assertRoundTrip(IntStream.range(0, 5)
+                .mapToObj(i -> createTuple(i, "row_data"))
+                .collect(toImmutableList()));
+        assertRoundTrip(IntStream.range(0, 20)
+                .mapToObj(i -> createTuple(i, ""))
+                .collect(toImmutableList()));
+        assertRoundTrip(IntStream.range(0, 20)
+                .mapToObj(i -> createTuple(0, ""))
+                .collect(toImmutableList()));
+    }
+
+    @Test
+    public void testBuilderFull()
+    {
+        PrestoSparkRowBatchBuilder builder = PrestoSparkRowBatch.builder(10, 5, 10);
+        assertFalse(builder.isFull());
+        assertTrue(builder.isEmpty());
+        addRow(createTuple(1, "12345"), builder);
+        assertTrue(builder.isFull());
+        assertFalse(builder.isEmpty());
+    }
+
+    @Test
+    public void testReplicatedRows()
+    {
+        PrestoSparkRowBatchBuilder builder = PrestoSparkRowBatch.builder(1);
+        addReplicatedRow(createRow("replicated"), builder);
+        assertContains(builder.build(), ImmutableList.of(createTuple(0, "replicated")));
+
+        builder = PrestoSparkRowBatch.builder(2);
+        addReplicatedRow(createRow("replicated"), builder);
+        assertContains(builder.build(), ImmutableList.of(createTuple(1, "replicated"), createTuple(0, "replicated")));
+
+        builder = PrestoSparkRowBatch.builder(3);
+        addReplicatedRow(createRow("replicated"), builder);
+        assertContains(builder.build(), ImmutableList.of(createTuple(2, "replicated"), createTuple(1, "replicated"), createTuple(0, "replicated")));
+
+        builder = PrestoSparkRowBatch.builder(2);
+        addReplicatedRow(createRow("replicated"), builder);
+        addRow(createTuple(101, "non_replicated_1"), builder);
+        assertContains(builder.build(), ImmutableList.of(
+                createTuple(1, "replicated"),
+                createTuple(0, "replicated"),
+                createTuple(101, "non_replicated_1")));
+
+        builder = PrestoSparkRowBatch.builder(2);
+        addRow(createTuple(202, "non_replicated_22"), builder);
+        addReplicatedRow(createRow("replicated"), builder);
+        assertContains(builder.build(), ImmutableList.of(
+                createTuple(202, "non_replicated_22"),
+                createTuple(1, "replicated"),
+                createTuple(0, "replicated")));
+
+        builder = PrestoSparkRowBatch.builder(2);
+        addRow(createTuple(202, "non_replicated_22"), builder);
+        addReplicatedRow(createRow("replicated"), builder);
+        addRow(createTuple(101, "non_replicated_1"), builder);
+        assertContains(builder.build(), ImmutableList.of(
+                createTuple(202, "non_replicated_22"),
+                createTuple(1, "replicated"),
+                createTuple(0, "replicated"),
+                createTuple(101, "non_replicated_1")));
+
+        builder = PrestoSparkRowBatch.builder(2);
+        addRow(createTuple(202, "non_replicated_22"), builder);
+        addReplicatedRow(createRow("replicated"), builder);
+        addReplicatedRow(createRow("replicated"), builder);
+        addRow(createTuple(101, "non_replicated_1"), builder);
+        assertContains(builder.build(), ImmutableList.of(
+                createTuple(202, "non_replicated_22"),
+                createTuple(1, "replicated"),
+                createTuple(0, "replicated"),
+                createTuple(1, "replicated"),
+                createTuple(0, "replicated"),
+                createTuple(101, "non_replicated_1")));
+    }
+
+    private static void assertRoundTrip(List<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> rows)
+    {
+        PrestoSparkRowBatchBuilder builder = PrestoSparkRowBatch.builder(10);
+        assertTrue(builder.isEmpty());
+        rows.forEach(row -> addRow(row, builder));
+        assertFalse(builder.isFull());
+        PrestoSparkRowBatch rowBatch = builder.build();
+        assertContains(rowBatch, rows);
+    }
+
+    private static void addRow(Tuple2<MutablePartitionId, PrestoSparkMutableRow> row, PrestoSparkRowBatchBuilder builder)
+    {
+        SliceOutput output = builder.beginRowEntry();
+        ByteBuffer buffer = row._2.getBuffer();
+        output.writeBytes(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+        builder.closeEntryForNonReplicatedRow(row._1.getPartition());
+    }
+
+    private static void addReplicatedRow(PrestoSparkMutableRow row, PrestoSparkRowBatchBuilder builder)
+    {
+        SliceOutput output = builder.beginRowEntry();
+        ByteBuffer buffer = row.getBuffer();
+        output.writeBytes(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+        builder.closeEntryForReplicatedRow();
+    }
+
+    private static Tuple2<MutablePartitionId, PrestoSparkMutableRow> createTuple(int partition, String data)
+    {
+        MutablePartitionId mutablePartitionId = new MutablePartitionId();
+        mutablePartitionId.setPartition(partition);
+        return new Tuple2<>(mutablePartitionId, createRow(data));
+    }
+
+    private static PrestoSparkMutableRow createRow(String data)
+    {
+        PrestoSparkMutableRow mutableRow = new PrestoSparkMutableRow();
+        mutableRow.setBuffer(ByteBuffer.wrap(data.getBytes(UTF_8)));
+        return mutableRow;
+    }
+
+    private static void assertContains(PrestoSparkRowBatch rowBatch, List<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> expected)
+    {
+        Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> iterator = rowBatch.createRowTupleIterator();
+        List<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> actual = stream(iterator)
+                .map(TestPrestoSparkRowBatch::copy)
+                .collect(toImmutableList());
+        assertTupleEquals(actual, expected);
+    }
+
+    private static void assertTupleEquals(
+            List<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> actual,
+            List<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> expected)
+    {
+        assertEquals(actual.size(), expected.size());
+        for (int i = 0; i < actual.size(); i++) {
+            assertTupleEquals(actual.get(i), expected.get(i));
+        }
+    }
+
+    private static void assertTupleEquals(Tuple2<MutablePartitionId, PrestoSparkMutableRow> actual, Tuple2<MutablePartitionId, PrestoSparkMutableRow> expected)
+    {
+        assertEquals(actual._1.getPartition(), expected._1.getPartition());
+        ByteBuffer actualBuffer = actual._2.getBuffer();
+        String actualData = new String(actualBuffer.array(), actualBuffer.arrayOffset() + actualBuffer.position(), actualBuffer.remaining());
+        ByteBuffer expectedBuffer = expected._2.getBuffer();
+        String expectedData = new String(expectedBuffer.array(), expectedBuffer.arrayOffset() + expectedBuffer.position(), expectedBuffer.remaining());
+        assertEquals(actualData, expectedData);
+    }
+
+    private static Tuple2<MutablePartitionId, PrestoSparkMutableRow> copy(Tuple2<MutablePartitionId, PrestoSparkMutableRow> tuple)
+    {
+        return new Tuple2<>(copy(tuple._1), copy(tuple._2));
+    }
+
+    private static PrestoSparkMutableRow copy(PrestoSparkMutableRow mutableRow)
+    {
+        PrestoSparkMutableRow copy = new PrestoSparkMutableRow();
+        ByteBuffer bufferCopy = ByteBuffer.allocate(mutableRow.getBuffer().remaining());
+        bufferCopy.put(mutableRow.getBuffer());
+        bufferCopy.position(0);
+        copy.setBuffer(bufferCopy);
+        return copy;
+    }
+
+    private static MutablePartitionId copy(MutablePartitionId mutablePartitionId)
+    {
+        MutablePartitionId copy = new MutablePartitionId();
+        copy.setPartition(mutablePartitionId.getPartition());
+        return copy;
+    }
+}

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkTaskExecutor.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkTaskExecutor.java
@@ -17,7 +17,7 @@ import scala.Tuple2;
 
 import java.util.Iterator;
 
-public interface IPrestoSparkTaskExecutor
-        extends Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>
+public interface IPrestoSparkTaskExecutor<T>
+        extends Iterator<Tuple2<MutablePartitionId, T>>
 {
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkTaskExecutor.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkTaskExecutor.java
@@ -18,6 +18,6 @@ import scala.Tuple2;
 import java.util.Iterator;
 
 public interface IPrestoSparkTaskExecutor
-        extends Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>>
+        extends Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>
 {
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/MutablePartitionId.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/MutablePartitionId.java
@@ -13,11 +13,20 @@
  */
 package com.facebook.presto.spark.classloader_interface;
 
-import scala.Tuple2;
+import java.io.Serializable;
 
-import java.util.Iterator;
-
-public interface IPrestoSparkTaskExecutor
-        extends Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>>
+public class MutablePartitionId
+        implements Serializable
 {
+    private int partition;
+
+    public int getPartition()
+    {
+        return partition;
+    }
+
+    public void setPartition(int partition)
+    {
+        this.partition = partition;
+    }
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfInitializer.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfInitializer.java
@@ -34,6 +34,7 @@ public class PrestoSparkConfInitializer
     private static void registerKryoClasses(SparkConf sparkConf)
     {
         sparkConf.registerKryoClasses(new Class[] {
+                MutablePartitionId.class,
                 PrestoSparkRow.class,
                 PrestoSparkSerializedPage.class,
                 SerializedPrestoSparkTaskDescriptor.class,

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfInitializer.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfInitializer.java
@@ -35,7 +35,7 @@ public class PrestoSparkConfInitializer
     {
         sparkConf.registerKryoClasses(new Class[] {
                 MutablePartitionId.class,
-                PrestoSparkRow.class,
+                PrestoSparkMutableRow.class,
                 PrestoSparkSerializedPage.class,
                 SerializedPrestoSparkTaskDescriptor.class,
                 SerializedTaskStats.class

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfInitializer.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfInitializer.java
@@ -36,7 +36,6 @@ public class PrestoSparkConfInitializer
         sparkConf.registerKryoClasses(new Class[] {
                 MutablePartitionId.class,
                 PrestoSparkMutableRow.class,
-                PrestoSparkMaterializedRow.class,
                 PrestoSparkSerializedPage.class,
                 SerializedPrestoSparkTaskDescriptor.class,
                 SerializedTaskStats.class

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfInitializer.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfInitializer.java
@@ -36,6 +36,7 @@ public class PrestoSparkConfInitializer
         sparkConf.registerKryoClasses(new Class[] {
                 MutablePartitionId.class,
                 PrestoSparkMutableRow.class,
+                PrestoSparkMaterializedRow.class,
                 PrestoSparkSerializedPage.class,
                 SerializedPrestoSparkTaskDescriptor.class,
                 SerializedTaskStats.class

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMaterializedRow.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMaterializedRow.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.classloader_interface;
+
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkMaterializedRow
+        implements Serializable
+{
+    private final byte[] data;
+
+    public PrestoSparkMaterializedRow(byte[] data)
+    {
+        this.data = requireNonNull(data, "data is null");
+    }
+
+    public byte[] getData()
+    {
+        return data;
+    }
+
+    public PrestoSparkMutableRow toPrestoSparkMutableRow()
+    {
+        PrestoSparkMutableRow prestoSparkMutableRow = new PrestoSparkMutableRow();
+        prestoSparkMutableRow.setBuffer(ByteBuffer.wrap(data));
+        return prestoSparkMutableRow;
+    }
+}

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMutableRow.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMutableRow.java
@@ -24,7 +24,7 @@ import java.io.ObjectOutput;
 import java.nio.ByteBuffer;
 
 public class PrestoSparkMutableRow
-        implements Externalizable, KryoSerializable
+        implements Externalizable, KryoSerializable, PrestoSparkTaskOutput
 {
     private ByteBuffer buffer;
 
@@ -36,13 +36,6 @@ public class PrestoSparkMutableRow
     public void setBuffer(ByteBuffer buffer)
     {
         this.buffer = buffer;
-    }
-
-    public PrestoSparkMaterializedRow toMaterializedRow()
-    {
-        byte[] copy = new byte[buffer.remaining()];
-        System.arraycopy(buffer.array(), buffer.arrayOffset() + buffer.position(), copy, 0, buffer.remaining());
-        return new PrestoSparkMaterializedRow(copy);
     }
 
     @Override

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMutableRow.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMutableRow.java
@@ -17,7 +17,7 @@ import java.io.Serializable;
 
 import static java.util.Objects.requireNonNull;
 
-public class PrestoSparkRow
+public class PrestoSparkMutableRow
         implements Serializable
 {
     private static final int INSTANCE_SIZE = Long.BYTES * 2 /* headers */
@@ -31,7 +31,7 @@ public class PrestoSparkRow
     private final int length;
     private final byte[] bytes;
 
-    public PrestoSparkRow(int partition, int length, byte[] bytes)
+    public PrestoSparkMutableRow(int partition, int length, byte[] bytes)
     {
         this.partition = partition;
         this.length = length;

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMutableRow.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMutableRow.java
@@ -26,18 +26,7 @@ import java.nio.ByteBuffer;
 public class PrestoSparkMutableRow
         implements Externalizable, KryoSerializable
 {
-    private int partition;
     private ByteBuffer buffer;
-
-    public int getPartition()
-    {
-        return partition;
-    }
-
-    public void setPartition(int partition)
-    {
-        this.partition = partition;
-    }
 
     public ByteBuffer getBuffer()
     {
@@ -47,14 +36,6 @@ public class PrestoSparkMutableRow
     public void setBuffer(ByteBuffer buffer)
     {
         this.buffer = buffer;
-    }
-
-    /**
-     * TODO: Transitional method. Will be removed in the next commit.
-     */
-    public int getRetainedSize()
-    {
-        return Integer.SIZE + buffer.remaining();
     }
 
     public PrestoSparkMaterializedRow toMaterializedRow()

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMutableRow.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMutableRow.java
@@ -13,48 +13,85 @@
  */
 package com.facebook.presto.spark.classloader_interface;
 
-import java.io.Serializable;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 
-import static java.util.Objects.requireNonNull;
+import java.io.Externalizable;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
 
 public class PrestoSparkMutableRow
-        implements Serializable
+        implements Externalizable, KryoSerializable
 {
-    private static final int INSTANCE_SIZE = Long.BYTES * 2 /* headers */
-            + Integer.BYTES /* partition */
-            + Integer.BYTES /* length */
-            + Long.BYTES /* bytes pointer */
-            + Long.BYTES * 2 /* bytes headers */
-            + Integer.BYTES /* bytes length */;
-
-    private final int partition;
-    private final int length;
-    private final byte[] bytes;
-
-    public PrestoSparkMutableRow(int partition, int length, byte[] bytes)
-    {
-        this.partition = partition;
-        this.length = length;
-        this.bytes = requireNonNull(bytes, "bytes is null");
-    }
+    private int partition;
+    private ByteBuffer buffer;
 
     public int getPartition()
     {
         return partition;
     }
 
-    public int getLength()
+    public void setPartition(int partition)
     {
-        return length;
+        this.partition = partition;
     }
 
-    public byte[] getBytes()
+    public ByteBuffer getBuffer()
     {
-        return bytes;
+        return buffer;
     }
 
-    public long getRetainedSize()
+    public void setBuffer(ByteBuffer buffer)
     {
-        return INSTANCE_SIZE + bytes.length;
+        this.buffer = buffer;
+    }
+
+    /**
+     * TODO: Transitional method. Will be removed in the next commit.
+     */
+    public int getRetainedSize()
+    {
+        return Integer.SIZE + buffer.remaining();
+    }
+
+    public PrestoSparkMaterializedRow toMaterializedRow()
+    {
+        byte[] copy = new byte[buffer.remaining()];
+        System.arraycopy(buffer.array(), buffer.arrayOffset() + buffer.position(), copy, 0, buffer.remaining());
+        return new PrestoSparkMaterializedRow(copy);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output)
+    {
+        throw serializationNotSupportedException();
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input)
+    {
+        throw serializationNotSupportedException();
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput output)
+    {
+        throw serializationNotSupportedException();
+    }
+
+    @Override
+    public void readExternal(ObjectInput input)
+    {
+        throw serializationNotSupportedException();
+    }
+
+    private static RuntimeException serializationNotSupportedException()
+    {
+        // PrestoSparkMutableRow is expected to be serialized only during shuffle.
+        // During shuffle rows are always serialized with PrestoSparkShuffleSerializer.
+        return new UnsupportedOperationException("PrestoSparkUnsafeRow is not expected to be serialized with Kryo or standard Java serialization");
     }
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkPartitioner.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkPartitioner.java
@@ -18,12 +18,12 @@ import org.apache.spark.Partitioner;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-public class IntegerIdentityPartitioner
+public class PrestoSparkPartitioner
         extends Partitioner
 {
     private final int numPartitions;
 
-    public IntegerIdentityPartitioner(int numPartitions)
+    public PrestoSparkPartitioner(int numPartitions)
     {
         this.numPartitions = numPartitions;
     }
@@ -37,7 +37,9 @@ public class IntegerIdentityPartitioner
     @Override
     public int getPartition(Object key)
     {
-        int partition = requireNonNull((Integer) key, "key is null");
+        requireNonNull(key, "key is null");
+        MutablePartitionId mutablePartitionId = (MutablePartitionId) key;
+        int partition = mutablePartitionId.getPartition();
         if (!(partition >= 0 && partition < numPartitions)) {
             throw new IllegalArgumentException(format("Unexpected partition: %s. Total number of partitions: %s.", partition, numPartitions));
         }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkSerializedPage.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkSerializedPage.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 import static java.util.Objects.requireNonNull;
 
 public class PrestoSparkSerializedPage
-        implements Serializable
+        implements Serializable, PrestoSparkTaskOutput
 {
     private final byte[] bytes;
     private final int positionCount;

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkShuffleSerializer.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkShuffleSerializer.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.classloader_interface;
+
+import org.apache.spark.serializer.DeserializationStream;
+import org.apache.spark.serializer.SerializationStream;
+import org.apache.spark.serializer.Serializer;
+import org.apache.spark.serializer.SerializerInstance;
+import scala.Tuple2;
+import scala.collection.Iterator;
+import scala.reflect.ClassTag;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.NoSuchElementException;
+
+import static java.util.Objects.requireNonNull;
+import static scala.collection.JavaConversions.asScalaIterator;
+
+public class PrestoSparkShuffleSerializer
+        extends Serializer
+        implements Serializable
+{
+    @Override
+    public SerializerInstance newInstance()
+    {
+        return new PrestoSparkShuffleSerializerInstance();
+    }
+
+    @Override
+    public boolean supportsRelocationOfSerializedObjects()
+    {
+        return true;
+    }
+
+    public static class PrestoSparkShuffleSerializerInstance
+            extends SerializerInstance
+    {
+        @Override
+        public SerializationStream serializeStream(OutputStream outputStream)
+        {
+            return new PrestoSparkShuffleSerializationStream(outputStream);
+        }
+
+        @Override
+        public DeserializationStream deserializeStream(InputStream inputStream)
+        {
+            return new PrestoSparkShuffleDeserializationStream(inputStream);
+        }
+
+        @Override
+        public <T> ByteBuffer serialize(T tuple, ClassTag<T> classTag)
+        {
+            throw new UnsupportedOperationException("this method is never used by shuffle");
+        }
+
+        @Override
+        public <T> T deserialize(ByteBuffer buffer, ClassTag<T> classTag)
+        {
+            throw new UnsupportedOperationException("this method is never used by shuffle");
+        }
+
+        @Override
+        public <T> T deserialize(ByteBuffer bytes, ClassLoader loader, ClassTag<T> classTag)
+        {
+            throw new UnsupportedOperationException("this method is never used by shuffle");
+        }
+    }
+
+    public static class PrestoSparkShuffleSerializationStream
+            extends SerializationStream
+    {
+        private final DataOutputStream outputStream;
+
+        public PrestoSparkShuffleSerializationStream(OutputStream outputStream)
+        {
+            this.outputStream = new DataOutputStream(requireNonNull(outputStream, "outputStream is null"));
+        }
+
+        @Override
+        public <T> SerializationStream writeKey(T key, ClassTag<T> classTag)
+        {
+            // key is only needed to select partition
+            return this;
+        }
+
+        @Override
+        public <T> SerializationStream writeValue(T value, ClassTag<T> classTag)
+        {
+            PrestoSparkMutableRow row = (PrestoSparkMutableRow) value;
+            ByteBuffer buffer = row.getBuffer();
+            int length = buffer.remaining();
+            try {
+                outputStream.writeInt(length);
+                outputStream.write(buffer.array(), buffer.arrayOffset() + buffer.position(), length);
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            return this;
+        }
+
+        @Override
+        public void flush()
+        {
+            try {
+                outputStream.flush();
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public void close()
+        {
+            try {
+                outputStream.close();
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public <T> SerializationStream writeObject(T tuple, ClassTag<T> classTag)
+        {
+            throw new UnsupportedOperationException("this method is never used by shuffle");
+        }
+
+        @Override
+        public <T> SerializationStream writeAll(Iterator<T> iterator, ClassTag<T> classTag)
+        {
+            throw new UnsupportedOperationException("this method is never used by shuffle");
+        }
+    }
+
+    public static class PrestoSparkShuffleDeserializationStream
+            extends DeserializationStream
+    {
+        private final DataInputStream inputStream;
+
+        private final MutablePartitionId mutablePartitionId = new MutablePartitionId();
+        private final PrestoSparkMutableRow row = new PrestoSparkMutableRow();
+        private final Tuple2<Object, Object> tuple = new Tuple2<>(mutablePartitionId, row);
+
+        private byte[] bytes;
+        private ByteBuffer buffer;
+
+        public PrestoSparkShuffleDeserializationStream(InputStream inputStream)
+        {
+            this.inputStream = new DataInputStream(requireNonNull(inputStream, "inputStream is null"));
+        }
+
+        @Override
+        public Iterator<Tuple2<Object, Object>> asKeyValueIterator()
+        {
+            return asScalaIterator(new java.util.Iterator<Tuple2<Object, Object>>()
+            {
+                private Tuple2<Object, Object> next;
+
+                @Override
+                public boolean hasNext()
+                {
+                    if (next == null) {
+                        next = tryComputeNext();
+                    }
+                    return next != null;
+                }
+
+                @Override
+                public Tuple2<Object, Object> next()
+                {
+                    if (next == null) {
+                        next = tryComputeNext();
+                    }
+                    if (next == null) {
+                        throw new NoSuchElementException();
+                    }
+                    Tuple2<Object, Object> result = next;
+                    next = null;
+                    return result;
+                }
+
+                private Tuple2<Object, Object> tryComputeNext()
+                {
+                    int length;
+                    try {
+                        length = inputStream.readInt();
+                    }
+                    catch (EOFException e) {
+                        return null;
+                    }
+                    catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+
+                    // ensure capacity
+                    if (bytes == null || bytes.length < length) {
+                        bytes = new byte[length];
+                        buffer = ByteBuffer.wrap(bytes);
+                    }
+
+                    try {
+                        inputStream.readFully(bytes, 0, length);
+                    }
+                    catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+
+                    buffer.position(0);
+                    buffer.limit(length);
+                    row.setBuffer(buffer);
+                    return tuple;
+                }
+            });
+        }
+
+        @Override
+        public <T> T readKey(ClassTag<T> classTag)
+        {
+            throw new UnsupportedOperationException("this method is never used by shuffle");
+        }
+
+        @Override
+        public <T> T readValue(ClassTag<T> classTag)
+        {
+            throw new UnsupportedOperationException("this method is never used by shuffle");
+        }
+
+        @Override
+        public Iterator<Object> asIterator()
+        {
+            throw new UnsupportedOperationException("this method is never used by shuffle");
+        }
+
+        @Override
+        public <T> T readObject(ClassTag<T> classTag)
+        {
+            throw new UnsupportedOperationException("this method is never used by shuffle");
+        }
+
+        @Override
+        public void close()
+        {
+            try {
+                inputStream.close();
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+}

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskInputs.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskInputs.java
@@ -27,18 +27,18 @@ import static java.util.Objects.requireNonNull;
 public class PrestoSparkTaskInputs
 {
     // fragmentId -> Iterator<[partitionId, page]>
-    private final Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>>> shuffleInputs;
+    private final Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputs;
     private final Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs;
 
     public PrestoSparkTaskInputs(
-            Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>>> shuffleInputs,
+            Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputs,
             Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs)
     {
         this.shuffleInputs = unmodifiableMap(new HashMap<>(requireNonNull(shuffleInputs, "shuffleInputs is null")));
         this.broadcastInputs = unmodifiableMap(new HashMap<>(requireNonNull(broadcastInputs, "broadcastInputs is null")));
     }
 
-    public Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>>> getShuffleInputs()
+    public Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> getShuffleInputs()
     {
         return shuffleInputs;
     }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskInputs.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskInputs.java
@@ -27,18 +27,18 @@ import static java.util.Objects.requireNonNull;
 public class PrestoSparkTaskInputs
 {
     // fragmentId -> Iterator<[partitionId, page]>
-    private final Map<String, Iterator<Tuple2<Integer, PrestoSparkRow>>> shuffleInputs;
+    private final Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>>> shuffleInputs;
     private final Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs;
 
     public PrestoSparkTaskInputs(
-            Map<String, Iterator<Tuple2<Integer, PrestoSparkRow>>> shuffleInputs,
+            Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>>> shuffleInputs,
             Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs)
     {
         this.shuffleInputs = unmodifiableMap(new HashMap<>(requireNonNull(shuffleInputs, "shuffleInputs is null")));
         this.broadcastInputs = unmodifiableMap(new HashMap<>(requireNonNull(broadcastInputs, "broadcastInputs is null")));
     }
 
-    public Map<String, Iterator<Tuple2<Integer, PrestoSparkRow>>> getShuffleInputs()
+    public Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>>> getShuffleInputs()
     {
         return shuffleInputs;
     }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskInputs.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskInputs.java
@@ -29,13 +29,17 @@ public class PrestoSparkTaskInputs
     // fragmentId -> Iterator<[partitionId, page]>
     private final Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputs;
     private final Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs;
+    // For the COORDINATOR_ONLY fragment we first collect the inputs on the Driver
+    private final Map<String, List<PrestoSparkSerializedPage>> inMemoryInputs;
 
     public PrestoSparkTaskInputs(
             Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputs,
-            Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs)
+            Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs,
+            Map<String, List<PrestoSparkSerializedPage>> inMemoryInputs)
     {
         this.shuffleInputs = unmodifiableMap(new HashMap<>(requireNonNull(shuffleInputs, "shuffleInputs is null")));
         this.broadcastInputs = unmodifiableMap(new HashMap<>(requireNonNull(broadcastInputs, "broadcastInputs is null")));
+        this.inMemoryInputs = unmodifiableMap(new HashMap<>(requireNonNull(inMemoryInputs, "inMemoryInputs is null")));
     }
 
     public Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> getShuffleInputs()
@@ -46,5 +50,10 @@ public class PrestoSparkTaskInputs
     public Map<String, Broadcast<List<PrestoSparkSerializedPage>>> getBroadcastInputs()
     {
         return broadcastInputs;
+    }
+
+    public Map<String, List<PrestoSparkSerializedPage>> getInMemoryInputs()
+    {
+        return inMemoryInputs;
     }
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskOutput.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskOutput.java
@@ -13,18 +13,6 @@
  */
 package com.facebook.presto.spark.classloader_interface;
 
-import org.apache.spark.util.CollectionAccumulator;
-
-import java.util.Iterator;
-
-public interface IPrestoSparkTaskExecutorFactory
+public interface PrestoSparkTaskOutput
 {
-    <T extends PrestoSparkTaskOutput> IPrestoSparkTaskExecutor<T> create(
-            int partitionId,
-            int attemptNumber,
-            SerializedPrestoSparkTaskDescriptor taskDescriptor,
-            Iterator<SerializedPrestoSparkTaskSource> serializedTaskSources,
-            PrestoSparkTaskInputs inputs,
-            CollectionAccumulator<SerializedTaskStats> taskStatsCollector,
-            Class<T> outputType);
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskProcessor.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskProcessor.java
@@ -47,10 +47,10 @@ public class PrestoSparkTaskProcessor
         this.broadcastInputs = new HashMap<>(requireNonNull(broadcastInputs, "broadcastInputs is null"));
     }
 
-    public Iterator<Tuple2<Integer, PrestoSparkRow>> process(
+    public Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>> process(
             Iterator<SerializedPrestoSparkTaskSource> serializedTaskSources,
             // fragmentId -> Iterator<[partitionId, page]>
-            Map<String, Iterator<Tuple2<Integer, PrestoSparkRow>>> shuffleInputs)
+            Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>>> shuffleInputs)
     {
         int partitionId = TaskContext.get().partitionId();
         int attemptNumber = TaskContext.get().attemptNumber();

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskProcessor.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskProcessor.java
@@ -47,10 +47,10 @@ public class PrestoSparkTaskProcessor
         this.broadcastInputs = new HashMap<>(requireNonNull(broadcastInputs, "broadcastInputs is null"));
     }
 
-    public Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>> process(
+    public Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> process(
             Iterator<SerializedPrestoSparkTaskSource> serializedTaskSources,
             // fragmentId -> Iterator<[partitionId, page]>
-            Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>>> shuffleInputs)
+            Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputs)
     {
         int partitionId = TaskContext.get().partitionId();
         int attemptNumber = TaskContext.get().attemptNumber();

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskProcessor.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskProcessor.java
@@ -24,9 +24,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 
-public class PrestoSparkTaskProcessor
+public class PrestoSparkTaskProcessor<T extends PrestoSparkTaskOutput>
         implements Serializable
 {
     private final PrestoSparkTaskExecutorFactoryProvider taskExecutorFactoryProvider;
@@ -34,20 +35,23 @@ public class PrestoSparkTaskProcessor
     private final CollectionAccumulator<SerializedTaskStats> taskStatsCollector;
     // fragmentId -> Broadcast
     private final Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs;
+    private final Class<T> outputType;
 
     public PrestoSparkTaskProcessor(
             PrestoSparkTaskExecutorFactoryProvider taskExecutorFactoryProvider,
             SerializedPrestoSparkTaskDescriptor serializedTaskDescriptor,
             CollectionAccumulator<SerializedTaskStats> taskStatsCollector,
-            Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs)
+            Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs,
+            Class<T> outputType)
     {
         this.taskExecutorFactoryProvider = requireNonNull(taskExecutorFactoryProvider, "taskExecutorFactoryProvider is null");
         this.serializedTaskDescriptor = requireNonNull(serializedTaskDescriptor, "serializedTaskDescriptor is null");
         this.taskStatsCollector = requireNonNull(taskStatsCollector, "taskStatsCollector is null");
         this.broadcastInputs = new HashMap<>(requireNonNull(broadcastInputs, "broadcastInputs is null"));
+        this.outputType = requireNonNull(outputType, "outputType is null");
     }
 
-    public Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> process(
+    public Iterator<Tuple2<MutablePartitionId, T>> process(
             Iterator<SerializedPrestoSparkTaskSource> serializedTaskSources,
             // fragmentId -> Iterator<[partitionId, page]>
             Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputs)
@@ -59,7 +63,8 @@ public class PrestoSparkTaskProcessor
                 attemptNumber,
                 serializedTaskDescriptor,
                 serializedTaskSources,
-                new PrestoSparkTaskInputs(shuffleInputs, broadcastInputs),
-                taskStatsCollector);
+                new PrestoSparkTaskInputs(shuffleInputs, broadcastInputs, emptyMap()),
+                taskStatsCollector,
+                outputType);
     }
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskRdd.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskRdd.java
@@ -57,10 +57,10 @@ import static scala.collection.JavaConversions.seqAsJavaList;
  * The broadcast inputs are encapsulated in taskProcessor.
  */
 public class PrestoSparkTaskRdd
-        extends ZippedPartitionsBaseRDD<Tuple2<MutablePartitionId, PrestoSparkRow>>
+        extends ZippedPartitionsBaseRDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>
 {
     private List<String> shuffleInputFragmentIds;
-    private List<RDD<Tuple2<MutablePartitionId, PrestoSparkRow>>> shuffleInputRdds;
+    private List<RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputRdds;
     private PrestoSparkTaskSourceRdd taskSourceRdd;
     private PrestoSparkTaskProcessor taskProcessor;
 
@@ -68,7 +68,7 @@ public class PrestoSparkTaskRdd
             SparkContext context,
             Optional<PrestoSparkTaskSourceRdd> taskSourceRdd,
             // fragmentId -> RDD
-            Map<String, RDD<Tuple2<MutablePartitionId, PrestoSparkRow>>> shuffleInputRddMap,
+            Map<String, RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputRddMap,
             PrestoSparkTaskProcessor taskProcessor)
     {
         requireNonNull(context, "context is null");
@@ -76,8 +76,8 @@ public class PrestoSparkTaskRdd
         requireNonNull(shuffleInputRddMap, "shuffleInputRdds is null");
         requireNonNull(taskProcessor, "taskProcessor is null");
         List<String> shuffleInputFragmentIds = new ArrayList<>();
-        List<RDD<Tuple2<MutablePartitionId, PrestoSparkRow>>> shuffleInputRdds = new ArrayList<>();
-        for (Map.Entry<String, RDD<Tuple2<MutablePartitionId, PrestoSparkRow>>> entry : shuffleInputRddMap.entrySet()) {
+        List<RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputRdds = new ArrayList<>();
+        for (Map.Entry<String, RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> entry : shuffleInputRddMap.entrySet()) {
             shuffleInputFragmentIds.add(entry.getKey());
             shuffleInputRdds.add(entry.getValue());
         }
@@ -88,7 +88,7 @@ public class PrestoSparkTaskRdd
             SparkContext context,
             Optional<PrestoSparkTaskSourceRdd> taskSourceRdd,
             List<String> shuffleInputFragmentIds,
-            List<RDD<Tuple2<MutablePartitionId, PrestoSparkRow>>> shuffleInputRdds,
+            List<RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputRdds,
             PrestoSparkTaskProcessor taskProcessor)
     {
         super(context, getRDDSequence(taskSourceRdd, shuffleInputRdds), false, fakeClassTag());
@@ -99,7 +99,7 @@ public class PrestoSparkTaskRdd
         this.taskProcessor = context.clean(taskProcessor, true);
     }
 
-    private static Seq<RDD<?>> getRDDSequence(Optional<PrestoSparkTaskSourceRdd> taskSourceRdd, List<RDD<Tuple2<MutablePartitionId, PrestoSparkRow>>> shuffleInputRdds)
+    private static Seq<RDD<?>> getRDDSequence(Optional<PrestoSparkTaskSourceRdd> taskSourceRdd, List<RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputRdds)
     {
         List<RDD<?>> list = new ArrayList<>(shuffleInputRdds);
         taskSourceRdd.ifPresent(list::add);
@@ -112,7 +112,7 @@ public class PrestoSparkTaskRdd
     }
 
     @Override
-    public scala.collection.Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>> compute(Partition split, TaskContext context)
+    public scala.collection.Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> compute(Partition split, TaskContext context)
     {
         List<Partition> partitions = seqAsJavaList(((ZippedPartitionsPartition) split).partitions());
         int expectedPartitionsSize = (taskSourceRdd != null ? 1 : 0) + shuffleInputRdds.size();
@@ -120,7 +120,7 @@ public class PrestoSparkTaskRdd
             throw new IllegalArgumentException(format("Unexpected partitions size. Expected: %s. Actual: %s.", expectedPartitionsSize, partitions.size()));
         }
 
-        Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkRow>>> shuffleInputIterators = new HashMap<>();
+        Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputIterators = new HashMap<>();
         for (int inputIndex = 0; inputIndex < shuffleInputRdds.size(); inputIndex++) {
             shuffleInputIterators.put(
                     shuffleInputFragmentIds.get(inputIndex),

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskRdd.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskRdd.java
@@ -56,20 +56,20 @@ import static scala.collection.JavaConversions.seqAsJavaList;
  * <p>
  * The broadcast inputs are encapsulated in taskProcessor.
  */
-public class PrestoSparkTaskRdd
-        extends ZippedPartitionsBaseRDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>
+public class PrestoSparkTaskRdd<T extends PrestoSparkTaskOutput>
+        extends ZippedPartitionsBaseRDD<Tuple2<MutablePartitionId, T>>
 {
     private List<String> shuffleInputFragmentIds;
     private List<RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputRdds;
     private PrestoSparkTaskSourceRdd taskSourceRdd;
-    private PrestoSparkTaskProcessor taskProcessor;
+    private PrestoSparkTaskProcessor<T> taskProcessor;
 
-    public static PrestoSparkTaskRdd create(
+    public static <T extends PrestoSparkTaskOutput> PrestoSparkTaskRdd<T> create(
             SparkContext context,
             Optional<PrestoSparkTaskSourceRdd> taskSourceRdd,
             // fragmentId -> RDD
             Map<String, RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputRddMap,
-            PrestoSparkTaskProcessor taskProcessor)
+            PrestoSparkTaskProcessor<T> taskProcessor)
     {
         requireNonNull(context, "context is null");
         requireNonNull(taskSourceRdd, "taskSourceRdd is null");
@@ -81,7 +81,7 @@ public class PrestoSparkTaskRdd
             shuffleInputFragmentIds.add(entry.getKey());
             shuffleInputRdds.add(entry.getValue());
         }
-        return new PrestoSparkTaskRdd(context, taskSourceRdd, shuffleInputFragmentIds, shuffleInputRdds, taskProcessor);
+        return new PrestoSparkTaskRdd<>(context, taskSourceRdd, shuffleInputFragmentIds, shuffleInputRdds, taskProcessor);
     }
 
     private PrestoSparkTaskRdd(
@@ -89,7 +89,7 @@ public class PrestoSparkTaskRdd
             Optional<PrestoSparkTaskSourceRdd> taskSourceRdd,
             List<String> shuffleInputFragmentIds,
             List<RDD<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputRdds,
-            PrestoSparkTaskProcessor taskProcessor)
+            PrestoSparkTaskProcessor<T> taskProcessor)
     {
         super(context, getRDDSequence(taskSourceRdd, shuffleInputRdds), false, fakeClassTag());
         this.shuffleInputFragmentIds = shuffleInputFragmentIds;
@@ -112,7 +112,7 @@ public class PrestoSparkTaskRdd
     }
 
     @Override
-    public scala.collection.Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> compute(Partition split, TaskContext context)
+    public scala.collection.Iterator<Tuple2<MutablePartitionId, T>> compute(Partition split, TaskContext context)
     {
         List<Partition> partitions = seqAsJavaList(((ZippedPartitionsPartition) split).partitions());
         int expectedPartitionsSize = (taskSourceRdd != null ? 1 : 0) + shuffleInputRdds.size();

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkToMaterializedRowFunction.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkToMaterializedRowFunction.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.classloader_interface;
+
+import org.apache.spark.api.java.function.Function;
+
+public class PrestoSparkToMaterializedRowFunction
+        implements Function<PrestoSparkMutableRow, PrestoSparkMaterializedRow>
+{
+    @Override
+    public PrestoSparkMaterializedRow call(PrestoSparkMutableRow row)
+    {
+        return row.toMaterializedRow();
+    }
+}


### PR DESCRIPTION
If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
