### PR TITLE
Avoid fetching encryption information when no columns requested

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/AbstractDwrfEncryptionInformationSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/AbstractDwrfEncryptionInformationSource.java
@@ -106,7 +106,12 @@ public abstract class AbstractDwrfEncryptionInformationSource
 
         Map<String, String> fieldToKeyReference;
         if (encryptTable.isPresent()) {
-            fieldToKeyReference = ImmutableMap.of(DwrfEncryptionMetadata.TABLE_IDENTIFIER, encryptTable.get());
+            if (!requestedColumns.isPresent() || !requestedColumns.get().isEmpty()) {
+                fieldToKeyReference = ImmutableMap.of(DwrfEncryptionMetadata.TABLE_IDENTIFIER, encryptTable.get());
+            }
+            else {
+                fieldToKeyReference = ImmutableMap.of();
+            }
         }
         else if (columnEncryptionInformation.isPresent()) {
             Map<ColumnWithStructSubfield, String> allFieldsToKeyReference = columnEncryptionInformation.get().getColumnToKeyReference();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
@@ -120,6 +120,26 @@ public class TestAbstractDwrfEncryptionInformationSource
     }
 
     @Test
+    public void testGetReadEncryptionInformationForPartitionedTableWithTableLevelEncryptionAndNoRequestedColumns()
+    {
+        Table table = createTable(DWRF, Optional.of(forTable("key1", "algo", "provider")), true);
+        Optional<Map<String, EncryptionInformation>> encryptionInformation = encryptionInformationSource.getReadEncryptionInformation(
+                SESSION,
+                table,
+                Optional.of(ImmutableSet.of()),
+                ImmutableMap.of(
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of()),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of())));
+
+        assertTrue(encryptionInformation.isPresent());
+        assertEquals(
+                encryptionInformation.get(),
+                ImmutableMap.of(
+                        "ds=2020-01-01", EncryptionInformation.fromEncryptionMetadata(DwrfEncryptionMetadata.forPerField(ImmutableMap.of(), ImmutableMap.of(TEST_EXTRA_METADATA, "ds=2020-01-01"), "algo", "provider")),
+                        "ds=2020-01-02", EncryptionInformation.fromEncryptionMetadata(DwrfEncryptionMetadata.forPerField(ImmutableMap.of(), ImmutableMap.of(TEST_EXTRA_METADATA, "ds=2020-01-02"), "algo", "provider"))));
+    }
+
+    @Test
     public void testGetReadEncryptionInformationForPartitionedTableWithColumnLevelEncryption()
     {
         Table table = createTable(DWRF, Optional.of(forPerColumn(fromHiveProperty("key1:col_string,col_struct.b.b2;key2:col_bigint,col_struct.a"), "algo", "provider")), true);


### PR DESCRIPTION
This can happen if the user is only asking for partition columns or something like count(*). As of now,
if the table has table level encryption key, we will try getting the key metadata for that key where
as it is not needed. This change will allow users who don't have access to the table data to still be able
to get the partition columns or count(*) and bring the implementation at par with column level encryption
key specification

```
== NO RELEASE NOTE ==
```
