### PR TITLE
Fix artificially high queued query metrics

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerStats.java
@@ -76,12 +76,17 @@ public class QueryManagerStats
     {
         startedQueries.update(1);
         runningQueries.incrementAndGet();
-        queuedQueries.decrementAndGet();
+        queryDequeued();
     }
 
     private void queryStopped()
     {
         runningQueries.decrementAndGet();
+    }
+
+    private void queryDequeued()
+    {
+        queuedQueries.decrementAndGet();
     }
 
     private void queryFinished(BasicQueryInfo info)
@@ -169,6 +174,9 @@ public class QueryManagerStats
                     stopped = true;
                     if (started) {
                         queryStopped();
+                    }
+                    else {
+                        queryDequeued();
                     }
                     finalQueryInfoSupplier.get()
                             .ifPresent(QueryManagerStats.this::queryFinished);


### PR DESCRIPTION
Fixes #14705

Fixed a bug where queries that users cancelled early in their life-cycle would not decrement the queued queries counter, causing this metric to be artificially high.

```
== NO RELEASE NOTE ==
```