### PR TITLE
Treat SQL function parameter case-insensitive

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateFunctionTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateFunctionTask.java
@@ -41,7 +41,6 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.SqlFormatter.formatSql;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
-import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class CreateFunctionTask
@@ -85,7 +84,7 @@ public class CreateFunctionTask
     {
         QualifiedFunctionName functionName = qualifyFunctionName(statement.getFunctionName());
         List<Parameter> parameters = statement.getParameters().stream()
-                .map(parameter -> new Parameter(parameter.getName().toString().toLowerCase(ENGLISH), parseTypeSignature(parameter.getType())))
+                .map(parameter -> new Parameter(parameter.getName().toString(), parseTypeSignature(parameter.getType())))
                 .collect(toImmutableList());
         TypeSignature returnType = parseTypeSignature(statement.getReturnType());
         String description = statement.getComment().orElse("");

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlFunctionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlFunctionUtils.java
@@ -51,8 +51,11 @@ import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatm
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 
 public final class SqlFunctionUtils
 {
@@ -61,14 +64,17 @@ public final class SqlFunctionUtils
     public static Expression getSqlFunctionExpression(FunctionMetadata functionMetadata, SqlInvokedScalarFunctionImplementation implementation, SqlFunctionProperties sqlFunctionProperties, List<Expression> arguments)
     {
         checkArgument(functionMetadata.getImplementationType().equals(SQL), format("Expect SQL function, get %s", functionMetadata.getImplementationType()));
-        checkArgument(functionMetadata.getArgumentNames().isPresent(), "Argument name is missing");
-        Expression expression = parseSqlFunctionExpression(implementation, sqlFunctionProperties);
+        checkArgument(functionMetadata.getArgumentNames().isPresent(), "ArgumentNames is missing");
+        Expression expression = normalizeParameters(functionMetadata.getArgumentNames().get(), parseSqlFunctionExpression(implementation, sqlFunctionProperties));
         return SqlFunctionArgumentBinder.bindFunctionArguments(expression, functionMetadata.getArgumentNames().get(), arguments);
     }
 
     public static RowExpression getSqlFunctionRowExpression(FunctionMetadata functionMetadata, SqlInvokedScalarFunctionImplementation functionImplementation, Metadata metadata, SqlFunctionProperties sqlFunctionProperties, List<RowExpression> arguments)
     {
-        Expression expression = coerceIfNecessary(functionMetadata, parseSqlFunctionExpression(functionImplementation, sqlFunctionProperties), sqlFunctionProperties, metadata);
+        checkArgument(functionMetadata.getImplementationType().equals(SQL), format("Expect SQL function, get %s", functionMetadata.getImplementationType()));
+        checkArgument(functionMetadata.getArgumentNames().isPresent(), "ArgumentNames is missing");
+        Expression normalized = normalizeParameters(functionMetadata.getArgumentNames().get(), parseSqlFunctionExpression(functionImplementation, sqlFunctionProperties));
+        Expression expression = coerceIfNecessary(functionMetadata, normalized, sqlFunctionProperties, metadata);
 
         // Allocate variables for identifiers
         PlanVariableAllocator variableAllocator = new PlanVariableAllocator();
@@ -98,6 +104,22 @@ public final class SqlFunctionUtils
                         .map(variable -> variable.map(VariableReferenceExpression::getName))
                         .collect(toImmutableList()),
                 arguments);
+    }
+
+    private static Expression normalizeParameters(List<String> argumentNames, Expression sqlFunction)
+    {
+        return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Map<String, String>>()
+        {
+            @Override
+            public Expression rewriteIdentifier(Identifier node, Map<String, String> context, ExpressionTreeRewriter<Map<String, String>> treeRewriter)
+            {
+                String name = node.getValue().toLowerCase(ENGLISH);
+                if (context.containsKey(name)) {
+                    return new Identifier(context.get(name));
+                }
+                return node;
+            }
+        }, sqlFunction, argumentNames.stream().collect(toImmutableMap(String::toLowerCase, identity())));
     }
 
     private static Expression parseSqlFunctionExpression(SqlInvokedScalarFunctionImplementation functionImplementation, SqlFunctionProperties sqlFunctionProperties)

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -522,7 +522,7 @@ final class ShowQueriesRewrite
                         node.getName(),
                         false,
                         sqlFunction.getParameters().stream()
-                                .map(parameter -> new SqlParameterDeclaration(new Identifier(parameter.getName(), true), parameter.getType().toString()))
+                                .map(parameter -> new SqlParameterDeclaration(new Identifier(parameter.getName()), parameter.getType().toString()))
                                 .collect(toImmutableList()),
                         sqlFunction.getSignature().getReturnType().toString(),
                         Optional.of(sqlFunction.getDescription()),


### PR DESCRIPTION
Function parameters should be case-insensitive.
Also fixing:
* Store the parameter names as originally provided by users
* Use identifier default setting for delimited

```
== RELEASE NOTES ==

General Changes
* Fix case sensitivity issue in SQL function parameters. Function parameters should be treated case-insensitive.