### PR TITLE
Handle CAST in canonicalized LambdaDefinitionExpression

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/LambdaDefinitionExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/LambdaDefinitionExpression.java
@@ -133,7 +133,7 @@ public final class LambdaDefinitionExpression
         @Override
         public String visitCall(CallExpression call, Void context)
         {
-            return format("%s.%s(%s)", call.getFunctionHandle().getFunctionNamespace(), call.getDisplayName(), String.join(", ", call.getArguments().stream().map(e -> e.accept(this, null)).collect(Collectors.toList())));
+            return format("%s.%s(%s):%s", call.getFunctionHandle().getFunctionNamespace(), call.getDisplayName(), String.join(", ", call.getArguments().stream().map(e -> e.accept(this, null)).collect(Collectors.toList())), call.getType());
         }
 
         @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -282,6 +282,14 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testTryLambdaWithCast()
+    {
+        assertQuery(
+                "SELECT IF(TRY(CAST(a AS INT)) IN (1, 5), TRY(CAST(b AS DOUBLE)), 0.0) FROM (VALUES (varchar'1', varchar'2.1'), (varchar'5', varchar'3.4')) t(a, b)",
+                "VALUES 2.1, 3.4");
+    }
+
+    @Test
     public void testNonDeterministicFilter()
     {
         MaterializedResult materializedResult = computeActual("SELECT u FROM ( SELECT if(rand() > 0.5, 0, 1) AS u ) WHERE u <> u");


### PR DESCRIPTION
Include CallExpression return type in canonicalized LambdaDefinitionExpression
so CAST with same input type would not be mistakenly canonicalized.

```
== RELEASE NOTES ==

General Changes
* Fix LambdaDefinitionExpression canonicalization did not handle CAST
```
