### PR TITLE
Convert revocable memory to user memory on hash aggregation finish

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -66,7 +66,6 @@ public class InMemoryHashAggregationBuilder
     private final boolean useSystemMemory;
 
     private boolean full;
-    private boolean hasBuiltFinalResult;
 
     public InMemoryHashAggregationBuilder(
             List<AccumulatorFactory> accumulatorFactories,
@@ -254,7 +253,6 @@ public class InMemoryHashAggregationBuilder
     @Override
     public WorkProcessor<Page> buildResult()
     {
-        hasBuiltFinalResult = true;
         for (Aggregator aggregator : aggregators) {
             aggregator.prepareFinal();
         }
@@ -273,11 +271,6 @@ public class InMemoryHashAggregationBuilder
             types.add(aggregator.getIntermediateType());
         }
         return types;
-    }
-
-    public boolean hasBuiltFinalResult()
-    {
-        return hasBuiltFinalResult;
     }
 
     @VisibleForTesting

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -36,7 +36,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
+import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.lang.Math.max;
@@ -68,6 +70,7 @@ public class SpillableHashAggregationBuilder
 
     private long hashCollisions;
     private double expectedHashCollisions;
+    private boolean producingOutput;
 
     public SpillableHashAggregationBuilder(
             List<AccumulatorFactory> accumulatorFactories,
@@ -112,6 +115,11 @@ public class SpillableHashAggregationBuilder
     public void updateMemory()
     {
         checkState(spillInProgress.isDone());
+        if (producingOutput) {
+            localRevocableMemoryContext.setBytes(0);
+            localUserMemoryContext.setBytes(hashAggregationBuilder.getSizeInMemory());
+            return;
+        }
         localUserMemoryContext.setBytes(emptyHashAggregationBuilderSize);
         localRevocableMemoryContext.setBytes(hashAggregationBuilder.getSizeInMemory() - emptyHashAggregationBuilderSize);
     }
@@ -155,10 +163,11 @@ public class SpillableHashAggregationBuilder
     public ListenableFuture<?> startMemoryRevoke()
     {
         checkState(spillInProgress.isDone());
-        if (hashAggregationBuilder.hasBuiltFinalResult()) {
-            // If the hashAggregationBuilder has already completed, decline memory revoking. At this point, buildResult has already been called
-            // on InMemoryHashAggregationBuilder and it is no longer accepting any input so no point in spilling.
-            return spillInProgress;
+        if (producingOutput) {
+            // All revocable memory has been released in buildResult method.
+            // At this point, InMemoryHashAggregationBuilder is no longer accepting any input so no point in spilling.
+            verify(localRevocableMemoryContext.getBytes() == 0);
+            return NOT_BLOCKED;
         }
         spillToDisk();
         return spillInProgress;
@@ -167,10 +176,6 @@ public class SpillableHashAggregationBuilder
     @Override
     public void finishMemoryRevoke()
     {
-        if (hashAggregationBuilder.hasBuiltFinalResult()) {
-            // Do not update memory if we never spilt during startMemoryRevoke if hashAggregationBuilder has already built it's final result
-            return;
-        }
         updateMemory();
     }
 
@@ -183,6 +188,22 @@ public class SpillableHashAggregationBuilder
     public WorkProcessor<Page> buildResult()
     {
         checkState(hasPreviousSpillCompletedSuccessfully(), "Previous spill hasn't yet finished");
+        producingOutput = true;
+
+        // Convert revocable memory to user memory as returned WorkProcessor holds on to memory so we no longer can revoke.
+        if (localRevocableMemoryContext.getBytes() > 0) {
+            long currentRevocableBytes = localRevocableMemoryContext.getBytes();
+            localRevocableMemoryContext.setBytes(0);
+            if (!localUserMemoryContext.trySetBytes(localUserMemoryContext.getBytes() + currentRevocableBytes)) {
+                // TODO: this might fail (even though we have just released memory), but we don't
+                // have a proper way to atomically convert memory reservations
+                localRevocableMemoryContext.setBytes(currentRevocableBytes);
+                // spill since revocable memory could not be converted to user memory immediately
+                // TODO: this should be asynchronous
+                getFutureValue(spillToDisk());
+                updateMemory();
+            }
+        }
 
         if (!spiller.isPresent()) {
             return hashAggregationBuilder.buildResult();

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -129,11 +129,15 @@ public class TestHashAggregationOperator
     public static Object[][] hashEnabledAndMemoryLimitForMergeValuesProvider()
     {
         return new Object[][] {
-                {true, true, 8, Integer.MAX_VALUE},
-                {false, false, 0, 0},
-                {false, true, 0, 0},
-                {false, true, 8, 0},
-                {false, true, 8, Integer.MAX_VALUE}};
+                {true, true, true, 8, Integer.MAX_VALUE},
+                {true, true, false, 8, Integer.MAX_VALUE},
+                {false, false, false, 0, 0},
+                {false, true, true, 0, 0},
+                {false, true, false, 0, 0},
+                {false, true, true, 8, 0},
+                {false, true, false, 8, 0},
+                {false, true, true, 8, Integer.MAX_VALUE},
+                {false, true, false, 8, Integer.MAX_VALUE}};
     }
 
     @DataProvider
@@ -151,7 +155,7 @@ public class TestHashAggregationOperator
     }
 
     @Test(dataProvider = "hashEnabledAndMemoryLimitForMergeValues")
-    public void testHashAggregation(boolean hashEnabled, boolean spillEnabled, long memoryLimitForMerge, long memoryLimitForMergeWithMemory)
+    public void testHashAggregation(boolean hashEnabled, boolean spillEnabled, boolean revokeMemoryWhenAddingPages, long memoryLimitForMerge, long memoryLimitForMergeWithMemory)
     {
         // make operator produce multiple pages during finish phase
         int numberOfRows = 40_000;
@@ -199,7 +203,7 @@ public class TestHashAggregationOperator
         }
         MaterializedResult expected = expectedBuilder.build();
 
-        List<Page> pages = toPages(operatorFactory, driverContext, input);
+        List<Page> pages = toPages(operatorFactory, driverContext, input, revokeMemoryWhenAddingPages);
         assertGreaterThan(pages.size(), 1, "Expected more than one output page");
         assertPagesEqualIgnoreOrder(driverContext, pages, expected, hashEnabled, Optional.of(hashChannels.size()));
 
@@ -207,7 +211,7 @@ public class TestHashAggregationOperator
     }
 
     @Test(dataProvider = "hashEnabledAndMemoryLimitForMergeValues")
-    public void testHashAggregationWithGlobals(boolean hashEnabled, boolean spillEnabled, long memoryLimitForMerge, long memoryLimitForMergeWithMemory)
+    public void testHashAggregationWithGlobals(boolean hashEnabled, boolean spillEnabled, boolean revokeMemoryWhenAddingPages, long memoryLimitForMerge, long memoryLimitForMergeWithMemory)
     {
         InternalAggregationFunction countVarcharColumn = getAggregation("count", VARCHAR);
         InternalAggregationFunction countBooleanColumn = getAggregation("count", BOOLEAN);
@@ -250,11 +254,11 @@ public class TestHashAggregationOperator
                 .row(null, 49L, 0L, null, null, null, 0L, 0L)
                 .build();
 
-        assertOperatorEqualsIgnoreOrder(operatorFactory, driverContext, input, expected, hashEnabled, Optional.of(groupByChannels.size()));
+        assertOperatorEqualsIgnoreOrder(operatorFactory, driverContext, input, expected, hashEnabled, Optional.of(groupByChannels.size()), revokeMemoryWhenAddingPages);
     }
 
     @Test(dataProvider = "hashEnabledAndMemoryLimitForMergeValues")
-    public void testHashAggregationMemoryReservation(boolean hashEnabled, boolean spillEnabled, long memoryLimitForMerge, long memoryLimitForMergeWithMemory)
+    public void testHashAggregationMemoryReservation(boolean hashEnabled, boolean spillEnabled, boolean revokeMemoryWhenAddingPages, long memoryLimitForMerge, long memoryLimitForMergeWithMemory)
     {
         InternalAggregationFunction arrayAggColumn = getAggregation("array_agg", BIGINT);
 
@@ -291,7 +295,7 @@ public class TestHashAggregationOperator
                 false);
 
         Operator operator = operatorFactory.createOperator(driverContext);
-        toPages(operator, input.iterator());
+        toPages(operator, input.iterator(), revokeMemoryWhenAddingPages);
         assertEquals(operator.getOperatorContext().getOperatorStats().getUserMemoryReservation().toBytes(), 0);
     }
 
@@ -334,7 +338,7 @@ public class TestHashAggregationOperator
     }
 
     @Test(dataProvider = "hashEnabledAndMemoryLimitForMergeValues")
-    public void testHashBuilderResize(boolean hashEnabled, boolean spillEnabled, long memoryLimitForMerge, long memoryLimitForMergeWithMemory)
+    public void testHashBuilderResize(boolean hashEnabled, boolean spillEnabled, boolean revokeMemoryWhenAddingPages, long memoryLimitForMerge, long memoryLimitForMergeWithMemory)
     {
         BlockBuilder builder = VARCHAR.createBlockBuilder(null, 1, MAX_BLOCK_SIZE_IN_BYTES);
         VARCHAR.writeSlice(builder, Slices.allocate(200_000)); // this must be larger than MAX_BLOCK_SIZE_IN_BYTES, 64K
@@ -370,7 +374,7 @@ public class TestHashAggregationOperator
                 joinCompiler,
                 false);
 
-        toPages(operatorFactory, driverContext, input);
+        toPages(operatorFactory, driverContext, input, revokeMemoryWhenAddingPages);
     }
 
     @Test(dataProvider = "dataType")


### PR DESCRIPTION
Spillable hash aggregation keeps allocated memory in revocable memory pool instead of converting it during finish. This is a bug. I have also moved some of our tracking logic  for when operator is finishing to SpillableHashAggregationBuilder.

Adapted from second commit in https://github.com/prestosql/presto/pull/164.

```
== NO RELEASE NOTE ==
```
