### PR TITLE
Enums support #1: base types and operators

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
@@ -14,9 +14,11 @@
 package com.facebook.presto.client;
 
 import com.facebook.airlift.json.ObjectMapperProvider;
+import com.facebook.presto.common.type.LongEnumType.LongEnumMap;
 import com.facebook.presto.common.type.NamedTypeSignature;
 import com.facebook.presto.common.type.ParameterKind;
 import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.VarcharEnumType.VarcharEnumMap;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
@@ -52,6 +54,12 @@ public class ClientTypeSignatureParameter
                 break;
             case NAMED_TYPE:
                 value = typeParameterSignature.getNamedTypeSignature();
+                break;
+            case LONG_ENUM:
+                value = typeParameterSignature.getLongEnumMap();
+                break;
+            case VARCHAR_ENUM:
+                value = typeParameterSignature.getVarcharEnumMap();
                 break;
             default:
                 throw new UnsupportedOperationException(format("Unknown kind [%s]", kind));
@@ -152,6 +160,12 @@ public class ClientTypeSignatureParameter
                     break;
                 case LONG:
                     value = MAPPER.readValue(jsonValue, Long.class);
+                    break;
+                case LONG_ENUM:
+                    value = MAPPER.readValue(jsonValue, LongEnumMap.class);
+                    break;
+                case VARCHAR_ENUM:
+                    value = MAPPER.readValue(jsonValue, VarcharEnumMap.class);
                     break;
                 default:
                     throw new UnsupportedOperationException(format("Unsupported kind [%s]", kind));

--- a/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
@@ -124,6 +124,9 @@ final class FixJsonDataUtils
             }
             return fixedValue;
         }
+        if (signature.isVarcharEnum()) {
+            return String.class.cast(value);
+        }
         switch (signature.getBase()) {
             case BIGINT:
                 if (value instanceof String) {

--- a/presto-common/src/main/java/com/facebook/presto/common/type/AbstractVarcharType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/AbstractVarcharType.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.function.SqlFunctionProperties;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.util.Objects;
+
+public class AbstractVarcharType
+        extends AbstractVariableWidthType
+{
+    public static final int UNBOUNDED_LENGTH = Integer.MAX_VALUE;
+    public static final int MAX_LENGTH = Integer.MAX_VALUE - 1;
+
+    private final int length;
+
+    AbstractVarcharType(int length, TypeSignature typeSignature)
+    {
+        super(typeSignature, Slice.class);
+
+        if (length < 0) {
+            throw new IllegalArgumentException("Invalid VARCHAR length " + length);
+        }
+        this.length = length;
+    }
+
+    @Deprecated
+    public int getLength()
+    {
+        return length;
+    }
+
+    public int getLengthSafe()
+    {
+        if (isUnbounded()) {
+            throw new IllegalStateException("Cannot get size of unbounded VARCHAR.");
+        }
+        return length;
+    }
+
+    public boolean isUnbounded()
+    {
+        return length == UNBOUNDED_LENGTH;
+    }
+
+    @Override
+    public boolean isComparable()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isOrderable()
+    {
+        return true;
+    }
+
+    @Override
+    public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+
+        return block.getSlice(position, 0, block.getSliceLength(position)).toStringUtf8();
+    }
+
+    @Override
+    public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        int leftLength = leftBlock.getSliceLength(leftPosition);
+        int rightLength = rightBlock.getSliceLength(rightPosition);
+        if (leftLength != rightLength) {
+            return false;
+        }
+        return leftBlock.equals(leftPosition, 0, rightBlock, rightPosition, 0, leftLength);
+    }
+
+    @Override
+    public long hash(Block block, int position)
+    {
+        return block.hash(position, 0, block.getSliceLength(position));
+    }
+
+    @Override
+    public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        int leftLength = leftBlock.getSliceLength(leftPosition);
+        int rightLength = rightBlock.getSliceLength(rightPosition);
+        return leftBlock.compareTo(leftPosition, 0, leftLength, rightBlock, rightPosition, 0, rightLength);
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            blockBuilder.appendNull();
+        }
+        else {
+            block.writeBytesTo(position, 0, block.getSliceLength(position), blockBuilder);
+            blockBuilder.closeEntry();
+        }
+    }
+
+    @Override
+    public Slice getSlice(Block block, int position)
+    {
+        return block.getSlice(position, 0, block.getSliceLength(position));
+    }
+
+    @Override
+    public Slice getSliceUnchecked(Block block, int internalPosition)
+    {
+        return block.getSliceUnchecked(internalPosition, 0, block.getSliceLengthUnchecked(internalPosition));
+    }
+
+    public void writeString(BlockBuilder blockBuilder, String value)
+    {
+        writeSlice(blockBuilder, Slices.utf8Slice(value));
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value)
+    {
+        writeSlice(blockBuilder, value, 0, value.length());
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
+    {
+        blockBuilder.writeBytes(value, offset, length).closeEntry();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AbstractVarcharType other = (AbstractVarcharType) o;
+
+        return Objects.equals(this.length, other.length);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(length);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        if (length == UNBOUNDED_LENGTH) {
+            return getTypeSignature().getBase();
+        }
+
+        return getTypeSignature().toString();
+    }
+
+    @Override
+    public String toString()
+    {
+        return getDisplayName();
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/EnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/EnumType.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import java.util.Map;
+
+public interface EnumType<T>
+        extends Type
+{
+    Map<String, T> getEnumMap();
+
+    Type getValueType();
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/LongEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/LongEnumType.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.function.SqlFunctionProperties;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.TypeUtils.normalizeEnumMap;
+import static com.facebook.presto.common.type.TypeUtils.validateEnumMap;
+import static java.lang.String.format;
+
+public class LongEnumType
+        extends AbstractLongType
+        implements EnumType<Long>
+{
+    private final LongEnumMap enumMap;
+
+    public LongEnumType(String name, LongEnumMap enumMap)
+    {
+        super(new TypeSignature(name, TypeSignatureParameter.of(enumMap)));
+        this.enumMap = enumMap;
+    }
+
+    @Override
+    public Map<String, Long> getEnumMap()
+    {
+        return enumMap.getEnumMap();
+    }
+
+    @Override
+    public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+
+        return block.getLong(position);
+    }
+
+    @Override
+    public Type getValueType()
+    {
+        return BIGINT;
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return getTypeSignature().getBase();
+    }
+
+    public static class LongEnumMap
+    {
+        private final Map<String, Long> enumMap;
+
+        @JsonCreator
+        public LongEnumMap(@JsonProperty("enumMap") Map<String, Long> enumMap)
+        {
+            validateEnumMap(enumMap);
+            this.enumMap = normalizeEnumMap(enumMap);
+        }
+
+        @JsonProperty
+        public Map<String, Long> getEnumMap()
+        {
+            return enumMap;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            LongEnumMap other = (LongEnumMap) o;
+
+            return Objects.equals(this.enumMap, other.enumMap);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "enum:bigint{"
+                    + enumMap.entrySet()
+                    .stream()
+                    .sorted(Comparator.comparing(Map.Entry::getKey))
+                    .map(e -> format("\"%s\": %d", e.getKey().replaceAll("\"", "\"\""), e.getValue()))
+                    .collect(Collectors.joining(", "))
+                    + "}";
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(enumMap);
+        }
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/ParameterKind.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/ParameterKind.java
@@ -23,7 +23,9 @@ public enum ParameterKind
     TYPE(Optional.of("TYPE_SIGNATURE")),
     NAMED_TYPE(Optional.of("NAMED_TYPE_SIGNATURE")),
     LONG(Optional.of("LONG_LITERAL")),
-    VARIABLE(Optional.empty());
+    VARIABLE(Optional.empty()),
+    LONG_ENUM(Optional.of("LONG_ENUM")),
+    VARCHAR_ENUM(Optional.of("VARCHAR_ENUM"));
 
     // TODO: drop special serialization code as soon as all clients
     //       migrate to version which can deserialize new format.

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeParameter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeParameter.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.type;
 
+import com.facebook.presto.common.type.LongEnumType.LongEnumMap;
+import com.facebook.presto.common.type.VarcharEnumType.VarcharEnumMap;
+
 import java.util.Objects;
 
 import static java.lang.String.format;
@@ -48,6 +51,16 @@ public class TypeParameter
         return new TypeParameter(ParameterKind.VARIABLE, variable);
     }
 
+    public static TypeParameter of(LongEnumMap enumMap)
+    {
+        return new TypeParameter(ParameterKind.LONG_ENUM, enumMap);
+    }
+
+    public static TypeParameter of(VarcharEnumMap enumMap)
+    {
+        return new TypeParameter(ParameterKind.VARCHAR_ENUM, enumMap);
+    }
+
     public static TypeParameter of(TypeSignatureParameter parameter, TypeManager typeManager)
     {
         switch (parameter.getKind()) {
@@ -65,6 +78,10 @@ public class TypeParameter
             }
             case VARIABLE:
                 return of(parameter.getVariable());
+            case LONG_ENUM:
+                return of(parameter.getLongEnumMap());
+            case VARCHAR_ENUM:
+                return of(parameter.getVarcharEnumMap());
             default:
                 throw new UnsupportedOperationException(format("Unsupported parameter [%s]", parameter));
         }
@@ -96,6 +113,16 @@ public class TypeParameter
     public Long getLongLiteral()
     {
         return getValue(ParameterKind.LONG, Long.class);
+    }
+
+    public LongEnumMap getLongEnumMap()
+    {
+        return getValue(ParameterKind.LONG_ENUM, LongEnumMap.class);
+    }
+
+    public VarcharEnumMap getVarcharEnumMap()
+    {
+        return getValue(ParameterKind.VARCHAR_ENUM, VarcharEnumMap.class);
     }
 
     public NamedType getNamedType()

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
@@ -13,13 +13,15 @@
  */
 package com.facebook.presto.common.type;
 
+import com.facebook.presto.common.type.LongEnumType.LongEnumMap;
+import com.facebook.presto.common.type.VarcharEnumType.VarcharEnumMap;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,11 +29,13 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static java.lang.Character.isDigit;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
+import static java.util.Locale.ENGLISH;
 
 public class TypeSignature
 {
@@ -44,6 +48,9 @@ public class TypeSignature
             new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     private static final Set<String> SIMPLE_TYPE_WITH_SPACES =
             new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+    private static final String LONG_ENUM_PREFIX = "enum:bigint";
+    private static final String VARCHAR_ENUM_PREFIX = "enum:varchar";
 
     static {
         BASE_NAME_ALIAS_TO_CANONICAL.put("int", StandardTypes.INTEGER);
@@ -100,6 +107,21 @@ public class TypeSignature
         return calculated;
     }
 
+    public boolean isEnum()
+    {
+        return isLongEnum() || isVarcharEnum();
+    }
+
+    public boolean isLongEnum()
+    {
+        return parameters.size() == 1 && parameters.get(0).isLongEnum();
+    }
+
+    public boolean isVarcharEnum()
+    {
+        return parameters.size() == 1 && parameters.get(0).isVarcharEnum();
+    }
+
     @JsonCreator
     public static TypeSignature parseTypeSignature(String signature)
     {
@@ -115,7 +137,7 @@ public class TypeSignature
             checkArgument(!literalCalculationParameters.contains(signature), "Bad type signature: '%s'", signature);
             return new TypeSignature(canonicalizeBaseName(signature), new ArrayList<>());
         }
-        if (signature.toLowerCase(Locale.ENGLISH).startsWith(StandardTypes.ROW + "(")) {
+        if (signature.toLowerCase(ENGLISH).startsWith(StandardTypes.ROW + "(")) {
             return parseRowTypeSignature(signature, literalCalculationParameters);
         }
 
@@ -123,8 +145,12 @@ public class TypeSignature
         List<TypeSignatureParameter> parameters = new ArrayList<>();
         int parameterStart = -1;
         int bracketCount = 0;
+        int parameterEnd = -1;
 
         for (int i = 0; i < signature.length(); i++) {
+            if (i < parameterEnd) {
+                continue;
+            }
             char c = signature.charAt(i);
             // TODO: remove angle brackets support once ROW<TYPE>(name) will be dropped
             // Angle brackets here are checked not for the support of ARRAY<> and MAP<>
@@ -151,6 +177,9 @@ public class TypeSignature
                     }
                 }
             }
+            else if (isEnumMapStart(signature, i)) {
+                parameterEnd = parseEnumMap(signature, i).mapEndIndex;
+            }
             else if (c == ',') {
                 if (bracketCount == 1) {
                     checkArgument(parameterStart >= 0, "Bad type signature: '%s'", signature);
@@ -161,6 +190,133 @@ public class TypeSignature
         }
 
         throw new IllegalArgumentException(format("Bad type signature: '%s'", signature));
+    }
+
+    private static class EnumMapParsingData
+    {
+        final int mapEndIndex;
+        private final Map<String, String> map;
+        final boolean isLongEnum;
+
+        EnumMapParsingData(int mapEndIndex, Map<String, String> map, boolean isLongEnum)
+        {
+            this.mapEndIndex = mapEndIndex;
+            this.map = map;
+            this.isLongEnum = isLongEnum;
+        }
+
+        LongEnumMap getLongEnumMap()
+        {
+            checkArgument(isLongEnum, "Invalid enum map format");
+            return new LongEnumMap(
+                    map.entrySet().stream()
+                            .collect(Collectors.toMap(Map.Entry::getKey, e -> Long.parseLong(e.getValue()))));
+        }
+
+        VarcharEnumMap getVarcharEnumMap()
+        {
+            checkArgument(!isLongEnum, "Invalid enum map format");
+            return new VarcharEnumMap(map);
+        }
+    }
+
+    private static boolean isEnumMapStart(String signature, int startIndex)
+    {
+        String suffix = signature.substring(startIndex).toLowerCase(ENGLISH);
+        return suffix.startsWith(LONG_ENUM_PREFIX + "{") || suffix.startsWith(VARCHAR_ENUM_PREFIX + "{");
+    }
+
+    private enum EnumMapParsingState
+    {
+        EXPECT_KEY,
+        IN_KEY,
+        IN_KEY_ESCAPE,
+        EXPECT_COLON,
+        EXPECT_VALUE,
+        IN_NUM_VALUE,
+        IN_STR_VALUE,
+        IN_STR_VALUE_ESCAPE,
+        EXPECT_COMMA_OR_CLOSING_BRACKET
+    }
+
+    private static EnumMapParsingData parseEnumMap(String signature, int startIndex)
+    {
+        EnumMapParsingState state = EnumMapParsingState.EXPECT_KEY;
+        boolean isLongEnum = signature.substring(startIndex).trim().toLowerCase(ENGLISH).startsWith(LONG_ENUM_PREFIX);
+        int openBracketIndex = startIndex + (isLongEnum ? LONG_ENUM_PREFIX.length() : VARCHAR_ENUM_PREFIX.length()) + 1;
+        String key = null;
+        StringBuilder keyOrValue = new StringBuilder();
+        Map<String, String> map = new HashMap<>();
+
+        for (int i = openBracketIndex; i < signature.length(); i++) {
+            char c = signature.charAt(i);
+            if (state == EnumMapParsingState.IN_KEY_ESCAPE) {
+                state = EnumMapParsingState.IN_KEY;
+                keyOrValue.append(c);
+            }
+            if (state == EnumMapParsingState.IN_STR_VALUE_ESCAPE) {
+                state = EnumMapParsingState.IN_STR_VALUE;
+                keyOrValue.append(c);
+            }
+            else if (c == '"') {
+                if (state == EnumMapParsingState.EXPECT_KEY) {
+                    state = EnumMapParsingState.IN_KEY;
+                }
+                else if (state == EnumMapParsingState.EXPECT_VALUE) {
+                    if (isLongEnum) {
+                        throw new IllegalStateException("Unexpected varchar value in numeric enum signature");
+                    }
+                    state = EnumMapParsingState.IN_STR_VALUE;
+                }
+                else if ((state == EnumMapParsingState.IN_KEY || state == EnumMapParsingState.IN_STR_VALUE)
+                        && i + 1 < signature.length() && signature.charAt(i + 1) == '"') {
+                    state = state == EnumMapParsingState.IN_KEY ? EnumMapParsingState.IN_KEY_ESCAPE : EnumMapParsingState.IN_STR_VALUE_ESCAPE;
+                }
+                else if (state == EnumMapParsingState.IN_KEY) {
+                    state = EnumMapParsingState.EXPECT_COLON;
+                }
+                else if (state == EnumMapParsingState.IN_STR_VALUE) {
+                    state = EnumMapParsingState.EXPECT_COMMA_OR_CLOSING_BRACKET;
+                }
+                else {
+                    throw new IllegalStateException("Cannot parse enum signature");
+                }
+            }
+            else if (state == EnumMapParsingState.IN_KEY || state == EnumMapParsingState.IN_STR_VALUE) {
+                keyOrValue.append(c);
+            }
+            else if (c == ':' && state == EnumMapParsingState.EXPECT_COLON) {
+                key = keyOrValue.toString();
+                keyOrValue = new StringBuilder();
+                state = EnumMapParsingState.EXPECT_VALUE;
+            }
+            else if ((Character.isDigit(c) || c == '-') && state == EnumMapParsingState.EXPECT_VALUE) {
+                if (!isLongEnum) {
+                    throw new IllegalStateException("Unexpected numeric value in varchar enum signature");
+                }
+                state = EnumMapParsingState.IN_NUM_VALUE;
+                keyOrValue.append(c);
+            }
+            else if (Character.isDigit(c) && state == EnumMapParsingState.IN_NUM_VALUE) {
+                keyOrValue.append(c);
+            }
+            else if ((c == ',' || c == '}') && (state == EnumMapParsingState.EXPECT_COMMA_OR_CLOSING_BRACKET || state == EnumMapParsingState.IN_NUM_VALUE)) {
+                if (key == null) {
+                    throw new IllegalStateException("Cannot parse enum signature");
+                }
+                map.put(key, keyOrValue.toString());
+                if (c == '}') {
+                    return new EnumMapParsingData(i, map, isLongEnum);
+                }
+                key = null;
+                keyOrValue = new StringBuilder();
+                state = EnumMapParsingState.EXPECT_KEY;
+            }
+            else if (!Character.isWhitespace(c)) {
+                throw new IllegalStateException("Cannot parse enum signature");
+            }
+        }
+        throw new IllegalStateException("Cannot parse enum signature");
     }
 
     private enum RowTypeSignatureParsingState
@@ -175,7 +331,7 @@ public class TypeSignature
 
     private static TypeSignature parseRowTypeSignature(String signature, Set<String> literalParameters)
     {
-        checkArgument(signature.toLowerCase(Locale.ENGLISH).startsWith(StandardTypes.ROW + "("), "Not a row type signature: '%s'", signature);
+        checkArgument(signature.toLowerCase(ENGLISH).startsWith(StandardTypes.ROW + "("), "Not a row type signature: '%s'", signature);
 
         RowTypeSignatureParsingState state = RowTypeSignatureParsingState.START_OF_FIELD;
         int bracketLevel = 1;
@@ -318,6 +474,18 @@ public class TypeSignature
         else if (literalCalculationParameters.contains(parameterName)) {
             return TypeSignatureParameter.of(parameterName);
         }
+        else if (isEnumMapStart(signature, begin)) {
+            if (!parameterName.endsWith("}")) {
+                throw new IllegalStateException("Cannot parse enum signature");
+            }
+            EnumMapParsingData enumMapData = parseEnumMap(signature, begin);
+            if (enumMapData.isLongEnum) {
+                return TypeSignatureParameter.of(enumMapData.getLongEnumMap());
+            }
+            else {
+                return TypeSignatureParameter.of(enumMapData.getVarcharEnumMap());
+            }
+        }
         else {
             return TypeSignatureParameter.of(parseTypeSignature(parameterName, literalCalculationParameters));
         }
@@ -394,13 +562,13 @@ public class TypeSignature
 
         TypeSignature other = (TypeSignature) o;
 
-        return Objects.equals(this.base.toLowerCase(Locale.ENGLISH), other.base.toLowerCase(Locale.ENGLISH)) &&
+        return Objects.equals(this.base.toLowerCase(ENGLISH), other.base.toLowerCase(ENGLISH)) &&
                 Objects.equals(this.parameters, other.parameters);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(base.toLowerCase(Locale.ENGLISH), parameters);
+        return Objects.hash(base.toLowerCase(ENGLISH), parameters);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureParameter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureParameter.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.type;
 
+import com.facebook.presto.common.type.LongEnumType.LongEnumMap;
+import com.facebook.presto.common.type.VarcharEnumType.VarcharEnumMap;
+
 import java.util.Objects;
 import java.util.Optional;
 
@@ -42,6 +45,16 @@ public class TypeSignatureParameter
     public static TypeSignatureParameter of(String variable)
     {
         return new TypeSignatureParameter(ParameterKind.VARIABLE, variable);
+    }
+
+    public static TypeSignatureParameter of(LongEnumMap enumMap)
+    {
+        return new TypeSignatureParameter(ParameterKind.LONG_ENUM, enumMap);
+    }
+
+    public static TypeSignatureParameter of(VarcharEnumMap enumMap)
+    {
+        return new TypeSignatureParameter(ParameterKind.VARCHAR_ENUM, enumMap);
     }
 
     private TypeSignatureParameter(ParameterKind kind, Object value)
@@ -81,6 +94,16 @@ public class TypeSignatureParameter
         return kind == ParameterKind.VARIABLE;
     }
 
+    public boolean isLongEnum()
+    {
+        return kind == ParameterKind.LONG_ENUM;
+    }
+
+    public boolean isVarcharEnum()
+    {
+        return kind == ParameterKind.VARCHAR_ENUM;
+    }
+
     private <A> A getValue(ParameterKind expectedParameterKind, Class<A> target)
     {
         if (kind != expectedParameterKind) {
@@ -109,6 +132,16 @@ public class TypeSignatureParameter
         return getValue(ParameterKind.VARIABLE, String.class);
     }
 
+    public LongEnumMap getLongEnumMap()
+    {
+        return getValue(ParameterKind.LONG_ENUM, LongEnumMap.class);
+    }
+
+    public VarcharEnumMap getVarcharEnumMap()
+    {
+        return getValue(ParameterKind.VARCHAR_ENUM, VarcharEnumMap.class);
+    }
+
     public Optional<TypeSignature> getTypeSignatureOrNamedTypeSignature()
     {
         switch (kind) {
@@ -129,6 +162,8 @@ public class TypeSignatureParameter
             case NAMED_TYPE:
                 return getNamedTypeSignature().getTypeSignature().isCalculated();
             case LONG:
+            case LONG_ENUM:
+            case VARCHAR_ENUM:
                 return false;
             case VARIABLE:
                 return true;

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
@@ -19,6 +19,14 @@ import com.facebook.presto.common.block.BlockBuilder;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static java.util.Locale.ENGLISH;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+
 public final class TypeUtils
 {
     public static final int NULL_HASH_CODE = 0;
@@ -100,5 +108,27 @@ public final class TypeUtils
         if (isNull) {
             throw new NotSupportedException(errorMsg);
         }
+    }
+
+    static void validateEnumMap(Map<String, ?> enumMap)
+    {
+        if (enumMap.containsKey(null)) {
+            throw new IllegalArgumentException("Enum cannot contain null key");
+        }
+        int nUniqueAndNotNullValues = enumMap.values().stream()
+                .filter(Objects::nonNull).collect(toSet()).size();
+        if (nUniqueAndNotNullValues != enumMap.size()) {
+            throw new IllegalArgumentException("Enum cannot contain null or duplicate values");
+        }
+        int nCaseInsensitiveKeys = enumMap.keySet().stream().map(k -> k.toUpperCase(ENGLISH)).collect(Collectors.toSet()).size();
+        if (nCaseInsensitiveKeys != enumMap.size()) {
+            throw new IllegalArgumentException("Enum cannot contain case-insensitive duplicate keys");
+        }
+    }
+
+    static <V> Map<String, V> normalizeEnumMap(Map<String, V> entries)
+    {
+        return entries.entrySet().stream()
+                .collect(toMap(e -> e.getKey().toUpperCase(ENGLISH), Map.Entry::getValue));
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumType.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.TypeUtils.normalizeEnumMap;
+import static com.facebook.presto.common.type.TypeUtils.validateEnumMap;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+
+public class VarcharEnumType
+        extends AbstractVarcharType
+        implements EnumType<String>
+{
+    private final VarcharEnumMap enumMap;
+
+    public VarcharEnumType(String name, VarcharEnumMap enumMap)
+    {
+        super(VarcharType.UNBOUNDED_LENGTH, new TypeSignature(name, TypeSignatureParameter.of(enumMap)));
+        this.enumMap = enumMap;
+    }
+
+    @Override
+    public Map<String, String> getEnumMap()
+    {
+        return enumMap.getEnumMap();
+    }
+
+    @Override
+    public Type getValueType()
+    {
+        return VARCHAR;
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return getTypeSignature().getBase();
+    }
+
+    public static class VarcharEnumMap
+    {
+        private final Map<String, String> enumMap;
+
+        @JsonCreator
+        public VarcharEnumMap(@JsonProperty("enumMap") Map<String, String> enumMap)
+        {
+            validateEnumMap(enumMap);
+            this.enumMap = normalizeEnumMap(enumMap);
+        }
+
+        @JsonProperty
+        public Map<String, String> getEnumMap()
+        {
+            return enumMap;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            VarcharEnumMap other = (VarcharEnumMap) o;
+
+            return Objects.equals(this.enumMap, other.enumMap);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "enum:varchar{"
+                    + enumMap.entrySet()
+                    .stream()
+                    .sorted(Comparator.comparing(Map.Entry::getKey))
+                    .map(e -> format("\"%s\": \"%s\"", e.getKey().replaceAll("\"", "\"\""), e.getValue().replaceAll("\"", "\"\"")))
+                    .collect(Collectors.joining(", "))
+                    + "}";
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(enumMap);
+        }
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarcharType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarcharType.java
@@ -13,21 +13,11 @@
  */
 package com.facebook.presto.common.type;
 
-import com.facebook.presto.common.block.Block;
-import com.facebook.presto.common.block.BlockBuilder;
-import com.facebook.presto.common.function.SqlFunctionProperties;
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
-
-import java.util.Objects;
-
 import static java.util.Collections.singletonList;
 
 public final class VarcharType
-        extends AbstractVariableWidthType
+        extends AbstractVarcharType
 {
-    public static final int UNBOUNDED_LENGTH = Integer.MAX_VALUE;
-    public static final int MAX_LENGTH = Integer.MAX_VALUE - 1;
     public static final VarcharType VARCHAR = new VarcharType(UNBOUNDED_LENGTH);
 
     public static VarcharType createUnboundedVarcharType()
@@ -49,163 +39,12 @@ public final class VarcharType
         return new TypeSignature(StandardTypes.VARCHAR, TypeSignatureParameter.of(param));
     }
 
-    private final int length;
-
     private VarcharType(int length)
     {
         super(
+                length,
                 new TypeSignature(
                         StandardTypes.VARCHAR,
-                        singletonList(TypeSignatureParameter.of((long) length))),
-                Slice.class);
-
-        if (length < 0) {
-            throw new IllegalArgumentException("Invalid VARCHAR length " + length);
-        }
-        this.length = length;
-    }
-
-    @Deprecated
-    public int getLength()
-    {
-        return length;
-    }
-
-    public int getLengthSafe()
-    {
-        if (isUnbounded()) {
-            throw new IllegalStateException("Cannot get size of unbounded VARCHAR.");
-        }
-        return length;
-    }
-
-    public boolean isUnbounded()
-    {
-        return length == UNBOUNDED_LENGTH;
-    }
-
-    @Override
-    public boolean isComparable()
-    {
-        return true;
-    }
-
-    @Override
-    public boolean isOrderable()
-    {
-        return true;
-    }
-
-    @Override
-    public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
-    {
-        if (block.isNull(position)) {
-            return null;
-        }
-
-        return block.getSlice(position, 0, block.getSliceLength(position)).toStringUtf8();
-    }
-
-    @Override
-    public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
-    {
-        int leftLength = leftBlock.getSliceLength(leftPosition);
-        int rightLength = rightBlock.getSliceLength(rightPosition);
-        if (leftLength != rightLength) {
-            return false;
-        }
-        return leftBlock.equals(leftPosition, 0, rightBlock, rightPosition, 0, leftLength);
-    }
-
-    @Override
-    public long hash(Block block, int position)
-    {
-        return block.hash(position, 0, block.getSliceLength(position));
-    }
-
-    @Override
-    public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
-    {
-        int leftLength = leftBlock.getSliceLength(leftPosition);
-        int rightLength = rightBlock.getSliceLength(rightPosition);
-        return leftBlock.compareTo(leftPosition, 0, leftLength, rightBlock, rightPosition, 0, rightLength);
-    }
-
-    @Override
-    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
-    {
-        if (block.isNull(position)) {
-            blockBuilder.appendNull();
-        }
-        else {
-            block.writeBytesTo(position, 0, block.getSliceLength(position), blockBuilder);
-            blockBuilder.closeEntry();
-        }
-    }
-
-    @Override
-    public Slice getSlice(Block block, int position)
-    {
-        return block.getSlice(position, 0, block.getSliceLength(position));
-    }
-
-    @Override
-    public Slice getSliceUnchecked(Block block, int internalPosition)
-    {
-        return block.getSliceUnchecked(internalPosition, 0, block.getSliceLengthUnchecked(internalPosition));
-    }
-
-    public void writeString(BlockBuilder blockBuilder, String value)
-    {
-        writeSlice(blockBuilder, Slices.utf8Slice(value));
-    }
-
-    @Override
-    public void writeSlice(BlockBuilder blockBuilder, Slice value)
-    {
-        writeSlice(blockBuilder, value, 0, value.length());
-    }
-
-    @Override
-    public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
-    {
-        blockBuilder.writeBytes(value, offset, length).closeEntry();
-    }
-
-    @Override
-    public boolean equals(Object o)
-    {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        VarcharType other = (VarcharType) o;
-
-        return Objects.equals(this.length, other.length);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(length);
-    }
-
-    @Override
-    public String getDisplayName()
-    {
-        if (length == UNBOUNDED_LENGTH) {
-            return getTypeSignature().getBase();
-        }
-
-        return getTypeSignature().toString();
-    }
-
-    @Override
-    public String toString()
-    {
-        return getDisplayName();
+                        singletonList(TypeSignatureParameter.of((long) length))));
     }
 }

--- a/presto-docs/src/main/sphinx/develop/functions.rst
+++ b/presto-docs/src/main/sphinx/develop/functions.rst
@@ -116,8 +116,11 @@ To make our previous example work with any type we need the following:
   The ``@TypeParameter`` annotation is used to declare a type parameter which can
   be used in the argument types ``@SqlType`` annotation, or return type of the function.
   It can also be used to annotate a parameter of type ``Type``. At runtime, the engine
-  will bind the concrete type to this parameter. ``@OperatorDependency`` may be used
-  to declare that an additional function for operating on the given type parameter is needed.
+  will bind the concrete type to this parameter. Optionally, the type parameter
+  can be constrained to descendants of a particular type by providing a ``boundedBy``
+  type class to ``@TypeParameter``.
+  ``@OperatorDependency`` may be used to declare that an additional function
+  for operating on the given type parameter is needed.
   For example, the following function will only bind to types which have an equals function
   defined:
 

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
@@ -191,6 +191,7 @@ import com.facebook.presto.type.DateOperators;
 import com.facebook.presto.type.DateTimeOperators;
 import com.facebook.presto.type.DecimalOperators;
 import com.facebook.presto.type.DoubleOperators;
+import com.facebook.presto.type.EnumCasts;
 import com.facebook.presto.type.HyperLogLogOperators;
 import com.facebook.presto.type.IntegerOperators;
 import com.facebook.presto.type.IntervalDayTimeOperators;
@@ -198,6 +199,7 @@ import com.facebook.presto.type.IntervalYearMonthOperators;
 import com.facebook.presto.type.IpAddressOperators;
 import com.facebook.presto.type.IpPrefixOperators;
 import com.facebook.presto.type.LikeFunctions;
+import com.facebook.presto.type.LongEnumOperators;
 import com.facebook.presto.type.QuantileDigestOperators;
 import com.facebook.presto.type.RealOperators;
 import com.facebook.presto.type.SmallintOperators;
@@ -209,6 +211,7 @@ import com.facebook.presto.type.TimestampWithTimeZoneOperators;
 import com.facebook.presto.type.TinyintOperators;
 import com.facebook.presto.type.UnknownOperators;
 import com.facebook.presto.type.VarbinaryOperators;
+import com.facebook.presto.type.VarcharEnumOperators;
 import com.facebook.presto.type.VarcharOperators;
 import com.facebook.presto.type.khyperloglog.KHyperLogLogAggregationFunction;
 import com.facebook.presto.type.khyperloglog.KHyperLogLogFunctions;
@@ -705,7 +708,10 @@ public class BuiltInFunctionNamespaceManager
                 .function(MergeTDigestFunction.MERGE)
                 .sqlInvokedScalar(MapNormalizeFunction.class)
                 .sqlInvokedScalars(ArrayArithmeticFunctions.class)
-                .scalar(DynamicFilterPlaceholderFunction.class);
+                .scalar(DynamicFilterPlaceholderFunction.class)
+                .scalars(EnumCasts.class)
+                .scalars(LongEnumOperators.class)
+                .scalars(VarcharEnumOperators.class);
 
         switch (featuresConfig.getRegexLibrary()) {
             case JONI:

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SignatureBinder.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SignatureBinder.java
@@ -323,7 +323,8 @@ public class SignatureBinder
                     actualType,
                     typeVariableConstraint.isComparableRequired(),
                     typeVariableConstraint.isOrderableRequired(),
-                    Optional.ofNullable(typeVariableConstraint.getVariadicBound())));
+                    Optional.ofNullable(typeVariableConstraint.getVariadicBound()),
+                    typeVariableConstraint.getTypeBound()));
             return true;
         }
 
@@ -595,14 +596,22 @@ public class SignatureBinder
         private final boolean comparableRequired;
         private final boolean orderableRequired;
         private final Optional<String> requiredBaseName;
+        private final Class<? extends Type> typeBound;
 
-        public TypeParameterSolver(String typeParameter, Type actualType, boolean comparableRequired, boolean orderableRequired, Optional<String> requiredBaseName)
+        public TypeParameterSolver(
+                String typeParameter,
+                Type actualType,
+                boolean comparableRequired,
+                boolean orderableRequired,
+                Optional<String> requiredBaseName,
+                Class<? extends Type> typeBound)
         {
             this.typeParameter = typeParameter;
             this.actualType = actualType;
             this.comparableRequired = comparableRequired;
             this.orderableRequired = orderableRequired;
             this.requiredBaseName = requiredBaseName;
+            this.typeBound = typeBound;
         }
 
         @Override
@@ -637,6 +646,9 @@ public class SignatureBinder
                 return false;
             }
             if (orderableRequired && !type.isOrderable()) {
+                return false;
+            }
+            if (!typeBound.isInstance(type)) {
                 return false;
             }
             if (requiredBaseName.isPresent() && !UNKNOWN.equals(type) && !requiredBaseName.get().equals(type.getTypeSignature().getBase())) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/annotations/FunctionsParserHelper.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/annotations/FunctionsParserHelper.java
@@ -57,9 +57,6 @@ import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.operator.annotations.ImplementationDependency.isImplementationDependencyAnnotation;
-import static com.facebook.presto.spi.function.Signature.comparableTypeParameter;
-import static com.facebook.presto.spi.function.Signature.orderableTypeParameter;
-import static com.facebook.presto.spi.function.Signature.typeVariable;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -112,13 +109,13 @@ public class FunctionsParserHelper
         for (TypeParameter typeParameter : typeParameters) {
             String name = typeParameter.value();
             if (orderableRequired.contains(name)) {
-                typeVariableConstraints.add(orderableTypeParameter(name));
+                typeVariableConstraints.add(new TypeVariableConstraint(name, false, true, null, typeParameter.boundedBy()));
             }
             else if (comparableRequired.contains(name)) {
-                typeVariableConstraints.add(comparableTypeParameter(name));
+                typeVariableConstraints.add(new TypeVariableConstraint(name, true, false, null, typeParameter.boundedBy()));
             }
             else {
-                typeVariableConstraints.add(typeVariable(name));
+                typeVariableConstraints.add(new TypeVariableConstraint(name, false, false, null, typeParameter.boundedBy()));
             }
         }
         return typeVariableConstraints.build();

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
@@ -13,23 +13,34 @@
  */
 package com.facebook.presto.sql.analyzer;
 
+import com.facebook.presto.common.type.EnumType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.DefaultExpressionTraversalVisitor;
+import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NodeRef;
+import com.facebook.presto.sql.tree.QualifiedName;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Predicate;
 
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.function.FunctionKind.AGGREGATE;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public final class ExpressionTreeUtils
@@ -111,5 +122,51 @@ public final class ExpressionTreeUtils
     public static boolean isEqualComparisonExpression(Expression expression)
     {
         return expression instanceof ComparisonExpression && ((ComparisonExpression) expression).getOperator() == ComparisonExpression.Operator.EQUAL;
+    }
+
+    static Optional<EnumType> tryResolveEnumLiteralType(QualifiedName qualifiedName, TypeManager typeManager)
+    {
+        Optional<QualifiedName> prefix = qualifiedName.getPrefix();
+        if (!prefix.isPresent()) {
+            // an enum literal should be of the form `MyEnum.my_key`
+            return Optional.empty();
+        }
+        try {
+            Type baseType = typeManager.getType(parseTypeSignature(prefix.get().toString()));
+            if (baseType instanceof EnumType) {
+                return Optional.of((EnumType) baseType);
+            }
+        }
+        catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isEnumLiteral(DereferenceExpression node, Type nodeType)
+    {
+        if (!(nodeType instanceof EnumType)) {
+            return false;
+        }
+        QualifiedName qualifiedName = DereferenceExpression.getQualifiedName(node);
+        if (qualifiedName == null) {
+            return false;
+        }
+        Optional<QualifiedName> prefix = qualifiedName.getPrefix();
+        return prefix.isPresent()
+                && prefix.get().toString().equalsIgnoreCase(nodeType.getTypeSignature().getBase());
+    }
+
+    public static Optional<Object> tryResolveEnumLiteral(DereferenceExpression node, Type nodeType)
+    {
+        QualifiedName qualifiedName = DereferenceExpression.getQualifiedName(node);
+        if (!isEnumLiteral(node, nodeType)) {
+            return Optional.empty();
+        }
+        EnumType enumType = (EnumType) nodeType;
+        String enumKey = qualifiedName.getSuffix().toUpperCase(ENGLISH);
+        checkArgument(enumType.getEnumMap().containsKey(enumKey), format("No key '%s' in enum '%s'", enumKey, nodeType.getDisplayName()));
+        Object enumValue = enumType.getEnumMap().get(enumKey);
+        return enumValue instanceof String ? Optional.of(utf8Slice((String) enumValue)) : Optional.of(enumValue);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/SemanticExceptions.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/SemanticExceptions.java
@@ -29,7 +29,11 @@ public final class SemanticExceptions
 
     public static SemanticException missingAttributeException(Expression node, QualifiedName name)
     {
-        throw new SemanticException(MISSING_ATTRIBUTE, node, "Column '%s' cannot be resolved", name);
+        throw new SemanticException(
+                MISSING_ATTRIBUTE,
+                node,
+                name.getPrefix().isPresent() ? "'%s' cannot be resolved" : "Column '%s' cannot be resolved",
+                name);
     }
 
     /**

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
@@ -48,6 +48,7 @@ import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.CharLiteral;
 import com.facebook.presto.sql.tree.DecimalLiteral;
 import com.facebook.presto.sql.tree.DoubleLiteral;
+import com.facebook.presto.sql.tree.EnumLiteral;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.GenericLiteral;
 import com.facebook.presto.sql.tree.IntervalLiteral;
@@ -231,6 +232,12 @@ public final class LiteralInterpreter
 
         @Override
         protected Slice visitBinaryLiteral(BinaryLiteral node, ConnectorSession session)
+        {
+            return node.getValue();
+        }
+
+        @Override
+        protected Object visitEnumLiteral(EnumLiteral node, ConnectorSession context)
         {
             return node.getValue();
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -53,8 +53,11 @@ import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.DereferenceExpression;
+import com.facebook.presto.sql.tree.EnumLiteral;
 import com.facebook.presto.sql.tree.Except;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.InPredicate;
@@ -97,6 +100,7 @@ import java.util.Set;
 import static com.facebook.presto.spi.plan.AggregationNode.singleGroupingSet;
 import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.isEqualComparisonExpression;
+import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.tryResolveEnumLiteral;
 import static com.facebook.presto.sql.analyzer.SemanticExceptions.notSupportedException;
 import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identitiesAsSymbolReferences;
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.asSymbolReference;
@@ -670,20 +674,38 @@ class RelationPlanner
             ImmutableList.Builder<RowExpression> values = ImmutableList.builder();
             if (row instanceof Row) {
                 for (Expression item : ((Row) row).getItems()) {
-                    Expression expression = Coercer.addCoercions(item, analysis);
-                    values.add(castToRowExpression(ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(analysis.getParameters(), analysis), expression)));
+                    values.add(rewriteRow(item));
                 }
             }
             else {
-                Expression expression = Coercer.addCoercions(row, analysis);
-                values.add(castToRowExpression(ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(analysis.getParameters(), analysis), expression)));
+                values.add(rewriteRow(row));
             }
-
             rowsBuilder.add(values.build());
         }
 
         ValuesNode valuesNode = new ValuesNode(idAllocator.getNextId(), outputVariablesBuilder.build(), rowsBuilder.build());
         return new RelationPlan(valuesNode, scope, outputVariablesBuilder.build());
+    }
+
+    private RowExpression rewriteRow(Expression row)
+    {
+        Expression expression = Coercer.addCoercions(row, analysis);
+        expression = ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(analysis.getParameters(), analysis), expression);
+
+        // resolve enum literals
+        expression = ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>() {
+            @Override
+            public Expression rewriteDereferenceExpression(DereferenceExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                Type nodeType = analysis.getType(node);
+                Optional<Object> maybeEnumValue = tryResolveEnumLiteral(node, nodeType);
+                if (maybeEnumValue.isPresent()) {
+                    return new EnumLiteral(nodeType.getTypeSignature().toString(), maybeEnumValue.get());
+                }
+                return node;
+            }
+        }, expression);
+        return castToRowExpression(expression);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslationMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/TranslationMap.java
@@ -19,6 +19,7 @@ import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.ResolvedField;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.DereferenceExpression;
+import com.facebook.presto.sql.tree.EnumLiteral;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.tryResolveEnumLiteral;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -234,6 +236,13 @@ class TranslationMap
                     // do not rewrite outer references, it will be handled in outer scope planner
                     return node;
                 }
+
+                Type nodeType = analysis.getType(node);
+                Optional<Object> maybeEnumValue = tryResolveEnumLiteral(node, nodeType);
+                if (maybeEnumValue.isPresent()) {
+                    return new EnumLiteral(nodeType.getTypeSignature().toString(), maybeEnumValue.get());
+                }
+
                 return rewriteExpression(node, context, treeRewriter);
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -121,6 +121,7 @@ import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.ROW_CONSTRUCTOR;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.SWITCH;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.WHEN;
+import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.tryResolveEnumLiteral;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
@@ -562,6 +563,12 @@ public final class SqlToRowExpressionTranslator
         @Override
         protected RowExpression visitDereferenceExpression(DereferenceExpression node, Void context)
         {
+            Type returnType = getType(node);
+            Optional<Object> maybeEnumLiteral = tryResolveEnumLiteral(node, returnType);
+            if (maybeEnumLiteral.isPresent()) {
+                return constant(maybeEnumLiteral.get(), returnType);
+            }
+
             RowType rowType = (RowType) getType(node.getBase());
             String fieldName = node.getField().getValue();
             List<Field> fields = rowType.getFields();
@@ -582,7 +589,6 @@ public final class SqlToRowExpressionTranslator
             }
 
             checkState(index >= 0, "could not find field name: %s", node.getField());
-            Type returnType = getType(node);
             return specialForm(DEREFERENCE, returnType, process(node.getBase(), context), constant((long) index, INTEGER));
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/type/EnumCasts.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/EnumCasts.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.type.LongEnumType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarcharEnumType;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.common.function.OperatorType.CAST;
+import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+
+public final class EnumCasts
+{
+    private EnumCasts()
+    {
+    }
+
+    @ScalarOperator(CAST)
+    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @SqlType("T")
+    public static Slice castVarcharToEnum(@TypeParameter("T") Type enumType, @SqlType(StandardTypes.VARCHAR) Slice value)
+    {
+        if (!(((VarcharEnumType) enumType).getEnumMap().values().contains(value.toStringUtf8()))) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT,
+                    String.format(
+                            "No value '%s' in enum '%s'",
+                            value.toStringUtf8(),
+                            enumType.getTypeSignature().getBase()));
+        }
+        return value;
+    }
+
+    @ScalarOperator(CAST)
+    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice castEnumToVarchar(@SqlType("T") Slice value)
+    {
+        return value;
+    }
+
+    @ScalarOperator(CAST)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType("T")
+    public static long castBigintToEnum(@TypeParameter("T") Type enumType, @SqlType(BIGINT) long value)
+    {
+        return castLongToEnum(enumType, value);
+    }
+
+    @ScalarOperator(CAST)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType("T")
+    public static long castIntegerToEnum(@TypeParameter("T") Type enumType, @SqlType(StandardTypes.INTEGER) long value)
+    {
+        return castLongToEnum(enumType, value);
+    }
+
+    @ScalarOperator(CAST)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType("T")
+    public static long castSmallintToEnum(@TypeParameter("T") Type enumType, @SqlType(StandardTypes.SMALLINT) long value)
+    {
+        return castLongToEnum(enumType, value);
+    }
+
+    @ScalarOperator(CAST)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType("T")
+    public static long castTinyintToEnum(@TypeParameter("T") Type enumType, @SqlType(StandardTypes.TINYINT) long value)
+    {
+        return castLongToEnum(enumType, value);
+    }
+
+    private static long castLongToEnum(Type enumType, long value)
+    {
+        if (!((LongEnumType) enumType).getEnumMap().values().contains(value)) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT,
+                    String.format(
+                            "No value '%d' in enum '%s'",
+                            value,
+                            enumType.getTypeSignature().getBase()));
+        }
+        return value;
+    }
+
+    @ScalarOperator(CAST)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType(BIGINT)
+    public static long castEnumToBigint(@SqlType("T") long value)
+    {
+        return value;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/LongEnumOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LongEnumOperators.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.type.AbstractLongType;
+import com.facebook.presto.common.type.LongEnumType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.IsNull;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import io.airlift.slice.XxHash64;
+
+import static com.facebook.presto.common.function.OperatorType.BETWEEN;
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.HASH_CODE;
+import static com.facebook.presto.common.function.OperatorType.INDETERMINATE;
+import static com.facebook.presto.common.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.XX_HASH_64;
+import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+
+public final class LongEnumOperators
+{
+    private LongEnumOperators() {}
+
+    @ScalarOperator(EQUAL)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType(BOOLEAN)
+    @SqlNullable
+    public static Boolean equal(@SqlType("T") long left, @SqlType("T") long right)
+    {
+        return left == right;
+    }
+
+    @ScalarOperator(NOT_EQUAL)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType(BOOLEAN)
+    @SqlNullable
+    public static Boolean notEqual(@SqlType("T") long left, @SqlType("T") long right)
+    {
+        return left != right;
+    }
+
+    @ScalarOperator(IS_DISTINCT_FROM)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType(BOOLEAN)
+    public static boolean isDistinctFrom(
+            @SqlType("T") long left,
+            @IsNull boolean leftNull,
+            @SqlType("T") long right,
+            @IsNull boolean rightNull)
+    {
+        if (leftNull != rightNull) {
+            return true;
+        }
+        if (leftNull) {
+            return false;
+        }
+        return notEqual(left, right);
+    }
+
+    @ScalarOperator(HASH_CODE)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType(BIGINT)
+    public static long hashCode(@SqlType("T") long value)
+    {
+        return AbstractLongType.hash(value);
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType(BIGINT)
+    public static long xxHash64(@SqlType("T") long value)
+    {
+        return XxHash64.hash(value);
+    }
+
+    @ScalarOperator(INDETERMINATE)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType(BOOLEAN)
+    public static boolean indeterminate(@SqlType("T") long value, @IsNull boolean isNull)
+    {
+        return isNull;
+    }
+
+    @ScalarOperator(LESS_THAN)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThan(@SqlType("T") long left, @SqlType("T") long right)
+    {
+        return left < right;
+    }
+
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThanOrEqual(@SqlType("T") long left, @SqlType("T") long right)
+    {
+        return left <= right;
+    }
+
+    @ScalarOperator(GREATER_THAN)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThan(@SqlType("T") long left, @SqlType("T") long right)
+    {
+        return left > right;
+    }
+
+    @ScalarOperator(GREATER_THAN_OR_EQUAL)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThanOrEqual(@SqlType("T") long left, @SqlType("T") long right)
+    {
+        return left >= right;
+    }
+
+    @ScalarOperator(BETWEEN)
+    @TypeParameter(value = "T", boundedBy = LongEnumType.class)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean between(@SqlType("T") long value, @SqlType("T") long min, @SqlType("T") long max)
+    {
+        return min <= value && value <= max;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/LongEnumParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LongEnumParametricType.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.type.LongEnumType;
+import com.facebook.presto.common.type.LongEnumType.LongEnumMap;
+import com.facebook.presto.common.type.ParameterKind;
+import com.facebook.presto.common.type.ParametricType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeParameter;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class LongEnumParametricType
+        implements ParametricType
+{
+    private final String name;
+    private final LongEnumMap enumMap;
+
+    public LongEnumParametricType(String name, LongEnumMap enumMap)
+    {
+        this.name = name;
+        this.enumMap = enumMap;
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    {
+        if (parameters.isEmpty()) {
+            return new LongEnumType(name, enumMap);
+        }
+        checkArgument(parameters.size() == 1, "Enum type expects exactly one parameter, got %s", parameters);
+        checkArgument(
+                parameters.get(0).getKind() == ParameterKind.LONG_ENUM,
+                "Enum definition expected, got %s",
+                parameters);
+        return new LongEnumType(name, parameters.get(0).getLongEnumMap());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/VarcharEnumOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarcharEnumOperators.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.VarcharEnumType;
+import com.facebook.presto.spi.function.IsNull;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
+
+import static com.facebook.presto.common.function.OperatorType.BETWEEN;
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.HASH_CODE;
+import static com.facebook.presto.common.function.OperatorType.INDETERMINATE;
+import static com.facebook.presto.common.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.XX_HASH_64;
+import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+
+public final class VarcharEnumOperators
+{
+    private VarcharEnumOperators() {}
+
+    @ScalarOperator(EQUAL)
+    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @SqlType(BOOLEAN)
+    @SqlNullable
+    public static Boolean equal(@SqlType("T") Slice left, @SqlType("T") Slice right)
+    {
+        return left.equals(right);
+    }
+
+    @ScalarOperator(NOT_EQUAL)
+    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @SqlType(BOOLEAN)
+    @SqlNullable
+    public static Boolean notEqual(@SqlType("T") Slice left, @SqlType("T") Slice right)
+    {
+        return !left.equals(right);
+    }
+
+    @ScalarOperator(IS_DISTINCT_FROM)
+    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @SqlType(BOOLEAN)
+    public static boolean isDistinctFrom(
+            @SqlType("T") Slice left,
+            @IsNull boolean leftNull,
+            @SqlType("T") Slice right,
+            @IsNull boolean rightNull)
+    {
+        if (leftNull != rightNull) {
+            return true;
+        }
+        if (leftNull) {
+            return false;
+        }
+        return notEqual(left, right);
+    }
+
+    @ScalarOperator(HASH_CODE)
+    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @SqlType(BIGINT)
+    public static long hashCode(@SqlType("T") Slice value)
+    {
+        return xxHash64(value);
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @SqlType(BIGINT)
+    public static long xxHash64(@SqlType("T") Slice value)
+    {
+        return XxHash64.hash(value);
+    }
+
+    @ScalarOperator(INDETERMINATE)
+    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @SqlType(BOOLEAN)
+    public static boolean indeterminate(@SqlType("T") Slice value, @IsNull boolean isNull)
+    {
+        return isNull;
+    }
+
+    @ScalarOperator(LESS_THAN)
+    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThan(@SqlType("T") Slice left, @SqlType("T") Slice right)
+    {
+        return left.compareTo(right) < 0;
+    }
+
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
+    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThanOrEqual(@SqlType("T") Slice left, @SqlType("T") Slice right)
+    {
+        return left.compareTo(right) <= 0;
+    }
+
+    @ScalarOperator(GREATER_THAN)
+    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThan(@SqlType("T") Slice left, @SqlType("T") Slice right)
+    {
+        return left.compareTo(right) > 0;
+    }
+
+    @ScalarOperator(GREATER_THAN_OR_EQUAL)
+    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThanOrEqual(@SqlType("T") Slice left, @SqlType("T") Slice right)
+    {
+        return left.compareTo(right) >= 0;
+    }
+
+    @ScalarOperator(BETWEEN)
+    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean between(@SqlType("T") Slice value, @SqlType("T") Slice min, @SqlType("T") Slice max)
+    {
+        return min.compareTo(value) <= 0 && value.compareTo(max) <= 0;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/VarcharEnumParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarcharEnumParametricType.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.type.ParameterKind;
+import com.facebook.presto.common.type.ParametricType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeParameter;
+import com.facebook.presto.common.type.VarcharEnumType;
+import com.facebook.presto.common.type.VarcharEnumType.VarcharEnumMap;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class VarcharEnumParametricType
+        implements ParametricType
+{
+    private final String name;
+    private final VarcharEnumMap enumMap;
+
+    public VarcharEnumParametricType(String name, VarcharEnumMap enumMap)
+    {
+        this.name = name;
+        this.enumMap = enumMap;
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    {
+        if (parameters.isEmpty()) {
+            return new VarcharEnumType(name, enumMap);
+        }
+        checkArgument(parameters.size() == 1, "Enum type expects exactly one parameter, got %s", parameters);
+        checkArgument(
+                parameters.get(0).getKind() == ParameterKind.VARCHAR_ENUM,
+                "Enum definition expected, got %s",
+                parameters);
+        return new VarcharEnumType(name, parameters.get(0).getVarcharEnumMap());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -437,7 +437,7 @@ public class TestAnalyzer
         assertFails(MISSING_ATTRIBUTE, "SELECT * FROM t1 WHERE f > 1");
     }
 
-    @Test(expectedExceptions = SemanticException.class, expectedExceptionsMessageRegExp = "line 1:8: Column 't.y' cannot be resolved")
+    @Test(expectedExceptions = SemanticException.class, expectedExceptionsMessageRegExp = "line 1:8: 't.y' cannot be resolved")
     public void testInvalidAttributeCorrectErrorMessage()
     {
         analyze("SELECT t.y FROM (VALUES 1) t(x)");
@@ -1165,7 +1165,7 @@ public class TestAnalyzer
         assertFails(MISMATCHED_COLUMN_ALIASES, 1, 19, "CREATE TABLE test(x, y) AS (VALUES 1)");
         assertFails(DUPLICATE_COLUMN_NAME, 1, 24, "CREATE TABLE test(abc, AbC) AS SELECT 1, 2");
         assertFails(COLUMN_TYPE_UNKNOWN, 1, 1, "CREATE TABLE test(x) AS SELECT null");
-        assertFails(MISSING_ATTRIBUTE, ".*Column 'y' cannot be resolved", "CREATE TABLE test(x) WITH (p1 = y) AS SELECT null");
+        assertFails(MISSING_ATTRIBUTE, ".*'y' cannot be resolved", "CREATE TABLE test(x) WITH (p1 = y) AS SELECT null");
         assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1", "CREATE TABLE test(x) WITH (p1 = 'p1', p2 = 'p2', p1 = 'p3') AS SELECT null");
         assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1", "CREATE TABLE test(x) WITH (p1 = 'p1', \"p1\" = 'p2') AS SELECT null");
     }
@@ -1176,7 +1176,7 @@ public class TestAnalyzer
         analyze("CREATE TABLE test (id bigint)");
         analyze("CREATE TABLE test (id bigint) WITH (p1 = 'p1')");
 
-        assertFails(MISSING_ATTRIBUTE, ".*Column 'y' cannot be resolved", "CREATE TABLE test (x bigint) WITH (p1 = y)");
+        assertFails(MISSING_ATTRIBUTE, ".*'y' cannot be resolved", "CREATE TABLE test (x bigint) WITH (p1 = y)");
         assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1", "CREATE TABLE test (id bigint) WITH (p1 = 'p1', p2 = 'p2', p1 = 'p3')");
         assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1", "CREATE TABLE test (id bigint) WITH (p1 = 'p1', \"p1\" = 'p2')");
     }
@@ -1197,7 +1197,7 @@ public class TestAnalyzer
         analyze("CREATE SCHEMA test");
         analyze("CREATE SCHEMA test WITH (p1 = 'p1')");
 
-        assertFails(MISSING_ATTRIBUTE, ".*Column 'y' cannot be resolved", "CREATE SCHEMA test WITH (p1 = y)");
+        assertFails(MISSING_ATTRIBUTE, ".*'y' cannot be resolved", "CREATE SCHEMA test WITH (p1 = y)");
         assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1", "CREATE SCHEMA test WITH (p1 = 'p1', p2 = 'p2', p1 = 'p3')");
         assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1", "CREATE SCHEMA test WITH (p1 = 'p1', \"p1\" = 'p2')");
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestJoinUsing.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestJoinUsing.java
@@ -47,7 +47,7 @@ public class TestJoinUsing
                 "SELECT t.k FROM " +
                         "(VALUES (1, 'a')) AS t(k, v1) JOIN" +
                         "(VALUES (1, 'b')) AS u(k, v2) USING (k)",
-                ".*Column 't.k' cannot be resolved.*");
+                ".*'t.k' cannot be resolved.*");
     }
 
     @Test

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -307,6 +307,11 @@ public abstract class AstVisitor<R, C>
         return visitLiteral(node, context);
     }
 
+    protected R visitEnumLiteral(EnumLiteral node, C context)
+    {
+        return visitLiteral(node, context);
+    }
+
     protected R visitInListExpression(InListExpression node, C context)
     {
         return visitExpression(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/EnumLiteral.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/EnumLiteral.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class EnumLiteral
+        extends Literal
+{
+    private final Object value;
+    private final String type;
+
+    public EnumLiteral(String type, Object value)
+    {
+        this(Optional.empty(), type, value);
+    }
+
+    private EnumLiteral(Optional<NodeLocation> location, String type, Object value)
+    {
+        super(location);
+        this.type = requireNonNull(type, "type is null");
+        this.value = requireNonNull(value, "value is null");
+    }
+
+    public Object getValue()
+    {
+        return value;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitEnumLiteral(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EnumLiteral that = (EnumLiteral) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(value);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeParameter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeParameter.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.spi.function;
 
+import com.facebook.presto.common.type.Type;
+
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -28,4 +30,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface TypeParameter
 {
     String value();
+
+    Class<? extends Type> boundedBy() default Type.class;
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeVariableConstraint.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeVariableConstraint.java
@@ -27,18 +27,30 @@ public class TypeVariableConstraint
     private final boolean comparableRequired;
     private final boolean orderableRequired;
     private final String variadicBound;
+    private final Class<? extends Type> typeBound;
 
     @JsonCreator
     public TypeVariableConstraint(
             @JsonProperty("name") String name,
             @JsonProperty("comparableRequired") boolean comparableRequired,
             @JsonProperty("orderableRequired") boolean orderableRequired,
-            @JsonProperty("variadicBound") @Nullable String variadicBound)
+            @JsonProperty("variadicBound") @Nullable String variadicBound,
+            @JsonProperty("boundedBy") Class<? extends Type> typeBound)
     {
         this.name = name;
         this.comparableRequired = comparableRequired;
         this.orderableRequired = orderableRequired;
         this.variadicBound = variadicBound;
+        this.typeBound = typeBound;
+    }
+
+    public TypeVariableConstraint(
+            @JsonProperty("name") String name,
+            @JsonProperty("comparableRequired") boolean comparableRequired,
+            @JsonProperty("orderableRequired") boolean orderableRequired,
+            @JsonProperty("variadicBound") @Nullable String variadicBound)
+    {
+        this(name, comparableRequired, orderableRequired, variadicBound, Type.class);
     }
 
     @JsonProperty
@@ -65,12 +77,21 @@ public class TypeVariableConstraint
         return variadicBound;
     }
 
+    @JsonProperty
+    public Class<? extends Type> getTypeBound()
+    {
+        return typeBound;
+    }
+
     public boolean canBind(Type type)
     {
         if (comparableRequired && !type.isComparable()) {
             return false;
         }
         if (orderableRequired && !type.isOrderable()) {
+            return false;
+        }
+        if (!typeBound.isInstance(type)) {
             return false;
         }
         if (variadicBound != null && !type.getTypeSignature().getBase().equals(variadicBound)) {
@@ -92,6 +113,9 @@ public class TypeVariableConstraint
         if (variadicBound != null) {
             value += ":" + variadicBound + "<*>";
         }
+        if (!typeBound.equals(Type.class)) {
+            value += " extends " + typeBound.getSimpleName();
+        }
         return value;
     }
 
@@ -108,12 +132,13 @@ public class TypeVariableConstraint
         return comparableRequired == that.comparableRequired &&
                 orderableRequired == that.orderableRequired &&
                 Objects.equals(name, that.name) &&
-                Objects.equals(variadicBound, that.variadicBound);
+                Objects.equals(variadicBound, that.variadicBound) &&
+                Objects.equals(typeBound, that.typeBound);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, comparableRequired, orderableRequired, variadicBound);
+        return Objects.hash(name, comparableRequired, orderableRequired, variadicBound, typeBound);
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -20,11 +20,14 @@ import com.facebook.presto.client.QueryData;
 import com.facebook.presto.client.QueryStatusInfo;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.JsonType;
+import com.facebook.presto.common.type.LongEnumType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.SqlTimestamp;
 import com.facebook.presto.common.type.SqlTimestampWithTimeZone;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarcharEnumType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.spi.PrestoWarning;
@@ -253,6 +256,15 @@ public class TestingPrestoClient
         }
         else if (type instanceof DecimalType) {
             return new BigDecimal((String) value);
+        }
+        else if (type instanceof JsonType) {
+            return value;
+        }
+        else if (type instanceof VarcharEnumType) {
+            return value;
+        }
+        else if (type instanceof LongEnumType) {
+            return ((Number) value).longValue();
         }
         else if (type.getTypeSignature().getBase().equals("ObjectId")) {
             return value;

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.LongEnumType.LongEnumMap;
+import com.facebook.presto.common.type.ParametricType;
+import com.facebook.presto.common.type.VarcharEnumType.VarcharEnumMap;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.type.LongEnumParametricType;
+import com.facebook.presto.type.VarcharEnumParametricType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.util.Collections.singletonList;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestEnums
+        extends AbstractTestQueryFramework
+{
+    private static final Long BIG_VALUE = Integer.MAX_VALUE + 10L; // 2147483657
+
+    private static final LongEnumParametricType MOOD_ENUM = new LongEnumParametricType("Mood", new LongEnumMap(ImmutableMap.of(
+            "HAPPY", 0L,
+            "SAD", 1L,
+            "MELLOW", BIG_VALUE,
+            "curious", -2L)));
+    private static final VarcharEnumParametricType COUNTRY_ENUM = new VarcharEnumParametricType("Country", new VarcharEnumMap(ImmutableMap.of(
+            "US", "United States",
+            "BAHAMAS", "The Bahamas",
+            "FRANCE", "France",
+            "CHINA", "中国",
+            "भारत", "India")));
+    private static final VarcharEnumParametricType TEST_ENUM = new VarcharEnumParametricType("TestEnum", new VarcharEnumMap(ImmutableMap.of(
+            "TEST", "\"}\"",
+            "TEST2", "",
+            "TEST3", " ",
+            "TEST4", ")))\"\"")));
+
+    static class TestEnumPlugin
+            implements Plugin
+    {
+        @Override
+        public Iterable<ParametricType> getParametricTypes()
+        {
+            return ImmutableList.of(MOOD_ENUM, COUNTRY_ENUM, TEST_ENUM);
+        }
+    }
+
+    protected TestEnums()
+    {
+        super(TestEnums::createQueryRunner);
+    }
+
+    private static QueryRunner createQueryRunner()
+    {
+        try {
+            Session session = testSessionBuilder().build();
+            QueryRunner queryRunner = DistributedQueryRunner.builder(session).setNodeCount(1).build();
+            queryRunner.installPlugin(new TestEnumPlugin());
+            return queryRunner;
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void assertQueryResultUnordered(@Language("SQL") String query, List<List<Object>> expectedRows)
+    {
+        MaterializedResult rows = computeActual(query);
+        assertEquals(
+                ImmutableSet.copyOf(rows.getMaterializedRows()),
+                expectedRows.stream().map(row -> new MaterializedRow(1, row)).collect(Collectors.toSet()));
+    }
+
+    private void assertSingleValue(@Language("SQL") String expression, Object expectedResult)
+    {
+        assertQueryResultUnordered("SELECT " + expression, singletonList(singletonList(expectedResult)));
+    }
+
+    @Test
+    public void testEnumLiterals()
+    {
+        assertQueryResultUnordered(
+                "SELECT Mood.HAPPY, mood.happY, \"mood\".SAD, \"mood\".\"mellow\"",
+                singletonList(ImmutableList.of(0L, 0L, 1L, BIG_VALUE)));
+
+        assertQueryResultUnordered(
+                "SELECT Country.us, country.\"CHINA\", Country.\"भारत\"",
+                singletonList(ImmutableList.of("United States", "中国", "India")));
+
+        assertQueryResultUnordered(
+                "SELECT testEnum.TEST, testEnum.TEST2, testEnum.TEST3, array[testEnum.TEST4]",
+                singletonList(ImmutableList.of("\"}\"", "", " ", ImmutableList.of(")))\"\""))));
+
+        assertQueryFails("SELECT mood.hello", ".*No key 'HELLO' in enum 'Mood'");
+    }
+
+    @Test
+    public void testEnumCasts()
+    {
+        assertSingleValue("CAST(CAST(1 AS TINYINT) AS Mood)", 1L);
+        assertSingleValue("CAST('The Bahamas' AS COUNTRY)", "The Bahamas");
+        assertSingleValue("CAST(row(1, 1) as row(x BIGINT, y Mood))", ImmutableList.of(1L, 1L));
+        assertSingleValue("CAST(mood.MELLOW AS BIGINT)", BIG_VALUE);
+        assertSingleValue(
+                "cast(map(array[country.FRANCE], array[array[mood.HAPPY]]) as JSON)",
+                "{\"France\":[0]}");
+        assertSingleValue(
+                "map_filter(MAP(ARRAY[country.FRANCE, country.US], ARRAY[mood.HAPPY, mood.SAD]), (k,v) -> CAST(v AS BIGINT) > 0)",
+                ImmutableMap.of("United States", 1L));
+        assertSingleValue(
+                "cast(JSON '{\"France\": [0]}' as MAP<Country,ARRAY<Mood>>)",
+                ImmutableMap.of("France", singletonList(0L)));
+        assertQueryFails("select cast(7 as mood)", ".*No value '7' in enum 'Mood'");
+    }
+
+    @Test
+    public void testVarcharEnumComparisonOperators()
+    {
+        assertSingleValue("country.US = CAST('United States' AS country)", true);
+        assertSingleValue("country.FRANCE = country.BAHAMAS", false);
+
+        assertSingleValue("country.FRANCE != country.US", true);
+        assertSingleValue("array[country.FRANCE, country.BAHAMAS] != array[country.US, country.BAHAMAS]", true);
+
+        assertSingleValue("country.CHINA IN (country.US, null, country.BAHAMAS, country.China)", true);
+        assertSingleValue("country.BAHAMAS IN (country.US, country.FRANCE)", false);
+
+        assertSingleValue("country.BAHAMAS < country.US", true);
+        assertSingleValue("country.BAHAMAS < country.BAHAMAS", false);
+
+        assertSingleValue("country.\"भारत\" <= country.\"भारत\"", true);
+        assertSingleValue("country.\"भारत\" <= country.FRANCE", false);
+
+        assertSingleValue("country.\"भारत\" >= country.FRANCE", true);
+        assertSingleValue("country.BAHAMAS >= country.US", false);
+
+        assertSingleValue("country.\"भारत\" > country.FRANCE", true);
+        assertSingleValue("country.CHINA > country.CHINA", false);
+
+        assertSingleValue("country.\"भारत\" between country.FRANCE and country.BAHAMAS", true);
+        assertSingleValue("country.US between country.FRANCE and country.\"भारत\"", false);
+
+        assertQueryFails("select country.US = mood.HAPPY", ".* '=' cannot be applied to Country.*, Mood.*");
+        assertQueryFails("select country.US IN (country.CHINA, mood.SAD)", ".* All IN list values must be the same type.*");
+        assertQueryFails("select country.US IN (mood.HAPPY, mood.SAD)", ".* IN value and list items must be the same type: Country");
+        assertQueryFails("select country.US > 2", ".* '>' cannot be applied to Country.*, integer");
+    }
+
+    @Test
+    public void testLongEnumComparisonOperators()
+    {
+        assertSingleValue("mood.HAPPY = CAST(0 AS mood)", true);
+        assertSingleValue("mood.HAPPY = mood.SAD", false);
+
+        assertSingleValue("mood.SAD != mood.MELLOW", true);
+        assertSingleValue("array[mood.HAPPY, mood.SAD] != array[mood.SAD, mood.HAPPY]", true);
+
+        assertSingleValue("mood.SAD IN (mood.HAPPY, null, mood.SAD)", true);
+        assertSingleValue("mood.HAPPY IN (mood.SAD, mood.MELLOW)", false);
+
+        assertSingleValue("mood.CURIOUS < mood.MELLOW", true);
+        assertSingleValue("mood.SAD < mood.HAPPY", false);
+
+        assertSingleValue("mood.HAPPY <= mood.HAPPY", true);
+        assertSingleValue("mood.HAPPY <= mood.CURIOUS", false);
+
+        assertSingleValue("mood.MELLOW >= mood.SAD", true);
+        assertSingleValue("mood.HAPPY >= mood.SAD", false);
+
+        assertSingleValue("mood.SAD > mood.HAPPY", true);
+        assertSingleValue("mood.HAPPY > mood.HAPPY", false);
+
+        assertSingleValue("mood.HAPPY between mood.CURIOUS and mood.SAD ", true);
+        assertSingleValue("mood.MELLOW between mood.SAD and mood.HAPPY", false);
+
+        assertQueryFails("select mood.HAPPY = 3", ".* '=' cannot be applied to Mood.*, integer");
+    }
+
+    @Test
+    public void testEnumHashOperators()
+    {
+        assertQueryResultUnordered(
+                "SELECT DISTINCT x " +
+                        "FROM (VALUES mood.happy, mood.sad, mood.sad, mood.happy) t(x)",
+                ImmutableList.of(
+                        ImmutableList.of(0L),
+                        ImmutableList.of(1L)));
+
+        assertQueryResultUnordered(
+                "SELECT DISTINCT x " +
+                        "FROM (VALUES country.FRANCE, country.FRANCE, country.\"भारत\") t(x)",
+                ImmutableList.of(
+                        ImmutableList.of("France"),
+                        ImmutableList.of("India")));
+
+        assertQueryResultUnordered(
+                "SELECT APPROX_DISTINCT(x), APPROX_DISTINCT(y)" +
+                        "FROM (VALUES (country.FRANCE, mood.HAPPY), " +
+                        "             (country.FRANCE, mood.SAD)," +
+                        "             (country.US, mood.HAPPY)) t(x, y)",
+                ImmutableList.of(
+                        ImmutableList.of(2L, 2L)));
+    }
+
+    @Test
+    public void testEnumAggregation()
+    {
+        assertQueryResultUnordered(
+                "  SELECT a, ARRAY_AGG(DISTINCT b) " +
+                        "FROM (VALUES (mood.happy, country.us), " +
+                        "             (mood.happy, country.china)," +
+                        "             (mood.happy, country.CHINA)," +
+                        "             (mood.sad, country.us)) t(a, b)" +
+                        "GROUP BY a",
+                ImmutableList.of(
+                        ImmutableList.of(0L, ImmutableList.of("United States", "中国")),
+                        ImmutableList.of(1L, ImmutableList.of("United States"))));
+    }
+
+    @Test
+    public void testEnumJoin()
+    {
+        assertQueryResultUnordered(
+                "  SELECT t1.a, t2.b " +
+                        "FROM (VALUES mood.happy, mood.sad, mood.mellow) t1(a) " +
+                        "JOIN (VALUES (mood.sad, 'hello'), (mood.happy, 'world')) t2(a, b) " +
+                        "ON t1.a = t2.a",
+                ImmutableList.of(
+                        ImmutableList.of(1L, "hello"),
+                        ImmutableList.of(0L, "world")));
+    }
+
+    @Test
+    public void testEnumWindow()
+    {
+        assertQueryResultUnordered(
+                "  SELECT first_value(b) OVER (PARTITION BY a ORDER BY a) AS rnk " +
+                        "FROM (VALUES (mood.happy, 1), (mood.happy, 3), (mood.sad, 5)) t(a, b)",
+                ImmutableList.of(singletonList(1), singletonList(1), singletonList(5)));
+    }
+}


### PR DESCRIPTION
This PR is the first in a series that aims to introduce support for user-defined types, and specifically user-defined enums, into Presto (see #14691 for an overview of the work).

This one focuses specifically on introducing the base types and generic operators that apply to enums. 
We support
* enum literals, eg `Mood.HAPPY`
* cast to and from base types
* `=`, `!=` and `IS_DISTINCT`
* hash operator used for `IN (...)` and `APPROX_DISTINCT()`
* cast to and from JSON
* comparisons and ordering (using the rules of the underlying types)


## Implementation notes
* Enum literals like `Mood.HAPPY` are parsed as Dereferences in the AST (like `my_table.my_col`) and they are then rewritten as EnumLiterals in the TranslationMap's rewriter. 
* I added a new type bound constraint to express that we want a given type to be a long enum or varchar enum, so that we can have enum operator signatures like `<T extends LongEnumType> equals(T, T): bool` . This constraint is similar to the `orderable` and `comparable` constraint we use to define the type signature of functions like the equal operator on arrays.

In future PRs, I will introduce 
* the ability to register enum types from plugins
* the ability to serialize enum data to the client




