### PR TITLE
Support return type coercion in CREATE FUNCTION

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -592,7 +592,7 @@ class StatementAnalyzer
             if (node.getBody() instanceof Return) {
                 Expression returnExpression = ((Return) node.getBody()).getExpression();
                 Type bodyType = analyzeExpression(returnExpression, functionScope).getExpressionTypes().get(NodeRef.of(returnExpression));
-                if (!bodyType.equals(returnType)) {
+                if (!metadata.getTypeManager().canCoerce(bodyType, returnType)) {
                     throw new SemanticException(TYPE_MISMATCH, node, "Function implementation type '%s' does not match declared return type '%s'", bodyType, returnType);
                 }
 


### PR DESCRIPTION
Currently, within CREATE FUNCTION syntax, we currently restrict that the return type declared by the RETURNS clause must exactly match the expression type in the body. The change here will be relaxing that restrictions. 

```
=== RELEASE NOTES ===

General Change
* Add support to create functions whose function body type is coercible to the declared return type.
```
