### PR TITLE
Fix #14693: support TRUNCATE function for DOUBLE and REAL

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -163,6 +163,16 @@ Mathematical Functions
 
     Returns ``x`` rounded to integer by dropping digits after decimal point.
 
+.. function:: truncate(x, n) -> double
+
+    Returns ``x`` truncated to ``n`` decimal places.
+    ``n`` can be negative to truncate ``n`` digits left of the decimal point. 
+
+    Example:
+    ``truncate(REAL '12.333', -1)`` -> result is 10.0
+    ``truncate(REAL '12.333', 0)``  -> result is 12.0
+    ``truncate(REAL '12.333', 1)``  -> result is 12.3
+
 .. function:: width_bucket(x, bound1, bound2, n) -> bigint
 
     Returns the bin number of ``x`` in an equi-width histogram with the

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -33,6 +33,7 @@ import io.airlift.slice.Slice;
 import org.apache.commons.math3.distribution.BetaDistribution;
 import org.apache.commons.math3.special.Erf;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -325,6 +326,49 @@ public final class MathFunctions
     {
         float numInFloat = intBitsToFloat((int) num);
         return floatToRawIntBits((float) (Math.signum(numInFloat) * Math.floor(Math.abs(numInFloat))));
+    }
+
+    @Description("truncate to double by dropping digits after decimal point")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double truncate(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.INTEGER) long decimals)
+    {
+        if (Double.isNaN(num) || Double.isInfinite(num)) {
+            // compatible with truncate(DOUBLE)
+            return num;
+        }
+        if (decimals == 0) {
+            if (num >= 0) {
+                return Math.floor(num);
+            }
+            else {
+                return Math.ceil(num);
+            }
+        }
+
+        return BigDecimal.valueOf(num).setScale((int) decimals, BigDecimal.ROUND_DOWN).doubleValue();
+    }
+
+    @Description("truncate to float by dropping digits after decimal point")
+    @ScalarFunction
+    @SqlType(StandardTypes.REAL)
+    public static long truncate(@SqlType(StandardTypes.REAL) long num, @SqlType(StandardTypes.INTEGER) long decimals)
+    {
+        float numBitsToFloats = intBitsToFloat((int) num);
+        if (Float.isNaN(numBitsToFloats) || Float.isInfinite(numBitsToFloats)) {
+            // compatible with truncate(REAL)
+            return num;
+        }
+        if (decimals == 0) {
+            if (numBitsToFloats >= 0) {
+                return floatToRawIntBits((float) Math.floor(numBitsToFloats));
+            }
+            else {
+                return floatToRawIntBits((float) Math.ceil(numBitsToFloats));
+            }
+        }
+
+        return floatToRawIntBits(new BigDecimal(Float.toString(numBitsToFloats)).setScale((int) decimals, BigDecimal.ROUND_DOWN).floatValue());
     }
 
     @Description("cosine")

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTruncateWithPrecision.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTruncateWithPrecision.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.RealType.REAL;
+
+public class TestTruncateWithPrecision
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testTruncate()
+    {
+        // TRUNCATE DOUBLE -> DOUBLE
+        assertFunction("truncate(nan(),-1)", DOUBLE, Double.NaN);
+        assertFunction("truncate(infinity(),1)", DOUBLE, Double.POSITIVE_INFINITY);
+        assertFunction("truncate(-infinity(),1)", DOUBLE, Double.NEGATIVE_INFINITY);
+        assertFunction("truncate(DOUBLE '17.1', -1)", DOUBLE, 10.0);
+        assertFunction("truncate(DOUBLE '1234.56', 1)", DOUBLE, 1234.5);
+        assertFunction("truncate(DOUBLE '1234.56', 0)", DOUBLE, 1234.0);
+        assertFunction("truncate(DOUBLE '-1234.56', 0)", DOUBLE, -1234.0);
+        assertFunction("truncate(DOUBLE '-1234.56', -500)", DOUBLE, 0.0);
+        assertFunction("truncate(DOUBLE '1234.567', 2)", DOUBLE, 1234.56);
+        assertFunction("truncate(DOUBLE '1234.567', 2)", DOUBLE, 1234.56);
+        assertFunction("truncate(DOUBLE '" + Double.MAX_VALUE + "', -408)", DOUBLE, 0.0);
+        assertFunction("truncate(DOUBLE '" + -Double.MAX_VALUE / 10 + "', 408)", DOUBLE, -Double.MAX_VALUE / 10);
+        assertFunction("truncate(DOUBLE '" + (double) Long.MAX_VALUE + "', -15)", DOUBLE, 9.223E18);
+
+        // TRUNCATE REAL -> REAL
+
+        assertFunction("truncate(REAL '12.333', 0)", REAL, 12.0f);
+        assertFunction("truncate(REAL '-12.333', 0)", REAL, -12.0f);
+        assertFunction("truncate(REAL '12.123456789011234567892', 10)", REAL, 12.12345695499999f);
+        assertFunction("truncate(REAL '12.333', -1)", REAL, 10.0f);
+        assertFunction("truncate(REAL '12.333', -500)", REAL, 0.0f);
+        assertFunction("truncate(REAL '3.40287e37', -35)", REAL, 3.4E37f);
+        assertFunction("truncate(REAL '3.40287e37', -488)", REAL, 0.0f);
+        assertFunction("truncate(REAL '" + (float) Long.MAX_VALUE + "', -15)", REAL, 9.223E18f);
+    }
+}


### PR DESCRIPTION

== RELEASE NOTES ==
```
General Changes
```
The solution is to fix issue #14693 by adding an enhancement to TRUNCATE function for allowing DOUBLE and REAL types.
Following examples show how user may use this feature:<br>

`truncate(DOUBLE '1234.56', 1)` -> The outcome of the evaluation is `1234.5`<br>

`truncate(REAL '-12.333', -1)` -> The outcome of the evaluation is `-10.0`<br>

<br><br>
NOTE: Neither does this patch change any behaviors of current mathemtical functionalities, nor is the existing workload being impacted. In addition, there is zero impact to data/workload migration.
