### PR TITLE
Add runtimeOptimizedStages in QueryCompletedEvent

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestEventListenerWithExchangeMaterialization.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestEventListenerWithExchangeMaterialization.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.StageId;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.eventlistener.EventListener;
+import com.facebook.presto.spi.eventlistener.EventListenerFactory;
+import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
+import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
+import com.facebook.presto.spi.eventlistener.QueryMetadata;
+import com.facebook.presto.spi.eventlistener.SplitCompletedEvent;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.hive.HiveQueryRunner.createQueryRunner;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.airlift.tpch.TpchTable.getTables;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestEventListenerWithExchangeMaterialization
+{
+    private EventsBuilder generatedEvents = new EventsBuilder();
+    private DistributedQueryRunner queryRunner;
+    private Session session;
+
+    @BeforeClass
+    private void setUp()
+            throws Exception
+    {
+        queryRunner = createQueryRunner(
+                getTables(),
+                new ImmutableMap.Builder<String, String>()
+                        .put("query.partitioning-provider-catalog", "hive")
+                        .put("query.exchange-materialization-strategy", "ALL")
+                        .put("experimental.runtime-optimizer-enabled", "true")
+                        .put("experimental.enable-stats-collection-for-temporary-table", "true")
+                        .put("join-distribution-type", "PARTITIONED")
+                        .put("optimizer.join-reordering-strategy", "ELIMINATE_CROSS_JOINS")
+                        .put("query.hash-partition-count", "11")
+                        .put("colocated-joins-enabled", "true")
+                        .put("grouped-execution-for-aggregation-enabled", "true")
+                        .build(),
+                Optional.empty());
+        queryRunner.installPlugin(new TestingEventListenerPlugin(generatedEvents));
+        session = queryRunner.getDefaultSession();
+    }
+
+    @AfterClass(alwaysRun = true)
+    private void tearDown()
+    {
+        queryRunner.close();
+        queryRunner = null;
+        session = null;
+        generatedEvents = null;
+    }
+
+    private MaterializedResult runQueryAndWaitForEvents(@Language("SQL") String sql, int numEventsExpected)
+            throws Exception
+    {
+        generatedEvents.initialize(numEventsExpected);
+        MaterializedResult result = queryRunner.execute(session, sql);
+        generatedEvents.waitForEvents(100);
+        return result;
+    }
+
+    @Test
+    public void testRuntimeOptimizedStagesCorrectness()
+            throws Exception
+    {
+        // We expect one runtime optimized stage: 1.
+        int expectedEvents = 2;
+        runQueryAndWaitForEvents("SELECT phone, regionkey FROM nation INNER JOIN supplier ON supplier.nationkey=nation.nationkey", expectedEvents);
+        QueryCreatedEvent queryCreatedEvent = getOnlyElement(generatedEvents.getQueryCreatedEvents());
+        QueryCompletedEvent queryCompletedEvent = getOnlyElement(generatedEvents.getQueryCompletedEvents());
+        QueryMetadata queryMetadata = queryCompletedEvent.getMetadata();
+        Optional<List<StageId>> runtimeOptimizedStages = queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(new QueryId(queryCreatedEvent.getMetadata().getQueryId())).getRuntimeOptimizedStages();
+
+        assertEquals(queryMetadata.getRuntimeOptimizedStages().size(), 1);
+        assertEquals(queryMetadata.getRuntimeOptimizedStages().get(0), "1");
+        assertTrue(runtimeOptimizedStages.isPresent());
+        assertEquals(runtimeOptimizedStages.get().size(), 1);
+        assertEquals(queryMetadata.getRuntimeOptimizedStages(), runtimeOptimizedStages.get().stream()
+                .map(stageId -> String.valueOf(stageId.getId()))
+                .collect(toImmutableList()));
+
+        // Now, the following query should not trigger runtime optimizations, so should have empty list of runtime optimized stages.
+        runQueryAndWaitForEvents("SELECT phone, regionkey FROM supplier INNER JOIN nation ON supplier.nationkey=nation.nationkey", expectedEvents);
+        queryCreatedEvent = getOnlyElement(generatedEvents.getQueryCreatedEvents());
+        queryCompletedEvent = getOnlyElement(generatedEvents.getQueryCompletedEvents());
+        runtimeOptimizedStages = queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(new QueryId(queryCreatedEvent.getMetadata().getQueryId())).getRuntimeOptimizedStages();
+
+        assertTrue(queryCompletedEvent.getMetadata().getRuntimeOptimizedStages().isEmpty());
+        assertFalse(runtimeOptimizedStages.isPresent());
+
+        // Now, the following query should have two optimized joins in a single stage (both on the same nationkey), therefore expect only one optimized stage: 1.
+        runQueryAndWaitForEvents("SELECT supplier.phone, regionkey, custkey FROM nation INNER JOIN supplier ON supplier.nationkey=nation.nationkey INNER JOIN customer ON nation.nationkey=customer.nationkey", expectedEvents);
+        queryCreatedEvent = getOnlyElement(generatedEvents.getQueryCreatedEvents());
+        queryCompletedEvent = getOnlyElement(generatedEvents.getQueryCompletedEvents());
+        queryMetadata = queryCompletedEvent.getMetadata();
+        runtimeOptimizedStages = queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(new QueryId(queryCreatedEvent.getMetadata().getQueryId())).getRuntimeOptimizedStages();
+
+        assertEquals(queryMetadata.getRuntimeOptimizedStages().size(), 1);
+        assertEquals(queryMetadata.getRuntimeOptimizedStages().get(0), "1");
+        assertTrue(runtimeOptimizedStages.isPresent());
+        assertEquals(runtimeOptimizedStages.get().size(), 1);
+        assertEquals(queryMetadata.getRuntimeOptimizedStages(), runtimeOptimizedStages.get().stream()
+                .map(stageId -> String.valueOf(stageId.getId()))
+                .collect(toImmutableList()));
+
+        // Now, the following query should have two runtime optimized stages: 1 and 4, corresponding to the two join operations (on regionkey and nationkey respectively).
+        runQueryAndWaitForEvents("WITH natreg AS (SELECT nation.regionkey, nationkey, region.name FROM region INNER JOIN nation ON nation.regionkey=region.regionkey) SELECT phone, regionkey FROM natreg INNER JOIN supplier ON supplier.nationkey=natreg.nationkey", expectedEvents);
+        queryCreatedEvent = getOnlyElement(generatedEvents.getQueryCreatedEvents());
+        queryCompletedEvent = getOnlyElement(generatedEvents.getQueryCompletedEvents());
+        queryMetadata = queryCompletedEvent.getMetadata();
+        runtimeOptimizedStages = queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(new QueryId(queryCreatedEvent.getMetadata().getQueryId())).getRuntimeOptimizedStages();
+
+        assertEquals(queryMetadata.getRuntimeOptimizedStages().size(), 2);
+        assertEquals(ImmutableSet.copyOf(queryMetadata.getRuntimeOptimizedStages()), ImmutableSet.of("1", "4"));
+        assertTrue(runtimeOptimizedStages.isPresent());
+        assertEquals(runtimeOptimizedStages.get().size(), 2);
+        assertEquals(queryMetadata.getRuntimeOptimizedStages(), runtimeOptimizedStages.get().stream()
+                .map(stageId -> String.valueOf(stageId.getId()))
+                .collect(toImmutableList()));
+    }
+
+    static class TestingEventListenerPlugin
+            implements Plugin
+    {
+        private final EventsBuilder eventsBuilder;
+
+        public TestingEventListenerPlugin(EventsBuilder eventsBuilder)
+        {
+            this.eventsBuilder = requireNonNull(eventsBuilder, "eventsBuilder is null");
+        }
+
+        @Override
+        public Iterable<EventListenerFactory> getEventListenerFactories()
+        {
+            return ImmutableList.of(new TestingEventListenerFactory(eventsBuilder));
+        }
+    }
+
+    private static class TestingEventListenerFactory
+            implements EventListenerFactory
+    {
+        private final EventsBuilder eventsBuilder;
+
+        public TestingEventListenerFactory(EventsBuilder eventsBuilder)
+        {
+            this.eventsBuilder = eventsBuilder;
+        }
+
+        @Override
+        public String getName()
+        {
+            return "test";
+        }
+
+        @Override
+        public EventListener create(Map<String, String> config)
+        {
+            return new TestingEventListener(eventsBuilder);
+        }
+    }
+
+    private static class TestingEventListener
+            implements EventListener
+    {
+        private final EventsBuilder eventsBuilder;
+
+        public TestingEventListener(EventsBuilder eventsBuilder)
+        {
+            this.eventsBuilder = eventsBuilder;
+        }
+
+        @Override
+        public void queryCreated(QueryCreatedEvent queryCreatedEvent)
+        {
+            eventsBuilder.addQueryCreated(queryCreatedEvent);
+        }
+
+        @Override
+        public void queryCompleted(QueryCompletedEvent queryCompletedEvent)
+        {
+            eventsBuilder.addQueryCompleted(queryCompletedEvent);
+        }
+
+        @Override
+        public void splitCompleted(SplitCompletedEvent splitCompletedEvent)
+        {
+        }
+    }
+
+    static class EventsBuilder
+    {
+        private ImmutableList.Builder<QueryCreatedEvent> queryCreatedEvents;
+        private ImmutableList.Builder<QueryCompletedEvent> queryCompletedEvents;
+
+        private CountDownLatch eventsLatch;
+
+        public synchronized void initialize(int numEvents)
+        {
+            queryCreatedEvents = ImmutableList.builder();
+            queryCompletedEvents = ImmutableList.builder();
+
+            eventsLatch = new CountDownLatch(numEvents);
+        }
+
+        public void waitForEvents(int timeoutSeconds)
+                throws InterruptedException
+        {
+            eventsLatch.await(timeoutSeconds, TimeUnit.SECONDS);
+        }
+
+        public synchronized void addQueryCreated(QueryCreatedEvent event)
+        {
+            queryCreatedEvents.add(event);
+            eventsLatch.countDown();
+        }
+
+        public synchronized void addQueryCompleted(QueryCompletedEvent event)
+        {
+            queryCompletedEvents.add(event);
+            eventsLatch.countDown();
+        }
+
+        public List<QueryCreatedEvent> getQueryCreatedEvents()
+        {
+            return queryCreatedEvents.build();
+        }
+
+        public List<QueryCompletedEvent> getQueryCompletedEvents()
+        {
+            return queryCompletedEvents.build();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -127,7 +127,8 @@ public class QueryMonitor
                                 queryInfo.getSelf(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                Optional.empty())));
+                                Optional.empty(),
+                                ImmutableList.of())));
     }
 
     public void queryImmediateFailureEvent(BasicQueryInfo queryInfo, ExecutionFailureInfo failure)
@@ -141,7 +142,8 @@ public class QueryMonitor
                         queryInfo.getSelf(),
                         Optional.empty(),
                         Optional.empty(),
-                        Optional.empty()),
+                        Optional.empty(),
+                        ImmutableList.of()),
                 new QueryStatistics(
                         ofMillis(0),
                         ofMillis(0),
@@ -232,7 +234,10 @@ public class QueryMonitor
                 queryInfo.getSelf(),
                 createTextQueryPlan(queryInfo),
                 createJsonQueryPlan(queryInfo),
-                queryInfo.getOutputStage().flatMap(stage -> stageInfoCodec.toJsonWithLengthLimit(stage, maxJsonLimit)));
+                queryInfo.getOutputStage().flatMap(stage -> stageInfoCodec.toJsonWithLengthLimit(stage, maxJsonLimit)),
+                queryInfo.getRuntimeOptimizedStages().orElse(ImmutableList.of()).stream()
+                        .map(stageId -> String.valueOf(stageId.getId()))
+                        .collect(toImmutableList()));
     }
 
     private QueryStatistics createQueryStatistics(QueryInfo queryInfo)

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -80,6 +80,8 @@ public class QueryInfo
     private final Optional<QueryType> queryType;
     // failedTasks is only available for final query info because the construction is expensive.
     private final Optional<List<TaskId>> failedTasks;
+    // RuntimeOptimizedStages is only available for final query info, because it is appended during runtime.
+    private final Optional<List<StageId>> runtimeOptimizedStages;
 
     @JsonCreator
     public QueryInfo(
@@ -111,7 +113,8 @@ public class QueryInfo
             @JsonProperty("completeInfo") boolean completeInfo,
             @JsonProperty("resourceGroupId") Optional<ResourceGroupId> resourceGroupId,
             @JsonProperty("queryType") Optional<QueryType> queryType,
-            @JsonProperty("failedTasks") Optional<List<TaskId>> failedTasks)
+            @JsonProperty("failedTasks") Optional<List<TaskId>> failedTasks,
+            @JsonProperty("runtimeOptimizedStages") Optional<List<StageId>> runtimeOptimizedStages)
     {
         requireNonNull(queryId, "queryId is null");
         requireNonNull(session, "session is null");
@@ -134,6 +137,7 @@ public class QueryInfo
         requireNonNull(warnings, "warnings is null");
         requireNonNull(queryType, "queryType is null");
         requireNonNull(failedTasks, "failedTasks is null");
+        requireNonNull(runtimeOptimizedStages, "runtimeOptimizedStages is null");
 
         this.queryId = queryId;
         this.session = session;
@@ -165,6 +169,7 @@ public class QueryInfo
         this.resourceGroupId = resourceGroupId;
         this.queryType = queryType;
         this.failedTasks = failedTasks;
+        this.runtimeOptimizedStages = runtimeOptimizedStages;
     }
 
     public static QueryInfo immediateFailureQueryInfo(Session session, String query, URI self, Optional<ResourceGroupId> resourceGroupId, ExecutionFailureInfo failureCause)
@@ -197,6 +202,7 @@ public class QueryInfo
                 Optional.empty(),
                 false,
                 resourceGroupId,
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 
@@ -385,6 +391,12 @@ public class QueryInfo
     public Optional<List<TaskId>> getFailedTasks()
     {
         return failedTasks;
+    }
+
+    @JsonProperty
+    public Optional<List<StageId>> getRuntimeOptimizedStages()
+    {
+        return runtimeOptimizedStages;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageInfo.java
@@ -40,6 +40,8 @@ public class StageInfo
 
     private final List<StageInfo> subStages;
 
+    private final boolean isRuntimeOptimized;
+
     @JsonCreator
     public StageInfo(
             @JsonProperty("stageId") StageId stageId,
@@ -47,7 +49,8 @@ public class StageInfo
             @JsonProperty("plan") Optional<PlanFragment> plan,
             @JsonProperty("latestAttemptExecutionInfo") StageExecutionInfo latestAttemptExecutionInfo,
             @JsonProperty("previousAttemptsExecutionInfos") List<StageExecutionInfo> previousAttemptsExecutionInfos,
-            @JsonProperty("subStages") List<StageInfo> subStages)
+            @JsonProperty("subStages") List<StageInfo> subStages,
+            @JsonProperty("isRuntimeOptimized") boolean isRuntimeOptimized)
     {
         this.stageId = requireNonNull(stageId, "stageId is null");
         this.self = requireNonNull(self, "self is null");
@@ -55,6 +58,7 @@ public class StageInfo
         this.latestAttemptExecutionInfo = requireNonNull(latestAttemptExecutionInfo, "latestAttemptExecutionInfo is null");
         this.previousAttemptsExecutionInfos = ImmutableList.copyOf(requireNonNull(previousAttemptsExecutionInfos, "previousAttemptsExecutionInfos is null"));
         this.subStages = ImmutableList.copyOf(requireNonNull(subStages, "subStages is null"));
+        this.isRuntimeOptimized = isRuntimeOptimized;
     }
 
     @JsonProperty
@@ -91,6 +95,12 @@ public class StageInfo
     public List<StageInfo> getSubStages()
     {
         return subStages;
+    }
+
+    @JsonProperty
+    public boolean isRuntimeOptimized()
+    {
+        return isRuntimeOptimized;
     }
 
     public boolean isFinalStageInfo()

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
@@ -180,6 +180,7 @@ public class MockManagedQueryExecution
                 false,
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -128,6 +128,7 @@ public class TestBasicQueryInfo
                         false,
                         Optional.empty(),
                         Optional.of(QueryType.INSERT),
+                        Optional.empty(),
                         Optional.empty()));
 
         assertEquals(basicInfo.getQueryId().getId(), "0");

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -170,6 +170,7 @@ public class TestQueryStateInfo
                 false,
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -455,6 +455,7 @@ public class PrestoSparkQueryExecutionFactory
                 true,
                 Optional.empty(),
                 planAndMore.flatMap(PlanAndMore::getQueryType),
+                Optional.empty(),
                 Optional.empty());
     }
 
@@ -497,7 +498,8 @@ public class PrestoSparkQueryExecutionFactory
                 ImmutableList.of(),
                 plan.getChildren().stream()
                         .map(child -> createStageInfo(queryId, child, taskInfoMap))
-                        .collect(toImmutableList()));
+                        .collect(toImmutableList()),
+                false);
     }
 
     private static void writeQueryInfo(Path queryInfoOutputPath, QueryInfo queryInfo, JsonCodec<QueryInfo> queryInfoJsonCodec)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryMetadata.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi.eventlistener;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -36,6 +37,8 @@ public class QueryMetadata
 
     private final Optional<String> payload;
 
+    private final List<String> runtimeOptimizedStages;
+
     public QueryMetadata(
             String queryId,
             Optional<String> transactionId,
@@ -44,7 +47,8 @@ public class QueryMetadata
             URI uri,
             Optional<String> plan,
             Optional<String> jsonPlan,
-            Optional<String> payload)
+            Optional<String> payload,
+            List<String> runtimeOptimizedStages)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.transactionId = requireNonNull(transactionId, "transactionId is null");
@@ -54,6 +58,7 @@ public class QueryMetadata
         this.plan = requireNonNull(plan, "plan is null");
         this.jsonPlan = requireNonNull(jsonPlan, "jsonPlan is null");
         this.payload = requireNonNull(payload, "payload is null");
+        this.runtimeOptimizedStages = requireNonNull(runtimeOptimizedStages, "runtimeOptimizedStages is null");
     }
 
     @JsonProperty
@@ -102,5 +107,11 @@ public class QueryMetadata
     public Optional<String> getPayload()
     {
         return payload;
+    }
+
+    @JsonProperty
+    public List<String> getRuntimeOptimizedStages()
+    {
+        return runtimeOptimizedStages;
     }
 }


### PR DESCRIPTION
This PR adds runtimeOptimizedStages field in QueryMetadata of the QueryCompletedEvent, so that the runtime optimization information can be processed and logged later acordingly.

```
== NO RELEASE NOTE ==
```
