### PR TITLE
Fix flaky testAndInFilter test

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -8446,11 +8446,11 @@ public abstract class AbstractTestQueries
     public void testAndInFilter()
     {
         assertQuery(
-                "SELECT count() from (select * from orders where orderkey < random(10)) where ((orderkey > 100 and custkey > 100) or (orderkey > 200 and custkey < 200))",
+                "SELECT count() from (select * from orders where orderkey < 10) where ((orderkey > 100 and custkey > 100) or (orderkey > 200 and custkey < 200))",
                 "values 0");
 
         assertQuery(
-                "SELECT ((orderkey > 100 and custkey > 100) or (orderkey > 200 and custkey < 200)) from (select * from orders where orderkey < random(10) limit 1)",
+                "SELECT ((orderkey > 100 and custkey > 100) or (orderkey > 200 and custkey < 200)) from (select * from orders where orderkey < 10 limit 1)",
                 "values false");
     }
 


### PR DESCRIPTION
random(10) was returning 0 sometimes causing tests to be flaky


```
== NO RELEASE NOTE ==
```
