### PR TITLE
Add Presto JDBC URL flag to add session property overrides

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
@@ -50,6 +50,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<File> KERBEROS_CREDENTIAL_CACHE_PATH = new KerberosCredentialCachePath();
     public static final ConnectionProperty<String> ACCESS_TOKEN = new AccessToken();
     public static final ConnectionProperty<Map<String, String>> EXTRA_CREDENTIALS = new ExtraCredentials();
+    public static final ConnectionProperty<Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
 
     private static final Set<ConnectionProperty<?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?>>builder()
             .add(USER)
@@ -70,6 +71,7 @@ final class ConnectionProperties
             .add(KERBEROS_CREDENTIAL_CACHE_PATH)
             .add(ACCESS_TOKEN)
             .add(EXTRA_CREDENTIALS)
+            .add(SESSION_PROPERTIES)
             .build();
 
     private static final Map<String, ConnectionProperty<?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -284,6 +286,15 @@ final class ConnectionProperties
         public ExtraCredentials()
         {
             super("extraCredentials", NOT_REQUIRED, ALLOWED, STRING_MAP_CONVERTER);
+        }
+    }
+
+    private static class SessionProperties
+            extends AbstractConnectionProperty<Map<String, String>>
+    {
+        public SessionProperties()
+        {
+            super("sessionProperties", NOT_REQUIRED, ALLOWED, STRING_MAP_CONVERTER);
         }
     }
 }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
@@ -13,23 +13,19 @@
  */
 package com.facebook.presto.jdbc;
 
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 
 import java.io.File;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import static com.facebook.presto.jdbc.AbstractConnectionProperty.StringMapConverter.STRING_MAP_CONVERTER;
 import static com.facebook.presto.jdbc.AbstractConnectionProperty.checkedPredicate;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
@@ -285,34 +281,9 @@ final class ConnectionProperties
     private static class ExtraCredentials
             extends AbstractConnectionProperty<Map<String, String>>
     {
-        private static final CharMatcher PRINTABLE_ASCII = CharMatcher.inRange((char) 0x21, (char) 0x7E);
-
         public ExtraCredentials()
         {
-            super("extraCredentials", NOT_REQUIRED, ALLOWED, ExtraCredentials::parseExtraCredentials);
-        }
-
-        // Extra credentials consists of a list of credential name value pairs.
-        // E.g., `jdbc:presto://example.net:8080/?extraCredentials=abc:xyz;foo:bar` will create credentials `abc=xyz` and `foo=bar`
-        public static Map<String, String> parseExtraCredentials(String extraCredentialString)
-        {
-            return Splitter.on(';').splitToList(extraCredentialString).stream()
-                    .map(ExtraCredentials::parseSingleCredential)
-                    .collect(toImmutableMap(entry -> entry.get(0), entry -> entry.get(1)));
-        }
-
-        public static List<String> parseSingleCredential(String credential)
-        {
-            List<String> nameValue = Splitter.on(':').splitToList(credential);
-            checkArgument(nameValue.size() == 2, "Malformed credential: %s", credential);
-            String name = nameValue.get(0);
-            String value = nameValue.get(1);
-            checkArgument(!name.isEmpty(), "Credential name is empty");
-            checkArgument(!value.isEmpty(), "Credential value is empty");
-
-            checkArgument(PRINTABLE_ASCII.matchesAllOf(name), "Credential name contains spaces or is not printable ASCII: %s", name);
-            checkArgument(PRINTABLE_ASCII.matchesAllOf(value), "Credential value contains spaces or is not printable ASCII: %s", name);
-            return nameValue;
+            super("extraCredentials", NOT_REQUIRED, ALLOWED, STRING_MAP_CONVERTER);
         }
     }
 }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -85,9 +85,9 @@ public class PrestoConnection
     private final URI httpUri;
     private final String user;
     private final Map<String, String> extraCredentials;
+    private final Map<String, String> sessionProperties;
     private final Optional<String> applicationNamePrefix;
     private final Map<String, String> clientInfo = new ConcurrentHashMap<>();
-    private final Map<String, String> sessionProperties = new ConcurrentHashMap<>();
     private final Map<String, String> preparedStatements = new ConcurrentHashMap<>();
     private final Map<String, SelectedRole> roles = new ConcurrentHashMap<>();
     private final AtomicReference<String> transactionId = new AtomicReference<>();
@@ -106,6 +106,7 @@ public class PrestoConnection
         this.applicationNamePrefix = uri.getApplicationNamePrefix();
 
         this.extraCredentials = uri.getExtraCredentials();
+        this.sessionProperties = new ConcurrentHashMap<>(uri.getSessionProperties());
         this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
 
         timeZoneId.set(TimeZone.getDefault().getID());
@@ -631,6 +632,11 @@ public class PrestoConnection
     Map<String, String> getExtraCredentials()
     {
         return ImmutableMap.copyOf(extraCredentials);
+    }
+
+    Map<String, String> getSessionProperties()
+    {
+        return ImmutableMap.copyOf(sessionProperties);
     }
 
     ServerInfo getServerInfo()

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
@@ -50,6 +50,7 @@ import static com.facebook.presto.jdbc.ConnectionProperties.KERBEROS_PRINCIPAL;
 import static com.facebook.presto.jdbc.ConnectionProperties.KERBEROS_REMOTE_SERVICE_NAME;
 import static com.facebook.presto.jdbc.ConnectionProperties.KERBEROS_USE_CANONICAL_HOSTNAME;
 import static com.facebook.presto.jdbc.ConnectionProperties.PASSWORD;
+import static com.facebook.presto.jdbc.ConnectionProperties.SESSION_PROPERTIES;
 import static com.facebook.presto.jdbc.ConnectionProperties.SOCKS_PROXY;
 import static com.facebook.presto.jdbc.ConnectionProperties.SSL;
 import static com.facebook.presto.jdbc.ConnectionProperties.SSL_KEY_STORE_PASSWORD;
@@ -143,6 +144,12 @@ final class PrestoDriverUri
             throws SQLException
     {
         return EXTRA_CREDENTIALS.getValue(properties).orElse(ImmutableMap.of());
+    }
+
+    public Map<String, String> getSessionProperties()
+            throws SQLException
+    {
+        return SESSION_PROPERTIES.getValue(properties).orElse(ImmutableMap.of());
     }
 
     public void setupClient(OkHttpClient.Builder builder)

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
@@ -167,10 +167,12 @@ public class TestJdbcConnection
     public void testSession()
             throws SQLException
     {
-        try (Connection connection = createConnection()) {
+        try (Connection connection = createConnection("sessionProperties=query_max_run_time:2d;max_failed_task_percentage:0.6")) {
             assertThat(listSession(connection))
                     .contains("join_distribution_type|PARTITIONED|PARTITIONED")
-                    .contains("exchange_compression|false|false");
+                    .contains("exchange_compression|false|false")
+                    .contains("query_max_run_time|2d|100.00d")
+                    .contains("max_failed_task_percentage|0.6|0.3");
 
             try (Statement statement = connection.createStatement()) {
                 statement.execute("SET SESSION join_distribution_type = 'BROADCAST'");

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 
 import static com.facebook.presto.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
 import static com.facebook.presto.jdbc.ConnectionProperties.HTTP_PROXY;
+import static com.facebook.presto.jdbc.ConnectionProperties.SESSION_PROPERTIES;
 import static com.facebook.presto.jdbc.ConnectionProperties.SOCKS_PROXY;
 import static com.facebook.presto.jdbc.ConnectionProperties.SSL_TRUST_STORE_PASSWORD;
 import static com.facebook.presto.jdbc.ConnectionProperties.SSL_TRUST_STORE_PATH;
@@ -103,6 +104,9 @@ public class TestPrestoDriverUri
 
         // empty extra credentials
         assertInvalid("presto://localhost:8080?extraCredentials=", "Connection property 'extraCredentials' value is empty");
+
+        assertInvalid("presto://localhost:8080?sessionProperties=", "Connection property 'sessionProperties' value is empty");
+        assertInvalid("presto://localhost:8080?sessionProperties=sdf", "Connection property 'sessionProperties' value is invalid: sdf");
     }
 
     @Test(expectedExceptions = SQLException.class, expectedExceptionsMessageRegExp = "Connection property 'user' is required")
@@ -233,6 +237,16 @@ public class TestPrestoDriverUri
         PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?extraCredentials=" + extraCredentials);
         Properties properties = parameters.getProperties();
         assertEquals(properties.getProperty(EXTRA_CREDENTIALS.getKey()), extraCredentials);
+    }
+
+    @Test
+    public void testUriWithSessionProperties()
+            throws SQLException
+    {
+        String sessionProperties = "sessionProp1:sessionValue1;sessionProp2:sessionValue2";
+        PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?sessionProperties=" + sessionProperties);
+        Properties properties = parameters.getProperties();
+        assertEquals(properties.getProperty(SESSION_PROPERTIES.getKey()), sessionProperties);
     }
 
     private static void assertUriPortScheme(PrestoDriverUri parameters, int port, String scheme)


### PR DESCRIPTION
Session property overrides can be specified by the sessionProperty flag,
with each session property separated by `;`, and each key value pair
separated by `:`.

For example:

`jdbc:presto://localhost:8080?sessionProperties=prop1:value1;prop2:value2`

```
== RELEASE NOTES ==

General Changes
* Add sessionProperty override to Presto JDBC URI
```