### PR TITLE
Fix SingleMapBlock.seekKeyExact bug

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
@@ -352,7 +352,14 @@ public class SingleMapBlock
             Boolean match;
             try {
                 // assuming maps with indeterminate keys are not supported
-                match = mapBlock.getRawKeyBlock().bytesEqual(offset / 2 + keyPosition, 0, nativeValue, 0, nativeValue.length());
+                Block rawKeyBlock = mapBlock.getRawKeyBlock();
+
+                if (rawKeyBlock.getSliceLength(offset / 2 + keyPosition) != nativeValue.length()) {
+                    match = false;
+                }
+                else {
+                    match = rawKeyBlock.bytesEqual(offset / 2 + keyPosition, 0, nativeValue, 0, nativeValue.length());
+                }
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);

--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
 
 import static com.facebook.presto.common.block.ArrayBlock.fromElementBlock;
 import static com.facebook.presto.common.block.DictionaryId.randomDictionaryId;
@@ -135,7 +136,7 @@ public final class BlockAssertions
 
     public static Block createStringsBlock(Iterable<String> values)
     {
-        BlockBuilder builder = VARCHAR.createBlockBuilder(null, 100);
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, (int) StreamSupport.stream(values.spliterator(), false).count());
 
         for (String value : values) {
             if (value == null) {


### PR DESCRIPTION
When seeking map key of Slice type, we need to compare the bytes value
in the key block to the key value. When the current position in the
key block is shorter than the key's length, it could return wrong
results or IndexOutOfBoundsException. This commit fixes this issue.

```
== NO RELEASE NOTE ==
```
