### PR TITLE
Fixes for completion events post-dispatching

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
@@ -76,13 +76,13 @@ public class LocalDispatchQuery
         this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
         this.querySubmitter = requireNonNull(querySubmitter, "querySubmitter is null");
 
-        addExceptionCallback(queryExecutionFuture, stateMachine::transitionToFailed);
+        addExceptionCallback(queryExecutionFuture, throwable -> {
+            stateMachine.transitionToFailed(throwable);
+            queryMonitor.queryImmediateFailureEvent(stateMachine.getBasicQueryInfo(Optional.empty()), toFailure(throwable));
+        });
         stateMachine.addStateChangeListener(state -> {
             if (state.isDone()) {
                 submitted.set(null);
-            }
-            if (state == FAILED) {
-                queryMonitor.queryCompletedEvent(getQueryInfo());
             }
         });
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/DataDefinitionExecution.java
@@ -222,6 +222,7 @@ public class DataDefinitionExecution<T extends Statement>
     public void fail(Throwable cause)
     {
         stateMachine.transitionToFailed(cause);
+        stateMachine.updateQueryInfo(Optional.empty());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -500,6 +500,12 @@ public class SqlQueryExecution
         requireNonNull(cause, "cause is null");
 
         stateMachine.transitionToFailed(cause);
+
+        // acquire reference to scheduler before checking finalQueryInfo, because
+        // state change listener sets finalQueryInfo and then clears scheduler when
+        // the query finishes.
+        SqlQuerySchedulerInterface scheduler = queryScheduler.get();
+        stateMachine.updateQueryInfo(Optional.ofNullable(scheduler).map(SqlQuerySchedulerInterface::getStageInfo));
     }
 
     @Override


### PR DESCRIPTION
Improvement on #14784 

* Removes a potential duplicate completion event
* Additional fix for certain DDL and pre-execution SQL execution problems where completion event may not be logged