### PR TITLE
Add Session property to ignore non-readable hive partitions and pass the warning to the user

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
@@ -43,6 +43,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -193,7 +194,7 @@ public abstract class AbstractOperatorBenchmark
 
     private Split getLocalQuerySplit(Session session, TableHandle handle)
     {
-        SplitSource splitSource = localQueryRunner.getSplitManager().getSplits(session, handle, UNGROUPED_SCHEDULING);
+        SplitSource splitSource = localQueryRunner.getSplitManager().getSplits(session, handle, UNGROUPED_SCHEDULING, WarningCollector.NOOP);
         List<Split> splits = new ArrayList<>();
         while (!splitSource.isFinished()) {
             splits.addAll(getNextBatch(splitSource));

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.SchemaNotFoundException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
@@ -178,7 +179,7 @@ public class TestCassandraConnector
 
         List<ConnectorTableLayoutResult> layouts = metadata.getTableLayouts(SESSION, tableHandle, Constraint.alwaysTrue(), Optional.empty());
         ConnectorTableLayoutHandle layout = getOnlyElement(layouts).getTableLayout().getHandle();
-        List<ConnectorSplit> splits = getAllSplits(splitManager.getSplits(transaction, SESSION, layout, new SplitSchedulingContext(UNGROUPED_SCHEDULING, false)));
+        List<ConnectorSplit> splits = getAllSplits(splitManager.getSplits(transaction, SESSION, layout, new SplitSchedulingContext(UNGROUPED_SCHEDULING, false, WarningCollector.NOOP)));
 
         long rowNumber = 0;
         for (ConnectorSplit split : splits) {

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveWarningCode.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveWarningCode.java
@@ -11,14 +11,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.split;
+package com.facebook.presto.hive;
 
-import com.facebook.presto.Session;
-import com.facebook.presto.spi.TableHandle;
-import com.facebook.presto.spi.WarningCollector;
-import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
+import com.facebook.presto.spi.WarningCode;
+import com.facebook.presto.spi.WarningCodeSupplier;
 
-public interface SplitSourceProvider
+public enum HiveWarningCode
+        implements WarningCodeSupplier
 {
-    SplitSource getSplits(Session session, TableHandle tableHandle, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector);
+    PARTITION_NOT_READABLE(1),
+    /**/;
+    private final WarningCode warningCode;
+
+    public static final int WARNING_CODE_MASK = 0x0100_0000;
+
+    HiveWarningCode(int code)
+    {
+        warningCode = new WarningCode(code + WARNING_CODE_MASK, name());
+    }
+
+    @Override
+    public WarningCode toWarningCode()
+    {
+        return warningCode;
+    }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -133,6 +133,7 @@ public class HiveClientConfig
     private boolean sortedWritingEnabled = true;
     private BucketFunctionType bucketFunctionTypeForExchange = HIVE_COMPATIBLE;
     private boolean ignoreTableBucketing;
+    private boolean ignoreUnreadablePartition;
     private int minBucketCountToNotIgnoreTableBucketing;
     private int maxBucketsForGroupedExecution = 1_000_000;
     // TODO: Clean up this gatekeeper config and related code/session property once the roll out is done.
@@ -1097,6 +1098,19 @@ public class HiveClientConfig
     public BucketFunctionType getBucketFunctionTypeForExchange()
     {
         return bucketFunctionTypeForExchange;
+    }
+
+    @Config("hive.ignore-unreadable-partition")
+    @ConfigDescription("Ignore unreadable partitions and report as warnings instead of failing the query")
+    public HiveClientConfig setIgnoreUnreadablePartition(boolean ignoreUnreadablePartition)
+    {
+        this.ignoreUnreadablePartition = ignoreUnreadablePartition;
+        return this;
+    }
+
+    public boolean isIgnoreUnreadablePartition()
+    {
+        return ignoreUnreadablePartition;
     }
 
     @Config("hive.ignore-table-bucketing")

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -106,7 +106,7 @@ public final class HiveSessionProperties
     private static final String PARQUET_BATCH_READER_VERIFICATION_ENABLED = "parquet_batch_reader_verification_enabled";
     private static final String BUCKET_FUNCTION_TYPE_FOR_EXCHANGE = "bucket_function_type_for_exchange";
     public static final String PARQUET_DEREFERENCE_PUSHDOWN_ENABLED = "parquet_dereference_pushdown_enabled";
-    private static final String IGNORE_UNREADABLE_PARTITION = "ignore_unreadable_partition";
+    public static final String IGNORE_UNREADABLE_PARTITION = "ignore_unreadable_partition";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -106,6 +106,7 @@ public final class HiveSessionProperties
     private static final String PARQUET_BATCH_READER_VERIFICATION_ENABLED = "parquet_batch_reader_verification_enabled";
     private static final String BUCKET_FUNCTION_TYPE_FOR_EXCHANGE = "bucket_function_type_for_exchange";
     public static final String PARQUET_DEREFERENCE_PUSHDOWN_ENABLED = "parquet_dereference_pushdown_enabled";
+    private static final String IGNORE_UNREADABLE_PARTITION = "ignore_unreadable_partition";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -477,6 +478,11 @@ public final class HiveSessionProperties
                         "Is Parquet batch reader verification enabled? This is for testing purposes only, not to be used in production",
                         hiveClientConfig.isParquetBatchReaderVerificationEnabled(),
                         false),
+                booleanProperty(
+                        IGNORE_UNREADABLE_PARTITION,
+                        "Ignore unreadable partitions and report as warnings instead of failing the query",
+                        hiveClientConfig.isIgnoreUnreadablePartition(),
+                        false),
                 new PropertyMetadata<>(
                         BUCKET_FUNCTION_TYPE_FOR_EXCHANGE,
                         "hash function type for bucketed table exchange",
@@ -792,6 +798,11 @@ public final class HiveSessionProperties
     public static boolean isOfflineDataDebugModeEnabled(ConnectorSession session)
     {
         return session.getProperty(OFFLINE_DATA_DEBUG_MODE_ENABLED, Boolean.class);
+    }
+
+    public static boolean shouldIgnoreUnreadablePartition(ConnectorSession session)
+    {
+        return session.getProperty(IGNORE_UNREADABLE_PARTITION, Boolean.class);
     }
 
     public static boolean isShufflePartitionedColumnsForTableWriteEnabled(ConnectorSession session)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -385,9 +385,9 @@ public class HiveSplitManager
                         if (!shouldIgnoreUnreadablePartition(session)) {
                             throw new HiveNotReadableException(tableName, Optional.of(partName), partitionNotReadable);
                         }
-                        warningCollector.add(
-                                new PrestoWarning(PARTITION_NOT_READABLE,
-                                        format("Table '%s' partition '%s' is not readable: %s", tableName, partName, partitionNotReadable)));
+                        warningCollector.add(new PrestoWarning(
+                                PARTITION_NOT_READABLE,
+                                format("Table '%s' partition '%s' is not readable: %s", tableName, partName, partitionNotReadable)));
                         continue;
                     }
                 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -28,8 +28,10 @@ import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.FixedSplitSource;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.common.collect.AbstractIterator;
@@ -61,6 +63,8 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_SCHEMA_MISMA
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_TRANSACTION_NOT_FOUND;
 import static com.facebook.presto.hive.HivePartition.UNPARTITIONED_ID;
 import static com.facebook.presto.hive.HiveSessionProperties.isOfflineDataDebugModeEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.shouldIgnoreUnreadablePartition;
+import static com.facebook.presto.hive.HiveWarningCode.PARTITION_NOT_READABLE;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getProtectMode;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.makePartName;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.verifyOnline;
@@ -223,7 +227,15 @@ public class HiveSplitManager
         // sort partitions
         partitions = Ordering.natural().onResultOf(HivePartition::getPartitionId).reverse().sortedCopy(partitions);
 
-        Iterable<HivePartitionMetadata> hivePartitions = getPartitionMetadata(metastore, table, tableName, partitions, bucketHandle, session, layout.getRequestedColumns());
+        Iterable<HivePartitionMetadata> hivePartitions = getPartitionMetadata(
+                metastore,
+                table,
+                tableName,
+                partitions,
+                bucketHandle,
+                session,
+                splitSchedulingContext.getWarningCollector(),
+                layout.getRequestedColumns());
 
         HiveSplitLoader hiveSplitLoader = new BackgroundHiveSplitLoader(
                 table,
@@ -312,6 +324,7 @@ public class HiveSplitManager
             List<HivePartition> hivePartitions,
             Optional<HiveBucketHandle> hiveBucketHandle,
             ConnectorSession session,
+            WarningCollector warningCollector,
             Optional<Set<HiveColumnHandle>> requestedColumns)
     {
         if (hivePartitions.isEmpty()) {
@@ -369,7 +382,13 @@ public class HiveSplitManager
                     // verify partition is not marked as non-readable
                     String partitionNotReadable = partition.getParameters().get(OBJECT_NOT_READABLE);
                     if (!isNullOrEmpty(partitionNotReadable)) {
-                        throw new HiveNotReadableException(tableName, Optional.of(partName), partitionNotReadable);
+                        if (!shouldIgnoreUnreadablePartition(session)) {
+                            throw new HiveNotReadableException(tableName, Optional.of(partName), partitionNotReadable);
+                        }
+                        warningCollector.add(
+                                new PrestoWarning(PARTITION_NOT_READABLE,
+                                        format("Table '%s' partition '%s' is not readable: %s", tableName, partName, partitionNotReadable)));
+                        continue;
                     }
                 }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -91,6 +91,7 @@ import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.ViewNotFoundException;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
@@ -674,7 +675,7 @@ public abstract class AbstractTestHiveClient
             .row("3", "value6")
             .build();
 
-    public static final SplitSchedulingContext SPLIT_SCHEDULING_CONTEXT = new SplitSchedulingContext(UNGROUPED_SCHEDULING, false);
+    public static final SplitSchedulingContext SPLIT_SCHEDULING_CONTEXT = new SplitSchedulingContext(UNGROUPED_SCHEDULING, false, WarningCollector.NOOP);
 
     protected String clientId;
     protected String database;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -2466,7 +2466,7 @@ public abstract class AbstractTestHiveClient
         }
     }
 
-    private ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorMetadata metadata, ConnectorTableHandle tableHandle, Constraint<ColumnHandle> constraint, Transaction transaction)
+    protected ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorMetadata metadata, ConnectorTableHandle tableHandle, Constraint<ColumnHandle> constraint, Transaction transaction)
     {
         if (HiveSessionProperties.isPushdownFilterEnabled(session)) {
             assertTrue(constraint.getSummary().isAll());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -49,6 +49,7 @@ import com.facebook.presto.spi.PageSinkProperties;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
@@ -118,7 +119,7 @@ import static org.testng.Assert.assertTrue;
 public abstract class AbstractTestHiveFileSystem
 {
     private static final HdfsContext TESTING_CONTEXT = new HdfsContext(new ConnectorIdentity("test", Optional.empty(), Optional.empty()));
-    public static final SplitSchedulingContext SPLIT_SCHEDULING_CONTEXT = new SplitSchedulingContext(UNGROUPED_SCHEDULING, false);
+    public static final SplitSchedulingContext SPLIT_SCHEDULING_CONTEXT = new SplitSchedulingContext(UNGROUPED_SCHEDULING, false, WarningCollector.NOOP);
 
     protected String database;
     protected SchemaTableName table;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -139,7 +139,8 @@ public class TestHiveClientConfig
                 .setParquetBatchReaderVerificationEnabled(false)
                 .setParquetBatchReadOptimizationEnabled(false)
                 .setBucketFunctionTypeForExchange(HIVE_COMPATIBLE)
-                .setParquetDereferencePushdownEnabled(false));
+                .setParquetDereferencePushdownEnabled(false)
+                .setIgnoreUnreadablePartition(false));
     }
 
     @Test
@@ -240,6 +241,7 @@ public class TestHiveClientConfig
                 .put("hive.enable-parquet-batch-reader-verification", "true")
                 .put("hive.bucket-function-type-for-exchange", "PRESTO_NATIVE")
                 .put("hive.enable-parquet-dereference-pushdown", "true")
+                .put("hive.ignore-unreadable-partition", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -337,7 +339,8 @@ public class TestHiveClientConfig
                 .setParquetBatchReaderVerificationEnabled(true)
                 .setParquetBatchReadOptimizationEnabled(true)
                 .setBucketFunctionTypeForExchange(PRESTO_NATIVE)
-                .setParquetDereferencePushdownEnabled(true);
+                .setParquetDereferencePushdownEnabled(true)
+                .setIgnoreUnreadablePartition(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientFileMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientFileMetastore.java
@@ -13,17 +13,58 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.execution.warnings.DefaultWarningCollector;
+import com.facebook.presto.execution.warnings.WarningCollectorConfig;
+import com.facebook.presto.execution.warnings.WarningHandlingLevel;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.PartitionStatistics;
+import com.facebook.presto.hive.metastore.PartitionWithStatistics;
+import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayout;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.SkipException;
+import org.testng.annotations.Test;
 
 import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveMetadata.PRESTO_VERSION_NAME;
+import static com.facebook.presto.hive.HiveSplitManager.OBJECT_NOT_READABLE;
+import static com.facebook.presto.hive.HiveStorageFormat.ORC;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_QUERY_ID_NAME;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.toPartitionValues;
+import static com.facebook.presto.hive.metastore.StorageFormat.fromHiveStorageFormat;
+import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingContext;
+import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.apache.hadoop.hive.common.FileUtils.makePartName;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
 
 public class TestHiveClientFileMetastore
         extends AbstractTestHiveClientLocal
 {
+    private static final SplitSchedulingContext SPLIT_SCHEDULING_CONTEXT = new SplitSchedulingContext(
+            UNGROUPED_SCHEDULING,
+            false,
+            new DefaultWarningCollector(new WarningCollectorConfig(), WarningHandlingLevel.NORMAL));
+
     @Override
     protected ExtendedHiveMetastore createMetastore(File tempDir)
     {
@@ -65,5 +106,119 @@ public class TestHiveClientFileMetastore
     public void testTransactionDeleteInsert()
     {
         // FileHiveMetastore has various incompatibilities
+    }
+
+    @Test
+    public void testPartitionNotReadable()
+    {
+        SchemaTableName tableName = temporaryTable("tempTable");
+        Map<String, String> dynamicPartitionParameters = ImmutableMap.of(OBJECT_NOT_READABLE, "Testing Unreadable Partition");
+        try {
+            createDummyPartitionedTable(tableName, STATISTICS_PARTITIONED_TABLE_COLUMNS, dynamicPartitionParameters);
+
+            try (Transaction transaction = newTransaction()) {
+                ConnectorMetadata metadata = transaction.getMetadata();
+                ConnectorSession session = newSession();
+
+                ConnectorTableHandle tableHandle = getTableHandle(metadata, tableName);
+                assertNotNull(tableHandle);
+
+                ColumnHandle dsColumn = metadata.getColumnHandles(session, tableHandle).get("ds");
+                assertNotNull(dsColumn);
+
+                ConnectorTableLayout tableLayout = getTableLayout(session, metadata, tableHandle, Constraint.alwaysTrue(), transaction);
+                try {
+                    getSplitCount(splitManager.getSplits(transaction.getTransactionHandle(), session, tableLayout.getHandle(), SPLIT_SCHEDULING_CONTEXT));
+                    fail("Expected HiveNotReadableException");
+                }
+                catch (HiveNotReadableException e) {
+                    assertEquals(e.getTableName(), tableName);
+                    assertNotNull(SPLIT_SCHEDULING_CONTEXT.getWarningCollector());
+                    assertEquals(SPLIT_SCHEDULING_CONTEXT.getWarningCollector().getWarnings().size(), 0);
+                }
+            }
+
+            try (Transaction transaction = newTransaction()) {
+                ConnectorMetadata metadata = transaction.getMetadata();
+                ConnectorSession session = newSession(ImmutableMap.of(HiveSessionProperties.IGNORE_UNREADABLE_PARTITION, true));
+
+                ConnectorTableHandle tableHandle = getTableHandle(metadata, tableName);
+                assertNotNull(tableHandle);
+
+                ColumnHandle dsColumn = metadata.getColumnHandles(session, tableHandle).get("ds");
+                assertNotNull(dsColumn);
+
+                ConnectorTableLayout tableLayout = getTableLayout(session, metadata, tableHandle, Constraint.alwaysTrue(), transaction);
+                splitManager.getSplits(transaction.getTransactionHandle(), session, tableLayout.getHandle(), SPLIT_SCHEDULING_CONTEXT);
+                assertNotNull(SPLIT_SCHEDULING_CONTEXT.getWarningCollector());
+                assertEquals(SPLIT_SCHEDULING_CONTEXT.getWarningCollector().getWarnings().size(), 1);
+            }
+        }
+        catch (Exception e) {
+            fail("Exception not expected");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    private void createDummyPartitionedTable(SchemaTableName tableName, List<ColumnMetadata> columns, Map<String, String> dynamicPartitionParameters)
+            throws Exception
+    {
+        doCreateEmptyTable(tableName, ORC, columns);
+
+        ExtendedHiveMetastore metastoreClient = getMetastoreClient();
+        Table table = metastoreClient.getTable(tableName.getSchemaName(), tableName.getTableName())
+                .orElseThrow(() -> new TableNotFoundException(tableName));
+
+        List<String> firstPartitionValues = ImmutableList.of("2020-01-01");
+        List<String> secondPartitionValues = ImmutableList.of("2020-01-02");
+        List<String> thirdPartitionValues = ImmutableList.of("2020-01-03");
+
+        String firstPartitionName = makePartName(ImmutableList.of("ds"), firstPartitionValues);
+        String secondPartitionName = makePartName(ImmutableList.of("ds"), secondPartitionValues);
+        String thirdPartitionName = makePartName(ImmutableList.of("ds"), thirdPartitionValues);
+
+        List<PartitionWithStatistics> partitions = ImmutableList.of(firstPartitionName, secondPartitionName)
+                .stream()
+                .map(partitionName -> new PartitionWithStatistics(createDummyPartition(table, partitionName), partitionName, PartitionStatistics.empty()))
+                .collect(toImmutableList());
+        metastoreClient.addPartitions(tableName.getSchemaName(), tableName.getTableName(), partitions);
+        metastoreClient.updatePartitionStatistics(tableName.getSchemaName(), tableName.getTableName(), firstPartitionName, currentStatistics -> EMPTY_TABLE_STATISTICS);
+        metastoreClient.updatePartitionStatistics(tableName.getSchemaName(), tableName.getTableName(), secondPartitionName, currentStatistics -> EMPTY_TABLE_STATISTICS);
+
+        List<PartitionWithStatistics> partitionsNotReadable = ImmutableList.of(thirdPartitionName)
+                .stream()
+                .map(partitionName -> new PartitionWithStatistics(createDummyPartition(table, partitionName, dynamicPartitionParameters), partitionName, PartitionStatistics.empty()))
+                .collect(toImmutableList());
+        metastoreClient.addPartitions(tableName.getSchemaName(), tableName.getTableName(), partitionsNotReadable);
+        metastoreClient.updatePartitionStatistics(tableName.getSchemaName(), tableName.getTableName(), thirdPartitionName, currentStatistics -> EMPTY_TABLE_STATISTICS);
+    }
+
+    private Partition createDummyPartition(Table table, String partitionName, Map<String, String> dynamicPartitionParameters)
+    {
+        return createDummyPartition(table, partitionName, Optional.empty(), dynamicPartitionParameters);
+    }
+
+    private Partition createDummyPartition(Table table, String partitionName, Optional<HiveBucketProperty> bucketProperty, Map<String, String> dynamicPartitionParameters)
+    {
+        Map<String, String> staticPartitionParameters = ImmutableMap.of(
+                PRESTO_VERSION_NAME, "testversion",
+                PRESTO_QUERY_ID_NAME, "20200101_123456_00001_x1y2z");
+        Map<String, String> partitionParameters = ImmutableMap.<String, String>builder()
+                .putAll(staticPartitionParameters)
+                .putAll(dynamicPartitionParameters)
+                .build();
+        return Partition.builder()
+                .setDatabaseName(table.getDatabaseName())
+                .setTableName(table.getTableName())
+                .setColumns(table.getDataColumns())
+                .setValues(toPartitionValues(partitionName))
+                .withStorage(storage -> storage
+                        .setStorageFormat(fromHiveStorageFormat(HiveStorageFormat.ORC))
+                        .setLocation(partitionTargetPath(new SchemaTableName(table.getDatabaseName(), table.getTableName()), partitionName))
+                        .setBucketProperty(bucketProperty))
+                .setParameters(partitionParameters)
+                .build();
     }
 }

--- a/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxSplitManager.java
+++ b/presto-jmx/src/test/java/com/facebook/presto/connector/jmx/TestJmxSplitManager.java
@@ -28,6 +28,7 @@ import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingContext;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
@@ -107,7 +108,7 @@ public class TestJmxSplitManager
             TupleDomain<ColumnHandle> nodeTupleDomain = TupleDomain.fromFixedValues(ImmutableMap.of(columnHandle, NullableValue.of(createUnboundedVarcharType(), utf8Slice(nodeIdentifier))));
             ConnectorTableLayoutHandle layout = new JmxTableLayoutHandle(tableHandle, nodeTupleDomain);
 
-            ConnectorSplitSource splitSource = splitManager.getSplits(JmxTransactionHandle.INSTANCE, SESSION, layout, new SplitSchedulingContext(UNGROUPED_SCHEDULING, false));
+            ConnectorSplitSource splitSource = splitManager.getSplits(JmxTransactionHandle.INSTANCE, SESSION, layout, new SplitSchedulingContext(UNGROUPED_SCHEDULING, false, WarningCollector.NOOP));
             List<ConnectorSplit> allSplits = getAllSplits(splitSource);
 
             assertEquals(allSplits.size(), 1);
@@ -121,7 +122,7 @@ public class TestJmxSplitManager
             throws Exception
     {
         ConnectorTableLayoutHandle layout = new JmxTableLayoutHandle(tableHandle, TupleDomain.all());
-        ConnectorSplitSource splitSource = splitManager.getSplits(JmxTransactionHandle.INSTANCE, SESSION, layout, new SplitSchedulingContext(UNGROUPED_SCHEDULING, false));
+        ConnectorSplitSource splitSource = splitManager.getSplits(JmxTransactionHandle.INSTANCE, SESSION, layout, new SplitSchedulingContext(UNGROUPED_SCHEDULING, false, WarningCollector.NOOP));
         List<ConnectorSplit> allSplits = getAllSplits(splitSource);
         assertEquals(allSplits.size(), nodes.size());
 
@@ -198,7 +199,7 @@ public class TestJmxSplitManager
         List<ColumnHandle> columnHandles = ImmutableList.copyOf(metadata.getColumnHandles(SESSION, tableHandle).values());
 
         ConnectorTableLayoutHandle layout = new JmxTableLayoutHandle(tableHandle, TupleDomain.all());
-        ConnectorSplitSource splitSource = splitManager.getSplits(JmxTransactionHandle.INSTANCE, SESSION, layout, new SplitSchedulingContext(UNGROUPED_SCHEDULING, false));
+        ConnectorSplitSource splitSource = splitManager.getSplits(JmxTransactionHandle.INSTANCE, SESSION, layout, new SplitSchedulingContext(UNGROUPED_SCHEDULING, false, WarningCollector.NOOP));
         List<ConnectorSplit> allSplits = getAllSplits(splitSource);
         assertEquals(allSplits.size(), nodes.size());
         ConnectorSplit split = allSplits.get(0);

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -460,7 +460,7 @@ public class SqlQueryExecution
                 .withBuffer(OUTPUT_BUFFER_ID, BROADCAST_PARTITION_ID)
                 .withNoMoreBufferIds();
 
-        SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider);
+        SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, stateMachine.getWarningCollector());
         // build the stage execution objects (this doesn't schedule execution)
         SqlQuerySchedulerInterface scheduler = isUseLegacyScheduler(getSession()) ?
                 LegacySqlQueryScheduler.createSqlQueryScheduler(

--- a/presto-main/src/main/java/com/facebook/presto/split/CloseableSplitSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/CloseableSplitSourceProvider.java
@@ -16,6 +16,7 @@ package com.facebook.presto.split;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
 import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -45,10 +46,10 @@ public class CloseableSplitSourceProvider
     }
 
     @Override
-    public synchronized SplitSource getSplits(Session session, TableHandle tableHandle, SplitSchedulingStrategy splitSchedulingStrategy)
+    public synchronized SplitSource getSplits(Session session, TableHandle tableHandle, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector)
     {
         checkState(!closed, "split source provider is closed");
-        SplitSource splitSource = delegate.getSplits(session, tableHandle, splitSchedulingStrategy);
+        SplitSource splitSource = delegate.getSplits(session, tableHandle, splitSchedulingStrategy, warningCollector);
         splitSources.add(splitSource);
         return splitSource;
     }

--- a/presto-main/src/main/java/com/facebook/presto/split/SplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/SplitManager.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingContext;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
@@ -67,7 +68,7 @@ public class SplitManager
         splitManagers.remove(connectorId);
     }
 
-    public SplitSource getSplits(Session session, TableHandle table, SplitSchedulingStrategy splitSchedulingStrategy)
+    public SplitSource getSplits(Session session, TableHandle table, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector)
     {
         ConnectorId connectorId = table.getConnectorId();
         ConnectorSplitManager splitManager = getConnectorSplitManager(connectorId);
@@ -88,7 +89,7 @@ public class SplitManager
                 table.getTransaction(),
                 connectorSession,
                 layout,
-                new SplitSchedulingContext(splitSchedulingStrategy, preferSplitHostAddresses));
+                new SplitSchedulingContext(splitSchedulingStrategy, preferSplitHostAddresses, warningCollector));
 
         SplitSource splitSource = new ConnectorAwareSplitSource(connectorId, table.getTransaction(), source);
         if (minScheduleSplitBatchSize > 1) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
@@ -19,6 +19,7 @@ import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.execution.scheduler.TableWriteInfo.DeleteScanInfo;
 import com.facebook.presto.operator.StageExecutionDescriptor;
 import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
@@ -78,10 +79,12 @@ public class SplitSourceFactory
     private static final Logger log = Logger.get(SplitSourceFactory.class);
 
     private final SplitSourceProvider splitSourceProvider;
+    private final WarningCollector warningCollector;
 
-    public SplitSourceFactory(SplitSourceProvider splitSourceProvider)
+    public SplitSourceFactory(SplitSourceProvider splitSourceProvider, WarningCollector warningCollector)
     {
         this.splitSourceProvider = requireNonNull(splitSourceProvider, "splitSourceProvider is null");
+        this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
     }
 
     public Map<PlanNodeId, SplitSource> createSplitSources(PlanFragment fragment, Session session, TableWriteInfo tableWriteInfo)
@@ -152,7 +155,8 @@ public class SplitSourceFactory
             Supplier<SplitSource> splitSourceSupplier = () -> splitSourceProvider.getSplits(
                     session,
                     table,
-                    getSplitSchedulingStrategy(stageExecutionDescriptor, node.getId()));
+                    getSplitSchedulingStrategy(stageExecutionDescriptor, node.getId()),
+                    warningCollector);
 
             SplitSource splitSource = new LazySplitSource(splitSourceSupplier);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExtractSpatialJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExtractSpatialJoins.java
@@ -36,6 +36,7 @@ import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.plan.Assignments;
@@ -527,7 +528,7 @@ public class ExtractSpatialJoins
         TableHandle newTableHandle = layout.getLayout().getNewTableHandle();
 
         Optional<KdbTree> kdbTree = Optional.empty();
-        try (SplitSource splitSource = splitManager.getSplits(session, newTableHandle, UNGROUPED_SCHEDULING)) {
+        try (SplitSource splitSource = splitManager.getSplits(session, newTableHandle, UNGROUPED_SCHEDULING, WarningCollector.NOOP)) {
             while (!Thread.currentThread().isInterrupted()) {
                 SplitBatch splitBatch = getFutureValue(splitSource.getNextBatch(NOT_PARTITIONED, Lifespan.taskWide(), 1000));
                 List<Split> splits = splitBatch.getSplits();

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -817,7 +817,8 @@ public class LocalQueryRunner
             SplitSource splitSource = splitManager.getSplits(
                     session,
                     tableScan.getTable(),
-                    getSplitSchedulingStrategy(stageExecutionDescriptor, tableScan.getId()));
+                    getSplitSchedulingStrategy(stageExecutionDescriptor, tableScan.getId()),
+                    WarningCollector.NOOP);
 
             ImmutableSet.Builder<ScheduledSplit> scheduledSplits = ImmutableSet.builder();
             while (!splitSource.isFinished()) {

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorSplitManager.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorSplitManager.java
@@ -34,6 +34,7 @@ import com.facebook.presto.spi.ConnectorTableLayoutResult;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingContext;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.testing.TestingNodeManager;
@@ -215,7 +216,7 @@ public class TestRaptorSplitManager
     private static ConnectorSplitSource getSplits(RaptorSplitManager splitManager, ConnectorTableLayoutResult layout)
     {
         ConnectorTransactionHandle transaction = new RaptorTransactionHandle();
-        return splitManager.getSplits(transaction, SESSION, layout.getTableLayout().getHandle(), new SplitSchedulingContext(UNGROUPED_SCHEDULING, true));
+        return splitManager.getSplits(transaction, SESSION, layout.getTableLayout().getHandle(), new SplitSchedulingContext(UNGROUPED_SCHEDULING, true, WarningCollector.NOOP));
     }
 
     private static List<ConnectorSplit> getSplits(ConnectorSplitSource source, int maxSize)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
@@ -39,6 +39,7 @@ import com.facebook.presto.spark.util.PrestoSparkUtils;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
@@ -300,7 +301,7 @@ public class PrestoSparkRddFactory
         List<TableScanNode> tableScans = findTableScanNodes(fragment.getRoot());
         if (!tableScans.isEmpty()) {
             try (CloseableSplitSourceProvider splitSourceProvider = new CloseableSplitSourceProvider(splitManager::getSplits)) {
-                SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider);
+                SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, WarningCollector.NOOP);
                 Map<PlanNodeId, SplitSource> splitSources = splitSourceFactory.createSplitSources(fragment, session, tableWriteInfo);
                 taskSourceRdd = Optional.of(createTaskSourcesRdd(
                         sparkContext,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorSplitManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorSplitManager.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi.connector;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.WarningCollector;
 
 import static java.util.Objects.requireNonNull;
 
@@ -38,6 +39,7 @@ public interface ConnectorSplitManager
     {
         private final SplitSchedulingStrategy splitSchedulingStrategy;
         private final boolean schedulerUsesHostAddresses;
+        private final WarningCollector warningCollector;
 
         /**
          * @param splitSchedulingStrategy the method by which splits are scheduled
@@ -47,10 +49,11 @@ public interface ConnectorSplitManager
          * splits without any performance loss.  Non-remotely accessible splits always
          * need to provide host addresses.
          */
-        public SplitSchedulingContext(SplitSchedulingStrategy splitSchedulingStrategy, boolean schedulerUsesHostAddresses)
+        public SplitSchedulingContext(SplitSchedulingStrategy splitSchedulingStrategy, boolean schedulerUsesHostAddresses, WarningCollector warningCollector)
         {
             this.splitSchedulingStrategy = requireNonNull(splitSchedulingStrategy, "splitSchedulingStrategy is null");
             this.schedulerUsesHostAddresses = schedulerUsesHostAddresses;
+            this.warningCollector = requireNonNull(warningCollector, "warningCollector is null ");
         }
 
         public SplitSchedulingStrategy getSplitSchedulingStrategy()
@@ -61,6 +64,11 @@ public interface ConnectorSplitManager
         public boolean schedulerUsesHostAddresses()
         {
             return schedulerUsesHostAddresses;
+        }
+
+        public WarningCollector getWarningCollector()
+        {
+            return warningCollector;
         }
     }
 }


### PR DESCRIPTION
Depended by https://github.com/facebookexternal/presto-facebook/pull/1124

Add Session property to ignore non-readable hive partitions and pass that as a warning back to the user

Hive Config
hive.ignore-unreadable-partition

Session property
ignore_unreadable_partition

```
== NO RELEASE NOTE ==
```