### PR TITLE
add property 'kudu.client.tablet-split-size-bytes', which can improve scan performance significantly

### DIFF
--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <kudu.version>1.8.0</kudu.version>
+        <kudu.version>1.12.0</kudu.version>
     </properties>
 
     <dependencies>
@@ -21,6 +21,12 @@
             <groupId>org.apache.kudu</groupId>
             <artifactId>kudu-client</artifactId>
             <version>${kudu.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduClientConfig.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduClientConfig.java
@@ -44,6 +44,7 @@ public class KuduClientConfig
     private String kerberosPrincipal;
     private String kerberosKeytab;
     private boolean kerberosAuthDebugEnabled;
+    private long tabletSplitSizeBytes = 1024L * 1024;
 
     @NotNull
     @Size(min = 1)
@@ -70,6 +71,18 @@ public class KuduClientConfig
     {
         this.defaultAdminOperationTimeout = timeout;
         return this;
+    }
+
+    @Config("kudu.client.tablet-split-size-bytes")
+    public KuduClientConfig setSplitSizeBytes(long tabletSplitSizeBytes)
+    {
+        this.tabletSplitSizeBytes = tabletSplitSizeBytes;
+        return this;
+    }
+
+    public long getTabletSplitSizeBytes()
+    {
+        return tabletSplitSizeBytes;
     }
 
     @MinDuration("1s")

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduClientSession.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduClientSession.java
@@ -77,13 +77,15 @@ public class KuduClientSession
     private final KuduClient client;
     private final SchemaEmulation schemaEmulation;
     private final boolean kerberosAuthEnabled;
+    private final long tabletSplitSizeBytes;
 
-    public KuduClientSession(KuduConnectorId connectorId, KuduClient client, SchemaEmulation schemaEmulation, boolean kerberosAuthEnabled)
+    public KuduClientSession(KuduConnectorId connectorId, KuduClient client, SchemaEmulation schemaEmulation, KuduClientConfig config)
     {
         this.connectorId = connectorId;
         this.client = client;
         this.schemaEmulation = schemaEmulation;
-        this.kerberosAuthEnabled = kerberosAuthEnabled;
+        this.kerberosAuthEnabled = config.isKerberosAuthEnabled();
+        this.tabletSplitSizeBytes = config.getTabletSplitSizeBytes();
     }
 
     public List<String> listSchemaNames()
@@ -154,6 +156,7 @@ public class KuduClientSession
         KuduTable table = tableHandle.getTable(this);
         final int primaryKeyColumnCount = table.getSchema().getPrimaryKeyColumnCount();
         KuduScanToken.KuduScanTokenBuilder builder = client.newScanTokenBuilder(table);
+        builder.setSplitSizeBytes(tabletSplitSizeBytes);
 
         TupleDomain<ColumnHandle> constraintSummary = layoutHandle.getConstraintSummary();
         if (!addConstraintPredicates(table, builder, constraintSummary)) {

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduModule.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduModule.java
@@ -107,6 +107,6 @@ public class KuduModule
         else {
             strategy = new NoSchemaEmulation();
         }
-        return new KuduClientSession(connectorId, client, strategy, config.isKerberosAuthEnabled());
+        return new KuduClientSession(connectorId, client, strategy, config);
     }
 }


### PR DESCRIPTION
1.upgrade kudu-cliet -> 1.12.0
2.add property 'kudu.client.tablet-split-size-bytes', which can improve scan performance significantly

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
