### PR TITLE
Enable async page transport by default

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -73,7 +73,7 @@ public class TaskManagerConfig
     private Integer partitionedWriterCount;
     private int taskConcurrency = 16;
     private int httpResponseThreads = 100;
-    private int httpTimeoutConcurrency = 1;
+    private int httpTimeoutConcurrency = 3;
     private int httpTimeoutThreads = 3;
 
     private int taskNotificationThreads = 5;

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientConfig.java
@@ -38,7 +38,7 @@ public class ExchangeClientConfig
     private int pageBufferClientMaxCallbackThreads = 25;
     private boolean acknowledgePages = true;
     private double responseSizeExponentialMovingAverageDecayingAlpha = 0.1;
-    private boolean asyncPageTransportEnabled;
+    private boolean asyncPageTransportEnabled = true;
 
     @NotNull
     public DataSize getMaxBufferSize()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -61,7 +61,7 @@ public class TestTaskManagerConfig
                 .setPartitionedWriterCount(null)
                 .setTaskConcurrency(16)
                 .setHttpResponseThreads(100)
-                .setHttpTimeoutConcurrency(1)
+                .setHttpTimeoutConcurrency(3)
                 .setHttpTimeoutThreads(3)
                 .setTaskNotificationThreads(5)
                 .setTaskYieldThreads(3)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClientConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestExchangeClientConfig.java
@@ -43,7 +43,7 @@ public class TestExchangeClientConfig
                 .setClientThreads(25)
                 .setAcknowledgePages(true)
                 .setResponseSizeExponentialMovingAverageDecayingAlpha(0.1)
-                .setAsyncPageTransportEnabled(false));
+                .setAsyncPageTransportEnabled(true));
     }
 
     @Test
@@ -60,7 +60,7 @@ public class TestExchangeClientConfig
                 .put("exchange.page-buffer-client.max-callback-threads", "16")
                 .put("exchange.acknowledge-pages", "false")
                 .put("exchange.response-size-exponential-moving-average-decaying-alpha", "0.42")
-                .put("exchange.async-page-transport-enabled", "true")
+                .put("exchange.async-page-transport-enabled", "false")
                 .build();
 
         ExchangeClientConfig expected = new ExchangeClientConfig()
@@ -74,7 +74,7 @@ public class TestExchangeClientConfig
                 .setPageBufferClientMaxCallbackThreads(16)
                 .setAcknowledgePages(false)
                 .setResponseSizeExponentialMovingAverageDecayingAlpha(0.42)
-                .setAsyncPageTransportEnabled(true);
+                .setAsyncPageTransportEnabled(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION

```
== RELEASE NOTES ==

General Changes
* Enable async page transport with non-blocking IO by default. This can be disabled by setting ``exchange.async-page-transport-enabled`` configuration property to false.
```
