### PR TITLE
Add support of caching for glue metastore

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueMetastoreModule.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueMetastoreModule.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.hive.metastore.glue;
 
 import com.facebook.airlift.concurrent.BoundedExecutor;
+import com.facebook.presto.hive.ForCachingHiveMetastore;
+import com.facebook.presto.hive.metastore.CachingHiveMetastore;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -45,9 +47,10 @@ public class GlueMetastoreModule
     public void configure(Binder binder)
     {
         configBinder(binder).bindConfig(GlueHiveMetastoreConfig.class);
-        binder.bind(ExtendedHiveMetastore.class).to(GlueHiveMetastore.class).in(Scopes.SINGLETON);
+        binder.bind(ExtendedHiveMetastore.class).annotatedWith(ForCachingHiveMetastore.class).to(GlueHiveMetastore.class).in(Scopes.SINGLETON);
+        binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ExtendedHiveMetastore.class)
-                .as(generatedNameOf(GlueHiveMetastore.class, connectorId));
+                .as(generatedNameOf(CachingHiveMetastore.class, connectorId));
     }
 
     @Provides


### PR DESCRIPTION
Hive `GlueMatastoreModule` doesn't support caching, which caused performance issues in planning time, read throughput, and parallelism when filtering on a partitioning column.

This PR adds the support of caching to the `GlueMatastoreModule`. Adding this support won't enable caching unless `hive.metastore-cache-ttl` property is not 0.

```
== RELEASE NOTES ==
Hive Changes
* Add support for caching the Glue metastore.
```
