### PR TITLE
Shade classes in presto-jdbc uber jar

### DIFF
--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -272,6 +272,30 @@
                                     <pattern>okio</pattern>
                                     <shadedPattern>${shadeBase}.okio</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>com.google.api</pattern>
+                                    <shadedPattern>${shadeBase}.google.api</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.auth</pattern>
+                                    <shadedPattern>${shadeBase}.google.auth</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.j2objc</pattern>
+                                    <shadedPattern>${shadeBase}.j2objc</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>${shadeBase}.apache.commons</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.http</pattern>
+                                    <shadedPattern>${shadeBase}.apache.http</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.httpcomponents</pattern>
+                                    <shadedPattern>${shadeBase}.apache.httpcomponents</shadedPattern>
+                                </relocation>
                             </relocations>
                             <filters>
                                 <filter>


### PR DESCRIPTION
https://github.com/prestodb/presto/pull/14585 introduced new dependencies that entered
presto-jdbc uber jar. presto-jdbc shades out all dependencies other than the core jdbc
classes itself and this PR does the same.

Test plan - I will let all unittests succeed before landing this PR

```
== NO RELEASE NOTE ==
```
