### PR TITLE
Clean up KdbTree node intersection logic

### DIFF
--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/KdbTree.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/KdbTree.java
@@ -172,7 +172,13 @@ public class KdbTree
 
     public Map<Integer, Rectangle> findIntersectingLeaves(Rectangle envelope)
     {
-        return findLeaves(node -> node.extent.intersects(envelope));
+        return findLeaves(node -> {
+            // Nodes don't include their upper (yMax) or right (xMax) boundaries
+            return node.extent.getXMin() <= envelope.getXMax()
+                    && node.extent.getXMax() > envelope.getXMin()
+                    && node.extent.getYMin() <= envelope.getYMax()
+                    && node.extent.getYMax() > envelope.getYMin();
+        });
     }
 
     private Map<Integer, Rectangle> findLeaves(Predicate<Node> predicate)

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/Rectangle.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/Rectangle.java
@@ -111,6 +111,16 @@ public final class Rectangle
                 && yMin <= y && y <= yMax;
     }
 
+    /**
+     * Returns if this Rectangle contains only a single point.
+     *
+     * @return if xMax==xMin and yMax==yMin
+     */
+    public boolean isPointlike()
+    {
+        return xMin == xMax && yMin == yMax;
+    }
+
     @Override
     public Rectangle getExtent()
     {

--- a/presto-geospatial-toolkit/src/test/java/com/facebook/presto/geospatial/TestKdbTree.java
+++ b/presto-geospatial-toolkit/src/test/java/com/facebook/presto/geospatial/TestKdbTree.java
@@ -134,7 +134,7 @@ public class TestKdbTree
         assertPartitions(tree, new Rectangle(5, 1, 5, 1), ImmutableSet.of());
 
         // point on the border separating two partitions
-        assertPartitions(tree, new Rectangle(1, 4.5, 1, 4.5), ImmutableSet.of(0, 1));
+        assertPartitions(tree, new Rectangle(1, 4.5, 1, 4.5), ImmutableSet.of(1));
 
         // rectangles
         assertPartitions(tree, new Rectangle(1, 1, 2, 2), ImmutableSet.of(0));


### PR DESCRIPTION
KdbTree nodes don't contain their right or upper boundaries.  This
commit moves that logic internal to the KdbTree, so that callers
don't have to know about this and have logic handling cases where
a point might intersect more than one node.

```
== NO RELEASE NOTE ==
```
