### PR TITLE
Fetch results eagerly from coordinator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -29,7 +29,6 @@ import com.facebook.presto.dispatcher.DispatchManager;
 import com.facebook.presto.dispatcher.DispatchQueryFactory;
 import com.facebook.presto.dispatcher.FailedDispatchQueryFactory;
 import com.facebook.presto.dispatcher.LocalDispatchQueryFactory;
-import com.facebook.presto.dispatcher.QueuedStatementResource;
 import com.facebook.presto.event.QueryMonitor;
 import com.facebook.presto.event.QueryMonitorConfig;
 import com.facebook.presto.execution.AddColumnTask;
@@ -97,6 +96,8 @@ import com.facebook.presto.memory.TotalReservationOnBlockedNodesLowMemoryKiller;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.operator.ForScheduler;
 import com.facebook.presto.server.protocol.ExecutingStatementResource;
+import com.facebook.presto.server.protocol.LocalQueryProvider;
+import com.facebook.presto.server.protocol.QueuedStatementResource;
 import com.facebook.presto.server.remotetask.HttpRemoteTaskFactory;
 import com.facebook.presto.server.remotetask.RemoteTaskStats;
 import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
@@ -230,6 +231,8 @@ public class CoordinatorModule
         newExporter(binder).export(InternalResourceGroupManager.class).withGeneratedName();
         binder.bind(ResourceGroupManager.class).to(InternalResourceGroupManager.class);
         binder.bind(LegacyResourceGroupConfigurationManager.class).in(Scopes.SINGLETON);
+
+        binder.bind(LocalQueryProvider.class).in(Scopes.SINGLETON);
 
         // dispatcher
         binder.bind(DispatchManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingStatementResource.java
@@ -14,23 +14,13 @@
 package com.facebook.presto.server.protocol;
 
 import com.facebook.airlift.concurrent.BoundedExecutor;
-import com.facebook.airlift.log.Logger;
-import com.facebook.presto.Session;
-import com.facebook.presto.client.QueryResults;
-import com.facebook.presto.common.block.BlockEncodingSerde;
-import com.facebook.presto.execution.QueryManager;
-import com.facebook.presto.memory.context.SimpleLocalMemoryContext;
-import com.facebook.presto.operator.ExchangeClient;
-import com.facebook.presto.operator.ExchangeClientSupplier;
 import com.facebook.presto.server.ForStatementResource;
 import com.facebook.presto.spi.QueryId;
 import com.google.common.collect.Ordering;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
-import javax.annotation.PreDestroy;
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
@@ -40,108 +30,43 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
-import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.Map.Entry;
-import java.util.NoSuchElementException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ScheduledExecutorService;
-
-import static com.facebook.airlift.concurrent.Threads.threadsNamed;
 import static com.facebook.airlift.http.server.AsyncResponseHandler.bindAsyncResponse;
-import static com.facebook.presto.client.PrestoHeaders.PRESTO_ADDED_PREPARE;
-import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLEAR_SESSION;
-import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLEAR_TRANSACTION_ID;
-import static com.facebook.presto.client.PrestoHeaders.PRESTO_DEALLOCATED_PREPARE;
-import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_CATALOG;
-import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_ROLE;
-import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_SCHEMA;
-import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_SESSION;
-import static com.facebook.presto.client.PrestoHeaders.PRESTO_STARTED_TRANSACTION_ID;
-import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.server.protocol.QueryResourceUtil.toResponse;
 import static com.facebook.presto.server.security.RoleType.USER;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
+import static com.google.common.util.concurrent.Futures.transform;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 
 @Path("/")
 @RolesAllowed(USER)
 public class ExecutingStatementResource
 {
-    private static final Logger log = Logger.get(ExecutingStatementResource.class);
     private static final Duration MAX_WAIT_TIME = new Duration(1, SECONDS);
     private static final Ordering<Comparable<Duration>> WAIT_ORDERING = Ordering.natural().nullsLast();
-
     private static final DataSize DEFAULT_TARGET_RESULT_SIZE = new DataSize(1, MEGABYTE);
     private static final DataSize MAX_TARGET_RESULT_SIZE = new DataSize(128, MEGABYTE);
 
-    private final QueryManager queryManager;
-    private final ExchangeClientSupplier exchangeClientSupplier;
-    private final BlockEncodingSerde blockEncodingSerde;
     private final BoundedExecutor responseExecutor;
-    private final ScheduledExecutorService timeoutExecutor;
-
-    private final ConcurrentMap<QueryId, Query> queries = new ConcurrentHashMap<>();
-    private final ScheduledExecutorService queryPurger = newSingleThreadScheduledExecutor(threadsNamed("execution-query-purger"));
+    private final LocalQueryProvider queryProvider;
 
     @Inject
     public ExecutingStatementResource(
-            QueryManager queryManager,
-            ExchangeClientSupplier exchangeClientSupplier,
-            BlockEncodingSerde blockEncodingSerde,
             @ForStatementResource BoundedExecutor responseExecutor,
-            @ForStatementResource ScheduledExecutorService timeoutExecutor)
+            LocalQueryProvider queryProvider)
     {
-        this.queryManager = requireNonNull(queryManager, "queryManager is null");
-        this.exchangeClientSupplier = requireNonNull(exchangeClientSupplier, "exchangeClientSupplier is null");
-        this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
         this.responseExecutor = requireNonNull(responseExecutor, "responseExecutor is null");
-        this.timeoutExecutor = requireNonNull(timeoutExecutor, "timeoutExecutor is null");
-
-        queryPurger.scheduleWithFixedDelay(
-                () -> {
-                    try {
-                        for (Entry<QueryId, Query> entry : queries.entrySet()) {
-                            // forget about this query if the query manager is no longer tracking it
-                            try {
-                                queryManager.getQueryState(entry.getKey());
-                            }
-                            catch (NoSuchElementException e) {
-                                // query is no longer registered
-                                queries.remove(entry.getKey());
-                            }
-                        }
-                    }
-                    catch (Throwable e) {
-                        log.warn(e, "Error removing old queries");
-                    }
-                },
-                200,
-                200,
-                MILLISECONDS);
-    }
-
-    @PreDestroy
-    public void stop()
-    {
-        queryPurger.shutdownNow();
+        this.queryProvider = requireNonNull(queryProvider, "queryProvider is null");
     }
 
     @GET
@@ -157,59 +82,6 @@ public class ExecutingStatementResource
             @Context UriInfo uriInfo,
             @Suspended AsyncResponse asyncResponse)
     {
-        Query query = getQuery(queryId, slug);
-        if (isNullOrEmpty(proto)) {
-            proto = uriInfo.getRequestUri().getScheme();
-        }
-
-        asyncQueryResults(query, token, maxWait, targetResultSize, uriInfo, proto, asyncResponse);
-    }
-
-    protected Query getQuery(QueryId queryId, String slug)
-    {
-        Query query = queries.get(queryId);
-        if (query != null) {
-            if (!query.isSlugValid(slug)) {
-                throw notFound("Query not found");
-            }
-            return query;
-        }
-
-        // this is the first time the query has been accessed on this coordinator
-        Session session;
-        try {
-            if (!queryManager.isQuerySlugValid(queryId, slug)) {
-                throw notFound("Query not found");
-            }
-            session = queryManager.getQuerySession(queryId);
-        }
-        catch (NoSuchElementException e) {
-            throw notFound("Query not found");
-        }
-
-        query = queries.computeIfAbsent(queryId, id -> {
-            ExchangeClient exchangeClient = exchangeClientSupplier.get(new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), ExecutingStatementResource.class.getSimpleName()));
-            return Query.create(
-                    session,
-                    slug,
-                    queryManager,
-                    exchangeClient,
-                    responseExecutor,
-                    timeoutExecutor,
-                    blockEncodingSerde);
-        });
-        return query;
-    }
-
-    private void asyncQueryResults(
-            Query query,
-            long token,
-            Duration maxWait,
-            DataSize targetResultSize,
-            UriInfo uriInfo,
-            String scheme,
-            AsyncResponse asyncResponse)
-    {
         Duration wait = WAIT_ORDERING.min(MAX_WAIT_TIME, maxWait);
         if (targetResultSize == null) {
             targetResultSize = DEFAULT_TARGET_RESULT_SIZE;
@@ -217,55 +89,16 @@ public class ExecutingStatementResource
         else {
             targetResultSize = Ordering.natural().min(targetResultSize, MAX_TARGET_RESULT_SIZE);
         }
-        ListenableFuture<QueryResults> queryResultsFuture = query.waitForResults(token, uriInfo, scheme, wait, targetResultSize);
-
-        ListenableFuture<Response> response = Futures.transform(queryResultsFuture, queryResults -> toResponse(query, queryResults), directExecutor());
-
-        bindAsyncResponse(asyncResponse, response, responseExecutor);
-    }
-
-    private static Response toResponse(Query query, QueryResults queryResults)
-    {
-        ResponseBuilder response = Response.ok(queryResults);
-
-        // add set catalog and schema
-        query.getSetCatalog().ifPresent(catalog -> response.header(PRESTO_SET_CATALOG, catalog));
-        query.getSetSchema().ifPresent(schema -> response.header(PRESTO_SET_SCHEMA, schema));
-
-        // add set session properties
-        query.getSetSessionProperties()
-                .forEach((key, value) -> response.header(PRESTO_SET_SESSION, key + '=' + urlEncode(value)));
-
-        // add clear session properties
-        query.getResetSessionProperties()
-                .forEach(name -> response.header(PRESTO_CLEAR_SESSION, name));
-
-        // add set roles
-        query.getSetRoles()
-                .forEach((key, value) -> response.header(PRESTO_SET_ROLE, key + '=' + urlEncode(value.toString())));
-
-        // add added prepare statements
-        for (Entry<String, String> entry : query.getAddedPreparedStatements().entrySet()) {
-            String encodedKey = urlEncode(entry.getKey());
-            String encodedValue = urlEncode(entry.getValue());
-            response.header(PRESTO_ADDED_PREPARE, encodedKey + '=' + encodedValue);
+        if (isNullOrEmpty(proto)) {
+            proto = uriInfo.getRequestUri().getScheme();
         }
 
-        // add deallocated prepare statements
-        for (String name : query.getDeallocatedPreparedStatements()) {
-            response.header(PRESTO_DEALLOCATED_PREPARE, urlEncode(name));
-        }
-
-        // add new transaction ID
-        query.getStartedTransactionId()
-                .ifPresent(transactionId -> response.header(PRESTO_STARTED_TRANSACTION_ID, transactionId));
-
-        // add clear transaction ID directive
-        if (query.isClearTransactionId()) {
-            response.header(PRESTO_CLEAR_TRANSACTION_ID, true);
-        }
-
-        return response.build();
+        Query query = queryProvider.getQuery(queryId, slug);
+        ListenableFuture<Response> queryResultsFuture = transform(
+                query.waitForResults(token, uriInfo, proto, wait, targetResultSize),
+                results -> toResponse(query, results),
+                directExecutor());
+        bindAsyncResponse(asyncResponse, queryResultsFuture, responseExecutor);
     }
 
     @DELETE
@@ -276,44 +109,7 @@ public class ExecutingStatementResource
             @PathParam("token") long token,
             @QueryParam("slug") String slug)
     {
-        Query query = queries.get(queryId);
-        if (query != null) {
-            if (!query.isSlugValid(slug)) {
-                throw notFound("Query not found");
-            }
-            query.cancel();
-            return Response.noContent().build();
-        }
-
-        // cancel the query execution directly instead of creating the statement client
-        try {
-            if (!queryManager.isQuerySlugValid(queryId, slug)) {
-                throw notFound("Query not found");
-            }
-            queryManager.cancelQuery(queryId);
-            return Response.noContent().build();
-        }
-        catch (NoSuchElementException e) {
-            throw notFound("Query not found");
-        }
-    }
-
-    private static WebApplicationException notFound(String message)
-    {
-        throw new WebApplicationException(
-                Response.status(Status.NOT_FOUND)
-                        .type(TEXT_PLAIN_TYPE)
-                        .entity(message)
-                        .build());
-    }
-
-    private static String urlEncode(String value)
-    {
-        try {
-            return URLEncoder.encode(value, "UTF-8");
-        }
-        catch (UnsupportedEncodingException e) {
-            throw new AssertionError(e);
-        }
+        queryProvider.cancel(queryId, slug);
+        return Response.noContent().build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/LocalQueryProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/LocalQueryProvider.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.protocol;
+
+import com.facebook.airlift.concurrent.BoundedExecutor;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.Session;
+import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.memory.context.SimpleLocalMemoryContext;
+import com.facebook.presto.operator.ExchangeClient;
+import com.facebook.presto.operator.ExchangeClientSupplier;
+import com.facebook.presto.server.ForStatementResource;
+import com.facebook.presto.spi.QueryId;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.airlift.concurrent.Threads.threadsNamed;
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
+
+public class LocalQueryProvider
+{
+    private static final Logger log = Logger.get(LocalQueryProvider.class);
+
+    private final QueryManager queryManager;
+    private final ExchangeClientSupplier exchangeClientSupplier;
+    private final BlockEncodingSerde blockEncodingSerde;
+    private final BoundedExecutor responseExecutor;
+    private final ScheduledExecutorService timeoutExecutor;
+
+    private final ConcurrentMap<QueryId, Query> queries = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService queryPurger = newSingleThreadScheduledExecutor(threadsNamed("execution-query-purger"));
+
+    @Inject
+    public LocalQueryProvider(
+            QueryManager queryManager,
+            ExchangeClientSupplier exchangeClientSupplier,
+            BlockEncodingSerde blockEncodingSerde,
+            @ForStatementResource BoundedExecutor responseExecutor,
+            @ForStatementResource ScheduledExecutorService timeoutExecutor)
+    {
+        this.queryManager = requireNonNull(queryManager, "queryManager is null");
+        this.exchangeClientSupplier = requireNonNull(exchangeClientSupplier, "exchangeClientSupplier is null");
+        this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
+        this.responseExecutor = requireNonNull(responseExecutor, "responseExecutor is null");
+        this.timeoutExecutor = requireNonNull(timeoutExecutor, "timeoutExecutor is null");
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        queryPurger.scheduleWithFixedDelay(
+                () -> {
+                    try {
+                        for (Entry<QueryId, Query> entry : queries.entrySet()) {
+                            // forget about this query if the query manager is no longer tracking it
+                            try {
+                                queryManager.getQueryState(entry.getKey());
+                            }
+                            catch (NoSuchElementException e) {
+                                // query is no longer registered
+                                queries.remove(entry.getKey());
+                            }
+                        }
+                    }
+                    catch (Throwable e) {
+                        log.warn(e, "Error removing old queries");
+                    }
+                },
+                200,
+                200,
+                MILLISECONDS);
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        queryPurger.shutdownNow();
+    }
+
+    public Query getQuery(QueryId queryId, String slug)
+    {
+        Query query = queries.get(queryId);
+        if (query != null) {
+            if (!query.isSlugValid(slug)) {
+                throw notFound("Query not found");
+            }
+            return query;
+        }
+
+        // this is the first time the query has been accessed on this coordinator
+        Session session;
+        try {
+            if (!queryManager.isQuerySlugValid(queryId, slug)) {
+                throw notFound("Query not found");
+            }
+            session = queryManager.getQuerySession(queryId);
+        }
+        catch (NoSuchElementException e) {
+            throw notFound("Query not found");
+        }
+
+        query = queries.computeIfAbsent(queryId, id -> {
+            ExchangeClient exchangeClient = exchangeClientSupplier.get(new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), LocalQueryProvider.class.getSimpleName()));
+            return Query.create(
+                    session,
+                    slug,
+                    queryManager,
+                    exchangeClient,
+                    responseExecutor,
+                    timeoutExecutor,
+                    blockEncodingSerde);
+        });
+        return query;
+    }
+
+    public void cancel(QueryId queryId, String slug)
+    {
+        Query query = queries.get(queryId);
+        if (query != null) {
+            if (!query.isSlugValid(slug)) {
+                throw notFound("Query not found");
+            }
+            query.cancel();
+        }
+
+        // cancel the query execution directly instead of creating the statement client
+        try {
+            if (!queryManager.isQuerySlugValid(queryId, slug)) {
+                throw notFound("Query not found");
+            }
+            queryManager.cancelQuery(queryId);
+        }
+        catch (NoSuchElementException e) {
+            throw notFound("Query not found");
+        }
+    }
+
+    private static WebApplicationException notFound(String message)
+    {
+        throw new WebApplicationException(
+                Response.status(Status.NOT_FOUND)
+                        .type(TEXT_PLAIN_TYPE)
+                        .entity(message)
+                        .build());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.protocol;
+
+import com.facebook.presto.client.QueryResults;
+
+import javax.ws.rs.core.Response;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Map;
+
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_ADDED_PREPARE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLEAR_SESSION;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLEAR_TRANSACTION_ID;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_DEALLOCATED_PREPARE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_CATALOG;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_ROLE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_SCHEMA;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_SET_SESSION;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_STARTED_TRANSACTION_ID;
+
+public final class QueryResourceUtil
+{
+    private QueryResourceUtil() {}
+
+    public static Response toResponse(Query query, QueryResults queryResults)
+    {
+        Response.ResponseBuilder response = Response.ok(queryResults);
+
+        // add set catalog and schema
+        query.getSetCatalog().ifPresent(catalog -> response.header(PRESTO_SET_CATALOG, catalog));
+        query.getSetSchema().ifPresent(schema -> response.header(PRESTO_SET_SCHEMA, schema));
+
+        // add set session properties
+        query.getSetSessionProperties()
+                .forEach((key, value) -> response.header(PRESTO_SET_SESSION, key + '=' + urlEncode(value)));
+
+        // add clear session properties
+        query.getResetSessionProperties()
+                .forEach(name -> response.header(PRESTO_CLEAR_SESSION, name));
+
+        // add set roles
+        query.getSetRoles()
+                .forEach((key, value) -> response.header(PRESTO_SET_ROLE, key + '=' + urlEncode(value.toString())));
+
+        // add added prepare statements
+        for (Map.Entry<String, String> entry : query.getAddedPreparedStatements().entrySet()) {
+            String encodedKey = urlEncode(entry.getKey());
+            String encodedValue = urlEncode(entry.getValue());
+            response.header(PRESTO_ADDED_PREPARE, encodedKey + '=' + encodedValue);
+        }
+
+        // add deallocated prepare statements
+        for (String name : query.getDeallocatedPreparedStatements()) {
+            response.header(PRESTO_DEALLOCATED_PREPARE, urlEncode(name));
+        }
+
+        // add new transaction ID
+        query.getStartedTransactionId()
+                .ifPresent(transactionId -> response.header(PRESTO_STARTED_TRANSACTION_ID, transactionId));
+
+        // add clear transaction ID directive
+        if (query.isClearTransactionId()) {
+            response.header(PRESTO_CLEAR_TRANSACTION_ID, true);
+        }
+
+        return response.build();
+    }
+
+    private static String urlEncode(String value)
+    {
+        try {
+            return URLEncoder.encode(value, "UTF-8");
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new AssertionError(e);
+        }
+    }
+}


### PR DESCRIPTION
Before, the query results would only begin to be fetched once the client was
redirected to the executing query endpoint.  This introduces latency and may
not be acceptable for very low latency use cases.

```
== NO RELEASE NOTE ==
```
