### PR TITLE
Optimization for use of Distinct with Limit clause

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -47,6 +47,7 @@ import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY
 import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.doubleProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
+import static com.facebook.presto.spi.session.PropertyMetadata.longProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.BROADCAST;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.PARTITIONED;
@@ -154,6 +155,7 @@ public final class SystemSessionProperties
     public static final String OPTIMIZE_COMMON_SUB_EXPRESSIONS = "optimize_common_sub_expressions";
     public static final String PREFER_DISTRIBUTED_UNION = "prefer_distributed_union";
     public static final String WARNING_HANDLING = "warning_handling";
+    public static final String DISTINCTLIMIT_OPERATOR_THRESHOLD = "distinctlimit_operator_threshold";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -784,7 +786,12 @@ public final class SystemSessionProperties
                         warningCollectorConfig.getWarningHandlingLevel(),
                         false,
                         value -> WarningHandlingLevel.valueOf(((String) value).toUpperCase()),
-                        WarningHandlingLevel::name));
+                        WarningHandlingLevel::name),
+                longProperty(
+                        DISTINCTLIMIT_OPERATOR_THRESHOLD,
+                        "Threshold allowed for distinctLimit Operator",
+                        featuresConfig.getAllowedDistrinctLimitThreshold(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -1324,5 +1331,10 @@ public final class SystemSessionProperties
     public static WarningHandlingLevel getWarningHandlingLevel(Session session)
     {
         return session.getSystemProperty(WARNING_HANDLING, WarningHandlingLevel.class);
+    }
+
+    public static long getDistinctLimitOperatorThreshold(Session session)
+    {
+        return session.getSystemProperty(DISTINCTLIMIT_OPERATOR_THRESHOLD, Long.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -153,6 +153,9 @@ public class FeaturesConfig
     private boolean optimizeCommonSubExpressions = true;
     private boolean preferDistributedUnion = true;
 
+    private long allowedDistrinctLimitThreshold = 1000000;
+    private boolean enableDistinctLimit = true;
+
     private PartitioningPrecisionStrategy partitioningPrecisionStrategy = PartitioningPrecisionStrategy.AUTOMATIC;
 
     public enum PartitioningPrecisionStrategy
@@ -1248,6 +1251,18 @@ public class FeaturesConfig
     public FeaturesConfig setPreferDistributedUnion(boolean preferDistributedUnion)
     {
         this.preferDistributedUnion = preferDistributedUnion;
+        return this;
+    }
+
+    public long getAllowedDistrinctLimitThreshold()
+    {
+        return allowedDistrinctLimitThreshold;
+    }
+
+    @Config("allowed-distinct-limit-threshold")
+    public FeaturesConfig setAllowedDistinctLimitThrehold(long allowedDistinctLimitThrehold)
+    {
+        this.allowedDistrinctLimitThreshold = allowedDistinctLimitThrehold;
         return this;
     }
 }


### PR DESCRIPTION
== RELEASE NOTES ==

General Changes

Presto optimizer transforms a DISTINCT with LIMIT clause into a DistinctLimit Operator. This operator works well when Limit count size is in low watermark. It does not perform once the count goes beyond certain level. The reason is that the operator accumulates the aggregation of the unique dataset which consumes a single node's memory significantly. Under a performance benchmark, it has been measured that the optimal performance for this operator is set when the limit count is less than 1 million rows.  

Hence, this fix allows user to query a large dataset using DISTINCT with LIMIT clause and ensures that the query does not consumes all memory in a single node. Beyond the threshold, the optimizer will choose to generate a different operator for streaming data back to the user.

Hive Changes

```

== NO RELEASE NOTE ==
```
