### PR TITLE
Allow Raptor to run custom check before table creation

### DIFF
--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
@@ -559,6 +559,8 @@ public class RaptorMetadata
             throw new PrestoException(ALREADY_EXISTS, "View already exists: " + tableMetadata.getTable());
         }
 
+        runExtraEligibilityCheck(session, tableMetadata);
+
         Optional<RaptorPartitioningHandle> partitioning = layout
                 .map(ConnectorNewTableLayout::getPartitioning)
                 .map(RaptorPartitioningHandle.class::cast);
@@ -664,6 +666,11 @@ public class RaptorMetadata
             columnHandles.add(columnHandleMap.get(column));
         }
         return columnHandles.build();
+    }
+
+    protected void runExtraEligibilityCheck(ConnectorSession session, ConnectorTableMetadata tableMetadata)
+    {
+        // no-op
     }
 
     @Override


### PR DESCRIPTION
Test plan - This is a no-op for default set up in open source repo. For Facebook internal extension, added unit tests and will do deployment test

```
== NO RELEASE NOTE ==
```
