### PR TITLE
Add logging on Presto-on-Spark worker

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -267,6 +267,17 @@ public class PlanPrinter
         return builder.toString();
     }
 
+    public static String textPlanFragment(PlanFragment fragment, FunctionManager functionManager, Session session, boolean verbose)
+    {
+        return formatFragment(
+                functionManager,
+                session,
+                fragment,
+                Optional.empty(),
+                Optional.empty(),
+                verbose);
+    }
+
     public static String jsonLogicalPlan(
             PlanNode plan,
             TypeProvider types,
@@ -881,7 +892,11 @@ public class PlanPrinter
             }
 
             TupleDomain<ColumnHandle> predicate = node.getCurrentConstraint();
-            if (predicate.isNone()) {
+            if (predicate == null) {
+                // This happens when printing the plan framgnet on worker for debug purpose
+                nodeOutput.appendDetailsLine(":: PREDICATE INFORMATION UNAVAILABLE");
+            }
+            else if (predicate.isNone()) {
                 nodeOutput.appendDetailsLine(":: NONE");
             }
             else {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -136,6 +136,7 @@ import com.facebook.presto.sql.planner.ConnectorPlanOptimizerManager;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.NodePartitioningManager;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
+import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.PlanFragmenter;
 import com.facebook.presto.sql.planner.PlanOptimizers;
 import com.facebook.presto.sql.planner.sanity.PlanChecker;
@@ -212,6 +213,7 @@ public class PrestoSparkModule
         jsonCodecBinder(binder).bindJsonCodec(ViewDefinition.class);
         jsonCodecBinder(binder).bindJsonCodec(TaskInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(PrestoSparkTaskDescriptor.class);
+        jsonCodecBinder(binder).bindJsonCodec(PlanFragment.class);
         jsonCodecBinder(binder).bindJsonCodec(TaskSource.class);
         jsonCodecBinder(binder).bindJsonCodec(TableCommitContext.class);
         jsonCodecBinder(binder).bindJsonCodec(ExplainAnalyzeContext.class);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableScanNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableScanNode.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.HashMap;
@@ -109,11 +110,12 @@ public final class TableScanNode
      * <p>
      * This guarantee can have different origins.
      * For example, it may be successful predicate push down, or inherent guarantee provided by the underlying data.
+     *
+     * currentConstraint will only be used in planner. It is not transported to worker thus will be null on worker.
      */
+    @Nullable
     public TupleDomain<ColumnHandle> getCurrentConstraint()
     {
-        // currentConstraint can be pretty complex. As a result, it may incur a significant cost to serialize, store, and transport.
-        checkState(currentConstraint != null, "currentConstraint should only be used in planner. It is not transported to workers.");
         return currentConstraint;
     }
 


### PR DESCRIPTION
* Total split size. This can help debug skewed workers.
* The plan fragment. The RDD stage id is not matched with Presto plan
  fragment id. Thus today we will need to look at the worker log, get
  the Presto stage id, and look at the plan. This eases debugging by
  eliminating one step. In the future, we should investigate better
  integration with Spark UI.


```
== NO RELEASE NOTE ==
```
