### PR TITLE
Pushdown DistinctLimitNode in Pinot Connector

### DIFF
--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
@@ -223,6 +224,11 @@ public class TestPinotQueryBase
     protected LimitNode limit(PlanBuilder pb, long count, PlanNode source)
     {
         return new LimitNode(pb.getIdAllocator().getNextId(), source, count, FINAL);
+    }
+
+    protected DistinctLimitNode distinctLimit(PlanBuilder pb, List<VariableReferenceExpression> distinctVariables, long count, PlanNode source)
+    {
+        return new DistinctLimitNode(pb.getIdAllocator().getNextId(), source, count, false, distinctVariables, Optional.empty());
     }
 
     protected TopNNode topN(PlanBuilder pb, long count, List<String> orderingColumns, List<Boolean> ascending, PlanNode source)

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotPlanOptimizer.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotPlanOptimizer.java
@@ -68,7 +68,7 @@ public class TestPinotPlanOptimizer
             new RowExpressionDeterminismEvaluator(functionMetadataManager),
             new FunctionResolution(functionMetadataManager),
             functionMetadataManager);
-    private final PinotTableHandle pinotTable = TestPinotSplitManager.hybridTable;
+    protected final PinotTableHandle pinotTable = TestPinotSplitManager.hybridTable;
     protected final SessionHolder defaultSessionHolder = getDefaultSessionHolder();
 
     public SessionHolder getDefaultSessionHolder()

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotQueryGeneratorSql.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotQueryGeneratorSql.java
@@ -211,4 +211,10 @@ public class TestPinotQueryGeneratorSql
                 defaultSessionHolder,
                 ImmutableMap.of());
     }
+
+    @Override
+    protected String getExpectedDistinctOutput(String groupKeys)
+    {
+        return groupKeys;
+    }
 }


### PR DESCRIPTION
Push down DistinctLimitNode to Pinot Query.

For Presto query: `SELECT DISTINCT flightnum FROM airlinestats LIMIT 10`,
We will pushdown below query to Pinot:
-  SQL format: `SELECT FlightNum FROM airlineStats GROUP BY FlightNum LIMIT 10`.
-  PQL format: `SELECT count(*) FROM airlineStats GROUP BY FlightNum TOP 10`.

Below is the generated query plan for SQL mode.
```
presto:default> explain select distinct flightnum from airlinestats limit 10;
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 - Output[flightnum] => [flightnum:integer]
         Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}
     - RemoteStreamingExchange[GATHER] => [flightnum:integer]
             Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}
         - TableScan[TableHandle {connectorId='pinot', connectorHandle='PinotTableHandle{connectorId=pinot, schemaName=default, tableName=airlineStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=FlightNum, dataType=integer, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT FlightNum FROM airlineStats GROUP BY FlightNum LIMIT 10, format=SQL, table=airlineStats, expectedColumnIndices=[], groupByClauses=1, haveFilter=false, isQueryShort=true}]}', layout='Optional[PinotTableHandle{connectorId=pinot, schemaName=default, tableName=airlineStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=FlightNum, dataType=integer, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT FlightNum FROM airlineStats GROUP BY FlightNum LIMIT 10, format=SQL, table=airlineStats, expectedColumnIndices=[], groupByClauses=1, haveFilter=false, isQueryShort=true}]}]'}] => [flightnum:integer]
                 Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
                 flightnum := PinotColumnHandle{columnName=FlightNum, dataType=integer, type=REGULAR}
```

Below is the generated query plan for PQL mode.
```
presto:default> explain select distinct flightnum from airlinestats limit 10;

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 - Output[flightnum] => [flightnum:integer]
         Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}
     - RemoteStreamingExchange[GATHER] => [flightnum:integer]
             Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}
         - TableScan[TableHandle {connectorId='pinot', connectorHandle='PinotTableHandle{connectorId=pinot, schemaName=default, tableName=airlineStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=FlightNum, dataType=integer, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT count(*) FROM airlineStats GROUP BY FlightNum TOP 10, format=PQL, table=airlineStats, expectedColumnIndices=[0, -1], groupByClauses=1, haveFilter=false, isQueryShort=true}]}', layout='Optional[PinotTableHandle{connectorId=pinot, schemaName=default, tableName=airlineStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=FlightNum, dataType=integer, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT count(*) FROM airlineStats GROUP BY FlightNum TOP 10, format=PQL, table=airlineStats, expectedColumnIndices=[0, -1], groupByClauses=1, haveFilter=false, isQueryShort=true}]}]'}] => [flightnum:integer]
                 Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
                 flightnum := PinotColumnHandle{columnName=FlightNum, dataType=integer, type=REGULAR}

(1 row)
```
```
== RELEASE NOTES ==

Pinot Changes
* Pushdown DistinctLimitNode to Pinot Query in SQL mode.
```
