### PR TITLE
[WIP] Support for user-defined enums

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/Column.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/Column.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.client;
 
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeMetadata;
 import com.facebook.presto.common.type.TypeSignature;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -28,26 +29,33 @@ public class Column
     private final String name;
     private final String type;
     private final ClientTypeSignature typeSignature;
+    private final TypeMetadata typeMetadata;
 
     public Column(String name, Type type)
     {
-        this(name, type.getTypeSignature());
+        this(
+                name,
+                type.getTypeSignature().toString(),
+                new ClientTypeSignature(type.getTypeSignature()),
+                type.getTypeMetadata());
     }
 
     public Column(String name, TypeSignature signature)
     {
-        this(name, signature.toString(), new ClientTypeSignature(signature));
+        this(name, signature.toString(), new ClientTypeSignature(signature), null);
     }
 
     @JsonCreator
     public Column(
             @JsonProperty("name") String name,
             @JsonProperty("type") String type,
-            @JsonProperty("typeSignature") ClientTypeSignature typeSignature)
+            @JsonProperty("typeSignature") ClientTypeSignature typeSignature,
+            @JsonProperty("typeMetadata") TypeMetadata typeMetadata)
     {
         this.name = requireNonNull(name, "name is null");
         this.type = requireNonNull(type, "type is null");
         this.typeSignature = typeSignature;
+        this.typeMetadata = requireNonNull(typeMetadata, "typeMetadata is null");
     }
 
     @JsonProperty
@@ -66,5 +74,11 @@ public class Column
     public ClientTypeSignature getTypeSignature()
     {
         return typeSignature;
+    }
+
+    @JsonProperty
+    public TypeMetadata getTypeMetadata()
+    {
+        return typeMetadata;
     }
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
@@ -69,7 +69,10 @@ final class FixJsonDataUtils
         }
         requireNonNull(columns, "columns is null");
         List<TypeSignature> signatures = columns.stream()
-                .map(column -> parseTypeSignature(column.getType()))
+                .map(column -> {
+                    TypeSignature displayType = column.getTypeMetadata().getDisplayType();
+                    return displayType != null ? displayType : parseTypeSignature(column.getType());
+                })
                 .collect(toList());
         ImmutableList.Builder<List<Object>> rows = ImmutableList.builder();
         for (List<Object> row : data) {

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryData.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryData.java
@@ -18,4 +18,6 @@ import java.util.List;
 public interface QueryData
 {
     Iterable<List<Object>> getData();
+
+    List<Column> getColumns();
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/EnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/EnumType.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import java.util.Map;
+
+public interface EnumType<T>
+        extends Type
+{
+    Map<String, T> getEntries();
+
+    Type getValueType();
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/IntegerEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/IntegerEnumType.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.function.SqlFunctionProperties;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class IntegerEnumType
+        extends AbstractLongType
+        implements EnumType<Long>
+{
+    private final Map<String, Long> entries;
+
+    public IntegerEnumType(String name, Map<String, Long> entries)
+    {
+        super(TypeSignature.parseTypeSignature(name));
+        this.entries = entries;
+    }
+
+    @Override
+    public Map<String, Long> getEntries()
+    {
+        return entries;
+    }
+
+    @Override
+    public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+
+        return block.getLong(position);
+    }
+
+    @Override
+    public boolean isComparable()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isOrderable()
+    {
+        return false;
+    }
+
+    @Override
+    public Type getValueType() {
+        return BigintType.BIGINT;
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/IntegerEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/IntegerEnumType.java
@@ -28,6 +28,8 @@ public class IntegerEnumType
     public IntegerEnumType(String name, Map<String, Long> entries)
     {
         super(TypeSignature.parseTypeSignature(name));
+        TypeUtils.assertUniqueValues(entries.values(),
+                String.format("Unsupported enum %s with duplicate values", name));
         this.entries = entries;
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/type/IntegerEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/IntegerEnumType.java
@@ -60,7 +60,8 @@ public class IntegerEnumType
     }
 
     @Override
-    public Type getValueType() {
+    public Type getValueType()
+    {
         return BigintType.BIGINT;
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/type/IntegerEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/IntegerEnumType.java
@@ -63,4 +63,12 @@ public class IntegerEnumType
     public Type getValueType() {
         return BigintType.BIGINT;
     }
+
+    @Override
+    public TypeMetadata getTypeMetadata()
+    {
+        Map<String, String> stringifiedEntries = this.getEntries().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
+        return new TypeMetadata(getValueType().getTypeSignature(), stringifiedEntries);
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/IntegerEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/IntegerEnumType.java
@@ -52,7 +52,7 @@ public class IntegerEnumType
     @Override
     public boolean isComparable()
     {
-        return false;
+        return true;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/StringEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StringEnumType.java
@@ -50,4 +50,10 @@ public class StringEnumType
     {
         return VarcharType.VARCHAR;
     }
+
+    @Override
+    public TypeMetadata getTypeMetadata()
+    {
+        return new TypeMetadata(getValueType().getTypeSignature(), this.getEntries());
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/StringEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StringEnumType.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import java.util.Map;
+
+public class StringEnumType
+        extends VarcharType
+        implements EnumType<String>
+{
+    private final Map<String, String> entries;
+
+    public StringEnumType(String name, Map<String, String> entries)
+    {
+        super(VarcharType.MAX_LENGTH, TypeSignature.parseTypeSignature(name));
+        this.entries = entries;
+    }
+
+    @Override
+    public Map<String, String> getEntries()
+    {
+        return entries;
+    }
+
+    @Override
+    public boolean isOrderable()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isComparable()
+    {
+        return false;
+    }
+
+    @Override
+    public Type getValueType()
+    {
+        return VarcharType.VARCHAR;
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/StringEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StringEnumType.java
@@ -44,7 +44,7 @@ public class StringEnumType
     @Override
     public boolean isComparable()
     {
-        return false;
+        return true;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/StringEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StringEnumType.java
@@ -24,6 +24,8 @@ public class StringEnumType
     public StringEnumType(String name, Map<String, String> entries)
     {
         super(VarcharType.MAX_LENGTH, TypeSignature.parseTypeSignature(name));
+        TypeUtils.assertUniqueValues(entries.values(),
+                String.format("Unsupported enum %s with duplicate values", name));
         this.entries = entries;
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/type/Type.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/Type.java
@@ -186,4 +186,12 @@ public interface Type
      * Compare the values in the specified block at the specified positions equal.
      */
     int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition);
+
+    /**
+     * Return additional type information relevant to clients
+     */
+    default TypeMetadata getTypeMetadata()
+    {
+        return new TypeMetadata();
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeMetadata.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeMetadata.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Map;
+
+@Immutable
+public class TypeMetadata
+{
+    private final Map<String, String> enumValues;
+    private final TypeSignature displayType;
+
+    TypeMetadata()
+    {
+        this(null, null);
+    }
+
+    @JsonCreator
+    public TypeMetadata(
+            @JsonProperty TypeSignature displayType,
+            @JsonProperty Map<String, String> enumValues)
+    {
+        this.displayType = displayType;
+        this.enumValues = enumValues;
+    }
+
+    @JsonProperty
+    public TypeSignature getDisplayType()
+    {
+        return displayType;
+    }
+
+    @JsonProperty
+    public Map<String, String> getEnumValues()
+    {
+        return enumValues;
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
@@ -19,6 +19,10 @@ import com.facebook.presto.common.block.BlockBuilder;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
 public final class TypeUtils
 {
     public static final int NULL_HASH_CODE = 0;
@@ -99,6 +103,17 @@ public final class TypeUtils
     {
         if (isNull) {
             throw new NotSupportedException(errorMsg);
+        }
+    }
+
+    static <V> void assertUniqueValues(Collection<V> collection, String errorMsg)
+    {
+        Set<V> visited = new HashSet<>();
+        for (V value : collection) {
+            if (visited.contains(value)) {
+                throw new NotSupportedException(errorMsg);
+            }
+            visited.add(value);
         }
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarcharType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarcharType.java
@@ -23,12 +23,12 @@ import java.util.Objects;
 
 import static java.util.Collections.singletonList;
 
-public final class VarcharType
+public class VarcharType
         extends AbstractVariableWidthType
 {
     public static final int UNBOUNDED_LENGTH = Integer.MAX_VALUE;
     public static final int MAX_LENGTH = Integer.MAX_VALUE - 1;
-    public static final VarcharType VARCHAR = new VarcharType(UNBOUNDED_LENGTH);
+    public static final VarcharType VARCHAR = createVarcharTypeInternal(UNBOUNDED_LENGTH);
 
     public static VarcharType createUnboundedVarcharType()
     {
@@ -41,7 +41,14 @@ public final class VarcharType
             // Use createUnboundedVarcharType for unbounded VARCHAR.
             throw new IllegalArgumentException("Invalid VARCHAR length " + length);
         }
-        return new VarcharType(length);
+        return createVarcharTypeInternal(length);
+    }
+
+    private static VarcharType createVarcharTypeInternal(int length)
+    {
+        return new VarcharType(length, new TypeSignature(
+                StandardTypes.VARCHAR,
+                singletonList(TypeSignatureParameter.of((long) length))));
     }
 
     public static TypeSignature getParametrizedVarcharSignature(String param)
@@ -51,13 +58,9 @@ public final class VarcharType
 
     private final int length;
 
-    private VarcharType(int length)
+    protected VarcharType(int length, TypeSignature typeSignature)
     {
-        super(
-                new TypeSignature(
-                        StandardTypes.VARCHAR,
-                        singletonList(TypeSignatureParameter.of((long) length))),
-                Slice.class);
+        super(typeSignature, Slice.class);
 
         if (length < 0) {
             throw new IllegalArgumentException("Invalid VARCHAR length " + length);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.EnumType;
 import com.facebook.presto.common.type.NamedTypeSignature;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignatureParameter;
@@ -151,6 +152,10 @@ public class HiveTypeTranslator
                             .map(t -> translate(t, defaultHiveType))
                             .collect(toList()));
         }
+        if (type instanceof EnumType) {
+            return translate(((EnumType) type).getValueType(), defaultHiveType);
+        }
+
         return defaultHiveType
                 .orElseThrow(() -> new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type: %s", type)))
                 .getTypeInfo();

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
@@ -306,6 +306,15 @@ public class FunctionManager
             return new BuiltInFunctionHandle(getMagicLiteralFunctionSignature(type));
         }
 
+        Optional<SqlFunction> udtFunction = builtInFunctionNamespaceManager.getUdtFunctionImplementation(
+                functionName, parameterTypes.stream()
+                        .map(TypeSignatureProvider::getTypeSignature)
+                        .collect(Collectors.toList()),
+                null);
+        if (udtFunction.isPresent()) {
+            return new BuiltInFunctionHandle(udtFunction.get().getSignature());
+        }
+
         throw new PrestoException(FUNCTION_NOT_FOUND, constructFunctionNotFoundErrorMessage(functionName, parameterTypes, candidates));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionManager.java
@@ -685,6 +685,16 @@ public class FunctionManager
         return boundVariables.isPresent();
     }
 
+    // Called by TypeRegistry to look up types from FunctionNamespaceManagers
+    public Type resolveTypeDynamically(TypeSignature signature)
+    {
+        return functionNamespaceManagers.values().stream()
+                .map(manager -> manager.getType(signature))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
     private static class ApplicableFunction
     {
         private final Signature declaredSignature;

--- a/presto-main/src/main/java/com/facebook/presto/type/EnumOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/EnumOperators.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.annotation.UsedByGeneratedCode;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.EnumType;
+import com.facebook.presto.common.type.IntegerEnumType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.StringEnumType;
+import com.facebook.presto.common.type.TinyintType;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.metadata.SignatureBuilder;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.Signature;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.common.function.OperatorType.CAST;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+
+public final class EnumOperators
+{
+    private EnumOperators() {}
+
+    private static final String STRING_ENUM_KEYVAL_LOOKUP_METHOD = "stringEnumKeyOrValueLookup";
+    private static final String INTEGER_ENUM_KEY_LOOKUP_METHOD = "integerEnumKeyLookup";
+    private static final String INTEGER_ENUM_VALUE_LOOKUP_METHOD = "integerEnumValueLookup";
+
+    // TODO add cast functions from enum to base types too?
+
+    public static Collection<SqlScalarFunction> makeEnumCastFunctions(EnumType enumType)
+    {
+        if (enumType instanceof IntegerEnumType) {
+            Collection<SqlScalarFunction> casts = Stream.of(
+                    TinyintType.TINYINT, SmallintType.SMALLINT, IntegerType.INTEGER, BigintType.BIGINT)
+                    .map(intType -> makeCastFunction(intType.getTypeSignature(), enumType, INTEGER_ENUM_VALUE_LOOKUP_METHOD))
+                    .collect(Collectors.toCollection(ArrayList::new));
+            casts.add(makeCastFunction(VarcharType.VARCHAR.getTypeSignature(), enumType, INTEGER_ENUM_KEY_LOOKUP_METHOD));
+            return casts;
+        }
+        else if (enumType instanceof StringEnumType) {
+            return ImmutableList.of(
+                    // TODO find a way to disambiguate key CAST from value CAST for StringEnums?
+                    makeCastFunction(VarcharType.VARCHAR.getTypeSignature(), enumType, STRING_ENUM_KEYVAL_LOOKUP_METHOD));
+        }
+        else {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, String.format("Unexpected enum type: %s", enumType.getClass().getSimpleName()));
+        }
+    }
+
+    private static SqlScalarFunction makeCastFunction(TypeSignature fromType, EnumType enumType, String castMethodName)
+    {
+        Signature signature = SignatureBuilder.builder()
+                .kind(SCALAR)
+                .operatorType(CAST)
+                .argumentTypes(fromType)
+                .returnType(TypeSignature.parseTypeSignature(String.format("enum(%s)", enumType.getTypeSignature().getBase())))
+                .build();
+        return SqlScalarFunction.builder(EnumOperators.class, CAST)
+                .signature(signature)
+                .deterministic(true)
+                .choice(choice -> choice.implementation(
+                        methodsGroup -> methodsGroup.methods(castMethodName)
+                                .withExtraParameters(
+                                        context -> ImmutableList.of(enumType))))
+                .build();
+    }
+
+    @UsedByGeneratedCode
+    public static Slice stringEnumKeyOrValueLookup(Slice value, StringEnumType enumType)
+    {
+        final String enumValue = enumType.getEntries().get(value.toStringUtf8());
+        if (enumValue == null) {
+            if (!enumType.getEntries().values().contains(value.toStringUtf8())) {
+                throw new PrestoException(
+                        INVALID_CAST_ARGUMENT,
+                        String.format(
+                                "No key or value '%s' in enum '%s'",
+                                value.toStringUtf8(),
+                                enumType.getTypeSignature().getBase()));
+            }
+            return Slices.copyOf(value);
+        }
+        return Slices.utf8Slice(enumValue);
+    }
+
+    @UsedByGeneratedCode
+    public static long integerEnumKeyLookup(Slice value, IntegerEnumType enumType)
+    {
+        final Long enumValue = enumType.getEntries().get(value.toStringUtf8());
+        if (enumValue == null) {
+            throw new PrestoException(
+                    INVALID_CAST_ARGUMENT,
+                    String.format(
+                            "No key '%s' in enum '%s'",
+                            value.toStringUtf8(),
+                            enumType.getTypeSignature().getBase()));
+        }
+        return enumValue;
+    }
+
+    @UsedByGeneratedCode
+    public static long integerEnumValueLookup(long value, IntegerEnumType enumType)
+    {
+        if (!enumType.getEntries().values().contains(value)) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT,
+                    String.format(
+                            "No value '%d' in enum '%s'",
+                            value,
+                            enumType.getTypeSignature().getBase()));
+        }
+        return value;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/EnumOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/EnumOperators.java
@@ -77,7 +77,7 @@ public final class EnumOperators
                 .kind(SCALAR)
                 .operatorType(CAST)
                 .argumentTypes(fromType)
-                .returnType(TypeSignature.parseTypeSignature(String.format("enum(%s)", enumType.getTypeSignature().getBase())))
+                .returnType(enumType.getTypeSignature())
                 .build();
         return SqlScalarFunction.builder(EnumOperators.class, CAST)
                 .signature(signature)

--- a/presto-main/src/main/java/com/facebook/presto/type/EnumOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/EnumOperators.java
@@ -14,80 +14,224 @@
 package com.facebook.presto.type;
 
 import com.facebook.presto.annotation.UsedByGeneratedCode;
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.AbstractLongType;
 import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.common.type.EnumType;
 import com.facebook.presto.common.type.IntegerEnumType;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.StringEnumType;
 import com.facebook.presto.common.type.TinyintType;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
-import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.metadata.PolymorphicScalarFunctionBuilder;
 import com.facebook.presto.metadata.SignatureBuilder;
 import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.operator.scalar.BuiltInScalarFunctionImplementation;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.function.SqlFunction;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.airlift.slice.XxHash64;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.common.function.OperatorType.CAST;
-import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.operator.scalar.BuiltInScalarFunctionImplementation.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.BuiltInScalarFunctionImplementation.NullConvention.USE_NULL_FLAG;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static java.util.Objects.requireNonNull;
 
 public final class EnumOperators
 {
+
+    public static final TypeSignature BOOLEAN_TYPE_SIGNATURE = BooleanType.BOOLEAN.getTypeSignature();
+
     private EnumOperators() {}
 
-    private static final String STRING_ENUM_KEYVAL_LOOKUP_METHOD = "stringEnumKeyOrValueLookup";
-    private static final String INTEGER_ENUM_KEY_LOOKUP_METHOD = "integerEnumKeyLookup";
-    private static final String INTEGER_ENUM_VALUE_LOOKUP_METHOD = "integerEnumValueLookup";
+    private static final Set<TypeSignature> INTEGER_TYPES = Sets.newHashSet(
+            Stream.of(TinyintType.TINYINT, SmallintType.SMALLINT, IntegerType.INTEGER, BigintType.BIGINT)
+                    .map(Type::getTypeSignature).collect(Collectors.toSet())
+    );
 
     // TODO add cast functions from enum to base types too?
 
-    public static Collection<SqlScalarFunction> makeEnumCastFunctions(EnumType enumType)
+    public static Optional<SqlFunction> makeOperator(OperatorType operatorType, List<Type> argTypes, @Nullable Type returnType)
     {
-        if (enumType instanceof IntegerEnumType) {
-            Collection<SqlScalarFunction> casts = Stream.of(
-                    TinyintType.TINYINT, SmallintType.SMALLINT, IntegerType.INTEGER, BigintType.BIGINT)
-                    .map(intType -> makeCastFunction(intType.getTypeSignature(), enumType, INTEGER_ENUM_VALUE_LOOKUP_METHOD))
-                    .collect(Collectors.toCollection(ArrayList::new));
-            casts.add(makeCastFunction(VarcharType.VARCHAR.getTypeSignature(), enumType, INTEGER_ENUM_KEY_LOOKUP_METHOD));
-            return casts;
+        if (!(returnType instanceof EnumType) && argTypes.stream().noneMatch(t -> t instanceof EnumType)) {
+            return Optional.empty();
         }
-        else if (enumType instanceof StringEnumType) {
-            return ImmutableList.of(
-                    // TODO find a way to disambiguate key CAST from value CAST for StringEnums?
-                    makeCastFunction(VarcharType.VARCHAR.getTypeSignature(), enumType, STRING_ENUM_KEYVAL_LOOKUP_METHOD));
-        }
-        else {
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, String.format("Unexpected enum type: %s", enumType.getClass().getSimpleName()));
+
+        boolean isInt = !argTypes.isEmpty() && argTypes.get(0) instanceof IntegerEnumType;
+        List<TypeSignature> argTypeSignatures = argTypes.stream()
+                .map(Type::getTypeSignature)
+                .collect(Collectors.toList());
+
+        switch (operatorType) {
+            case CAST:
+                requireNonNull(returnType);  // return type must be provided for CAST function lookup
+                if (returnType instanceof EnumType) {
+                    return makeCastToEnum(argTypes.get(0).getTypeSignature(), (EnumType) returnType);
+                }
+                if (argTypes.get(0) instanceof EnumType) {
+                    return makeCastFromEnum((EnumType) argTypes.get(0), returnType.getTypeSignature());
+                }
+                return Optional.empty();
+            case EQUAL:
+            case NOT_EQUAL:
+                if (!(argTypes.get(0) instanceof EnumType) || !argTypes.get(0).equals(argTypes.get(1))) {
+                    return Optional.empty();
+                }
+                return Optional.of(buildFunction(
+                        operatorType,
+                        argTypeSignatures,
+                        BOOLEAN_TYPE_SIGNATURE,
+                        true,
+                        isInt ? "integerEnumCompare" : "stringEnumCompare",
+                        ImmutableList.of(OperatorType.NOT_EQUAL.equals(operatorType))));
+            case IS_DISTINCT_FROM:
+                if (!(argTypes.get(0) instanceof EnumType) || !argTypes.get(0).equals(argTypes.get(1))) {
+                    return Optional.empty();
+                }
+                return Optional.of(buildFunction(
+                        operatorType,
+                        argTypeSignatures,
+                        BOOLEAN_TYPE_SIGNATURE,
+                        false,
+                        isInt ? "integerEnumIsDistinct" : "stringEnumIsDistinct",
+                        ImmutableList.of(),
+                        new BuiltInScalarFunctionImplementation.ArgumentProperty[] {
+                                valueTypeArgumentProperty(USE_NULL_FLAG),
+                                valueTypeArgumentProperty(USE_NULL_FLAG)
+                        }
+                ));
+            case HASH_CODE:
+                return Optional.of(buildFunction(
+                        operatorType,
+                        argTypeSignatures,
+                        BigintType.BIGINT.getTypeSignature(),
+                        false,
+                        isInt ? "integerEnumHash" : "stringEnumHash",
+                        ImmutableList.of()
+                ));
+            case INDETERMINATE:
+                return Optional.of(buildFunction(
+                        operatorType,
+                        argTypeSignatures,
+                        BOOLEAN_TYPE_SIGNATURE,
+                        false,
+                        isInt ? "integerEnumIndeterminate" : "stringEnumIndeterminate",
+                        ImmutableList.of(),
+                        new BuiltInScalarFunctionImplementation.ArgumentProperty[] {
+                                valueTypeArgumentProperty(USE_NULL_FLAG)
+                        }));
+            default:
+                return Optional.empty();
         }
     }
 
-    private static SqlScalarFunction makeCastFunction(TypeSignature fromType, EnumType enumType, String castMethodName)
+    private static Optional<SqlFunction> makeCastToEnum(TypeSignature fromType, EnumType toType)
+    {
+        if (toType instanceof IntegerEnumType) {
+            if (INTEGER_TYPES.contains(fromType)) {
+                return Optional.of(buildCastToEnum(fromType, toType, "integerEnumValueLookup"));
+            }
+            if (StandardTypes.VARCHAR.equals(fromType.getBase())) {
+                return Optional.of(buildCastToEnum(fromType, toType, "integerEnumKeyLookup"));
+            }
+        }
+        if (toType instanceof StringEnumType) {
+            if (StandardTypes.VARCHAR.equals(fromType.getBase())) {
+                return Optional.of(buildCastToEnum(fromType, toType, "stringEnumKeyOrValueLookup"));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<SqlFunction> makeCastFromEnum(EnumType fromType, TypeSignature toType)
+    {
+        if (fromType instanceof IntegerEnumType) {
+            if (BigintType.BIGINT.getTypeSignature().equals(toType)) {
+                return Optional.of(buildCastFromEnum(fromType, toType, "integerEnumAsPrimitive"));
+            }
+        }
+        if (fromType instanceof StringEnumType) {
+            if (StandardTypes.VARCHAR.equals(toType.getBase())) {
+                return Optional.of(buildCastFromEnum(fromType, toType, "stringEnumAsPrimitive"));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static SqlScalarFunction buildCastToEnum(TypeSignature fromType, EnumType toType, String methodName)
+    {
+        return buildFunction(
+                CAST,
+                ImmutableList.of(fromType),
+                toType.getTypeSignature(),
+                false,
+                methodName,
+                ImmutableList.of(toType));
+    }
+
+    private static SqlScalarFunction buildCastFromEnum(EnumType fromType, TypeSignature toType, String methodName)
+    {
+        return buildFunction(
+                CAST,
+                ImmutableList.of(fromType.getTypeSignature()),
+                toType,
+                false,
+                methodName,
+                ImmutableList.of());
+    }
+
+    private static SqlScalarFunction buildFunction(OperatorType operatorType, List<TypeSignature> argTypes, TypeSignature returnType,
+            boolean nullableResult, String methodName, List<Object> extraParams)
+    {
+        return buildFunction(operatorType, argTypes, returnType, nullableResult, methodName, extraParams, null);
+    }
+
+    private static SqlScalarFunction buildFunction(OperatorType operatorType, List<TypeSignature> argTypes, TypeSignature returnType,
+            boolean nullableResult, String methodName, List<Object> extraParams, BuiltInScalarFunctionImplementation.ArgumentProperty[] argumentProperties)
     {
         Signature signature = SignatureBuilder.builder()
                 .kind(SCALAR)
-                .operatorType(CAST)
-                .argumentTypes(fromType)
-                .returnType(enumType.getTypeSignature())
+                .operatorType(operatorType)
+                .argumentTypes(argTypes)
+                .returnType(returnType)
                 .build();
-        return SqlScalarFunction.builder(EnumOperators.class, CAST)
+
+        return SqlScalarFunction.builder(EnumOperators.class)
+                .calledOnNullInput(true)
                 .signature(signature)
                 .deterministic(true)
-                .choice(choice -> choice.implementation(
-                        methodsGroup -> methodsGroup.methods(castMethodName)
-                                .withExtraParameters(
-                                        context -> ImmutableList.of(enumType))))
+                .choice(choice -> {
+                    PolymorphicScalarFunctionBuilder.ChoiceBuilder builder = choice
+                            .nullableResult(nullableResult);
+                    if (argumentProperties != null) {
+                        builder.argumentProperties(argumentProperties);
+                    }
+                    return builder.implementation(
+                            methodsGroup -> methodsGroup.methods(methodName)
+                                    .withExtraParameters(ctx -> extraParams));
+                })
                 .build();
     }
+
+    // -------------- Methods used by generated functions --------------------
 
     @UsedByGeneratedCode
     public static Slice stringEnumKeyOrValueLookup(Slice value, StringEnumType enumType)
@@ -133,5 +277,65 @@ public final class EnumOperators
                             enumType.getTypeSignature().getBase()));
         }
         return value;
+    }
+
+    @UsedByGeneratedCode
+    public static Boolean integerEnumCompare(long v1, long v2, boolean notEquals)
+    {
+        return notEquals == (v1 != v2);
+    }
+
+    @UsedByGeneratedCode
+    public static Boolean stringEnumCompare(Slice v1, Slice v2, boolean notEquals)
+    {
+        return notEquals != v1.equals(v2);
+    }
+
+    @UsedByGeneratedCode
+    public static long stringEnumHash(Slice value)
+    {
+        return XxHash64.hash(value);
+    }
+
+    @UsedByGeneratedCode
+    public static long integerEnumHash(long value)
+    {
+        return AbstractLongType.hash(value);
+    }
+
+    @UsedByGeneratedCode
+    public static boolean integerEnumIndeterminate(long value, boolean isNull)
+    {
+        return isNull;
+    }
+
+    @UsedByGeneratedCode
+    public static boolean stringEnumIndeterminate(Slice value, boolean isNull)
+    {
+        return isNull;
+    }
+
+    @UsedByGeneratedCode
+    public static long integerEnumAsPrimitive(long value)
+    {
+        return value;
+    }
+
+    @UsedByGeneratedCode
+    public static Slice stringEnumAsPrimitive(Slice value)
+    {
+        return value;
+    }
+
+    @UsedByGeneratedCode
+    public static boolean integerEnumIsDistinct(long left, boolean leftNull, long right, boolean rightNull)
+    {
+        return IntegerOperators.IntegerDistinctFromOperator.isDistinctFrom(left, leftNull, right, rightNull);
+    }
+
+    @UsedByGeneratedCode
+    public static boolean stringEnumIsDistinct(Slice left, boolean leftNull, Slice right, boolean rightNull)
+    {
+        return VarcharOperators.VarcharDistinctFromOperator.isDistinctFrom(left, leftNull, right, rightNull);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -182,6 +182,7 @@ public final class TypeRegistry
     public Type getType(TypeSignature signature)
     {
         Type type = types.get(signature);
+        type = type == null ? functionManager.resolveTypeDynamically(signature) : type;
         if (type == null) {
             try {
                 return parametricTypeCache.getUnchecked(signature);

--- a/presto-main/src/test/java/com/facebook/presto/type/TestEnumCasts.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestEnumCasts.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.type;
 
+import com.facebook.presto.common.NotSupportedException;
 import com.facebook.presto.common.type.IntegerEnumType;
 import com.facebook.presto.common.type.StringEnumType;
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
@@ -20,6 +21,8 @@ import com.facebook.presto.sql.analyzer.SemanticErrorCode;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertThrows;
 
 public class TestEnumCasts
         extends AbstractTestFunctions
@@ -81,5 +84,15 @@ public class TestEnumCasts
 
         assertInvalidCast("CAST('hello' AS Country)");
         assertUnavailableCast("CAST(1 AS Country)");
+    }
+
+    @Test
+    public void testInvalidEnumWithDuplicates()
+    {
+        assertThrows(NotSupportedException.class,
+                () -> new StringEnumType("my_invalid_enum",
+                        ImmutableMap.of(
+                                "k1", "value",
+                                "k2", "value")));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestEnumCasts.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestEnumCasts.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.type.IntegerEnumType;
+import com.facebook.presto.common.type.StringEnumType;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.sql.analyzer.SemanticErrorCode;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestEnumCasts
+        extends AbstractTestFunctions
+{
+    private static final Long BIG_VALUE = Integer.MAX_VALUE + 10L; // 2147483657
+
+    private static final IntegerEnumType MOOD_ENUM = new IntegerEnumType("Mood", ImmutableMap.of(
+            "HAPPY", 0L,
+            "SAD", 1L,
+            "MELLOW", BIG_VALUE));
+    private static final StringEnumType COUNTRY_ENUM = new StringEnumType("Country", ImmutableMap.of(
+            "US", "United States",
+            "BAHAMAS", "The Bahamas"));
+
+    @BeforeClass
+    public void initEnumTypes()
+    {
+        functionAssertions.getTypeRegistry().addType(MOOD_ENUM);
+        functionAssertions.getTypeRegistry().addType(COUNTRY_ENUM);
+    }
+
+    private void assertUnavailableCast(String projection)
+    {
+        assertInvalidFunction(projection, SemanticErrorCode.TYPE_MISMATCH);
+    }
+
+    @Test
+    public void testEnumLiterals()
+    {
+        assertFunction("Mood 'HAPPY'", MOOD_ENUM, 0L);
+        assertFunction("Mood 'MELLOW'", MOOD_ENUM, BIG_VALUE);
+        assertFunction("Country 'US'", COUNTRY_ENUM, "United States");
+        assertFunction("Country 'The Bahamas'", COUNTRY_ENUM, "The Bahamas");
+    }
+
+    @Test
+    public void testInvalidEnumLiterals()
+    {
+        assertInvalidCast("Mood 'happy'");
+        assertInvalidCast("Mood '0'");
+        assertInvalidCast("Country 'not_valid'");
+    }
+
+    @Test
+    public void testCastToEnum()
+    {
+        assertFunction("CAST(2147483657 AS Mood)", MOOD_ENUM, BIG_VALUE);
+        assertFunction("CAST(CAST(1 AS TINYINT) AS Mood)", MOOD_ENUM, 1L);
+        assertFunction("CAST(CAST(1 AS INTEGER) AS Mood)", MOOD_ENUM, 1L);
+        assertFunction("CAST(CAST(1 AS SMALLINT) AS Mood)", MOOD_ENUM, 1L);
+        assertFunction("CAST(CAST(1 AS BIGINT) AS Mood)", MOOD_ENUM, 1L);
+
+        assertInvalidCast("CAST(5 AS Mood)");
+        assertUnavailableCast("CAST(1.0 AS Mood)");
+
+        assertFunction("CAST('United States' AS Country)", COUNTRY_ENUM, "United States");
+        assertFunction("CAST('BAHAMAS' AS Country)", COUNTRY_ENUM, "The Bahamas");
+        assertFunction("CAST('The Bahamas' AS Country)", COUNTRY_ENUM, "The Bahamas");
+
+        assertInvalidCast("CAST('hello' AS Country)");
+        assertUnavailableCast("CAST(1 AS Country)");
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.function;
 
 import com.facebook.presto.common.function.QualifiedFunctionName;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.spi.api.Experimental;
 
@@ -72,4 +73,9 @@ public interface FunctionNamespaceManager<F extends SqlFunction>
     FunctionMetadata getFunctionMetadata(FunctionHandle functionHandle);
 
     ScalarFunctionImplementation getScalarFunctionImplementation(FunctionHandle functionHandle);
+
+    default Type getType(TypeSignature typeSignature)
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
The goal of this PR is to enable basic support for enum user-defined types (UDTs) in Presto. Enums already exist in Postgres and MySQL, and this would be a first step toward generic UDT support.

## Requirements

1. Support for both integer-valued (64-bit) and string-valued enums 
1. Enum types should be provided by plugins and kept up-to-date as they change (without the need to restart the server)
1. Enum literals should be supported, with case-insensitive type names, but case-sensitive keys eg `Mood 'HAPPY'`
1. CAST from primitive types to enums should be supported, failing if the provided value is not part of the enum
1. NULLs are allowed
1. Both enum keys and values must be unique for a given enum
1. Enum definition should be forwarded to clients (including the Presto CLI) for custom rendering
1. The fact that a given column is an enum should be persisted in table schemas
1. You can compare enum values of the same type (EQUAL, NOT_EQUAL operators)
1. [?] You can compare an enum value to a literal of the underlying primitive type, but not to a reference, i.e. `my_enum_column = 4` is OK, but `my_enum_column = my_int_column` is not. This would be in line with enum behavior in languages like Hack, and it would facilitate backwards-compatibility of existing queries that do not use enum literals 
1. [?] Support for ephemeral enum definitions forwarded by client session parameters

## Implementation

- Extend FunctionNamespaceManager to provide types
- Cast functions generated on-the-fly for enums

## TODO

[ ] Disambiguate key lookup from value lookup with string enums
[ ] Persist enum info to schema (separate PR)
[ ] Support =, != for enums
[ ] Support literal comparison
[ ] Move getTypeDynamically to TypeRegistry