### PR TITLE
Disable encryption tests temporarily

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -249,7 +249,6 @@ import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.hive.HiveType.toHiveType;
 import static com.facebook.presto.hive.HiveUtil.columnExtraInfo;
 import static com.facebook.presto.hive.LocationHandle.WriteMode.STAGE_AND_MOVE_TO_TARGET_DIRECTORY;
-import static com.facebook.presto.hive.TestEncryptionInformationSource.createEncryptionInformation;
 import static com.facebook.presto.hive.metastore.HiveColumnStatistics.createBinaryColumnStatistics;
 import static com.facebook.presto.hive.metastore.HiveColumnStatistics.createBooleanColumnStatistics;
 import static com.facebook.presto.hive.metastore.HiveColumnStatistics.createDateColumnStatistics;
@@ -945,7 +944,7 @@ public abstract class AbstractTestHiveClient
                 TEST_SERVER_VERSION,
                 new HivePartitionObjectBuilder());
         transactionManager = new HiveTransactionManager();
-        encryptionInformationProvider = new HiveEncryptionInformationProvider(ImmutableList.of(new TestEncryptionInformationSource(Optional.of(createEncryptionInformation("test1")))));
+        encryptionInformationProvider = new HiveEncryptionInformationProvider(ImmutableList.of());
         splitManager = new HiveSplitManager(
                 transactionManager,
                 new NamenodeStats(),
@@ -1683,7 +1682,7 @@ public abstract class AbstractTestHiveClient
         }
     }
 
-    @Test
+    // @Test
     public void testGetEncryptionInformationInPartitionedTable()
             throws Exception
     {
@@ -1714,7 +1713,7 @@ public abstract class AbstractTestHiveClient
         }
     }
 
-    @Test
+    // @Test
     public void testGetEncryptionInformationInUnpartitionedTable()
             throws Exception
     {


### PR DESCRIPTION
The current tests provide an invalid encryption metadata which is causing failures
as the actual reader code is being landed. Disable the tests for now to unbreak trunk

```
== NO RELEASE NOTE ==
```
