### PR TITLE
Support skipping control in Verifier

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/event/VerifierQueryEvent.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/event/VerifierQueryEvent.java
@@ -72,7 +72,7 @@ public class VerifierQueryEvent
             Optional<DeterminismAnalysis> determinismAnalysis,
             Optional<DeterminismAnalysisDetails> determinismAnalysisDetails,
             Optional<String> resolveMessage,
-            QueryInfo controlQueryInfo,
+            Optional<QueryInfo> controlQueryInfo,
             QueryInfo testQueryInfo,
             Optional<String> errorCode,
             Optional<String> errorMessage,
@@ -89,7 +89,7 @@ public class VerifierQueryEvent
         this.determinismAnalysis = determinismAnalysis.map(DeterminismAnalysis::name).orElse(null);
         this.determinismAnalysisDetails = determinismAnalysisDetails.orElse(null);
         this.resolveMessage = resolveMessage.orElse(null);
-        this.controlQueryInfo = requireNonNull(controlQueryInfo, "controlQueryInfo is null");
+        this.controlQueryInfo = controlQueryInfo.orElse(null);
         this.testQueryInfo = requireNonNull(testQueryInfo, "testQueryInfo is null");
         this.errorCode = errorCode.orElse(null);
         this.errorMessage = errorMessage.orElse(null);
@@ -102,7 +102,8 @@ public class VerifierQueryEvent
             String suite,
             String testId,
             SourceQuery sourceQuery,
-            SkippedReason skippedReason)
+            SkippedReason skippedReason,
+            boolean skipControl)
     {
         return new VerifierQueryEvent(
                 suite,
@@ -113,10 +114,12 @@ public class VerifierQueryEvent
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                new QueryInfo(
-                        sourceQuery.getControlConfiguration().getCatalog(),
-                        sourceQuery.getControlConfiguration().getSchema(),
-                        sourceQuery.getControlQuery()),
+                skipControl ?
+                        Optional.empty() :
+                        Optional.of(new QueryInfo(
+                                sourceQuery.getControlConfiguration().getCatalog(),
+                                sourceQuery.getControlConfiguration().getSchema(),
+                                sourceQuery.getControlQuery())),
                 new QueryInfo(
                         sourceQuery.getTestConfiguration().getCatalog(),
                         sourceQuery.getTestConfiguration().getSchema(),

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
@@ -50,6 +50,7 @@ public class VerifierConfig
 
     private boolean setupOnMainClusters = true;
     private boolean teardownOnMainClusters = true;
+    private boolean skipControl;
 
     @NotNull
     public Optional<Set<String>> getWhitelist()
@@ -286,6 +287,19 @@ public class VerifierConfig
     public VerifierConfig setTeardownOnMainClusters(boolean teardownOnMainClusters)
     {
         this.teardownOnMainClusters = teardownOnMainClusters;
+        return this;
+    }
+
+    public boolean isSkipControl()
+    {
+        return skipControl;
+    }
+
+    @ConfigDescription("Skip control queries and result comparison, only run test queries.")
+    @Config("skip-control")
+    public VerifierConfig setSkipControl(boolean skipControl)
+    {
+        this.skipControl = skipControl;
         return this;
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
@@ -44,7 +44,8 @@ public class TestVerifierConfig
                 .setSmartTeardown(false)
                 .setVerificationResubmissionLimit(2)
                 .setSetupOnMainClusters(true)
-                .setTeardownOnMainClusters(true));
+                .setTeardownOnMainClusters(true)
+                .setSkipControl(false));
     }
 
     @Test
@@ -68,6 +69,7 @@ public class TestVerifierConfig
                 .put("verification-resubmission.limit", "1")
                 .put("setup-on-main-clusters", "false")
                 .put("teardown-on-main-clusters", "false")
+                .put("skip-control", "true")
                 .build();
         VerifierConfig expected = new VerifierConfig()
                 .setWhitelist("a,b,c")
@@ -86,7 +88,8 @@ public class TestVerifierConfig
                 .setSmartTeardown(true)
                 .setVerificationResubmissionLimit(1)
                 .setSetupOnMainClusters(false)
-                .setTeardownOnMainClusters(false);
+                .setTeardownOnMainClusters(false)
+                .setSkipControl(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
```
== RELEASE NOTES ==

Verifier Changes
* Add support to skip running control queries and comparing results. This can be enabled by configuration property ``skip-control``.
```
