### PR TITLE
Ensure exception thrown by scheduled tasks are logged

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCacheManager.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCacheManager.java
@@ -153,8 +153,13 @@ public class FileMergeCacheManager
 
         this.cacheSizeCalculateExecutor.scheduleAtFixedRate(
                 () -> {
-                    cacheScopeFiles.keySet().forEach(cacheIdentifier -> cacheScopeSizeInBytes.put(cacheIdentifier, getCacheScopeSizeInBytes(cacheIdentifier)));
-                    cacheScopeSizeInBytes.keySet().removeIf(key -> !cacheScopeFiles.containsKey(key));
+                    try {
+                        cacheScopeFiles.keySet().forEach(cacheIdentifier -> cacheScopeSizeInBytes.put(cacheIdentifier, getCacheScopeSizeInBytes(cacheIdentifier)));
+                        cacheScopeSizeInBytes.keySet().removeIf(key -> !cacheScopeFiles.containsKey(key));
+                    }
+                    catch (Throwable t) {
+                        log.error(t, "Error calculating cache size");
+                    }
                 },
                 0,
                 15,

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -238,13 +238,13 @@ public class SqlTaskManager
                 removeOldTasks();
             }
             catch (Throwable e) {
-                log.warn(e, "Error removing old tasks");
+                log.error(e, "Error removing old tasks");
             }
             try {
                 failAbandonedTasks();
             }
             catch (Throwable e) {
-                log.warn(e, "Error canceling abandoned tasks");
+                log.error(e, "Error canceling abandoned tasks");
             }
         }, 200, 200, TimeUnit.MILLISECONDS);
 
@@ -253,7 +253,7 @@ public class SqlTaskManager
                 updateStats();
             }
             catch (Throwable e) {
-                log.warn(e, "Error updating stats");
+                log.error(e, "Error updating stats");
             }
         }, 0, 1, TimeUnit.SECONDS);
     }

--- a/presto-main/src/main/java/com/facebook/presto/failureDetector/HeartbeatFailureDetector.java
+++ b/presto-main/src/main/java/com/facebook/presto/failureDetector/HeartbeatFailureDetector.java
@@ -143,7 +143,7 @@ public class HeartbeatFailureDetector
                     }
                     catch (Throwable e) {
                         // ignore to avoid getting unscheduled
-                        log.warn(e, "Error updating services");
+                        log.error(e, "Error updating services");
                     }
                 }
             }, 0, 5, TimeUnit.SECONDS);
@@ -332,7 +332,7 @@ public class HeartbeatFailureDetector
                         }
                         catch (Throwable e) {
                             // ignore to avoid getting unscheduled
-                            log.warn(e, "Error pinging service %s (%s)", service.getId(), uri);
+                            log.error(e, "Error pinging service %s (%s)", service.getId(), uri);
                         }
                     }
                 }, heartbeat.toMillis(), heartbeat.toMillis(), TimeUnit.MILLISECONDS);

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
@@ -139,7 +139,7 @@ public class QueuedStatementResource
                         }
                     }
                     catch (Throwable e) {
-                        log.warn(e, "Error removing old queries");
+                        log.error(e, "Error removing old queries");
                     }
                 },
                 200,

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
@@ -176,14 +176,20 @@ public class TaskInfoFetcher
     private synchronized void scheduleUpdate()
     {
         scheduledFuture = updateScheduledExecutor.scheduleWithFixedDelay(() -> {
-            synchronized (this) {
-                // if the previous request still running, don't schedule a new request
-                if (future != null && !future.isDone()) {
-                    return;
+            try {
+                synchronized (this) {
+                    // if the previous request still running, don't schedule a new request
+                    if (future != null && !future.isDone()) {
+                        return;
+                    }
+                }
+                if (nanosSince(lastUpdateNanos.get()).toMillis() >= updateIntervalMillis) {
+                    sendNextRequest();
                 }
             }
-            if (nanosSince(lastUpdateNanos.get()).toMillis() >= updateIntervalMillis) {
-                sendNextRequest();
+            catch (Throwable t) {
+                fatal(t);
+                throw t;
             }
         }, 0, 100, MILLISECONDS);
     }


### PR DESCRIPTION
Regularly scheduled tasks are dying as long as at least single run fails.
Catching and logging the failures will help to debug problems in scheduled tasks.


```
== NO RELEASE NOTE ==
```
