### PR TITLE
Adding time type support for Pinot predicate pushdown

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPushdownUtils.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPushdownUtils.java
@@ -17,11 +17,15 @@ import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.common.type.BigintType;
 import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.common.type.CharType;
+import com.facebook.presto.common.type.DateTimeEncoding;
+import com.facebook.presto.common.type.DateType;
 import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.RealType;
 import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.TimestampWithTimeZoneType;
 import com.facebook.presto.common.type.TinyintType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
@@ -282,6 +286,13 @@ public class PinotPushdownUtils
         }
         if (type instanceof VarcharType || type instanceof CharType) {
             return "'" + ((Slice) node.getValue()).toStringUtf8() + "'";
+        }
+        if (type instanceof TimestampType || type instanceof DateType) {
+            return node.getValue().toString();
+        }
+        if (type instanceof TimestampWithTimeZoneType) {
+            Long millisUtc = DateTimeEncoding.unpackMillisUtc((Long) node.getValue());
+            return millisUtc.toString();
         }
         throw new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), String.format("Cannot handle the constant expression %s with value of type %s", node, type));
     }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotFilterExpressionConverter.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotFilterExpressionConverter.java
@@ -14,8 +14,14 @@
 package com.facebook.presto.pinot.query;
 
 import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.DateType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.TimestampWithTimeZoneType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.pinot.PinotException;
 import com.facebook.presto.pinot.query.PinotQueryGeneratorContext.Origin;
 import com.facebook.presto.pinot.query.PinotQueryGeneratorContext.Selection;
@@ -32,10 +38,13 @@ import com.facebook.presto.spi.relation.RowExpressionVisitor;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.google.common.collect.ImmutableSet;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -52,6 +61,8 @@ public class PinotFilterExpressionConverter
         implements RowExpressionVisitor<PinotExpression, Function<VariableReferenceExpression, Selection>>
 {
     private static final Set<String> LOGICAL_BINARY_OPS_FILTER = ImmutableSet.of("=", "<", "<=", ">", ">=", "<>");
+    private static final DateTimeFormatter DATE_FORMATTER = ISODateTimeFormat.date().withZoneUTC();
+
     private final TypeManager typeManager;
     private final FunctionMetadataManager functionMetadataManager;
     private final StandardFunctionResolution standardFunctionResolution;
@@ -89,13 +100,105 @@ public class PinotFilterExpressionConverter
         }
         List<RowExpression> arguments = call.getArguments();
         if (arguments.size() == 2) {
-            return derived(format(
-                    "(%s %s %s)",
-                    arguments.get(0).accept(this, context).getDefinition(),
-                    operator,
-                    arguments.get(1).accept(this, context).getDefinition()));
+            // Check if call compares a date/time column with a date/time constant. Otherwise just treat it like a regular binary operator.
+            return handleDateOrTimestampBinaryExpression(operator, arguments, context).orElseGet(
+                    () -> derived(format(
+                            "(%s %s %s)",
+                            arguments.get(0).accept(this, context).getDefinition(),
+                            operator,
+                            arguments.get(1).accept(this, context).getDefinition())));
         }
         throw new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), format("Unknown logical binary: '%s'", call));
+    }
+
+    private Optional<PinotExpression> handleDateOrTimestampBinaryExpression(String operator, List<RowExpression> arguments, Function<VariableReferenceExpression, Selection> context)
+    {
+        Optional<String> left = handleTimeValueCast(context, arguments.get(1), arguments.get(0));
+        Optional<String> right = handleTimeValueCast(context, arguments.get(0), arguments.get(1));
+        if (left.isPresent() && right.isPresent()) {
+            return Optional.of(derived(format("(%s %s %s)", left.get(), operator, right.get())));
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isDateTimeConstantType(Type type)
+    {
+        return type == DateType.DATE || type == TimestampType.TIMESTAMP || type == TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+    }
+
+    private Optional<String> handleTimeValueCast(Function<VariableReferenceExpression, Selection> context, RowExpression timeFieldExpression, RowExpression timeValueExpression)
+    {
+        // Handle the binary comparison logic of <DATE/TIMESTAMP field> <binary op> <DATE/TIMESTAMP literal>.
+        // Pinot stores time as:
+        //   - `DATE`: Stored as `INT`/`LONG` `daysSinceEpoch` value
+        //   - `TIMESTAMP`: Stored as `LONG` `millisSinceEpoch` value.
+        // In order to push down this predicate, we need to convert the literal to the type of Pinot time field.
+        // Below code compares the time type of both side:
+        //   - if same, then directly push down.
+        //   - if not same, then convert the literal time type to the field time type.
+        //   - if not compatible time types, returns Optional.empty(), indicates no change has been made in this cast.
+        // Take an example of comparing a `DATE` field to a `TIMESTAMP` literal:
+        //   - Sample predicate: `WHERE eventDate < current_time`.
+        //   - Input type is the `eventDate` field data type, which is `DATE`.
+        //   - Expect type is the right side `literal type`, which means right side is `TIMESTAMP`.
+        // The code below converts `current_time` from `millisSinceEpoch` value to `daysSinceEpoch` value, which is
+        // comparable to values in `eventDate` column.
+        Type inputType;
+        Type expectedType;
+        if (!isDateTimeConstantType(timeFieldExpression.getType()) || !isDateTimeConstantType(timeValueExpression.getType())) {
+            return Optional.empty();
+        }
+        String timeValueString = timeValueExpression.accept(this, context).getDefinition();
+        if (timeFieldExpression instanceof CallExpression) {
+            // Handles cases like: `cast(eventDate as TIMESTAMP) <  DATE '2014-01-31'`
+            // For cast function,
+            // - inputType is the argument type,
+            // - expectedType is the cast function return type.
+            CallExpression callExpression = (CallExpression) timeFieldExpression;
+            if (!standardFunctionResolution.isCastFunction(callExpression.getFunctionHandle())) {
+                return Optional.empty();
+            }
+            if (callExpression.getArguments().size() != 1) {
+                return Optional.empty();
+            }
+            inputType = callExpression.getArguments().get(0).getType();
+            expectedType = callExpression.getType();
+        }
+        else if (timeFieldExpression instanceof VariableReferenceExpression) {
+            // For VariableReferenceExpression,
+            // Handles queries like: `eventDate <  TIMESTAMP '2014-01-31 00:00:00 UTC'`
+            // - inputType is timeFieldExpression type,
+            // - expectedType is the timeValueExpression type.
+            inputType = timeFieldExpression.getType();
+            expectedType = timeValueExpression.getType();
+        }
+        else if (timeFieldExpression instanceof ConstantExpression) {
+            // timeFieldExpression is a ConstantExpression, directly return.
+            return Optional.of(timeValueString);
+        }
+        else {
+            return Optional.empty();
+        }
+        if (inputType == DateType.DATE && (expectedType == TimestampType.TIMESTAMP || expectedType == TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE)) {
+            // time field is `DATE`, try to convert time value from `TIMESTAMP` to `DATE`
+            try {
+                return Optional.of(Long.toString(TimeUnit.MILLISECONDS.toDays(Long.parseLong(timeValueString))));
+            }
+            catch (NumberFormatException e) {
+                throw new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), format("Unable to parse timestamp string: '%s'", timeValueString), e);
+            }
+        }
+        if ((inputType == TimestampType.TIMESTAMP || inputType == TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE) && expectedType == DateType.DATE) {
+            // time field is `TIMESTAMP`, try to convert time value from `DATE` to `TIMESTAMP`
+            try {
+                return Optional.of(Long.toString(TimeUnit.DAYS.toMillis(Long.parseLong(timeValueString))));
+            }
+            catch (NumberFormatException e) {
+                throw new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), format("Unable to parse date string: '%s'", timeValueString), e);
+            }
+        }
+        // Vacuous cast from variable to same type: cast(eventDate, DAYS). Already handled by handleCast.
+        return Optional.of(timeValueString);
     }
 
     private PinotExpression handleBetween(
@@ -141,6 +244,26 @@ public class PinotFilterExpressionConverter
             if (typeManager.canCoerce(input.getType(), expectedType)) {
                 return input.accept(this, context);
             }
+            // Expression like `DATE '2014-01-31'` is not cast to a constant number (like days since epoch) and thus it needs to be specifically handled here.
+            // `TIMESTAMP` type is cast correctly to milliseconds value.
+            if (expectedType == DateType.DATE) {
+                try {
+                    PinotExpression expression = input.accept(this, context);
+                    if (input.getType() == TimestampType.TIMESTAMP || input.getType() == TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE) {
+                        return expression;
+                    }
+                    // Special handling for Predicate like: "WHERE eventDate < DATE '2014-01-31'".
+                    // It converts ISO DateTime to daysSinceEpoch value so Pinot could understand this.
+                    if (input.getType() == VarcharType.VARCHAR) {
+                        // Remove the leading & trailing quote then parse
+                        Integer daysSinceEpoch = (int) TimeUnit.MILLISECONDS.toDays(DATE_FORMATTER.parseMillis(expression.getDefinition().substring(1, expression.getDefinition().length() - 1)));
+                        return new PinotExpression(daysSinceEpoch.toString(), expression.getOrigin());
+                    }
+                }
+                catch (Exception e) {
+                    throw new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), "Cast date value expression is not supported: " + cast);
+                }
+            }
             throw new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), "Non implicit casts not supported: " + cast);
         }
 
@@ -171,7 +294,26 @@ public class PinotFilterExpressionConverter
                 return handleLogicalBinary(operatorType.getOperator(), call, context);
             }
         }
+        // Handle queries like `eventTimestamp < 1391126400000`.
+        // Otherwise TypeManager.canCoerce(...) will return false and directly fail this query.
+        if (functionMetadata.getName().getFunctionName().equalsIgnoreCase("$literal$timestamp") ||
+                    functionMetadata.getName().getFunctionName().equalsIgnoreCase("$literal$date")) {
+            return handleDateAndTimestampMagicLiteralFunction(call, context);
+        }
         throw new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), format("function %s not supported in filter", call));
+    }
+
+    private PinotExpression handleDateAndTimestampMagicLiteralFunction(CallExpression timestamp, Function<VariableReferenceExpression, Selection> context)
+    {
+        if (timestamp.getArguments().size() == 1) {
+            RowExpression input = timestamp.getArguments().get(0);
+            Type expectedType = timestamp.getType();
+            if (typeManager.canCoerce(input.getType(), expectedType) || input.getType() == BigintType.BIGINT || input.getType() == IntegerType.INTEGER) {
+                return input.accept(this, context);
+            }
+            throw new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), "Non implicit Date/Timestamp Literal is not supported: " + timestamp);
+        }
+        throw new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), format("The Date/Timestamp Literal is not supported. Received: %s", timestamp));
     }
 
     @Override

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
@@ -68,7 +68,9 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DateType.DATE;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.pinot.PinotColumnHandle.PinotColumnType.REGULAR;
 import static com.facebook.presto.pinot.query.PinotQueryGeneratorContext.Origin.DERIVED;
@@ -94,6 +96,8 @@ public class TestPinotQueryBase
     protected static PinotColumnHandle city = new PinotColumnHandle("city", VARCHAR, REGULAR);
     protected static final PinotColumnHandle fare = new PinotColumnHandle("fare", DOUBLE, REGULAR);
     protected static final PinotColumnHandle secondsSinceEpoch = new PinotColumnHandle("secondsSinceEpoch", BIGINT, REGULAR);
+    protected static final PinotColumnHandle daysSinceEpoch = new PinotColumnHandle("daysSinceEpoch", DATE, REGULAR);
+    protected static final PinotColumnHandle millisSinceEpoch = new PinotColumnHandle("millisSinceEpoch", TIMESTAMP, REGULAR);
 
     protected static final Metadata metadata = MetadataManager.createTestMetadataManager();
 
@@ -108,6 +112,8 @@ public class TestPinotQueryBase
                     .put(new VariableReferenceExpression("totalfare", DOUBLE), new PinotQueryGeneratorContext.Selection("(fare + trip)", DERIVED)) // derived column
                     .put(new VariableReferenceExpression("count_regionid", BIGINT), new PinotQueryGeneratorContext.Selection("count(regionid)", DERIVED))// derived column
                     .put(new VariableReferenceExpression("secondssinceepoch", BIGINT), new PinotQueryGeneratorContext.Selection("secondsSinceEpoch", TABLE_COLUMN)) // column for datetime functions
+                    .put(new VariableReferenceExpression("dayssinceepoch", DATE), new PinotQueryGeneratorContext.Selection("daysSinceEpoch", TABLE_COLUMN)) // column for date functions
+                    .put(new VariableReferenceExpression("millissinceepoch", TIMESTAMP), new PinotQueryGeneratorContext.Selection("millisSinceEpoch", TABLE_COLUMN)) // column for timestamp functions
                     .build();
 
     protected final TypeProvider typeProvider = TypeProvider.fromVariables(testInput.keySet());


### PR DESCRIPTION
```
== RELEASE NOTES ==

Pinot Changes
* Support predicate pushdown for literals of type `DATE`, `TIMESTAMP`, or `TIMESTAMP_WITH_TIME_ZONE`

```
