### PR TITLE
Fix thread snapshot UI due to variable initialization

### DIFF
--- a/presto-main/src/main/resources/webapp/src/components/WorkerThreadList.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/WorkerThreadList.jsx
@@ -65,6 +65,7 @@ export class WorkerThreadList extends React.Component {
         const result = {};
 
         result[ALL_THREADS] = threads;
+        result[QUERY_THREADS] = [];
 
         for (let i = 0; i < threads.length; i++) {
             const thread = threads[i];


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* The worker page's thread snapshot UI does not work (no stack trace displayed on click) when there is active query load (tested under Chrome). This patch fixes an uninitialized variable in client JS that was causing this UI behavior.
```