### PR TITLE
Add session property for targetResultSize

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -157,6 +157,7 @@ public final class SystemSessionProperties
     public static final String PREFER_DISTRIBUTED_UNION = "prefer_distributed_union";
     public static final String WARNING_HANDLING = "warning_handling";
     public static final String OPTIMIZE_NULLS_IN_JOINS = "optimize_nulls_in_join";
+    public static final String TARGET_RESULT_SIZE = "target_result_size";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -806,7 +807,16 @@ public final class SystemSessionProperties
                         OPTIMIZE_NULLS_IN_JOINS,
                         "Filter nulls from inner side of join",
                         featuresConfig.isOptimizeNullsInJoin(),
-                        false));
+                        false),
+                new PropertyMetadata<>(
+                        TARGET_RESULT_SIZE,
+                        "Target result size for results being streamed from coordinator",
+                        VARCHAR,
+                        DataSize.class,
+                        null,
+                        false,
+                        value -> value != null ? DataSize.valueOf((String) value) : null,
+                        value -> value != null ? value.toString() : null));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -1361,5 +1371,10 @@ public final class SystemSessionProperties
     public static boolean isOptimizeNullsInJoin(Session session)
     {
         return session.getSystemProperty(OPTIMIZE_NULLS_IN_JOINS, Boolean.class);
+    }
+
+    public static Optional<DataSize> getTargetResultSize(Session session)
+    {
+        return Optional.ofNullable(session.getSystemProperty(TARGET_RESULT_SIZE, DataSize.class));
     }
 }


### PR DESCRIPTION
Setting the `target_result_size` session property will add the specified
`targetResultSize` as a parameter to the nextUri in a statement.

The default value for `targetResultSize` is 1MB.  It is useful to override this value in certain cases; for example, for scenarios which have limited bandwidth available, setting a larger value would mean larger payloads are streamed directly from the coordinator to the client before further requests for data are made, reducing wall time.

```
== RELEASE NOTES ==

General Changes
* Add ``target_result_size`` session property to customize data batch sizes being streamed from coordinator
```