### PR TITLE
Bump version of Alluxio client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>6.2.1</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
-        <dep.alluxio.version>2.2.0</dep.alluxio.version>
+        <dep.alluxio.version>2.2.2</dep.alluxio.version>
         <dep.kafka.version>2.3.1</dep.kafka.version>
         <dep.druid.version>0.17.0</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>


### PR DESCRIPTION
Alluxio 2.2.2 has a bunch of fixes related to [Presto local cache](https://prestodb.io/blog/2020/06/16/alluxio-datacaching)