### PR TITLE
Fix memorySize calculation for quantiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <dep.antlr.version>4.7.1</dep.antlr.version>
-        <dep.airlift.version>0.193</dep.airlift.version>
+        <dep.airlift.version>0.194</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.38</dep.slice.version>
         <dep.testing-mysql-server-5.version>0.6</dep.testing-mysql-server-5.version>

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayState.java
@@ -31,5 +31,5 @@ public interface DigestAndPercentileArrayState
 
     List<Double> getPercentiles();
 
-    void addMemoryUsage(int value);
+    void addMemoryUsage(long value);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileArrayStateFactory.java
@@ -91,7 +91,7 @@ public class DigestAndPercentileArrayStateFactory
         }
 
         @Override
-        public void addMemoryUsage(int value)
+        public void addMemoryUsage(long value)
         {
             size += value;
         }
@@ -135,7 +135,7 @@ public class DigestAndPercentileArrayStateFactory
         }
 
         @Override
-        public void addMemoryUsage(int value)
+        public void addMemoryUsage(long value)
         {
             // noop
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileState.java
@@ -29,5 +29,5 @@ public interface DigestAndPercentileState
 
     void setPercentile(double percentile);
 
-    void addMemoryUsage(int value);
+    void addMemoryUsage(long value);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/DigestAndPercentileStateFactory.java
@@ -90,7 +90,7 @@ public class DigestAndPercentileStateFactory
         }
 
         @Override
-        public void addMemoryUsage(int value)
+        public void addMemoryUsage(long value)
         {
             size += value;
         }
@@ -134,7 +134,7 @@ public class DigestAndPercentileStateFactory
         }
 
         @Override
-        public void addMemoryUsage(int value)
+        public void addMemoryUsage(long value)
         {
             // noop
         }


### PR DESCRIPTION
Use long type to account for memory as long to int underflow causes query failures.
depended by https://github.com/facebookexternal/presto-facebook/pull/1113
```
== NO RELEASE NOTE ==
```
