### PR TITLE
Put time limit on `TestDistributedSpillQueries#testJoinPredicatePushdown`

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
 
 import java.nio.file.Paths;
 
@@ -61,6 +62,13 @@ public class TestDistributedSpilledQueries
             queryRunner.close();
             throw e;
         }
+    }
+
+    @Test(timeOut = 4 * 60 * 1000)
+    @Override
+    public void testJoinPredicatePushdown()
+    {
+        super.testJoinPredicatePushdown();
     }
 
     @Override


### PR DESCRIPTION
We are seeing this test get stuck multiple times and putting this limit
will help it fail fast and help us investigate. The normal success runtimes
for this test are less than 5 seconds - so this is way more buffer than
needed

```
== NO RELEASE NOTE ==
```
