### PR TITLE
Remove duplicated test initialization code

### DIFF
--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/TestGeometryStateSerializer.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/aggregation/TestGeometryStateSerializer.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
 import com.facebook.presto.spi.function.AccumulatorStateFactory;
 import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.plugin.geospatial.aggregation.GeometryStateFactory.GroupedGeometryState;
@@ -28,11 +29,19 @@ import static org.testng.Assert.assertNull;
 
 public class TestGeometryStateSerializer
 {
+    private AccumulatorStateFactory<GeometryState> factory;
+    private AccumulatorStateSerializer<GeometryState> serializer;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        factory = StateCompiler.generateStateFactory(GeometryState.class);
+        serializer = StateCompiler.generateStateSerializer(GeometryState.class);
+    }
+
     @Test
     public void testSerializeDeserialize()
     {
-        AccumulatorStateFactory<GeometryState> factory = StateCompiler.generateStateFactory(GeometryState.class);
-        AccumulatorStateSerializer<GeometryState> serializer = StateCompiler.generateStateSerializer(GeometryState.class);
         GeometryState state = factory.createSingleState();
 
         state.setGeometry(OGCGeometry.fromText("POINT (1 2)"), 0);
@@ -53,8 +62,6 @@ public class TestGeometryStateSerializer
     @Test
     public void testSerializeDeserializeGrouped()
     {
-        AccumulatorStateFactory<GeometryState> factory = StateCompiler.generateStateFactory(GeometryState.class);
-        AccumulatorStateSerializer<GeometryState> serializer = StateCompiler.generateStateSerializer(GeometryState.class);
         GroupedGeometryState state = (GroupedGeometryState) factory.createGroupedState();
 
         // Add state to group 1

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.net.URI;
@@ -82,6 +83,8 @@ public class TestSqlTask
 
     private final AtomicInteger nextTaskId = new AtomicInteger();
 
+    private SqlTask sqlTask;
+
     public TestSqlTask()
     {
         taskExecutor = new TaskExecutor(8, 16, 3, 4, TASK_FAIR, Ticker.systemTicker());
@@ -102,6 +105,12 @@ public class TestSqlTask
                 new TaskManagerConfig());
     }
 
+    @BeforeMethod
+    public void setUp()
+    {
+        sqlTask = createInitialTask();
+    }
+
     @AfterClass(alwaysRun = true)
     public void destroy()
     {
@@ -113,8 +122,6 @@ public class TestSqlTask
     @Test
     public void testEmptyQuery()
     {
-        SqlTask sqlTask = createInitialTask();
-
         TaskInfo taskInfo = sqlTask.updateTask(TEST_SESSION,
                 Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(),
@@ -142,8 +149,6 @@ public class TestSqlTask
     public void testSimpleQuery()
             throws Exception
     {
-        SqlTask sqlTask = createInitialTask();
-
         TaskInfo taskInfo = sqlTask.updateTask(TEST_SESSION,
                 Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.of(SPLIT), true)),
@@ -178,8 +183,6 @@ public class TestSqlTask
     @Test
     public void testCancel()
     {
-        SqlTask sqlTask = createInitialTask();
-
         TaskInfo taskInfo = sqlTask.updateTask(TEST_SESSION,
                 Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(),
@@ -207,8 +210,6 @@ public class TestSqlTask
     public void testAbort()
             throws Exception
     {
-        SqlTask sqlTask = createInitialTask();
-
         TaskInfo taskInfo = sqlTask.updateTask(TEST_SESSION,
                 Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.of(SPLIT), true)),
@@ -232,8 +233,6 @@ public class TestSqlTask
     public void testBufferCloseOnFinish()
             throws Exception
     {
-        SqlTask sqlTask = createInitialTask();
-
         OutputBuffers outputBuffers = createInitialEmptyOutputBuffers(PARTITIONED).withBuffer(OUT, 0).withNoMoreBufferIds();
         updateTask(sqlTask, EMPTY_SOURCES, outputBuffers);
 
@@ -259,8 +258,6 @@ public class TestSqlTask
     public void testBufferCloseOnCancel()
             throws Exception
     {
-        SqlTask sqlTask = createInitialTask();
-
         updateTask(sqlTask, EMPTY_SOURCES, createInitialEmptyOutputBuffers(PARTITIONED).withBuffer(OUT, 0).withNoMoreBufferIds());
 
         ListenableFuture<BufferResult> bufferResult = sqlTask.getTaskResults(OUT, 0, new DataSize(1, MEGABYTE));
@@ -281,8 +278,6 @@ public class TestSqlTask
     public void testBufferNotCloseOnFail()
             throws Exception
     {
-        SqlTask sqlTask = createInitialTask();
-
         updateTask(sqlTask, EMPTY_SOURCES, createInitialEmptyOutputBuffers(PARTITIONED).withBuffer(OUT, 0).withNoMoreBufferIds());
 
         ListenableFuture<BufferResult> bufferResult = sqlTask.getTaskResults(OUT, 0, new DataSize(1, MEGABYTE));


### PR DESCRIPTION
In many test classes we observed the combination of private fields and @BeforeMethod initializations for variables used in testing. However, we found some classes that didn't use this feature, resulting in unnecessary duplicated code. 

This commit applies the feature in some classes, leaving them to be cleaner.

```
== NO RELEASE NOTE ==
```
