### PR TITLE
Add support for Hudi MOR queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dep.kafka.version>2.3.1</dep.kafka.version>
         <dep.druid.version>0.17.0</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
-
+        <dep.hudi.version>0.5.3</dep.hudi.version>
         <!--
           America/Bahia_Banderas has:
            - offset change since 1970 (offset Jan 1970: -08:00, offset Jan 2018: -06:00)
@@ -1002,7 +1002,7 @@
             <dependency>
                 <groupId>org.apache.hudi</groupId>
                 <artifactId>hudi-hadoop-mr</artifactId>
-                <version>0.5.1-incubating</version>
+                <version>${dep.hudi.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.objenesis</groupId>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -35,6 +35,12 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-parquet</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.parquet</groupId>
+                    <artifactId>parquet-encoding</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -55,6 +61,10 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -78,6 +88,7 @@
         <dependency>
             <groupId>org.apache.hudi</groupId>
             <artifactId>hudi-hadoop-mr</artifactId>
+            <version>${dep.hudi.version}</version>
         </dependency>
 
         <dependency>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 import org.apache.hudi.hadoop.HoodieROTablePathFilter;
+import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -371,7 +372,7 @@ public class BackgroundHiveSplitLoader
                 schedulerUsesHostAddresses,
                 partition.getEncryptionInformation());
 
-        if (!isHudiInputFormat(inputFormat) && shouldUseFileSplitsFromInputFormat(inputFormat)) {
+        if (!isHudiParquetInputFormat(inputFormat) && shouldUseFileSplitsFromInputFormat(inputFormat)) {
             if (tableBucketInfo.isPresent()) {
                 throw new PrestoException(NOT_SUPPORTED, "Presto cannot read bucketed partition in an input format with UseFileSplitsFromInputFormat annotation: " + inputFormat.getClass().getSimpleName());
             }
@@ -381,7 +382,7 @@ public class BackgroundHiveSplitLoader
 
             return addSplitsToSource(splits, splitFactory);
         }
-        PathFilter pathFilter = isHudiInputFormat(inputFormat) ? hoodiePathFilterSupplier.get() : path1 -> true;
+        PathFilter pathFilter = isHudiParquetInputFormat(inputFormat) ? hoodiePathFilterSupplier.get() : path1 -> true;
         // S3 Select pushdown works at the granularity of individual S3 objects,
         // therefore we must not split files when it is enabled.
         Properties schema = getHiveSchema(storage.getSerdeParameters(), table.getParameters());
@@ -421,8 +422,11 @@ public class BackgroundHiveSplitLoader
         return lastResult;
     }
 
-    private static boolean isHudiInputFormat(InputFormat<?, ?> inputFormat)
+    private static boolean isHudiParquetInputFormat(InputFormat<?, ?> inputFormat)
     {
+        if (inputFormat instanceof HoodieParquetRealtimeInputFormat) {
+            return false;
+        }
         return inputFormat instanceof HoodieParquetInputFormat;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursorProvider.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -58,7 +59,8 @@ public class GenericHiveRecordCursorProvider
             TupleDomain<HiveColumnHandle> effectivePredicate,
             DateTimeZone hiveStorageTimeZone,
             TypeManager typeManager,
-            boolean s3SelectPushdownEnabled)
+            boolean s3SelectPushdownEnabled,
+            Map<String, String> customSplitInfo)
     {
         // make sure the FileSystem is created with the proper Configuration object
         try {
@@ -69,7 +71,7 @@ public class GenericHiveRecordCursorProvider
         }
 
         RecordReader<?, ?> recordReader = hdfsEnvironment.doAs(session.getUser(),
-                () -> HiveUtil.createRecordReader(configuration, path, start, length, schema, columns));
+                () -> HiveUtil.createRecordReader(configuration, path, start, length, schema, columns, customSplitInfo));
 
         return Optional.of(new GenericHiveRecordCursor<>(
                 configuration,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -184,7 +184,8 @@ public class HivePageSourceProvider
                 hiveLayout.getRemainingPredicate(),
                 hiveLayout.isPushdownFilterEnabled(),
                 rowExpressionService,
-                encryptionInformation);
+                encryptionInformation,
+                hiveSplit.getCustomSplitInfo());
         if (pageSource.isPresent()) {
             return pageSource.get();
         }
@@ -318,7 +319,8 @@ public class HivePageSourceProvider
             RowExpression remainingPredicate,
             boolean isPushdownFilterEnabled,
             RowExpressionService rowExpressionService,
-            Optional<EncryptionInformation> encryptionInformation)
+            Optional<EncryptionInformation> encryptionInformation,
+            Map<String, String> customSplitInfo)
     {
         List<HiveColumnHandle> allColumns;
 
@@ -422,7 +424,8 @@ public class HivePageSourceProvider
                     effectivePredicate,
                     hiveStorageTimeZone,
                     typeManager,
-                    s3SelectPushdownEnabled);
+                    s3SelectPushdownEnabled,
+                    customSplitInfo);
 
             if (cursor.isPresent()) {
                 RecordCursor delegate = cursor.get();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveRecordCursorProvider.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.Path;
 import org.joda.time.DateTimeZone;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -39,5 +40,6 @@ public interface HiveRecordCursorProvider
             TupleDomain<HiveColumnHandle> effectivePredicate,
             DateTimeZone hiveStorageTimeZone,
             TypeManager typeManager,
-            boolean s3SelectPushdownEnabled);
+            boolean s3SelectPushdownEnabled,
+            Map<String, String> customSplitInfo);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
@@ -60,6 +60,7 @@ public class HiveSplit
     private final Optional<byte[]> extraFileInfo;
     private final CacheQuotaRequirement cacheQuotaRequirement;
     private final Optional<EncryptionInformation> encryptionInformation;
+    private final Map<String, String> customSplitInfo;
 
     @JsonCreator
     public HiveSplit(
@@ -82,7 +83,8 @@ public class HiveSplit
             @JsonProperty("s3SelectPushdownEnabled") boolean s3SelectPushdownEnabled,
             @JsonProperty("extraFileInfo") Optional<byte[]> extraFileInfo,
             @JsonProperty("cacheQuota") CacheQuotaRequirement cacheQuotaRequirement,
-            @JsonProperty("encryptionMetadata") Optional<EncryptionInformation> encryptionInformation)
+            @JsonProperty("encryptionMetadata") Optional<EncryptionInformation> encryptionInformation,
+            @JsonProperty("customSplitInfo") Map<String, String> customSplitInfo)
     {
         checkArgument(start >= 0, "start must be positive");
         checkArgument(length >= 0, "length must be positive");
@@ -123,6 +125,7 @@ public class HiveSplit
         this.extraFileInfo = extraFileInfo;
         this.cacheQuotaRequirement = cacheQuotaRequirement;
         this.encryptionInformation = encryptionInformation;
+        this.customSplitInfo = ImmutableMap.copyOf(requireNonNull(customSplitInfo, "customSplitInfo is null"));
     }
 
     @JsonProperty
@@ -263,6 +266,12 @@ public class HiveSplit
     public Optional<EncryptionInformation> getEncryptionInformation()
     {
         return encryptionInformation;
+    }
+
+    @JsonProperty
+    public Map<String, String> getCustomSplitInfo()
+    {
+        return customSplitInfo;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
@@ -503,7 +503,8 @@ class HiveSplitSource
                         internalSplit.isS3SelectPushdownEnabled(),
                         internalSplit.getExtraFileInfo(),
                         cacheQuotaRequirement,
-                        internalSplit.getEncryptionInformation()));
+                        internalSplit.getEncryptionInformation(),
+                        internalSplit.getCustomSplitInfo()));
 
                 internalSplit.increaseStart(splitBytes);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -28,9 +28,11 @@ import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.hadoop.TextLineLengthLimitExceededException;
 import com.facebook.presto.hive.avro.PrestoAvroSerDe;
 import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.hive.pagefile.PageInputFormat;
 import com.facebook.presto.hive.util.FooterAwareRecordReader;
+import com.facebook.presto.hive.util.HudiRealtimeSplitConverter;
 import com.facebook.presto.orc.OrcReader;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorTableHandle;
@@ -38,6 +40,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
 import com.google.common.base.Splitter;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
@@ -72,6 +75,7 @@ import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.hudi.hadoop.realtime.HoodieRealtimeFileSplit;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -83,11 +87,13 @@ import org.joda.time.format.ISODateTimeFormat;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -133,6 +139,7 @@ import static com.facebook.presto.hive.metastore.MetastoreUtil.HIVE_DEFAULT_DYNA
 import static com.facebook.presto.hive.metastore.MetastoreUtil.checkCondition;
 import static com.facebook.presto.hive.util.ConfigurationUtils.copy;
 import static com.facebook.presto.hive.util.ConfigurationUtils.toJobConf;
+import static com.facebook.presto.hive.util.CustomSplitConversionUtils.recreateSplitWithCustomInfo;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -158,6 +165,7 @@ import static org.apache.hadoop.hive.serde.serdeConstants.DECIMAL_TYPE_NAME;
 import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_LIB;
 import static org.apache.hadoop.hive.serde2.ColumnProjectionUtils.READ_ALL_COLUMNS;
 import static org.apache.hadoop.hive.serde2.ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR;
+import static org.apache.hadoop.hive.serde2.ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
 
 public final class HiveUtil
@@ -202,7 +210,7 @@ public final class HiveUtil
     {
     }
 
-    public static RecordReader<?, ?> createRecordReader(Configuration configuration, Path path, long start, long length, Properties schema, List<HiveColumnHandle> columns)
+    public static RecordReader<?, ?> createRecordReader(Configuration configuration, Path path, long start, long length, Properties schema, List<HiveColumnHandle> columns, Map<String, String> customSplitInfo)
     {
         // determine which hive columns we will read
         List<HiveColumnHandle> readColumns = ImmutableList.copyOf(filter(columns, column -> column.getColumnType() == REGULAR));
@@ -211,14 +219,26 @@ public final class HiveUtil
         // Tell hive the columns we would like to read, this lets hive optimize reading column oriented files
         setReadColumns(configuration, readHiveColumnIndexes);
 
+        // Only propagate serialization schema configs by default
+        Predicate<String> schemaFilter = schemaProperty -> schemaProperty.startsWith("serialization.");
+
         InputFormat<?, ?> inputFormat = getInputFormat(configuration, getInputFormatName(schema), true);
         JobConf jobConf = toJobConf(configuration);
         FileSplit fileSplit = new FileSplit(path, start, length, (String[]) null);
+        if (!customSplitInfo.isEmpty() && isHudiRealtimeSplit(customSplitInfo)) {
+            fileSplit = recreateSplitWithCustomInfo(fileSplit, customSplitInfo);
 
-        // propagate serialization configuration to getRecordReader
+            // Add additional column information for record reader
+            List<String> readHiveColumnNames = ImmutableList.copyOf(transform(readColumns, HiveColumnHandle::getName));
+            jobConf.set(READ_COLUMN_NAMES_CONF_STR, Joiner.on(',').join(readHiveColumnNames));
+
+            // Remove filter when using customSplitInfo as the record reader requires complete schema configs
+            schemaFilter = schemaProperty -> true;
+        }
+
         schema.stringPropertyNames().stream()
-                .filter(name -> name.startsWith("serialization."))
-                .forEach(name -> jobConf.set(name, schema.getProperty(name)));
+            .filter(schemaFilter)
+            .forEach(name -> jobConf.set(name, schema.getProperty(name)));
 
         // add Airlift LZO and LZOP to head of codecs list so as to not override existing entries
         List<String> codecs = newArrayList(Splitter.on(",").trimResults().omitEmptyStrings().split(jobConf.get("io.compression.codecs", "")));
@@ -261,6 +281,12 @@ public final class HiveUtil
         }
     }
 
+    private static boolean isHudiRealtimeSplit(Map<String, String> customSplitInfo)
+    {
+        String customSplitClass = customSplitInfo.get(HudiRealtimeSplitConverter.CUSTOM_SPLIT_CLASS_KEY);
+        return HoodieRealtimeFileSplit.class.getName().equals(customSplitClass);
+    }
+
     public static void setReadColumns(Configuration configuration, List<Integer> readHiveColumnIndexes)
     {
         configuration.set(READ_COLUMN_IDS_CONF_STR, Joiner.on(',').join(readHiveColumnIndexes));
@@ -285,7 +311,7 @@ public final class HiveUtil
         return Optional.ofNullable(compressionCodecFactory.getCodec(file));
     }
 
-    static InputFormat<?, ?> getInputFormat(Configuration configuration, String inputFormatName, boolean symlinkTarget)
+    public static InputFormat<?, ?> getInputFormat(Configuration configuration, String inputFormatName, boolean symlinkTarget)
     {
         try {
             JobConf jobConf = toJobConf(configuration);
@@ -326,6 +352,15 @@ public final class HiveUtil
         String name = schema.getProperty(FILE_INPUT_FORMAT);
         checkCondition(name != null, HIVE_INVALID_METADATA, "Table or partition is missing Hive input format property: %s", FILE_INPUT_FORMAT);
         return name;
+    }
+
+    public static boolean shouldUseRecordReaderFromInputFormat(Configuration configuration, Storage storage)
+    {
+        InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(configuration, storage.getStorageFormat().getInputFormat(), false);
+        return Arrays.stream(inputFormat.getClass().getAnnotations())
+            .map(Annotation::annotationType)
+            .map(Class::getSimpleName)
+            .anyMatch(name -> name.equals("UseRecordReaderFromInputFormat"));
     }
 
     public static long parseHiveDate(String value)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/InternalHiveSplit.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.fs.Path;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -65,6 +66,7 @@ public class InternalHiveSplit
     private final HiveSplitPartitionInfo partitionInfo;
     private final Optional<byte[]> extraFileInfo;
     private final Optional<EncryptionInformation> encryptionInformation;
+    private final Map<String, String> customSplitInfo;
 
     private long start;
     private int currentBlockIndex;
@@ -82,7 +84,8 @@ public class InternalHiveSplit
             boolean s3SelectPushdownEnabled,
             HiveSplitPartitionInfo partitionInfo,
             Optional<byte[]> extraFileInfo,
-            Optional<EncryptionInformation> encryptionInformation)
+            Optional<EncryptionInformation> encryptionInformation,
+            Map<String, String> customSplitInfo)
     {
         checkArgument(start >= 0, "start must be positive");
         checkArgument(end >= 0, "end must be positive");
@@ -106,6 +109,8 @@ public class InternalHiveSplit
         this.s3SelectPushdownEnabled = s3SelectPushdownEnabled;
         this.partitionInfo = partitionInfo;
         this.extraFileInfo = extraFileInfo;
+        this.customSplitInfo = ImmutableMap
+            .copyOf(requireNonNull(customSplitInfo, "customSplitInfo is null"));
 
         ImmutableList.Builder<List<HostAddress>> addressesBuilder = ImmutableList.builder();
         blockEndOffsets = new long[blocks.size()];
@@ -220,6 +225,11 @@ public class InternalHiveSplit
     public Optional<EncryptionInformation> getEncryptionInformation()
     {
         return this.encryptionInformation;
+    }
+
+    public Map<String, String> getCustomSplitInfo()
+    {
+        return customSplitInfo;
     }
 
     public void reset()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/S3SelectRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/S3SelectRecordCursorProvider.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -69,7 +70,8 @@ public class S3SelectRecordCursorProvider
             TupleDomain<HiveColumnHandle> effectivePredicate,
             DateTimeZone hiveStorageTimeZone,
             TypeManager typeManager,
-            boolean s3SelectPushdownEnabled)
+            boolean s3SelectPushdownEnabled,
+            Map<String, String> customSplitInfo)
     {
         if (!s3SelectPushdownEnabled) {
             return Optional.empty();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -91,6 +91,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.isFailOnCorruptedPa
 import static com.facebook.presto.hive.HiveSessionProperties.isParquetBatchReaderVerificationEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isParquetBatchReadsEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isUseParquetColumnNames;
+import static com.facebook.presto.hive.HiveUtil.shouldUseRecordReaderFromInputFormat;
 import static com.facebook.presto.hive.parquet.HdfsParquetDataSource.buildHdfsParquetDataSource;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.parquet.ParquetTypeUtils.getColumnIO;
@@ -142,7 +143,7 @@ public class ParquetPageSourceFactory
             HiveFileContext hiveFileContext,
             Optional<EncryptionInformation> encryptionInformation)
     {
-        if (!PARQUET_SERDE_CLASS_NAMES.contains(storage.getStorageFormat().getSerDe())) {
+        if (!PARQUET_SERDE_CLASS_NAMES.contains(storage.getStorageFormat().getSerDe()) || shouldUseRecordReaderFromInputFormat(configuration, storage)) {
             return Optional.empty();
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/CustomSplitConversionUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/CustomSplitConversionUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.util;
+
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.mapred.FileSplit;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
+
+/**
+ * Utility class for both extracting customSplitInfo Map from a custom FileSplit and transforming the customSplitInfo back into a FileSplit.
+ */
+public class CustomSplitConversionUtils
+{
+    private static final List<CustomSplitConverter> converters = ImmutableList.of(new HudiRealtimeSplitConverter());
+
+    private CustomSplitConversionUtils()
+    {
+    }
+
+    public static Map<String, String> extractCustomSplitInfo(FileSplit split)
+    {
+        for (CustomSplitConverter converter : converters) {
+            Optional<Map<String, String>> customSplitData = converter.extractCustomSplitInfo(split);
+            if (customSplitData.isPresent()) {
+                return customSplitData.get();
+            }
+        }
+        return ImmutableMap.of();
+    }
+
+    public static FileSplit recreateSplitWithCustomInfo(FileSplit split, Map<String, String> customSplitInfo)
+    {
+        for (CustomSplitConverter converter : converters) {
+            Optional<FileSplit> fileSplit;
+            try {
+                fileSplit = converter.recreateFileSplitWithCustomInfo(split, customSplitInfo);
+            }
+            catch (IOException e) {
+                throw new PrestoException(HIVE_UNSUPPORTED_FORMAT, String.format("Split converter %s failed to create FileSplit.", converter.getClass()), e);
+            }
+            if (fileSplit.isPresent()) {
+                return fileSplit.get();
+            }
+        }
+        return split;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/CustomSplitConverter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/CustomSplitConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.util;
+
+import org.apache.hadoop.mapred.FileSplit;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Interface for Split specific implementation of conversion from Split -> customSplitInfo Map and back.
+ */
+public interface CustomSplitConverter
+{
+    /**
+     * This method is expected to return optional.empty() if the FileSplit does not match the split converter.
+     */
+    Optional<Map<String, String>> extractCustomSplitInfo(FileSplit split);
+
+    /**
+     * This method is expected to merge the customSplitInfo with split to recreate the custom FileSplit.
+     * It is expected to return optional.empty() if the customSplitInfo does not match the split converter.
+     */
+    Optional<FileSplit> recreateFileSplitWithCustomInfo(FileSplit split, Map<String, String> customSplitInfo) throws IOException;
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/HudiRealtimeSplitConverter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/HudiRealtimeSplitConverter.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.util;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hudi.hadoop.realtime.HoodieRealtimeFileSplit;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * HoodieRealtimeFileSplit specific implementation of CustomSplitConverter.
+ * Extracts customSplitInfo from HoodieRealtimeFileSplit and reconstructs HoodieRealtimeFileSplit from Map.
+ */
+public class HudiRealtimeSplitConverter
+        implements CustomSplitConverter
+{
+    public static final String CUSTOM_SPLIT_CLASS_KEY = "custom_split_class";
+    private static final String HUDI_DELTA_FILEPATHS_KEY = "hudi_delta_filepaths";
+    private static final String HUDI_BASEPATH_KEY = "hudi_basepath";
+    private static final String HUDI_MAX_COMMIT_TIME_KEY = "hudi_max_commit_time";
+
+    @Override
+    public Optional<Map<String, String>> extractCustomSplitInfo(FileSplit split)
+    {
+        if (split instanceof HoodieRealtimeFileSplit) {
+            HoodieRealtimeFileSplit hudiSplit = (HoodieRealtimeFileSplit) split;
+            Map<String, String> customSplitInfo = ImmutableMap.<String, String>builder()
+                    .put(CUSTOM_SPLIT_CLASS_KEY, HoodieRealtimeFileSplit.class.getName())
+                    .put(HUDI_DELTA_FILEPATHS_KEY, String.join(",", hudiSplit.getDeltaLogPaths()))
+                    .put(HUDI_BASEPATH_KEY, hudiSplit.getBasePath())
+                    .put(HUDI_MAX_COMMIT_TIME_KEY, hudiSplit.getMaxCommitTime())
+                    .build();
+            return Optional.of(customSplitInfo);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<FileSplit> recreateFileSplitWithCustomInfo(FileSplit split, Map<String, String> customSplitInfo) throws IOException
+    {
+        String customSplitClass = customSplitInfo.get(CUSTOM_SPLIT_CLASS_KEY);
+        if (HoodieRealtimeFileSplit.class.getName().equals(customSplitClass)) {
+            requireNonNull(customSplitInfo.get(HUDI_DELTA_FILEPATHS_KEY), "HUDI_DELTA_FILEPATHS_KEY is missing");
+            List<String> deltaLogPaths = Arrays.asList(customSplitInfo.get(HUDI_DELTA_FILEPATHS_KEY).split(","));
+            return Optional.of(new HoodieRealtimeFileSplit(
+                split,
+                requireNonNull(customSplitInfo.get(HUDI_BASEPATH_KEY), "HUDI_BASEPATH_KEY is missing"),
+                deltaLogPaths,
+                requireNonNull(customSplitInfo.get(HUDI_MAX_COMMIT_TIME_KEY), "HUDI_MAX_COMMIT_TIME_KEY is missing")));
+        }
+        return Optional.empty();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
@@ -23,6 +23,7 @@ import com.facebook.presto.hive.S3SelectPushdown;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
@@ -36,10 +37,12 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.facebook.presto.hive.HiveUtil.isSplittable;
+import static com.facebook.presto.hive.util.CustomSplitConversionUtils.extractCustomSplitInfo;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.HARD_AFFINITY;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -105,13 +108,15 @@ public class InternalHiveSplitFactory
                 readBucketNumber,
                 tableBucketNumber,
                 splittable,
-                fileInfo.getExtraFileInfo());
+                fileInfo.getExtraFileInfo(),
+                ImmutableMap.of());
     }
 
     public Optional<InternalHiveSplit> createInternalHiveSplit(FileSplit split)
             throws IOException
     {
         FileStatus file = fileSystem.getFileStatus(split.getPath());
+        Map<String, String> customSplitInfo = extractCustomSplitInfo(split);
         return createInternalHiveSplit(
                 split.getPath(),
                 fileSystem.getFileBlockLocations(file, split.getStart(), split.getLength()),
@@ -121,7 +126,8 @@ public class InternalHiveSplitFactory
                 OptionalInt.empty(),
                 OptionalInt.empty(),
                 false,
-                Optional.empty());
+                Optional.empty(),
+                customSplitInfo);
     }
 
     private Optional<InternalHiveSplit> createInternalHiveSplit(
@@ -133,7 +139,8 @@ public class InternalHiveSplitFactory
             OptionalInt readBucketNumber,
             OptionalInt tableBucketNumber,
             boolean splittable,
-            Optional<byte[]> extraFileInfo)
+            Optional<byte[]> extraFileInfo,
+            Map<String, String> customSplitInfo)
     {
         String pathString = path.toString();
         if (!pathMatchesPredicate(pathDomain, pathString)) {
@@ -196,7 +203,8 @@ public class InternalHiveSplitFactory
                 s3SelectPushdownEnabled && S3SelectPushdown.isCompressionCodecSupported(inputFormat, path),
                 partitionInfo,
                 extraFileInfo,
-                encryptionInformation));
+                encryptionInformation,
+                customSplitInfo));
     }
 
     private boolean needsHostAddresses(boolean forceLocalScheduling, List<HostAddress> addresses)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
@@ -905,7 +905,8 @@ public class TestHiveFileFormats
                 TRUE_CONSTANT,
                 false,
                 ROW_EXPRESSION_SERVICE,
-                Optional.empty());
+                Optional.empty(),
+                ImmutableMap.of());
 
         RecordCursor cursor = ((RecordPageSource) pageSource.get()).getCursor();
 
@@ -968,7 +969,8 @@ public class TestHiveFileFormats
                 TRUE_CONSTANT,
                 false,
                 ROW_EXPRESSION_SERVICE,
-                Optional.empty());
+                Optional.empty(),
+                ImmutableMap.of());
 
         assertTrue(pageSource.isPresent());
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -246,7 +246,9 @@ public class TestHivePageSink
                 false,
                 Optional.empty(),
                 NO_CACHE_REQUIREMENT,
-                Optional.empty());
+                Optional.empty(),
+                ImmutableMap.of());
+
         TableHandle tableHandle = new TableHandle(
                 new ConnectorId(HIVE_CATALOG),
                 new HiveTableHandle(SCHEMA_NAME, TABLE_NAME),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
@@ -66,7 +66,8 @@ public class TestHivePageSourceProvider
                 false,
                 Optional.empty(),
                 NO_CACHE_REQUIREMENT,
-                Optional.empty());
+                Optional.empty(),
+                ImmutableMap.of());
 
         CacheQuota cacheQuota = HivePageSourceProvider.generateCacheQuota(split);
         CacheQuota expectedCacheQuota = new CacheQuota(".", Optional.empty());
@@ -98,7 +99,8 @@ public class TestHivePageSourceProvider
                 false,
                 Optional.empty(),
                 new CacheQuotaRequirement(PARTITION, Optional.of(DataSize.succinctDataSize(1, DataSize.Unit.MEGABYTE))),
-                Optional.empty());
+                Optional.empty(),
+                ImmutableMap.of());
 
         cacheQuota = HivePageSourceProvider.generateCacheQuota(split);
         expectedCacheQuota = new CacheQuota(SCHEMA_NAME + "." + TABLE_NAME + "." + PARTITION_NAME, Optional.of(DataSize.succinctDataSize(1, DataSize.Unit.MEGABYTE)));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
@@ -41,6 +41,7 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 import org.testng.annotations.Test;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -63,6 +64,7 @@ public class TestHiveSplit
     {
         ImmutableList<HivePartitionKey> partitionKeys = ImmutableList.of(new HivePartitionKey("a", "apple"), new HivePartitionKey("b", "42"));
         ImmutableList<HostAddress> addresses = ImmutableList.of(HostAddress.fromParts("127.0.0.1", 44), HostAddress.fromParts("127.0.0.1", 45));
+        Map<String, String> customSplitInfo = ImmutableMap.of("key", "value");
         HiveSplit expected = new HiveSplit(
                 "db",
                 "table",
@@ -96,7 +98,8 @@ public class TestHiveSplit
                         ImmutableMap.of("field1", "test1".getBytes()),
                         ImmutableMap.of(),
                         "test_algo",
-                        "test_provider"))));
+                        "test_provider"))),
+                customSplitInfo);
 
         JsonCodec<HiveSplit> codec = getJsonCodec();
         String json = codec.toJson(expected);
@@ -119,6 +122,7 @@ public class TestHiveSplit
         assertEquals(actual.isS3SelectPushdownEnabled(), expected.isS3SelectPushdownEnabled());
         assertEquals(actual.getCacheQuotaRequirement(), expected.getCacheQuotaRequirement());
         assertEquals(actual.getEncryptionInformation(), expected.getEncryptionInformation());
+        assertEquals(actual.getCustomSplitInfo(), expected.getCustomSplitInfo());
     }
 
     private JsonCodec<HiveSplit> getJsonCodec()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -544,7 +544,8 @@ public class TestHiveSplitSource
                             ImmutableMap.of(),
                             Optional.empty()),
                     Optional.empty(),
-                    Optional.empty());
+                    Optional.empty(),
+                    ImmutableMap.of());
         }
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveUtil.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveUtil.java
@@ -14,7 +14,10 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.metastore.StorageFormat;
 import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.Warehouse;
@@ -31,16 +34,20 @@ import java.io.File;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 
 import static com.facebook.airlift.testing.Assertions.assertInstanceOf;
 import static com.facebook.presto.hive.HiveUtil.getDeserializer;
 import static com.facebook.presto.hive.HiveUtil.parseHiveTimestamp;
+import static com.facebook.presto.hive.HiveUtil.shouldUseRecordReaderFromInputFormat;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.toPartitionValues;
 import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_CLASS;
 import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_FORMAT;
 import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_LIB;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestHiveUtil
 {
@@ -85,6 +92,16 @@ public class TestHiveUtil
         assertToPartitionValues("a=1");
         assertToPartitionValues("pk=!@%23$%25%5E&%2A()%2F%3D");
         assertToPartitionValues("pk=__HIVE_DEFAULT_PARTITION__");
+    }
+
+    @Test
+    public void testShouldUseRecordReaderFromInputFormat()
+    {
+        StorageFormat hudiStorageFormat = StorageFormat.create("parquet.hive.serde.ParquetHiveSerDe", "org.apache.hudi.hadoop.HoodieParquetInputFormat", "");
+        assertFalse(shouldUseRecordReaderFromInputFormat(new Configuration(), new Storage(hudiStorageFormat, "test", Optional.empty(), true, ImmutableMap.of(), ImmutableMap.of())));
+
+        StorageFormat hudiRealtimeStorageFormat = StorageFormat.create("parquet.hive.serde.ParquetHiveSerDe", "org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat", "");
+        assertTrue(shouldUseRecordReaderFromInputFormat(new Configuration(), new Storage(hudiRealtimeStorageFormat, "test", Optional.empty(), true, ImmutableMap.of(), ImmutableMap.of())));
     }
 
     private static void assertToPartitionValues(String partitionName)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
@@ -513,7 +513,8 @@ public class TestOrcBatchPageSourceMemoryTracking
                     null,
                     false,
                     ROW_EXPRESSION_SERVICE,
-                    Optional.empty())
+                    Optional.empty(),
+                    ImmutableMap.of())
                     .get();
         }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -436,7 +436,8 @@ public enum FileFormat
                         TupleDomain.all(),
                         DateTimeZone.forID(session.getSqlFunctionProperties().getTimeZoneKey().getId()),
                         TYPE_MANAGER,
-                        false)
+                        false,
+                        ImmutableMap.of())
                 .get();
         return new RecordPageSource(columnTypes, recordCursor);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestParquetPageSourceFactory.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestParquetPageSourceFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.parquet;
+
+import com.facebook.presto.common.type.TestingTypeManager;
+import com.facebook.presto.hive.FileFormatDataSourceStats;
+import com.facebook.presto.hive.HdfsConfigurationInitializer;
+import com.facebook.presto.hive.HdfsEnvironment;
+import com.facebook.presto.hive.HiveClientConfig;
+import com.facebook.presto.hive.HiveHdfsConfiguration;
+import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.metastore.StorageFormat;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertFalse;
+
+public class TestParquetPageSourceFactory
+{
+    private static final String PARQUET_HIVE_SERDE = "parquet.hive.serde.ParquetHiveSerDe";
+
+    private ParquetPageSourceFactory parquetPageSourceFactory;
+
+    @BeforeClass
+    public void setUp()
+    {
+        HiveHdfsConfiguration hiveHdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(new HiveClientConfig(), new MetastoreClientConfig()), ImmutableSet.of());
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hiveHdfsConfiguration, new MetastoreClientConfig(), new NoHdfsAuthentication());
+        parquetPageSourceFactory = new ParquetPageSourceFactory(new TestingTypeManager(), hdfsEnvironment, new FileFormatDataSourceStats());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanUp()
+    {
+        parquetPageSourceFactory = null;
+    }
+
+    @Test
+    public void testCreatePageSourceEmptyWithoutParquetSerDe()
+    {
+        StorageFormat storageFormat = StorageFormat.create("random.test.serde", "random.test.inputformat", "");
+        Storage storage = new Storage(storageFormat, "test", Optional.empty(), true, ImmutableMap.of(), ImmutableMap.of());
+        Optional<? extends ConnectorPageSource> optionalPageSource = parquetPageSourceFactory.createPageSource(new Configuration(), null, null, 0L, 0L, 0L, storage, null, null, null, null, null, null, Optional.empty());
+        assertFalse(optionalPageSource.isPresent());
+    }
+
+    @Test
+    public void testCreatePageSourceEmptyWithParquetSerDeAndAnnotation()
+    {
+        StorageFormat storageFormat = StorageFormat.create(PARQUET_HIVE_SERDE, HoodieParquetRealtimeInputFormat.class.getName(), "");
+        Storage storage = new Storage(storageFormat, "test", Optional.empty(), true, ImmutableMap.of(), ImmutableMap.of());
+        Optional<? extends ConnectorPageSource> optionalPageSource = parquetPageSourceFactory.createPageSource(new Configuration(), null, null, 0L, 0L, 0L, storage, null, null, null, null, null, null, Optional.empty());
+        assertFalse(optionalPageSource.isPresent());
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/util/TestCustomSplitConversionUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/util/TestCustomSplitConversionUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.util;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hudi.hadoop.realtime.HoodieRealtimeFileSplit;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestCustomSplitConversionUtils
+{
+    @Test
+    public void testHudiRealtimeSplitConverterRoundTrip() throws IOException
+    {
+        Path expectedPath = new Path("s3://test/path");
+        long expectedStart = 1L;
+        long expectedLength = 2L;
+        String[] expectedLocations = new String[] {"one", "two"};
+        String expectedBasepath = "basepath";
+        List<String> expectedDeltaLogPaths = Arrays.asList("test1", "test2", "test3");
+        String expectedMaxCommitTime = "max_commit_time";
+
+        FileSplit baseSplit = new FileSplit(expectedPath, expectedStart, expectedLength, expectedLocations);
+        FileSplit hudiSplit = new HoodieRealtimeFileSplit(baseSplit, expectedBasepath, expectedDeltaLogPaths, expectedMaxCommitTime);
+
+        // Test conversion of HudiSplit -> customSplitInfo
+        Map<String, String> customSplitInfo = CustomSplitConversionUtils.extractCustomSplitInfo(hudiSplit);
+
+        // Test conversion of (customSplitInfo + baseSplit) -> HudiSplit
+        FileSplit recreatedSplit = CustomSplitConversionUtils.recreateSplitWithCustomInfo(baseSplit, customSplitInfo);
+
+        assertEquals(recreatedSplit.getPath(), expectedPath);
+        assertEquals(recreatedSplit.getStart(), expectedStart);
+        assertEquals(recreatedSplit.getLength(), expectedLength);
+        assertEquals(recreatedSplit.getLocations(), expectedLocations);
+        assertEquals(((HoodieRealtimeFileSplit) recreatedSplit).getBasePath(), expectedBasepath);
+        assertEquals(((HoodieRealtimeFileSplit) recreatedSplit).getDeltaLogPaths(), expectedDeltaLogPaths);
+        assertEquals(((HoodieRealtimeFileSplit) recreatedSplit).getMaxCommitTime(), expectedMaxCommitTime);
+    }
+}


### PR DESCRIPTION
Allows presto-hive to support the use of custom input formats with custom
file splits and record readers. Tested using Hudi merge-on-read table
input format.

This is a rebase of the hudi presto realtime query patch on presto mainline. Tests are passing but need to double check for any possible new issues for Hudi given the rebase. Just wanted to get this opened for feedback ASAP.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

Hive Changes
* Allows presto-hive to use custom parquet input formats 
* Add support for Hudi realtime input format for hudi realtime queries

