### PR TITLE
Make TaskStatus Leaner

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -71,7 +71,7 @@ public class SqlTask
     private static final Logger log = Logger.get(SqlTask.class);
 
     private final TaskId taskId;
-    private final String taskInstanceId;
+    private final TaskInstanceId taskInstanceId;
     private final URI location;
     private final String nodeId;
     private final TaskStateMachine taskStateMachine;
@@ -123,7 +123,7 @@ public class SqlTask
             DataSize maxBufferSize)
     {
         this.taskId = requireNonNull(taskId, "taskId is null");
-        this.taskInstanceId = UUID.randomUUID().toString();
+        this.taskInstanceId = new TaskInstanceId(UUID.randomUUID());
         this.location = requireNonNull(location, "location is null");
         this.nodeId = requireNonNull(nodeId, "nodeId is null");
         this.queryContext = requireNonNull(queryContext, "queryContext is null");
@@ -135,7 +135,7 @@ public class SqlTask
         this.taskExchangeClientManager = new TaskExchangeClientManager(exchangeClientSupplier);
         outputBuffer = new LazyOutputBuffer(
                 taskId,
-                taskInstanceId,
+                taskInstanceId.getUuidString(),
                 taskNotificationExecutor,
                 maxBufferSize,
                 // Pass a memory context supplier instead of a memory context to the output buffer,
@@ -213,7 +213,7 @@ public class SqlTask
 
     public String getTaskInstanceId()
     {
-        return taskInstanceId;
+        return taskInstanceId.getUuidString();
     }
 
     public void recordHeartbeat()
@@ -284,7 +284,8 @@ public class SqlTask
         }
 
         return new TaskStatus(
-                taskInstanceId,
+                taskInstanceId.getUuidLeastSignificantBits(),
+                taskInstanceId.getUuidMostSignificantBits(),
                 versionNumber,
                 state,
                 location,
@@ -560,5 +561,35 @@ public class SqlTask
     public QueryContext getQueryContext()
     {
         return queryContext;
+    }
+
+    private static class TaskInstanceId
+    {
+        private final long uuidLeastSignificantBits;
+        private final long uuidMostSignificantBits;
+        private final String uuidString;
+
+        public TaskInstanceId(UUID uuid)
+        {
+            requireNonNull(uuid, "uuid is null");
+            this.uuidLeastSignificantBits = uuid.getLeastSignificantBits();
+            this.uuidMostSignificantBits = uuid.getMostSignificantBits();
+            this.uuidString = uuid.toString();
+        }
+
+        public long getUuidLeastSignificantBits()
+        {
+            return uuidLeastSignificantBits;
+        }
+
+        public long getUuidMostSignificantBits()
+        {
+            return uuidMostSignificantBits;
+        }
+
+        public String getUuidString()
+        {
+            return uuidString;
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
@@ -47,7 +47,8 @@ public class TaskStatus
      */
     private static final long MAX_VERSION = Long.MAX_VALUE;
 
-    private final String taskInstanceId;
+    private final long taskInstanceIdLeastSignificantBits;
+    private final long taskInstanceIdMostSignificantBits;
     private final long version;
     private final TaskState state;
     private final URI self;
@@ -70,7 +71,8 @@ public class TaskStatus
 
     @JsonCreator
     public TaskStatus(
-            @JsonProperty("taskInstanceId") String taskInstanceId,
+            @JsonProperty("taskInstanceIdLeastSignificantBits") long taskInstanceIdLeastSignificantBits,
+            @JsonProperty("taskInstanceIdMostSignificantBits") long taskInstanceIdMostSignificantBits,
             @JsonProperty("version") long version,
             @JsonProperty("state") TaskState state,
             @JsonProperty("self") URI self,
@@ -86,8 +88,8 @@ public class TaskStatus
             @JsonProperty("fullGcCount") long fullGcCount,
             @JsonProperty("fullGcTimeInMillis") long fullGcTimeInMillis)
     {
-        this.taskInstanceId = requireNonNull(taskInstanceId, "taskInstanceId is null");
-
+        this.taskInstanceIdLeastSignificantBits = taskInstanceIdLeastSignificantBits;
+        this.taskInstanceIdMostSignificantBits = taskInstanceIdMostSignificantBits;
         checkState(version >= MIN_VERSION, "version must be >= MIN_VERSION");
         this.version = version;
         this.state = requireNonNull(state, "state is null");
@@ -115,9 +117,15 @@ public class TaskStatus
     }
 
     @JsonProperty
-    public String getTaskInstanceId()
+    public long getTaskInstanceIdLeastSignificantBits()
     {
-        return taskInstanceId;
+        return taskInstanceIdLeastSignificantBits;
+    }
+
+    @JsonProperty
+    public long getTaskInstanceIdMostSignificantBits()
+    {
+        return taskInstanceIdMostSignificantBits;
     }
 
     @JsonProperty
@@ -215,7 +223,8 @@ public class TaskStatus
     public static TaskStatus initialTaskStatus(URI location)
     {
         return new TaskStatus(
-                "",
+                0L,
+                0L,
                 MIN_VERSION,
                 PLANNED,
                 location,
@@ -235,7 +244,8 @@ public class TaskStatus
     public static TaskStatus failWith(TaskStatus taskStatus, TaskState state, List<ExecutionFailureInfo> exceptions)
     {
         return new TaskStatus(
-                taskStatus.getTaskInstanceId(),
+                taskStatus.getTaskInstanceIdLeastSignificantBits(),
+                taskStatus.getTaskInstanceIdMostSignificantBits(),
                 MAX_VERSION,
                 state,
                 taskStatus.getSelf(),

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcher.java
@@ -48,7 +48,6 @@ import static com.facebook.presto.server.smile.FullSmileResponseHandler.createFu
 import static com.facebook.presto.server.smile.JsonCodecWrapper.unwrapJsonCodec;
 import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_MISMATCH;
 import static com.facebook.presto.util.Failures.REMOTE_TASK_MISMATCH_ERROR;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.airlift.units.Duration.nanosSince;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -230,7 +229,10 @@ class ContinuousTaskStatusFetcher
         AtomicBoolean taskMismatch = new AtomicBoolean();
         taskStatus.setIf(newValue, oldValue -> {
             // did the task instance id change
-            if (!isNullOrEmpty(oldValue.getTaskInstanceId()) && !oldValue.getTaskInstanceId().equals(newValue.getTaskInstanceId())) {
+            boolean isEmpty = oldValue.getTaskInstanceIdLeastSignificantBits() == 0 && oldValue.getTaskInstanceIdMostSignificantBits() == 0;
+            if (!isEmpty &&
+                    !(oldValue.getTaskInstanceIdLeastSignificantBits() == newValue.getTaskInstanceIdLeastSignificantBits() &&
+                            oldValue.getTaskInstanceIdMostSignificantBits() == newValue.getTaskInstanceIdMostSignificantBits())) {
                 taskMismatch.set(true);
                 return false;
             }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -68,6 +68,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -92,7 +93,7 @@ import static java.util.Objects.requireNonNull;
 public class MockRemoteTaskFactory
         implements RemoteTaskFactory
 {
-    private static final String TASK_INSTANCE_ID = "task-instance-id";
+    private static final UUID TASK_INSTANCE_ID = UUID.randomUUID();
     private final Executor executor;
     private final ScheduledExecutorService scheduledExecutor;
 
@@ -210,7 +211,7 @@ public class MockRemoteTaskFactory
 
             this.outputBuffer = new LazyOutputBuffer(
                     taskId,
-                    TASK_INSTANCE_ID,
+                    TASK_INSTANCE_ID.toString(),
                     executor,
                     new DataSize(1, BYTE),
                     () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"));
@@ -247,7 +248,8 @@ public class MockRemoteTaskFactory
             return new TaskInfo(
                     taskStateMachine.getTaskId(),
                     new TaskStatus(
-                            TASK_INSTANCE_ID,
+                            TASK_INSTANCE_ID.getLeastSignificantBits(),
+                            TASK_INSTANCE_ID.getMostSignificantBits(),
                             nextTaskInfoVersion.getAndIncrement(),
                             state,
                             location,
@@ -279,7 +281,9 @@ public class MockRemoteTaskFactory
         public TaskStatus getTaskStatus()
         {
             TaskStats stats = taskContext.getTaskStats();
-            return new TaskStatus(TASK_INSTANCE_ID,
+            return new TaskStatus(
+                    TASK_INSTANCE_ID.getLeastSignificantBits(),
+                    TASK_INSTANCE_ID.getMostSignificantBits(),
                     nextTaskInfoVersion.get(),
                     taskStateMachine.getState(),
                     location,

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -83,6 +83,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -342,8 +343,8 @@ public class TestHttpRemoteTask
     @Path("/task/{nodeId}")
     public static class TestingTaskResource
     {
-        private static final String INITIAL_TASK_INSTANCE_ID = "task-instance-id";
-        private static final String NEW_TASK_INSTANCE_ID = "task-instance-id-x";
+        private static final UUID INITIAL_TASK_INSTANCE_ID = UUID.randomUUID();
+        private static final UUID NEW_TASK_INSTANCE_ID = UUID.randomUUID();
 
         private final AtomicLong lastActivityNanos;
         private final FailureScenario failureScenario;
@@ -354,7 +355,8 @@ public class TestHttpRemoteTask
         private TaskStatus initialTaskStatus;
         private long version;
         private TaskState taskState;
-        private String taskInstanceId = INITIAL_TASK_INSTANCE_ID;
+        private long taskInstanceIdLeastSignificantBits = INITIAL_TASK_INSTANCE_ID.getLeastSignificantBits();
+        private long taskInstanceIdMostSignificantBits = INITIAL_TASK_INSTANCE_ID.getMostSignificantBits();
 
         private long statusFetchCounter;
 
@@ -480,7 +482,8 @@ public class TestHttpRemoteTask
                 case TASK_MISMATCH:
                 case TASK_MISMATCH_WHEN_VERSION_IS_HIGH:
                     if (statusFetchCounter == 10) {
-                        taskInstanceId = NEW_TASK_INSTANCE_ID;
+                        taskInstanceIdLeastSignificantBits = NEW_TASK_INSTANCE_ID.getLeastSignificantBits();
+                        taskInstanceIdMostSignificantBits = NEW_TASK_INSTANCE_ID.getMostSignificantBits();
                         version = 0;
                     }
                     break;
@@ -497,7 +500,8 @@ public class TestHttpRemoteTask
             }
 
             return new TaskStatus(
-                    taskInstanceId,
+                    taskInstanceIdLeastSignificantBits,
+                    taskInstanceIdMostSignificantBits,
                     ++version,
                     taskState,
                     initialTaskStatus.getSelf(),


### PR DESCRIPTION
taskInstanceId field is currently represented as a UUID string which
takes up 72 bytes whereas representing them as two longs takes only
16 bytes which is a 78% improvement.

```
== NO RELEASE NOTE ==
```