### PR TITLE
Remove DistributionStat for PeakRunningTasks

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerStats.java
@@ -55,7 +55,6 @@ public class QueryManagerStats
     private final TimeStat queuedTime = new TimeStat(MILLISECONDS);
     private final DistributionStat wallInputBytesRate = new DistributionStat();
     private final DistributionStat cpuInputByteRate = new DistributionStat();
-    private final DistributionStat peakRunningTasksStat = new DistributionStat();
 
     public void trackQueryStats(DispatchQuery managedQueryExecution)
     {
@@ -109,11 +108,6 @@ public class QueryManagerStats
         long executionCpuMillis = info.getQueryStats().getTotalCpuTime().toMillis();
         if (executionCpuMillis > 0) {
             cpuInputByteRate.add(rawInputBytes * 1000 / executionCpuMillis);
-        }
-
-        long peakRunningTasks = info.getQueryStats().getPeakRunningTasks();
-        if (peakRunningTasks > 0) {
-            peakRunningTasksStat.add(peakRunningTasks);
         }
 
         if (info.getErrorCode() != null) {
@@ -321,12 +315,5 @@ public class QueryManagerStats
     public DistributionStat getCpuInputByteRate()
     {
         return cpuInputByteRate;
-    }
-
-    @Managed(description = "Distribution of query peak running tasks")
-    @Nested
-    public DistributionStat getPeakRunningTasksStat()
-    {
-        return peakRunningTasksStat;
     }
 }


### PR DESCRIPTION
DistributionStat is relatively more expensive, use QueryManager:RunningTaskCount instead.

This stat is not very useful in practice as one minute resolution may average out, please use eventlistener/QueryStatistics to identify query with highest peak running task count.

```
== NO RELEASE NOTE ==
```
