### PR TITLE
Modify regex for compatibility with both mysql, mariadb

### DIFF
--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManager.java
@@ -308,7 +308,7 @@ public class TestMySqlFunctionNamespaceManager
         assertGetFunctions(TANGENT, tangentV2);
     }
 
-    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Function 'unittest\\.memory\\.power_tower' has multiple signatures: unittest\\.memory\\.power_tower\\(double\\):double; unittest\\.memory\\.power_tower\\(integer\\):integer\\. Please specify parameter types\\.")
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Function 'unittest\\.memory\\.power_tower' has multiple signatures: unittest\\.memory\\.power_tower(\\(integer\\):integer|\\(double\\):double); unittest\\.memory\\.power_tower(\\(double\\):double|\\(integer\\):integer)\\. Please specify parameter types\\.")
     public void testAlterFunctionAmbiguous()
     {
         createFunction(FUNCTION_POWER_TOWER_DOUBLE, false);
@@ -356,7 +356,7 @@ public class TestMySqlFunctionNamespaceManager
         dropFunction(POWER_TOWER, Optional.empty(), false);
     }
 
-    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Function 'unittest\\.memory\\.power_tower' has multiple signatures: unittest\\.memory\\.power_tower\\(double\\):double; unittest\\.memory\\.power_tower\\(integer\\):integer\\. Please specify parameter types\\.")
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Function 'unittest\\.memory\\.power_tower' has multiple signatures: unittest\\.memory\\.power_tower(\\(integer\\):integer|\\(double\\):double); unittest\\.memory\\.power_tower(\\(double\\):double|\\(integer\\):integer)\\. Please specify parameter types\\.")
     public void testDropFunctionAmbiguous()
     {
         createFunction(FUNCTION_POWER_TOWER_DOUBLE, false);


### PR DESCRIPTION
The regular expressions used to match the expected exception message
for testAlterFunctionAmbiguous and testDropFunctionAmbiguous tests
in presto-function-namespace-managers was hard bound to the message
returned by mysql. Modified that to match MariaDB's message too
when used as a replacement for mysql.

Fixes this issue: https://github.com/prestodb/testing-mysql-server/issues/12#issuecomment-650223303

```
== NO RELEASE NOTE ==
```
