### PR TITLE
Fix stats for dwrf encryption

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -615,7 +615,19 @@ public class OrcWriter
         ImmutableListMultimap.Builder<Integer, ColumnStatistics> encryptedStatsBuilder = ImmutableListMultimap.builder();
         for (int i = 0; i < fileStats.size(); i++) {
             if (dwrfEncryptionInfo.getGroupByNodeId(i).isPresent()) {
-                encryptedStatsBuilder.put(dwrfEncryptionInfo.getGroupByNodeId(i).get(), fileStats.get(i));
+                ColumnStatistics stats = fileStats.get(i);
+                encryptedStatsBuilder.put(dwrfEncryptionInfo.getGroupByNodeId(i).get(), stats);
+                unencryptedStatsBuilder.add(new ColumnStatistics(
+                        stats.getNumberOfValues(),
+                        stats.getMinAverageValueSizeInBytes(),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null));
             }
             else {
                 unencryptedStatsBuilder.add(fileStats.get(i));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -291,6 +291,7 @@ public class DwrfMetadataWriter
                 .setKind(toColumnEncodingKind(columnEncoding.getColumnEncodingKind()))
                 .setDictionarySize(columnEncoding.getDictionarySize())
                 .setColumn(columnId)
+                .setSequence(0)
                 .build();
     }
 


### PR DESCRIPTION
Unencrypted stats need dummy entries for encrypted columns to ensure
backwards compatibility.

```
== NO RELEASE NOTE ==
```
