### PR TITLE
Limit pushdown support

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -34,6 +34,7 @@ import com.facebook.presto.spi.api.Experimental;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
+import com.facebook.presto.spi.connector.LimitApplicationResult;
 import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrestoPrincipal;
@@ -462,4 +463,6 @@ public interface Metadata
     {
         return NOT_APPLICABLE;
     }
+
+    Optional<LimitApplicationResult<TableHandle>> applyLimit(Session session, TableHandle table, long limit);
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -71,6 +71,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PruneTopNColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneWindowColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PushAggregationThroughOuterJoin;
+import com.facebook.presto.sql.planner.iterative.rule.PushLimitIntoTableScan;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughMarkDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughOuterJoin;
 import com.facebook.presto.sql.planner.iterative.rule.PushLimitThroughProject;
@@ -306,6 +307,7 @@ public class PlanOptimizers
                                         new PushLimitThroughMarkDistinct(),
                                         new PushLimitThroughOuterJoin(),
                                         new PushLimitThroughSemiJoin(),
+                                        new PushLimitIntoTableScan(metadata),
                                         new RemoveTrivialFilters(),
                                         new ImplementFilteredAggregations(),
                                         new SingleDistinctAggregationToGroupBy(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitIntoTableScan.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushLimitIntoTableScan.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.LimitNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.sql.planner.iterative.Rule;
+
+import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.sql.planner.plan.Patterns.limit;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.facebook.presto.sql.planner.plan.Patterns.tableScan;
+
+public class PushLimitIntoTableScan
+        implements Rule<LimitNode>
+{
+    private static final Capture<TableScanNode> TABLE_SCAN = newCapture();
+    private static final Pattern<LimitNode> PATTERN = limit().with(source().matching(
+            tableScan().capturedAs(TABLE_SCAN)));
+
+    private final Metadata metadata;
+
+    public PushLimitIntoTableScan(Metadata metadata)
+    {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public Pattern<LimitNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Rule.Result apply(LimitNode limit, Captures captures, Rule.Context context)
+    {
+        TableScanNode tableScan = captures.get(TABLE_SCAN);
+
+        return metadata.applyLimit(context.getSession(), tableScan.getTable(), limit.getCount())
+                .map(result -> {
+                    PlanNode node = new TableScanNode(
+                            tableScan.getId(),
+                            result.getHandle(),
+                            tableScan.getOutputVariables(),
+                            tableScan.getAssignments(),
+                            tableScan.getCurrentConstraint(),
+                            tableScan.getEnforcedConstraint());
+
+                    if (!result.isLimitGuaranteed()) {
+                        node = new LimitNode(limit.getId(), node, limit.getCount(), limit.getStep());
+                    }
+
+                    return Result.ofPlanNode(node);
+                })
+                .orElseGet(Result::empty);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
+import com.facebook.presto.spi.connector.LimitApplicationResult;
 import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrestoPrincipal;
@@ -564,5 +565,11 @@ public abstract class AbstractMockMetadata
     public Set<ConnectorCapabilities> getConnectorCapabilities(Session session, ConnectorId catalogName)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<LimitApplicationResult<TableHandle>> applyLimit(Session session, TableHandle table, long limit)
+    {
+        return Optional.empty();
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -704,4 +704,28 @@ public interface ConnectorMetadata
     {
         return NOT_APPLICABLE;
     }
+
+     /**
+     * Attempt to push down the provided limit into the table.
+     * <p>
+     * Connectors can indicate whether they don't support limit pushdown or that the action had no effect
+     * by returning {@link Optional#empty()}. Connectors should expect this method to be called multiple times
+     * during the optimization of a given query.
+     * <p>
+     * <b>Note</b>: it's critical for connectors to return Optional.empty() if calling this method has no effect for that
+     * invocation, even if the connector generally supports limit pushdown. Doing otherwise can cause the optimizer
+     * to loop indefinitely.
+     * </p>
+     * <p>
+     * If the connector could benefit from the information but can't guarantee that it will be able to produce
+     * fewer rows than the provided limit, it should return a non-empty result containing a new handle for the
+     * derived table and the "limit guaranteed" flag set to false.
+     * <p>
+     * If the connector can guarantee it will produce fewer rows than the provided limit, it should return a
+     * non-empty result with the "limit guaranteed" flag set to true.
+     */
+    default Optional<LimitApplicationResult<ConnectorTableHandle>> applyLimit(ConnectorTableHandle handle, long limit)
+    {
+        return Optional.empty();
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/LimitApplicationResult.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/LimitApplicationResult.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.connector;
+
+import static java.util.Objects.requireNonNull;
+
+public class LimitApplicationResult<T>
+{
+    private final T handle;
+    private final boolean limitGuaranteed;
+
+    public LimitApplicationResult(T handle, boolean limitGuaranteed)
+    {
+        this.handle = requireNonNull(handle, "handle is null");
+        this.limitGuaranteed = limitGuaranteed;
+    }
+
+    public T getHandle()
+    {
+        return handle;
+    }
+
+    public boolean isLimitGuaranteed()
+    {
+        return limitGuaranteed;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -38,6 +38,7 @@ import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorPartitioningMetadata;
+import com.facebook.presto.spi.connector.LimitApplicationResult;
 import com.facebook.presto.spi.security.GrantInfo;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.Privilege;
@@ -630,6 +631,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getTableLayoutFilterCoverage(tableHandle, relevantPartitionColumns);
+        }
+    }
+
+    @Override
+    public Optional<LimitApplicationResult<ConnectorTableHandle>> applyLimit(ConnectorTableHandle table, long limit)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.applyLimit(table, limit);
         }
     }
 }


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes

This is a change to pushdown `limit` to connectors. This is a modified version from prestosql github https://github.com/prestosql/presto/pull/421 (Credits to @martint )

Hive Changes
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
