### PR TITLE
Fix NPE in geometry_invalid_reason

### DIFF
--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
@@ -44,6 +44,7 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -289,14 +290,14 @@ public final class GeometryUtils
         return GEOMETRY_FACTORY.createPolygon();
     }
 
-    public static String getGeometryInvalidReason(org.locationtech.jts.geom.Geometry geometry)
+    public static Optional<String> getGeometryInvalidReason(org.locationtech.jts.geom.Geometry geometry)
     {
         IsValidOp validOp = new IsValidOp(geometry);
         IsSimpleOp simpleOp = new IsSimpleOp(geometry);
         try {
             TopologyValidationError err = validOp.getValidationError();
             if (err != null) {
-                return err.getMessage();
+                return Optional.of(err.getMessage());
             }
         }
         catch (UnsupportedOperationException e) {
@@ -329,9 +330,9 @@ public final class GeometryUtils
                     throw new PrestoException(INVALID_FUNCTION_ARGUMENT, format("Unknown geometry type: %s", geometryType));
             }
             org.locationtech.jts.geom.Coordinate nonSimpleLocation = simpleOp.getNonSimpleLocation();
-            return format("[%s] %s: (%s %s)", geometryType, errorDescription, nonSimpleLocation.getX(), nonSimpleLocation.getY());
+            return Optional.of(format("[%s] %s: (%s %s)", geometryType, errorDescription, nonSimpleLocation.getX(), nonSimpleLocation.getY()));
         }
-        return null;
+        return Optional.empty();
     }
 
     /**

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/GeoFunctions.java
@@ -46,6 +46,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import io.airlift.slice.BasicSliceInput;
 import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.Geometry;
@@ -414,7 +415,7 @@ public final class GeoFunctions
     {
         try {
             Geometry geometry = deserialize(input);
-            return utf8Slice(getGeometryInvalidReason(geometry));
+            return getGeometryInvalidReason(geometry).map(Slices::utf8Slice).orElse(null);
         }
         catch (PrestoException e) {
             if (e.getCause() instanceof TopologyException) {

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -465,6 +465,11 @@ public class TestGeoFunctions
         assertInvalidReason("MULTIPOINT (1 2, 2 4, 3 6, 1 2)", "[MultiPoint] Repeated point: (1.0 2.0)");
         assertInvalidReason("LINESTRING (0 0, 1 1, 1 0, 0 1)", "[LineString] Self-intersection at or near: (0.5 0.5)");
         assertInvalidReason("MULTILINESTRING ((1 1, 5 1), (2 4, 4 0))", "[MultiLineString] Self-intersection at or near: (3.5 1.0)");
+
+        // valid geometries
+        assertInvalidReason("POINT (1 2)", null);
+        assertInvalidReason("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", null);
+        assertInvalidReason("GEOMETRYCOLLECTION (MULTIPOINT (1 0, 1 1, 0 1, 0 0))", null);
     }
 
     private void assertInvalidReason(String wkt, String reason)


### PR DESCRIPTION
Embarassingly, this method threw an NPE on valid geometries, which it
was not supposed to.  This commit uses Optional and adds a guard.

```
== RELEASE NOTES ==

Geospatial Changes
* Fix NPE in :func:`geometry_invalid_reason`.
```
