### PR TITLE
Reduce redundant calls to setNull in DoubleSumAggregation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleSumAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DoubleSumAggregation.java
@@ -32,8 +32,13 @@ public final class DoubleSumAggregation
     @InputFunction
     public static void sum(@AggregationState NullableDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
     {
-        state.setNull(false);
-        state.setDouble(state.getDouble() + value);
+        if (state.isNull()) {
+            state.setNull(false);
+            state.setDouble(value);
+        }
+        else {
+            state.setDouble(state.getDouble() + value);
+        }
     }
 
     @CombineFunction


### PR DESCRIPTION
Minor performance fix to avoid calling setNull on the state multiple times. I have seen CPU time for just the agg part go down from 6.1hrs to 5.8hrs for some queries - indicating a ~5% improvement.

```
== NO RELEASE NOTE ==
```
