### PR TITLE
Turn off failure detector by default in tests

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -104,9 +104,6 @@ public class TestHivePushdownFilterQueries
     {
         DistributedQueryRunner queryRunner = HiveQueryRunner.createQueryRunner(getTables(),
                 ImmutableMap.of("experimental.pushdown-subfields-enabled", "true"),
-                // TODO: enable failure detector.  Currently this test has a ton of major GC activity on travis,
-                //  and the failure detector may make the test run longer
-                ImmutableMap.of("failure-detector.enabled", "false"),
                 "sql-standard",
                 ImmutableMap.of("hive.pushdown-filter-enabled", "true"),
                 Optional.empty());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
@@ -102,6 +102,7 @@ public class TestHiveRecoverableExecution
 
         extraCoordinatorPropertiesBuilder
                 // decrease the heartbeat interval so we detect failed nodes faster
+                .put("failure-detector.enabled", "true")
                 .put("failure-detector.heartbeat-interval", "1s")
                 .put("failure-detector.http-client.request-timeout", "500ms")
                 .put("failure-detector.exponential-decay-seconds", "1")

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/JmxQueryRunner.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/JmxQueryRunner.java
@@ -15,7 +15,6 @@ package com.facebook.presto.connector.jmx;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.tests.DistributedQueryRunner;
-import com.google.common.collect.ImmutableMap;
 
 import static com.facebook.airlift.testing.Closeables.closeAllSuppress;
 import static com.facebook.presto.connector.jmx.JmxMetadata.JMX_SCHEMA_NAME;
@@ -33,8 +32,6 @@ public final class JmxQueryRunner
         try {
             queryRunner = DistributedQueryRunner.builder(createSession())
                     .setNodeCount(3)
-                    // disable failure-detector to prevent flaky tests since the jmx tests rely on the number of nodes being consistent
-                    .setCoordinatorProperties(ImmutableMap.of("failure-detector.enabled", "false"))
                     .build();
 
             queryRunner.installPlugin(new JmxPlugin());

--- a/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryWorkerCrash.java
+++ b/presto-memory/src/test/java/com/facebook/presto/plugin/memory/TestMemoryWorkerCrash.java
@@ -16,12 +16,10 @@ package com.facebook.presto.plugin.memory;
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.facebook.presto.tests.DistributedQueryRunner;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import static com.facebook.airlift.testing.Assertions.assertLessThan;
-import static com.facebook.presto.plugin.memory.MemoryQueryRunner.createQueryRunner;
 import static io.airlift.units.Duration.nanosSince;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -32,8 +30,7 @@ public class TestMemoryWorkerCrash
 {
     protected TestMemoryWorkerCrash()
     {
-        // failure detector causes test flakiness
-        super(() -> createQueryRunner(ImmutableMap.of("failure-detector.enabled", "false"), ImmutableMap.of()));
+        super(MemoryQueryRunner::createQueryRunner);
     }
 
     @Test

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/RaptorQueryRunner.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/RaptorQueryRunner.java
@@ -59,8 +59,6 @@ public final class RaptorQueryRunner
     {
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(createSession("tpch"))
                 .setNodeCount(2)
-                // TODO: enable failure-detector for raptor. Currently enabling the failure detector causes failures.
-                .setCoordinatorProperties(ImmutableMap.of("failure-detector.enabled", "false"))
                 .setExtraProperties(extraProperties)
                 .build();
 


### PR DESCRIPTION
The node failure detector can make tests flakey by marking active nodes
offline.


```
== NO RELEASE NOTE ==
```
