### PR TITLE
Do not prune duplicate ConstantExpression

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneRedundantProjectionAssignments.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PruneRedundantProjectionAssignments.java
@@ -17,6 +17,7 @@ import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.iterative.Rule;
@@ -46,7 +47,7 @@ public class PruneRedundantProjectionAssignments
     public Result apply(ProjectNode node, Captures captures, Context context)
     {
         Map<Boolean, List<Map.Entry<VariableReferenceExpression, RowExpression>>> projections = node.getAssignments().entrySet().stream()
-                .collect(Collectors.partitioningBy(entry -> entry.getValue() instanceof VariableReferenceExpression));
+                .collect(Collectors.partitioningBy(entry -> entry.getValue() instanceof VariableReferenceExpression || entry.getValue() instanceof ConstantExpression));
         Map<RowExpression, ImmutableMap<VariableReferenceExpression, RowExpression>> uniqueProjections = projections.get(false).stream()
                 .collect(Collectors.groupingBy(Map.Entry::getValue, toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
         if (uniqueProjections.size() == projections.get(false).size()) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -8489,7 +8489,7 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testRedundantLambda()
+    public void testRedundantProjection()
     {
         assertQuery(
                 "SELECT x, reduce(x, 0, (s, x) -> s + x, s -> s), reduce(x, 0, (s, x) -> s + x, s -> s) FROM (VALUES (array[1, 2, 3])) t(x)",
@@ -8497,6 +8497,8 @@ public abstract class AbstractTestQueries
         assertQuery(
                 "SELECT x, filter(x, v -> date(v) BETWEEN date'2020-01-01' AND date'2020-06-30'), filter(x, v -> date(v) BETWEEN date'2020-01-01' AND date_add('day', 2, date'2020-06-28')) FROM (VALUES (array['2020-03-01', '2020-07-01'])) t(x)",
                 "SELECT array['2020-03-01', '2020-07-01'], array['2020-03-01'], array['2020-03-01']");
+        assertQuerySucceeds(
+                "SELECT DISTINCT null AS a, NULL AS b, orderstatus FROM (SELECT orderstatus FROM orders GROUP BY orderstatus)");
     }
 
     protected Session noJoinReordering()


### PR DESCRIPTION
We added PruneRedundantProjectionAssignments to eliminate duplicate projections
so PageFunctionCompiler would not need to handle compiling duplicate
projections. This should only apply to expressions that are not
InputReferenceExpression (which maps to VariableReferenceExpression at planning)
or ConstantExpression, because those are compiled differently. So it's safe to
avoid prune ConstantExpression here.
```
== NO RELEASE NOTE ==
```
