### PR TITLE
Timestamp literal pushdown for Druid connector

### DIFF
--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidAggregationProjectConverter.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidAggregationProjectConverter.java
@@ -15,6 +15,7 @@ package com.facebook.presto.druid;
 
 import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
@@ -50,11 +51,17 @@ public class DruidAggregationProjectConverter
     private static final String DATE_TRUNC = "date_trunc";
 
     private final FunctionMetadataManager functionMetadataManager;
+    private final ConnectorSession session;
 
-    public DruidAggregationProjectConverter(TypeManager typeManager, FunctionMetadataManager functionMetadataManager, StandardFunctionResolution standardFunctionResolution)
+    public DruidAggregationProjectConverter(
+            ConnectorSession session,
+            TypeManager typeManager,
+            FunctionMetadataManager functionMetadataManager,
+            StandardFunctionResolution standardFunctionResolution)
     {
         super(typeManager, standardFunctionResolution);
         this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
+        this.session = requireNonNull(session, "session is null");
     }
 
     @Override
@@ -86,7 +93,7 @@ public class DruidAggregationProjectConverter
             ConstantExpression literal,
             Map<VariableReferenceExpression, DruidQueryGeneratorContext.Selection> context)
     {
-        return new DruidExpression(getLiteralAsString(literal), DruidQueryGeneratorContext.Origin.LITERAL);
+        return new DruidExpression(getLiteralAsString(session, literal), DruidQueryGeneratorContext.Origin.LITERAL);
     }
 
     private DruidExpression handleDateTruncationViaDateTruncation(

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidBrokerPageSource.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidBrokerPageSource.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -122,6 +123,12 @@ public class DruidBrokerPageSource
                 }
                 else {
                     JsonNode rootNode = OBJECT_MAPPER.readTree(readLine);
+                    if (!(rootNode instanceof ArrayNode)) {
+                        if (rootNode instanceof ObjectNode) {
+                            throw new PrestoException(DRUID_BROKER_RESULT_ERROR, ((ObjectNode) rootNode).findValue("errorMessage").asText());
+                        }
+                        throw new PrestoException(DRUID_BROKER_RESULT_ERROR, rootNode.toString());
+                    }
                     ArrayNode arrayNode = (ArrayNode) rootNode;
                     for (int i = 0; i < columnHandles.size(); i++) {
                         Type type = columnTypes.get(i);

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidFilterExpressionConverter.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidFilterExpressionConverter.java
@@ -200,7 +200,7 @@ public class DruidFilterExpressionConverter
     @Override
     public DruidExpression visitConstant(ConstantExpression literal, Function<VariableReferenceExpression, Selection> context)
     {
-        return new DruidExpression(getLiteralAsString(literal), Origin.LITERAL);
+        return new DruidExpression(getLiteralAsString(session, literal), Origin.LITERAL);
     }
 
     @Override

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidFilterExpressionConverter.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidFilterExpressionConverter.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.druid;
 
 import com.facebook.presto.common.function.OperatorType;
-import com.facebook.presto.common.type.SqlTimestamp;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.druid.DruidQueryGeneratorContext.Origin;
@@ -41,19 +40,16 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP;
 import static com.facebook.presto.druid.DruidErrorCode.DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION;
 import static com.facebook.presto.druid.DruidExpression.derived;
 import static com.facebook.presto.druid.DruidPushdownUtils.getLiteralAsString;
 import static java.lang.String.format;
-import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class DruidFilterExpressionConverter
         implements RowExpressionVisitor<DruidExpression, Function<VariableReferenceExpression, Selection>>
 {
     private static final Set<String> LOGICAL_BINARY_OPS_FILTER = ImmutableSet.of("=", "<", "<=", ">", ">=", "<>");
-    private static final String TIMESTAMP_LITERAL = "$literal$timestamp";
 
     private final TypeManager typeManager;
     private final FunctionMetadataManager functionMetadataManager;
@@ -176,16 +172,6 @@ public class DruidFilterExpressionConverter
             if (operatorType.isComparisonOperator()) {
                 return handleLogicalBinary(operatorType.getOperator(), call, context);
             }
-        }
-        if (call.getDisplayName().toLowerCase(ENGLISH).equals(TIMESTAMP_LITERAL)
-                && call.getArguments().size() == 1
-                && call.getType().getDisplayName().equals(TIMESTAMP)) {
-            RowExpression argument = call.getArguments().get(0);
-            if (!(argument instanceof ConstantExpression)) {
-                throw new PrestoException(DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION, "Invalid Timestamp literal in Druid filter: " + argument.toString());
-            }
-            SqlTimestamp value = new SqlTimestamp((long) ((ConstantExpression) argument).getValue(), session.getSqlFunctionProperties().getTimeZoneKey());
-            return new DruidExpression("'" + value.toString() + "'", Origin.LITERAL);
         }
 
         throw new PrestoException(DRUID_PUSHDOWN_UNSUPPORTED_EXPRESSION, "Function " + call + " not supported in Druid filter");

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidQueryGenerator.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidQueryGenerator.java
@@ -225,7 +225,7 @@ public class DruidQueryGenerator
                 RowExpression expression = node.getAssignments().get(variable);
                 DruidProjectExpressionConverter projectExpressionConverter = druidProjectExpressionConverter;
                 if (contextIn.getVariablesInAggregation().contains(variable)) {
-                    projectExpressionConverter = new DruidAggregationProjectConverter(typeManager, functionMetadataManager, standardFunctionResolution);
+                    projectExpressionConverter = new DruidAggregationProjectConverter(session, typeManager, functionMetadataManager, standardFunctionResolution);
                 }
                 DruidExpression druidExpression = expression.accept(
                         projectExpressionConverter,

--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidQueryBase.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidQueryBase.java
@@ -66,6 +66,7 @@ import java.util.stream.IntStream;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.druid.DruidColumnHandle.DruidColumnType.REGULAR;
 import static com.facebook.presto.druid.DruidQueryGeneratorContext.Origin.DERIVED;
@@ -92,17 +93,21 @@ public class TestDruidQueryBase
     protected static DruidColumnHandle city = new DruidColumnHandle("city", VARCHAR, REGULAR);
     protected static final DruidColumnHandle fare = new DruidColumnHandle("fare", DOUBLE, REGULAR);
     protected static final DruidColumnHandle secondsSinceEpoch = new DruidColumnHandle("secondsSinceEpoch", BIGINT, REGULAR);
+    protected static final DruidColumnHandle datetime = new DruidColumnHandle("datetime", TIMESTAMP, REGULAR);
 
     protected static final Metadata metadata = MetadataManager.createTestMetadataManager();
 
     protected final DruidConfig druidConfig = new DruidConfig();
 
-    protected static final Map<VariableReferenceExpression, DruidQueryGeneratorContext.Selection> testInput = ImmutableMap.of(
-            new VariableReferenceExpression("region.id", BIGINT), new DruidQueryGeneratorContext.Selection("region.Id", TABLE_COLUMN),
-            new VariableReferenceExpression("city", VARCHAR), new DruidQueryGeneratorContext.Selection("city", TABLE_COLUMN),
-            new VariableReferenceExpression("fare", DOUBLE), new DruidQueryGeneratorContext.Selection("fare", TABLE_COLUMN),
-            new VariableReferenceExpression("totalfare", DOUBLE), new DruidQueryGeneratorContext.Selection("(fare + trip)", DERIVED),
-            new VariableReferenceExpression("secondssinceepoch", BIGINT), new DruidQueryGeneratorContext.Selection("secondsSinceEpoch", TABLE_COLUMN));
+    protected static final Map<VariableReferenceExpression, DruidQueryGeneratorContext.Selection> testInput =
+            new ImmutableMap.Builder<VariableReferenceExpression, DruidQueryGeneratorContext.Selection>()
+                    .put(new VariableReferenceExpression("region.id", BIGINT), new DruidQueryGeneratorContext.Selection("region.Id", TABLE_COLUMN))
+                    .put(new VariableReferenceExpression("city", VARCHAR), new DruidQueryGeneratorContext.Selection("city", TABLE_COLUMN))
+                    .put(new VariableReferenceExpression("fare", DOUBLE), new DruidQueryGeneratorContext.Selection("fare", TABLE_COLUMN))
+                    .put(new VariableReferenceExpression("totalfare", DOUBLE), new DruidQueryGeneratorContext.Selection("(fare + trip)", DERIVED))
+                    .put(new VariableReferenceExpression("secondssinceepoch", BIGINT), new DruidQueryGeneratorContext.Selection("secondsSinceEpoch", TABLE_COLUMN))
+                    .put(new VariableReferenceExpression("datetime", TIMESTAMP), new DruidQueryGeneratorContext.Selection("datetime", TABLE_COLUMN))
+                    .build();
 
     protected final TypeProvider typeProvider = TypeProvider.fromVariables(testInput.keySet());
 

--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidQueryGenerator.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidQueryGenerator.java
@@ -171,4 +171,31 @@ public class TestDruidQueryGenerator
                                 .addAggregation(variable("region.id"), getRowExpression("count(\"region.id\")", defaultSessionHolder))),
                 "SELECT \"city\", count ( distinct \"region.Id\") FROM \"realtimeOnly\" GROUP BY \"city\"");
     }
+
+    @Test
+    public void testTimestampLiteralPushdown()
+    {
+        //the timezone of the session is Pacific/Apia UTC+13
+        //the timezone of the connector session is UTC
+        //so the time needs to be adjust for 13 hours if the timezone not specified
+        testDQL(
+                planBuilder -> project(
+                        planBuilder,
+                        filter(
+                                planBuilder,
+                                tableScan(planBuilder, druidTable, regionId, city, fare, datetime),
+                                getRowExpression("datetime = timestamp '2016-06-26 19:00:00.000'", defaultSessionHolder)),
+                        ImmutableList.of("city", "datetime")),
+                "SELECT \"city\", \"datetime\" FROM \"realtimeOnly\" WHERE (\"datetime\" = TIMESTAMP '2016-06-26 06:00:00.000')");
+        //test timestamp with timezone
+        testDQL(
+                planBuilder -> project(
+                        planBuilder,
+                        filter(
+                                planBuilder,
+                                tableScan(planBuilder, druidTable, regionId, city, fare, datetime),
+                                getRowExpression("datetime > timestamp '2016-06-26 19:00:00.000 UTC'", defaultSessionHolder)),
+                        ImmutableList.of("city", "datetime")),
+                "SELECT \"city\", \"datetime\" FROM \"realtimeOnly\" WHERE (\"datetime\" > TIMESTAMP '2016-06-26 19:00:00.000')");
+    }
 }

--- a/presto-main/etc/catalog/druid.properties
+++ b/presto-main/etc/catalog/druid.properties
@@ -1,0 +1,3 @@
+connector.name=druid
+druid.coordinator-url=http://localhost:8081
+druid.broker-url=http://localhost:8082

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -41,7 +41,8 @@ plugin.bundles=\
   ../presto-postgresql/pom.xml, \
   ../presto-tpcds/pom.xml, \
   ../presto-i18n-functions/pom.xml,\
-  ../presto-function-namespace-managers/pom.xml
+  ../presto-function-namespace-managers/pom.xml,\
+  ../presto-druid/pom.xml
 
 presto.version=testversion
 node-scheduler.include-coordinator=true


### PR DESCRIPTION
Push down the timestamp to druid
`select * from druid.wikipedia where __time > timestamp '2016-06-26 18:00:00.000'`
or the timestamp with timezone:
`select * from druid.wikipedia where __time > timestamp '2016-06-26 19:00:00.000 UTC';`
or cast:
`select * from druid.wikipedia where __time > CAST('2016-06-26 18:00:00.000' as TIMESTAMP);`

In this PR, I also added the druid connector to presto server's config (for devel only) and improved the error message handling.

```
== NO RELEASE NOTE ==
```
