### PR TITLE
Fix pushdown subfields optimizer to properly handle plan node assignments

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -621,8 +621,6 @@ public class PushdownSubfields
                 }
 
                 List<Subfield> matchingSubfields = findSubfields(variable.getName());
-                verify(!matchingSubfields.isEmpty(), "Missing variable: " + variable);
-
                 matchingSubfields.stream()
                         .map(Subfield::getPath)
                         .map(path -> new Subfield(otherVariable.getName(), path))


### PR DESCRIPTION
Previously we are not adding the project node assignments correctly when using pushdown filter/subfields. Sometimes there are some assignments in project node which are referenced in the source aggregation node. But these variables are not needed as they have been optimized or replaced by other expressions. So when trying to add these variables to context we are failing because of the verify check. This PR removes that check and ignores this variable or the other option if matchingSubfields is empty add the variable to context variables.
```
== NO RELEASE NOTE ==
```
