### PR TITLE
Upgrade presto-hadoop-apache2 for GCS token refreshing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -548,7 +548,7 @@
             <dependency>
                 <groupId>com.facebook.presto.hadoop</groupId>
                 <artifactId>hadoop-apache2</artifactId>
-                <version>2.7.4-7</version>
+                <version>2.7.4-8</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Fix #14832 
Upgrade presto-hadoop-apache2 to pick up the commit prestodb/presto-hadoop-apache2#43 , which will fix the GCS token not refreshing issue.