### PR TITLE
Add a fast path using totalSize to plan join swapping

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/statistics/MetastoreHiveStatisticsProvider.java
@@ -158,6 +158,7 @@ public class MetastoreHiveStatisticsProvider
     {
         TableStatistics.Builder result = TableStatistics.builder();
         result.setRowCount(Estimate.of(0));
+        result.setTotalSize(Estimate.of(0));
         columns.forEach((columnName, columnHandle) -> {
             Type columnType = columnTypes.get(columnName);
             verify(columnType != null, "columnType is missing for column: %s", columnName);
@@ -404,6 +405,15 @@ public class MetastoreHiveStatisticsProvider
 
         TableStatistics.Builder result = TableStatistics.builder();
         result.setRowCount(Estimate.of(rowCount));
+
+        OptionalDouble optionalAverageSizePerPartition = calculateAverageSizePerPartition(statistics.values());
+        if (optionalAverageSizePerPartition.isPresent()) {
+            double averageSizePerPartition = optionalAverageSizePerPartition.getAsDouble();
+            verify(averageSizePerPartition >= 0, "averageSizePerPartition must be greater than or equal to zero: %s", averageSizePerPartition);
+            double totalSize = averageSizePerPartition * queriedPartitionsCount;
+            result.setTotalSize(Estimate.of(totalSize));
+        }
+
         for (Map.Entry<String, ColumnHandle> column : columns.entrySet()) {
             String columnName = column.getKey();
             HiveColumnHandle columnHandle = (HiveColumnHandle) column.getValue();
@@ -429,6 +439,18 @@ public class MetastoreHiveStatisticsProvider
                 .filter(OptionalLong::isPresent)
                 .mapToLong(OptionalLong::getAsLong)
                 .peek(count -> verify(count >= 0, "count must be greater than or equal to zero"))
+                .average();
+    }
+
+    @VisibleForTesting
+    static OptionalDouble calculateAverageSizePerPartition(Collection<PartitionStatistics> statistics)
+    {
+        return statistics.stream()
+                .map(PartitionStatistics::getBasicStatistics)
+                .map(HiveBasicStatistics::getInMemoryDataSizeInBytes)
+                .filter(OptionalLong::isPresent)
+                .mapToLong(OptionalLong::getAsLong)
+                .peek(size -> verify(size >= 0, "size must be greater than or equal to zero"))
                 .average();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/cost/ConnectorFilterStatsCalculatorService.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/ConnectorFilterStatsCalculatorService.java
@@ -58,7 +58,23 @@ public class ConnectorFilterStatsCalculatorService
             filteredStats = tableStats.mapOutputRowCount(sourceRowCount -> tableStats.getOutputRowCount() * UNKNOWN_FILTER_COEFFICIENT);
         }
 
-        return toTableStatistics(filteredStats, ImmutableBiMap.copyOf(columnNames).inverse());
+        TableStatistics filteredStatistics = toTableStatistics(filteredStats, ImmutableBiMap.copyOf(columnNames).inverse());
+        // Fill in the totalSize after filter, estimated proportional to the rowCount after versus before filter.
+        TableStatistics.Builder filteredStatsWithSize = TableStatistics.builder();
+        filteredStatsWithSize.setRowCount(filteredStatistics.getRowCount());
+        filteredStatistics.getColumnStatistics().forEach(filteredStatsWithSize::setColumnStatistics);
+        // If the rowCount before or after filter is zero, totalSize will also be zero
+        if (!tableStatistics.getRowCount().isUnknown() && tableStatistics.getRowCount().getValue() == 0
+                || !filteredStatistics.getRowCount().isUnknown() && filteredStatistics.getRowCount().getValue() == 0) {
+            filteredStatsWithSize.setTotalSize(Estimate.of(0));
+        }
+        else if (!tableStatistics.getTotalSize().isUnknown()
+                && !filteredStatistics.getRowCount().isUnknown()
+                && !tableStatistics.getRowCount().isUnknown()) {
+            double totalSizeAfterFilter = filteredStatistics.getRowCount().getValue() / tableStatistics.getRowCount().getValue() * tableStatistics.getTotalSize().getValue();
+            filteredStatsWithSize.setTotalSize(Estimate.of(totalSizeAfterFilter));
+        }
+        return filteredStatsWithSize.build();
     }
 
     private static PlanNodeStatsEstimate toPlanNodeStats(

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsNormalizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsNormalizer.java
@@ -56,7 +56,8 @@ public class StatsNormalizer
             return PlanNodeStatsEstimate.unknown();
         }
 
-        PlanNodeStatsEstimate.Builder normalized = PlanNodeStatsEstimate.buildFrom(stats);
+        PlanNodeStatsEstimate.Builder normalized = PlanNodeStatsEstimate.buildFrom(stats)
+                .setTotalSize(stats.getOutputSizeInBytes());
 
         Predicate<VariableReferenceExpression> variableFilter = outputVariables
                 .map(ImmutableSet::copyOf)

--- a/presto-main/src/main/java/com/facebook/presto/cost/TableScanStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/TableScanStatsRule.java
@@ -68,6 +68,7 @@ public class TableScanStatsRule
 
         return Optional.of(PlanNodeStatsEstimate.builder()
                 .setOutputRowCount(tableStatistics.getRowCount().getValue())
+                .setTotalSize(tableStatistics.getTotalSize().getValue())
                 .addVariableStatistics(outputVariableStats)
                 .build());
     }

--- a/presto-main/src/test/java/com/facebook/presto/cost/PlanNodeStatsAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/PlanNodeStatsAssertion.java
@@ -44,6 +44,12 @@ public class PlanNodeStatsAssertion
         return this;
     }
 
+    public PlanNodeStatsAssertion totalSize(double expected)
+    {
+        assertEstimateEquals(actual.getOutputSizeInBytes(), expected, "totalSize mismatch");
+        return this;
+    }
+
     public PlanNodeStatsAssertion outputRowsCountUnknown()
     {
         assertTrue(Double.isNaN(actual.getOutputRowCount()), "expected unknown outputRowsCount but got " + actual.getOutputRowCount());

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestConnectorFilterStatsCalculatorService.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestConnectorFilterStatsCalculatorService.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.cost;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.TestingColumnHandle;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.statistics.ColumnStatistics;
+import com.facebook.presto.spi.statistics.DoubleRange;
+import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.sql.TestingRowExpressionTranslator;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.tree.Expression;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+
+public class TestConnectorFilterStatsCalculatorService
+{
+    private Session session;
+    private ConnectorFilterStatsCalculatorService statsCalculatorService;
+    private ColumnHandle xColumn = new TestingColumnHandle("x");
+    private ColumnStatistics xStats;
+    private TableStatistics originalTableStatistics;
+    private TableStatistics originalTableStatisticsWithoutTotalSize;
+    private TableStatistics zeroTableStatistics;
+    private TypeProvider standardTypes;
+    private TestingRowExpressionTranslator translator;
+
+    @BeforeClass
+    public void setUp()
+    {
+        session = testSessionBuilder().build();
+        MetadataManager metadata = MetadataManager.createTestMetadataManager();
+        FilterStatsCalculator statsCalculator = new FilterStatsCalculator(metadata, new ScalarStatsCalculator(metadata), new StatsNormalizer());
+        statsCalculatorService = new ConnectorFilterStatsCalculatorService(statsCalculator);
+        xStats = ColumnStatistics.builder()
+                .setDistinctValuesCount(Estimate.of(40))
+                .setRange(new DoubleRange(-10, 10))
+                .setNullsFraction(Estimate.of(0.25))
+                .build();
+        zeroTableStatistics = TableStatistics.builder()
+                .setRowCount(Estimate.zero())
+                .setTotalSize(Estimate.zero())
+                .build();
+        originalTableStatistics = TableStatistics.builder()
+                .setRowCount(Estimate.of(100))
+                .setTotalSize(Estimate.of(800))
+                .setColumnStatistics(xColumn, xStats)
+                .build();
+        originalTableStatisticsWithoutTotalSize = TableStatistics.builder()
+                .setRowCount(Estimate.of(100))
+                .setColumnStatistics(xColumn, xStats)
+                .build();
+        standardTypes = TypeProvider.fromVariables(ImmutableList.<VariableReferenceExpression>builder()
+                .add(new VariableReferenceExpression("x", DOUBLE))
+                .build());
+        translator = new TestingRowExpressionTranslator(MetadataManager.createTestMetadataManager());
+    }
+
+    @Test
+    public void testTableStatisticsAfterFilter()
+    {
+        // totalSize always be zero
+        assertPredicate("true", zeroTableStatistics, zeroTableStatistics);
+        assertPredicate("x < 3e0", zeroTableStatistics, zeroTableStatistics);
+        assertPredicate("false", zeroTableStatistics, zeroTableStatistics);
+
+        // rowCount and totalSize all NaN
+        assertPredicate("true", TableStatistics.empty(), TableStatistics.empty());
+        // rowCount and totalSize from NaN to 0.0
+        assertPredicate("false", TableStatistics.empty(), TableStatistics.builder().setRowCount(Estimate.zero()).setTotalSize(Estimate.zero()).build());
+
+        TableStatistics filteredToZeroStatistics = TableStatistics.builder()
+                .setRowCount(Estimate.zero())
+                .setTotalSize(Estimate.zero())
+                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.of(1.0), Estimate.zero(), Estimate.zero(), Optional.empty()))
+                .build();
+        assertPredicate("false", originalTableStatistics, filteredToZeroStatistics);
+
+        TableStatistics filteredStatistics = TableStatistics.builder()
+                .setRowCount(Estimate.of(37.5))
+                .setTotalSize(Estimate.of(300))
+                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.zero(), Estimate.of(20), Estimate.unknown(), Optional.of(new DoubleRange(-10, 0))))
+                .build();
+        assertPredicate("x < 0", originalTableStatistics, filteredStatistics);
+
+        TableStatistics filteredStatisticsWithoutTotalSize = TableStatistics.builder()
+                .setRowCount(Estimate.of(37.5))
+                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.zero(), Estimate.of(20), Estimate.unknown(), Optional.of(new DoubleRange(-10, 0))))
+                .build();
+        assertPredicate("x < 0", originalTableStatisticsWithoutTotalSize, filteredStatisticsWithoutTotalSize);
+    }
+
+    private void assertPredicate(String filterExpression, TableStatistics tableStatistics, TableStatistics expectedStatistics)
+    {
+        assertPredicate(expression(filterExpression), tableStatistics, expectedStatistics);
+    }
+
+    private void assertPredicate(Expression filterExpression, TableStatistics tableStatistics, TableStatistics expectedStatistics)
+    {
+        RowExpression predicate = translator.translateAndOptimize(filterExpression, standardTypes);
+        TableStatistics filteredStatistics = statsCalculatorService.filterStats(tableStatistics, predicate, session.toConnectorSession(),
+                ImmutableMap.of(xColumn, "x"), ImmutableMap.of("x", DOUBLE));
+        assertEquals(filteredStatistics, expectedStatistics);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestExchangeStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestExchangeStatsRule.java
@@ -44,6 +44,7 @@ public class TestExchangeStatsRule
                         .addSource(pb.values(pb.variable("i21", BIGINT), pb.variable("i22", BIGINT), pb.variable("i23", BIGINT), pb.variable("i24", BIGINT)))))
                 .withSourceStats(0, PlanNodeStatsEstimate.builder()
                         .setOutputRowCount(10)
+                        .setTotalSize(40)
                         .addVariableStatistics(new VariableReferenceExpression("i11", BIGINT), VariableStatsEstimate.builder()
                                 .setLowValue(1)
                                 .setHighValue(10)
@@ -71,6 +72,7 @@ public class TestExchangeStatsRule
                         .build())
                 .withSourceStats(1, PlanNodeStatsEstimate.builder()
                         .setOutputRowCount(20)
+                        .setTotalSize(80)
                         .addVariableStatistics(new VariableReferenceExpression("i21", BIGINT), VariableStatsEstimate.builder()
                                 .setLowValue(11)
                                 .setHighValue(20)
@@ -94,6 +96,7 @@ public class TestExchangeStatsRule
                         .build())
                 .check(check -> check
                         .outputRowsCount(30)
+                        .totalSize(120)
                         .variableStats(new VariableReferenceExpression("o1", BIGINT), assertion -> assertion
                                 .lowValue(1)
                                 .highValue(20)

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestStatsNormalizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestStatsNormalizer.java
@@ -53,10 +53,12 @@ public class TestStatsNormalizer
         VariableReferenceExpression a = new VariableReferenceExpression("a", BIGINT);
         PlanNodeStatsEstimate estimate = PlanNodeStatsEstimate.builder()
                 .setOutputRowCount(30)
+                .setTotalSize(120)
                 .addVariableStatistics(a, VariableStatsEstimate.builder().setDistinctValuesCount(20).build())
                 .build();
 
         assertNormalized(estimate)
+                .totalSize(120)
                 .variableStats(a, variableAssert -> variableAssert.distinctValuesCount(20));
     }
 
@@ -68,12 +70,14 @@ public class TestStatsNormalizer
         VariableReferenceExpression c = new VariableReferenceExpression("c", BIGINT);
         PlanNodeStatsEstimate estimate = PlanNodeStatsEstimate.builder()
                 .setOutputRowCount(40)
+                .setTotalSize(160)
                 .addVariableStatistics(a, VariableStatsEstimate.builder().setDistinctValuesCount(20).build())
                 .addVariableStatistics(b, VariableStatsEstimate.builder().setDistinctValuesCount(30).build())
                 .addVariableStatistics(c, VariableStatsEstimate.unknown())
                 .build();
 
         PlanNodeStatsAssertion.assertThat(normalizer.normalize(estimate, ImmutableList.of(b, c)))
+                .totalSize(160)
                 .variablesWithKnownStats(b)
                 .variableStats(b, variableAssert -> variableAssert.distinctValuesCount(30));
     }
@@ -89,9 +93,11 @@ public class TestStatsNormalizer
                 .addVariableStatistics(b, VariableStatsEstimate.builder().setNullsFraction(0.4).setDistinctValuesCount(20).build())
                 .addVariableStatistics(c, VariableStatsEstimate.unknown())
                 .setOutputRowCount(10)
+                .setTotalSize(40)
                 .build();
 
         assertNormalized(estimate)
+                .totalSize(40)
                 .variableStats(a, variableAssert -> variableAssert.distinctValuesCount(10))
                 .variableStats(b, variableAssert -> variableAssert.distinctValuesCount(8))
                 .variableStats(c, VariableStatsAssertion::distinctValuesCountUnknown);
@@ -138,9 +144,11 @@ public class TestStatsNormalizer
                 .build();
         PlanNodeStatsEstimate estimate = PlanNodeStatsEstimate.builder()
                 .setOutputRowCount(10000000000L)
+                .setTotalSize(40000000000L)
                 .addVariableStatistics(variable, symbolStats).build();
 
         assertNormalized(estimate)
+                .totalSize(40000000000L)
                 .variableStats(variable, variableAssert -> variableAssert.distinctValuesCount(expectedNormalizedNdv));
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/TableStatistics.java
@@ -30,6 +30,7 @@ public final class TableStatistics
     private static final TableStatistics EMPTY = TableStatistics.builder().build();
 
     private final Estimate rowCount;
+    private final Estimate totalSize;
     private final Map<ColumnHandle, ColumnStatistics> columnStatistics;
 
     public static TableStatistics empty()
@@ -37,11 +38,15 @@ public final class TableStatistics
         return EMPTY;
     }
 
-    private TableStatistics(Estimate rowCount, Map<ColumnHandle, ColumnStatistics> columnStatistics)
+    private TableStatistics(Estimate rowCount, Estimate totalSize, Map<ColumnHandle, ColumnStatistics> columnStatistics)
     {
         this.rowCount = requireNonNull(rowCount, "rowCount can not be null");
         if (!rowCount.isUnknown() && rowCount.getValue() < 0) {
             throw new IllegalArgumentException(format("rowCount must be greater than or equal to 0: %s", rowCount.getValue()));
+        }
+        this.totalSize = requireNonNull(totalSize, "totalSize can not be null");
+        if (!totalSize.isUnknown() && totalSize.getValue() < 0) {
+            throw new IllegalArgumentException(format("totalSize must be greater than or equal to 0: %s", totalSize.getValue()));
         }
         this.columnStatistics = unmodifiableMap(requireNonNull(columnStatistics, "columnStatistics can not be null"));
     }
@@ -50,6 +55,12 @@ public final class TableStatistics
     public Estimate getRowCount()
     {
         return rowCount;
+    }
+
+    @JsonProperty
+    public Estimate getTotalSize()
+    {
+        return totalSize;
     }
 
     @JsonProperty
@@ -69,13 +80,14 @@ public final class TableStatistics
         }
         TableStatistics that = (TableStatistics) o;
         return Objects.equals(rowCount, that.rowCount) &&
+                Objects.equals(totalSize, that.totalSize) &&
                 Objects.equals(columnStatistics, that.columnStatistics);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(rowCount, columnStatistics);
+        return Objects.hash(rowCount, totalSize, columnStatistics);
     }
 
     @Override
@@ -83,6 +95,7 @@ public final class TableStatistics
     {
         return "TableStatistics{" +
                 "rowCount=" + rowCount +
+                ", totalSize=" + totalSize +
                 ", columnStatistics=" + columnStatistics +
                 '}';
     }
@@ -95,11 +108,18 @@ public final class TableStatistics
     public static final class Builder
     {
         private Estimate rowCount = Estimate.unknown();
+        private Estimate totalSize = Estimate.unknown();
         private Map<ColumnHandle, ColumnStatistics> columnStatisticsMap = new LinkedHashMap<>();
 
         public Builder setRowCount(Estimate rowCount)
         {
             this.rowCount = requireNonNull(rowCount, "rowCount can not be null");
+            return this;
+        }
+
+        public Builder setTotalSize(Estimate totalSize)
+        {
+            this.totalSize = requireNonNull(totalSize, "totalSize can not be null");
             return this;
         }
 
@@ -113,7 +133,7 @@ public final class TableStatistics
 
         public TableStatistics build()
         {
-            return new TableStatistics(rowCount, columnStatisticsMap);
+            return new TableStatistics(rowCount, totalSize, columnStatisticsMap);
         }
     }
 }

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsMetadataStatistics.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsMetadataStatistics.java
@@ -189,6 +189,9 @@ public class TestTpcdsMetadataStatistics
                 "  \"rowCount\" : {\n" +
                 "    \"value\" : 30.0\n" +
                 "  },\n" +
+                "  \"totalSize\" : {\n" +
+                "    \"value\" : \"NaN\"\n" +
+                "  },\n" +
                 "  \"columnStatistics\" : {\n" +
                 "    \"tpcds:web_site_sk\" : {\n" +
                 "      \"nullsFraction\" : {\n" +


### PR DESCRIPTION
For simple plans (join on two tables directly without intermediate operations), directly leverage the `totalSize` statistics to plan the join swapping, which avoids either the per-column statistics collection cost or the inaccurate size estimations from CBO statsCalculator (especially for nested data structures e.g., map<varchar, array<bigint>>).

```
== NO RELEASE NOTE ==
```
