### PR TITLE
Add bing_tile_children and bing_tile_parent functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -497,6 +497,28 @@ represent a valid tile will raise an exception.
 
     Creates a Bing tile object from a quadkey.
 
+.. function:: bing_tile_parent(tile) -> BingTile
+
+    Returns the parent of the Bing tile at one lower zoom level.
+    Throws an exception if tile is at zoom level 0.
+
+.. function:: bing_tile_parent(tile, newZoom) -> BingTile
+
+    Returns the parent of the Bing tile at the specified lower zoom level.
+    Throws an exception if newZoom is less than 0, or newZoom is greater than
+    the tile's zoom.
+
+.. function:: bing_tile_children(tile) -> array(BingTile)
+
+    Returns the children of the Bing tile at one higher zoom level.
+    Throws an exception if tile is at max zoom level.
+
+.. function:: bing_tile_children(tile, newZoom) -> array(BingTile)
+
+    Returns the children of the Bing tile at the specified higher zoom level.
+    Throws an exception if newZoom is greater than the max zoom level, or
+    newZoom is less than the tile's zoom.
+
 .. function:: bing_tile_at(latitude, longitude, zoom_level) -> BingTile
 
     Returns a Bing tile at a given zoom level containing a point at a given latitude

--- a/presto-geospatial/pom.xml
+++ b/presto-geospatial/pom.xml
@@ -161,6 +161,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Small helper functions to find the children and parent of a BingTile.

```
== RELEASE NOTES ==

Geospatial Changes
* Introduce ``bing_tile_children`` and ``bing_tile_parent`` functions to get parents and children of a Bing tile.
```
