### PR TITLE
[WIP] [Coordinator Transport Revamp] Thriftify TaskStatus

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -213,6 +213,11 @@
 
         <dependency>
             <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-protocol</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
             <artifactId>drift-client</artifactId>
         </dependency>
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/Lifespan.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/Lifespan.java
@@ -14,6 +14,9 @@
 
 package com.facebook.presto.execution;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -23,9 +26,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Integer.parseInt;
 
+@ThriftStruct
 public class Lifespan
 {
-    private static final Lifespan TASK_WIDE = new Lifespan(false, 0);
+    private static final Lifespan TASK_WIDE = new Lifespan("TaskWide");
 
     private final boolean grouped;
     private final int groupId;
@@ -38,6 +42,20 @@ public class Lifespan
     public static Lifespan driverGroup(int id)
     {
         return new Lifespan(true, id);
+    }
+
+    @ThriftConstructor
+    public Lifespan(String value)
+    {
+        if (value.equals("TaskWide")) {
+            this.grouped = false;
+            this.groupId = 0;
+        }
+        else {
+            checkArgument(value.startsWith("Group"));
+            this.grouped = true;
+            this.groupId = parseInt(value.substring("Group".length()));
+        }
     }
 
     private Lifespan(boolean grouped, int groupId)
@@ -67,6 +85,7 @@ public class Lifespan
         return Lifespan.driverGroup(parseInt(value.substring("Group".length())));
     }
 
+    @ThriftField(value = 1, name = "value")
     @JsonValue
     public String toString()
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskState.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskState.java
@@ -13,11 +13,15 @@
  */
 package com.facebook.presto.execution;
 
+import com.facebook.drift.annotations.ThriftEnum;
+import com.facebook.drift.annotations.ThriftEnumValue;
+
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
+@ThriftEnum
 public enum TaskState
 {
     /**
@@ -63,5 +67,11 @@ public enum TaskState
     public boolean isDone()
     {
         return doneState;
+    }
+
+    @ThriftEnumValue
+    public int getValue()
+    {
+        return ordinal();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/thrift/BenchmarkThriftTaskStatus.java
+++ b/presto-main/src/test/java/com/facebook/presto/thrift/BenchmarkThriftTaskStatus.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.thrift;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.drift.codec.internal.coercion.DefaultJavaCoercions;
+import com.facebook.drift.codec.internal.compiler.CompilerThriftCodecFactory;
+import com.facebook.drift.protocol.TBinaryProtocol;
+import com.facebook.drift.protocol.TCompactProtocol;
+import com.facebook.drift.protocol.TFacebookCompactProtocol;
+import com.facebook.drift.protocol.TMemoryBuffer;
+import com.facebook.drift.protocol.TProtocol;
+import com.facebook.drift.protocol.TTransport;
+import com.facebook.drift.protocol.TTransportException;
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.TaskState;
+import com.facebook.presto.execution.TaskStatus;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.net.URI;
+import java.util.function.Function;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 10, batchSize = 100)
+@Measurement(iterations = 10, batchSize = 100)
+@BenchmarkMode(Mode.All)
+public class BenchmarkThriftTaskStatus
+{
+    private static final JsonCodec<TaskStatus> TASK_STATUS_CODEC = jsonCodec(TaskStatus.class);
+    private static final TaskStatus TASK_STATUS = getTaskStatus();
+    private static final ThriftCodecManager READ_CODEC_MANAGER = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+    private static final ThriftCodecManager WRITE_CODEC_MANAGER = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+    private static final ThriftCodec<TaskStatus> READ_CODEC = READ_CODEC_MANAGER.getCodec(TaskStatus.class);
+    private static final ThriftCodec<TaskStatus> WRITE_CODEC = WRITE_CODEC_MANAGER.getCodec(TaskStatus.class);
+    TMemoryBuffer transport = new TMemoryBuffer(100 * 1024);
+
+    @Benchmark
+    public void serDeJson()
+    {
+        String json = TASK_STATUS_CODEC.toJson(TASK_STATUS);
+        TASK_STATUS_CODEC.fromJson(json);
+    }
+
+    @Benchmark
+    public void serDeTBinaryProtocol()
+            throws Throwable
+    {
+        getRoundTripSerialize(TBinaryProtocol::new);
+    }
+
+    @Benchmark
+    public void serDeTCompactProtocol()
+            throws Throwable
+    {
+        getRoundTripSerialize(TCompactProtocol::new);
+    }
+
+    @Benchmark
+    public void serDeTFacebookCompactProtocol()
+            throws Throwable
+    {
+        getRoundTripSerialize(TFacebookCompactProtocol::new);
+    }
+
+    private TaskStatus getRoundTripSerialize(Function<TTransport, TProtocol> protocolFactory)
+            throws Throwable
+    {
+        TProtocol protocol = protocolFactory.apply(transport);
+        WRITE_CODEC.write(TASK_STATUS, protocol);
+        return READ_CODEC.read(protocol);
+    }
+
+    public static void checkSizes()
+            throws Throwable
+    {
+        int size = getSize(TBinaryProtocol::new);
+        System.out.println("TBinaryProtocol: " + size + " bytes");
+        size = getSize(TCompactProtocol::new);
+        System.out.println("TCompactProtocol: " + size + " bytes");
+        size = getSize(TFacebookCompactProtocol::new);
+        System.out.println("TFacebookCompactProtocol: " + size + " bytes");
+        size = TASK_STATUS_CODEC.toJson(TASK_STATUS).getBytes().length;
+        System.out.println("Json: " + size + " bytes");
+    }
+
+    private static int getSize(Function<TTransport, TProtocol> protocolFactory)
+            throws Exception
+    {
+        TMemoryBuffer transport = new TMemoryBuffer(100 * 1024);
+        TProtocol protocol = protocolFactory.apply(transport);
+        WRITE_CODEC.write(TASK_STATUS, protocol);
+        int size = 0;
+        while (true) {
+            try {
+                transport.read(new byte[1], 0, 1);
+            }
+            catch (TTransportException e) {
+                break;
+            }
+            size++;
+        }
+        return size;
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        checkSizes();
+        READ_CODEC_MANAGER.getCatalog().addDefaultCoercions(DefaultJavaCoercions.class);
+        WRITE_CODEC_MANAGER.getCatalog().addDefaultCoercions(DefaultJavaCoercions.class);
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkThriftTaskStatus.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+
+    private static TaskStatus getTaskStatus()
+    {
+        return new TaskStatus(
+                "test",
+                1,
+                TaskState.RUNNING,
+                URI.create("fake://task/" + "1"),
+                ImmutableSet.of(Lifespan.taskWide(), Lifespan.taskWide()),
+                ImmutableList.of(),
+                0,
+                0,
+                0.0,
+                false,
+                0,
+                0,
+                0,
+                0,
+                0);
+    }
+}


### PR DESCRIPTION
- Thrift structure for TaskStatus

- Benchmark for run time and message size between thrift and Json. 

Message Size comparison:

TBinaryProtocol: 168 bytes
TCompactProtocol: 68 bytes
TFacebookCompactProtocol: 68 bytes
Json: 468 bytes

Avg ms per operation is below. TFacebookCompactProtocol is **2x** faster than Json.

BenchmarkThriftTaskStatus.serDeJson                                                    avgt     10    0.301 ± 0.019   ms/op
BenchmarkThriftTaskStatus.serDeTBinaryProtocol                                 avgt     10    0.210 ± 0.207   ms/op
BenchmarkThriftTaskStatus.serDeTCompactProtocol                             avgt     10    0.154 ± 0.016   ms/op
BenchmarkThriftTaskStatus.serDeTFacebookCompactProtocol            avgt     10    0.145 ± 0.021   ms/op



