### PR TITLE
Fix infinite loop in non-legacy SqlQueryScheduler

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -235,7 +235,6 @@ public class SqlQueryScheduler
     }
 
     @Override
-
     public void start()
     {
         if (started.compareAndSet(false, true)) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -283,6 +283,7 @@ public class SqlQueryScheduler
                         .collect(toImmutableList()));
                 if (queryStateMachine.isDone()) {
                     sectionExecutions.forEach(SectionExecution::abort);
+                    break;
                 }
 
                 sectionExecutions.forEach(sectionExecution -> scheduledStageExecutions.addAll(sectionExecution.getSectionStages()));


### PR DESCRIPTION
Queries that don't have table scan inputs could enter an infinite loop inthe scheduler if they hit the queryStateMachine.isDone() check and had any sections ready for execution. If the query is done (e.g. canceled or abandoned at this point), we abort the section.  Since "aborted" is a failed state, the section would continue to be considered "ready for execution"  in our next time through, and the loop would continue indefinitely. We need to explicitly exit the scheduling loop if the query is finished.

Queries with inputs didn't have this issue because the split scheduler would be closed when the query finished, so the scheduler would hit an error when it tried to create the scheduler for the scan stages.

I don't have a test because I was only able to reproduce the issue by explicitly calling queryStateMachine.transitionToFailed() here so we would enter the if statement.  Recommendations about how to test this are appreciated.


```
== RELEASE NOTES ==
General Changes
* Fix potential infinite loop when the setting ``use_legacy_scheduler`` is set to false.
```

