### PR TITLE
Add geometry_to_dissolved_bing_tiles and improve geometry_to_bing_tiles

### DIFF
--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -555,3 +555,11 @@ represent a valid tile will raise an exception.
 
     Returns the minimum set of Bing tiles that fully covers a given geometry at
     a given zoom level. Zoom levels from 1 to 23 are supported.
+
+.. function:: geometry_to_dissolved_bing_tiles(geometry, max_zoom_level) -> array(BingTile)
+
+    Returns the minimum set of Bing tiles that fully covers a given geometry at
+    a given zoom level, recursively dissolving full sets of children into parents.
+    This results in a smaller array of tiles of different zoom levels. For example,
+    if the non-dissolved covering is ["00", "01", "02", "03", "10"], the dissolved
+    covering would be ["0", "10"]. Zoom levels from 1 to 23 are supported.

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
@@ -18,6 +18,7 @@ import com.esri.core.geometry.Geometry;
 import com.esri.core.geometry.GeometryCursor;
 import com.esri.core.geometry.GeometryEngine;
 import com.esri.core.geometry.MultiVertexGeometry;
+import com.esri.core.geometry.Operator;
 import com.esri.core.geometry.Point;
 import com.esri.core.geometry.Polygon;
 import com.esri.core.geometry.ogc.OGCConcreteGeometryCollection;
@@ -346,6 +347,27 @@ public final class GeometryUtils
             return ImmutableList.of();
         }
         return () -> new GeometryCollectionIterator(geometry);
+    }
+
+    public static void accelerateGeometry(OGCGeometry ogcGeometry, Operator relateOperator)
+    {
+        accelerateGeometry(ogcGeometry, relateOperator, Geometry.GeometryAccelerationDegree.enumMild);
+    }
+
+    public static void accelerateGeometry(
+            OGCGeometry ogcGeometry,
+            Operator relateOperator,
+            Geometry.GeometryAccelerationDegree accelerationDegree)
+    {
+        // Recurse into GeometryCollections
+        GeometryCursor cursor = ogcGeometry.getEsriGeometryCursor();
+        while (true) {
+            Geometry esriGeometry = cursor.next();
+            if (esriGeometry == null) {
+                break;
+            }
+            relateOperator.accelerateGeometry(esriGeometry, null, accelerationDegree);
+        }
     }
 
     private static class GeometryCollectionIterator

--- a/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/BingTileUtils.java
+++ b/presto-geospatial/src/main/java/com/facebook/presto/plugin/geospatial/BingTileUtils.java
@@ -14,12 +14,29 @@
 package com.facebook.presto.plugin.geospatial;
 
 import com.esri.core.geometry.Envelope;
+import com.esri.core.geometry.Geometry;
+import com.esri.core.geometry.OperatorIntersects;
 import com.esri.core.geometry.Point;
+import com.esri.core.geometry.ogc.OGCGeometry;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.SqlType;
+import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static com.facebook.presto.geospatial.GeometryUtils.accelerateGeometry;
+import static com.facebook.presto.geospatial.GeometryUtils.getEnvelope;
 import static com.facebook.presto.plugin.geospatial.BingTile.MAX_ZOOM_LEVEL;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static java.lang.String.format;
@@ -39,6 +56,7 @@ public class BingTileUtils
     private static final String QUAD_KEY_TOO_LONG = "QuadKey must be " + MAX_ZOOM_LEVEL + " characters or less";
     private static final String ZOOM_LEVEL_TOO_SMALL = "Zoom level must be >= 0";
     private static final String ZOOM_LEVEL_TOO_LARGE = "Zoom level must be <= " + MAX_ZOOM_LEVEL;
+    private static final int MAX_COVERING_COUNT = 1_000_000;
 
     private BingTileUtils() {}
 
@@ -167,5 +185,164 @@ public class BingTileUtils
     {
         int tileAxis = (int) clip(axis * mapSize, 0, mapSize - 1);
         return tileAxis / TILE_PIXELS;
+    }
+
+    private static List<BingTile> findRawTileCovering(OGCGeometry ogcGeometry, int maxZoom)
+    {
+        Envelope envelope = getEnvelope(ogcGeometry);
+        Optional<List<BingTile>> trivialResult = handleTrivialCases(envelope, maxZoom);
+        if (trivialResult.isPresent()) {
+            return trivialResult.get();
+        }
+
+        accelerateGeometry(
+                ogcGeometry, OperatorIntersects.local(), Geometry.GeometryAccelerationDegree.enumMedium);
+
+        Deque<TilingEntry> stack = new ArrayDeque<>();
+        Consumer<BingTile> addIntersecting = tile -> {
+            TilingEntry tilingEntry = new TilingEntry(tile);
+            if (satisfiesTileEdgeCondition(envelope, tilingEntry)
+                    && ogcGeometry.intersects(tilingEntry.polygon)) {
+                stack.push(tilingEntry);
+            }
+        };
+
+        // Populate with initial tiles.  Since there aren't many low zoom tiles,
+        // and throwing away totally disjoint ones is cheap (envelope check),
+        // we might as well start comprehensively.
+        ImmutableList.of(
+                BingTile.fromCoordinates(0, 0, 1),
+                BingTile.fromCoordinates(0, 1, 1),
+                BingTile.fromCoordinates(1, 0, 1),
+                BingTile.fromCoordinates(1, 1, 1)
+        ).forEach(addIntersecting);
+
+        List<BingTile> outputTiles = new ArrayList<>();
+        while (!stack.isEmpty()) {
+            TilingEntry entry = stack.pop();
+            if (entry.tile.getZoomLevel() == maxZoom || ogcGeometry.contains(entry.polygon)) {
+                outputTiles.add(entry.tile);
+            }
+            else {
+                entry.tile.findChildren().forEach(addIntersecting);
+                checkCondition(
+                        outputTiles.size() + stack.size() <= MAX_COVERING_COUNT,
+                        "The zoom level is too high or the geometry is too large to compute a set " +
+                                "of covering Bing tiles. Please use a lower zoom level, or tile only a section " +
+                                "of the geometry.");
+            }
+        }
+        return outputTiles;
+    }
+
+    private static Optional<List<BingTile>> handleTrivialCases(Envelope envelope, int zoom)
+    {
+        checkZoomLevel(zoom);
+
+        if (envelope.isEmpty()) {
+            return Optional.of(ImmutableList.of());
+        }
+        checkLatitude(envelope.getYMin(), LATITUDE_SPAN_OUT_OF_RANGE);
+        checkLatitude(envelope.getYMax(), LATITUDE_SPAN_OUT_OF_RANGE);
+        checkLongitude(envelope.getXMin(), LONGITUDE_SPAN_OUT_OF_RANGE);
+        checkLongitude(envelope.getXMax(), LONGITUDE_SPAN_OUT_OF_RANGE);
+
+        if (zoom == 0) {
+            return Optional.of(ImmutableList.of(BingTile.fromCoordinates(0, 0, 0)));
+        }
+        if (envelope.getXMax() == envelope.getXMin() && envelope.getYMax() == envelope.getYMin()) {
+            return Optional.of(ImmutableList.of(latitudeLongitudeToTile(envelope.getYMax(), envelope.getXMax(), zoom)));
+        }
+
+        return Optional.empty();
+    }
+
+    /*
+     * BingTiles don't contain their eastern/southern edges, so that each point lies
+     * on a unique tile.  However, the easternmost and southernmost tiles must contain
+     * their eastern and southern bounds (respectively), because they are the only
+     * tiles that can.
+     */
+    private static boolean satisfiesTileEdgeCondition(Envelope query, TilingEntry entry)
+    {
+        BingTile tile = entry.tile;
+        int maxXY = (1 << tile.getZoomLevel()) - 1;
+        if (tile.getY() < maxXY && query.getYMax() == entry.envelope.getYMin()) {
+            return false;
+        }
+        if (tile.getX() < maxXY && query.getXMin() == entry.envelope.getXMax()) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Find a minimal set of BingTiles (at different zooms), covering the geometry.
+     * If a larger tile fits within the geometry, do not split it into smaller
+     * tiles.  Do not split a tile past maxZoom.
+     */
+    public static List<BingTile> findDissolvedTileCovering(OGCGeometry ogcGeometry, int maxZoom)
+    {
+        /*
+         * Define "full siblings" to be found distinct ties with the same parent -- ie, the parent's children.
+         * If we order a set of tiles first by zoom (descending) and then by quadkey, any siblings will adjacent
+         * to each other.  If we put the tiles on a min-heap (so head is the lowest zoom, first quadkey), then if
+         * the next four elements are full siblings, we can coalesce them into a parent which we put back on the
+         * heap.  If the first items in the heap are not full siblings, there is no possibility to make full siblings
+         * (since we are starting with highest zoom first), so we can add them to the results.
+         *
+         * In the end, we will have a fully dissolved set of tiles.
+         */
+
+        List<BingTile> rawTiles = findRawTileCovering(ogcGeometry, maxZoom);
+        if (rawTiles.isEmpty()) {
+            return rawTiles;
+        }
+        List<BingTile> results = new ArrayList<>(rawTiles.size());
+
+        Set<BingTile> candidates = new HashSet<>(4);
+        Comparator<BingTile> tileComparator = Comparator
+                .comparing(BingTile::getZoomLevel)
+                .thenComparing(BingTile::toQuadKey)
+                .reversed();
+        PriorityQueue<BingTile> queue = new PriorityQueue<>(rawTiles.size(), tileComparator);
+        queue.addAll(rawTiles);
+        while (!queue.isEmpty()) {
+            BingTile candidate = queue.poll();
+            if (candidate.getZoomLevel() == 0) {
+                results.add(candidate);
+                continue;
+            }
+
+            BingTile parent = candidate.findParent();
+            candidates.add(candidate);
+            while (!queue.isEmpty() && queue.peek().findParent().equals(parent)) {
+                candidates.add(queue.poll());
+            }
+            if (candidates.size() == 4) {
+                // We have a complete set!
+                queue.add(parent);
+            }
+            else {
+                results.addAll(candidates);
+            }
+            candidates.clear();
+        }
+
+        return results;
+    }
+
+    private static class TilingEntry
+    {
+        private final BingTile tile;
+        private final Envelope envelope;
+        private final OGCGeometry polygon;
+
+        public TilingEntry(BingTile tile)
+        {
+            this.tile = tile;
+            this.envelope = tileToEnvelope(tile);
+            this.polygon = OGCGeometry.createFromEsriGeometry(envelope, null);
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndexSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesSpatialIndexSupplier.java
@@ -13,8 +13,6 @@
  */
 package com.facebook.presto.operator;
 
-import com.esri.core.geometry.Geometry;
-import com.esri.core.geometry.GeometryCursor;
 import com.esri.core.geometry.Operator;
 import com.esri.core.geometry.OperatorFactoryLocal;
 import com.esri.core.geometry.ogc.OGCGeometry;
@@ -40,6 +38,7 @@ import java.util.function.Supplier;
 
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.geospatial.GeometryUtils.accelerateGeometry;
 import static com.facebook.presto.geospatial.serde.EsriGeometrySerde.deserialize;
 import static com.facebook.presto.operator.PagesSpatialIndex.EMPTY_INDEX;
 import static com.facebook.presto.operator.SyntheticAddress.decodePosition;
@@ -152,19 +151,6 @@ public class PagesSpatialIndexSupplier
         }
 
         return new Flatbush<>(geometries.toArray(new GeometryWithPosition[] {}));
-    }
-
-    private static void accelerateGeometry(OGCGeometry ogcGeometry, Operator relateOperator)
-    {
-        // Recurse into GeometryCollections
-        GeometryCursor cursor = ogcGeometry.getEsriGeometryCursor();
-        while (true) {
-            com.esri.core.geometry.Geometry esriGeometry = cursor.next();
-            if (esriGeometry == null) {
-                break;
-            }
-            relateOperator.accelerateGeometry(esriGeometry, null, Geometry.GeometryAccelerationDegree.enumMild);
-        }
     }
 
     // doesn't include memory used by channels and addresses which are shared with PagesIndex


### PR DESCRIPTION
NB: The first commit of this PR is in #14896; that should be merged first.

A useful feature (that is requested by users) is to have a tile covering
of a geometry that recursively dissolves complete sets of children into their
parents.  This results in a smaller set of tiles with non-uniform zoom
level.  This can be done efficiently, and actually can form the basis
of the current (uniform zoom level) minimal tile covering function.

This PR adds geometry_to_dissolved_bing_tiles, and refactors
geometry_to_bing_tiles to use an intermediate result in that algorithm.
This increases the performance by 50x on large/complex polygons,
removes the complexity restriction on the polygons, and fixes a
correctness bug (see below).

The benchmarks before and after:

    Baseline
    Benchmark                                         Mode  Cnt    Score    Error  Units
    BenchmarkGeometryToBingTiles.envelopeToBingTiles  avgt   10    0.013 ±  0.001  ms/op
    BenchmarkGeometryToBingTiles.geometryToBingTiles  avgt   10  330.286 ± 18.704  ms/op

    New Algorithm
    Benchmark                                         Mode  Cnt  Score   Error  Units
    BenchmarkGeometryToBingTiles.envelopeToBingTiles  avgt   10  0.044 ± 0.002  ms/op
    BenchmarkGeometryToBingTiles.geometryToBingTiles  avgt   10  7.697 ± 0.635  ms/op

The correctness bug is as follows: We consider Bing tiles to not include their southern and
eastern border.  This prevents duplicating points that are on the border of one or more tiles.
However, this restriction was not in the previous geometry_to_bing_tiles algorithm, so the
zoom=1 covering of `POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))` was the tile `"1"`, but the covering
for `POINT (0 0)` (clearly intersecting the above polygon) was the tile `"3"`.  This would result
in some intersections being missed in a tile-based join.  The new algorithm expands them
correctly, which leads to the correct but non-intuitive result of the covering of the polygon of a
Bing tile to not only be that tile, but its east, south, and southeast neighbors.  The intuitive
conflict can be resolved by noting that while the Bing tile does not include its eastern or southern
border, the polygon derived from it does, so to cover that, we must include those adjacent tiles.


```
== RELEASE NOTES ==

Geospatial Changes
* Add geometry_to_dissolved_bing_tiles function, which dissolves complete sets of child tiles to their parent.
* Improve geometry_to_bing_tiles.  It is 50x faster on complex polygons, the limit on polygon complexity is removed, and some correctness bugs have been fixed.
```
