### PR TITLE
Avoid wrapping iterators

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -94,6 +94,8 @@ import java.util.concurrent.Future;
 import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
 import static com.facebook.presto.execution.scheduler.StreamingPlanSection.extractStreamingSections;
 import static com.facebook.presto.execution.scheduler.TableWriteInfo.createTableWriteInfo;
+import static com.facebook.presto.spark.classloader_interface.ScalaUtils.collectScalaIterator;
+import static com.facebook.presto.spark.classloader_interface.ScalaUtils.emptyScalaIterator;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.toSerializedPage;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.connector.ConnectorCapabilities.SUPPORTS_PAGE_SINK_COMMIT;
@@ -108,7 +110,6 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.Futures.getUnchecked;
-import static java.util.Collections.emptyIterator;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -455,11 +456,11 @@ public class PrestoSparkQueryExecutionFactory
                         0,
                         0,
                         serializedTaskDescriptor,
-                        emptyIterator(),
+                        emptyScalaIterator(),
                         new PrestoSparkTaskInputs(ImmutableMap.of(), ImmutableMap.of(), inputs),
                         taskStatsCollector,
                         PrestoSparkSerializedPage.class);
-                return ImmutableList.copyOf(prestoSparkTaskExecutor);
+                return collectScalaIterator(prestoSparkTaskExecutor);
             }
 
             RddAndMore<PrestoSparkSerializedPage> rootRdd = createRdd(root, PrestoSparkSerializedPage.class);

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkTaskExecutor.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkTaskExecutor.java
@@ -14,8 +14,7 @@
 package com.facebook.presto.spark.classloader_interface;
 
 import scala.Tuple2;
-
-import java.util.Iterator;
+import scala.collection.Iterator;
 
 public interface IPrestoSparkTaskExecutor<T>
         extends Iterator<Tuple2<MutablePartitionId, T>>

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/IPrestoSparkTaskExecutorFactory.java
@@ -14,8 +14,7 @@
 package com.facebook.presto.spark.classloader_interface;
 
 import org.apache.spark.util.CollectionAccumulator;
-
-import java.util.Iterator;
+import scala.collection.Iterator;
 
 public interface IPrestoSparkTaskExecutorFactory
 {

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkShuffleSerializer.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkShuffleSerializer.java
@@ -18,6 +18,7 @@ import org.apache.spark.serializer.SerializationStream;
 import org.apache.spark.serializer.Serializer;
 import org.apache.spark.serializer.SerializerInstance;
 import scala.Tuple2;
+import scala.collection.AbstractIterator;
 import scala.collection.Iterator;
 import scala.reflect.ClassTag;
 
@@ -33,7 +34,6 @@ import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
 
 import static java.util.Objects.requireNonNull;
-import static scala.collection.JavaConversions.asScalaIterator;
 
 public class PrestoSparkShuffleSerializer
         extends Serializer
@@ -173,7 +173,7 @@ public class PrestoSparkShuffleSerializer
         @Override
         public Iterator<Tuple2<Object, Object>> asKeyValueIterator()
         {
-            return asScalaIterator(new java.util.Iterator<Tuple2<Object, Object>>()
+            return new AbstractIterator<Tuple2<Object, Object>>()
             {
                 private Tuple2<Object, Object> next;
 
@@ -231,7 +231,7 @@ public class PrestoSparkShuffleSerializer
                     row.setBuffer(buffer);
                     return tuple;
                 }
-            });
+            };
         }
 
         @Override

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskInputs.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskInputs.java
@@ -15,9 +15,9 @@ package com.facebook.presto.spark.classloader_interface;
 
 import org.apache.spark.broadcast.Broadcast;
 import scala.Tuple2;
+import scala.collection.Iterator;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskProcessor.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskProcessor.java
@@ -17,10 +17,10 @@ import org.apache.spark.TaskContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.util.CollectionAccumulator;
 import scala.Tuple2;
+import scala.collection.Iterator;
 
 import java.io.Serializable;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/ScalaUtils.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/ScalaUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.classloader_interface;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static java.util.Collections.unmodifiableList;
+
+public class ScalaUtils
+{
+    private ScalaUtils() {}
+
+    public static <T> List<T> collectScalaIterator(scala.collection.Iterator<T> iterator)
+    {
+        List<T> result = new ArrayList<>();
+        while (iterator.hasNext()) {
+            result.add(iterator.next());
+        }
+        return unmodifiableList(result);
+    }
+
+    public static <T> scala.collection.Iterator<T> emptyScalaIterator()
+    {
+        return new scala.collection.AbstractIterator<T>()
+        {
+            @Override
+            public boolean hasNext()
+            {
+                return false;
+            }
+
+            @Override
+            public T next()
+            {
+                throw new NoSuchElementException();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Wrapping iterators results is large stacks when all method invocations are virtual potentially degrading the performance when the average row size is tiny.

Additionally it makes much harder to "downcast" the iterator provided by Spark if some further optimizations are needed. 

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
