### PR TITLE
Added conversion functions between Geometry and GeoJSON format. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1632,6 +1632,18 @@
             </dependency>
 
             <dependency>
+                <groupId>org.locationtech.jts.io</groupId>
+                <artifactId>jts-io-common</artifactId>
+                <version>1.17.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>org.anarres.lzo</groupId>
                 <artifactId>lzo-hadoop</artifactId>
                 <version>1.0.5</version>
@@ -1662,6 +1674,10 @@
                 <artifactId>cassandra-server</artifactId>
                 <version>2.1.16-1</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>com.googlecode.json-simple</groupId>
+                        <artifactId>json-simple</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>io.netty</groupId>
                         <artifactId>netty-all</artifactId>

--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -463,6 +463,16 @@ Accessors
 
     Returns the great-circle distance between two points on Earth's surface in kilometers.
 
+.. function:: geometry_as_geojson(Geometry) -> varchar
+
+    Returns the GeoJSON encoded defined by the input geometry.
+    If the geometry is atomic (non-multi) empty, this function would return null.
+
+.. function:: geometry_from_geojson(varchar) -> Geometry
+
+    Returns the geometry type object from the GeoJSON representation.
+    The geometry cannot be empty if it is an atomic (non-multi) geometry type.
+
 Aggregations
 ------------
 .. function:: convex_hull_agg(Geometry) -> Geometry

--- a/presto-geospatial-toolkit/pom.xml
+++ b/presto-geospatial-toolkit/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.locationtech.jts.io</groupId>
+            <artifactId>jts-io-common</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestGeoFunctions.java
@@ -1266,4 +1266,68 @@ public class TestGeoFunctions
     {
         assertFunction(format("ST_AsText(ST_GeomFromBinary(ST_AsBinary(ST_GeometryFromText('%s'))))", wkt), VARCHAR, wkt);
     }
+
+    @Test
+    public void testGeometryJsonConversion()
+    {
+        // empty atomic (non-multi) geometries should return null
+        assertEmptyGeoToJson("POINT EMPTY");
+        assertEmptyGeoToJson("LINESTRING EMPTY");
+        assertEmptyGeoToJson("POLYGON EMPTY");
+
+        // empty multi geometries should return empty
+        assertGeoToAndFromJson("MULTIPOINT EMPTY");
+        assertGeoToAndFromJson("MULTILINESTRING EMPTY");
+        assertGeoToAndFromJson("MULTIPOLYGON EMPTY");
+        assertGeoToAndFromJson("GEOMETRYCOLLECTION EMPTY");
+
+        // valid nonempty geometries should return as is.
+        assertGeoToAndFromJson("POINT (1 2)");
+        assertGeoToAndFromJson("MULTIPOINT ((1 2), (3 4))");
+        assertGeoToAndFromJson("LINESTRING (0 0, 1 2, 3 4)");
+        assertGeoToAndFromJson("MULTILINESTRING ((1 1, 5 1), (2 4, 4 4))");
+        assertGeoToAndFromJson("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))");
+        assertGeoToAndFromJson("POLYGON ((0 0, 0 3, 3 3, 3 0, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1))");
+        assertGeoToAndFromJson("MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1, 1 1)), ((2 4, 2 6, 6 6, 6 4, 2 4)))");
+        assertGeoToAndFromJson("GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (0 0, 1 2, 3 4), POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)))");
+
+        // invalid geometries should return as is.
+        assertGeoToAndFromJson("MULTIPOINT ((0 0), (0 1), (1 1), (0 1))");
+        assertGeoToAndFromJson("LINESTRING (0 0, 0 1, 0 1, 1 1, 1 0, 0 0)");
+        assertGeoToAndFromJson("LINESTRING (0 0, 1 1, 1 0, 0 1)");
+
+        // explicit JSON test cases should valid but return empty or null
+        assertValidGeometryJson("{\"type\":\"LineString\",\"coordinates\":[]}", "LINESTRING EMPTY");
+        assertValidGeometryJson("{\"type\":\"MultiPoint\",\"coordinates\":[]}", "MULTIPOINT EMPTY");
+        assertValidGeometryJson("{\"type\":\"MultiPolygon\",\"coordinates\":[]}", "MULTIPOLYGON EMPTY");
+        assertValidGeometryJson("{\"type\":\"MultiLineString\",\"coordinates\":[[[0.0,0.0],[1,10]],[[10,10],[20,30]],[[123,123],[456,789]]]}", "MULTILINESTRING ((0 0, 1 10), (10 10, 20 30), (123 123, 456 789))");
+
+        // Valid JSON with invalid Geometry definition
+        assertInvalidGeometryJson("{\"type\":\"Polygon\",\"coordinates\":[]}");
+        assertInvalidGeometryJson("{\"type\":\"MultiPoint\",\"invalidField\":[]}");
+        assertInvalidGeometryJson("{\"coordinates\":[[[0.0,0.0],[1,10]],[[10,10],[20,30]],[[123,123],[456,789]]]}");
+
+        // Invalid JSON
+        assertInvalidGeometryJson("{\"type\":\"MultiPoint\",\"crashMe\"}");
+    }
+
+    private void assertEmptyGeoToJson(String wkt)
+    {
+        assertFunction(format("geometry_as_geojson(ST_GeometryFromText('%s'))", wkt), VARCHAR, null);
+    }
+
+    private void assertGeoToAndFromJson(String wkt)
+    {
+        assertFunction(format("ST_AsText(geometry_from_geojson(geometry_as_geojson(ST_GeometryFromText('%s'))))", wkt), VARCHAR, wkt);
+    }
+
+    private void assertValidGeometryJson(String json, String wkt)
+    {
+        assertFunction("ST_AsText(geometry_from_geojson('" + json + "'))", VARCHAR, wkt);
+    }
+
+    private void assertInvalidGeometryJson(String json)
+    {
+        assertInvalidFunction("geometry_from_geojson('" + json + "')", "Invalid GeoJSON:.*");
+    }
 }


### PR DESCRIPTION
Test plan - Unit tests added in `TestGeoFunctions` for forward and backward conversion between JSON and Geometry format.

```
== RELEASE NOTES ==

General Changes
* Added :func:`geometry_from_geojson` and :func:`geometry_as_geojson` to convert geometries from and to GeoJSON format.
```

