### PR TITLE
Rename files written by PageSink

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/CachingFileSystem.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/CachingFileSystem.java
@@ -16,6 +16,7 @@ package com.facebook.presto.cache;
 import com.facebook.presto.hive.HiveFileContext;
 import com.facebook.presto.hive.HiveFileInfo;
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.ContentSummary;
@@ -497,5 +498,12 @@ public abstract class CachingFileSystem
             throws IOException
     {
         return dataTier.listFiles(path);
+    }
+
+    @Override
+    public ListenableFuture<Void> renameFileAsync(Path source, Path destination)
+            throws IOException
+    {
+        return dataTier.renameFileAsync(source, destination);
     }
 }

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/filesystem/ExtendedFileSystem.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/filesystem/ExtendedFileSystem.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.filesystem;
 
 import com.facebook.presto.hive.HiveFileContext;
 import com.facebook.presto.hive.HiveFileInfo;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -39,6 +40,12 @@ public abstract class ExtendedFileSystem
     }
 
     public RemoteIterator<LocatedFileStatus> listDirectory(Path path)
+            throws IOException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    public ListenableFuture<Void> renameFileAsync(Path source, Path destination)
             throws IOException
     {
         throw new UnsupportedOperationException();

--- a/presto-hive-common/src/main/java/org/apache/hadoop/fs/HadoopExtendedFileSystem.java
+++ b/presto-hive-common/src/main/java/org/apache/hadoop/fs/HadoopExtendedFileSystem.java
@@ -15,6 +15,7 @@ package org.apache.hadoop.fs;
 
 import com.facebook.presto.hive.HiveFileContext;
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclStatus;
@@ -28,6 +29,8 @@ import java.net.URISyntaxException;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 public class HadoopExtendedFileSystem
         extends ExtendedFileSystem
@@ -187,6 +190,14 @@ public class HadoopExtendedFileSystem
             throws IOException
     {
         return fs.rename(src, dst);
+    }
+
+    @Override
+    public ListenableFuture<Void> renameFileAsync(Path src, Path dst)
+            throws IOException
+    {
+        fs.rename(src, dst);
+        return immediateFuture(null);
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -181,6 +181,8 @@ public class HiveClientConfig
     private boolean isPartialAggregationPushdownEnabled;
     private boolean isPartialAggregationPushdownForVariableLengthDatatypesEnabled;
 
+    private boolean fileRenamingEnabled;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -1508,5 +1510,18 @@ public class HiveClientConfig
     public boolean isPartialAggregationPushdownForVariableLengthDatatypesEnabled()
     {
         return this.isPartialAggregationPushdownForVariableLengthDatatypesEnabled;
+    }
+
+    @Config("hive.file_renaming_enabled")
+    @ConfigDescription("enable file renaming")
+    public HiveClientConfig setFileRenamingEnabled(boolean fileRenamingEnabled)
+    {
+        this.fileRenamingEnabled = fileRenamingEnabled;
+        return this;
+    }
+
+    public boolean isFileRenamingEnabled()
+    {
+        return this.fileRenamingEnabled;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -126,6 +126,9 @@ public class HiveClientModule
         binder.bind(HiveWriterStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(HiveWriterStats.class).as(generatedNameOf(HiveWriterStats.class, connectorId));
 
+        binder.bind(HiveFileRenamer.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(HiveFileRenamer.class).as(generatedNameOf(HiveFileRenamer.class, connectorId));
+
         newSetBinder(binder, EventClient.class).addBinding().to(HiveEventClient.class).in(Scopes.SINGLETON);
         binder.bind(HivePartitionManager.class).in(Scopes.SINGLETON);
         binder.bind(LocationService.class).to(HiveLocationService.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveFileRenamer.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveFileRenamer.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.ConnectorMetadataUpdateHandle;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.collect.ImmutableList;
+import org.weakref.jmx.Managed;
+
+import javax.annotation.PreDestroy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.google.common.base.Verify.verify;
+
+public class HiveFileRenamer
+{
+    private final Map<QueryId, Map<HiveMetadataUpdateKey, AtomicLong>> queryPartitionFileCounterMap = new ConcurrentHashMap<>();
+    private final Map<QueryId, Map<HiveMetadataUpdateHandle, String>> queryHiveMetadataResultMap = new ConcurrentHashMap<>();
+
+    public List<ConnectorMetadataUpdateHandle> getMetadataUpdateResults(List<ConnectorMetadataUpdateHandle> metadataUpdateRequests, QueryId queryId)
+    {
+        ImmutableList.Builder<ConnectorMetadataUpdateHandle> metadataUpdateResults = ImmutableList.builder();
+
+        for (ConnectorMetadataUpdateHandle connectorMetadataUpdateHandle : metadataUpdateRequests) {
+            HiveMetadataUpdateHandle request = (HiveMetadataUpdateHandle) connectorMetadataUpdateHandle;
+            String fileName = getFileName(request, queryId);
+            metadataUpdateResults.add(new HiveMetadataUpdateHandle(request.getRequestId(), request.getSchemaTableName(), request.getPartitionName(), Optional.of(fileName)));
+        }
+        return metadataUpdateResults.build();
+    }
+
+    public void cleanup(QueryId queryId)
+    {
+        queryPartitionFileCounterMap.remove(queryId);
+        queryHiveMetadataResultMap.remove(queryId);
+    }
+
+    private String getFileName(HiveMetadataUpdateHandle request, QueryId queryId)
+    {
+        if (!queryPartitionFileCounterMap.containsKey(queryId) || !queryHiveMetadataResultMap.containsKey(queryId)) {
+            queryPartitionFileCounterMap.putIfAbsent(queryId, new ConcurrentHashMap<>());
+            queryHiveMetadataResultMap.putIfAbsent(queryId, new ConcurrentHashMap<>());
+        }
+
+        // To keep track of the file counter per query per partition
+        Map<HiveMetadataUpdateKey, AtomicLong> partitionFileCounterMap = queryPartitionFileCounterMap.get(queryId);
+
+        // To keep track of the file name result per query per request
+        // This is to make sure that request - fileName mapping is 1:1
+        Map<HiveMetadataUpdateHandle, String> hiveMetadataResultMap = queryHiveMetadataResultMap.get(queryId);
+
+        // If we have seen this request before then directly return the result.
+        if (hiveMetadataResultMap.containsKey(request)) {
+            // We come here if for some reason the worker did not receive the fileName and it retried the request.
+            return hiveMetadataResultMap.get(request);
+        }
+
+        HiveMetadataUpdateKey key = new HiveMetadataUpdateKey(request);
+        // File names start from 0
+        partitionFileCounterMap.putIfAbsent(key, new AtomicLong(0));
+
+        AtomicLong fileCount = partitionFileCounterMap.get(key);
+        String fileName = Long.valueOf(fileCount.getAndIncrement()).toString();
+
+        // Store the request - fileName mapping
+        hiveMetadataResultMap.put(request, fileName);
+
+        return fileName;
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        // Mappings should be deleted when query finishes. So verify that map is empty before its closed.
+        verify(queryPartitionFileCounterMap.isEmpty(), "Query partition file counter map has %s entries left behind", queryPartitionFileCounterMap.size());
+        verify(queryHiveMetadataResultMap.isEmpty(), "Query hive metadata result map has %s entries left behind", queryHiveMetadataResultMap.size());
+    }
+
+    @Managed
+    public int getQueryPartitionFileCounterMapSize()
+    {
+        return queryPartitionFileCounterMap.size();
+    }
+
+    @Managed
+    public int getHiveMetadataUpdateResultMapSize()
+    {
+        return queryHiveMetadataResultMap.size();
+    }
+
+    private static class HiveMetadataUpdateKey
+    {
+        private final SchemaTableName schemaTableName;
+        private final Optional<String> partitionName;
+
+        private HiveMetadataUpdateKey(HiveMetadataUpdateHandle hiveMetadataUpdateHandle)
+        {
+            this.schemaTableName = hiveMetadataUpdateHandle.getSchemaTableName();
+            this.partitionName = hiveMetadataUpdateHandle.getPartitionName();
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            HiveMetadataUpdateKey o = (HiveMetadataUpdateKey) obj;
+            return schemaTableName.equals(o.schemaTableName) &&
+                    partitionName.equals(o.partitionName);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(schemaTableName, partitionName);
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -47,6 +47,7 @@ import com.facebook.presto.hive.statistics.HiveStatisticsProvider;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorMetadataUpdateHandle;
 import com.facebook.presto.spi.ConnectorNewTableLayout;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorSession;
@@ -61,6 +62,7 @@ import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.DiscretePredicates;
 import com.facebook.presto.spi.InMemoryRecordSet;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
@@ -356,6 +358,7 @@ public class HiveMetadata
     private final PartitionObjectBuilder partitionObjectBuilder;
     private final HiveEncryptionInformationProvider encryptionInformationProvider;
     private final HivePartitionStats hivePartitionStats;
+    private final HiveFileRenamer hiveFileRenamer;
 
     public HiveMetadata(
             SemiTransactionalHiveMetastore metastore,
@@ -380,7 +383,8 @@ public class HiveMetadata
             ZeroRowFileCreator zeroRowFileCreator,
             PartitionObjectBuilder partitionObjectBuilder,
             HiveEncryptionInformationProvider encryptionInformationProvider,
-            HivePartitionStats hivePartitionStats)
+            HivePartitionStats hivePartitionStats,
+            HiveFileRenamer hiveFileRenamer)
     {
         this.allowCorruptWritesForTesting = allowCorruptWritesForTesting;
 
@@ -406,6 +410,7 @@ public class HiveMetadata
         this.partitionObjectBuilder = requireNonNull(partitionObjectBuilder, "partitionObjectBuilder is null");
         this.encryptionInformationProvider = requireNonNull(encryptionInformationProvider, "encryptionInformationProvider is null");
         this.hivePartitionStats = requireNonNull(hivePartitionStats, "hivePartitionStats is null");
+        this.hiveFileRenamer = requireNonNull(hiveFileRenamer, "hiveFileRenamer is null");
     }
 
     public SemiTransactionalHiveMetastore getMetastore()
@@ -2877,6 +2882,18 @@ public class HiveMetadata
     {
         HiveInsertTableHandle handle = (HiveInsertTableHandle) tableHandle;
         return toCompletableFuture(stagingFileCommitter.commitFiles(session, handle.getSchemaName(), handle.getTableName(), getPartitionUpdates(fragments)));
+    }
+
+    @Override
+    public List<ConnectorMetadataUpdateHandle> getMetadataUpdateResults(List<ConnectorMetadataUpdateHandle> metadataUpdateRequests, QueryId queryId)
+    {
+        return hiveFileRenamer.getMetadataUpdateResults(metadataUpdateRequests, queryId);
+    }
+
+    @Override
+    public void doMetadataUpdateCleanup(QueryId queryId)
+    {
+        hiveFileRenamer.cleanup(queryId);
     }
 
     private List<GrantInfo> buildGrants(SchemaTableName tableName, PrestoPrincipal principal)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -63,6 +63,7 @@ public class HiveMetadataFactory
     private final PartitionObjectBuilder partitionObjectBuilder;
     private final HiveEncryptionInformationProvider encryptionInformationProvider;
     private final HivePartitionStats hivePartitionStats;
+    private final HiveFileRenamer hiveFileRenamer;
 
     @Inject
     @SuppressWarnings("deprecation")
@@ -86,7 +87,8 @@ public class HiveMetadataFactory
             NodeVersion nodeVersion,
             PartitionObjectBuilder partitionObjectBuilder,
             HiveEncryptionInformationProvider encryptionInformationProvider,
-            HivePartitionStats hivePartitionStats)
+            HivePartitionStats hivePartitionStats,
+            HiveFileRenamer hiveFileRenamer)
     {
         this(
                 metastore,
@@ -114,7 +116,8 @@ public class HiveMetadataFactory
                 nodeVersion.toString(),
                 partitionObjectBuilder,
                 encryptionInformationProvider,
-                hivePartitionStats);
+                hivePartitionStats,
+                hiveFileRenamer);
     }
 
     public HiveMetadataFactory(
@@ -143,7 +146,8 @@ public class HiveMetadataFactory
             String prestoVersion,
             PartitionObjectBuilder partitionObjectBuilder,
             HiveEncryptionInformationProvider encryptionInformationProvider,
-            HivePartitionStats hivePartitionStats)
+            HivePartitionStats hivePartitionStats,
+            HiveFileRenamer hiveFileRenamer)
     {
         this.allowCorruptWritesForTesting = allowCorruptWritesForTesting;
         this.skipDeletionForAlter = skipDeletionForAlter;
@@ -172,6 +176,7 @@ public class HiveMetadataFactory
         this.partitionObjectBuilder = requireNonNull(partitionObjectBuilder, "partitionObjectBuilder is null");
         this.encryptionInformationProvider = requireNonNull(encryptionInformationProvider, "encryptionInformationProvider is null");
         this.hivePartitionStats = requireNonNull(hivePartitionStats, "hivePartitionStats is null");
+        this.hiveFileRenamer = requireNonNull(hiveFileRenamer, "hiveFileRenamer is null");
 
         if (!allowCorruptWritesForTesting && !timeZone.equals(DateTimeZone.getDefault())) {
             log.warn("Hive writes are disabled. " +
@@ -214,6 +219,7 @@ public class HiveMetadataFactory
                 zeroRowFileCreator,
                 partitionObjectBuilder,
                 encryptionInformationProvider,
-                hivePartitionStats);
+                hivePartitionStats,
+                hiveFileRenamer);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
@@ -21,6 +21,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.IntArrayBlockBuilder;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
 import com.facebook.presto.spi.ConnectorPageSink;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PageIndexer;
@@ -31,10 +32,13 @@ import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.slice.Slice;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import org.apache.hadoop.fs.Path;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -46,11 +50,16 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 
+import static com.facebook.airlift.concurrent.MoreFutures.addSuccessCallback;
+import static com.facebook.airlift.concurrent.MoreFutures.toListenableFuture;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.hive.HiveBucketFunction.createHiveCompatibleBucketFunction;
 import static com.facebook.presto.hive.HiveBucketFunction.createPrestoNativeBucketFunction;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_TOO_MANY_OPEN_PARTITIONS;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
+import static com.facebook.presto.hive.PartitionUpdate.FileWriteInfo;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -93,6 +102,8 @@ public class HivePageSink
     private long writtenBytes;
     private long systemMemoryUsage;
     private long validationCpuNanos;
+
+    private boolean waitForFileRenaming;
 
     public HivePageSink(
             HiveWriterFactory writerFactory,
@@ -228,6 +239,19 @@ public class HivePageSink
                 .mapToLong(HiveWriter::getValidationCpuNanos)
                 .sum();
 
+        if (waitForFileRenaming && verificationTasks.isEmpty()) {
+            ImmutableList.Builder<Slice> partitionUpdatesWithRenamedFileNames = ImmutableList.builder();
+            List<ListenableFuture<?>> futures = new ArrayList<>();
+            for (int i = 0; i < writers.size(); i++) {
+                int writerIndex = i;
+                ListenableFuture<?> fileNameFuture = toListenableFuture(hiveMetadataUpdater.getMetadataResult(writerIndex));
+                SettableFuture renamingFuture = SettableFuture.create();
+                futures.add(renamingFuture);
+                addSuccessCallback(fileNameFuture, obj -> renameFiles((String) obj, writerIndex, renamingFuture, partitionUpdatesWithRenamedFileNames));
+            }
+            return Futures.transform(Futures.allAsList(futures), input -> partitionUpdatesWithRenamedFileNames.build(), directExecutor());
+        }
+
         if (verificationTasks.isEmpty()) {
             return Futures.immediateFuture(result);
         }
@@ -354,6 +378,47 @@ public class HivePageSink
             return;
         }
         hiveMetadataUpdater.addMetadataUpdateRequest(schemaName, tableName, partitionName, writerIndex);
+        waitForFileRenaming = true;
+    }
+
+    private void renameFiles(String fileName, int writerIndex, SettableFuture<?> renamingFuture, ImmutableList.Builder<Slice> partitionUpdatesWithRenamedFileNames)
+    {
+        HdfsContext context = new HdfsContext(session, schemaName, tableName);
+        HiveWriter writer = writers.get(writerIndex);
+        PartitionUpdate partitionUpdate = writer.getPartitionUpdate();
+
+        // Check that only one file is written by a writer
+        checkArgument(partitionUpdate.getFileWriteInfos().size() == 1, "HiveWriter wrote data to more than one file");
+
+        FileWriteInfo fileWriteInfo = partitionUpdate.getFileWriteInfos().get(0);
+        Path fromPath = new Path(partitionUpdate.getWritePath(), fileWriteInfo.getWriteFileName());
+        Path toPath = new Path(partitionUpdate.getWritePath(), fileName);
+        try {
+            ExtendedFileSystem fileSystem = hdfsEnvironment.getFileSystem(context, fromPath);
+            ListenableFuture<Void> asyncFuture = fileSystem.renameFileAsync(fromPath, toPath);
+            addSuccessCallback(asyncFuture, () -> updateFileInfo(partitionUpdatesWithRenamedFileNames, renamingFuture, partitionUpdate, fileName, fileWriteInfo, writerIndex));
+        }
+        catch (IOException e) {
+            throw new PrestoException(HIVE_FILESYSTEM_ERROR, format("Error renaming file. fromPath: %s toPath: %s", fromPath, toPath), e);
+        }
+    }
+
+    private void updateFileInfo(ImmutableList.Builder<Slice> partitionUpdatesWithRenamedFileNames, SettableFuture<?> renamingFuture, PartitionUpdate partitionUpdate, String fileName, FileWriteInfo fileWriteInfo, int writerIndex)
+    {
+        // Update the file info in partitionUpdate with new filename
+        FileWriteInfo fileInfoWithRenamedFileName = new FileWriteInfo(fileName, fileName, fileWriteInfo.getFileSize());
+        PartitionUpdate partitionUpdateWithRenamedFileName = new PartitionUpdate(partitionUpdate.getName(),
+                partitionUpdate.getUpdateMode(),
+                partitionUpdate.getWritePath(),
+                partitionUpdate.getTargetPath(),
+                ImmutableList.of(fileInfoWithRenamedFileName),
+                partitionUpdate.getRowCount(),
+                partitionUpdate.getInMemoryDataSizeInBytes(),
+                partitionUpdate.getOnDiskDataSizeInBytes());
+        partitionUpdatesWithRenamedFileNames.add(wrappedBuffer(partitionUpdateCodec.toJsonBytes(partitionUpdateWithRenamedFileName)));
+
+        hiveMetadataUpdater.removeResultFuture(writerIndex);
+        renamingFuture.set(null);
     }
 
     private int[] getWriterIndexes(Page page)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
@@ -98,6 +98,7 @@ public class HivePageSink
 
     private final ConnectorSession session;
     private final HiveMetadataUpdater hiveMetadataUpdater;
+    private final boolean fileRenamingEnabled;
 
     private long writtenBytes;
     private long systemMemoryUsage;
@@ -189,6 +190,7 @@ public class HivePageSink
 
         this.session = requireNonNull(session, "session is null");
         this.hiveMetadataUpdater = requireNonNull(hiveMetadataUpdater, "hiveMetadataUpdater is null");
+        this.fileRenamingEnabled = HiveSessionProperties.isFileRenamingEnabled(session);
     }
 
     @Override
@@ -374,7 +376,7 @@ public class HivePageSink
     private void sendMetadataUpdateRequest(Optional<String> partitionName, int writerIndex)
     {
         // Bucketed tables already have unique bucket number as part of fileName. So no need to rename.
-        if (bucketFunction != null) {
+        if (!fileRenamingEnabled || bucketFunction != null) {
             return;
         }
         hiveMetadataUpdater.addMetadataUpdateRequest(schemaName, tableName, partitionName, writerIndex);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
@@ -180,7 +180,7 @@ public class HivePageSinkProvider
                 handle.getInputColumns(),
                 handle.getBucketProperty(),
                 handle.getSchemaName(),
-                handle.getSchemaName(),
+                handle.getTableName(),
                 pageIndexerFactory,
                 typeManager,
                 hdfsEnvironment,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
@@ -179,6 +179,8 @@ public class HivePageSinkProvider
                 writerFactory,
                 handle.getInputColumns(),
                 handle.getBucketProperty(),
+                handle.getSchemaName(),
+                handle.getSchemaName(),
                 pageIndexerFactory,
                 typeManager,
                 hdfsEnvironment,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -110,6 +110,7 @@ public final class HiveSessionProperties
     public static final String IGNORE_UNREADABLE_PARTITION = "ignore_unreadable_partition";
     public static final String PARTIAL_AGGREGATION_PUSHDOWN_ENABLED = "partial_aggregation_pushdown_enabled";
     public static final String PARTIAL_AGGREGATION_PUSHDOWN_FOR_VARIABLE_LENGTH_DATATYPES_ENABLED = "partial_aggregation_pushdown_for_variable_length_datatypes_enabled";
+    public static final String FILE_RENAMING_ENABLED = "file_renaming_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -514,6 +515,11 @@ public final class HiveSessionProperties
                         PARTIAL_AGGREGATION_PUSHDOWN_FOR_VARIABLE_LENGTH_DATATYPES_ENABLED,
                         "Is partial aggregation pushdown enabled for variable length datatypes",
                         hiveClientConfig.isPartialAggregationPushdownForVariableLengthDatatypesEnabled(),
+                        false),
+                booleanProperty(
+                        FILE_RENAMING_ENABLED,
+                        "Enable renaming the files written by writers",
+                        hiveClientConfig.isFileRenamingEnabled(),
                         false));
     }
 
@@ -898,5 +904,10 @@ public final class HiveSessionProperties
     public static boolean isPartialAggregationPushdownForVariableLengthDatatypesEnabled(ConnectorSession session)
     {
         return session.getProperty(PARTIAL_AGGREGATION_PUSHDOWN_FOR_VARIABLE_LENGTH_DATATYPES_ENABLED, Boolean.class);
+    }
+
+    public static boolean isFileRenamingEnabled(ConnectorSession session)
+    {
+        return session.getProperty(FILE_RENAMING_ENABLED, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriter.java
@@ -75,6 +75,11 @@ public class HiveWriter
         return rowCount;
     }
 
+    public Optional<String> getPartitionName()
+    {
+        return partitionName;
+    }
+
     public void append(Page dataPage)
     {
         // getRegionSizeInBytes for each row can be expensive; use getRetainedSizeInBytes for estimation

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
@@ -325,7 +325,8 @@ public class HiveWriterFactory
         String extension = getFileExtension(writerParameters.getOutputStorageFormat(), compressionCodec);
         String targetFileName;
         if (bucketNumber.isPresent()) {
-            targetFileName = computeBucketedFileName(filePrefix, bucketNumber.getAsInt()) + extension;
+            // Use the bucket number for file name.
+            targetFileName = bucketNumber.getAsInt() + extension;
         }
         else {
             targetFileName = filePrefix + "_" + randomUUID() + extension;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
@@ -325,8 +325,8 @@ public class HiveWriterFactory
         String extension = getFileExtension(writerParameters.getOutputStorageFormat(), compressionCodec);
         String targetFileName;
         if (bucketNumber.isPresent()) {
-            // Use the bucket number for file name.
-            targetFileName = bucketNumber.getAsInt() + extension;
+            // Use the bucket number for file name when fileRenaming is enabled
+            targetFileName = HiveSessionProperties.isFileRenamingEnabled(session) ? String.valueOf(bucketNumber.getAsInt()) : computeBucketedFileName(filePrefix, bucketNumber.getAsInt()) + extension;
         }
         else {
             targetFileName = filePrefix + "_" + randomUUID() + extension;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -957,7 +957,8 @@ public abstract class AbstractTestHiveClient
                 TEST_SERVER_VERSION,
                 new HivePartitionObjectBuilder(),
                 new HiveEncryptionInformationProvider(ImmutableList.of()),
-                new HivePartitionStats());
+                new HivePartitionStats(),
+                new HiveFileRenamer());
         transactionManager = new HiveTransactionManager();
         encryptionInformationProvider = new HiveEncryptionInformationProvider(ImmutableList.of());
         splitManager = new HiveSplitManager(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -209,7 +209,8 @@ public abstract class AbstractTestHiveFileSystem
                 new NodeVersion("test_version"),
                 new HivePartitionObjectBuilder(),
                 new HiveEncryptionInformationProvider(ImmutableList.of()),
-                new HivePartitionStats());
+                new HivePartitionStats(),
+                new HiveFileRenamer());
         transactionManager = new HiveTransactionManager();
         splitManager = new HiveSplitManager(
                 transactionManager,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -144,7 +144,8 @@ public class TestHiveClientConfig
                 .setIgnoreUnreadablePartition(false)
                 .setMaxMetadataUpdaterThreads(100)
                 .setPartialAggregationPushdownEnabled(false)
-                .setPartialAggregationPushdownForVariableLengthDatatypesEnabled(false));
+                .setPartialAggregationPushdownForVariableLengthDatatypesEnabled(false)
+                .setFileRenamingEnabled(false));
     }
 
     @Test
@@ -250,6 +251,7 @@ public class TestHiveClientConfig
                 .put("hive.max-metadata-updater-threads", "1000")
                 .put("hive.partial_aggregation_pushdown_enabled", "true")
                 .put("hive.partial_aggregation_pushdown_for_variable_length_datatypes_enabled", "true")
+                .put("hive.file_renaming_enabled", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -352,7 +354,8 @@ public class TestHiveClientConfig
                 .setIgnoreUnreadablePartition(true)
                 .setMaxMetadataUpdaterThreads(1000)
                 .setPartialAggregationPushdownEnabled(true)
-                .setPartialAggregationPushdownForVariableLengthDatatypesEnabled(true);
+                .setPartialAggregationPushdownForVariableLengthDatatypesEnabled(true)
+                .setFileRenamingEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileRenamer.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileRenamer.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.ConnectorMetadataUpdateHandle;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.hive.TestHiveMetadataUpdateHandle.TEST_HIVE_METADATA_UPDATE_REQUEST;
+import static com.facebook.presto.hive.TestHiveMetadataUpdateHandle.TEST_PARTITION_NAME;
+import static com.facebook.presto.hive.TestHiveMetadataUpdateHandle.TEST_REQUEST_ID;
+import static com.facebook.presto.hive.TestHiveMetadataUpdateHandle.TEST_SCHEMA_NAME;
+import static com.facebook.presto.hive.TestHiveMetadataUpdateHandle.TEST_SCHEMA_TABLE_NAME;
+import static com.facebook.presto.hive.TestHiveMetadataUpdateHandle.TEST_TABLE_NAME;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test
+public class TestHiveFileRenamer
+{
+    private static final QueryId TEST_QUERY_ID = new QueryId("test");
+    private static final int REQUEST_COUNT = 10;
+    private static final int PARTITION_COUNT = 10;
+    private static final int TABLE_COUNT = 10;
+    private static final int THREAD_COUNT = 100;
+    private static final int THREAD_POOL_SIZE = 10;
+
+    @Test
+    public void testHiveFileRenamer()
+    {
+        HiveFileRenamer hiveFileRenamer = new HiveFileRenamer();
+        List<ConnectorMetadataUpdateHandle> requests = ImmutableList.of(TEST_HIVE_METADATA_UPDATE_REQUEST);
+        List<ConnectorMetadataUpdateHandle> results = hiveFileRenamer.getMetadataUpdateResults(requests, TEST_QUERY_ID);
+
+        // Assert # of requests is equal to # of results
+        assertEquals(requests.size(), results.size());
+
+        HiveMetadataUpdateHandle result = (HiveMetadataUpdateHandle) results.get(0);
+
+        assertEquals(result.getRequestId(), TEST_REQUEST_ID);
+        assertEquals(result.getSchemaTableName(), TEST_SCHEMA_TABLE_NAME);
+        assertEquals(result.getPartitionName(), Optional.of(TEST_PARTITION_NAME));
+
+        // Assert file name returned is "1"
+        assertEquals(result.getMetadataUpdate(), Optional.of("0"));
+    }
+
+    @Test
+    public void testFileNamesForSinglePartition()
+    {
+        HiveFileRenamer hiveFileRenamer = new HiveFileRenamer();
+        List<ConnectorMetadataUpdateHandle> requests = createHiveMetadataUpdateRequests(TEST_SCHEMA_NAME, TEST_TABLE_NAME, TEST_PARTITION_NAME);
+        List<String> fileNames = getFileNames(hiveFileRenamer, requests);
+        List<String> aggregatedFileNames = new ArrayList<>(fileNames);
+
+        assertTrue(areFileNamesIncreasingSequentially(fileNames));
+
+        // Send more requests
+        requests = createHiveMetadataUpdateRequests(TEST_SCHEMA_NAME, TEST_TABLE_NAME, TEST_PARTITION_NAME);
+        fileNames = getFileNames(hiveFileRenamer, requests);
+        aggregatedFileNames.addAll(fileNames);
+
+        // Assert that the # of filenames is equal to # of requests
+        assertEquals(fileNames.size(), REQUEST_COUNT);
+
+        // Assert that the file names are continuous increasing numbers
+        assertTrue(areFileNamesIncreasingSequentially(aggregatedFileNames));
+    }
+
+    @Test
+    public void testFileNamesForMultiplePartitions()
+    {
+        HiveFileRenamer hiveFileRenamer = new HiveFileRenamer();
+        for (int partitionNumber = 1; partitionNumber <= PARTITION_COUNT; partitionNumber++) {
+            List<ConnectorMetadataUpdateHandle> requests = createHiveMetadataUpdateRequests(TEST_SCHEMA_NAME, TEST_TABLE_NAME, "partition_" + partitionNumber);
+            List<String> fileNames = getFileNames(hiveFileRenamer, requests);
+
+            // Assert that the # of filenames is equal to # of requests
+            assertEquals(fileNames.size(), REQUEST_COUNT);
+
+            assertTrue(areFileNamesIncreasingSequentially(fileNames));
+        }
+    }
+
+    @Test
+    public void testFileNamesForMultipleTables()
+    {
+        HiveFileRenamer hiveFileRenamer = new HiveFileRenamer();
+        for (int tableNumber = 1; tableNumber <= TABLE_COUNT; tableNumber++) {
+            List<ConnectorMetadataUpdateHandle> requests = createHiveMetadataUpdateRequests(TEST_SCHEMA_NAME, "table_" + tableNumber, TEST_PARTITION_NAME);
+            List<String> fileNames = getFileNames(hiveFileRenamer, requests);
+
+            // Assert that the # of filenames is equal to # of requests
+            assertEquals(fileNames.size(), REQUEST_COUNT);
+
+            assertTrue(areFileNamesIncreasingSequentially(fileNames));
+        }
+    }
+
+    @Test
+    public void testFileNameResultCache()
+    {
+        HiveFileRenamer hiveFileRenamer = new HiveFileRenamer();
+        List<ConnectorMetadataUpdateHandle> requests = createHiveMetadataUpdateRequests(TEST_SCHEMA_NAME, TEST_TABLE_NAME, TEST_PARTITION_NAME);
+
+        // Get the file names 1st time
+        List<String> fileNames = getFileNames(hiveFileRenamer, requests);
+
+        // Get the file names 2nd time, for the same set of requests. This should be served from cache.
+        List<String> fileNamesList = getFileNames(hiveFileRenamer, requests);
+
+        // Assert that the file name is same for a given request. This is to imitate retries from workers.
+        assertEquals(fileNames, fileNamesList);
+        assertEquals(fileNames, getFileNames(hiveFileRenamer, requests));
+    }
+
+    @Test
+    public void testMultiThreadedRequests()
+            throws InterruptedException
+    {
+        ExecutorService service = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
+        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+
+        List<String> fileNames = new CopyOnWriteArrayList<>();
+        HiveFileRenamer hiveFileRenamer = new HiveFileRenamer();
+
+        // Spawn THREAD_COUNT threads. And each thread will send REQUEST_COUNT requests to HiveFileRenamer
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            service.execute(() -> {
+                List<ConnectorMetadataUpdateHandle> requests = createHiveMetadataUpdateRequests(TEST_SCHEMA_NAME, TEST_TABLE_NAME, TEST_PARTITION_NAME);
+                fileNames.addAll(getFileNames(hiveFileRenamer, requests));
+                latch.countDown();
+            });
+        }
+
+        // wait for all threads to finish
+        latch.await();
+
+        // Assert the # of filenames
+        assertEquals(fileNames.size(), THREAD_COUNT * REQUEST_COUNT);
+
+        // Assert that the filenames are an increasing sequence
+        assertTrue(areFileNamesIncreasingSequentially(fileNames));
+    }
+
+    @Test
+    public void testCleanup()
+    {
+        HiveFileRenamer hiveFileRenamer = new HiveFileRenamer();
+        List<ConnectorMetadataUpdateHandle> requests = ImmutableList.of(TEST_HIVE_METADATA_UPDATE_REQUEST);
+        List<ConnectorMetadataUpdateHandle> results = hiveFileRenamer.getMetadataUpdateResults(requests, TEST_QUERY_ID);
+        assertEquals(results.size(), 1);
+        HiveMetadataUpdateHandle result = (HiveMetadataUpdateHandle) results.get(0);
+        assertEquals(result.getMetadataUpdate(), Optional.of("0"));
+
+        hiveFileRenamer.cleanup(TEST_QUERY_ID);
+
+        requests = ImmutableList.of(TEST_HIVE_METADATA_UPDATE_REQUEST);
+        results = hiveFileRenamer.getMetadataUpdateResults(requests, TEST_QUERY_ID);
+        assertEquals(results.size(), 1);
+        result = (HiveMetadataUpdateHandle) results.get(0);
+        assertEquals(result.getMetadataUpdate(), Optional.of("0"));
+    }
+
+    private List<String> getFileNames(HiveFileRenamer hiveFileRenamer, List<ConnectorMetadataUpdateHandle> requests)
+    {
+        List<ConnectorMetadataUpdateHandle> results = hiveFileRenamer.getMetadataUpdateResults(requests, TEST_QUERY_ID);
+        return results.stream()
+                .map(result -> {
+                    Optional<String> fileName = ((HiveMetadataUpdateHandle) result).getMetadataUpdate();
+                    assertTrue(fileName.isPresent());
+                    return fileName.get();
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<ConnectorMetadataUpdateHandle> createHiveMetadataUpdateRequests(String schemaName, String tableName, String partitionName)
+    {
+        List<ConnectorMetadataUpdateHandle> requests = new ArrayList<>();
+        for (int i = 1; i <= REQUEST_COUNT; i++) {
+            requests.add(new HiveMetadataUpdateHandle(UUID.randomUUID(), new SchemaTableName(schemaName, tableName), Optional.of(partitionName), Optional.empty()));
+        }
+        return requests;
+    }
+
+    private boolean areFileNamesIncreasingSequentially(List<String> fileNames)
+    {
+        // Sort the filenames
+        fileNames.sort(Comparator.comparingInt(Integer::valueOf));
+
+        long start = 0;
+
+        for (String fileName : fileNames) {
+            if (!fileName.equals(String.valueOf(start))) {
+                return false;
+            }
+            start++;
+        }
+        return true;
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
@@ -127,7 +127,8 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                 TEST_SERVER_VERSION,
                 new HivePartitionObjectBuilder(),
                 new HiveEncryptionInformationProvider(ImmutableList.of(new TestDwrfEncryptionInformationSource())),
-                new HivePartitionStats());
+                new HivePartitionStats(),
+                new HiveFileRenamer());
 
         metastore.createDatabase(Database.builder()
                 .setDatabaseName(TEST_DB_NAME)

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -448,6 +448,11 @@ public class SqlTask
         return getTaskInfo();
     }
 
+    public TaskMetadataContext getTaskMetadataContext()
+    {
+        return taskHolderReference.get().taskExecution.getTaskContext().getTaskMetadataContext();
+    }
+
     public ListenableFuture<BufferResult> getTaskResults(OutputBufferId bufferId, long startingSequenceId, DataSize maxSize)
     {
         requireNonNull(bufferId, "bufferId is null");

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -33,9 +33,11 @@ import com.facebook.presto.memory.MemoryPoolAssignment;
 import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
 import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.memory.QueryContext;
+import com.facebook.presto.metadata.MetadataUpdates;
 import com.facebook.presto.operator.ExchangeClientSupplier;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.connector.ConnectorMetadataUpdater;
 import com.facebook.presto.spiller.LocalSpillManager;
 import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.sql.gen.OrderingCompiler;
@@ -393,6 +395,15 @@ public class SqlTaskManager
         SqlTask sqlTask = tasks.getUnchecked(taskId);
         sqlTask.recordHeartbeat();
         return sqlTask.updateTask(session, fragment, sources, outputBuffers, tableWriteInfo);
+    }
+
+    @Override
+    public void updateMetadataResults(TaskId taskId, MetadataUpdates metadataUpdates)
+    {
+        TaskMetadataContext metadataContext = tasks.getUnchecked(taskId).getTaskMetadataContext();
+        for (ConnectorMetadataUpdater metadataUpdater : metadataContext.getMetadataUpdaters()) {
+            metadataUpdater.setMetadataUpdateResults(metadataUpdates.getMetadataUpdates());
+        }
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManager.java
@@ -20,6 +20,7 @@ import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
+import com.facebook.presto.metadata.MetadataUpdates;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
@@ -142,4 +143,9 @@ public interface TaskManager
      * from {@code remoteSourceTaskId} will be ignored.
      */
     void removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId);
+
+    /**
+     * Update the results of metadata requests sent
+     */
+    void updateMetadataResults(TaskId taskId, MetadataUpdates metadataUpdates);
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -20,6 +20,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
@@ -27,6 +28,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.TableLayoutFilterCoverage;
@@ -434,6 +436,8 @@ public interface Metadata
     @Experimental
     ListenableFuture<Void> commitPageSinkAsync(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments);
 
+    MetadataUpdates getMetadataUpdateResults(Session session, QueryManager queryManager, MetadataUpdates metadataUpdates, QueryId queryId);
+
     FunctionManager getFunctionManager();
 
     ProcedureRegistry getProcedureRegistry();
@@ -456,6 +460,7 @@ public interface Metadata
 
     /**
      * Check if there is filter coverage of the specified partitioning keys
+     *
      * @return NOT_APPLICABLE if partitioning is unsupported, not applicable, or the partitioning key is not relevant, NONE or COVERED otherwise
      */
     default TableLayoutFilterCoverage getTableLayoutFilterCoverage(Session session, TableHandle tableHandle, Set<String> relevantPartitionColumn)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUpdates.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataUpdates.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ConnectorMetadataUpdateHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class MetadataUpdates
+{
+    public static final MetadataUpdates DEFAULT_METADATA_UPDATES = new MetadataUpdates(null, ImmutableList.of());
+
+    private final ConnectorId connectorId;
+    private final List<ConnectorMetadataUpdateHandle> metadataUpdates;
+
+    @JsonCreator
+    public MetadataUpdates(
+            @JsonProperty("connectorId") @Nullable ConnectorId connectorId,
+            @JsonProperty("metadataUpdates") List<ConnectorMetadataUpdateHandle> metadataUpdates)
+    {
+        this.connectorId = connectorId;
+        this.metadataUpdates = ImmutableList.copyOf(requireNonNull(metadataUpdates, "metadataUpdates is null"));
+    }
+
+    @JsonProperty
+    public ConnectorId getConnectorId()
+    {
+        return connectorId;
+    }
+
+    @JsonProperty
+    public List<ConnectorMetadataUpdateHandle> getMetadataUpdates()
+    {
+        return metadataUpdates;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -83,6 +83,7 @@ import com.facebook.presto.metadata.HandleJsonModule;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.MetadataUpdates;
 import com.facebook.presto.metadata.SchemaPropertyManager;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.metadata.StaticCatalogStore;
@@ -471,6 +472,10 @@ public class ServerMainModule
         jsonBinder(binder).addSerializerBinding(Expression.class).to(ExpressionSerializer.class);
         jsonBinder(binder).addDeserializerBinding(Expression.class).to(ExpressionDeserializer.class);
         jsonBinder(binder).addDeserializerBinding(FunctionCall.class).to(FunctionCallDeserializer.class);
+
+        // metadata updates
+        jsonCodecBinder(binder).bindJsonCodec(MetadataUpdates.class);
+        smileCodecBinder(binder).bindSmileCodec(MetadataUpdates.class);
 
         // split monitor
         binder.bind(SplitMonitor.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskResource.java
@@ -25,6 +25,7 @@ import com.facebook.presto.execution.TaskState;
 import com.facebook.presto.execution.TaskStatus;
 import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
+import com.facebook.presto.metadata.MetadataUpdates;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.server.smile.Codec;
 import com.facebook.presto.server.smile.SmileCodec;
@@ -227,6 +228,16 @@ public class TaskResource
         Duration timeout = new Duration(waitTime.toMillis() + ADDITIONAL_WAIT_TIME.toMillis(), MILLISECONDS);
         bindAsyncResponse(asyncResponse, futureTaskStatus, responseExecutor)
                 .withTimeout(timeout);
+    }
+
+    @POST
+    @Path("{taskId}/metadataresults")
+    @Consumes({APPLICATION_JSON, APPLICATION_JACKSON_SMILE})
+    public Response updateMetadataResults(@PathParam("taskId") TaskId taskId, MetadataUpdates metadataUpdates, @Context UriInfo uriInfo)
+    {
+        requireNonNull(metadataUpdates, "metadataUpdates is null");
+        taskManager.updateMetadataResults(taskId, metadataUpdates);
+        return Response.ok().build();
     }
 
     @DELETE

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/TaskInfoFetcher.java
@@ -17,12 +17,17 @@ import com.facebook.airlift.concurrent.SetThreadName;
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.client.HttpUriBuilder;
 import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.Response;
 import com.facebook.airlift.http.client.ResponseHandler;
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.StateMachine;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskInfo;
 import com.facebook.presto.execution.TaskStatus;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.MetadataUpdates;
 import com.facebook.presto.server.RequestErrorTracker;
 import com.facebook.presto.server.SimpleHttpResponseCallback;
 import com.facebook.presto.server.SimpleHttpResponseHandler;
@@ -46,6 +51,9 @@ import java.util.function.Consumer;
 
 import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.facebook.airlift.http.client.ResponseHandlerUtils.propagate;
+import static com.facebook.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CURRENT_STATE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_MAX_WAIT;
 import static com.facebook.presto.server.RequestErrorTracker.taskRequestErrorTracker;
@@ -66,6 +74,7 @@ public class TaskInfoFetcher
     private final StateMachine<TaskInfo> taskInfo;
     private final StateMachine<Optional<TaskInfo>> finalTaskInfo;
     private final Codec<TaskInfo> taskInfoCodec;
+    private final Codec<MetadataUpdates> metadataUpdatesCodec;
 
     private final long updateIntervalMillis;
     private final Duration taskInfoRefreshMaxWait;
@@ -93,7 +102,13 @@ public class TaskInfoFetcher
     @GuardedBy("this")
     private ListenableFuture<BaseResponse<TaskInfo>> future;
 
+    @GuardedBy("this")
+    private ListenableFuture<?> metadataUpdateFuture;
+
     private final boolean isBinaryTransportEnabled;
+    private final Session session;
+    private final MetadataManager metadataManager;
+    private final QueryManager queryManager;
 
     public TaskInfoFetcher(
             Consumer<Throwable> onFail,
@@ -102,13 +117,17 @@ public class TaskInfoFetcher
             Duration updateInterval,
             Duration taskInfoRefreshMaxWait,
             Codec<TaskInfo> taskInfoCodec,
+            Codec<MetadataUpdates> metadataUpdatesCodec,
             Duration maxErrorDuration,
             boolean summarizeTaskInfo,
             Executor executor,
             ScheduledExecutorService updateScheduledExecutor,
             ScheduledExecutorService errorScheduledExecutor,
             RemoteTaskStats stats,
-            boolean isBinaryTransportEnabled)
+            boolean isBinaryTransportEnabled,
+            Session session,
+            MetadataManager metadataManager,
+            QueryManager queryManager)
     {
         requireNonNull(initialTask, "initialTask is null");
         requireNonNull(errorScheduledExecutor, "errorScheduledExecutor is null");
@@ -118,6 +137,8 @@ public class TaskInfoFetcher
         this.taskInfo = new StateMachine<>("task " + taskId, executor, initialTask);
         this.finalTaskInfo = new StateMachine<>("task-" + taskId, executor, Optional.empty());
         this.taskInfoCodec = requireNonNull(taskInfoCodec, "taskInfoCodec is null");
+
+        this.metadataUpdatesCodec = requireNonNull(metadataUpdatesCodec, "metadataUpdatesCodec is null");
 
         this.updateIntervalMillis = requireNonNull(updateInterval, "updateInterval is null").toMillis();
         this.taskInfoRefreshMaxWait = requireNonNull(taskInfoRefreshMaxWait, "taskInfoRefreshMaxWait is null");
@@ -130,6 +151,9 @@ public class TaskInfoFetcher
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.stats = requireNonNull(stats, "stats is null");
         this.isBinaryTransportEnabled = isBinaryTransportEnabled;
+        this.session = requireNonNull(session, "session is null");
+        this.metadataManager = requireNonNull(metadataManager, "metadataManager is null");
+        this.queryManager = requireNonNull(queryManager, "queryManager is null");
     }
 
     public TaskInfo getTaskInfo()
@@ -201,7 +225,8 @@ public class TaskInfoFetcher
 
     private synchronized void sendNextRequest()
     {
-        TaskStatus taskStatus = getTaskInfo().getTaskStatus();
+        TaskInfo taskInfo = getTaskInfo();
+        TaskStatus taskStatus = taskInfo.getTaskStatus();
 
         if (!running) {
             return;
@@ -223,6 +248,11 @@ public class TaskInfoFetcher
         if (!errorRateLimit.isDone()) {
             errorRateLimit.addListener(this::sendNextRequest, executor);
             return;
+        }
+
+        MetadataUpdates metadataUpdateRequests = taskInfo.getMetadataUpdates();
+        if (!metadataUpdateRequests.getMetadataUpdates().isEmpty()) {
+            scheduleMetadataUpdates(metadataUpdateRequests);
         }
 
         HttpUriBuilder httpUriBuilder = uriBuilderFrom(taskStatus.getSelf());
@@ -323,5 +353,51 @@ public class TaskInfoFetcher
     private static boolean isDone(TaskInfo taskInfo)
     {
         return taskInfo.getTaskStatus().getState().isDone();
+    }
+
+    private void scheduleMetadataUpdates(MetadataUpdates metadataUpdateRequests)
+    {
+        MetadataUpdates results = metadataManager.getMetadataUpdateResults(session, queryManager, metadataUpdateRequests, taskId.getQueryId());
+        executor.execute(() -> sendMetadataUpdates(results));
+    }
+
+    private synchronized void sendMetadataUpdates(MetadataUpdates results)
+    {
+        TaskStatus taskStatus = getTaskInfo().getTaskStatus();
+
+        // we already have the final task info
+        if (isDone(getTaskInfo())) {
+            stop();
+            return;
+        }
+
+        // outstanding request?
+        if (metadataUpdateFuture != null && !metadataUpdateFuture.isDone()) {
+            // this should never happen
+            return;
+        }
+
+        byte[] metadataUpdatesJson = metadataUpdatesCodec.toBytes(results);
+        Request request = setContentTypeHeaders(isBinaryTransportEnabled, preparePost())
+                .setUri(uriBuilderFrom(taskStatus.getSelf()).appendPath("metadataresults").build())
+                .setBodyGenerator(createStaticBodyGenerator(metadataUpdatesJson))
+                .build();
+
+        errorTracker.startRequest();
+        metadataUpdateFuture = httpClient.executeAsync(request, new ResponseHandler<Response, RuntimeException>()
+        {
+            @Override
+            public Response handleException(Request request, Exception exception)
+            {
+                throw propagate(request, exception);
+            }
+
+            @Override
+            public Response handle(Request request, Response response)
+            {
+                return response;
+            }
+        });
+        currentRequestStartNanos.set(System.nanoTime());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -81,6 +81,7 @@ import static com.facebook.presto.execution.StateMachine.StateChangeListener;
 import static com.facebook.presto.execution.buffer.OutputBuffers.BufferType.BROADCAST;
 import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.metadata.MetadataUpdates.DEFAULT_METADATA_UPDATES;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
 import static com.facebook.presto.util.Failures.toFailures;
@@ -268,7 +269,8 @@ public class MockRemoteTaskFactory
                     outputBuffer.getInfo(),
                     ImmutableSet.of(),
                     taskContext.getTaskStats(),
-                    true);
+                    true,
+                    DEFAULT_METADATA_UPDATES);
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManager.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.spi.QueryId;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+
+public class TestQueryManager
+        implements QueryManager
+{
+    public List<BasicQueryInfo> getQueries()
+    {
+        return ImmutableList.of();
+    }
+
+    public void addOutputInfoListener(QueryId queryId, Consumer<QueryExecution.QueryOutputInfo> listener)
+    {}
+
+    public void addStateChangeListener(QueryId queryId, StateMachine.StateChangeListener<QueryState> listener)
+    {}
+
+    public ListenableFuture<QueryState> getStateChange(QueryId queryId, QueryState currentState)
+    {
+        return immediateFuture(null);
+    }
+
+    public BasicQueryInfo getQueryInfo(QueryId queryId)
+    {
+        return null;
+    }
+
+    public QueryInfo getFullQueryInfo(QueryId queryId)
+    {
+        return null;
+    }
+
+    public Session getQuerySession(QueryId queryId)
+    {
+        return null;
+    }
+
+    public boolean isQuerySlugValid(QueryId queryId, String slug)
+    {
+        return true;
+    }
+
+    public QueryState getQueryState(QueryId queryId)
+    {
+        return null;
+    }
+
+    public void recordHeartbeat(QueryId queryId)
+    {}
+
+    public void createQuery(QueryExecution execution)
+    {}
+
+    public void failQuery(QueryId queryId, Throwable cause)
+    {}
+
+    public void cancelQuery(QueryId queryId)
+    {}
+
+    public void cancelStage(StageId stageId)
+    {}
+
+    public QueryManagerStats getStats()
+    {
+        return null;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -20,11 +20,13 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
@@ -490,6 +492,12 @@ public abstract class AbstractMockMetadata
 
     @Override
     public ListenableFuture<Void> commitPageSinkAsync(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MetadataUpdates getMetadataUpdateResults(Session session, QueryManager queryManager, MetadataUpdates metadataUpdateRequests, QueryId queryId)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestThriftServerInfoIntegration.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestThriftServerInfoIntegration.java
@@ -37,6 +37,7 @@ import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
+import com.facebook.presto.metadata.MetadataUpdates;
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.server.thrift.ThriftServerInfoClient;
 import com.facebook.presto.server.thrift.ThriftServerInfoService;
@@ -144,7 +145,8 @@ public class TestThriftServerInfoIntegration
         @Singleton
         public static TaskManager createTaskManager()
         {
-            return new TaskManager() {
+            return new TaskManager()
+            {
                 @Override
                 public List<TaskInfo> getAllTaskInfo()
                 {
@@ -231,6 +233,12 @@ public class TestThriftServerInfoIntegration
 
                 @Override
                 public void removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public void updateMetadataResults(TaskId taskId, MetadataUpdates metadataUpdates)
                 {
                     throw new UnsupportedOperationException();
                 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestThriftTaskIntegration.java
@@ -39,6 +39,7 @@ import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
 import com.facebook.presto.execution.buffer.ThriftBufferResult;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
+import com.facebook.presto.metadata.MetadataUpdates;
 import com.facebook.presto.server.thrift.ThriftTaskClient;
 import com.facebook.presto.server.thrift.ThriftTaskService;
 import com.facebook.presto.sql.planner.PlanFragment;
@@ -177,7 +178,8 @@ public class TestThriftTaskIntegration
         @Singleton
         public static TaskManager createTaskManager()
         {
-            return new TaskManager() {
+            return new TaskManager()
+            {
                 @Override
                 public List<TaskInfo> getAllTaskInfo()
                 {
@@ -270,6 +272,12 @@ public class TestThriftTaskIntegration
 
                 @Override
                 public void removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId)
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public void updateMetadataResults(TaskId taskId, MetadataUpdates metadataUpdates)
                 {
                     throw new UnsupportedOperationException();
                 }

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -471,7 +471,8 @@ public class TestHttpRemoteTask
                     initialTaskInfo.getOutputBuffers(),
                     initialTaskInfo.getNoMoreSplits(),
                     initialTaskInfo.getStats(),
-                    initialTaskInfo.isNeedsPlan());
+                    initialTaskInfo.isNeedsPlan(),
+                    initialTaskInfo.getMetadataUpdates());
         }
 
         private TaskStatus buildTaskStatus()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -103,6 +103,7 @@ import static com.facebook.presto.SystemSessionProperties.getHashPartitionCount;
 import static com.facebook.presto.execution.TaskState.FAILED;
 import static com.facebook.presto.execution.TaskStatus.STARTING_VERSION;
 import static com.facebook.presto.execution.buffer.BufferState.FINISHED;
+import static com.facebook.presto.metadata.MetadataUpdates.DEFAULT_METADATA_UPDATES;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getShuffleOutputTargetAverageRowSize;
 import static com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleStats.Operation.WRITE;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.compress;
@@ -694,7 +695,8 @@ public class PrestoSparkTaskExecutorFactory
                     outputBufferInfo,
                     ImmutableSet.of(),
                     taskStats,
-                    false);
+                    false,
+                    DEFAULT_METADATA_UPDATES);
         }
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkTaskManager.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkTaskManager.java
@@ -25,6 +25,7 @@ import com.facebook.presto.execution.buffer.BufferResult;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.memory.MemoryPoolAssignmentsRequest;
+import com.facebook.presto.metadata.MetadataUpdates;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
@@ -121,6 +122,12 @@ public class PrestoSparkTaskManager
 
     @Override
     public void removeRemoteSource(TaskId taskId, TaskId remoteSourceTaskId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateMetadataResults(TaskId taskId, MetadataUpdates metadataUpdates)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorMetadataUpdateHandle;
 import com.facebook.presto.spi.ConnectorNewTableLayout;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorResolvedIndex;
@@ -30,6 +31,7 @@ import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.SystemTable;
@@ -698,6 +700,19 @@ public interface ConnectorMetadata
     default CompletableFuture<Void> commitPageSinkAsync(ConnectorSession session, ConnectorInsertTableHandle tableHandle, Collection<Slice> fragments)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support page sink commit");
+    }
+
+    /**
+     * Handles metadata update requests and sends the results back to worker
+     */
+    default List<ConnectorMetadataUpdateHandle> getMetadataUpdateResults(List<ConnectorMetadataUpdateHandle> metadataUpdateRequests, QueryId queryId)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support metadata update requests");
+    }
+
+    default void doMetadataUpdateCleanup(QueryId queryId)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support metadata update cleanup");
     }
 
     default TableLayoutFilterCoverage getTableLayoutFilterCoverage(ConnectorTableLayoutHandle tableHandle, Set<String> relevantPartitionColumns)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorMetadataUpdateHandle;
 import com.facebook.presto.spi.ConnectorNewTableLayout;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorResolvedIndex;
@@ -29,6 +30,7 @@ import com.facebook.presto.spi.ConnectorTableLayoutResult;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.SystemTable;
@@ -622,6 +624,22 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.commitPageSinkAsync(session, tableHandle, fragments);
+        }
+    }
+
+    @Override
+    public List<ConnectorMetadataUpdateHandle> getMetadataUpdateResults(List<ConnectorMetadataUpdateHandle> metadataUpdateRequests, QueryId queryId)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getMetadataUpdateResults(metadataUpdateRequests, queryId);
+        }
+    }
+
+    @Override
+    public void doMetadataUpdateCleanup(QueryId queryId)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.doMetadataUpdateCleanup(queryId);
         }
     }
 


### PR DESCRIPTION
This PR enables the workers to send / receive metadata requests /responses from coordinator. 
If this feature is enabled for Hive, then all the files written by the HivePageSink for a given partition will have increasing whole numbers as file names. (For ex: Lets say this we enabled this feature and ds=2020-09-30 is written by HivePageSink. Then we can expect the file names of that partition to be 0,1,2,3..N etc ).

depended by https://github.com/facebookexternal/presto-facebook/pull/1125
```
== RELEASE NOTES ==
General Changes
* Add support for file renaming for Hive connector. This can be enabled with ``hive.file_renaming_enabled`` configuration property
```
