### PR TITLE
Fix bad verify check in DwrfEncryptionInfo

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/DwrfEncryptionInfo.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DwrfEncryptionInfo.java
@@ -87,7 +87,7 @@ public class DwrfEncryptionInfo
 
     public DwrfDataEncryptor getEncryptorByGroupId(int groupId)
     {
-        verify(groupId < dwrfEncryptors.size(), "groupId %s exceeds the size of dwrfDecryptors %s", groupId, dwrfEncryptors.size());
+        verify(dwrfEncryptors.containsKey(groupId), "no encryptor available for group %s", groupId);
         return dwrfEncryptors.get(groupId);
     }
 


### PR DESCRIPTION
The check was left over from when the encryptors were a list, and was
incorrectly causing failures.

