### PR TITLE
Fix confusion matrix computation for classification function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -505,7 +505,7 @@ To find the `ROC curve <https://en.wikipedia.org/wiki/Receiver_operating_charact
     .. math ::
 
         {
-            \sum_{i \;|\; x_i \leq t_j \bigwedge y_i = 0} \left[ w_i \right]
+            \sum_{i \;|\; x_i > t_j \bigwedge y_i = 0} \left[ w_i \right]
             \over
             \sum_{i \;|\; y_i = 0} \left[ w_i \right]
         },

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/PrecisionRecallAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/PrecisionRecallAggregation.java
@@ -220,8 +220,8 @@ public abstract class PrecisionRecallAggregation
                         totalFalseWeight,
                         totalTrueWeight - runningTrueWeight,
                         runningFalseWeight,
-                        runningTrueWeight,
-                        totalFalseWeight - runningFalseWeight);
+                        totalFalseWeight - runningFalseWeight,
+                        runningTrueWeight);
 
                 runningTrueWeight += trueResult.getWeight();
                 runningFalseWeight += falseResult.getWeight();

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationMissRateAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationMissRateAggregation.java
@@ -34,7 +34,9 @@ public class TestClassificationMissRateAggregation
         final ArrayList<Double> expected = new ArrayList<>();
         while (iterator.hasNext()) {
             final BucketResult result = iterator.next();
-            final double missRate = result.remainingFalseWeight / result.totalTrueWeight;
+            final double positive = result.totalTrueWeight;
+            final double falseNegative = result.totalTrueWeight - result.remainingTrueWeight;
+            final double missRate = falseNegative / positive;
             expected.add(missRate);
         }
         return expected;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationPrecisionAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestClassificationPrecisionAggregation.java
@@ -34,8 +34,9 @@ public class TestClassificationPrecisionAggregation
         final ArrayList<Double> expected = new ArrayList<>();
         while (iterator.hasNext()) {
             final TestPrecisionRecallAggregation.BucketResult result = iterator.next();
-            final double precision = result.remainingTrueWeight /
-                    (result.remainingTrueWeight + result.remainingFalseWeight);
+            final double truePositive = result.remainingTrueWeight;
+            final double falseNegative = result.totalTrueWeight - result.remainingTrueWeight;
+            final double precision = truePositive / (truePositive + falseNegative);
             expected.add(precision);
         }
         return expected;


### PR DESCRIPTION
Fixes #14731 and fixes #14750
1. fix document mistake for `classification_fall_out`
2. fix confusion matrix computation.

Definition: https://en.wikipedia.org/wiki/Precision_and_recall#Definition_(classification_context)

|  | predicated positive | predicated negative |
| --- | --- | --- |
| condition positive | True Positive(TP) | False Negative(FN) |
| condition negative | False Positive(FP) | True Negative(TN) |

there are some variables in code.
```
totalTrueWeight = {sum of condition positive}
totalFalseWeight = {sum of condition negative}
runningTrueWeight = {sum of predicated negative in {condition positive}}
runningFalseWeight = {sum of predicated negative in {condition negative}}
```

So we got

|  | predicated positive | predicated negative | |
| --- | --- | --- | --- |
| condition positive | totalTrueWeight - runningTrueWeight | runningTrueWeight | totalTrueWeight |
| condition negative | totalFalseWeight - runningFalseWeight | runningFalseWeight | totalFalseWeight |

```
== RELEASE NOTES ==

General Changes
* Fix  :func:`classification_miss_rate` and :func:`classification_fall_out` functions (:pr:`14740`)
