### PR TITLE
Partition filtering warning

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.TableLayoutFilterCoverage;
 import com.facebook.presto.spi.api.Experimental;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
@@ -51,6 +52,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+
+import static com.facebook.presto.spi.TableLayoutFilterCoverage.NOT_APPLICABLE;
 
 public interface Metadata
 {
@@ -450,4 +453,13 @@ public interface Metadata
     AnalyzePropertyManager getAnalyzePropertyManager();
 
     Set<ConnectorCapabilities> getConnectorCapabilities(Session session, ConnectorId catalogName);
+
+    /**
+     * Check if there is filter coverage of the specified partitioning keys
+     * @return NOT_APPLICABLE if partitioning is unsupported, not applicable, or the partitioning key is not relevant, NONE or COVERED otherwise
+     */
+    default TableLayoutFilterCoverage getTableLayoutFilterCoverage(Session session, TableHandle tableHandle, Set<String> relevantPartitionColumn)
+    {
+        return NOT_APPLICABLE;
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -146,6 +146,7 @@ import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.tree.Expression;
@@ -226,6 +227,8 @@ public class ServerMainModule
         install(new InternalCommunicationModule());
 
         configBinder(binder).bindConfig(FeaturesConfig.class);
+
+        binder.bind(PlanChecker.class).in(Scopes.SINGLETON);
 
         binder.bind(SqlParser.class).in(Scopes.SINGLETON);
         binder.bind(SqlParserOptions.class).toInstance(sqlParserOptions);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -156,6 +156,8 @@ public class FeaturesConfig
     private boolean preferDistributedUnion = true;
     private boolean optimizeNullsInJoin;
 
+    private String warnOnNoTableLayoutFilter = "";
+
     private PartitioningPrecisionStrategy partitioningPrecisionStrategy = PartitioningPrecisionStrategy.AUTOMATIC;
 
     public enum PartitioningPrecisionStrategy
@@ -1288,6 +1290,18 @@ public class FeaturesConfig
     public FeaturesConfig setOptimizeNullsInJoin(boolean optimizeNullsInJoin)
     {
         this.optimizeNullsInJoin = optimizeNullsInJoin;
+        return this;
+    }
+
+    public String getWarnOnNoTableLayoutFilter()
+    {
+        return warnOnNoTableLayoutFilter;
+    }
+
+    @Config("warn-on-no-table-layout-filter")
+    public FeaturesConfig setWarnOnNoTableLayoutFilter(String warnOnNoTableLayoutFilter)
+    {
+        this.warnOnNoTableLayoutFilter = warnOnNoTableLayoutFilter;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -101,7 +101,6 @@ import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.CreateName;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.InsertReference;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.WriterTarget;
-import static com.facebook.presto.sql.planner.sanity.PlanChecker.DISTRIBUTED_PLAN_CHECKER;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.google.common.base.Preconditions.checkState;
@@ -141,9 +140,10 @@ public class LogicalPlanner
             SqlParser sqlParser,
             StatsCalculator statsCalculator,
             CostCalculator costCalculator,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            PlanChecker planChecker)
     {
-        this(explain, session, planOptimizers, DISTRIBUTED_PLAN_CHECKER, idAllocator, metadata, sqlParser, statsCalculator, costCalculator, warningCollector);
+        this(explain, session, planOptimizers, planChecker, idAllocator, metadata, sqlParser, statsCalculator, costCalculator, warningCollector);
     }
 
     public LogicalPlanner(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -63,7 +63,7 @@ import com.facebook.presto.sql.planner.plan.StatisticsWriterNode;
 import com.facebook.presto.sql.planner.plan.TableFinishNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode.DeleteHandle;
-import com.facebook.presto.sql.planner.sanity.PlanSanityChecker;
+import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.sql.tree.Analyze;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
@@ -101,7 +101,7 @@ import static com.facebook.presto.spi.statistics.TableStatisticType.ROW_COUNT;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.CreateName;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.InsertReference;
 import static com.facebook.presto.sql.planner.plan.TableWriterNode.WriterTarget;
-import static com.facebook.presto.sql.planner.sanity.PlanSanityChecker.DISTRIBUTED_PLAN_SANITY_CHECKER;
+import static com.facebook.presto.sql.planner.sanity.PlanChecker.DISTRIBUTED_PLAN_CHECKER;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
 import static com.google.common.base.Preconditions.checkState;
@@ -123,7 +123,7 @@ public class LogicalPlanner
     private final PlanNodeIdAllocator idAllocator;
     private final Session session;
     private final List<PlanOptimizer> planOptimizers;
-    private final PlanSanityChecker planSanityChecker;
+    private final PlanChecker planChecker;
     private final PlanVariableAllocator variableAllocator = new PlanVariableAllocator();
     private final Metadata metadata;
     private final SqlParser sqlParser;
@@ -143,14 +143,14 @@ public class LogicalPlanner
             CostCalculator costCalculator,
             WarningCollector warningCollector)
     {
-        this(explain, session, planOptimizers, DISTRIBUTED_PLAN_SANITY_CHECKER, idAllocator, metadata, sqlParser, statsCalculator, costCalculator, warningCollector);
+        this(explain, session, planOptimizers, DISTRIBUTED_PLAN_CHECKER, idAllocator, metadata, sqlParser, statsCalculator, costCalculator, warningCollector);
     }
 
     public LogicalPlanner(
             boolean explain,
             Session session,
             List<PlanOptimizer> planOptimizers,
-            PlanSanityChecker planSanityChecker,
+            PlanChecker planChecker,
             PlanNodeIdAllocator idAllocator,
             Metadata metadata,
             SqlParser sqlParser,
@@ -161,7 +161,7 @@ public class LogicalPlanner
         this.explain = explain;
         this.session = requireNonNull(session, "session is null");
         this.planOptimizers = requireNonNull(planOptimizers, "planOptimizers is null");
-        this.planSanityChecker = requireNonNull(planSanityChecker, "planSanityChecker is null");
+        this.planChecker = requireNonNull(planChecker, "planChecker is null");
         this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
@@ -180,7 +180,7 @@ public class LogicalPlanner
     {
         PlanNode root = planStatement(analysis, analysis.getStatement());
 
-        planSanityChecker.validateIntermediatePlan(root, session, metadata, sqlParser, variableAllocator.getTypes(), warningCollector);
+        planChecker.validateIntermediatePlan(root, session, metadata, sqlParser, variableAllocator.getTypes(), warningCollector);
 
         if (stage.ordinal() >= Stage.OPTIMIZED.ordinal()) {
             for (PlanOptimizer optimizer : planOptimizers) {
@@ -191,7 +191,7 @@ public class LogicalPlanner
 
         if (stage.ordinal() >= Stage.OPTIMIZED_AND_VALIDATED.ordinal()) {
             // make sure we produce a valid plan after optimizations run. This is mainly to catch programming errors
-            planSanityChecker.validateFinalPlan(root, session, metadata, sqlParser, variableAllocator.getTypes(), warningCollector);
+            planChecker.validateFinalPlan(root, session, metadata, sqlParser, variableAllocator.getTypes(), warningCollector);
         }
 
         TypeProvider types = variableAllocator.getTypes();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -72,7 +72,7 @@ import com.facebook.presto.sql.planner.plan.TableWriterNode.InsertReference;
 import com.facebook.presto.sql.planner.plan.TableWriterNode.WriterTarget;
 import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.WindowNode;
-import com.facebook.presto.sql.planner.sanity.PlanSanityChecker;
+import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -166,7 +166,7 @@ public class PlanFragmenter
                 session,
                 metadata,
                 plan.getStatsAndCosts(),
-                new PlanSanityChecker(forceSingleNode),
+                new PlanChecker(forceSingleNode),
                 warningCollector,
                 sqlParser,
                 idAllocator,
@@ -343,7 +343,7 @@ public class PlanFragmenter
         private final PlanNodeIdAllocator idAllocator;
         private final PlanVariableAllocator variableAllocator;
         private final StatsAndCosts statsAndCosts;
-        private final PlanSanityChecker planSanityChecker;
+        private final PlanChecker planChecker;
         private final WarningCollector warningCollector;
         private final SqlParser sqlParser;
         private final Set<PlanNodeId> outputTableWriterNodeIds;
@@ -354,7 +354,7 @@ public class PlanFragmenter
                 Session session,
                 Metadata metadata,
                 StatsAndCosts statsAndCosts,
-                PlanSanityChecker planSanityChecker,
+                PlanChecker planChecker,
                 WarningCollector warningCollector,
                 SqlParser sqlParser,
                 PlanNodeIdAllocator idAllocator,
@@ -364,7 +364,7 @@ public class PlanFragmenter
             this.session = requireNonNull(session, "session is null");
             this.metadata = requireNonNull(metadata, "metadata is null");
             this.statsAndCosts = requireNonNull(statsAndCosts, "statsAndCosts is null");
-            this.planSanityChecker = requireNonNull(planSanityChecker, "planSanityChecker is null");
+            this.planChecker = requireNonNull(planChecker, "planChecker is null");
             this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
             this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
@@ -393,7 +393,7 @@ public class PlanFragmenter
                     properties.getPartitionedSources());
 
             Set<VariableReferenceExpression> fragmentVariableTypes = extractOutputVariables(root);
-            planSanityChecker.validatePlanFragment(root, session, metadata, sqlParser, TypeProvider.fromVariables(fragmentVariableTypes), warningCollector);
+            planChecker.validatePlanFragment(root, session, metadata, sqlParser, TypeProvider.fromVariables(fragmentVariableTypes), warningCollector);
 
             Set<PlanNodeId> tableWriterNodeIds = getTableWriterNodeIds(root);
             boolean outputTableWriterFragment = tableWriterNodeIds.stream().anyMatch(outputTableWriterNodeIds::contains);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -1341,7 +1341,7 @@ public class AddExchanges
 
         private ActualProperties deriveProperties(PlanNode result, List<ActualProperties> inputProperties)
         {
-            // TODO: move this logic to PlanSanityChecker once PropertyDerivations.deriveProperties fully supports local exchanges
+            // TODO: move this logic to PlanChecker once PropertyDerivations.deriveProperties fully supports local exchanges
             ActualProperties outputProperties = PropertyDerivations.deriveProperties(result, inputProperties, metadata, session, types, parser);
             verify(result instanceof SemiJoinNode || inputProperties.stream().noneMatch(ActualProperties::isNullsAndAnyReplicated) || outputProperties.isNullsAndAnyReplicated(),
                     "SemiJoinNode is the only node that can strip null replication");

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoDuplicatePlanNodeIdsChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoDuplicatePlanNodeIdsChecker.java
@@ -30,7 +30,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class NoDuplicatePlanNodeIdsChecker
-        implements PlanSanityChecker.Checker
+        implements PlanChecker.Checker
 {
     @Override
     public void validate(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoIdentifierLeftChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoIdentifierLeftChecker.java
@@ -29,7 +29,7 @@ import java.util.List;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public final class NoIdentifierLeftChecker
-        implements PlanSanityChecker.Checker
+        implements PlanChecker.Checker
 {
     @Override
     public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoSubqueryExpressionLeftChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/NoSubqueryExpressionLeftChecker.java
@@ -31,7 +31,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 
 public final class NoSubqueryExpressionLeftChecker
-        implements PlanSanityChecker.Checker
+        implements PlanChecker.Checker
 {
     @Override
     public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
@@ -23,15 +23,15 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
 
 /**
- * It is going to be executed to verify logical planner correctness
+ * Perform checks on the plan that may generate warnings or errors.
  */
-public final class PlanSanityChecker
+public final class PlanChecker
 {
-    public static final PlanSanityChecker DISTRIBUTED_PLAN_SANITY_CHECKER = new PlanSanityChecker(false);
+    public static final PlanChecker DISTRIBUTED_PLAN_CHECKER = new PlanChecker(false);
 
     private final Multimap<Stage, Checker> checkers;
 
-    public PlanSanityChecker(boolean forceSingleNode)
+    public PlanChecker(boolean forceSingleNode)
     {
         checkers = ImmutableListMultimap.<Stage, Checker>builder()
                 .putAll(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/TypeValidator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/TypeValidator.java
@@ -53,7 +53,7 @@ import static java.util.Objects.requireNonNull;
  * Ensures that all the expressions and FunctionCalls matches their output symbols
  */
 public final class TypeValidator
-        implements PlanSanityChecker.Checker
+        implements PlanChecker.Checker
 {
     public TypeValidator() {}
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateAggregationsWithDefaultValues.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateAggregationsWithDefaultValues.java
@@ -26,7 +26,7 @@ import com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations;
 import com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
-import com.facebook.presto.sql.planner.sanity.PlanSanityChecker.Checker;
+import com.facebook.presto.sql.planner.sanity.PlanChecker.Checker;
 
 import java.util.List;
 import java.util.Optional;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -88,7 +88,7 @@ import static java.util.Objects.requireNonNull;
  * Ensures that all dependencies (i.e., symbols in expressions) for a plan node are provided by its source nodes
  */
 public final class ValidateDependenciesChecker
-        implements PlanSanityChecker.Checker
+        implements PlanChecker.Checker
 {
     @Override
     public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateStreamingAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateStreamingAggregations.java
@@ -26,7 +26,7 @@ import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.optimizations.LocalProperties;
 import com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
-import com.facebook.presto.sql.planner.sanity.PlanSanityChecker.Checker;
+import com.facebook.presto.sql.planner.sanity.PlanChecker.Checker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoFilteredAggregations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoFilteredAggregations.java
@@ -24,7 +24,7 @@ import com.facebook.presto.sql.planner.TypeProvider;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 
 public final class VerifyNoFilteredAggregations
-        implements PlanSanityChecker.Checker
+        implements PlanChecker.Checker
 {
     @Override
     public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoOriginalExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoOriginalExpression.java
@@ -40,7 +40,7 @@ import static com.facebook.presto.sql.relational.OriginalExpressionUtils.isExpre
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class VerifyNoOriginalExpression
-        implements PlanSanityChecker.Checker
+        implements PlanChecker.Checker
 {
     @Override
     public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyOnlyOneOutputNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyOnlyOneOutputNode.java
@@ -25,7 +25,7 @@ import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.sea
 import static com.google.common.base.Preconditions.checkState;
 
 public final class VerifyOnlyOneOutputNode
-        implements PlanSanityChecker.Checker
+        implements PlanChecker.Checker
 {
     @Override
     public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/WarnOnScanWithoutPartitionPredicate.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/WarnOnScanWithoutPartitionPredicate.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.warnings.WarningCollector;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.TableLayoutFilterCoverage;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+import static com.facebook.presto.spi.StandardWarningCode.PERFORMANCE_WARNING;
+import static com.facebook.presto.spi.TableLayoutFilterCoverage.NOT_COVERED;
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+
+public final class WarnOnScanWithoutPartitionPredicate
+        implements PlanChecker.Checker
+{
+    private final Set<String> warnOnNoTableLayoutFilter;
+
+    WarnOnScanWithoutPartitionPredicate(FeaturesConfig featuresConfig)
+    {
+        warnOnNoTableLayoutFilter = ImmutableSet.copyOf(Splitter.on(",").trimResults().omitEmptyStrings().split(featuresConfig.getWarnOnNoTableLayoutFilter()));
+    }
+
+    @Override
+    public void validate(PlanNode plan, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    {
+        for (TableScanNode scan : searchFrom(plan)
+                .where(TableScanNode.class::isInstance)
+                .<TableScanNode>findAll()) {
+            TableHandle tableHandle = scan.getTable();
+            TableLayoutFilterCoverage partitioningFilterCoverage = metadata.getTableLayoutFilterCoverage(session, tableHandle, warnOnNoTableLayoutFilter);
+            if (partitioningFilterCoverage == NOT_COVERED) {
+                String warningMessage = String.format("No partition filter for scan of table %s", scan.getTable().getConnectorHandle());
+                warningCollector.add(new PrestoWarning(PERFORMANCE_WARNING, warningMessage));
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -156,7 +156,7 @@ import com.facebook.presto.sql.planner.RemoteSourceFactory;
 import com.facebook.presto.sql.planner.SubPlan;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.planPrinter.PlanPrinter;
-import com.facebook.presto.sql.planner.sanity.PlanSanityChecker;
+import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.tree.AlterFunction;
@@ -959,7 +959,7 @@ public class LocalQueryRunner
                 dataDefinitionTask);
         Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.of(queryExplainer), preparedQuery.getParameters(), warningCollector);
 
-        LogicalPlanner logicalPlanner = new LogicalPlanner(wrappedStatement instanceof Explain, session, optimizers, new PlanSanityChecker(true), idAllocator, metadata, sqlParser, statsCalculator, costCalculator, warningCollector);
+        LogicalPlanner logicalPlanner = new LogicalPlanner(wrappedStatement instanceof Explain, session, optimizers, new PlanChecker(true), idAllocator, metadata, sqlParser, statsCalculator, costCalculator, warningCollector);
 
         Analysis analysis = analyzer.analyze(preparedQuery.getStatement());
         return logicalPlanner.plan(analysis, stage);

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -137,7 +137,7 @@ public class TestCostCalculator
                 new NodeTaskMap(finalizerService));
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager);
-        planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new SqlParser());
+        planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new SqlParser(), new FeaturesConfig());
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -136,7 +136,8 @@ public class TestFeaturesConfig
                 .setUseLegacyScheduler(true)
                 .setOptimizeCommonSubExpressions(true)
                 .setPreferDistributedUnion(true)
-                .setOptimizeNullsInJoin(false));
+                .setOptimizeNullsInJoin(false)
+                .setWarnOnNoTableLayoutFilter(""));
     }
 
     @Test
@@ -229,6 +230,7 @@ public class TestFeaturesConfig
                 .put("optimize-common-sub-expressions", "false")
                 .put("prefer-distributed-union", "false")
                 .put("optimize-nulls-in-join", "true")
+                .put("warn-on-no-table-layout-filter", "ry@nlikestheyankees,ds")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -317,7 +319,8 @@ public class TestFeaturesConfig
                 .setUseLegacyScheduler(false)
                 .setOptimizeCommonSubExpressions(false)
                 .setPreferDistributedUnion(false)
-                .setOptimizeNullsInJoin(true);
+                .setOptimizeNullsInJoin(true)
+                .setWarnOnNoTableLayoutFilter("ry@nlikestheyankees,ds");
         assertFullMapping(properties, expected);
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -138,6 +138,7 @@ import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.PlanFragmenter;
 import com.facebook.presto.sql.planner.PlanOptimizers;
+import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.tree.Statement;
@@ -315,6 +316,7 @@ public class PrestoSparkModule
         binder.bind(QueryExplainer.class).in(Scopes.SINGLETON);
 
         // parser
+        binder.bind(PlanChecker.class).in(Scopes.SINGLETON);
         binder.bind(SqlParser.class).in(Scopes.SINGLETON);
         binder.bind(SqlParserOptions.class).toInstance(new SqlParserOptions());
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
@@ -34,6 +34,7 @@ import com.facebook.presto.sql.planner.OutputExtractor;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.PlanOptimizers;
 import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -56,6 +57,7 @@ public class PrestoSparkQueryPlanner
     private final StatsCalculator statsCalculator;
     private final CostCalculator costCalculator;
     private final AccessControl accessControl;
+    private final PlanChecker planChecker;
 
     @Inject
     public PrestoSparkQueryPlanner(
@@ -65,7 +67,8 @@ public class PrestoSparkQueryPlanner
             Metadata metadata,
             StatsCalculator statsCalculator,
             CostCalculator costCalculator,
-            AccessControl accessControl)
+            AccessControl accessControl,
+            PlanChecker planChecker)
     {
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.optimizers = requireNonNull(optimizers, "optimizers is null");
@@ -74,6 +77,7 @@ public class PrestoSparkQueryPlanner
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
         this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.planChecker = requireNonNull(planChecker, "planChecker is null");
     }
 
     public PlanAndMore createQueryPlan(Session session, PreparedQuery preparedQuery, WarningCollector warningCollector)
@@ -98,7 +102,8 @@ public class PrestoSparkQueryPlanner
                 sqlParser,
                 statsCalculator,
                 costCalculator,
-                warningCollector);
+                warningCollector,
+                planChecker);
 
         Analysis analysis = analyzer.analyze(preparedQuery.getStatement());
         Plan plan = logicalPlanner.plan(analysis, OPTIMIZED_AND_VALIDATED);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/TableLayoutFilterCoverage.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/TableLayoutFilterCoverage.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+/**
+ * Result indicating whether a set of filters on partition columns retricts the range of values
+ * on the columns
+ */
+public enum TableLayoutFilterCoverage
+{
+    // No columns are restricted
+    NOT_COVERED,
+    // Unknown, not checked, or inapplicable
+    NOT_APPLICABLE,
+    // At least some columns are restricted
+    COVERED
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -33,6 +33,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.SystemTable;
+import com.facebook.presto.spi.TableLayoutFilterCoverage;
 import com.facebook.presto.spi.api.Experimental;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrestoPrincipal;
@@ -54,6 +55,7 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.spi.TableLayoutFilterCoverage.NOT_APPLICABLE;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
@@ -696,5 +698,10 @@ public interface ConnectorMetadata
     default CompletableFuture<Void> commitPageSinkAsync(ConnectorSession session, ConnectorInsertTableHandle tableHandle, Collection<Slice> fragments)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support page sink commit");
+    }
+
+    default TableLayoutFilterCoverage getTableLayoutFilterCoverage(ConnectorTableLayoutHandle tableHandle, Set<String> relevantPartitionColumns)
+    {
+        return NOT_APPLICABLE;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.SystemTable;
+import com.facebook.presto.spi.TableLayoutFilterCoverage;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
@@ -621,6 +622,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.commitPageSinkAsync(session, tableHandle, fragments);
+        }
+    }
+
+    @Override
+    public TableLayoutFilterCoverage getTableLayoutFilterCoverage(ConnectorTableLayoutHandle tableHandle, Set<String> relevantPartitionColumns)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getTableLayoutFilterCoverage(tableHandle, relevantPartitionColumns);
         }
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -33,6 +33,7 @@ import com.facebook.presto.sql.planner.PlanOptimizers;
 import com.facebook.presto.sql.planner.assertions.PlanAssert;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
+import com.facebook.presto.sql.planner.sanity.PlanChecker;
 import com.facebook.presto.sql.tree.ExplainType;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
@@ -398,13 +399,14 @@ public abstract class AbstractTestQueryFramework
                 taskCountEstimator).get();
         return new QueryExplainer(
                 optimizers,
-                new PlanFragmenter(metadata, queryRunner.getNodePartitioningManager(), new QueryManagerConfig(), sqlParser),
+                new PlanFragmenter(metadata, queryRunner.getNodePartitioningManager(), new QueryManagerConfig(), sqlParser, new FeaturesConfig()),
                 metadata,
                 queryRunner.getAccessControl(),
                 sqlParser,
                 queryRunner.getStatsCalculator(),
                 costCalculator,
-                ImmutableMap.of());
+                ImmutableMap.of(),
+                new PlanChecker(new FeaturesConfig(), false));
     }
 
     protected static void skipTestUnless(boolean requirement)


### PR DESCRIPTION
Still cleaning this up. Not ready for review.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* Add support for warning on unfiltered partition keys using `partition-keys-to-warn-on-no-filtering` system property.
```