### PR TITLE
Enums support #2: provide enums via FunctionNamespaceManagers

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
@@ -31,6 +31,8 @@ import com.facebook.presto.metadata.HandleJsonModule;
 import com.facebook.presto.metadata.HandleResolver;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.transaction.NoOpTransactionManager;
+import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.type.TypeDeserializer;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
@@ -132,6 +134,8 @@ public class TestHiveSplit
             binder.install(new JsonModule());
             binder.install(new HandleJsonModule());
             configBinder(binder).bindConfig(FeaturesConfig.class);
+
+            binder.bind(TransactionManager.class).to(NoOpTransactionManager.class).in(Scopes.SINGLETON);
 
             binder.bind(TypeManager.class).to(TypeRegistry.class).in(Scopes.SINGLETON);
             jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionNamespaceLoader.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionNamespaceLoader.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.spi.function.FunctionNamespaceManager;
+import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
+import com.facebook.presto.spi.function.SqlFunction;
+import com.facebook.presto.transaction.TransactionManager;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public abstract class FunctionNamespaceLoader
+{
+    private final Map<String, FunctionNamespaceManagerFactory> functionNamespaceManagerFactories = new ConcurrentHashMap<>();
+    private final HandleResolver handleResolver;
+    final TransactionManager transactionManager;
+
+    protected final Map<String, FunctionNamespaceManager<? extends SqlFunction>> functionNamespaceManagers = new ConcurrentHashMap<>();
+
+    public FunctionNamespaceLoader(
+            TransactionManager transactionManager,
+            HandleResolver handleResolver)
+    {
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.handleResolver = handleResolver;
+    }
+
+    public void loadFunctionNamespaceManager(
+            String functionNamespaceManagerName,
+            String catalogName,
+            Map<String, String> properties)
+    {
+        requireNonNull(functionNamespaceManagerName, "functionNamespaceManagerName is null");
+        FunctionNamespaceManagerFactory factory = functionNamespaceManagerFactories.get(functionNamespaceManagerName);
+        checkState(factory != null, "No factory for function namespace manager %s", functionNamespaceManagerName);
+        FunctionNamespaceManager<?> functionNamespaceManager = factory.create(catalogName, properties);
+
+        transactionManager.registerFunctionNamespaceManager(catalogName, functionNamespaceManager);
+        if (functionNamespaceManagers.putIfAbsent(catalogName, functionNamespaceManager) != null) {
+            throw new IllegalArgumentException(format("Function namespace manager is already registered for catalog [%s]", catalogName));
+        }
+    }
+
+    public void addFunctionNamespaceFactory(FunctionNamespaceManagerFactory factory)
+    {
+        if (functionNamespaceManagerFactories.putIfAbsent(factory.getName(), factory) != null) {
+            throw new IllegalArgumentException(format("Resource group configuration manager '%s' is already registered", factory.getName()));
+        }
+        handleResolver.addFunctionNamespace(factory.getName(), factory.getHandleResolver());
+    }
+
+    @VisibleForTesting
+    public void addFunctionNamespace(String catalogName, FunctionNamespaceManager functionNamespaceManager)
+    {
+        transactionManager.registerFunctionNamespaceManager(catalogName, functionNamespaceManager);
+        if (functionNamespaceManagers.putIfAbsent(catalogName, functionNamespaceManager) != null) {
+            throw new IllegalArgumentException(format("Function namespace manager is already registered for catalog [%s]", catalogName));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/HandleResolver.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/HandleResolver.java
@@ -65,7 +65,7 @@ public class HandleResolver
         requireNonNull(name, "name is null");
         requireNonNull(resolver, "resolver is null");
         MaterializedHandleResolver existingResolver = handleResolvers.putIfAbsent(name, new MaterializedHandleResolver(resolver));
-        checkState(existingResolver == null || existingResolver.equals(resolver),
+        checkState(existingResolver == null || existingResolver.equals(new MaterializedHandleResolver(resolver)),
                 "Connector '%s' is already assigned to resolver: %s", name, existingResolver);
     }
 
@@ -74,7 +74,7 @@ public class HandleResolver
         requireNonNull(name, "name is null");
         requireNonNull(resolver, "resolver is null");
         MaterializedFunctionHandleResolver existingResolver = functionHandleResolvers.putIfAbsent(name, new MaterializedFunctionHandleResolver(resolver));
-        checkState(existingResolver == null || existingResolver.equals(resolver), "Name %s is already assigned to function resolver: %s", name, existingResolver);
+        checkState(existingResolver == null || existingResolver.equals(new MaterializedFunctionHandleResolver(resolver)), "Name %s is already assigned to function resolver: %s", name, existingResolver);
     }
 
     public String getId(ConnectorTableHandle tableHandle)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -213,7 +213,7 @@ public class MetadataManager
 
     public static MetadataManager createTestMetadataManager(TransactionManager transactionManager, FeaturesConfig featuresConfig)
     {
-        TypeManager typeManager = new TypeRegistry(ImmutableSet.of(), featuresConfig);
+        TypeManager typeManager = new TypeRegistry(ImmutableSet.of(), featuresConfig, transactionManager, new HandleResolver());
         return new MetadataManager(
                 featuresConfig,
                 typeManager,

--- a/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespaceStore.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespaceStore.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.type.TypeRegistry;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
@@ -35,13 +36,15 @@ public class StaticFunctionNamespaceStore
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
     private final FunctionManager functionManager;
+    private final TypeRegistry typeRegistry;
     private final File configDir;
     private final AtomicBoolean functionNamespaceLoading = new AtomicBoolean();
 
     @Inject
-    public StaticFunctionNamespaceStore(FunctionManager functionManager, StaticFunctionNamespaceStoreConfig config)
+    public StaticFunctionNamespaceStore(FunctionManager functionManager, StaticFunctionNamespaceStoreConfig config, TypeRegistry typeRegistry)
     {
         this.functionManager = functionManager;
+        this.typeRegistry = typeRegistry;
         this.configDir = config.getFunctionNamespaceConfigurationDir();
     }
 
@@ -70,6 +73,7 @@ public class StaticFunctionNamespaceStore
         checkState(functionNamespaceManagerName != null, "Function namespace configuration %s does not contain function-namespace-manager.name", file.getAbsoluteFile());
 
         functionManager.loadFunctionNamespaceManager(functionNamespaceManagerName, catalogName, properties);
+        typeRegistry.loadFunctionNamespaceManager(functionNamespaceManagerName, catalogName, properties);
         log.info("-- Added function namespace manager [%s] --", catalogName);
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -215,6 +215,7 @@ public class PluginManager
         for (FunctionNamespaceManagerFactory functionNamespaceManagerFactory : plugin.getFunctionNamespaceManagerFactories()) {
             log.info("Registering function namespace manager %s", functionNamespaceManagerFactory.getName());
             metadata.getFunctionManager().addFunctionNamespaceFactory(functionNamespaceManagerFactory);
+            typeRegistry.addFunctionNamespaceFactory(functionNamespaceManagerFactory);
         }
 
         for (SessionPropertyConfigurationManagerFactory sessionConfigFactory : plugin.getSessionPropertyConfigurationManagerFactories()) {

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -621,6 +621,7 @@ public class LocalQueryRunner
     public void loadFunctionNamespaceManager(String functionNamespaceManagerName, String catalogName, Map<String, String> properties)
     {
         metadata.getFunctionManager().loadFunctionNamespaceManager(functionNamespaceManagerName, catalogName, properties);
+        typeRegistry.loadFunctionNamespaceManager(functionNamespaceManagerName, catalogName, properties);
     }
 
     public LocalQueryRunner printPlan()

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -53,6 +53,8 @@ import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.testing.TestingHandleResolver;
 import com.facebook.presto.testing.TestingSplit;
 import com.facebook.presto.testing.TestingTransactionHandle;
+import com.facebook.presto.transaction.NoOpTransactionManager;
+import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.type.TypeDeserializer;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableMultimap;
@@ -241,6 +243,7 @@ public class TestHttpRemoteTask
                         binder.bind(JsonMapper.class);
                         configBinder(binder).bindConfig(FeaturesConfig.class);
                         binder.bind(TypeRegistry.class).in(Scopes.SINGLETON);
+                        binder.bind(TransactionManager.class).to(NoOpTransactionManager.class).in(Scopes.SINGLETON);
                         binder.bind(TypeManager.class).to(TypeRegistry.class).in(Scopes.SINGLETON);
                         jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
                         newSetBinder(binder, Type.class);

--- a/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -45,6 +45,8 @@ import com.facebook.presto.sql.relational.RowExpressionOptimizer;
 import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.NodeRef;
+import com.facebook.presto.transaction.NoOpTransactionManager;
+import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.type.TypeDeserializer;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.collect.ImmutableList;
@@ -247,6 +249,7 @@ public class TestRowExpressionSerde
             configBinder(binder).bindConfig(FeaturesConfig.class);
 
             binder.bind(TypeManager.class).to(TypeRegistry.class).in(Scopes.SINGLETON);
+            binder.bind(TransactionManager.class).to(NoOpTransactionManager.class).in(Scopes.SINGLETON);
             jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
             newSetBinder(binder, Type.class);
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.function;
 
 import com.facebook.presto.common.function.QualifiedFunctionName;
+import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.spi.api.Experimental;
 
@@ -72,4 +73,9 @@ public interface FunctionNamespaceManager<F extends SqlFunction>
     FunctionMetadata getFunctionMetadata(FunctionHandle functionHandle);
 
     ScalarFunctionImplementation getScalarFunctionImplementation(FunctionHandle functionHandle);
+
+    default ParametricType getParametricType(TypeSignature typeSignature)
+    {
+        return null;
+    }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
@@ -18,23 +18,15 @@ import com.facebook.presto.common.type.LongEnumType.LongEnumMap;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.VarcharEnumType.VarcharEnumMap;
 import com.facebook.presto.spi.Plugin;
-import com.facebook.presto.testing.MaterializedResult;
-import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.type.LongEnumParametricType;
 import com.facebook.presto.type.VarcharEnumParametricType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static java.util.Collections.singletonList;
-import static org.testng.Assert.assertEquals;
 
 @Test(singleThreaded = true)
 public class TestEnums
@@ -85,19 +77,6 @@ public class TestEnums
         catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private void assertQueryResultUnordered(@Language("SQL") String query, List<List<Object>> expectedRows)
-    {
-        MaterializedResult rows = computeActual(query);
-        assertEquals(
-                ImmutableSet.copyOf(rows.getMaterializedRows()),
-                expectedRows.stream().map(row -> new MaterializedRow(1, row)).collect(Collectors.toSet()));
-    }
-
-    private void assertSingleValue(@Language("SQL") String expression, Object expectedResult)
-    {
-        assertQueryResultUnordered("SELECT " + expression, singletonList(singletonList(expectedResult)));
     }
 
     @Test

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestFunctionNamespaceManagerWithTypes.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestFunctionNamespaceManagerWithTypes.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.common.function.QualifiedFunctionName;
+import com.facebook.presto.common.type.ParametricType;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.VarcharEnumType.VarcharEnumMap;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.function.AlterRoutineCharacteristics;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionHandleResolver;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.FunctionNamespaceManager;
+import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
+import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
+import com.facebook.presto.spi.function.ScalarFunctionImplementation;
+import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.function.SqlFunctionHandle;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.type.VarcharEnumParametricType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.util.Collections.singletonList;
+
+@Test(singleThreaded = true)
+public class TestFunctionNamespaceManagerWithTypes
+        extends AbstractTestQueryFramework
+{
+    static class TestEnumsFunctionNamespaceManager
+            implements FunctionNamespaceManager<SqlInvokedFunction>
+    {
+        private List<ParametricType> types = ImmutableList.of(
+                new VarcharEnumParametricType("animal", new VarcharEnumMap(ImmutableMap.of(
+                        "CAT", "cat",
+                        "DOG", "dog"))));
+
+        @Override
+        public ParametricType getParametricType(TypeSignature typeSignature)
+        {
+            return types.stream()
+                    .filter(type -> type.getName().equals(typeSignature.getBase()))
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        // None of the methods below are supported:
+        // ------------------------------------------
+
+        @Override
+        public void dropFunction(QualifiedFunctionName functionName, Optional parameterTypes, boolean exists)
+        {
+        }
+
+        @Override
+        public void alterFunction(QualifiedFunctionName functionName, Optional parameterTypes, AlterRoutineCharacteristics alterRoutineCharacteristics)
+        {
+        }
+
+        @Override
+        public FunctionNamespaceTransactionHandle beginTransaction()
+        {
+            return null;
+        }
+
+        @Override
+        public void commit(FunctionNamespaceTransactionHandle transactionHandle)
+        {
+        }
+
+        @Override
+        public void abort(FunctionNamespaceTransactionHandle transactionHandle)
+        {
+        }
+
+        @Override
+        public void createFunction(SqlInvokedFunction function, boolean replace)
+        {
+        }
+
+        @Override
+        public Collection<SqlInvokedFunction> listFunctions()
+        {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Collection<SqlInvokedFunction> getFunctions(Optional<? extends FunctionNamespaceTransactionHandle> transactionHandle, QualifiedFunctionName functionName)
+        {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public FunctionHandle getFunctionHandle(Optional<? extends FunctionNamespaceTransactionHandle> transactionHandle, Signature signature)
+        {
+            return null;
+        }
+
+        @Override
+        public FunctionMetadata getFunctionMetadata(FunctionHandle functionHandle)
+        {
+            return null;
+        }
+
+        @Override
+        public ScalarFunctionImplementation getScalarFunctionImplementation(FunctionHandle functionHandle)
+        {
+            return null;
+        }
+    }
+
+    static class TestEnumsFunctionNamespaceManagerFactory
+            implements FunctionNamespaceManagerFactory
+    {
+        @Override
+        public String getName()
+        {
+            return "testEnums";
+        }
+
+        @Override
+        public FunctionHandleResolver getHandleResolver()
+        {
+            return new SqlFunctionHandle.Resolver();
+        }
+
+        @Override
+        public FunctionNamespaceManager<?> create(String catalogName, Map<String, String> config)
+        {
+            return new TestEnumsFunctionNamespaceManager();
+        }
+    }
+
+    static class EnumTestingPlugin
+            implements Plugin
+    {
+        @Override
+        public Iterable<FunctionNamespaceManagerFactory> getFunctionNamespaceManagerFactories()
+        {
+            return singletonList(new TestEnumsFunctionNamespaceManagerFactory());
+        }
+    }
+
+    protected TestFunctionNamespaceManagerWithTypes()
+    {
+        super(TestFunctionNamespaceManagerWithTypes::createQueryRunner);
+    }
+
+    private static QueryRunner createQueryRunner()
+    {
+        QueryRunner queryRunner = new LocalQueryRunner(testSessionBuilder()
+                .build());
+        queryRunner.installPlugin(new EnumTestingPlugin());
+        queryRunner.loadFunctionNamespaceManager("testEnums", "testEnums", ImmutableMap.of());
+        return queryRunner;
+    }
+
+    @Test
+    public void testTypeQuery()
+    {
+        assertQueryResultUnordered("SELECT animal.dog", singletonList(ImmutableList.of("dog")));
+    }
+}


### PR DESCRIPTION
This PR follows #14728
Commits start from "provide types from FunctionNamespaceMgr" (seems like we can't do stacked PRs?)

## Design
We want plugins to be able to provide enum definitions. However, the current `getTypes` method on the `Plugin` interface is not sufficient, because these types are only loaded at server startup time. Instead, if people modify existing enums, or register new ones, we want those to be usable in queries immediately, without the need to reset the cluster.

These requirements are similar to those of user-defined SQL functions, which is why it makes sense to expose these types via the FunctionNamespaceManager (FNM) interface. Another argument in favor of doing this is that if users want to register UDFs that use these custom types in their signature, we don't end up with dependencies between different plugins/FNMs: the same FNM can provide the enums and the functions.

## Implementation
The gist of the change is in `TypeRegistry::getType`, where we look up a type signature in the available FNMs if it can't be found in our built-in list of types.
The rest of the code is refactoring the plumbing to load FNMs inside a TypeRegistry.