### PR TITLE
Introduce NodeProvider interface and consistent hashing algorithm for unbucketed table scheduling

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/AccumuloSplit.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/AccumuloSplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.accumulo.model;
 import com.facebook.presto.accumulo.serializers.AccumuloRowSerializer;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -168,7 +169,7 @@ public class AccumuloSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return addresses;
     }

--- a/presto-atop/src/main/java/com/facebook/presto/atop/AtopSplit.java
+++ b/presto-atop/src/main/java/com/facebook/presto/atop/AtopSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.atop;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -85,7 +86,7 @@ public class AtopSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         // discard the port number
         return ImmutableList.of(HostAddress.fromString(host.getHostText()));

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplit.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplit.java
@@ -18,6 +18,7 @@ import com.facebook.presto.plugin.jdbc.optimization.JdbcExpression;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -108,7 +109,7 @@ public class JdbcSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return ImmutableList.of();
     }

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleSplit.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.plugin.blackhole;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -79,7 +80,7 @@ public final class BlackHoleSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return ImmutableList.of();
     }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSplit.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.cassandra;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -97,7 +98,7 @@ public class CassandraSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return addresses;
     }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidSplit.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidSplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.druid;
 import com.facebook.presto.druid.metadata.DruidSegmentInfo;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -106,7 +107,7 @@ public class DruidSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return address.map(ImmutableList::of).orElse(ImmutableList.of());
     }

--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchSplit.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchSplit.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -81,7 +82,7 @@ public class ElasticsearchSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return address.map(host -> ImmutableList.of(HostAddress.fromString(host)))
                 .orElseGet(ImmutableList::of);

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleSplit.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.example;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -86,7 +87,7 @@ public class ExampleSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return addresses;
     }

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxSplit.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.connector.jmx;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -59,7 +60,7 @@ public class JmxSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return addresses;
     }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSplit.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.kafka;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -137,7 +138,7 @@ public class KafkaSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return ImmutableList.of(leader);
     }

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduSplit.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.kudu;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -67,7 +68,7 @@ public class KuduSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return ImmutableList.of();
     }

--- a/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileSplit.java
+++ b/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileSplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.localfile;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -71,7 +72,7 @@ public class LocalFileSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return ImmutableList.of(address);
     }

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.connector.informationSchema;
 import com.facebook.presto.metadata.QualifiedTablePrefix;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -64,7 +65,7 @@ public class InformationSchemaSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return addresses;
     }

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplit.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -78,7 +79,7 @@ public class SystemSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return addresses;
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeMap.java
@@ -67,4 +67,9 @@ public class NodeMap
     {
         return coordinatorNodeIds;
     }
+
+    public Set<HostAddress> getHostAndAddress()
+    {
+        return nodesByHostAndPort.keySet();
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -73,6 +73,7 @@ public class NodeScheduler
     private final boolean includeCoordinator;
     private final int maxSplitsPerNode;
     private final int maxPendingSplitsPerTask;
+    private final NodeSelectionHashFunction nodeSelectionHashFunction;
     private final NodeTaskMap nodeTaskMap;
     private final boolean useNetworkTopology;
     private final Duration nodeMapRefreshInterval;
@@ -102,6 +103,7 @@ public class NodeScheduler
         this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
         checkArgument(maxSplitsPerNode >= maxPendingSplitsPerTask, "maxSplitsPerNode must be > maxPendingSplitsPerTask");
         this.useNetworkTopology = !config.getNetworkTopology().equals(NetworkTopologyType.LEGACY);
+        this.nodeSelectionHashFunction = config.getNodeSelectionHashFunction();
 
         ImmutableList.Builder<CounterStat> builder = ImmutableList.builder();
         if (useNetworkTopology) {
@@ -156,10 +158,21 @@ public class NodeScheduler
                     maxPendingSplitsPerTask,
                     topologicalSplitCounters,
                     networkLocationSegmentNames,
-                    networkLocationCache);
+                    networkLocationCache,
+                    nodeSelectionHashFunction);
         }
         else {
-            return new SimpleNodeSelector(nodeManager, nodeSelectionStats, nodeTaskMap, includeCoordinator, nodeMap, minCandidates, maxSplitsPerNode, maxPendingSplitsPerTask, maxTasksPerStage);
+            return new SimpleNodeSelector(
+                    nodeManager,
+                    nodeSelectionStats,
+                    nodeTaskMap,
+                    includeCoordinator,
+                    nodeMap,
+                    minCandidates,
+                    maxSplitsPerNode,
+                    maxPendingSplitsPerTask,
+                    maxTasksPerStage,
+                    nodeSelectionHashFunction);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
@@ -20,6 +20,8 @@ import com.facebook.airlift.configuration.LegacyConfig;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
+import static com.facebook.presto.execution.scheduler.NodeSelectionHashFunction.MODULAR;
+
 @DefunctConfig({"node-scheduler.location-aware-scheduling-enabled", "node-scheduler.multiple-tasks-per-node-enabled"})
 public class NodeSchedulerConfig
 {
@@ -34,6 +36,7 @@ public class NodeSchedulerConfig
     private boolean includeCoordinator = true;
     private int maxSplitsPerNode = 100;
     private int maxPendingSplitsPerTask = 10;
+    private NodeSelectionHashFunction nodeSelectionHashFunction = MODULAR;
     private String networkTopology = NetworkTopologyType.LEGACY;
 
     @NotNull
@@ -96,6 +99,18 @@ public class NodeSchedulerConfig
     public NodeSchedulerConfig setMaxSplitsPerNode(int maxSplitsPerNode)
     {
         this.maxSplitsPerNode = maxSplitsPerNode;
+        return this;
+    }
+
+    public NodeSelectionHashFunction getNodeSelectionHashFunction()
+    {
+        return nodeSelectionHashFunction;
+    }
+
+    @Config("node-scheduler.node-selection-hash-function")
+    public NodeSchedulerConfig setNodeSelectionHashFunction(NodeSelectionHashFunction nodeSelectionHashFunction)
+    {
+        this.nodeSelectionHashFunction = nodeSelectionHashFunction;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSelectionHashFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSelectionHashFunction.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+public enum NodeSelectionHashFunction
+{
+    MODULAR,
+    CONSISTENT_HASHING
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Split.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Split.java
@@ -17,6 +17,7 @@ import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.SplitContext;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
@@ -94,9 +95,9 @@ public final class Split
         return connectorSplit.getInfo();
     }
 
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
-        return connectorSplit.getPreferredNodes(sortedCandidates);
+        return connectorSplit.getPreferredNodes(nodeProvider);
     }
 
     public NodeSelectionStrategy getNodeSelectionStrategy()

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.index;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 
@@ -39,7 +40,7 @@ public class IndexSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/main/java/com/facebook/presto/split/EmptySplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/EmptySplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.split;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -45,7 +46,7 @@ public class EmptySplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return ImmutableList.of();
     }

--- a/presto-main/src/main/java/com/facebook/presto/split/RemoteSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/RemoteSplit.java
@@ -17,6 +17,7 @@ import com.facebook.presto.execution.Location;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -66,7 +67,7 @@ public class RemoteSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return ImmutableList.of();
     }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.testing;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -69,7 +70,7 @@ public class TestingSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return addresses;
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
@@ -28,6 +28,7 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.facebook.presto.testing.TestingTransactionHandle;
@@ -272,7 +273,7 @@ public class BenchmarkNodeScheduler
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
         {
             return hosts;
         }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
@@ -21,6 +21,8 @@ import org.testng.annotations.Test;
 import java.util.Map;
 
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.LEGACY;
+import static com.facebook.presto.execution.scheduler.NodeSelectionHashFunction.CONSISTENT_HASHING;
+import static com.facebook.presto.execution.scheduler.NodeSelectionHashFunction.MODULAR;
 
 public class TestNodeSchedulerConfig
 {
@@ -32,6 +34,7 @@ public class TestNodeSchedulerConfig
                 .setMinCandidates(10)
                 .setMaxSplitsPerNode(100)
                 .setMaxPendingSplitsPerTask(10)
+                .setNodeSelectionHashFunction(MODULAR)
                 .setIncludeCoordinator(true));
     }
 
@@ -43,6 +46,7 @@ public class TestNodeSchedulerConfig
                 .put("node-scheduler.min-candidates", "11")
                 .put("node-scheduler.include-coordinator", "false")
                 .put("node-scheduler.max-pending-splits-per-task", "11")
+                .put("node-scheduler.node-selection-hash-function", "CONSISTENT_HASHING")
                 .put("node-scheduler.max-splits-per-node", "101")
                 .build();
 
@@ -51,6 +55,7 @@ public class TestNodeSchedulerConfig
                 .setIncludeCoordinator(false)
                 .setMaxSplitsPerNode(101)
                 .setMaxPendingSplitsPerTask(11)
+                .setNodeSelectionHashFunction(CONSISTENT_HASHING)
                 .setMinCandidates(11);
 
         ConfigAssertions.assertFullMapping(properties, expected);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -44,6 +44,7 @@ import com.facebook.presto.operator.ValuesOperator.ValuesOperatorFactory;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.UpdatablePageSource;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
@@ -1343,7 +1344,7 @@ public class TestSqlTaskExecution
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
         {
             return ImmutableList.of();
         }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/group/TestDynamicLifespanScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/group/TestDynamicLifespanScheduler.java
@@ -21,6 +21,7 @@ import com.facebook.presto.execution.scheduler.SourceScheduler;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
@@ -295,7 +296,7 @@ public class TestDynamicLifespanScheduler
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
         {
             return ImmutableList.of();
         }

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestSystemMemoryBlocking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestSystemMemoryBlocking.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
@@ -165,7 +166,7 @@ public class TestSystemMemoryBlocking
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
         {
             return ImmutableList.of();
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
@@ -545,7 +546,7 @@ public class TestDriver
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
         {
             return ImmutableList.of();
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -46,6 +46,7 @@ import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.InMemoryRecordSet;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordPageSource;
 import com.facebook.presto.spi.RecordSet;
@@ -1145,7 +1146,7 @@ public final class FunctionAssertions
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
         {
             return ImmutableList.of();
         }

--- a/presto-main/src/test/java/com/facebook/presto/split/MockSplitSource.java
+++ b/presto-main/src/test/java/com/facebook/presto/split/MockSplitSource.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
@@ -171,7 +172,7 @@ public class MockSplitSource
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
         {
             return ImmutableList.of();
         }

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplit.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.plugin.memory;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -92,7 +93,7 @@ public class MemorySplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return ImmutableList.of(address);
     }

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSplit.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSplit.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -71,7 +72,7 @@ public class MongoSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return addresses;
     }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSplit.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.pinot;
 import com.facebook.presto.pinot.query.PinotQueryGenerator;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -160,7 +161,7 @@ public class PinotSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return ImmutableList.of();
     }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplit.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplit.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -151,7 +152,7 @@ public class RaptorSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return addresses;
     }

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisSplit.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.redis;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -143,7 +144,7 @@ public final class RedisSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return nodes;
     }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestQueries.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestQueries.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.facebook.presto.testing.TestingTransactionHandle;
@@ -315,7 +316,7 @@ public class TestPrestoSparkAbstractTestQueries
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
         {
             throw new UnsupportedOperationException();
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplit.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplit.java
@@ -34,8 +34,9 @@ public interface ConnectorSplit
      * 2. Otherwise, the scheduler will prioritize the provided nodes if the strategy is SOFT_AFFINITY.
      * But there is no guarantee that the scheduler will pick them if the provided nodes are busy.
      * 3. Empty list indicates no preference.
+     * @param nodeProvider
      */
-    List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates);
+    List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider);
 
     Object getInfo();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConsistentHashingNodeProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConsistentHashingNodeProvider.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
+import static java.util.Collections.unmodifiableList;
+
+public class ConsistentHashingNodeProvider<T>
+        implements NodeProvider<T>
+{
+    private final SortedMap<Integer, T> circle = new TreeMap<>();
+
+    public ConsistentHashingNodeProvider(Collection<T> nodes)
+    {
+        if (nodes == null || nodes.isEmpty()) {
+            throw new PrestoException(NO_NODES_AVAILABLE, "nodes is null or empty for ConsistentHashingNodeProvider");
+        }
+        for (T node : nodes) {
+            add(node);
+        }
+    }
+
+    /**
+     * Get target nodes for a particular key
+     * By first locating the node for the key and clockwise append the rest of the nodes in hash ring to the target list
+     * Until we have reached the number of nodes or we have exhausted the hash ring
+     *
+     */
+    public List<T> get(Object key, int count)
+    {
+        if (circle.isEmpty() || key == null) {
+            return unmodifiableList(new ArrayList<>());
+        }
+
+        List<T> nodes = new ArrayList<>();
+        int targetPosition = findPosition(key);
+        Iterator<T> iterator = circle.tailMap(targetPosition).values().iterator();
+        while (nodes.size() < count && nodes.size() < circle.size() && iterator.hasNext()) {
+            nodes.add(iterator.next());
+        }
+
+        iterator = circle.values().iterator();
+        while (nodes.size() < count && nodes.size() < circle.size()) {
+            nodes.add(iterator.next());
+        }
+
+        return unmodifiableList(nodes);
+    }
+
+    private int findPosition(Object key)
+    {
+        int position = key.hashCode();
+        if (!circle.containsKey(position)) {
+            SortedMap<Integer, T> tailMap = circle.tailMap(position);
+            position = tailMap.isEmpty() ? circle.firstKey() : tailMap.firstKey();
+        }
+        return position;
+    }
+
+    private void add(T node)
+    {
+        circle.put(node.hashCode(), node);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ModularHashingNodeProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ModularHashingNodeProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
+import static java.util.Collections.unmodifiableList;
+
+public class ModularHashingNodeProvider<T>
+        implements NodeProvider<T>
+{
+    private final List<T> sortedCandidates;
+
+    public ModularHashingNodeProvider(List<T> sortedCandidates)
+    {
+        if (sortedCandidates == null || sortedCandidates.isEmpty()) {
+            throw new PrestoException(NO_NODES_AVAILABLE, "sortedCandidates is null or empty for ModularHashingNodeProvider");
+        }
+        this.sortedCandidates = sortedCandidates;
+    }
+
+    /**
+     * Provider function that returns a list of nodes for a given key, internally it will use modular hashing function
+     * Use key's hashcode to mode node candidates size as the target position and get the corresponding node from the list
+     * If target count is larger than one, sequentially get the rest of the nodes following the target node
+     *
+     * @param key
+     * @param count
+     * @return Optional<List < T>>
+     */
+    @Override
+    public List<T> get(Object key, int count)
+    {
+        int size = sortedCandidates.size();
+        int mod = key.hashCode() % size;
+        int position = mod < 0 ? mod + size : mod;
+        List<T> chosenCandidates = new ArrayList<>();
+        for (int i = 0; i < count && i < sortedCandidates.size(); i++) {
+            chosenCandidates.add(sortedCandidates.get((position + i) % size));
+        }
+        return unmodifiableList(chosenCandidates);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ModularHashingNodeProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ModularHashingNodeProvider.java
@@ -37,9 +37,6 @@ public class ModularHashingNodeProvider<T>
      * Use key's hashcode to mode node candidates size as the target position and get the corresponding node from the list
      * If target count is larger than one, sequentially get the rest of the nodes following the target node
      *
-     * @param key
-     * @param count
-     * @return Optional<List < T>>
      */
     @Override
     public List<T> get(Object key, int count)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/NodeProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/NodeProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import java.util.List;
+
+public interface NodeProvider<T>
+{
+    /**
+     * @param key   a hashable identity to indicate how to obtain the nodes
+     * @param count how many desirable nodes to be returned
+     * @return a list of the chosen nodes by specific hash function
+     */
+    List<T> get(Object key, int count);
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestConsistentHashingNodeProvider.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestConsistentHashingNodeProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestConsistentHashingNodeProvider
+{
+    @Test
+    public void testEquality()
+    {
+        TestingProviderNode node1 = new TestingProviderNode(10);
+        TestingProviderNode node2 = new TestingProviderNode(20);
+        TestingProviderNode node3 = new TestingProviderNode(30);
+        TestingProviderNode node4 = new TestingProviderNode(40);
+        NodeProvider<TestingProviderNode> nodeProvider = new ConsistentHashingNodeProvider<>(ImmutableList.of(node1, node2, node3, node4));
+        assertEquals(nodeProvider.get(13, 2), ImmutableList.of(node2, node3));
+        assertEquals(nodeProvider.get(23, 5), ImmutableList.of(node3, node4, node1, node2));
+    }
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestModularHashingNodeProvider.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestModularHashingNodeProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestModularHashingNodeProvider
+{
+    @Test
+    public void testEquality()
+    {
+        TestingProviderNode node1 = new TestingProviderNode(10);
+        TestingProviderNode node2 = new TestingProviderNode(20);
+        TestingProviderNode node3 = new TestingProviderNode(30);
+        TestingProviderNode node4 = new TestingProviderNode(40);
+        NodeProvider<TestingProviderNode> nodeProvider = new ModularHashingNodeProvider<>(ImmutableList.of(node1, node2, node3, node4));
+        assertEquals(nodeProvider.get(13, 2), ImmutableList.of(node2, node3));
+        assertEquals(nodeProvider.get(23, 5), ImmutableList.of(node4, node1, node2, node3));
+    }
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestingProviderNode.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestingProviderNode.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+public class TestingProviderNode
+{
+    private final int identifier;
+
+    public TestingProviderNode(int identifier)
+    {
+        this.identifier = identifier;
+    }
+
+    public int getIdentifier()
+    {
+        return identifier;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TestingProviderNode testNode = (TestingProviderNode) o;
+        return identifier == testNode.identifier;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return identifier;
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorSplit.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorSplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.connector.thrift;
 import com.facebook.presto.connector.thrift.api.PrestoThriftId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -50,7 +51,7 @@ public class ThriftConnectorSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return addresses;
     }

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsSplit.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.tpcds;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -95,7 +96,7 @@ public class TpcdsSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return addresses;
     }

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchSplit.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchSplit.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -95,7 +96,7 @@ public class TpchSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider<HostAddress> nodeProvider)
     {
         return addresses;
     }


### PR DESCRIPTION
```
== RELEASE NOTES ==

SPI Changes
* Introduce `NodeProvider` which has two implementations: `ModularHashingNodeProvider` and `ConsistentHashingNodeProvider`. It provides different node selection algorithms.

General Changes
* Add config `node-scheduler.node-selection-hash-function` to choose `NodeSelectionHashFunction`, it will decide which node selection algorithm to apply for scheduler.
```

Todo
- [ ] Add more tests
