### PR TITLE
Add session parameter to control ARRAY_AGG NULL behavior

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -8464,6 +8464,14 @@ public abstract class AbstractTestQueries
                 "select count(distinct y) from " + input);
 
         assertQuery(
+                "select set_agg(x) is null from (select cast(null as bigint) x)",
+                "values true");
+
+        assertQuery(
+                "select y, set_agg(x) is null from (select 1 y, cast(null as bigint) x) group by y",
+                "values (1, true)");
+
+        assertQuery(
                 "select count() from " +
                         "(select set_agg(orderkey) = array_agg(distinct orderkey) eq from orders group by custkey) where eq",
                 "select count(distinct custkey) from orders");


### PR DESCRIPTION
ARRAY_AGG returns NULL if any of the inputs is null. But SET_AGG the way it was implemented will return ARRAY[NULL]. This is not desirable and leads to confusion. So we make SET_AGG behave just like ARRAY_AGG DISTINCT.

```
== RELEASE NOTES ==

General Changes
* SET_AGG(x) aggregation function evaluates to NULL if any of the input values is NULL.

```
