### PR TITLE
Add session property to set bucket function type

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+import static com.facebook.presto.hive.BucketFunctionType.HIVE_COMPATIBLE;
 import static com.facebook.presto.hive.HiveStorageFormat.ORC;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -130,6 +131,7 @@ public class HiveClientConfig
 
     private boolean bucketExecutionEnabled = true;
     private boolean sortedWritingEnabled = true;
+    private BucketFunctionType bucketFunctionTypeForExchange = HIVE_COMPATIBLE;
     private boolean ignoreTableBucketing;
     private int maxBucketsForGroupedExecution = 1_000_000;
     // TODO: Clean up this gatekeeper config and related code/session property once the roll out is done.
@@ -1080,6 +1082,19 @@ public class HiveClientConfig
     {
         this.sortedWritingEnabled = sortedWritingEnabled;
         return this;
+    }
+
+    @Config("hive.bucket-function-type-for-exchange")
+    @ConfigDescription("Hash function type for exchange")
+    public HiveClientConfig setBucketFunctionTypeForExchange(BucketFunctionType bucketFunctionTypeForExchange)
+    {
+        this.bucketFunctionTypeForExchange = bucketFunctionTypeForExchange;
+        return this;
+    }
+
+    public BucketFunctionType getBucketFunctionTypeForExchange()
+    {
+        return bucketFunctionTypeForExchange;
     }
 
     @Config("hive.ignore-table-bucketing")

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -103,6 +103,7 @@ public final class HiveSessionProperties
     public static final String USE_LIST_DIRECTORY_CACHE = "use_list_directory_cache";
     private static final String PARQUET_BATCH_READ_OPTIMIZATION_ENABLED = "parquet_batch_read_optimization_enabled";
     private static final String PARQUET_BATCH_READER_VERIFICATION_ENABLED = "parquet_batch_reader_verification_enabled";
+    private static final String BUCKET_FUNCTION_TYPE_FOR_EXCHANGE = "bucket_function_type_for_exchange";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -468,7 +469,16 @@ public final class HiveSessionProperties
                         PARQUET_BATCH_READER_VERIFICATION_ENABLED,
                         "Is Parquet batch reader verification enabled? This is for testing purposes only, not to be used in production",
                         hiveClientConfig.isParquetBatchReaderVerificationEnabled(),
-                        false));
+                        false),
+                new PropertyMetadata<>(
+                        BUCKET_FUNCTION_TYPE_FOR_EXCHANGE,
+                        "hash function type for bucketed table exchange",
+                        VARCHAR,
+                        BucketFunctionType.class,
+                        hiveClientConfig.getBucketFunctionTypeForExchange(),
+                        false,
+                        value -> BucketFunctionType.valueOf((String) value),
+                        BucketFunctionType::toString));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -817,5 +827,10 @@ public final class HiveSessionProperties
     public static boolean isParquetOptimizedWriterEnabled(ConnectorSession session)
     {
         return session.getProperty(PARQUET_OPTIMIZED_WRITER_ENABLED, Boolean.class);
+    }
+
+    public static BucketFunctionType getBucketFunctionTypeForExchange(ConnectorSession session)
+    {
+        return session.getProperty(BUCKET_FUNCTION_TYPE_FOR_EXCHANGE, BucketFunctionType.class);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+import static com.facebook.presto.hive.BucketFunctionType.HIVE_COMPATIBLE;
+import static com.facebook.presto.hive.BucketFunctionType.PRESTO_NATIVE;
 import static com.facebook.presto.hive.HiveCompressionCodec.NONE;
 import static com.facebook.presto.hive.HiveCompressionCodec.SNAPPY;
 import static com.facebook.presto.hive.HiveStorageFormat.DWRF;
@@ -134,7 +136,8 @@ public class TestHiveClientConfig
                 .setFileStatusCacheTables("")
                 .setPageFileStripeMaxSize(new DataSize(24, Unit.MEGABYTE))
                 .setParquetBatchReaderVerificationEnabled(false)
-                .setParquetBatchReadOptimizationEnabled(false));
+                .setParquetBatchReadOptimizationEnabled(false)
+                .setBucketFunctionTypeForExchange(HIVE_COMPATIBLE));
     }
 
     @Test
@@ -232,6 +235,7 @@ public class TestHiveClientConfig
                 .put("hive.pagefile.writer.stripe-max-size", "1kB")
                 .put("hive.parquet-batch-read-optimization-enabled", "true")
                 .put("hive.enable-parquet-batch-reader-verification", "true")
+                .put("hive.bucket-function-type-for-exchange", "PRESTO_NATIVE")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -326,7 +330,8 @@ public class TestHiveClientConfig
                 .setFileStatusCacheExpireAfterWrite(new Duration(30, TimeUnit.MINUTES))
                 .setPageFileStripeMaxSize(new DataSize(1, Unit.KILOBYTE))
                 .setParquetBatchReaderVerificationEnabled(true)
-                .setParquetBatchReadOptimizationEnabled(true);
+                .setParquetBatchReadOptimizationEnabled(true)
+                .setBucketFunctionTypeForExchange(PRESTO_NATIVE);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithExchangeMaterialization.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithExchangeMaterialization.java
@@ -77,6 +77,7 @@ public class TestHiveDistributedQueriesWithExchangeMaterialization
     {
         Session session = Session.builder(getSession())
                 .setCatalogSessionProperty("hive", "temporary_table_storage_format", "PAGEFILE")
+                .setCatalogSessionProperty("hive", "bucket_function_type_for_exchange", "PRESTO_NATIVE")
                 .build();
 
         assertUpdate(session, "CREATE TABLE test_materialize_bucket_by_non_hive_types AS\n" +


### PR DESCRIPTION
```
== RELEASE NOTES ==

Hive Changes
*  Add support for exchange materialization of table bucketed by non-hive types. This can be enabled using value ``PRESTO_NATIVE`` for the ``bucket_function_type_for_exchange`` session property  or the ``hive.bucket-function-type-for-exchange `` configuration property.
```

