### PR TITLE
Make skip.header.line.count=1 files splittable

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -385,7 +385,8 @@ public class BackgroundHiveSplitLoader
         // S3 Select pushdown works at the granularity of individual S3 objects,
         // therefore we must not split files when it is enabled.
         Properties schema = getHiveSchema(storage.getSerdeParameters(), table.getParameters());
-        boolean splittable = getHeaderCount(schema) == 0 && getFooterCount(schema) == 0 && !s3SelectPushdownEnabled;
+        // Skip header / footer lines are not splittable except for a special case when skip.header.line.count=1
+        boolean splittable = !s3SelectPushdownEnabled && getFooterCount(schema) == 0 && getHeaderCount(schema) <= 1;
 
         // Bucketed partitions are fully loaded immediately since all files must be loaded to determine the file to bucket mapping
         if (tableBucketInfo.isPresent()) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -234,7 +234,8 @@ public final class HiveUtil
             RecordReader<WritableComparable, Writable> recordReader = (RecordReader<WritableComparable, Writable>) inputFormat.getRecordReader(fileSplit, jobConf, Reporter.NULL);
 
             int headerCount = getHeaderCount(schema);
-            if (headerCount > 0) {
+            //  Only skip header rows when the split is at the beginning of the file
+            if (start == 0 && headerCount > 0) {
                 Utilities.skipHeader(recordReader, headerCount, recordReader.createKey(), recordReader.createValue());
             }
 


### PR DESCRIPTION
In general, files with arbitrarily many header lines are not currently considered splittable because the hive record reading logic does not work when rows might span over multiple splits. However, the relatively common case of having a single header row to skip is actually safe and can be considered splittable.
Observe:
- when skip.header.line.count = 1, the hive split boundary handling works even if the header line extends into the subsequent split because the reader of the next split will only process rows that start within the boundary of the split, not rows that extend into the split from the previous one. No additional logic required.
- when skip.header.line.count > 1 and the header rows extend past the first split end boundary, it becomes impossible for a reader to know which rows should be skipped without reading from the beginning. This is still considered unsplittable.

```
== RELEASE NOTES ==
Hive Changes
* Adds support for splitting hive files when skip.header.line.count=1
```
