### PR TITLE
Fix bytecode generation for SQL functions

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestSqlFunctions.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestSqlFunctions.java
@@ -306,4 +306,15 @@ public class TestSqlFunctions
         assertQuery("SELECT testing.common.ARRAY_APPEND(Array, ITEM) FROM (VALUES (array[1, 2, 3], 4), (array[2, 3, 4], 5)) t(array, item)", "VALUES array[1, 2, 3, 4], array[2, 3, 4, 5]");
         assertQuery("SELECT testing.common.array_sum(Array) FROM (VALUES (array[1, 2, 3]), (array[4, 5, 6])) t(array)", "VALUES 6L, 15L");
     }
+
+    @Test
+    void testLambdaVariableScoping()
+    {
+        @Language("SQL") String createFunction = "CREATE FUNCTION testing.test.array_sum(x array<int>)\n" +
+                "RETURNS int \n" +
+                "RETURN reduce(x, 0, (s, x) -> s + x, s -> s)";
+        assertQuerySucceeds(createFunction);
+
+        assertQuery("SELECT testing.test.array_sum(array[1, 2, 3])", "VALUES 6L");
+    }
 }


### PR DESCRIPTION
A lambda expression inside the body of a SQL function might have
the same argument name, as one of the arguments of the function
itself. Bytecode generation fails in this case.
    
Example:
CREATE FUNCTION testing.test.array_sum(x array<int>) RETURNS int
RETURN reduce(x, 0, (s, x) -> s + x, s -> s)
    
Here "x" is an argument for both the function and the lambda
expression in the function body. This change fixes the bug by
properly scoping variables in the lambda expression body, so that
there is no conflict with variables of the same name defined
outside the lambda expression's scope.

```
== NO RELEASE NOTE ==
```