### PR TITLE
Add "Test plan" field to PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,3 +1,5 @@
+Test plan - (Please fill in how you tested your changes)
+
 Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.
 
 Fill in the release notes towards the bottom of the PR description.


### PR DESCRIPTION
Based on the discussion in the TSC meeting of presto on 7/7/2020, adding
a new field called as Test plan to motivate contributors to think better
about the testing method for their PRs and giving committers an
opportunity to assess the same and recommend changes/suggestions to the
same.

```
== NO RELEASE NOTE ==
```
