### PR TITLE
Bump zookeeper from 3.4.13 to 3.4.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1216,7 +1216,7 @@
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.4.13</version>
+                <version>3.4.14</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>jline</artifactId>


### PR DESCRIPTION
Bumps zookeeper from 3.4.13 to 3.4.14.

Signed-off-by: dependabot[bot] <support@github.com>

I created a new PR for https://github.com/prestodb/presto/pull/14068 because it wasn't running travis tests properly when I changed myself to the author (for cla purposes)

```
== RELEASE NOTES ==

General Changes
* Update zookeeper version to 3.4.14
```
