### PR TITLE
Add max Spark input partition count for auto tune

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
@@ -25,6 +25,7 @@ import static io.airlift.units.DataSize.Unit.KILOBYTE;
 public class PrestoSparkConfig
 {
     private boolean sparkPartitionCountAutoTuneEnabled = true;
+    private int maxSparkInputPartitionCountForAutoTune = 1000;
     private int initialSparkPartitionCount = 16;
     private DataSize maxSplitsDataSizePerSparkPartition = new DataSize(2, GIGABYTE);
     private DataSize shuffleOutputTargetAverageRowSize = new DataSize(1, KILOBYTE);
@@ -40,6 +41,19 @@ public class PrestoSparkConfig
     {
         this.sparkPartitionCountAutoTuneEnabled = sparkPartitionCountAutoTuneEnabled;
         return this;
+    }
+
+    @Config("spark.max-spark-input-partition-count-for-auto-tune")
+    @ConfigDescription("Max Spark input partition count when Spark partition auto tune is enabled")
+    public PrestoSparkConfig setMaxSparkInputPartitionCountForAutoTune(int maxSparkInputPartitionCountForAutoTune)
+    {
+        this.maxSparkInputPartitionCountForAutoTune = maxSparkInputPartitionCountForAutoTune;
+        return this;
+    }
+
+    public int getMaxSparkInputPartitionCountForAutoTune()
+    {
+        return maxSparkInputPartitionCountForAutoTune;
     }
 
     public int getInitialSparkPartitionCount()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
@@ -29,6 +29,7 @@ import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
 public class PrestoSparkSessionProperties
 {
     public static final String SPARK_PARTITION_COUNT_AUTO_TUNE_ENABLED = "spark_partition_count_auto_tune_enabled";
+    public static final String MAX_SPARK_INPUT_PARTITION_COUNT_FOR_AUTO_TUNE = "max_spark_input_partition_count_for_auto_tune";
     public static final String SPARK_INITIAL_PARTITION_COUNT = "spark_initial_partition_count";
     public static final String MAX_SPLITS_DATA_SIZE_PER_SPARK_PARTITION = "max_splits_data_size_per_spark_partition";
     public static final String SHUFFLE_OUTPUT_TARGET_AVERAGE_ROW_SIZE = "shuffle_output_target_average_row_size";
@@ -43,6 +44,11 @@ public class PrestoSparkSessionProperties
                         SPARK_PARTITION_COUNT_AUTO_TUNE_ENABLED,
                         "Automatic tuning of spark initial partition count based on splits size per partition",
                         prestoSparkConfig.isSparkPartitionCountAutoTuneEnabled(),
+                        false),
+                integerProperty(
+                        MAX_SPARK_INPUT_PARTITION_COUNT_FOR_AUTO_TUNE,
+                        "Max Spark input partition count when Spark partition auto tune is enabled",
+                        prestoSparkConfig.getMaxSparkInputPartitionCountForAutoTune(),
                         false),
                 integerProperty(
                         SPARK_INITIAL_PARTITION_COUNT,
@@ -69,6 +75,11 @@ public class PrestoSparkSessionProperties
     public static boolean isSparkPartitionCountAutoTuneEnabled(Session session)
     {
         return session.getSystemProperty(SPARK_PARTITION_COUNT_AUTO_TUNE_ENABLED, Boolean.class);
+    }
+
+    public static int getMaxSparkInputPartitionCountForAutoTune(Session session)
+    {
+        return session.getSystemProperty(MAX_SPARK_INPUT_PARTITION_COUNT_FOR_AUTO_TUNE, Integer.class);
     }
 
     public static int getSparkInitialPartitionCount(Session session)

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
@@ -33,6 +33,7 @@ public class TestPrestoSparkConfig
         assertRecordedDefaults(ConfigAssertions.recordDefaults(PrestoSparkConfig.class)
                 .setSparkPartitionCountAutoTuneEnabled(true)
                 .setInitialSparkPartitionCount(16)
+                .setMaxSparkInputPartitionCountForAutoTune(1000)
                 .setMaxSplitsDataSizePerSparkPartition(new DataSize(2, GIGABYTE))
                 .setShuffleOutputTargetAverageRowSize(new DataSize(1, KILOBYTE)));
     }
@@ -43,12 +44,14 @@ public class TestPrestoSparkConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("spark.partition-count-auto-tune-enabled", "false")
                 .put("spark.initial-partition-count", "128")
+                .put("spark.max-spark-input-partition-count-for-auto-tune", "2000")
                 .put("spark.max-splits-data-size-per-partition", "4GB")
                 .put("spark.shuffle-output-target-average-row-size", "10kB")
                 .build();
         PrestoSparkConfig expected = new PrestoSparkConfig()
                 .setSparkPartitionCountAutoTuneEnabled(false)
                 .setInitialSparkPartitionCount(128)
+                .setMaxSparkInputPartitionCountForAutoTune(2000)
                 .setMaxSplitsDataSizePerSparkPartition(new DataSize(4, GIGABYTE))
                 .setShuffleOutputTargetAverageRowSize(new DataSize(10, KILOBYTE));
         assertFullMapping(properties, expected);


### PR DESCRIPTION
When scanning over very large tables (hundreds of TBs or even PBs),
using the default `spark.max-splits-data-size-per-partition` might
result in too many Spark executors (e.g. >50K) and cause jobs to be
unstable.

The long term solution is to set
`spark.max-splits-data-size-per-partition` to be reasonably large, and
leverage historic based optimizer to figure out the optimal split size
per partition. In a short term, having a max Spark input partition count
makes it makes it easier for job auto migration.

Test plan - Tested with a large-scale Spark job.

```
== NO RELEASE NOTE ==
```
