### PR TITLE
Fix estimated serialized size for BlockEncodingBuffers

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
@@ -110,6 +110,18 @@ public abstract class AbstractArrayBlock
     }
 
     @Override
+    public long getRegionLogicalSizeInBytes(int position, int length)
+    {
+        int positionCount = getPositionCount();
+        checkValidRegion(positionCount, position, length);
+
+        int valueStart = getOffsets()[getOffsetBase() + position];
+        int valueEnd = getOffsets()[getOffsetBase() + position + length];
+
+        return getRawElementBlock().getRegionLogicalSizeInBytes(valueStart, valueEnd - valueStart) + ((Integer.BYTES + Byte.BYTES) * (long) length);
+    }
+
+    @Override
     public long getPositionsSizeInBytes(boolean[] positions)
     {
         checkValidPositions(positions, getPositionCount());

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractRowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractRowBlock.java
@@ -114,6 +114,23 @@ public abstract class AbstractRowBlock
     }
 
     @Override
+    public long getRegionLogicalSizeInBytes(int position, int length)
+    {
+        int positionCount = getPositionCount();
+        checkValidRegion(positionCount, position, length);
+
+        int startFieldBlockOffset = getFieldBlockOffset(position);
+        int endFieldBlockOffset = getFieldBlockOffset(position + length);
+        int fieldBlockLength = endFieldBlockOffset - startFieldBlockOffset;
+
+        long regionLogicalSizeInBytes = (Integer.BYTES + Byte.BYTES) * (long) length;
+        for (int i = 0; i < numFields; i++) {
+            regionLogicalSizeInBytes += getRawFieldBlocks()[i].getRegionLogicalSizeInBytes(startFieldBlockOffset, fieldBlockLength);
+        }
+        return regionLogicalSizeInBytes;
+    }
+
+    @Override
     public long getPositionsSizeInBytes(boolean[] positions)
     {
         checkValidPositions(positions, getPositionCount());

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
@@ -36,6 +36,7 @@ public class ArrayBlock
     private final int[] offsets;
 
     private volatile long sizeInBytes;
+    private volatile long logicalSizeInBytes;
     private final long retainedSizeInBytes;
 
     /**
@@ -104,6 +105,7 @@ public class ArrayBlock
         this.values = requireNonNull(values);
 
         sizeInBytes = -1;
+        logicalSizeInBytes = -1;
         retainedSizeInBytes = INSTANCE_SIZE + values.getRetainedSizeInBytes() + sizeOf(offsets) + sizeOf(valueIsNull);
     }
 
@@ -122,11 +124,27 @@ public class ArrayBlock
         return sizeInBytes;
     }
 
+    @Override
+    public long getLogicalSizeInBytes()
+    {
+        if (logicalSizeInBytes < 0) {
+            calculateLogicalSize();
+        }
+        return logicalSizeInBytes;
+    }
+
     private void calculateSize()
     {
         int valueStart = offsets[arrayOffset];
         int valueEnd = offsets[arrayOffset + positionCount];
         sizeInBytes = values.getRegionSizeInBytes(valueStart, valueEnd - valueStart) + ((Integer.BYTES + Byte.BYTES) * (long) this.positionCount);
+    }
+
+    private void calculateLogicalSize()
+    {
+        int valueStart = offsets[arrayOffset];
+        int valueEnd = offsets[arrayOffset + positionCount];
+        logicalSizeInBytes = values.getRegionLogicalSizeInBytes(valueStart, valueEnd - valueStart) + ((Integer.BYTES + Byte.BYTES) * (long) this.positionCount);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -206,6 +206,15 @@ public interface Block
     long getRegionSizeInBytes(int position, int length);
 
     /**
+     * Returns the size of {@code block.getRegion(position, length)}.
+     * The method can be expensive. Do not use it outside an implementation of Block.
+     */
+    default long getRegionLogicalSizeInBytes(int position, int length)
+    {
+        return getRegionSizeInBytes(position, length);
+    }
+
+    /**
      * Returns the size of of all positions marked true in the positions array.
      * This is equivalent to multiple calls of {@code block.getRegionSizeInBytes(position, length)}
      * where you mark all positions for the regions first.

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
@@ -193,6 +193,7 @@ public class MapBlock
         this.valueBlock = valueBlock;
         this.hashTables = hashTables;
         this.sizeInBytes = -1;
+        this.logicalSizeInBytes = -1;
 
         // We will add the hashtable size to the retained size even if it's not built yet. This could be overestimating
         // but is necessary to avoid reliability issues. Currently the memory counting framework only pull the retained

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
@@ -100,6 +100,7 @@ public class MapBlockBuilder
         this.keyBlockBuilder = requireNonNull(keyBlockBuilder, "keyBlockBuilder is null");
         this.valueBlockBuilder = requireNonNull(valueBlockBuilder, "valueBlockBuilder is null");
         this.hashTables = new HashTables(Optional.of(requireNonNull(rawHashTables, "hashTables is null")), 0, rawHashTables.length);
+        this.logicalSizeInBytes = -1;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
@@ -148,6 +148,12 @@ public class RunLengthEncodedBlock
     }
 
     @Override
+    public long getRegionLogicalSizeInBytes(int position, int length)
+    {
+        return length * value.getLogicalSizeInBytes();
+    }
+
+    @Override
     public long getPositionsSizeInBytes(boolean[] positions)
     {
         return value.getSizeInBytes();

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
@@ -205,7 +205,7 @@ public abstract class AbstractBlockEncodingBuffer
         this.positionsOffset = 0;
         this.positionsMapped = false;
 
-        double decodedBlockPageSizeFraction = (decodedBlockNode.getEstimatedSerializedSizeInBytes() - decodedBlockNode.getChildrenEstimatedSerializedSizeInBytes()) / ((double) estimatedSerializedPageSize);
+        double decodedBlockPageSizeFraction = (decodedBlockNode.getEstimatedSerializedSizeInBytes()) / ((double) estimatedSerializedPageSize);
 
         setupDecodedBlockAndMapPositions(decodedBlockNode, partitionBufferCapacity, decodedBlockPageSizeFraction);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
@@ -257,6 +257,11 @@ public abstract class AbstractBlockEncodingBuffer
         this.estimatedNullsBufferMaxCapacity = estimatedNullsBufferMaxCapacity;
     }
 
+    protected static int getEstimatedBufferMaxCapacity(double targetBufferSize, int unitSize, int positionSize)
+    {
+        return (int) (targetBufferSize * unitSize / positionSize * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
+    }
+
     /**
      * Map the positions for DictionaryBlock to its nested dictionaryBlock, and positions for RunLengthEncodedBlock
      * to its nested value block. For example, positions [0, 2, 5] on DictionaryBlock with dictionary block ['a', 'b', 'c']

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
@@ -240,6 +240,15 @@ public abstract class AbstractBlockEncodingBuffer
                 .toString();
     }
 
+    @VisibleForTesting
+    abstract int getEstimatedValueBufferMaxCapacity();
+
+    @VisibleForTesting
+    int getEstimatedNullsBufferMaxCapacity()
+    {
+        return estimatedNullsBufferMaxCapacity;
+    }
+
     protected void setEstimatedNullsBufferMaxCapacity(int estimatedNullsBufferMaxCapacity)
     {
         this.estimatedNullsBufferMaxCapacity = estimatedNullsBufferMaxCapacity;

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
@@ -65,6 +65,9 @@ import static java.util.Objects.requireNonNull;
 public abstract class AbstractBlockEncodingBuffer
         implements BlockEncodingBuffer
 {
+    @VisibleForTesting
+    public static final double GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY = 1.2f;
+
     // The allocator for internal buffers
     protected final ArrayAllocator bufferAllocator;
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
@@ -207,6 +207,24 @@ public class ArrayBlockEncodingBuffer
     }
 
     @Override
+    int getEstimatedValueBufferMaxCapacity()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @VisibleForTesting
+    int getEstimatedOffsetBufferMaxCapacity()
+    {
+        return estimatedOffsetBufferMaxCapacity;
+    }
+
+    @VisibleForTesting
+    BlockEncodingBuffer getValuesBuffers()
+    {
+        return valuesBuffers;
+    }
+
+    @Override
     protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode, int partitionBufferCapacity, double decodedBlockPageSizeFraction)
     {
         requireNonNull(decodedBlockNode, "decodedBlockNode is null");

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
@@ -238,13 +238,9 @@ public class ArrayBlockEncodingBuffer
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction *
                 (estimatedSerializedSizeInBytes - childrenEstimatedSerializedSizeInBytes) / estimatedSerializedSizeInBytes;
-        if (decodedBlock.mayHaveNull()) {
-            setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-            estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE);
-        }
-        else {
-            estimatedOffsetBufferMaxCapacity = (int) targetBufferSize;
-        }
+
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
+        estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE);
 
         populateNestedPositions(columnarArray);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
@@ -239,8 +239,8 @@ public class ArrayBlockEncodingBuffer
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction *
                 (estimatedSerializedSizeInBytes - childrenEstimatedSerializedSizeInBytes) / estimatedSerializedSizeInBytes;
 
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-        estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE);
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
+        estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
 
         populateNestedPositions(columnarArray);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ArrayBlockEncodingBuffer.java
@@ -239,8 +239,8 @@ public class ArrayBlockEncodingBuffer
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction *
                 (estimatedSerializedSizeInBytes - childrenEstimatedSerializedSizeInBytes) / estimatedSerializedSizeInBytes;
 
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
-        estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
+        setEstimatedNullsBufferMaxCapacity(getEstimatedBufferMaxCapacity(targetBufferSize, Byte.BYTES, POSITION_SIZE));
+        estimatedOffsetBufferMaxCapacity = getEstimatedBufferMaxCapacity(targetBufferSize, Integer.BYTES, POSITION_SIZE);
 
         populateNestedPositions(columnarArray);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
@@ -160,13 +160,8 @@ public class ByteArrayBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        if (decodedBlock.mayHaveNull()) {
-            setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-            estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Byte.BYTES / POSITION_SIZE);
-        }
-        else {
-            estimatedValueBufferMaxCapacity = (int) targetBufferSize;
-        }
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
+        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Byte.BYTES / POSITION_SIZE);
     }
 
     private void appendValuesToBuffer()

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
@@ -160,8 +160,9 @@ public class ByteArrayBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
-        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
+
+        setEstimatedNullsBufferMaxCapacity(getEstimatedBufferMaxCapacity(targetBufferSize, Byte.BYTES, POSITION_SIZE));
+        estimatedValueBufferMaxCapacity = getEstimatedBufferMaxCapacity(targetBufferSize, Byte.BYTES, POSITION_SIZE);
     }
 
     private void appendValuesToBuffer()

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
@@ -146,6 +146,13 @@ public class ByteArrayBlockEncodingBuffer
                 .toString();
     }
 
+    @VisibleForTesting
+    @Override
+    int getEstimatedValueBufferMaxCapacity()
+    {
+        return estimatedValueBufferMaxCapacity;
+    }
+
     @Override
     protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode, int partitionBufferCapacity, double decodedBlockPageSizeFraction)
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ByteArrayBlockEncodingBuffer.java
@@ -160,8 +160,8 @@ public class ByteArrayBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Byte.BYTES / POSITION_SIZE);
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
+        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
     }
 
     private void appendValuesToBuffer()

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/DecodedBlockNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/DecodedBlockNode.java
@@ -43,7 +43,6 @@ class DecodedBlockNode
     private final List<DecodedBlockNode> children;
     private final long retainedSizeInBytes;
     private final long estimatedSerializedSizeInBytes;
-    private final long childrenEstimatedSerializedSizeInBytes;
 
     public DecodedBlockNode(Object decodedBlock, List<DecodedBlockNode> children)
     {
@@ -73,12 +72,6 @@ class DecodedBlockNode
 
         retainedSizeInBytes = retainedSize;
         estimatedSerializedSizeInBytes = estimatedSerializedSize;
-
-        long childrenEstimatedSerializedSize = 0;
-        for (int i = 0; i < children.size(); i++) {
-            childrenEstimatedSerializedSize += children.get(i).getEstimatedSerializedSizeInBytes();
-        }
-        childrenEstimatedSerializedSizeInBytes = childrenEstimatedSerializedSize;
     }
 
     public Object getDecodedBlock()
@@ -89,11 +82,6 @@ class DecodedBlockNode
     public List<DecodedBlockNode> getChildren()
     {
         return children;
-    }
-
-    public long getChildrenEstimatedSerializedSizeInBytes()
-    {
-        return childrenEstimatedSerializedSizeInBytes;
     }
 
     public long getRetainedSizeInBytes()

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/DecodedBlockNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/DecodedBlockNode.java
@@ -13,10 +13,6 @@
  */
 package com.facebook.presto.operator.repartition;
 
-import com.facebook.presto.common.block.Block;
-import com.facebook.presto.common.block.ColumnarArray;
-import com.facebook.presto.common.block.ColumnarMap;
-import com.facebook.presto.common.block.ColumnarRow;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
@@ -44,34 +40,12 @@ class DecodedBlockNode
     private final long retainedSizeInBytes;
     private final long estimatedSerializedSizeInBytes;
 
-    public DecodedBlockNode(Object decodedBlock, List<DecodedBlockNode> children)
+    public DecodedBlockNode(Object decodedBlock, List<DecodedBlockNode> children, long decodedBlockRetainedSizeInBytes, long estimatedSerializedSizeInBytes)
     {
         this.decodedBlock = requireNonNull(decodedBlock, "decodedBlock is null");
         this.children = requireNonNull(children, "children is null");
-
-        long retainedSize = INSTANCE_SIZE;
-        long estimatedSerializedSize = 0;
-
-        if (decodedBlock instanceof Block) {
-            retainedSize += ((Block) decodedBlock).getRetainedSizeInBytes();
-            // We use logical size as an estimation of the serialized size. For DictionaryBlock and RunLengthEncodedBlock, the logical size accounts for the size as if they were inflated.
-            estimatedSerializedSize += ((Block) decodedBlock).getLogicalSizeInBytes();
-        }
-        else if (decodedBlock instanceof ColumnarArray) {
-            retainedSize += ((ColumnarArray) decodedBlock).getRetainedSizeInBytes();
-            estimatedSerializedSize += ((ColumnarArray) decodedBlock).getEstimatedSerializedSizeInBytes();
-        }
-        else if (decodedBlock instanceof ColumnarMap) {
-            retainedSize += ((ColumnarMap) decodedBlock).getRetainedSizeInBytes();
-            estimatedSerializedSize += ((ColumnarMap) decodedBlock).getEstimatedSerializedSizeInBytes();
-        }
-        else if (decodedBlock instanceof ColumnarRow) {
-            retainedSize += ((ColumnarRow) decodedBlock).getRetainedSizeInBytes();
-            estimatedSerializedSize += ((ColumnarRow) decodedBlock).getEstimatedSerializedSizeInBytes();
-        }
-
-        retainedSizeInBytes = retainedSize;
-        estimatedSerializedSizeInBytes = estimatedSerializedSize;
+        this.retainedSizeInBytes = decodedBlockRetainedSizeInBytes + INSTANCE_SIZE;
+        this.estimatedSerializedSizeInBytes = estimatedSerializedSizeInBytes;
     }
 
     public Object getDecodedBlock()

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
@@ -139,6 +139,12 @@ public class Int128ArrayBlockEncodingBuffer
                 .toString();
     }
 
+    @VisibleForTesting
+    int getEstimatedValueBufferMaxCapacity()
+    {
+        return estimatedValueBufferMaxCapacity;
+    }
+
     @Override
     protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode, int partitionBufferCapacity, double decodedBlockPageSizeFraction)
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
@@ -152,8 +152,9 @@ public class Int128ArrayBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
-        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Long.BYTES * 2 / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
+
+        setEstimatedNullsBufferMaxCapacity(getEstimatedBufferMaxCapacity(targetBufferSize, Byte.BYTES, POSITION_SIZE));
+        estimatedValueBufferMaxCapacity = getEstimatedBufferMaxCapacity(targetBufferSize, Long.BYTES * 2, POSITION_SIZE);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
@@ -152,8 +152,8 @@ public class Int128ArrayBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Long.BYTES * 2 / POSITION_SIZE);
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
+        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Long.BYTES * 2 / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/Int128ArrayBlockEncodingBuffer.java
@@ -152,13 +152,8 @@ public class Int128ArrayBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        if (decodedBlock.mayHaveNull()) {
-            setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-            estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Long.BYTES * 2 / POSITION_SIZE);
-        }
-        else {
-            estimatedValueBufferMaxCapacity = (int) targetBufferSize;
-        }
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
+        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Long.BYTES * 2 / POSITION_SIZE);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
@@ -152,13 +152,8 @@ public class IntArrayBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        if (decodedBlock.mayHaveNull()) {
-            setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-            estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE);
-        }
-        else {
-            estimatedValueBufferMaxCapacity = (int) targetBufferSize;
-        }
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
+        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
@@ -139,6 +139,12 @@ public class IntArrayBlockEncodingBuffer
                 .toString();
     }
 
+    @VisibleForTesting
+    int getEstimatedValueBufferMaxCapacity()
+    {
+        return estimatedValueBufferMaxCapacity;
+    }
+
     @Override
     protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode, int partitionBufferCapacity, double decodedBlockPageSizeFraction)
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
@@ -152,8 +152,8 @@ public class IntArrayBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE);
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
+        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/IntArrayBlockEncodingBuffer.java
@@ -152,8 +152,9 @@ public class IntArrayBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
-        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
+
+        setEstimatedNullsBufferMaxCapacity(getEstimatedBufferMaxCapacity(targetBufferSize, Byte.BYTES, POSITION_SIZE));
+        estimatedValueBufferMaxCapacity = getEstimatedBufferMaxCapacity(targetBufferSize, Integer.BYTES, POSITION_SIZE);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
@@ -138,13 +138,8 @@ public class LongArrayBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        if (decodedBlock.mayHaveNull()) {
-            setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-            estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Long.BYTES / POSITION_SIZE);
-        }
-        else {
-            estimatedValueBufferMaxCapacity = (int) targetBufferSize;
-        }
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
+        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Long.BYTES / POSITION_SIZE);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
@@ -138,8 +138,8 @@ public class LongArrayBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Long.BYTES / POSITION_SIZE);
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
+        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Long.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
@@ -138,8 +138,9 @@ public class LongArrayBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
-        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Long.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
+
+        setEstimatedNullsBufferMaxCapacity(getEstimatedBufferMaxCapacity(targetBufferSize, Byte.BYTES, POSITION_SIZE));
+        estimatedValueBufferMaxCapacity = getEstimatedBufferMaxCapacity(targetBufferSize, Long.BYTES, POSITION_SIZE);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/LongArrayBlockEncodingBuffer.java
@@ -125,6 +125,12 @@ public class LongArrayBlockEncodingBuffer
                 .toString();
     }
 
+    @VisibleForTesting
+    public int getEstimatedValueBufferMaxCapacity()
+    {
+        return estimatedValueBufferMaxCapacity;
+    }
+
     @Override
     protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode, int partitionBufferCapacity, double decodedBlockPageSizeFraction)
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
@@ -315,9 +315,9 @@ public class MapBlockEncodingBuffer
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction *
                 (estimatedSerializedSizeInBytes - keyBufferEstimatedSerializedSizeInBytes - valueBufferEstimatedSerializedSizeInBytes) / estimatedSerializedSizeInBytes;
 
-        estimatedHashTableBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES * HASH_MULTIPLIER / POSITION_SIZE_WITH_HASHTABLE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE_WITH_HASHTABLE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
-        estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE_WITH_HASHTABLE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
+        estimatedHashTableBufferMaxCapacity = getEstimatedBufferMaxCapacity(targetBufferSize, Integer.BYTES * HASH_MULTIPLIER, POSITION_SIZE_WITH_HASHTABLE);
+        setEstimatedNullsBufferMaxCapacity(getEstimatedBufferMaxCapacity(targetBufferSize, Byte.BYTES, POSITION_SIZE_WITH_HASHTABLE));
+        estimatedOffsetBufferMaxCapacity = getEstimatedBufferMaxCapacity(targetBufferSize, Integer.BYTES, POSITION_SIZE_WITH_HASHTABLE);
 
         populateNestedPositions();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
@@ -53,10 +53,11 @@ public class MapBlockEncodingBuffer
     @VisibleForTesting
     static final int POSITION_SIZE = SIZE_OF_INT + SIZE_OF_BYTE;
 
+    @VisibleForTesting
+    static final int HASH_MULTIPLIER = 2;
+
     private static final String NAME = "MAP";
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapBlockEncodingBuffer.class).instanceSize();
-
-    private static final int HASH_MULTIPLIER = 2;
 
     // The buffer for the hashtables for all incoming blocks so far
     private byte[] hashTablesBuffer;
@@ -265,6 +266,36 @@ public class MapBlockEncodingBuffer
                 .add("keyBuffers", keyBuffers)
                 .add("valueBuffers", valueBuffers)
                 .toString();
+    }
+
+    @Override
+    protected int getEstimatedValueBufferMaxCapacity()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @VisibleForTesting
+    int getEstimatedOffsetBufferMaxCapacity()
+    {
+        return estimatedOffsetBufferMaxCapacity;
+    }
+
+    @VisibleForTesting
+    int getEstimatedHashTableBufferMaxCapacity()
+    {
+        return estimatedHashTableBufferMaxCapacity;
+    }
+
+    @VisibleForTesting
+    BlockEncodingBuffer getKeyBuffers()
+    {
+        return keyBuffers;
+    }
+
+    @VisibleForTesting
+    BlockEncodingBuffer getValueBuffers()
+    {
+        return valueBuffers;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/MapBlockEncodingBuffer.java
@@ -315,9 +315,9 @@ public class MapBlockEncodingBuffer
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction *
                 (estimatedSerializedSizeInBytes - keyBufferEstimatedSerializedSizeInBytes - valueBufferEstimatedSerializedSizeInBytes) / estimatedSerializedSizeInBytes;
 
-        estimatedHashTableBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES * HASH_MULTIPLIER / POSITION_SIZE_WITH_HASHTABLE);
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE_WITH_HASHTABLE));
-        estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE_WITH_HASHTABLE);
+        estimatedHashTableBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES * HASH_MULTIPLIER / POSITION_SIZE_WITH_HASHTABLE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE_WITH_HASHTABLE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
+        estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE_WITH_HASHTABLE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
 
         populateNestedPositions();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
@@ -266,8 +266,8 @@ public class RowBlockEncodingBuffer
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction * (estimatedSerializedSizeInBytes - childrenEstimatedSerializedSizeInBytes) / estimatedSerializedSizeInBytes;
 
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
-        estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
+        setEstimatedNullsBufferMaxCapacity(getEstimatedBufferMaxCapacity(targetBufferSize, Byte.BYTES, POSITION_SIZE));
+        estimatedOffsetBufferMaxCapacity = getEstimatedBufferMaxCapacity(targetBufferSize, Integer.BYTES, POSITION_SIZE);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
@@ -266,8 +266,8 @@ public class RowBlockEncodingBuffer
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction * (estimatedSerializedSizeInBytes - childrenEstimatedSerializedSizeInBytes) / estimatedSerializedSizeInBytes;
 
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-        estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE);
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
+        estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
@@ -266,13 +266,8 @@ public class RowBlockEncodingBuffer
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction * (estimatedSerializedSizeInBytes - childrenEstimatedSerializedSizeInBytes) / estimatedSerializedSizeInBytes;
 
-        if (decodedBlock.mayHaveNull()) {
-            setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-            estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE);
-        }
-        else {
-            estimatedOffsetBufferMaxCapacity = (int) targetBufferSize;
-        }
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
+        estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize * Integer.BYTES / POSITION_SIZE);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/RowBlockEncodingBuffer.java
@@ -304,6 +304,24 @@ public class RowBlockEncodingBuffer
         }
     }
 
+    @Override
+    int getEstimatedValueBufferMaxCapacity()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @VisibleForTesting
+    int getEstimatedOffsetBufferMaxCapacity()
+    {
+        return estimatedOffsetBufferMaxCapacity;
+    }
+
+    @VisibleForTesting
+    BlockEncodingBuffer[] getFieldBuffers()
+    {
+        return fieldBuffers;
+    }
+
     private void populateNestedPositions(ColumnarRow columnarRow)
     {
         // Reset nested level positions before checking positionCount. Failing to do so may result in elementsBuffers having stale values when positionCount is 0.

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
@@ -153,8 +153,8 @@ public class ShortArrayBlockEncodingBuffer
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
 
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Short.BYTES / POSITION_SIZE);
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
+        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Short.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
@@ -139,6 +139,12 @@ public class ShortArrayBlockEncodingBuffer
                 .toString();
     }
 
+    @VisibleForTesting
+    int getEstimatedValueBufferMaxCapacity()
+    {
+        return estimatedValueBufferMaxCapacity;
+    }
+
     @Override
     protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode, int partitionBufferCapacity, double decodedBlockPageSizeFraction)
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
@@ -153,8 +153,8 @@ public class ShortArrayBlockEncodingBuffer
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
 
-        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
-        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Short.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
+        setEstimatedNullsBufferMaxCapacity(getEstimatedBufferMaxCapacity(targetBufferSize, Byte.BYTES, POSITION_SIZE));
+        estimatedValueBufferMaxCapacity = getEstimatedBufferMaxCapacity(targetBufferSize, Short.BYTES, POSITION_SIZE);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
@@ -148,7 +148,7 @@ public class ShortArrayBlockEncodingBuffer
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
         if (decodedBlock.mayHaveNull()) {
             setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-            estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Byte.BYTES / POSITION_SIZE);
+            estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Short.BYTES / POSITION_SIZE);
         }
         else {
             estimatedValueBufferMaxCapacity = (int) targetBufferSize;

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/ShortArrayBlockEncodingBuffer.java
@@ -152,13 +152,9 @@ public class ShortArrayBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        if (decodedBlock.mayHaveNull()) {
-            setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
-            estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Short.BYTES / POSITION_SIZE);
-        }
-        else {
-            estimatedValueBufferMaxCapacity = (int) targetBufferSize;
-        }
+
+        setEstimatedNullsBufferMaxCapacity((int) (targetBufferSize * Byte.BYTES / POSITION_SIZE));
+        estimatedValueBufferMaxCapacity = (int) (targetBufferSize * Short.BYTES / POSITION_SIZE);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/VariableWidthBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/VariableWidthBlockEncodingBuffer.java
@@ -217,8 +217,9 @@ public class VariableWidthBlockEncodingBuffer
         estimatedSliceBufferMaxCapacity = (int) (targetBufferSize *
                 (((VariableWidthBlock) decodedBlock).getPositionOffset(decodedBlock.getPositionCount()) - ((VariableWidthBlock) decodedBlock).getPositionOffset(0)) /
                 decodedBlock.getLogicalSizeInBytes());
-        setEstimatedNullsBufferMaxCapacity((int) ((targetBufferSize - estimatedSliceBufferMaxCapacity) * Byte.BYTES / POSITION_SIZE));
-        estimatedOffsetBufferMaxCapacity = (int) ((targetBufferSize - estimatedSliceBufferMaxCapacity) * Integer.BYTES / POSITION_SIZE);
+        setEstimatedNullsBufferMaxCapacity((int) ((targetBufferSize - estimatedSliceBufferMaxCapacity) * Byte.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY));
+        estimatedOffsetBufferMaxCapacity = (int) ((targetBufferSize - estimatedSliceBufferMaxCapacity) * Integer.BYTES / POSITION_SIZE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY);
+        estimatedSliceBufferMaxCapacity *= GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/VariableWidthBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/VariableWidthBlockEncodingBuffer.java
@@ -188,6 +188,24 @@ public class VariableWidthBlockEncodingBuffer
                 .toString();
     }
 
+    @VisibleForTesting
+    int getEstimatedOffsetBufferMaxCapacity()
+    {
+        return estimatedOffsetBufferMaxCapacity;
+    }
+
+    @VisibleForTesting
+    int getEstimatedSliceBufferMaxCapacity()
+    {
+        return estimatedSliceBufferMaxCapacity;
+    }
+
+    @Override
+    int getEstimatedValueBufferMaxCapacity()
+    {
+        throw new UnsupportedOperationException();
+    }
+
     @Override
     protected void setupDecodedBlockAndMapPositions(DecodedBlockNode decodedBlockNode, int partitionBufferCapacity, double decodedBlockPageSizeFraction)
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/VariableWidthBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/VariableWidthBlockEncodingBuffer.java
@@ -213,14 +213,12 @@ public class VariableWidthBlockEncodingBuffer
         decodedBlock = (Block) mapPositionsToNestedBlock(decodedBlockNode).getDecodedBlock();
 
         double targetBufferSize = partitionBufferCapacity * decodedBlockPageSizeFraction;
-        estimatedSliceBufferMaxCapacity = (int) (targetBufferSize * ((VariableWidthBlock) decodedBlock).getRawSlice(0).getRetainedSize() / decodedBlock.getRetainedSizeInBytes());
-        if (decodedBlock.mayHaveNull()) {
-            setEstimatedNullsBufferMaxCapacity((int) ((targetBufferSize - estimatedSliceBufferMaxCapacity) * Byte.BYTES / POSITION_SIZE));
-            estimatedOffsetBufferMaxCapacity = (int) ((targetBufferSize - estimatedSliceBufferMaxCapacity) * Integer.BYTES / POSITION_SIZE);
-        }
-        else {
-            estimatedOffsetBufferMaxCapacity = (int) (targetBufferSize - estimatedSliceBufferMaxCapacity);
-        }
+
+        estimatedSliceBufferMaxCapacity = (int) (targetBufferSize *
+                (((VariableWidthBlock) decodedBlock).getPositionOffset(decodedBlock.getPositionCount()) - ((VariableWidthBlock) decodedBlock).getPositionOffset(0)) /
+                decodedBlock.getLogicalSizeInBytes());
+        setEstimatedNullsBufferMaxCapacity((int) ((targetBufferSize - estimatedSliceBufferMaxCapacity) * Byte.BYTES / POSITION_SIZE));
+        estimatedOffsetBufferMaxCapacity = (int) ((targetBufferSize - estimatedSliceBufferMaxCapacity) * Integer.BYTES / POSITION_SIZE);
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -229,15 +229,30 @@ public abstract class AbstractTestBlock
         assertEquals(block.getSizeInBytes(), expectedBlockSize);
         assertEquals(block.getRegionSizeInBytes(0, block.getPositionCount()), expectedBlockSize);
 
+        long expectedLogicalBlockSize = copyBlockViaBlockSerde(block).getLogicalSizeInBytes();
+        assertEquals(block.getLogicalSizeInBytes(), expectedLogicalBlockSize);
+        assertEquals(block.getRegionLogicalSizeInBytes(0, block.getPositionCount()), expectedLogicalBlockSize);
+
         List<Block> splitBlock = splitBlock(block, 2);
         Block firstHalf = splitBlock.get(0);
+
         long expectedFirstHalfSize = copyBlockViaBlockSerde(firstHalf).getSizeInBytes();
         assertEquals(firstHalf.getSizeInBytes(), expectedFirstHalfSize);
         assertEquals(block.getRegionSizeInBytes(0, firstHalf.getPositionCount()), expectedFirstHalfSize);
+
+        long expectedFirstHalfLogicalSize = copyBlockViaBlockSerde(firstHalf).getLogicalSizeInBytes();
+        assertEquals(firstHalf.getLogicalSizeInBytes(), expectedFirstHalfLogicalSize);
+        assertEquals(firstHalf.getRegionLogicalSizeInBytes(0, firstHalf.getPositionCount()), expectedFirstHalfLogicalSize);
+
         Block secondHalf = splitBlock.get(1);
+
         long expectedSecondHalfSize = copyBlockViaBlockSerde(secondHalf).getSizeInBytes();
         assertEquals(secondHalf.getSizeInBytes(), expectedSecondHalfSize);
         assertEquals(block.getRegionSizeInBytes(firstHalf.getPositionCount(), secondHalf.getPositionCount()), expectedSecondHalfSize);
+
+        long expectedSecondHalfLogicalSize = copyBlockViaBlockSerde(secondHalf).getLogicalSizeInBytes();
+        assertEquals(secondHalf.getLogicalSizeInBytes(), expectedSecondHalfLogicalSize);
+        assertEquals(secondHalf.getRegionLogicalSizeInBytes(0, secondHalf.getPositionCount()), expectedSecondHalfLogicalSize);
 
         boolean[] positions = new boolean[block.getPositionCount()];
         fill(positions, 0, firstHalf.getPositionCount(), true);

--- a/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
@@ -23,7 +23,13 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 import java.util.Random;
+import java.util.stream.IntStream;
 
+import static com.facebook.presto.block.BlockAssertions.createLongDictionaryBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.block.BlockAssertions.createRandomDictionaryBlock;
+import static com.facebook.presto.block.BlockAssertions.createRandomLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createRleBlockWithRandomValue;
 import static com.facebook.presto.common.block.ArrayBlock.fromElementBlock;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -156,6 +162,38 @@ public class TestArrayBlock
             assertEquals(blockBuilder.getEstimatedDataSizeForStats(i), expectedSize);
             assertEquals(block.getEstimatedDataSizeForStats(i), expectedSize);
         }
+    }
+
+    @Test
+    public void testLogicalSizeInBytes()
+    {
+        int positionCount = 100;
+        int[] offsets = IntStream.rangeClosed(0, positionCount).toArray();
+        boolean[] nulls = new boolean[positionCount];
+
+        // Array(LongArrayBlock)
+        Block arrayOfLong = fromElementBlock(positionCount, Optional.of(nulls), offsets, createRandomLongsBlock(positionCount, 0));
+        assertEquals(arrayOfLong.getLogicalSizeInBytes(), 1400);
+
+        // Array(RLE(LongArrayBlock))
+        Block arrayOfRleOfLong = fromElementBlock(positionCount, Optional.of(nulls), offsets, createRLEBlock(1, 100));
+        assertEquals(arrayOfRleOfLong.getLogicalSizeInBytes(), 1400);
+
+        // Array(RLE(Array(LongArrayBlock)))
+        Block arrayOfRleOfArrayOfLong = fromElementBlock(positionCount, Optional.of(nulls), offsets, createRleBlockWithRandomValue(arrayOfLong, 100));
+        assertEquals(arrayOfRleOfArrayOfLong.getLogicalSizeInBytes(), 1900);
+
+        // Array(Dictionary(LongArrayBlock))
+        Block arrayOfDictionaryOfLong = fromElementBlock(positionCount, Optional.of(nulls), offsets, createLongDictionaryBlock(0, 100));
+        assertEquals(arrayOfDictionaryOfLong.getLogicalSizeInBytes(), 1400);
+
+        // Array(Array(Dictionary(LongArrayBlock)))
+        Block arrayOfArrayOfDictionaryOfLong = fromElementBlock(positionCount, Optional.of(nulls), offsets, arrayOfDictionaryOfLong);
+        assertEquals(arrayOfArrayOfDictionaryOfLong.getLogicalSizeInBytes(), 1900);
+
+        // Array(Dictionary(Array(LongArrayBlock)))
+        Block arrayOfDictionaryOfArrayOfLong = fromElementBlock(positionCount, Optional.of(nulls), offsets, createRandomDictionaryBlock(arrayOfDictionaryOfLong, 100, true));
+        assertEquals(arrayOfDictionaryOfArrayOfLong.getLogicalSizeInBytes(), 1900);
     }
 
     private static int getExpectedEstimatedDataSize(long[][] values)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
@@ -22,6 +22,9 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.block.BlockAssertions.createRandomDictionaryBlock;
+import static com.facebook.presto.block.BlockAssertions.createRandomLongsBlock;
 import static com.facebook.presto.block.BlockAssertions.createSlicesBlock;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static org.testng.Assert.assertEquals;
@@ -64,6 +67,15 @@ public class TestDictionaryBlock
 
         // The null positions should be included in the logical size.
         assertEquals(dictionaryBlock.getLogicalSizeInBytes(), 150 * 10);
+
+        Block longArrayBlock = createRandomLongsBlock(100, 0.5f);
+        DictionaryBlock dictionaryDictionaryBlock = createRandomDictionaryBlock(createRandomDictionaryBlock(longArrayBlock, 50), 10);
+        assertEquals(dictionaryDictionaryBlock.getDictionary().getLogicalSizeInBytes(), 450);
+        assertEquals(dictionaryDictionaryBlock.getLogicalSizeInBytes(), 90);
+
+        DictionaryBlock dictionaryRleBlock = createRandomDictionaryBlock(createRLEBlock(1, 50), 10);
+        assertEquals(dictionaryRleBlock.getDictionary().getLogicalSizeInBytes(), 450);
+        assertEquals(dictionaryRleBlock.getLogicalSizeInBytes(), 90);
     }
 
     @Test
@@ -89,7 +101,8 @@ public class TestDictionaryBlock
         assertEquals(copiedBlock.getDictionary().getPositionCount(), 1);
         assertEquals(copiedBlock.getPositionCount(), positionsToCopy.length);
         assertBlock(copiedBlock.getDictionary(), TestDictionaryBlock::createBlockBuilder, new Slice[] {firstExpectedValue});
-        assertBlock(copiedBlock, TestDictionaryBlock::createBlockBuilder, new Slice[] {firstExpectedValue, firstExpectedValue, firstExpectedValue, firstExpectedValue, firstExpectedValue});
+        assertBlock(copiedBlock, TestDictionaryBlock::createBlockBuilder, new Slice[] {firstExpectedValue, firstExpectedValue, firstExpectedValue, firstExpectedValue,
+                firstExpectedValue});
     }
 
     @Test
@@ -177,7 +190,8 @@ public class TestDictionaryBlock
     {
         Slice[] expectedValues = createExpectedValues(10);
         Block dictionaryBlock = new DictionaryBlock(createSlicesBlock(expectedValues), new int[] {0, 1, 2, 3, 4, 5});
-        assertBlock(dictionaryBlock, TestDictionaryBlock::createBlockBuilder, new Slice[] {expectedValues[0], expectedValues[1], expectedValues[2], expectedValues[3], expectedValues[4], expectedValues[5]});
+        assertBlock(dictionaryBlock, TestDictionaryBlock::createBlockBuilder, new Slice[] {expectedValues[0], expectedValues[1], expectedValues[2], expectedValues[3],
+                expectedValues[4], expectedValues[5]});
         DictionaryId dictionaryId = ((DictionaryBlock) dictionaryBlock).getDictionarySourceId();
 
         // first getPositions
@@ -202,7 +216,8 @@ public class TestDictionaryBlock
 
         // duplicated getPositions
         dictionaryBlock = dictionaryBlock.getPositions(new int[] {1, 1, 1, 1, 1}, 0, 5);
-        assertBlock(dictionaryBlock, TestDictionaryBlock::createBlockBuilder, new Slice[] {expectedValues[5], expectedValues[5], expectedValues[5], expectedValues[5], expectedValues[5]});
+        assertBlock(dictionaryBlock, TestDictionaryBlock::createBlockBuilder, new Slice[] {expectedValues[5], expectedValues[5], expectedValues[5], expectedValues[5],
+                expectedValues[5]});
         assertEquals(((DictionaryBlock) dictionaryBlock).getDictionarySourceId(), dictionaryId);
 
         // out of range

--- a/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
@@ -36,7 +36,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
+import static com.facebook.presto.block.BlockAssertions.createLongDictionaryBlock;
 import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.block.BlockAssertions.createRandomLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createRleBlockWithRandomValue;
 import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
@@ -105,6 +109,50 @@ public class TestMapBlock
         assertEquals(singleMapBlock.seekKeyExact(Slices.utf8Slice(new String(new char[10]).replace("\0", "Doudou"))), -1);
         // Testing found case.
         assertEquals(singleMapBlock.seekKeyExact(Slices.utf8Slice("k")), 1);
+    }
+
+    @Test
+    public void testLogicalSizeInBytes()
+    {
+        int positionCount = 100;
+        int[] offsets = IntStream.rangeClosed(0, positionCount).toArray();
+        boolean[] nulls = new boolean[positionCount];
+
+        // Map(LongArrayBlock, LongArrayBlock)
+        Block keyBlock1 = createRandomLongsBlock(positionCount, 0);
+        Block valueBlock1 = createRandomLongsBlock(positionCount, 0);
+        Block mapOfLongAndLong = mapType(BIGINT, BIGINT).createBlockFromKeyValue(positionCount, Optional.of(nulls), offsets, keyBlock1, valueBlock1);
+        assertEquals(mapOfLongAndLong.getLogicalSizeInBytes(), 3100);
+
+        // Map(RLE(LongArrayBlock), RLE(LongArrayBlock))
+        Block keyBlock2 = createRLEBlock(1, positionCount);
+        Block valueBlock2 = createRLEBlock(2, positionCount);
+        Block mapOfRleOfLongAndRleOfLong = mapType(BIGINT, BIGINT).createBlockFromKeyValue(positionCount, Optional.of(nulls), offsets, keyBlock2, valueBlock2);
+        assertEquals(mapOfRleOfLongAndRleOfLong.getLogicalSizeInBytes(), 3100);
+
+        // Map(RLE(LongArrayBlock), RLE(Map(LongArrayBlock, LongArrayBlock)))
+        Block keyBlock3 = createRLEBlock(1, positionCount);
+        Block valueBlock3 = createRleBlockWithRandomValue(mapType(BIGINT, BIGINT).createBlockFromKeyValue(positionCount, Optional.of(nulls), offsets, keyBlock1, valueBlock1), positionCount); //createRleBlockWithRandomValue(fromElementBlock(positionCount, Optional.of(nulls), arrayOffsets, createRandomLongsBlock(positionCount * 2, 0)), positionCount);
+        Block mapOfRleOfLongAndRleOfMapOfLongAndLong = mapType(BIGINT, mapType(BIGINT, BIGINT)).createBlockFromKeyValue(positionCount, Optional.of(nulls), offsets, keyBlock3, valueBlock3);
+        assertEquals(mapOfRleOfLongAndRleOfMapOfLongAndLong.getLogicalSizeInBytes(), 5300);
+
+        // Map(RLE(LongArrayBlock), Map(LongArrayBlock, RLE(LongArrayBlock)))
+        Block keyBlock4 = createRLEBlock(1, positionCount);
+        Block valueBlock4 = mapType(BIGINT, BIGINT).createBlockFromKeyValue(positionCount, Optional.of(nulls), offsets, keyBlock1, createRLEBlock(1, positionCount));
+        Block mapBlock4 = mapType(BIGINT, mapType(BIGINT, BIGINT)).createBlockFromKeyValue(positionCount, Optional.of(nulls), offsets, keyBlock4, valueBlock4);
+        assertEquals(mapBlock4.getLogicalSizeInBytes(), 5300);
+
+        // Map(Dictionary(LongArrayBlock), Dictionary(LongArrayBlock))
+        Block keyBlock5 = createLongDictionaryBlock(0, positionCount);
+        Block valuesBlock5 = createLongDictionaryBlock(0, positionCount);
+        Block mapBlock5 = mapType(BIGINT, BIGINT).createBlockFromKeyValue(positionCount, Optional.of(nulls), offsets, keyBlock5, valuesBlock5);
+        assertEquals(mapBlock5.getLogicalSizeInBytes(), 3100);
+
+        // Map(Dictionary(LongArrayBlock), Map(LongArrayBlock, Dictionary(LongArrayBlock)))
+        Block keyBlock6 = createLongDictionaryBlock(0, positionCount);
+        Block valuesBlock6 = mapType(BIGINT, BIGINT).createBlockFromKeyValue(positionCount, Optional.of(nulls), offsets, keyBlock1, createLongDictionaryBlock(0, positionCount));
+        Block mapBlock6 = mapType(BIGINT, BIGINT).createBlockFromKeyValue(positionCount, Optional.of(nulls), offsets, keyBlock6, valuesBlock6);
+        assertEquals(mapBlock6.getLogicalSizeInBytes(), 5300);
     }
 
     private void assertLazyHashTableBuildOverBlockRegion(Map<String, Long>[] testValues)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
@@ -28,7 +28,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
+import static com.facebook.presto.block.BlockAssertions.createLongDictionaryBlock;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
+import static com.facebook.presto.block.BlockAssertions.createRandomDictionaryBlock;
+import static com.facebook.presto.block.BlockAssertions.createRandomLongsBlock;
+import static com.facebook.presto.block.BlockAssertions.createRleBlockWithRandomValue;
 import static com.facebook.presto.common.block.RowBlock.fromFieldBlocks;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -96,6 +102,46 @@ public class TestRowBlock
         // underlying field blocks are not compact
         testIncompactBlock(fromFieldBlocks(rowIsNull.length, Optional.of(rowIsNull), new Block[] {incompactFiledBlock1, incompactFiledBlock2}));
         testIncompactBlock(fromFieldBlocks(rowIsNull.length, Optional.of(rowIsNull), new Block[] {incompactFiledBlock1, incompactFiledBlock2}));
+    }
+
+    @Test
+    public void testLogicalSizeInBytes()
+    {
+        int positionCount = 100;
+        int[] offsets = IntStream.rangeClosed(0, positionCount).toArray();
+        boolean[] nulls = new boolean[positionCount];
+
+        // Row(LongArrayBlock, LongArrayBlock)
+        Block fieldBlock11 = createRandomLongsBlock(positionCount, 0);
+        Block fieldBlock12 = createRandomLongsBlock(positionCount, 0);
+        Block rowOfLongAndLong = fromFieldBlocks(positionCount, Optional.of(nulls), new Block[] {fieldBlock11, fieldBlock12});
+        assertEquals(rowOfLongAndLong.getLogicalSizeInBytes(), 2300);
+
+        // Row(RLE(LongArrayBlock), RLE(LongArrayBlock))
+        Block fieldBlock21 = createRLEBlock(1, positionCount);
+        Block fieldBlock22 = createRLEBlock(2, positionCount);
+        Block rowOfRleOfLongAndRleOfLong = fromFieldBlocks(positionCount, Optional.of(nulls), new Block[] {fieldBlock21, fieldBlock22});
+        assertEquals(rowOfRleOfLongAndRleOfLong.getLogicalSizeInBytes(), 2300);
+
+        // Row(RLE(LongArrayBlock), RLE(Row(LongArrayBlock, LongArrayBlock)))
+        Block fieldBlock31 = createRLEBlock(1, positionCount);
+        Block fieldBlock32 = createRleBlockWithRandomValue(fromFieldBlocks(positionCount, Optional.of(nulls), new Block[] {createRandomLongsBlock(positionCount, 0),
+                createRandomLongsBlock(positionCount, 0)}), positionCount); //createRleBlockWithRandomValue(fromElementBlock(positionCount, Optional.of(nulls), arrayOffsets, createRandomLongsBlock(positionCount * 2, 0)), positionCount);
+        Block rowOfRleOfLongAndRleOfRowOfLongAndLong = fromFieldBlocks(positionCount, Optional.of(nulls), new Block[] {fieldBlock31, fieldBlock32});
+        assertEquals(rowOfRleOfLongAndRleOfRowOfLongAndLong.getLogicalSizeInBytes(), 3700);
+
+        // Row(Dictionary(LongArrayBlock), Dictionary(LongArrayBlock))
+        Block fieldBlock41 = createLongDictionaryBlock(0, positionCount);
+        Block fieldBlock42 = createLongDictionaryBlock(0, positionCount);
+        Block rowOfDictionaryOfLongAndDictionaryOfLong = fromFieldBlocks(positionCount, Optional.of(nulls), new Block[] {fieldBlock41, fieldBlock42});
+        assertEquals(rowOfDictionaryOfLongAndDictionaryOfLong.getLogicalSizeInBytes(), 2300);
+
+        // Row(Dictionary(LongArrayBlock), Dictionary(Row(LongArrayBlock, LongArrayBlock)))
+        Block fieldBlock51 = createLongDictionaryBlock(1, positionCount);
+        Block fieldBlock52 = createRandomDictionaryBlock(fromFieldBlocks(positionCount, Optional.of(nulls), new Block[] {createRandomLongsBlock(positionCount, 0),
+                createRandomLongsBlock(positionCount, 0)}), positionCount, false); //createRleBlockWithRandomValue(fromElementBlock(positionCount, Optional.of(nulls), arrayOffsets, createRandomLongsBlock(positionCount * 2, 0)), positionCount);
+        Block rowOfDictionaryOfLongAndDictionaryOfRowOfLongAndLong = fromFieldBlocks(positionCount, Optional.of(nulls), new Block[] {fieldBlock51, fieldBlock52});
+        assertEquals(rowOfDictionaryOfLongAndDictionaryOfRowOfLongAndLong.getLogicalSizeInBytes(), 3700);
     }
 
     private void testWith(List<Type> fieldTypes, List<Object>[] expectedValues)

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
@@ -86,6 +86,7 @@ import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.RowType.withDefaultFieldNames;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.operator.repartition.AbstractBlockEncodingBuffer.GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY;
 import static com.facebook.presto.operator.repartition.AbstractBlockEncodingBuffer.createBlockEncodingBuffers;
 import static com.facebook.presto.operator.repartition.MapBlockEncodingBuffer.HASH_MULTIPLIER;
 import static com.facebook.presto.operator.repartition.OptimizedPartitionedOutputOperator.decodeBlock;
@@ -256,11 +257,11 @@ public class TestBlockEncodingBuffers
         blocks[1] = createStringsBlock(strings);
 
         List<Object> expectedMaxBufferCapacities = ImmutableList.of(
-                ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
+                ImmutableList.of((int) (POSITIONS_PER_BLOCK * SIZE_OF_BYTE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY), (int) (POSITIONS_PER_BLOCK * SIZE_OF_LONG * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY)),
                 ImmutableList.of(
-                        POSITIONS_PER_BLOCK * SIZE_OF_BYTE,   // nullsBuffer
-                        POSITIONS_PER_BLOCK * SIZE_OF_INT,    // offsetsBuffer
-                        POSITIONS_PER_BLOCK * STRING_VALUE.length()));  //sliceBuffer
+                        (int) (POSITIONS_PER_BLOCK * SIZE_OF_BYTE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY),   // nullsBuffer
+                        (int) (POSITIONS_PER_BLOCK * SIZE_OF_INT * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY),    // offsetsBuffer
+                        (int) (POSITIONS_PER_BLOCK * STRING_VALUE.length() * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY)));  //sliceBuffer
         assertEstimatedBufferMaxCapacities(new Page(blocks), expectedMaxBufferCapacities);
 
         // 0: LongArrayBlock 1: Rle(VariableWidthBlock)
@@ -282,14 +283,14 @@ public class TestBlockEncodingBuffers
         blocks[1] = fromElementBlock(POSITIONS_PER_BLOCK, Optional.of(nulls), offsets, createStringsBlock(strings));
 
         expectedMaxBufferCapacities = ImmutableList.of(
-                ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
+                ImmutableList.of((int) (POSITIONS_PER_BLOCK * SIZE_OF_BYTE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY), (int) (POSITIONS_PER_BLOCK * SIZE_OF_LONG * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY)),
                 ImmutableList.of(
-                        POSITIONS_PER_BLOCK * SIZE_OF_BYTE,  // nullsBuffer
-                        POSITIONS_PER_BLOCK * SIZE_OF_INT,   // offsetsBuffer
+                        (int) (POSITIONS_PER_BLOCK * SIZE_OF_BYTE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY),  // nullsBuffer
+                        (int) (POSITIONS_PER_BLOCK * SIZE_OF_INT * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY),   // offsetsBuffer
                         ImmutableList.of(
-                                POSITIONS_PER_BLOCK * SIZE_OF_BYTE,   // nullsBuffer
-                                POSITIONS_PER_BLOCK * SIZE_OF_INT,    // offsetsBuffer
-                                POSITIONS_PER_BLOCK * STRING_VALUE.length())));  //sliceBuffer
+                                (int) (POSITIONS_PER_BLOCK * SIZE_OF_BYTE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY),   // nullsBuffer
+                                (int) (POSITIONS_PER_BLOCK * SIZE_OF_INT * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY),    // offsetsBuffer
+                                (int) (POSITIONS_PER_BLOCK * STRING_VALUE.length() * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY))));  //sliceBuffer
         assertEstimatedBufferMaxCapacities(new Page(blocks), expectedMaxBufferCapacities);
 
         // 0: Dictionary(LongArrayBlock) 1: Array(Dictionary(VariableWidthBlock))
@@ -304,28 +305,28 @@ public class TestBlockEncodingBuffers
         blocks[1] = mapType(BIGINT, mapType(BIGINT, BIGINT)).createBlockFromKeyValue(POSITIONS_PER_BLOCK, Optional.of(nulls), offsets, keyBlock, valueBlock);
 
         expectedMaxBufferCapacities = ImmutableList.of(
-                ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
+                ImmutableList.of((int) (POSITIONS_PER_BLOCK * SIZE_OF_BYTE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY), (int) (POSITIONS_PER_BLOCK * SIZE_OF_LONG * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY)),
                 ImmutableList.of(
-                        POSITIONS_PER_BLOCK * SIZE_OF_INT,
-                        POSITIONS_PER_BLOCK * SIZE_OF_INT * HASH_MULTIPLIER,
-                        ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
+                        (int) (POSITIONS_PER_BLOCK * SIZE_OF_INT * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY),
+                        (int) (POSITIONS_PER_BLOCK * SIZE_OF_INT * HASH_MULTIPLIER * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY),
+                        ImmutableList.of((int) (POSITIONS_PER_BLOCK * SIZE_OF_BYTE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY), (int) (POSITIONS_PER_BLOCK * SIZE_OF_LONG * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY)),
                         ImmutableList.of(
-                                POSITIONS_PER_BLOCK * SIZE_OF_INT,
-                                POSITIONS_PER_BLOCK * SIZE_OF_INT * HASH_MULTIPLIER,
-                                ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
-                                ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG))));
+                                (int) (POSITIONS_PER_BLOCK * SIZE_OF_INT * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY),
+                                (int) (POSITIONS_PER_BLOCK * SIZE_OF_INT * HASH_MULTIPLIER * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY),
+                                ImmutableList.of((int) (POSITIONS_PER_BLOCK * SIZE_OF_BYTE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY), (int) (POSITIONS_PER_BLOCK * SIZE_OF_LONG * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY)),
+                                ImmutableList.of((int) (POSITIONS_PER_BLOCK * SIZE_OF_BYTE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY), (int) (POSITIONS_PER_BLOCK * SIZE_OF_LONG * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY)))));
         assertEstimatedBufferMaxCapacities(new Page(blocks), expectedMaxBufferCapacities);
 
         // 0: Rle(LongArrayBlock) 1: Row(LongArrayBlock, Rle(LongArrayBlock))
         blocks[1] = fromFieldBlocks(POSITIONS_PER_BLOCK, Optional.of(nulls), new Block[] {createRandomLongsBlock(POSITIONS_PER_BLOCK, 0), createRLEBlock(1L, POSITIONS_PER_BLOCK)});
 
         expectedMaxBufferCapacities = ImmutableList.of(
-                ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
+                ImmutableList.of((int) (POSITIONS_PER_BLOCK * SIZE_OF_BYTE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY), (int) (POSITIONS_PER_BLOCK * SIZE_OF_LONG * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY)),
                 ImmutableList.of(
-                        POSITIONS_PER_BLOCK * SIZE_OF_BYTE,  // nullsBuffer
-                        POSITIONS_PER_BLOCK * SIZE_OF_INT,   // offsetsBuffer
-                        ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
-                        ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG)));
+                        (int) (POSITIONS_PER_BLOCK * SIZE_OF_BYTE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY),  // nullsBuffer
+                        (int) (POSITIONS_PER_BLOCK * SIZE_OF_INT * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY),   // offsetsBuffer
+                        ImmutableList.of((int) (POSITIONS_PER_BLOCK * SIZE_OF_BYTE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY), (int) (POSITIONS_PER_BLOCK * SIZE_OF_LONG * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY)),
+                        ImmutableList.of((int) (POSITIONS_PER_BLOCK * SIZE_OF_BYTE * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY), (int) (POSITIONS_PER_BLOCK * SIZE_OF_LONG * GRACE_FACTOR_FOR_MAX_BUFFER_CAPACITY))));
         assertEstimatedBufferMaxCapacities(new Page(blocks), expectedMaxBufferCapacities);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
@@ -29,6 +29,7 @@ package com.facebook.presto.operator.repartition;
 
 import com.facebook.presto.block.BlockAssertions.Encoding;
 import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockFlattener;
 import com.facebook.presto.common.block.DictionaryBlock;
@@ -59,6 +60,7 @@ import static com.facebook.presto.block.BlockAssertions.Encoding.RUN_LENGTH;
 import static com.facebook.presto.block.BlockAssertions.assertBlockEquals;
 import static com.facebook.presto.block.BlockAssertions.createAllNullsBlock;
 import static com.facebook.presto.block.BlockAssertions.createMapType;
+import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
 import static com.facebook.presto.block.BlockAssertions.createRandomBooleansBlock;
 import static com.facebook.presto.block.BlockAssertions.createRandomDictionaryBlock;
 import static com.facebook.presto.block.BlockAssertions.createRandomIntsBlock;
@@ -68,6 +70,7 @@ import static com.facebook.presto.block.BlockAssertions.createRandomShortDecimal
 import static com.facebook.presto.block.BlockAssertions.createRandomSmallintsBlock;
 import static com.facebook.presto.block.BlockAssertions.createRandomStringBlock;
 import static com.facebook.presto.block.BlockAssertions.createRleBlockWithRandomValue;
+import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
 import static com.facebook.presto.block.BlockAssertions.wrapBlock;
 import static com.facebook.presto.common.block.ArrayBlock.fromElementBlock;
 import static com.facebook.presto.common.block.BlockSerdeUtil.readBlock;
@@ -84,9 +87,14 @@ import static com.facebook.presto.common.type.RowType.withDefaultFieldNames;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.operator.repartition.AbstractBlockEncodingBuffer.createBlockEncodingBuffers;
+import static com.facebook.presto.operator.repartition.MapBlockEncodingBuffer.HASH_MULTIPLIER;
 import static com.facebook.presto.operator.repartition.OptimizedPartitionedOutputOperator.decodeBlock;
 import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
+import static com.facebook.presto.util.StructuralTestUtil.mapType;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -95,6 +103,7 @@ import static org.testng.Assert.assertEquals;
 public class TestBlockEncodingBuffers
 {
     private static final int POSITIONS_PER_BLOCK = 1000;
+    public static final String STRING_VALUE = "0123456789";
 
     @Test
     public void testBigint()
@@ -233,6 +242,158 @@ public class TestBlockEncodingBuffers
         testNestedBlock(withDefaultFieldNames(ImmutableList.of(new ArrayType(SMALLINT), createMapType(SMALLINT, SMALLINT))));
         testNestedBlock(withDefaultFieldNames(ImmutableList.of(new ArrayType(BOOLEAN), createMapType(BOOLEAN, BOOLEAN))));
         testNestedBlock(withDefaultFieldNames(ImmutableList.of(new ArrayType(VARCHAR), createMapType(VARCHAR, VARCHAR))));
+    }
+
+    @Test
+    public void testBufferSizeEstimation()
+    {
+        Block[] blocks = new Block[2];
+
+        // 0: LongArrayBlock 1: VariableWidthBlock
+        blocks[0] = createRandomLongsBlock(POSITIONS_PER_BLOCK, 0.5f);
+        String[] strings = new String[POSITIONS_PER_BLOCK];
+        Arrays.fill(strings, STRING_VALUE);
+        blocks[1] = createStringsBlock(strings);
+
+        List<Object> expectedMaxBufferCapacities = ImmutableList.of(
+                ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
+                ImmutableList.of(
+                        POSITIONS_PER_BLOCK * SIZE_OF_BYTE,   // nullsBuffer
+                        POSITIONS_PER_BLOCK * SIZE_OF_INT,    // offsetsBuffer
+                        POSITIONS_PER_BLOCK * STRING_VALUE.length()));  //sliceBuffer
+        assertEstimatedBufferMaxCapacities(new Page(blocks), expectedMaxBufferCapacities);
+
+        // 0: LongArrayBlock 1: Rle(VariableWidthBlock)
+        blocks[0] = createRandomLongsBlock(POSITIONS_PER_BLOCK, 0);
+        blocks[1] = createRleBlockWithRandomValue(createStringsBlock(STRING_VALUE), POSITIONS_PER_BLOCK);
+
+        assertEstimatedBufferMaxCapacities(new Page(blocks), expectedMaxBufferCapacities);
+
+        // 0: Dictionary(LongArrayBlock) 1: Dictionary(VariableWidthBlock)
+        blocks[0] = createRandomDictionaryBlock(createRandomLongsBlock(POSITIONS_PER_BLOCK / 5, 0), POSITIONS_PER_BLOCK);
+        blocks[1] = createRandomDictionaryBlock(createStringsBlock(STRING_VALUE), POSITIONS_PER_BLOCK);
+
+        assertEstimatedBufferMaxCapacities(new Page(blocks), expectedMaxBufferCapacities);
+
+        // 0: Dictionary(LongArrayBlock) 1: Array(VariableWidthBlock)
+        int[] offsets = IntStream.rangeClosed(0, POSITIONS_PER_BLOCK).toArray();
+        boolean[] nulls = new boolean[POSITIONS_PER_BLOCK];
+
+        blocks[1] = fromElementBlock(POSITIONS_PER_BLOCK, Optional.of(nulls), offsets, createStringsBlock(strings));
+
+        expectedMaxBufferCapacities = ImmutableList.of(
+                ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
+                ImmutableList.of(
+                        POSITIONS_PER_BLOCK * SIZE_OF_BYTE,  // nullsBuffer
+                        POSITIONS_PER_BLOCK * SIZE_OF_INT,   // offsetsBuffer
+                        ImmutableList.of(
+                                POSITIONS_PER_BLOCK * SIZE_OF_BYTE,   // nullsBuffer
+                                POSITIONS_PER_BLOCK * SIZE_OF_INT,    // offsetsBuffer
+                                POSITIONS_PER_BLOCK * STRING_VALUE.length())));  //sliceBuffer
+        assertEstimatedBufferMaxCapacities(new Page(blocks), expectedMaxBufferCapacities);
+
+        // 0: Dictionary(LongArrayBlock) 1: Array(Dictionary(VariableWidthBlock))
+        blocks[1] = fromElementBlock(POSITIONS_PER_BLOCK, Optional.of(nulls), offsets, createRandomDictionaryBlock(createStringsBlock(STRING_VALUE, STRING_VALUE), POSITIONS_PER_BLOCK));
+        assertEstimatedBufferMaxCapacities(new Page(blocks), expectedMaxBufferCapacities);
+
+        // 0: Rle(LongArrayBlock) 1: Map(LongArrayBlock, Rle(LongArrayBlock))
+        Block keyBlock = createRLEBlock(1L, POSITIONS_PER_BLOCK);
+        Block valueBlock = mapType(BIGINT, BIGINT).createBlockFromKeyValue(POSITIONS_PER_BLOCK, Optional.of(nulls), offsets, createRandomLongsBlock(POSITIONS_PER_BLOCK, 0.5f), createRLEBlock(1L, POSITIONS_PER_BLOCK));
+
+        blocks[0] = createRandomLongsBlock(POSITIONS_PER_BLOCK, 0.5f);
+        blocks[1] = mapType(BIGINT, mapType(BIGINT, BIGINT)).createBlockFromKeyValue(POSITIONS_PER_BLOCK, Optional.of(nulls), offsets, keyBlock, valueBlock);
+
+        expectedMaxBufferCapacities = ImmutableList.of(
+                ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
+                ImmutableList.of(
+                        POSITIONS_PER_BLOCK * SIZE_OF_INT,
+                        POSITIONS_PER_BLOCK * SIZE_OF_INT * HASH_MULTIPLIER,
+                        ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
+                        ImmutableList.of(
+                                POSITIONS_PER_BLOCK * SIZE_OF_INT,
+                                POSITIONS_PER_BLOCK * SIZE_OF_INT * HASH_MULTIPLIER,
+                                ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
+                                ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG))));
+        assertEstimatedBufferMaxCapacities(new Page(blocks), expectedMaxBufferCapacities);
+
+        // 0: Rle(LongArrayBlock) 1: Row(LongArrayBlock, Rle(LongArrayBlock))
+        blocks[1] = fromFieldBlocks(POSITIONS_PER_BLOCK, Optional.of(nulls), new Block[] {createRandomLongsBlock(POSITIONS_PER_BLOCK, 0), createRLEBlock(1L, POSITIONS_PER_BLOCK)});
+
+        expectedMaxBufferCapacities = ImmutableList.of(
+                ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
+                ImmutableList.of(
+                        POSITIONS_PER_BLOCK * SIZE_OF_BYTE,  // nullsBuffer
+                        POSITIONS_PER_BLOCK * SIZE_OF_INT,   // offsetsBuffer
+                        ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG),
+                        ImmutableList.of(POSITIONS_PER_BLOCK * SIZE_OF_BYTE, POSITIONS_PER_BLOCK * SIZE_OF_LONG)));
+        assertEstimatedBufferMaxCapacities(new Page(blocks), expectedMaxBufferCapacities);
+    }
+
+    private void assertEstimatedBufferMaxCapacities(Page page, List<Object> expectedMaxBufferCapacities)
+    {
+        int channelCount = page.getChannelCount();
+        int positionCount = page.getPositionCount();
+        DecodedBlockNode[] decodedBlocks = new DecodedBlockNode[channelCount];
+
+        BlockFlattener flattener = new BlockFlattener(new UncheckedStackArrayAllocator());
+        Closer blockLeaseCloser = Closer.create();
+
+        long estimatedSerializedPageSize = 0;
+        for (int i = 0; i < decodedBlocks.length; i++) {
+            decodedBlocks[i] = decodeBlock(flattener, blockLeaseCloser, page.getBlock(i));
+            estimatedSerializedPageSize += decodedBlocks[i].getEstimatedSerializedSizeInBytes();
+        }
+
+        int[] positions = IntStream.range(0, positionCount).toArray();
+        for (int i = 0; i < decodedBlocks.length; i++) {
+            BlockEncodingBuffer buffer = createBlockEncodingBuffers(decodedBlocks[i], new UncheckedStackArrayAllocator(1000), false);
+            buffer.setupDecodedBlocksAndPositions(decodedBlocks[i], positions, positionCount, (int) estimatedSerializedPageSize, estimatedSerializedPageSize);
+            assertEstimatedBufferMaxCapacity(buffer, (List<Object>) expectedMaxBufferCapacities.get(i));
+        }
+
+        try {
+            blockLeaseCloser.close();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void assertEstimatedBufferMaxCapacity(BlockEncodingBuffer buffer, List<Object> expectedMaxBufferCapacities)
+    {
+        if (buffer instanceof ArrayBlockEncodingBuffer) {
+            assertEquals(expectedMaxBufferCapacities.size(), 3); // 1: nullsBuffer, 2: offsetsBuffer, 3: valuesBuffers
+            assertEquals(((ArrayBlockEncodingBuffer) buffer).getEstimatedNullsBufferMaxCapacity(), expectedMaxBufferCapacities.get(0));
+            assertEquals(((ArrayBlockEncodingBuffer) buffer).getEstimatedOffsetBufferMaxCapacity(), expectedMaxBufferCapacities.get(1));
+            assertEstimatedBufferMaxCapacity(((ArrayBlockEncodingBuffer) buffer).getValuesBuffers(), (List<Object>) expectedMaxBufferCapacities.get(2));
+        }
+        else if (buffer instanceof MapBlockEncodingBuffer) {
+            assertEquals(expectedMaxBufferCapacities.size(), 4); // 1: offsetsBuffer, 2: hashtableBuffer, 3. keyBuffers, 4: valueBuffers
+            assertEquals(((MapBlockEncodingBuffer) buffer).getEstimatedOffsetBufferMaxCapacity(), expectedMaxBufferCapacities.get(0));
+            assertEquals(((MapBlockEncodingBuffer) buffer).getEstimatedHashTableBufferMaxCapacity(), expectedMaxBufferCapacities.get(1));
+            assertEstimatedBufferMaxCapacity(((MapBlockEncodingBuffer) buffer).getKeyBuffers(), (List<Object>) expectedMaxBufferCapacities.get(2));
+            assertEstimatedBufferMaxCapacity(((MapBlockEncodingBuffer) buffer).getValueBuffers(), (List<Object>) expectedMaxBufferCapacities.get(3));
+        }
+        else if (buffer instanceof RowBlockEncodingBuffer) {
+            BlockEncodingBuffer[] fieldBuffers = ((RowBlockEncodingBuffer) buffer).getFieldBuffers();
+            assertEquals(expectedMaxBufferCapacities.size(), fieldBuffers.length + 2);
+            assertEquals(((RowBlockEncodingBuffer) buffer).getEstimatedNullsBufferMaxCapacity(), expectedMaxBufferCapacities.get(0));
+            assertEquals(((RowBlockEncodingBuffer) buffer).getEstimatedOffsetBufferMaxCapacity(), expectedMaxBufferCapacities.get(1));
+            for (int i = 0; i < fieldBuffers.length; i++) {
+                assertEstimatedBufferMaxCapacity(fieldBuffers[i], (List<Object>) expectedMaxBufferCapacities.get(i + 2));
+            }
+        }
+        else if (buffer instanceof VariableWidthBlockEncodingBuffer) {
+            assertEquals(expectedMaxBufferCapacities.size(), 3); // 1: nullsBuffer, 2:offsetsBuffer, 3: sliceBuffer
+            assertEquals(((VariableWidthBlockEncodingBuffer) buffer).getEstimatedNullsBufferMaxCapacity(), expectedMaxBufferCapacities.get(0));
+            assertEquals(((VariableWidthBlockEncodingBuffer) buffer).getEstimatedOffsetBufferMaxCapacity(), expectedMaxBufferCapacities.get(1));
+            assertEquals(((VariableWidthBlockEncodingBuffer) buffer).getEstimatedSliceBufferMaxCapacity(), expectedMaxBufferCapacities.get(2));
+        }
+        else {
+            assertEquals(expectedMaxBufferCapacities.size(), 2); // 1: offsetsBuffer, 2: valueeBuffer
+            assertEquals(((AbstractBlockEncodingBuffer) buffer).getEstimatedNullsBufferMaxCapacity(), expectedMaxBufferCapacities.get(0));
+            assertEquals(((AbstractBlockEncodingBuffer) buffer).getEstimatedValueBufferMaxCapacity(), expectedMaxBufferCapacities.get(1));
+        }
     }
 
     private void testBlock(Type type, Block block)


### PR DESCRIPTION
We used Blocks' sizeInBytes or logicalSizeInBytes to estimate the max capacity of the BlockEncodingBuffers. However, there were some error in calculating the max capacity from the decodedBlock.estimatedSerializedSizeInBytes such that the exclusive portion(exclusive of children BlockEncodingBuffers) of the current BlockEncodingBuffer was mistakenly passed to the children BlockEncodingBuffers as inclusive portion. Also, the max capacity for the nested blocks was incorrectly calculated if they are RLE or Dictionary Blocks . This PR fixes these two problems. With these fixes, the CPU time for the reported regressed query in T67972617 was reduced  from 100s to 20s.

```
== NO RELEASE NOTE ==
```
