### PR TITLE
Change TableStatistics constructor to private

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatistics.java
@@ -37,7 +37,7 @@ public final class TableStatistics
         return EMPTY;
     }
 
-    public TableStatistics(Estimate rowCount, Map<ColumnHandle, ColumnStatistics> columnStatistics)
+    private TableStatistics(Estimate rowCount, Map<ColumnHandle, ColumnStatistics> columnStatistics)
     {
         this.rowCount = requireNonNull(rowCount, "rowCount can not be null");
         if (!rowCount.isUnknown() && rowCount.getValue() < 0) {


### PR DESCRIPTION
It should be avoided to explicitly call the constructor of
TableStatistics, but instead should use TableStatistics.builder method.

```
== NO RELEASE NOTE ==
```
