### PR TITLE
Add release notes for 0.238

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.238
     release/release-0.237
     release/release-0.236
     release/release-0.235.1

--- a/presto-docs/src/main/sphinx/release/release-0.238.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.238.rst
@@ -1,0 +1,40 @@
+=============
+Release 0.238
+=============
+
+**Highlights**
+==============
+* Fix SQL function parameters to be case-insensitive.
+* Add support to create external function. (:issue:`13254`)
+* Add support for exchange materialization of table bucketed by non-hive types. This can be enabled by setting the ``bucket_function_type_for_exchange`` session property or ``hive.bucket-function-type-for-exchange `` configuration property to ``PRESTO_NATIVE``.
+* Add predicate pushdown support for ``DATE``, ``TIMESTAMP``, and ``TIMESTAMP_WITH_TIME_ZONE`` literals for Pinot connector.
+
+General Changes
+_______________
+* Fix SQL function parameters to be case-insensitive.
+* Add ``target_result_size`` session property to customize data batch sizes being streamed from coordinator.
+* Add optimization to push null filters to the INNER side of equijoins. The optimization can be enabled with ``optimize-nulls-in-joins``.
+* Add ``sessionProperty`` override to Presto JDBC URI.
+* Add support to create external function. (:issue:`13254`)
+* Add session property ``query_max_broadcast_memory`` to limit the memory a query can use for broadcast join.
+* Remove max buffer count configuration property ``driver.max-page-partitioning-buffer-count`` for optimized repartitioning.
+
+Geospatial Changes
+__________________
+* Fix error in :func:`geometry_invalid_reason`.
+* Fix integer overflow in certain cases with Bing Tiles.
+
+Hive Changes
+____________
+* Fix a bug in Parquet reader which manifests when there are nested column schema changes.
+* Add support for exchange materialization of table bucketed by non-hive types. This can be enabled by setting the ``bucket_function_type_for_exchange`` session property or ``hive.bucket-function-type-for-exchange `` configuration property to ``PRESTO_NATIVE``.
+
+Pinot Changes
+_____________
+* Add support to retry data fetch exception. This can be enabled by setting the configuration property ``pinot.mark-data-fetch-exceptions-as-retriable``.
+* Add predicate pushdown support for ``DATE``, ``TIMESTAMP``, and ``TIMESTAMP_WITH_TIME_ZONE`` literals.
+
+Verifier Changes
+________________
+* Fix an issue where session properties of control and test queries also affects checksum queries.
+* Add support to report peak task memory usage for control and test queries.


### PR DESCRIPTION
# Missing Release Notes
## Cem Cayiroglu
- [x] https://github.com/prestodb/presto/pull/14668 Fix for tasks not showing in Query details (Merged by: Leiqing Cai)

## Mayank Garg
- [x] https://github.com/prestodb/presto/pull/14681 Add metadata support for reading hive encrypted data (Merged by: Rebecca Schlussel)

## Peizhen Guo
- [ ] https://github.com/prestodb/presto/pull/14625 Enforce memory limits on broadcasted tables for lookup join (Merged by: Rebecca Schlussel)

## Swapnil Tailor
- [x] c7eecd9b972097653a01c2f1188aca8fb6ef9f6e Revert "Reliable Resource Groups with versioning"

# Extracted Release Notes
- #14219 (Author: Rongrong Zhong): Add syntax support for external function
  - Add support to create external function (this does not include external function execution).
- #14578 (Author: Saumitra Shahapure): Filtering nulls from left and right in inner join
  - Add optimization to push null filters to the INNER side of equijoins. The optimization can be enabled with `optimize-nulls-in-joins`.
- #14604 (Author: Ying Su): Optimize ArrayAllocator CPU usage in OptimizedPartitionedOutputOperator
  - Remove max buffer count config property `driver.max-page-partitioning-buffer-count` for optimized repartitioning.
- #14638 (Author: Leiqing Cai): Fix session properties for query execution
  - Fix an issue where session properties of control and test queries also affects checksum queries.
- #14640 (Author: Tim Meehan): Add Presto JDBC URL flag to add session property overrides
  - Add sessionProperty override to Presto JDBC URI.
- #14641 (Author: Tim Meehan): Add session property for targetResultSize
  - Add ``target_result_size`` session property to customize data batch sizes being streamed from coordinator.
- #14646 (Author: Xiang Fu): Adding time type support for Pinot predicate pushdown
  - Support predicate pushdown for literals of type `DATE`, `TIMESTAMP`, or `TIMESTAMP_WITH_TIME_ZONE`.
- #14649 (Author: Xiang Fu): Adding a config to retry on pinot exceptions
  - Adding config: `pinot.mark-data-fetch-exceptions-as-retriable` to let presto retry on pinot data fetcher related exceptions.
- #14659 (Author: Leiqing Cai): Add peakTaskTotalMemoryBytes to Verifier output
  - Add support to report peak task memory usage for control and test queries.
- #14669 (Author: Rongrong Zhong): Treat SQL function parameter case-insensitive
  - Fix case sensitivity issue in SQL function parameters. Function parameters should be treated case-insensitive.
- #14678 (Author: Venki Korukanti): Parquet: Handle nested column schema changes when subfield pruning is enabled
  - Fix a bug in Parquet reader which manifests when there are nested column schema changes.
- #14689 (Author: James Gill):     Fix integer overflow error in Bing Tiles
  - Fix integer overflow in certain cases with Bing Tiles.
- #14713 (Author: Vic Zhang): Add session property to set bucket function type
  - Add support for exchange materialization of table bucketed by non-hive types. This can be enabled using value ``PRESTO_NATIVE`` for the ``bucket_function_type_for_exchange`` session property  or the ``hive.bucket-function-type-for-exchange `` configuration property.
- #14725 (Author: James Gill): Fix NPE in geometry_invalid_reason
  - Fix NPE in :func:`geometry_invalid_reason`.

# All Commits
- c7eecd9b972097653a01c2f1188aca8fb6ef9f6e Revert "Reliable Resource Groups with versioning" (Swapnil Tailor)
- fc1f2bde5eb4d4eb2d16f31de49fd27f0e852d54 Add back address forwarding for Proxy (Tim Meehan)
- 9c17deb5be22cdbd87f16fa4dc5af21282e5b969 Fix logger crash for Kafka connector (liuququan)
- 1952222f409531e9e72d4f73f2f56f30ef668b62 Update documentation for SHOW FUNCTIONS and SHOW CREATE FUNCTION (Leiqing Cai)
- ccf8582158cc67d73bb8124ba1ea233dc7c0f73b Fix NPE in geometry_invalid_reason (James Gill)
- b89db16de87fed22b4413196c0ab78c16a1652fe Add session property to ignore table bucketing (Vic Zhang)
- a6b43aa097a0600489f800ea52d61db5374e366f Include table name and parquet file name in error message on schema mismatch (Vivek Bharathan)
- f5060f3d203b0b5018eb9ec06a56a060ff2c4bb5 Fix session properties for determinism analysis main queries (Leiqing Cai)
- 93f1fb10cd16e6c4f0d6fd00b52630dae5ccdb37 Add session property for targetResultSize (Tim Meehan)
- b476b693a72d9349fe7dee3e3f29e968bce3bf13 Replace FileSystemContext in presto-raptor by HdfsContext (fvcortes)
- 686152df953301020542d62f48731d57dd1130dd DDL support for DWRF encryption (Mayank Garg)
- 3e1227c7519e9c0d9a0dc82524d2adc901244dd7 Base classes for passing encryption information to `HiveSplit` (Mayank Garg)
- e7edcaa2f6d284f4bd4358cc27109b1d56d3b68d Pass requested columns to HiveTableLayoutHandle (Mayank Garg)
- ada52f6a4355eb379bd0d16bca8e603de0caa024 Add Presto JDBC URL flag to add session property overrides (Tim Meehan)
- 5be42efa5697c27ce63d359f56486e4ff385dfb9 Refactor map parsing in Presto JDBC connection URL (Tim Meehan)
- 00c3dfcf8bc40cbd02ccd88f36ec8f08fd978d8b Fix header handling in Presto Proxy (Tim Meehan)
- f0ebe6dd7542dfa6e144774c2db66baa04b50825 Treat SQL function parameter case-insensitive (Rongrong Zhong)
- f209297a6cb02a0a02415c48db15724547e3e0de Add support for creating external function (Rongrong Zhong)
- cb69e899efbabf35a09003852194800309f53dad Add session property to set bucket function type (Vic Zhang)
- 3a83e7273714ef7b3edb7526ce92a04a0d7711aa Make Proxy timeout configurable (Tim Meehan)
- 9e62ba7beea530b8780db558bbd8565cc718bce2 Upgrade ZSTD version (Rohit Jain)
- 837184878c79c3d7c5e71cd3d1549377c0f9b8b2 Refactor presto-common predicate tests (lucasdamo)
- 74e0bf4f402dbce31d6f00af1011ae814f710439 Adding time type support for Pinot predicate pushdown (Xiang Fu)
- 5526987a37f10c94aa10a2651f27da722941672c Add an optimizer rule to remove redundant assignments in ProjectNode (Rongrong Zhong)
- bc5da24d0221d2311d13335d6c86dcc312ad03cd Close PrestoSparkService on the Driver (Andrii Rosa)
- c8c88a5957f1dab8b6c32967dd70a41900f03fbe Join optimisation: filtering null rows explicitly (Saumitra Shahapure)
- 28fc102fd2475f4efb16abe78c3c0c5c70010090 Add additional connectors for presto-spark-package (Ravion)
- 1b0752f38ec7d04d4e14c32d19c7a99b26f4c675 Use alluxio version 2.2.2 (Rohit Jain)
- d783c836436cfe463b1e300e4fedb10d027abb43 Fix integer overflow error in Bing Tiles (James Gill)
- 53252da438e5cd2a8ac501b6b15f6f766f6e77c1 Move pure BingTile functions to BingTileUtils (James A. Gill)
- b6f7986d69120bc851934979488d751d85805b5a Parquet: Handle nested column schema changes when subfield pruning is enabled (Venki Korukanti)
- 093ac4aa9e3e63eea25e24d5da5008c5f5dfacfb Ignore HiveBucketFilter for buckted temporary table (Vic Zhang)
- 9d097a57910eac079666dc88534f2d707603ccd6 Refactor getPartitionMetadata method (Vic Zhang)
- db1466879d750b3c52a5395567cd636faddf52a4 Refactor HiveBucketProperty constructor method (Vic Zhang)
- 98c8c0327d8783a7d8f08d6c3d6b643adcbcfce2 Support all column types for hive temporary bucket table (Vic Zhang)
- b7ceddfb52ec3d381afd41f18cf19b2d604a6c5e Avoid wrapping iterators (Andrii Rosa)
- 298de509d09d09bd1ac57ba08643045caeb2a68f Adding a config to retry on pinot exceptions (Xiang Fu)
- 942cd399b9adaa12b427bd743c1ac1fe154f1cc5 Reduce redundant calls to setNull in DoubleSumAggregation (Sreeni Viswanadha)
- 9d6b3edf8669233b9aa3a054736f58b0260cde6a Fix for tasks not showing in Query details (Cem Cayiroglu)
- 9c5aee1bff00bc50e4e7c7ab527aeba12ae8f78a Make TaskStatus Leaner (Ajay George)
- 239519575308058cf97d46e9d5aecf0cf924c73d Use UncheckedStackArrayAllocator instead of SimpleArrayAllocator (Ying Su)
- 72bb533e14c69063357240f48b8a5ed1b668502e Revert "Add max buffer count config property for optimized repartitioning" (Ying Su)
- 7b87673681ee9374cf6f340beabb4a9b0d7d94dd Introduce UncheckedStackArrayAllocator (Ying Su)
- 76750f6141fa1464e80a07ab7c9032fcd75be0c3 Refactor TestSimpleArrayAllocator (Ying Su)
- a5dccb36139f0206e3108033b7ea77d346f43496 Pre-calculate totalSliceLength before ensureCapacity (Ying Su)
- 5d20801c400de01f5614db638114bd9ed197f583 Avoid unnecessary page to row conversions (Andrii Rosa)
- 3607e0850158c6b400167cebef3bd8dc768879fb Optimize PrestoSparkOutputOperator (Andrii Rosa)
- f5db3bdd038bbab6377881633df02ecfb5381d73 Optimize PrestoSparkRemoteSourceOperator (Andrii Rosa)
- 81261a56210cff6ebf9f0215fe8d17e00e2db8f1 Add custom shuffle serialization for Presto on Spark (Andrii Rosa)
- 2081d20d17b25bc110fb1747f32e3ce158d2c268 Rename PrestoSparkRow to PrestoSparkMutableRow (Andrii Rosa)
- 314769eec29af002201ab4a6a29935cfec8eb895 Implement MutablePartitionId (Andrii Rosa)
- 5e45c8a0758ebea01ccf43afeeb9cb514485766b Fix flaky TestFileSingleStreamSpiller (Andrii Rosa)
- a1d5f8a82f96e5e53e50f8ece51cadc54186a180 Print estimated buffer max capacities in BlockEncodingBuffers.toString() (Ying Su)
- ad8989be817494db115d36a4fc19420cf01e97c8 Add toString() to AbstractBlockEncodingBuffer (Ying Su)
- e10751b99e7d87e0a96d9cba3305b100f1875a9c Use ToStringHelper in BlockEncodingBuffers.toString() (Ying Su)
- 4bd9d192342f2c136357b6ddab8129a898c1135f Add peakTaskTotalMemoryBytes to Verifier output (Leiqing Cai)
- 5ee73fdd7cb1ec9b78cdc96073f76b73c80ed0d4 Upgrade drift to 1.25 (Mayank Garg)
- ae77e90a24683f5e2ad3c0b697f208c8c073f630 Add unit test for Alluxio data validation (zhiyua-git)
- 8fb6f1b0cbeb6deb6ad49f1aab2247c5c4ad6bef Add data validation to Alluxio data caching (Zhiyuan Hu)
- c6f1cbc8fa318d773b8899f97155a9380d6bea84 Canonicalize body of LambdaDefinitionExpression (Rongrong Zhong)
- 4b0f7c192280a6ffb046766c2fb263ba1f0a4614 Enable collocated join for Presto on Spark (Andrii Rosa)
- cb2da8321eadd3ded00bed3ed8667f4497cdd2fa Add support for bucketed tables in Presto on Spark (Andrii Rosa)
- 0b753220953fe3d5d7b8b81dc10a6169f950b6cf Refactor PrestoSparkRddFactory (Andrii Rosa)
- 21f0b0475b637cdb9ecc464398eb26906402a2c6 Add ConnectorNodePartitioningProvider#getBucketCount (Andrii Rosa)
- cbe1cb1a440d3b0e1136e5668a1a9dc1303558ef Fix SingleMapBlock.seekKeyExact bug (Ying Su)
- 35cd0888fb729ecb1a9760c61afb6062d56a4728 Change BlockBuilder's expectedEntries to be the number of values (Ying Su)
- 79b4a1872c63ae13dcb7a232210ba7dd085f17f9 Enforce memory limits on broadcasted tables for lookup join (Peizhen Guo)
- 21ca972b98e146eaa2b9dd732e3c66256b2e0fdc Fix session properties for query execution (Leiqing Cai)