### PR TITLE
Add metadata support for reading hive encrypted data

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveErrorCode.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveErrorCode.java
@@ -66,6 +66,8 @@ public enum HiveErrorCode
     HIVE_UNKNOWN_COLUMN_STATISTIC_TYPE(39, INTERNAL_ERROR),
     HIVE_TABLE_BUCKETING_IS_IGNORED(40, USER_ERROR),
     HIVE_TRANSACTION_NOT_FOUND(41, INTERNAL_ERROR),
+    // To be used for metadata inconsistencies and not for incorrect input from users
+    HIVE_INVALID_ENCRYPTION_METADATA(42, EXTERNAL),
     /**/;
 
     private final ErrorCode errorCode;

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/ColumnEncryptionInformation.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/ColumnEncryptionInformation.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.lang.String.format;
+import static java.util.Objects.hash;
+import static java.util.Objects.requireNonNull;
+
+public class ColumnEncryptionInformation
+{
+    private static final char HIVE_PROPERTY_COLUMN_DELIMITER = ',';
+    private static final char HIVE_PROPERTY_KEY_JOINER = ':';
+    private static final char HIVE_PROPERTY_ENTRY_DELIMITER = ';';
+
+    private final Map<ColumnWithStructSubfield, String> columnToKeyReference;
+
+    private ColumnEncryptionInformation(Map<ColumnWithStructSubfield, String> columnToKeyReference)
+    {
+        this.columnToKeyReference = ImmutableMap.copyOf(requireNonNull(columnToKeyReference, "columnToKeyReference is null"));
+    }
+
+    public Map<ColumnWithStructSubfield, String> getColumnToKeyReference()
+    {
+        return columnToKeyReference;
+    }
+
+    public boolean hasEntries()
+    {
+        return !columnToKeyReference.isEmpty();
+    }
+
+    private Map<String, List<String>> getKeyReferenceToColumns()
+    {
+        Map<String, List<String>> keyReferenceToColumns = new HashMap<>();
+        columnToKeyReference.forEach((column, keyReference) -> keyReferenceToColumns.computeIfAbsent(keyReference, unused -> new ArrayList<>()).add(column.toString()));
+        return keyReferenceToColumns;
+    }
+
+    public List<String> toTableProperty()
+    {
+        return getKeyReferenceToColumns()
+                .entrySet()
+                .stream()
+                .map(entry -> format("%s%s%s", entry.getKey(), HIVE_PROPERTY_KEY_JOINER, Joiner.on(HIVE_PROPERTY_COLUMN_DELIMITER).join(entry.getValue())))
+                .collect(toImmutableList());
+    }
+
+    public String toHiveProperty()
+    {
+        return Joiner.on(HIVE_PROPERTY_ENTRY_DELIMITER).join(toTableProperty());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return hash(columnToKeyReference);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || !this.getClass().equals(obj.getClass())) {
+            return false;
+        }
+
+        ColumnEncryptionInformation otherObj = (ColumnEncryptionInformation) obj;
+        return Objects.equals(this.columnToKeyReference, otherObj.columnToKeyReference);
+    }
+
+    public static ColumnEncryptionInformation fromHiveProperty(String value)
+    {
+        if (value == null) {
+            return new ColumnEncryptionInformation(ImmutableMap.of());
+        }
+
+        List<String> keyReferenceWithColumns = Splitter.on(HIVE_PROPERTY_ENTRY_DELIMITER).trimResults().splitToList(value);
+        return fromTableProperty(keyReferenceWithColumns);
+    }
+
+    public static ColumnEncryptionInformation fromTableProperty(Object value)
+    {
+        if (value == null) {
+            return new ColumnEncryptionInformation(ImmutableMap.of());
+        }
+
+        List<?> data = (List<?>) value;
+
+        Map<ColumnWithStructSubfield, String> columnToKeyReference = new HashMap<>();
+        for (Object entry : data) {
+            if (entry == null) {
+                throw new PrestoException(INVALID_TABLE_PROPERTY, "Encrypted columns property cannot have null value");
+            }
+
+            String keyEntry = (String) entry;
+
+            List<String> keyEntries = Splitter.on(HIVE_PROPERTY_KEY_JOINER).splitToList(keyEntry);
+
+            if (keyEntries.size() != 2) {
+                throw new PrestoException(INVALID_TABLE_PROPERTY, format("Encrypted column entry needs to be in the format 'key1:col1,col2'. Received: %s", keyEntry));
+            }
+
+            String keyReference = keyEntries.get(0);
+            String columns = keyEntries.get(1);
+
+            List<String> columnList = Splitter.on(HIVE_PROPERTY_COLUMN_DELIMITER).trimResults().splitToList(columns);
+
+            columnList.forEach(column -> {
+                String previousReferenceKey = columnToKeyReference.put(ColumnWithStructSubfield.valueOf(column), keyReference);
+                if (previousReferenceKey != null) {
+                    throw new PrestoException(
+                            INVALID_TABLE_PROPERTY,
+                            format("Column %s has been assigned 2 key references (%s and %s). Only 1 is allowed", column, keyReference, previousReferenceKey));
+                }
+            });
+        }
+        return new ColumnEncryptionInformation(columnToKeyReference);
+    }
+
+    public static ColumnEncryptionInformation fromMap(Map<String, String> columnToKeyReference)
+    {
+        return new ColumnEncryptionInformation(
+                columnToKeyReference
+                        .entrySet()
+                        .stream()
+                        .collect(toImmutableMap(entry -> ColumnWithStructSubfield.valueOf(entry.getKey()), Map.Entry::getValue)));
+    }
+
+    public static final class ColumnWithStructSubfield
+    {
+        private final String columnName;
+        private final Optional<String> subfieldPath;
+
+        private ColumnWithStructSubfield(String columnName, Optional<String> subfieldPath)
+        {
+            this.columnName = requireNonNull(columnName, "columnName is null");
+            this.subfieldPath = requireNonNull(subfieldPath, "subfieldPath is null");
+        }
+
+        public String getColumnName()
+        {
+            return columnName;
+        }
+
+        public Optional<String> getSubfieldPath()
+        {
+            return subfieldPath;
+        }
+
+        public Optional<ColumnWithStructSubfield> getChildField()
+        {
+            return subfieldPath.map(ColumnWithStructSubfield::valueOf);
+        }
+
+        public static ColumnWithStructSubfield valueOf(String columnExpression)
+        {
+            if (columnExpression == null) {
+                throw new PrestoException(GENERIC_INTERNAL_ERROR, "Cannot provide null column name for encryption columns");
+            }
+
+            List<String> splitParts = Splitter.on('.').limit(2).splitToList(columnExpression);
+
+            if (splitParts.size() == 1) {
+                return new ColumnWithStructSubfield(splitParts.get(0), Optional.empty());
+            }
+
+            return new ColumnWithStructSubfield(splitParts.get(0), Optional.of(splitParts.get(1)));
+        }
+
+        @Override
+        public String toString()
+        {
+            return columnName + subfieldPath.map(path -> "." + path).orElse("");
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return hash(columnName, subfieldPath);
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (other == null) {
+                return false;
+            }
+
+            if (!other.getClass().equals(this.getClass())) {
+                return false;
+            }
+
+            ColumnWithStructSubfield otherObj = (ColumnWithStructSubfield) other;
+            return Objects.equals(this.columnName, otherObj.columnName) &&
+                    Objects.equals(this.subfieldPath, otherObj.subfieldPath);
+        }
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/EncryptionProperties.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/EncryptionProperties.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+public class EncryptionProperties
+{
+    public static final String ENCRYPT_COLUMNS_KEY = "encrypt.columns";
+    public static final String ENCRYPT_TABLE_KEY = "encrypt.table";
+    public static final String DWRF_ENCRYPTION_ALGORITHM_KEY = "dwrf.encryption.algorithm";
+    public static final String DWRF_ENCRYPTION_PROVIDER_KEY = "dwrf.encryption.provider";
+
+    private EncryptionProperties()
+    {
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -324,7 +324,8 @@ public class BackgroundHiveSplitLoader
                         getNodeSelectionStrategy(session),
                         s3SelectPushdownEnabled,
                         new HiveSplitPartitionInfo(storage, path.toUri(), partitionKeys, partitionName, partitionDataColumnCount, partition.getPartitionSchemaDifference(), Optional.empty()),
-                        schedulerUsesHostAddresses);
+                        schedulerUsesHostAddresses,
+                        partition.getEncryptionInformation());
                 lastResult = addSplitsToSource(targetSplits, splitFactory);
                 if (stopped) {
                     return COMPLETED_FUTURE;
@@ -364,7 +365,8 @@ public class BackgroundHiveSplitLoader
                         partitionDataColumnCount,
                         partition.getPartitionSchemaDifference(),
                         bucketConversionRequiresWorkerParticipation ? bucketConversion : Optional.empty()),
-                schedulerUsesHostAddresses);
+                schedulerUsesHostAddresses,
+                partition.getEncryptionInformation());
 
         if (!isHudiInputFormat(inputFormat) && shouldUseFileSplitsFromInputFormat(inputFormat)) {
             if (tableBucketInfo.isPresent()) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/DwrfEncryptionMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/DwrfEncryptionMetadata.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static java.util.Objects.hash;
+import static java.util.Objects.requireNonNull;
+
+public class DwrfEncryptionMetadata
+        implements EncryptionMetadata
+{
+    private final Map<String, byte[]> fieldToKeyData;
+
+    @JsonCreator
+    public DwrfEncryptionMetadata(
+            @JsonProperty Map<String, byte[]> fieldToKeyData)
+    {
+        this.fieldToKeyData = ImmutableMap.copyOf(requireNonNull(fieldToKeyData, "fieldToKeyData is null"));
+    }
+
+    @JsonProperty
+    public Map<String, byte[]> getFieldToKeyData()
+    {
+        return fieldToKeyData;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return hash(fieldToKeyData);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj == null || !this.getClass().equals(obj.getClass())) {
+            return false;
+        }
+
+        DwrfEncryptionMetadata otherObj = (DwrfEncryptionMetadata) obj;
+        return compareFieldMap(this.fieldToKeyData, otherObj.fieldToKeyData);
+    }
+
+    private static boolean compareFieldMap(Map<String, byte[]> obj1, Map<String, byte[]> obj2)
+    {
+        if (obj1 == null && obj2 == null) {
+            return true;
+        }
+
+        if (obj1 == null || obj2 == null) {
+            return false;
+        }
+
+        if (obj1.size() != obj2.size()) {
+            return false;
+        }
+
+        return obj1.entrySet().stream().allMatch(entry -> Arrays.equals(entry.getValue(), obj2.get(entry.getKey())));
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/EncryptionInformation.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/EncryptionInformation.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.PrestoException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_ENCRYPTION_METADATA;
+import static java.util.Objects.hash;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * An object of {@link EncryptionInformation} will be passed to the readers and writers. The readers and writers
+ * can decide which fields they want to read and how to use it.
+ */
+public class EncryptionInformation
+{
+    // Add a field for new file format encryption types
+    private final Optional<DwrfEncryptionMetadata> dwrfEncryptionMetadata;
+
+    // Only to be used by Jackson. Otherwise use {@link this#fromEncryptionMetadata}
+    @JsonCreator
+    public EncryptionInformation(@JsonProperty Optional<DwrfEncryptionMetadata> dwrfEncryptionMetadata)
+    {
+        this.dwrfEncryptionMetadata = requireNonNull(dwrfEncryptionMetadata, "dwrfEncryptionMetadata is null");
+    }
+
+    @JsonProperty
+    public Optional<DwrfEncryptionMetadata> getDwrfEncryptionMetadata()
+    {
+        return dwrfEncryptionMetadata;
+    }
+
+    public static EncryptionInformation fromEncryptionMetadata(EncryptionMetadata encryptionMetadata)
+    {
+        requireNonNull(encryptionMetadata, "encryptionMetadata is null");
+
+        if (encryptionMetadata instanceof DwrfEncryptionMetadata) {
+            return new EncryptionInformation(Optional.of((DwrfEncryptionMetadata) encryptionMetadata));
+        }
+
+        throw new PrestoException(HIVE_INVALID_ENCRYPTION_METADATA, "Unknown encryptionMetadata type: " + encryptionMetadata.getClass());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return hash(dwrfEncryptionMetadata);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj == null || !this.getClass().equals(obj.getClass())) {
+            return false;
+        }
+
+        EncryptionInformation otherObj = (EncryptionInformation) obj;
+        return Objects.equals(this.dwrfEncryptionMetadata, otherObj.dwrfEncryptionMetadata);
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/EncryptionInformationSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/EncryptionInformationSource.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.ConnectorSession;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Responsible for taking care of returning an object which implements {@link EncryptionMetadata} if the passed in
+ * {@link Table} satisfies the criteria for the implementation.
+ */
+public interface EncryptionInformationSource
+{
+    /**
+     * Return encryption for a partitioned table
+     *
+     * @param session Session object for the associated query
+     * @param table Table information
+     * @param requestedColumns The columns that the query is requesting access to. The implementations can use this to only return information
+     *                         for the requested columns
+     * @param partitions Map from partition names to the column objects
+     * @return Map from the partition name to the encryption information for that respective partition. The implementation can decide to return
+     *         information for selected partitions. The implementation should return <code>Optional.empty()</code> if it does not have any
+     *         encryption information available for the given table and partitions, either due to the format or the table not having any encrypted
+     *         data.
+     */
+    Optional<Map<String, EncryptionInformation>> getEncryptionInformation(
+            ConnectorSession session,
+            Table table,
+            Optional<Set<HiveColumnHandle>> requestedColumns,
+            Map<String, Partition> partitions);
+
+    /**
+     * Return encryption information for an unpartitioned table
+     *
+     * @param session Session object for the associated query
+     * @param table Table information
+     * @param requestedColumns The columns that the query is requesting access to. The implementations can use this to only return information
+     *                         for the requested columns
+     * @return Encryption information for the given table. The implementation should return <code>Optional.empty()</code> if it does not have any
+     *         encryption information available for the given table, either due to the format or the table not having any encrypted data.
+     */
+    Optional<EncryptionInformation> getEncryptionInformation(
+            ConnectorSession session,
+            Table table,
+            Optional<Set<HiveColumnHandle>> requestedColumns);
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/EncryptionMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/EncryptionMetadata.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+/**
+ * Different file formats and implementations can choose the information needed by the readers/writers
+ * to encrypt and decrypt data.
+ */
+public interface EncryptionMetadata
+{
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -174,6 +174,9 @@ public class HiveClientModule
         configBinder(binder).bindConfig(ParquetFileWriterConfig.class);
         fileWriterFactoryBinder.addBinding().to(ParquetFileWriterFactory.class).in(Scopes.SINGLETON);
         binder.install(new MetastoreClientModule());
+
+        binder.bind(HiveEncryptionInformationProvider.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, EncryptionInformationSource.class);
     }
 
     @ForHiveClient

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveEncryptionInformationProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveEncryptionInformationProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.ConnectorSession;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class HiveEncryptionInformationProvider
+{
+    private final List<EncryptionInformationSource> sources;
+
+    @Inject
+    public HiveEncryptionInformationProvider(Set<EncryptionInformationSource> sources)
+    {
+        this(ImmutableList.copyOf(requireNonNull(sources, "sources is null")));
+    }
+
+    @VisibleForTesting
+    HiveEncryptionInformationProvider(List<EncryptionInformationSource> sources)
+    {
+        this.sources = ImmutableList.copyOf(requireNonNull(sources, "sources is null"));
+    }
+
+    public Optional<Map<String, EncryptionInformation>> getEncryptionInformation(
+            ConnectorSession session,
+            Table table,
+            Optional<Set<HiveColumnHandle>> requestedColumns,
+            Map<String, Partition> partitions)
+    {
+        for (EncryptionInformationSource source : sources) {
+            Optional<Map<String, EncryptionInformation>> result = source.getEncryptionInformation(session, table, requestedColumns, partitions);
+            if (result != null && result.isPresent()) {
+                return result.map(ImmutableMap::copyOf);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public Optional<EncryptionInformation> getEncryptionInformation(
+            ConnectorSession session,
+            Table table,
+            Optional<Set<HiveColumnHandle>> requestedColumns)
+    {
+        for (EncryptionInformationSource source : sources) {
+            Optional<EncryptionInformation> result = source.getEncryptionInformation(session, table, requestedColumns);
+            if (result != null && result.isPresent()) {
+                return result;
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -2046,7 +2046,8 @@ public class HiveMetadata
                                 hiveBucketHandle,
                                 hivePartitionResult.getBucketFilter(),
                                 false,
-                                createTableLayoutString(session, handle.getSchemaTableName(), hivePartitionResult.getBucketHandle(), hivePartitionResult.getBucketFilter(), TRUE_CONSTANT, domainPredicate))),
+                                createTableLayoutString(session, handle.getSchemaTableName(), hivePartitionResult.getBucketHandle(), hivePartitionResult.getBucketFilter(), TRUE_CONSTANT, domainPredicate),
+                                desiredColumns.map(columns -> columns.stream().map(column -> (HiveColumnHandle) column).collect(toImmutableSet())))),
                 hivePartitionResult.getUnenforcedConstraint()));
     }
 
@@ -2281,7 +2282,8 @@ public class HiveMetadata
                 Optional.of(new HiveBucketHandle(bucketHandle.getColumns(), bucketHandle.getTableBucketCount(), hivePartitioningHandle.getBucketCount())),
                 hiveLayoutHandle.getBucketFilter(),
                 hiveLayoutHandle.isPushdownFilterEnabled(),
-                hiveLayoutHandle.getLayoutString());
+                hiveLayoutHandle.getLayoutString(),
+                hiveLayoutHandle.getRequestedColumns());
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.NullableValue;
 import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.VarcharType;
@@ -116,7 +117,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -141,6 +144,11 @@ import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTAN
 import static com.facebook.presto.expressions.LogicalRowExpressions.binaryExpression;
 import static com.facebook.presto.hive.BucketFunctionType.HIVE_COMPATIBLE;
 import static com.facebook.presto.hive.BucketFunctionType.PRESTO_NATIVE;
+import static com.facebook.presto.hive.ColumnEncryptionInformation.ColumnWithStructSubfield;
+import static com.facebook.presto.hive.EncryptionProperties.DWRF_ENCRYPTION_ALGORITHM_KEY;
+import static com.facebook.presto.hive.EncryptionProperties.DWRF_ENCRYPTION_PROVIDER_KEY;
+import static com.facebook.presto.hive.EncryptionProperties.ENCRYPT_COLUMNS_KEY;
+import static com.facebook.presto.hive.EncryptionProperties.ENCRYPT_TABLE_KEY;
 import static com.facebook.presto.hive.HiveAnalyzeProperties.getPartitionList;
 import static com.facebook.presto.hive.HiveBasicStatistics.createEmptyStatistics;
 import static com.facebook.presto.hive.HiveBasicStatistics.createZeroStatistics;
@@ -155,6 +163,7 @@ import static com.facebook.presto.hive.HiveColumnHandle.PATH_COLUMN_NAME;
 import static com.facebook.presto.hive.HiveColumnHandle.updateRowIdHandle;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_COLUMN_ORDER_MISMATCH;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CONCURRENT_MODIFICATION_DETECTED;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_ENCRYPTION_METADATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_READ_ONLY;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_TIMEZONE_MISMATCH;
@@ -188,6 +197,10 @@ import static com.facebook.presto.hive.HiveStorageFormat.values;
 import static com.facebook.presto.hive.HiveTableProperties.AVRO_SCHEMA_URL;
 import static com.facebook.presto.hive.HiveTableProperties.BUCKETED_BY_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.BUCKET_COUNT_PROPERTY;
+import static com.facebook.presto.hive.HiveTableProperties.DWRF_ENCRYPTION_ALGORITHM;
+import static com.facebook.presto.hive.HiveTableProperties.DWRF_ENCRYPTION_PROVIDER;
+import static com.facebook.presto.hive.HiveTableProperties.ENCRYPT_COLUMNS;
+import static com.facebook.presto.hive.HiveTableProperties.ENCRYPT_TABLE;
 import static com.facebook.presto.hive.HiveTableProperties.EXTERNAL_LOCATION_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.ORC_BLOOM_FILTER_COLUMNS;
 import static com.facebook.presto.hive.HiveTableProperties.ORC_BLOOM_FILTER_FPP;
@@ -197,6 +210,10 @@ import static com.facebook.presto.hive.HiveTableProperties.SORTED_BY_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.STORAGE_FORMAT_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.getAvroSchemaUrl;
 import static com.facebook.presto.hive.HiveTableProperties.getBucketProperty;
+import static com.facebook.presto.hive.HiveTableProperties.getDwrfEncryptionAlgorithm;
+import static com.facebook.presto.hive.HiveTableProperties.getDwrfEncryptionProvider;
+import static com.facebook.presto.hive.HiveTableProperties.getEncryptColumns;
+import static com.facebook.presto.hive.HiveTableProperties.getEncryptTable;
 import static com.facebook.presto.hive.HiveTableProperties.getExternalLocation;
 import static com.facebook.presto.hive.HiveTableProperties.getHiveStorageFormat;
 import static com.facebook.presto.hive.HiveTableProperties.getOrcBloomFilterColumns;
@@ -524,12 +541,33 @@ public class HiveMetadata
         }
 
         // Storage format property
+        HiveStorageFormat format = null;
         try {
-            HiveStorageFormat format = extractHiveStorageFormat(table.get());
+            format = extractHiveStorageFormat(table.get());
             properties.put(STORAGE_FORMAT_PROPERTY, format);
         }
         catch (PrestoException ignored) {
             // todo fail if format is not known
+        }
+
+        String encryptTable = table.get().getParameters().get(ENCRYPT_TABLE_KEY);
+        String encryptColumns = table.get().getParameters().get(ENCRYPT_COLUMNS_KEY);
+
+        if (encryptTable != null || encryptColumns != null) {
+            if (format != DWRF) {
+                throw new PrestoException(HIVE_INVALID_ENCRYPTION_METADATA, "Encryption is supported only with DWRF");
+            }
+
+            if (encryptTable != null) {
+                properties.put(ENCRYPT_TABLE, encryptTable);
+            }
+
+            if (encryptColumns != null) {
+                properties.put(ENCRYPT_COLUMNS, ColumnEncryptionInformation.fromHiveProperty(encryptColumns));
+            }
+
+            properties.put(DWRF_ENCRYPTION_ALGORITHM, table.get().getParameters().get(DWRF_ENCRYPTION_ALGORITHM_KEY));
+            properties.put(DWRF_ENCRYPTION_PROVIDER, table.get().getParameters().get(DWRF_ENCRYPTION_PROVIDER_KEY));
         }
 
         // Partitioning property
@@ -794,7 +832,8 @@ public class HiveMetadata
         List<HiveColumnHandle> columnHandles = getColumnHandles(tableMetadata, ImmutableSet.copyOf(partitionedBy), typeTranslator);
         HiveStorageFormat hiveStorageFormat = getHiveStorageFormat(tableMetadata.getProperties());
         List<SortingColumn> preferredOrderingColumns = getPreferredOrderingColumns(tableMetadata.getProperties());
-        Map<String, String> tableProperties = getEmptyTableProperties(tableMetadata, !partitionedBy.isEmpty(), new HdfsContext(session, schemaName, tableName));
+
+        Map<String, String> tableProperties = getEmptyTableProperties(tableMetadata, partitionedBy, new HdfsContext(session, schemaName, tableName), hiveStorageFormat);
 
         validateColumns(hiveStorageFormat, columnHandles);
 
@@ -971,7 +1010,7 @@ public class HiveMetadata
         return (MapTypeInfo) typeInfo;
     }
 
-    private Map<String, String> getEmptyTableProperties(ConnectorTableMetadata tableMetadata, boolean partitioned, HdfsContext hdfsContext)
+    private Map<String, String> getEmptyTableProperties(ConnectorTableMetadata tableMetadata, List<String> partitionedBy, HdfsContext hdfsContext, HiveStorageFormat hiveStorageFormat)
     {
         Builder<String, String> tableProperties = ImmutableMap.builder();
 
@@ -988,7 +1027,6 @@ public class HiveMetadata
         // Avro specific properties
         String avroSchemaUrl = getAvroSchemaUrl(tableMetadata.getProperties());
         if (avroSchemaUrl != null) {
-            HiveStorageFormat hiveStorageFormat = getHiveStorageFormat(tableMetadata.getProperties());
             if (hiveStorageFormat != AVRO) {
                 throw new PrestoException(INVALID_TABLE_PROPERTY, format("Cannot specify %s table property for storage format: %s", AVRO_SCHEMA_URL, hiveStorageFormat));
             }
@@ -997,6 +1035,9 @@ public class HiveMetadata
 
         // Table comment property
         tableMetadata.getComment().ifPresent(value -> tableProperties.put(TABLE_COMMENT, value));
+
+        // Encryption specific settings
+        tableProperties.putAll(getEncryptionTableProperties(tableMetadata, hiveStorageFormat, partitionedBy));
 
         return tableProperties.build();
     }
@@ -1285,7 +1326,7 @@ public class HiveMetadata
         String schemaName = schemaTableName.getSchemaName();
         String tableName = schemaTableName.getTableName();
 
-        Map<String, String> tableProperties = getEmptyTableProperties(tableMetadata, !partitionedBy.isEmpty(), new HdfsContext(session, schemaName, tableName));
+        Map<String, String> tableProperties = getEmptyTableProperties(tableMetadata, partitionedBy, new HdfsContext(session, schemaName, tableName), tableStorageFormat);
         List<HiveColumnHandle> columnHandles = getColumnHandles(tableMetadata, ImmutableSet.copyOf(partitionedBy), typeTranslator);
         HiveStorageFormat partitionStorageFormat = isRespectTableFormat(session) ? tableStorageFormat : getHiveStorageFormat(session);
 
@@ -2776,6 +2817,109 @@ public class HiveMetadata
         if (!allColumns.subList(allColumns.size() - partitionedBy.size(), allColumns.size()).equals(partitionedBy)) {
             throw new PrestoException(HIVE_COLUMN_ORDER_MISMATCH, "Partition keys must be the last columns in the table and in the same order as the table properties: " + partitionedBy);
         }
+    }
+
+    private static Map<String, String> getEncryptionTableProperties(ConnectorTableMetadata tableMetadata, HiveStorageFormat hiveStorageFormat, List<String> partitionedBy)
+    {
+        ColumnEncryptionInformation columnEncryptionInformation = getEncryptColumns(tableMetadata.getProperties());
+        String tableEncryptionReference = getEncryptTable(tableMetadata.getProperties());
+
+        if (tableEncryptionReference == null && (columnEncryptionInformation == null || !columnEncryptionInformation.hasEntries())) {
+            return ImmutableMap.of();
+        }
+
+        if (tableEncryptionReference != null && columnEncryptionInformation.hasEntries()) {
+            throw new PrestoException(INVALID_TABLE_PROPERTY, format("Only one of %s or %s should be specified", ENCRYPT_TABLE, ENCRYPT_COLUMNS));
+        }
+
+        if (hiveStorageFormat != DWRF) {
+            throw new PrestoException(NOT_SUPPORTED, "Only DWRF file format supports encryption at this time");
+        }
+
+        // Change based on the file format as more file formats might support encryption
+        ImmutableMap.Builder<String, String> tableProperties = ImmutableMap.builder();
+        tableProperties.putAll(getDwrfEncryptionSettings(tableMetadata));
+
+        if (tableEncryptionReference != null) {
+            return tableProperties.put(ENCRYPT_TABLE_KEY, tableEncryptionReference).build();
+        }
+
+        partitionedBy.forEach(partitionColumn -> {
+            if (columnEncryptionInformation.getColumnToKeyReference().containsKey(ColumnWithStructSubfield.valueOf(partitionColumn))) {
+                throw new PrestoException(INVALID_TABLE_PROPERTY, format("Partition column (%s) cannot be used as an encryption column", partitionColumn));
+            }
+        });
+
+        Map<String, ColumnMetadata> columnMetadata = tableMetadata.getColumns().stream().collect(toImmutableMap(ColumnMetadata::getName, identity()));
+        // Sorting to ensure that we can find cases of multiple referenceKeys within the same struct chain. Example - a.b and a.b.c
+        // By sorting we ensure that we have already seen a.b and can find that when we visit a.b.c
+        List<ColumnWithStructSubfield> sortedColumns = new ArrayList<>(columnEncryptionInformation.getColumnToKeyReference().keySet());
+        sortedColumns.sort(Comparator.comparing(ColumnWithStructSubfield::toString));
+
+        Set<String> seenColumns = new HashSet<>();
+        for (ColumnWithStructSubfield columnWithSubfield : sortedColumns) {
+            ColumnMetadata column = columnMetadata.get(columnWithSubfield.getColumnName());
+            if (column == null) {
+                throw new PrestoException(INVALID_TABLE_PROPERTY, format("In %s unable to find column %s", ENCRYPT_COLUMNS, columnWithSubfield.getColumnName()));
+            }
+
+            if (seenColumns.contains(columnWithSubfield.toString())) {
+                throw new PrestoException(INVALID_TABLE_PROPERTY, format("The same column/subfield cannot have 2 encryption keys"));
+            }
+
+            if (columnWithSubfield.getSubfieldPath().isPresent()) {
+                Iterable<String> subfieldPathFragments = Splitter.on(".").split(columnWithSubfield.getSubfieldPath().get());
+                Type columnType = column.getType();
+                String parentPath = columnWithSubfield.getColumnName();
+
+                for (String pathFragment : subfieldPathFragments) {
+                    if (!(columnType instanceof RowType)) {
+                        throw new PrestoException(
+                                INVALID_TABLE_PROPERTY,
+                                format("In %s subfields declared in %s, but %s has type %s", ENCRYPT_COLUMNS, columnWithSubfield.toString(), column.getName(), column.getType().getDisplayName()));
+                    }
+
+                    if (seenColumns.contains(parentPath)) {
+                        throw new PrestoException(
+                                INVALID_TABLE_PROPERTY,
+                                format("For (%s) found a keyReference at a higher level field (%s)", columnWithSubfield.toString(), parentPath));
+                    }
+
+                    RowType row = (RowType) columnType;
+                    columnType = row.getFields().stream()
+                            .filter(f -> f.getName().orElse("").equals(pathFragment))
+                            .findAny()
+                            .map(RowType.Field::getType)
+                            .orElseThrow(() -> new PrestoException(
+                                    INVALID_TABLE_PROPERTY,
+                                    format("In %s subfields declared in %s, but %s has type %s", ENCRYPT_COLUMNS, columnWithSubfield.toString(), column.getName(), column.getType().getDisplayName())));
+
+                    parentPath = format("%s.%s", parentPath, pathFragment);
+                }
+            }
+
+            seenColumns.add(columnWithSubfield.toString());
+        }
+
+        return tableProperties.put(ENCRYPT_COLUMNS_KEY, columnEncryptionInformation.toHiveProperty()).build();
+    }
+
+    private static Map<String, String> getDwrfEncryptionSettings(ConnectorTableMetadata tableMetadata)
+    {
+        String encryptionAlgorithm = getDwrfEncryptionAlgorithm(tableMetadata.getProperties());
+        String encryptionProvider = getDwrfEncryptionProvider(tableMetadata.getProperties());
+
+        if (encryptionAlgorithm == null) {
+            throw new PrestoException(INVALID_TABLE_PROPERTY, format("%s needs to be provided for DWRF encrypted tables", DWRF_ENCRYPTION_ALGORITHM));
+        }
+
+        if (encryptionProvider == null) {
+            throw new PrestoException(INVALID_TABLE_PROPERTY, format("%s needs to be provided for DWRF encrypted tables", DWRF_ENCRYPTION_PROVIDER));
+        }
+
+        return ImmutableMap.of(
+                DWRF_ENCRYPTION_ALGORITHM_KEY, encryptionAlgorithm,
+                DWRF_ENCRYPTION_PROVIDER_KEY, encryptionProvider);
     }
 
     private static List<HiveColumnHandle> getColumnHandles(ConnectorTableMetadata tableMetadata, Set<String> partitionColumnNames, TypeTranslator typeTranslator)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionMetadata.java
@@ -26,15 +26,18 @@ public class HivePartitionMetadata
     private final Optional<Partition> partition;
     private final HivePartition hivePartition;
     private final Map<Integer, Column> partitionSchemaDifference;
+    private final Optional<EncryptionInformation> encryptionInformation;
 
     HivePartitionMetadata(
             HivePartition hivePartition,
             Optional<Partition> partition,
-            Map<Integer, Column> partitionSchemaDifference)
+            Map<Integer, Column> partitionSchemaDifference,
+            Optional<EncryptionInformation> encryptionInformation)
     {
         this.partition = requireNonNull(partition, "partition is null");
         this.hivePartition = requireNonNull(hivePartition, "hivePartition is null");
         this.partitionSchemaDifference = requireNonNull(partitionSchemaDifference, "partitionSchemaDifference is null");
+        this.encryptionInformation = requireNonNull(encryptionInformation, "encryptionInformation is null");
     }
 
     public HivePartition getHivePartition()
@@ -53,5 +56,10 @@ public class HivePartitionMetadata
     public Map<Integer, Column> getPartitionSchemaDifference()
     {
         return partitionSchemaDifference;
+    }
+
+    public Optional<EncryptionInformation> getEncryptionInformation()
+    {
+        return encryptionInformation;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
@@ -58,6 +58,7 @@ public class HiveSplit
     private final boolean s3SelectPushdownEnabled;
     private final Optional<byte[]> extraFileInfo;
     private final CacheQuotaRequirement cacheQuotaRequirement;
+    private final Optional<EncryptionInformation> encryptionInformation;
 
     @JsonCreator
     public HiveSplit(
@@ -79,7 +80,8 @@ public class HiveSplit
             @JsonProperty("bucketConversion") Optional<BucketConversion> bucketConversion,
             @JsonProperty("s3SelectPushdownEnabled") boolean s3SelectPushdownEnabled,
             @JsonProperty("extraFileInfo") Optional<byte[]> extraFileInfo,
-            @JsonProperty("cacheQuota") CacheQuotaRequirement cacheQuotaRequirement)
+            @JsonProperty("cacheQuota") CacheQuotaRequirement cacheQuotaRequirement,
+            @JsonProperty("encryptionMetadata") Optional<EncryptionInformation> encryptionInformation)
     {
         checkArgument(start >= 0, "start must be positive");
         checkArgument(length >= 0, "length must be positive");
@@ -98,6 +100,7 @@ public class HiveSplit
         requireNonNull(bucketConversion, "bucketConversion is null");
         requireNonNull(extraFileInfo, "extraFileInfo is null");
         requireNonNull(cacheQuotaRequirement, "cacheQuotaRequirement is null");
+        requireNonNull(encryptionInformation, "encryptionMetadata is null");
 
         this.database = database;
         this.table = table;
@@ -118,6 +121,7 @@ public class HiveSplit
         this.s3SelectPushdownEnabled = s3SelectPushdownEnabled;
         this.extraFileInfo = extraFileInfo;
         this.cacheQuotaRequirement = cacheQuotaRequirement;
+        this.encryptionInformation = encryptionInformation;
     }
 
     @JsonProperty
@@ -252,6 +256,12 @@ public class HiveSplit
     public CacheQuotaRequirement getCacheQuotaRequirement()
     {
         return cacheQuotaRequirement;
+    }
+
+    @JsonProperty
+    public Optional<EncryptionInformation> getEncryptionInformation()
+    {
+        return encryptionInformation;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
@@ -503,7 +503,8 @@ class HiveSplitSource
                         internalSplit.getBucketConversion(),
                         internalSplit.isS3SelectPushdownEnabled(),
                         internalSplit.getExtraFileInfo(),
-                        new CacheQuotaRequirement(cacheQuotaScope, configuredCacheQuota)));
+                        new CacheQuotaRequirement(cacheQuotaScope, configuredCacheQuota),
+                        internalSplit.getEncryptionInformation()));
 
                 internalSplit.increaseStart(splitBytes);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,6 +51,7 @@ public final class HiveTableLayoutHandle
     private final Optional<HiveBucketFilter> bucketFilter;
     private final boolean pushdownFilterEnabled;
     private final String layoutString;
+    private final Optional<Set<HiveColumnHandle>> requestedColumns;
 
     // coordinator-only properties
     @Nullable
@@ -68,7 +70,8 @@ public final class HiveTableLayoutHandle
             @JsonProperty("bucketHandle") Optional<HiveBucketHandle> bucketHandle,
             @JsonProperty("bucketFilter") Optional<HiveBucketFilter> bucketFilter,
             @JsonProperty("pushdownFilterEnabled") boolean pushdownFilterEnabled,
-            @JsonProperty("layoutString") String layoutString)
+            @JsonProperty("layoutString") String layoutString,
+            @JsonProperty("requestedColumns") Optional<Set<HiveColumnHandle>> requestedColumns)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "table is null");
         this.partitionColumns = ImmutableList.copyOf(requireNonNull(partitionColumns, "partitionColumns is null"));
@@ -83,6 +86,7 @@ public final class HiveTableLayoutHandle
         this.bucketFilter = requireNonNull(bucketFilter, "bucketFilter is null");
         this.pushdownFilterEnabled = pushdownFilterEnabled;
         this.layoutString = requireNonNull(layoutString, "layoutString is null");
+        this.requestedColumns = requireNonNull(requestedColumns, "requestedColumns is null");
     }
 
     public HiveTableLayoutHandle(
@@ -98,7 +102,8 @@ public final class HiveTableLayoutHandle
             Optional<HiveBucketHandle> bucketHandle,
             Optional<HiveBucketFilter> bucketFilter,
             boolean pushdownFilterEnabled,
-            String layoutString)
+            String layoutString,
+            Optional<Set<HiveColumnHandle>> requestedColumns)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "table is null");
         this.partitionColumns = ImmutableList.copyOf(requireNonNull(partitionColumns, "partitionColumns is null"));
@@ -113,6 +118,7 @@ public final class HiveTableLayoutHandle
         this.bucketFilter = requireNonNull(bucketFilter, "bucketFilter is null");
         this.pushdownFilterEnabled = pushdownFilterEnabled;
         this.layoutString = requireNonNull(layoutString, "layoutString is null");
+        this.requestedColumns = requireNonNull(requestedColumns, "requestedColumns is null");
     }
 
     @JsonProperty
@@ -196,6 +202,12 @@ public final class HiveTableLayoutHandle
     public String getLayoutString()
     {
         return layoutString;
+    }
+
+    @JsonProperty
+    public Optional<Set<HiveColumnHandle>> getRequestedColumns()
+    {
+        return requestedColumns;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
@@ -64,6 +64,7 @@ public class InternalHiveSplit
     private final boolean s3SelectPushdownEnabled;
     private final HiveSplitPartitionInfo partitionInfo;
     private final Optional<byte[]> extraFileInfo;
+    private final Optional<EncryptionInformation> encryptionInformation;
 
     private long start;
     private int currentBlockIndex;
@@ -80,7 +81,8 @@ public class InternalHiveSplit
             NodeSelectionStrategy nodeSelectionStrategy,
             boolean s3SelectPushdownEnabled,
             HiveSplitPartitionInfo partitionInfo,
-            Optional<byte[]> extraFileInfo)
+            Optional<byte[]> extraFileInfo,
+            Optional<EncryptionInformation> encryptionInformation)
     {
         checkArgument(start >= 0, "start must be positive");
         checkArgument(end >= 0, "end must be positive");
@@ -91,6 +93,7 @@ public class InternalHiveSplit
         requireNonNull(nodeSelectionStrategy, "nodeSelectionStrategy is null");
         requireNonNull(partitionInfo, "partitionInfo is null");
         requireNonNull(extraFileInfo, "extraFileInfo is null");
+        requireNonNull(encryptionInformation, "encryptionInformation is null");
 
         this.relativeUri = relativeUri.getBytes(UTF_8);
         this.start = start;
@@ -115,6 +118,7 @@ public class InternalHiveSplit
             blockEndOffsets[i] = block.getEnd();
         }
         blockAddresses = allAddressesEmpty ? ImmutableList.of() : addressesBuilder.build();
+        this.encryptionInformation = encryptionInformation;
     }
 
     public String getPath()
@@ -211,6 +215,11 @@ public class InternalHiveSplit
     public Optional<byte[]> getExtraFileInfo()
     {
         return extraFileInfo;
+    }
+
+    public Optional<EncryptionInformation> getEncryptionInformation()
+    {
+        return this.encryptionInformation;
     }
 
     public void reset()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveAddRequestedColumnsToLayout.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveAddRequestedColumnsToLayout.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.rule;
+
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.hive.HiveTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.PlanVisitor;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+public class HiveAddRequestedColumnsToLayout
+        implements ConnectorPlanOptimizer
+{
+    @Override
+    public PlanNode optimize(PlanNode maxSubplan, ConnectorSession session, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        requireNonNull(maxSubplan, "maxSubplan is null");
+        return maxSubplan.accept(new Visitor(), null);
+    }
+
+    private class Visitor
+            extends PlanVisitor<PlanNode, Void>
+    {
+        @Override
+        public PlanNode visitPlan(PlanNode node, Void context)
+        {
+            ImmutableList.Builder<PlanNode> children = ImmutableList.builder();
+            boolean changed = false;
+            for (PlanNode child : node.getSources()) {
+                PlanNode newChild = child.accept(this, null);
+                if (newChild != child) {
+                    changed = true;
+                }
+                children.add(newChild);
+            }
+
+            if (!changed) {
+                return node;
+            }
+            return node.replaceChildren(children.build());
+        }
+
+        @Override
+        public PlanNode visitTableScan(TableScanNode tableScan, Void context)
+        {
+            Optional<ConnectorTableLayoutHandle> layout = tableScan.getTable().getLayout();
+            if (!layout.isPresent()) {
+                return tableScan;
+            }
+
+            HiveTableLayoutHandle hiveLayout = (HiveTableLayoutHandle) layout.get();
+            HiveTableLayoutHandle hiveLayoutWithDesiredColumns = new HiveTableLayoutHandle(
+                    hiveLayout.getSchemaTableName(),
+                    hiveLayout.getPartitionColumns(),
+                    hiveLayout.getDataColumns(),
+                    hiveLayout.getTableParameters(),
+                    hiveLayout.getPartitions().get(),
+                    hiveLayout.getDomainPredicate(),
+                    hiveLayout.getRemainingPredicate(),
+                    hiveLayout.getPredicateColumns(),
+                    hiveLayout.getPartitionColumnPredicate(),
+                    hiveLayout.getBucketHandle(),
+                    hiveLayout.getBucketFilter(),
+                    hiveLayout.isPushdownFilterEnabled(),
+                    hiveLayout.getLayoutString(),
+                    Optional.of(tableScan.getOutputVariables().stream()
+                            .map(output -> (HiveColumnHandle) tableScan.getAssignments().get(output))
+                            .collect(toImmutableSet())));
+
+            return new TableScanNode(
+                    tableScan.getId(),
+                    new TableHandle(
+                            tableScan.getTable().getConnectorId(),
+                            tableScan.getTable().getConnectorHandle(),
+                            tableScan.getTable().getTransaction(),
+                            Optional.of(hiveLayoutWithDesiredColumns)),
+                    tableScan.getOutputVariables(),
+                    tableScan.getAssignments(),
+                    tableScan.getCurrentConstraint(),
+                    tableScan.getEnforcedConstraint());
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
@@ -272,7 +272,8 @@ public class HiveFilterPushdown
                                         hivePartitionResult.getBucketHandle(),
                                         hivePartitionResult.getBucketFilter(),
                                         decomposedFilter.getRemainingExpression(),
-                                        domainPredicate))),
+                                        domainPredicate),
+                                currentLayoutHandle.map(layout -> ((HiveTableLayoutHandle) layout).getRequestedColumns()).orElse(Optional.empty()))),
                 TRUE_CONSTANT);
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HivePlanOptimizerProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HivePlanOptimizerProvider.java
@@ -45,7 +45,9 @@ public class HivePlanOptimizerProvider
         requireNonNull(functionResolution, "functionResolution is null");
         requireNonNull(partitionManager, "partitionManager is null");
         requireNonNull(functionMetadataManager, "functionMetadataManager is null");
-        this.planOptimizers = ImmutableSet.of(new HiveFilterPushdown(transactionManager, rowExpressionService, functionResolution, partitionManager, functionMetadataManager));
+        this.planOptimizers = ImmutableSet.of(
+                new HiveFilterPushdown(transactionManager, rowExpressionService, functionResolution, partitionManager, functionMetadataManager),
+                new HiveAddRequestedColumnsToLayout());
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.util;
 
 import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.hive.EncryptionInformation;
 import com.facebook.presto.hive.HiveFileInfo;
 import com.facebook.presto.hive.HiveSplitPartitionInfo;
 import com.facebook.presto.hive.InternalHiveSplit;
@@ -53,6 +54,7 @@ public class InternalHiveSplitFactory
     private final boolean s3SelectPushdownEnabled;
     private final HiveSplitPartitionInfo partitionInfo;
     private final boolean schedulerUsesHostAddresses;
+    private final Optional<EncryptionInformation> encryptionInformation;
 
     public InternalHiveSplitFactory(
             FileSystem fileSystem,
@@ -61,7 +63,8 @@ public class InternalHiveSplitFactory
             NodeSelectionStrategy nodeSelectionStrategy,
             boolean s3SelectPushdownEnabled,
             HiveSplitPartitionInfo partitionInfo,
-            boolean schedulerUsesHostAddresses)
+            boolean schedulerUsesHostAddresses,
+            Optional<EncryptionInformation> encryptionInformation)
     {
         this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
         this.inputFormat = requireNonNull(inputFormat, "inputFormat is null");
@@ -70,6 +73,7 @@ public class InternalHiveSplitFactory
         this.s3SelectPushdownEnabled = s3SelectPushdownEnabled;
         this.partitionInfo = partitionInfo;
         this.schedulerUsesHostAddresses = schedulerUsesHostAddresses;
+        this.encryptionInformation = requireNonNull(encryptionInformation, "encryptionInformation is null");
     }
 
     public Optional<InternalHiveSplit> createInternalHiveSplit(HiveFileInfo fileInfo, boolean splittable)
@@ -184,7 +188,8 @@ public class InternalHiveSplitFactory
                 forceLocalScheduling && allBlocksHaveRealAddress(blocks) ? HARD_AFFINITY : nodeSelectionStrategy,
                 s3SelectPushdownEnabled && S3SelectPushdown.isCompressionCodecSupported(inputFormat, path),
                 partitionInfo,
-                extraFileInfo));
+                extraFileInfo,
+                encryptionInformation));
     }
 
     private boolean needsHostAddresses(boolean forceLocalScheduling, List<HostAddress> addresses)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -251,6 +251,7 @@ import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.hive.HiveType.toHiveType;
 import static com.facebook.presto.hive.HiveUtil.columnExtraInfo;
 import static com.facebook.presto.hive.LocationHandle.WriteMode.STAGE_AND_MOVE_TO_TARGET_DIRECTORY;
+import static com.facebook.presto.hive.TestEncryptionInformationSource.createEncryptionInformation;
 import static com.facebook.presto.hive.metastore.HiveColumnStatistics.createBinaryColumnStatistics;
 import static com.facebook.presto.hive.metastore.HiveColumnStatistics.createBooleanColumnStatistics;
 import static com.facebook.presto.hive.metastore.HiveColumnStatistics.createDateColumnStatistics;
@@ -719,6 +720,7 @@ public abstract class AbstractTestHiveClient
     protected HiveTransactionManager transactionManager;
     protected HivePartitionManager hivePartitionManager;
     protected ExtendedHiveMetastore metastoreClient;
+    protected HiveEncryptionInformationProvider encryptionInformationProvider;
     protected ConnectorSplitManager splitManager;
     protected ConnectorPageSourceProvider pageSourceProvider;
     protected ConnectorPageSinkProvider pageSinkProvider;
@@ -946,6 +948,7 @@ public abstract class AbstractTestHiveClient
                 TEST_SERVER_VERSION,
                 new HivePartitionObjectBuilder());
         transactionManager = new HiveTransactionManager();
+        encryptionInformationProvider = new HiveEncryptionInformationProvider(ImmutableList.of(new TestEncryptionInformationSource(Optional.of(createEncryptionInformation("test1")))));
         splitManager = new HiveSplitManager(
                 transactionManager,
                 new NamenodeStats(),
@@ -962,7 +965,8 @@ public abstract class AbstractTestHiveClient
                 hiveClientConfig.getSplitLoaderConcurrency(),
                 false,
                 cacheConfig.getCacheQuotaScope(),
-                cacheConfig.getDefaultCacheQuota());
+                cacheConfig.getDefaultCacheQuota(),
+                encryptionInformationProvider);
         pageSinkProvider = new HivePageSinkProvider(
                 getDefaultHiveFileWriterFactories(hiveClientConfig, metastoreClientConfig),
                 hdfsEnvironment,
@@ -1679,6 +1683,68 @@ public abstract class AbstractTestHiveClient
             ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, tableLayout.getHandle(), SPLIT_SCHEDULING_CONTEXT);
 
             assertEquals(getSplitCount(splitSource), partitionCount);
+        }
+    }
+
+    @Test
+    public void testGetEncryptionInformationInPartitionedTable()
+            throws Exception
+    {
+        SchemaTableName tableName = temporaryTable("test_encrypt_with_partitions");
+        ConnectorTableHandle tableHandle = new HiveTableHandle(tableName.getSchemaName(), tableName.getTableName());
+        try {
+            doInsertIntoNewPartition(ORC, tableName, PageSinkProperties.defaultProperties());
+
+            try (Transaction transaction = newTransaction()) {
+                ConnectorMetadata metadata = transaction.getMetadata();
+                ConnectorSession session = newSession();
+
+                ConnectorTableLayout tableLayout = getTableLayout(session, metadata, tableHandle, Constraint.alwaysTrue(), transaction);
+                ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, tableLayout.getHandle(), SPLIT_SCHEDULING_CONTEXT);
+                List<ConnectorSplit> allSplits = getAllSplits(splitSource);
+
+                assertTrue(allSplits.size() >= 1, "There should be atleast 1 split");
+
+                for (ConnectorSplit split : allSplits) {
+                    HiveSplit hiveSplit = (HiveSplit) split;
+                    assertTrue(hiveSplit.getEncryptionInformation().isPresent());
+                    assertTrue(hiveSplit.getEncryptionInformation().get().getDwrfEncryptionMetadata().isPresent());
+                }
+            }
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testGetEncryptionInformationInUnpartitionedTable()
+            throws Exception
+    {
+        SchemaTableName tableName = temporaryTable("test_encrypt_with_no_partitions");
+        ConnectorTableHandle tableHandle = new HiveTableHandle(tableName.getSchemaName(), tableName.getTableName());
+        try {
+            doInsert(ORC, tableName, PageSinkProperties.defaultProperties());
+
+            try (Transaction transaction = newTransaction()) {
+                ConnectorMetadata metadata = transaction.getMetadata();
+                ConnectorSession session = newSession();
+
+                ConnectorTableLayout tableLayout = getTableLayout(session, metadata, tableHandle, Constraint.alwaysTrue(), transaction);
+                ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, tableLayout.getHandle(), SPLIT_SCHEDULING_CONTEXT);
+                List<ConnectorSplit> allSplits = getAllSplits(splitSource);
+
+                assertTrue(allSplits.size() >= 1, "There should be atleast 1 split");
+
+                for (ConnectorSplit split : allSplits) {
+                    HiveSplit hiveSplit = (HiveSplit) split;
+                    assertTrue(hiveSplit.getEncryptionInformation().isPresent());
+                    assertTrue(hiveSplit.getEncryptionInformation().get().getDwrfEncryptionMetadata().isPresent());
+                }
+            }
+        }
+        finally {
+            dropTable(tableName);
         }
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.hive;
 
-import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.GroupByHashPageIndexerFactory;
@@ -159,7 +158,6 @@ import java.util.stream.LongStream;
 
 import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
-import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.airlift.testing.Assertions.assertEqualsIgnoreOrder;
 import static com.facebook.airlift.testing.Assertions.assertGreaterThan;
 import static com.facebook.airlift.testing.Assertions.assertGreaterThanOrEqual;
@@ -400,7 +398,6 @@ public abstract class AbstractTestHiveClient
             .add(new ColumnMetadata("ds", createUnboundedVarcharType()))
             .build();
 
-    private static final JsonCodec<PartitionUpdate> PARTITION_UPDATE_CODEC = jsonCodec(PartitionUpdate.class);
     private static final DataSize DEFAULT_QUOTA_SIZE = DataSize.succinctDataSize(2, GIGABYTE);
     private static final CacheQuotaScope CACHE_SCOPE = TABLE;
 
@@ -940,7 +937,7 @@ public abstract class AbstractTestHiveClient
                 ROW_EXPRESSION_SERVICE,
                 FILTER_STATS_CALCULATOR_SERVICE,
                 new TableParameterCodec(),
-                PARTITION_UPDATE_CODEC,
+                HiveTestUtils.PARTITION_UPDATE_CODEC,
                 listeningDecorator(executor),
                 new HiveTypeTranslator(),
                 new HiveStagingFileCommitter(hdfsEnvironment, listeningDecorator(executor)),
@@ -977,7 +974,7 @@ public abstract class AbstractTestHiveClient
                 getHiveClientConfig(),
                 getMetastoreClientConfig(),
                 locationService,
-                PARTITION_UPDATE_CODEC,
+                HiveTestUtils.PARTITION_UPDATE_CODEC,
                 new TestingNodeManager("fake-environment"),
                 new HiveEventClient(),
                 new HiveSessionProperties(hiveClientConfig, new OrcFileWriterConfig(), new ParquetFileWriterConfig()),
@@ -4347,7 +4344,7 @@ public abstract class AbstractTestHiveClient
     {
         fragments.stream()
                 .map(Slice::getBytes)
-                .map(PARTITION_UPDATE_CODEC::fromJson)
+                .map(HiveTestUtils.PARTITION_UPDATE_CODEC::fromJson)
                 .map(PartitionUpdate::getFileWriteInfos)
                 .flatMap(List::stream)
                 .forEach(fileWriteInfo -> assertNotEquals(fileWriteInfo.getWriteFileName(), fileWriteInfo.getTargetFileName()));
@@ -5376,7 +5373,7 @@ public abstract class AbstractTestHiveClient
                 if (conflictTrigger.isPresent()) {
                     List<PartitionUpdate> partitionUpdates = fragments.stream()
                             .map(Slice::getBytes)
-                            .map(PARTITION_UPDATE_CODEC::fromJson)
+                            .map(HiveTestUtils.PARTITION_UPDATE_CODEC::fromJson)
                             .collect(toList());
                     conflictTrigger.get().triggerConflict(session, tableName, insertTableHandle, partitionUpdates);
                 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -772,7 +772,8 @@ public abstract class AbstractTestHiveClient
                 Optional.empty(),
                 Optional.empty(),
                 false,
-                "layout");
+                "layout",
+                Optional.empty());
 
         int partitionColumnIndex = MAX_PARTITION_KEY_COLUMN_INDEX;
         dsColumn = new HiveColumnHandle("ds", HIVE_STRING, parseTypeSignature(StandardTypes.VARCHAR), partitionColumnIndex--, PARTITION_KEY, Optional.empty());
@@ -838,7 +839,8 @@ public abstract class AbstractTestHiveClient
                         Optional.empty(),
                         Optional.empty(),
                         false,
-                        "layout"),
+                        "layout",
+                        Optional.empty()),
                 Optional.empty(),
                 withColumnDomains(ImmutableMap.of(
                         dsColumn, Domain.create(ValueSet.ofRanges(Range.equal(createUnboundedVarcharType(), utf8Slice("2012-12-29"))), false),
@@ -880,7 +882,8 @@ public abstract class AbstractTestHiveClient
                 Optional.empty(),
                 Optional.empty(),
                 false,
-                "layout"));
+                "layout",
+                Optional.empty()));
         timeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(timeZoneId));
     }
 
@@ -1970,7 +1973,8 @@ public abstract class AbstractTestHiveClient
                     Optional.of(new HiveBucketHandle(bucketHandle.getColumns(), bucketHandle.getTableBucketCount(), 2)),
                     layoutHandle.getBucketFilter(),
                     false,
-                    "layout");
+                    "layout",
+                    Optional.empty());
 
             List<ConnectorSplit> splits = getAllSplits(session, transaction, modifiedReadBucketCountLayoutHandle);
             assertEquals(splits.size(), 16);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -64,6 +64,7 @@ import com.facebook.presto.testing.TestingNodeManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 import io.airlift.slice.Slice;
 import org.apache.hadoop.fs.FileSystem;
@@ -222,7 +223,8 @@ public abstract class AbstractTestHiveFileSystem
                 config.getSplitLoaderConcurrency(),
                 config.getRecursiveDirWalkerEnabled(),
                 cacheConfig.getCacheQuotaScope(),
-                cacheConfig.getDefaultCacheQuota());
+                cacheConfig.getDefaultCacheQuota(),
+                new HiveEncryptionInformationProvider(ImmutableSet.of()));
         pageSinkProvider = new HivePageSinkProvider(
                 getDefaultHiveFileWriterFactories(config, metastoreClientConfig),
                 hdfsEnvironment,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.PagesIndexPageSorter;
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.common.type.ArrayType;
@@ -74,6 +75,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Set;
 
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.common.type.Decimals.encodeScaledValue;
 import static java.util.stream.Collectors.toList;
 
@@ -82,6 +84,8 @@ public final class HiveTestUtils
     private HiveTestUtils()
     {
     }
+
+    public static final JsonCodec<PartitionUpdate> PARTITION_UPDATE_CODEC = jsonCodec(PartitionUpdate.class);
 
     public static final ConnectorSession SESSION = new TestingConnectorSession(
             new HiveSessionProperties(new HiveClientConfig(), new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -334,7 +334,8 @@ public class TestBackgroundHiveSplitLoader
                         new HivePartitionMetadata(
                                 new HivePartition(new SchemaTableName("testSchema", "table_name")),
                                 Optional.empty(),
-                                ImmutableMap.of()));
+                                ImmutableMap.of(),
+                                Optional.empty()));
 
         ConnectorSession connectorSession = new TestingConnectorSession(
                 new HiveSessionProperties(new HiveClientConfig().setMaxSplitSize(new DataSize(1.0, GIGABYTE)), new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties());
@@ -360,7 +361,8 @@ public class TestBackgroundHiveSplitLoader
                 new HivePartitionMetadata(
                         new HivePartition(new SchemaTableName("testSchema", "table_name")),
                         Optional.empty(),
-                        ImmutableMap.of()));
+                        ImmutableMap.of(),
+                        Optional.empty()));
 
         ConnectorSession connectorSession = new TestingConnectorSession(
                 new HiveSessionProperties(
@@ -423,7 +425,8 @@ public class TestBackgroundHiveSplitLoader
                         return new HivePartitionMetadata(
                                 new HivePartition(new SchemaTableName("testSchema", "table_name")),
                                 Optional.empty(),
-                                ImmutableMap.of());
+                                ImmutableMap.of(),
+                                Optional.empty());
                     case 1:
                         throw new RuntimeException("OFFLINE");
                     default:

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestColumnEncryptionInformation.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestColumnEncryptionInformation.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.ColumnEncryptionInformation.ColumnWithStructSubfield;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.hive.ColumnEncryptionInformation.fromHiveProperty;
+import static com.facebook.presto.hive.ColumnEncryptionInformation.fromTableProperty;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestColumnEncryptionInformation
+{
+    @Test
+    public void testFromTablePropertyNullInput()
+    {
+        ColumnEncryptionInformation encryptionInformation = fromTableProperty(null);
+        assertFalse(encryptionInformation.hasEntries());
+    }
+
+    @Test
+    public void testFromTablePropertyValidInput()
+    {
+        ColumnEncryptionInformation encryptionInformation = fromTableProperty(ImmutableList.of("key1: col1, col2", "key2: col4, col5.a.b"));
+        Map<ColumnWithStructSubfield, String> keyReferences = encryptionInformation.getColumnToKeyReference();
+
+        Map<ColumnWithStructSubfield, String> expectedKeyReferences = ImmutableMap.of(
+                ColumnWithStructSubfield.valueOf("col1"), "key1",
+                ColumnWithStructSubfield.valueOf("col2"), "key1",
+                ColumnWithStructSubfield.valueOf("col4"), "key2",
+                ColumnWithStructSubfield.valueOf("col5.a.b"), "key2");
+
+        assertEquals(keyReferences, expectedKeyReferences);
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Encrypted columns property cannot have null value")
+    public void testFromTablePropertyNullListEntries()
+    {
+        List<String> entries = new ArrayList<>();
+        entries.add(null);
+
+        fromTableProperty(entries);
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Column col1 has been assigned 2 key references \\(key2 and key1\\). Only 1 is allowed")
+    public void testFromTablePropertyDuplicateKeys()
+    {
+        fromTableProperty(ImmutableList.of("key1:col1", "key2:col1"));
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Encrypted column entry needs to be in the format 'key1:col1,col2'. Received: key1")
+    public void testFromTablePropertyNoColumnsSpecified()
+    {
+        fromTableProperty(ImmutableList.of("key1"));
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Encrypted column entry needs to be in the format 'key1:col1,col2'. Received: key1:key2:col1")
+    public void testFromTablePropertyMultipleKeys()
+    {
+        fromTableProperty(ImmutableList.of("key1:key2:col1"));
+    }
+
+    @Test
+    public void testToTableProperty()
+    {
+        List<String> originalEntries = ImmutableList.of("key1:col1,col2", "key2:col3,col4");
+        ColumnEncryptionInformation encryptionInformation = fromTableProperty(originalEntries);
+        List<String> tablePropertyFormat = encryptionInformation.toTableProperty();
+        ColumnEncryptionInformation encryptionInformationReconstructed = fromTableProperty(tablePropertyFormat);
+
+        assertEquals(encryptionInformationReconstructed.getColumnToKeyReference(), encryptionInformation.getColumnToKeyReference());
+    }
+
+    @Test
+    public void testFromHivePropertyNullInput()
+    {
+        ColumnEncryptionInformation encryptionInformation = fromHiveProperty(null);
+        assertFalse(encryptionInformation.hasEntries());
+    }
+
+    @Test
+    public void testFromHivePropertyValidInput()
+    {
+        ColumnEncryptionInformation encryptionInformation = fromHiveProperty("key1: col1, col2;key2: col4, col5.a.b");
+        Map<ColumnWithStructSubfield, String> keyReferences = encryptionInformation.getColumnToKeyReference();
+
+        Map<ColumnWithStructSubfield, String> expectedKeyReferences = ImmutableMap.of(
+                ColumnWithStructSubfield.valueOf("col1"), "key1",
+                ColumnWithStructSubfield.valueOf("col2"), "key1",
+                ColumnWithStructSubfield.valueOf("col4"), "key2",
+                ColumnWithStructSubfield.valueOf("col5.a.b"), "key2");
+
+        assertEquals(keyReferences, expectedKeyReferences);
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Column col1 has been assigned 2 key references \\(key2 and key1\\). Only 1 is allowed")
+    public void testFromHivePropertyDuplicateKeys()
+    {
+        fromHiveProperty("key1:col1;key2:col1");
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Encrypted column entry needs to be in the format 'key1:col1,col2'. Received: key1")
+    public void testFromHivePropertyNoColumnsSpecified()
+    {
+        fromHiveProperty("key1;key2:col1");
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Encrypted column entry needs to be in the format 'key1:col1,col2'. Received: key1:key2:col1")
+    public void testFromHivePropertyMultipleKeys()
+    {
+        fromHiveProperty("key1:key2:col1");
+    }
+
+    @Test
+    public void testToHiveProperty()
+    {
+        String originalInput = "key1:col1,col2;key2:col3,col4";
+        ColumnEncryptionInformation encryptionInformation = fromHiveProperty(originalInput);
+        String hivePropertyFormat = encryptionInformation.toHiveProperty();
+        ColumnEncryptionInformation encryptionInformationReconstructed = fromHiveProperty(hivePropertyFormat);
+
+        assertEquals(encryptionInformationReconstructed.getColumnToKeyReference(), encryptionInformation.getColumnToKeyReference());
+    }
+
+    @Test
+    public void testColumnWithStructSubfieldWithNoSubfield()
+    {
+        ColumnWithStructSubfield column = ColumnWithStructSubfield.valueOf("a");
+        assertEquals(column.getColumnName(), "a");
+        assertFalse(column.getSubfieldPath().isPresent());
+        assertFalse(column.getChildField().isPresent());
+    }
+
+    @Test
+    public void testColumnWithStructSubfieldWithSubfield()
+    {
+        ColumnWithStructSubfield column = ColumnWithStructSubfield.valueOf("a.b.c.d");
+        assertEquals(column.getColumnName(), "a");
+        assertTrue(column.getSubfieldPath().isPresent());
+        assertEquals(column.getSubfieldPath().get(), "b.c.d");
+        assertTrue(column.getChildField().isPresent());
+        assertEquals(column.getChildField().get(), ColumnWithStructSubfield.valueOf("b.c.d"));
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestEncryptionInformationSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestEncryptionInformationSource.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.ConnectorSession;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+
+class TestEncryptionInformationSource
+        implements EncryptionInformationSource
+{
+    private Optional<EncryptionInformation> encryptionInformation;
+
+    TestEncryptionInformationSource(Optional<EncryptionInformation> encryptionInformation)
+    {
+        this.encryptionInformation = requireNonNull(encryptionInformation, "encryptionInformation is null");
+    }
+
+    @Override
+    public Optional<Map<String, EncryptionInformation>> getEncryptionInformation(ConnectorSession session, Table table, Optional<Set<HiveColumnHandle>> requestedColumns, Map<String, Partition> partitions)
+    {
+        return encryptionInformation.map(information -> partitions.keySet().stream().collect(toImmutableMap(identity(), partitionId -> information)));
+    }
+
+    @Override
+    public Optional<EncryptionInformation> getEncryptionInformation(ConnectorSession session, Table table, Optional<Set<HiveColumnHandle>> requestedColumns)
+    {
+        return encryptionInformation;
+    }
+
+    public static EncryptionInformation createEncryptionInformation(String fieldName)
+    {
+        return EncryptionInformation.fromEncryptionMetadata(new DwrfEncryptionMetadata(ImmutableMap.of(fieldName, fieldName.getBytes())));
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.metastore.Table;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveTestUtils.SESSION;
+import static com.facebook.presto.hive.TestEncryptionInformationSource.createEncryptionInformation;
+import static com.facebook.presto.hive.metastore.PrestoTableType.MANAGED_TABLE;
+import static com.facebook.presto.hive.metastore.StorageFormat.VIEW_STORAGE_FORMAT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class TestHiveEncryptionInformationProvider
+{
+    private static final Table TEST_TABLE = new Table(
+            "test_db",
+            "test_table",
+            "test_owner",
+            MANAGED_TABLE,
+            new Storage(
+                    VIEW_STORAGE_FORMAT,
+                    "",
+                    Optional.empty(),
+                    false,
+                    ImmutableMap.of(),
+                    ImmutableMap.of()),
+            ImmutableList.of(),
+            ImmutableList.of(),
+            ImmutableMap.of(),
+            Optional.empty(),
+            Optional.empty());
+
+    @Test
+    public void testNoOneReturns()
+    {
+        HiveEncryptionInformationProvider provider = new HiveEncryptionInformationProvider(ImmutableList.of(
+                new TestEncryptionInformationSource(Optional.empty()),
+                new TestEncryptionInformationSource(Optional.empty())));
+
+        assertFalse(provider.getEncryptionInformation(SESSION, TEST_TABLE, Optional.empty()).isPresent());
+    }
+
+    @Test
+    public void testReturnsFirstNonEmptyObject()
+    {
+        EncryptionInformation encryptionInformation1 = createEncryptionInformation("test1");
+        EncryptionInformation encryptionInformation2 = createEncryptionInformation("test2");
+
+        HiveEncryptionInformationProvider provider = new HiveEncryptionInformationProvider(ImmutableList.of(
+                new TestEncryptionInformationSource(Optional.empty()),
+                new TestEncryptionInformationSource(Optional.empty()),
+                new TestEncryptionInformationSource(Optional.of(encryptionInformation1)),
+                new TestEncryptionInformationSource(Optional.of(encryptionInformation2))));
+
+        assertEquals(provider.getEncryptionInformation(SESSION, TEST_TABLE, Optional.empty()).get(), encryptionInformation1);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.hive.datasink.OutputStreamDataSinkFactory;
+import com.facebook.presto.hive.metastore.Database;
+import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
+import com.facebook.presto.hive.metastore.thrift.InMemoryHiveMetastore;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.security.PrincipalType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
+import org.joda.time.DateTimeZone;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TimeZone;
+import java.util.concurrent.ExecutorService;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.hive.HiveStorageFormat.DWRF;
+import static com.facebook.presto.hive.HiveTableProperties.BUCKETED_BY_PROPERTY;
+import static com.facebook.presto.hive.HiveTableProperties.BUCKET_COUNT_PROPERTY;
+import static com.facebook.presto.hive.HiveTableProperties.DWRF_ENCRYPTION_ALGORITHM;
+import static com.facebook.presto.hive.HiveTableProperties.DWRF_ENCRYPTION_PROVIDER;
+import static com.facebook.presto.hive.HiveTableProperties.ENCRYPT_COLUMNS;
+import static com.facebook.presto.hive.HiveTableProperties.ENCRYPT_TABLE;
+import static com.facebook.presto.hive.HiveTableProperties.PARTITIONED_BY_PROPERTY;
+import static com.facebook.presto.hive.HiveTableProperties.SORTED_BY_PROPERTY;
+import static com.facebook.presto.hive.HiveTableProperties.STORAGE_FORMAT_PROPERTY;
+import static com.facebook.presto.hive.HiveTestUtils.FILTER_STATS_CALCULATOR_SERVICE;
+import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_RESOLUTION;
+import static com.facebook.presto.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static com.facebook.presto.hive.HiveTestUtils.HIVE_CLIENT_CONFIG;
+import static com.facebook.presto.hive.HiveTestUtils.PARTITION_UPDATE_CODEC;
+import static com.facebook.presto.hive.HiveTestUtils.ROW_EXPRESSION_SERVICE;
+import static com.facebook.presto.hive.HiveTestUtils.SESSION;
+import static com.facebook.presto.hive.HiveTestUtils.TYPE_MANAGER;
+import static com.google.common.collect.ImmutableMap.builder;
+import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.testng.Assert.assertEquals;
+
+public class TestHiveMetadataFileFormatEncryptionSettings
+{
+    private static final String TEST_SERVER_VERSION = "test_version";
+    private static final String TEST_DB_NAME = "test_db";
+
+    private HiveMetadataFactory metadataFactory;
+    private HiveTransactionManager transactionManager;
+    private ExtendedHiveMetastore metastore;
+    private ExecutorService executor;
+    private File baseDirectory;
+
+    @BeforeClass
+    public void setup()
+    {
+        baseDirectory = new File(Files.createTempDir(), "metastore");
+        metastore = new BridgingHiveMetastore(new InMemoryHiveMetastore(baseDirectory));
+        executor = newCachedThreadPool(daemonThreadsNamed("hive-encryption-test-%s"));
+        transactionManager = new HiveTransactionManager();
+        metadataFactory = new HiveMetadataFactory(
+                metastore,
+                HDFS_ENVIRONMENT,
+                new HivePartitionManager(TYPE_MANAGER, HIVE_CLIENT_CONFIG),
+                DateTimeZone.forTimeZone(TimeZone.getTimeZone(HIVE_CLIENT_CONFIG.getTimeZone())),
+                true,
+                false,
+                false,
+                false,
+                true,
+                HIVE_CLIENT_CONFIG.getMaxPartitionBatchSize(),
+                HIVE_CLIENT_CONFIG.getMaxPartitionsPerScan(),
+                TYPE_MANAGER,
+                new HiveLocationService(HDFS_ENVIRONMENT),
+                FUNCTION_RESOLUTION,
+                ROW_EXPRESSION_SERVICE,
+                FILTER_STATS_CALCULATOR_SERVICE,
+                new TableParameterCodec(),
+                PARTITION_UPDATE_CODEC,
+                listeningDecorator(executor),
+                new HiveTypeTranslator(),
+                new HiveStagingFileCommitter(HDFS_ENVIRONMENT, listeningDecorator(executor)),
+                new HiveZeroRowFileCreator(HDFS_ENVIRONMENT, new OutputStreamDataSinkFactory(), listeningDecorator(executor)),
+                TEST_SERVER_VERSION,
+                new HivePartitionObjectBuilder());
+
+        metastore.createDatabase(Database.builder()
+                .setDatabaseName(TEST_DB_NAME)
+                .setOwnerName("public")
+                .setOwnerType(PrincipalType.ROLE)
+                .build());
+    }
+
+    @AfterClass
+    public void tearDown()
+    {
+        if (executor != null) {
+            executor.shutdownNow();
+            executor = null;
+        }
+    }
+
+    private static ConnectorTableMetadata getConnectorTableMetadata(String tableName, Map<String, Object> tableProperties)
+    {
+        ImmutableMap.Builder<String, Object> properties = builder();
+        properties.put(BUCKET_COUNT_PROPERTY, 0);
+        properties.put(BUCKETED_BY_PROPERTY, ImmutableList.of());
+        properties.put(SORTED_BY_PROPERTY, ImmutableList.of());
+        properties.put(PARTITIONED_BY_PROPERTY, ImmutableList.of("ds"));
+        properties.put(STORAGE_FORMAT_PROPERTY, DWRF);
+
+        properties.putAll(tableProperties);
+        return new ConnectorTableMetadata(
+                new SchemaTableName(TEST_DB_NAME, tableName),
+                ImmutableList.of(
+                        new ColumnMetadata("t_varchar", VARCHAR),
+                        new ColumnMetadata("t_bigint", BIGINT),
+                        new ColumnMetadata("t_struct", RowType.from(
+                                ImmutableList.of(
+                                        new RowType.Field(Optional.of("char"), VARCHAR),
+                                        new RowType.Field(Optional.of("str"), RowType.from(
+                                                ImmutableList.of(
+                                                        new RowType.Field(Optional.of("a"), VARCHAR),
+                                                        new RowType.Field(Optional.of("b"), BIGINT))))))),
+                        new ColumnMetadata("ds", VARCHAR)),
+                properties.build());
+    }
+
+    private void dropTable(String tableName)
+    {
+        try {
+            metadataFactory.get().dropTable(SESSION, new HiveTableHandle(TEST_DB_NAME, tableName));
+        }
+        catch (TableNotFoundException ex) {
+            // Do nothing
+        }
+    }
+
+    @Test
+    public void testTableCreationWithTableKeyReference()
+    {
+        String tableName = "test_enc_with_table_key";
+        ConnectorTableMetadata table = getConnectorTableMetadata(tableName, ImmutableMap.of(
+                ENCRYPT_TABLE, "keyReference1",
+                DWRF_ENCRYPTION_ALGORITHM, "test_algo",
+                DWRF_ENCRYPTION_PROVIDER, "test_provider"));
+
+        try {
+            HiveMetadata metadata = metadataFactory.get();
+            metadata.createTable(SESSION, table, false);
+            ConnectorTableMetadata receivedMetadata = metadata.getTableMetadata(SESSION, new HiveTableHandle(TEST_DB_NAME, tableName));
+
+            assertEquals(receivedMetadata.getProperties().get(ENCRYPT_TABLE), table.getProperties().get(ENCRYPT_TABLE));
+            assertEquals(receivedMetadata.getProperties().get(DWRF_ENCRYPTION_ALGORITHM), table.getProperties().get(DWRF_ENCRYPTION_ALGORITHM));
+            assertEquals(receivedMetadata.getProperties().get(DWRF_ENCRYPTION_PROVIDER), table.getProperties().get(DWRF_ENCRYPTION_PROVIDER));
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testTableCreationWithColumnKeyReference()
+    {
+        String tableName = "test_enc_with_column_key";
+        ConnectorTableMetadata table = getConnectorTableMetadata(tableName, ImmutableMap.of(
+                ENCRYPT_COLUMNS, ColumnEncryptionInformation.fromTableProperty(ImmutableList.of("key1:t_varchar,t_bigint", "key2: t_struct.char,t_struct.str.a")),
+                DWRF_ENCRYPTION_ALGORITHM, "test_algo",
+                DWRF_ENCRYPTION_PROVIDER, "test_provider"));
+
+        try {
+            HiveMetadata metadata = metadataFactory.get();
+            metadata.createTable(SESSION, table, false);
+            ConnectorTableMetadata receivedMetadata = metadata.getTableMetadata(SESSION, new HiveTableHandle(TEST_DB_NAME, tableName));
+
+            assertEquals(receivedMetadata.getProperties().get(ENCRYPT_COLUMNS), table.getProperties().get(ENCRYPT_COLUMNS));
+            assertEquals(receivedMetadata.getProperties().get(DWRF_ENCRYPTION_ALGORITHM), table.getProperties().get(DWRF_ENCRYPTION_ALGORITHM));
+            assertEquals(receivedMetadata.getProperties().get(DWRF_ENCRYPTION_PROVIDER), table.getProperties().get(DWRF_ENCRYPTION_PROVIDER));
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testCreateTableAsSelectWithColumnKeyReference()
+    {
+        String tableName = "test_ctas_enc_with_column_key";
+        ConnectorTableMetadata table = getConnectorTableMetadata(tableName, ImmutableMap.of(
+                ENCRYPT_COLUMNS, ColumnEncryptionInformation.fromTableProperty(ImmutableList.of("key1:t_varchar,t_bigint", "key2: t_struct.char,t_struct.str.a")),
+                DWRF_ENCRYPTION_ALGORITHM, "test_algo",
+                DWRF_ENCRYPTION_PROVIDER, "test_provider"));
+
+        try {
+            HiveMetadata metadata = metadataFactory.get();
+
+            HiveOutputTableHandle outputHandle = metadata.beginCreateTable(SESSION, table, Optional.empty());
+            metadata.finishCreateTable(SESSION, outputHandle, ImmutableList.of(), ImmutableList.of());
+
+            ConnectorTableMetadata receivedMetadata = metadata.getTableMetadata(SESSION, new HiveTableHandle(TEST_DB_NAME, tableName));
+
+            assertEquals(receivedMetadata.getProperties().get(ENCRYPT_COLUMNS), table.getProperties().get(ENCRYPT_COLUMNS));
+            assertEquals(receivedMetadata.getProperties().get(DWRF_ENCRYPTION_ALGORITHM), table.getProperties().get(DWRF_ENCRYPTION_ALGORITHM));
+            assertEquals(receivedMetadata.getProperties().get(DWRF_ENCRYPTION_PROVIDER), table.getProperties().get(DWRF_ENCRYPTION_PROVIDER));
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Only one of encrypt_table or encrypt_columns should be specified")
+    public void testTableCreationFailureWithColumnAndTableKeyReference()
+    {
+        String tableName = "test_enc_with_table_key_and_column_key";
+        ConnectorTableMetadata table = getConnectorTableMetadata(tableName, ImmutableMap.of(
+                ENCRYPT_TABLE, "tableKey",
+                ENCRYPT_COLUMNS, ColumnEncryptionInformation.fromTableProperty(ImmutableList.of("key1:t_varchar,t_bigint", "key2: t_struct.char,t_struct.str.a")),
+                DWRF_ENCRYPTION_ALGORITHM, "test_algo",
+                DWRF_ENCRYPTION_PROVIDER, "test_provider"));
+
+        try {
+            metadataFactory.get().createTable(SESSION, table, false);
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Partition column \\(ds\\) cannot be used as an encryption column")
+    public void testTableCreationFailureWithPartitionAsEncrypted()
+    {
+        String tableName = "test_enc_with_table_key_with_partition_enc";
+        ConnectorTableMetadata table = getConnectorTableMetadata(tableName, ImmutableMap.of(
+                ENCRYPT_COLUMNS, ColumnEncryptionInformation.fromTableProperty(ImmutableList.of("key1:ds")),
+                DWRF_ENCRYPTION_ALGORITHM, "test_algo",
+                DWRF_ENCRYPTION_PROVIDER, "test_provider"));
+
+        try {
+            metadataFactory.get().createTable(SESSION, table, false);
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "In encrypt_columns unable to find column this_column_does_not_exist")
+    public void testTableCreationFailureWithUnknownColumnAsEncrypted()
+    {
+        String tableName = "test_enc_with_table_key_with_unknown_col_enc";
+        ConnectorTableMetadata table = getConnectorTableMetadata(tableName, ImmutableMap.of(
+                ENCRYPT_COLUMNS, ColumnEncryptionInformation.fromTableProperty(ImmutableList.of("key1:this_column_does_not_exist")),
+                DWRF_ENCRYPTION_ALGORITHM, "test_algo",
+                DWRF_ENCRYPTION_PROVIDER, "test_provider"));
+
+        try {
+            metadataFactory.get().createTable(SESSION, table, false);
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "In encrypt_columns subfields declared in t_struct.does_not_exist_subfield, but t_struct has type .*")
+    public void testTableCreationFailureWithUnknownSubfieldAsEncrypted()
+    {
+        String tableName = "test_enc_with_table_key_with_unknown_col_enc";
+        ConnectorTableMetadata table = getConnectorTableMetadata(tableName, ImmutableMap.of(
+                ENCRYPT_COLUMNS, ColumnEncryptionInformation.fromTableProperty(ImmutableList.of("key1:t_struct.does_not_exist_subfield")),
+                DWRF_ENCRYPTION_ALGORITHM, "test_algo",
+                DWRF_ENCRYPTION_PROVIDER, "test_provider"));
+
+        try {
+            metadataFactory.get().createTable(SESSION, table, false);
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "For \\(t_struct.str.a\\) found a keyReference at a higher level field \\(t_struct.str\\)")
+    public void testTableCreationFailureWithSubfieldAlsoHavingASetting()
+    {
+        String tableName = "test_enc_with_table_key_with_subfield_also_having_a_setting";
+        ConnectorTableMetadata table = getConnectorTableMetadata(tableName, ImmutableMap.of(
+                ENCRYPT_COLUMNS, ColumnEncryptionInformation.fromTableProperty(ImmutableList.of("key1:t_struct.str", "key2:t_struct.str.a")),
+                DWRF_ENCRYPTION_ALGORITHM, "test_algo",
+                DWRF_ENCRYPTION_PROVIDER, "test_provider"));
+
+        try {
+            metadataFactory.get().createTable(SESSION, table, false);
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -264,7 +264,8 @@ public class TestHivePageSink
                         Optional.empty(),
                         Optional.empty(),
                         false,
-                        "layout")));
+                        "layout",
+                        Optional.empty())));
         HivePageSourceProvider provider = new HivePageSourceProvider(config, createTestHdfsEnvironment(config, metastoreClientConfig), getDefaultHiveRecordCursorProvider(config, metastoreClientConfig), getDefaultHiveBatchPageSourceFactories(config, metastoreClientConfig), getDefaultHiveSelectivePageSourceFactories(config, metastoreClientConfig), TYPE_MANAGER, ROW_EXPRESSION_SERVICE);
         return provider.createPageSource(transaction, getSession(config), split, tableHandle.getLayout().get(), ImmutableList.copyOf(getColumnHandles()), NON_CACHEABLE);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -245,7 +245,8 @@ public class TestHivePageSink
                 Optional.empty(),
                 false,
                 Optional.empty(),
-                NO_CACHE_REQUIREMENT);
+                NO_CACHE_REQUIREMENT,
+                Optional.empty());
         TableHandle tableHandle = new TableHandle(
                 new ConnectorId(HIVE_CATALOG),
                 new HiveTableHandle(SCHEMA_NAME, TABLE_NAME),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
@@ -65,7 +65,8 @@ public class TestHivePageSourceProvider
                 Optional.empty(),
                 false,
                 Optional.empty(),
-                NO_CACHE_REQUIREMENT);
+                NO_CACHE_REQUIREMENT,
+                Optional.empty());
 
         CacheQuota cacheQuota = HivePageSourceProvider.generateCacheQuota(split);
         CacheQuota expectedCacheQuota = new CacheQuota(".", Optional.empty());
@@ -96,7 +97,8 @@ public class TestHivePageSourceProvider
                 Optional.empty(),
                 false,
                 Optional.empty(),
-                new CacheQuotaRequirement(PARTITION, Optional.of(DataSize.succinctDataSize(1, DataSize.Unit.MEGABYTE))));
+                new CacheQuotaRequirement(PARTITION, Optional.of(DataSize.succinctDataSize(1, DataSize.Unit.MEGABYTE))),
+                Optional.empty());
 
         cacheQuota = HivePageSourceProvider.generateCacheQuota(split);
         expectedCacheQuota = new CacheQuota(SCHEMA_NAME + "." + TABLE_NAME + "." + PARTITION_NAME, Optional.of(DataSize.succinctDataSize(1, DataSize.Unit.MEGABYTE)));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
@@ -91,7 +91,8 @@ public class TestHiveSplit
                         ImmutableList.of(new HiveColumnHandle("col", HIVE_LONG, BIGINT.getTypeSignature(), 5, ColumnType.REGULAR, Optional.of("comment"))))),
                 false,
                 Optional.empty(),
-                NO_CACHE_REQUIREMENT);
+                NO_CACHE_REQUIREMENT,
+                Optional.of(EncryptionInformation.fromEncryptionMetadata(new DwrfEncryptionMetadata(ImmutableMap.of("field1", "test1".getBytes())))));
 
         JsonCodec<HiveSplit> codec = getJsonCodec();
         String json = codec.toJson(expected);
@@ -113,6 +114,7 @@ public class TestHiveSplit
         assertEquals(actual.getNodeSelectionStrategy(), expected.getNodeSelectionStrategy());
         assertEquals(actual.isS3SelectPushdownEnabled(), expected.isS3SelectPushdownEnabled());
         assertEquals(actual.getCacheQuotaRequirement(), expected.getCacheQuotaRequirement());
+        assertEquals(actual.getEncryptionInformation(), expected.getEncryptionInformation());
     }
 
     private JsonCodec<HiveSplit> getJsonCodec()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -518,6 +518,7 @@ public class TestHiveSplitSource
                             id,
                             ImmutableMap.of(),
                             Optional.empty()),
+                    Optional.empty(),
                     Optional.empty());
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -715,7 +715,7 @@ public final class SystemSessionProperties
                 booleanProperty(
                         PUSHDOWN_SUBFIELDS_ENABLED,
                         "Experimental: enable subfield pruning",
-                        featuresConfig.isPushdownSubfieldsEnabled(),
+                        true,
                         false),
                 booleanProperty(
                         TABLE_WRITER_MERGE_OPERATOR_ENABLED,


### PR DESCRIPTION
This PR adds metadata support #14621. Adds the constructs to pass encryption information to `HiveSplit` and also the table properties needed to define encryption settings for a table.

Encryption metadata support for writing data to Hive will add in an upcoming PR.

```
== RELEASE NOTES ==

Hive Changes
* Add support for reading Hive tables with DWRF encryption at rest.
```

depended by facebookexternal/presto-facebook#1040