### PR TITLE
Minor page optimizations

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/Page.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/Page.java
@@ -318,6 +318,28 @@ public final class Page
         return wrapBlocksWithoutCopy(length, blocks);
     }
 
+    public Page copyPositions(int[] retainedPositions, int offset, int length)
+    {
+        requireNonNull(retainedPositions, "retainedPositions is null");
+
+        Block[] blocks = new Block[this.blocks.length];
+        for (int i = 0; i < blocks.length; i++) {
+            blocks[i] = this.blocks[i].copyPositions(retainedPositions, offset, length);
+        }
+        return wrapBlocksWithoutCopy(length, blocks);
+    }
+
+    public Page extractChannels(int[] channels)
+    {
+        requireNonNull(channels, "channels is null");
+
+        Block[] blocks = new Block[channels.length];
+        for (int i = 0; i < channels.length; i++) {
+            blocks[i] = this.blocks[channels[i]];
+        }
+        return wrapBlocksWithoutCopy(positionCount, blocks);
+    }
+
     public Page prependColumn(Block column)
     {
         if (column.getPositionCount() != positionCount) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupedTopNBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupedTopNBuilder.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator;
 import com.facebook.presto.array.ObjectBigArray;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.PageBuilder;
-import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.Type;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.AbstractIterator;
@@ -315,11 +314,7 @@ public class GroupedTopNBuilder
             verify(index == usedPositionCount);
 
             // compact page
-            Block[] blocks = new Block[page.getChannelCount()];
-            for (int i = 0; i < page.getChannelCount(); i++) {
-                Block block = page.getBlock(i);
-                blocks[i] = block.copyPositions(positions, 0, usedPositionCount);
-            }
+            Page newPage = page.copyPositions(positions, 0, usedPositionCount);
 
             // update all the elements in the heaps that reference the current page
             for (int i = 0; i < usedPositionCount; i++) {
@@ -327,7 +322,7 @@ public class GroupedTopNBuilder
                 // it only updates the value of the elements; while keeping the same order
                 newReference[i].reset(i);
             }
-            page = new Page(usedPositionCount, blocks);
+            page = newPage;
             reference = newReference;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinUtils.java
@@ -28,16 +28,18 @@ public final class JoinUtils
 
     public static List<Page> channelsToPages(List<List<Block>> channels)
     {
-        ImmutableList.Builder<Page> pagesBuilder = ImmutableList.builder();
-        if (!channels.isEmpty()) {
-            int pagesCount = channels.get(0).size();
-            for (int pageIndex = 0; pageIndex < pagesCount; ++pageIndex) {
-                Block[] blocks = new Block[channels.size()];
-                for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
-                    blocks[channelIndex] = channels.get(channelIndex).get(pageIndex);
-                }
-                pagesBuilder.add(new Page(blocks));
+        if (channels.isEmpty()) {
+            return ImmutableList.of();
+        }
+
+        int pagesCount = channels.get(0).size();
+        ImmutableList.Builder<Page> pagesBuilder = ImmutableList.builderWithExpectedSize(pagesCount);
+        for (int pageIndex = 0; pageIndex < pagesCount; ++pageIndex) {
+            Block[] blocks = new Block[channels.size()];
+            for (int channelIndex = 0; channelIndex < channels.size(); ++channelIndex) {
+                blocks[channelIndex] = channels.get(channelIndex).get(pageIndex);
             }
+            pagesBuilder.add(new Page(blocks));
         }
         return pagesBuilder.build();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/LimitOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LimitOperator.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.common.Page;
-import com.facebook.presto.common.block.Block;
 import com.facebook.presto.spi.plan.PlanNodeId;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -106,12 +105,7 @@ public class LimitOperator
             nextPage = page;
         }
         else {
-            Block[] blocks = new Block[page.getChannelCount()];
-            for (int channel = 0; channel < page.getChannelCount(); channel++) {
-                Block block = page.getBlock(channel);
-                blocks[channel] = block.getRegion(0, (int) remainingLimit);
-            }
-            nextPage = new Page((int) remainingLimit, blocks);
+            nextPage = page.getRegion(0, (int) remainingLimit);
             remainingLimit = 0;
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPagesBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPagesBuilder.java
@@ -60,12 +60,12 @@ public class NestedLoopJoinPagesBuilder
     public void compact()
     {
         checkState(!finished, "NestedLoopJoinPagesBuilder is finished");
-
-        pages.stream()
-                .forEach(Page::compact);
-        estimatedSize = pages.stream()
-                .mapToLong(Page::getRetainedSizeInBytes)
-                .sum();
+        long estimatedSize = 0L;
+        for (Page page : pages) {
+            page.compact();
+            estimatedSize += page.getRetainedSizeInBytes();
+        }
+        this.estimatedSize = estimatedSize;
     }
 
     public NestedLoopJoinPages build()

--- a/presto-main/src/main/java/com/facebook/presto/operator/RowNumberOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/RowNumberOperator.java
@@ -26,7 +26,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -282,14 +281,12 @@ public class RowNumberOperator
 
     private Page getRowsWithRowNumber()
     {
-        Block rowNumberBlock = createRowNumberBlock();
-        Block[] sourceBlocks = new Block[inputPage.getChannelCount()];
+        Block[] outputBlocks = new Block[inputPage.getChannelCount() + 1]; // +1 for the row number column
         for (int i = 0; i < outputChannels.length; i++) {
-            sourceBlocks[i] = inputPage.getBlock(outputChannels[i]);
+            outputBlocks[i] = inputPage.getBlock(outputChannels[i]);
         }
 
-        Block[] outputBlocks = Arrays.copyOf(sourceBlocks, sourceBlocks.length + 1); // +1 for the row number column
-        outputBlocks[sourceBlocks.length] = rowNumberBlock;
+        outputBlocks[outputBlocks.length - 1] = createRowNumberBlock();
 
         return new Page(inputPage.getPositionCount(), outputBlocks);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/StreamingAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/StreamingAggregationOperator.java
@@ -188,9 +188,9 @@ public class StreamingAggregationOperator
     {
         requireNonNull(page, "page is null");
 
-        Page groupByPage = extractColumns(page, groupByChannels);
+        Page groupByPage = page.extractChannels(groupByChannels);
         if (currentGroup != null) {
-            if (!pagesHashStrategy.rowEqualsRow(0, extractColumns(currentGroup, groupByChannels), 0, groupByPage)) {
+            if (!pagesHashStrategy.rowEqualsRow(0, currentGroup.extractChannels(groupByChannels), 0, groupByPage)) {
                 // page starts with new group, so flush it
                 evaluateAndFlushGroup(currentGroup, 0);
             }
@@ -213,15 +213,6 @@ public class StreamingAggregationOperator
                 return;
             }
         }
-    }
-
-    private static Page extractColumns(Page page, int[] channels)
-    {
-        Block[] newBlocks = new Block[channels.length];
-        for (int i = 0; i < channels.length; i++) {
-            newBlocks[i] = page.getBlock(channels[i]);
-        }
-        return new Page(page.getPositionCount(), newBlocks);
     }
 
     private void addRowsToAggregates(Page page, int startPosition, int endPosition)

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/PageChannelSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/PageChannelSelector.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator.exchange;
 
 import com.facebook.presto.common.Page;
-import com.facebook.presto.common.block.Block;
 
 import java.util.function.Function;
 import java.util.stream.IntStream;
@@ -29,20 +28,13 @@ public class PageChannelSelector
 
     public PageChannelSelector(int... channels)
     {
-        checkArgument(IntStream.of(channels).allMatch(channel -> channel >= 0), "channels must be positive");
         this.channels = requireNonNull(channels, "channels is null").clone();
+        checkArgument(IntStream.of(channels).allMatch(channel -> channel >= 0), "channels must be positive");
     }
 
     @Override
     public Page apply(Page page)
     {
-        requireNonNull(page, "page is null");
-
-        Block[] blocks = new Block[channels.length];
-        for (int i = 0; i < channels.length; i++) {
-            int channel = channels[i];
-            blocks[i] = page.getBlock(channel);
-        }
-        return new Page(page.getPositionCount(), blocks);
+        return requireNonNull(page, "page is null").extractChannels(channels);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/InputChannels.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/InputChannels.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator.project;
 
 import com.facebook.presto.common.Page;
-import com.facebook.presto.common.block.Block;
 import com.google.common.primitives.Ints;
 
 import java.util.Arrays;
@@ -49,11 +48,7 @@ public class InputChannels
 
     public Page getInputChannels(Page page)
     {
-        Block[] blocks = new Block[inputChannels.length];
-        for (int i = 0; i < inputChannels.length; i++) {
-            blocks[i] = page.getBlock(inputChannels[i]);
-        }
-        return new Page(page.getPositionCount(), blocks);
+        return page.extractChannels(inputChannels);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/split/MappedPageSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/MappedPageSource.java
@@ -14,12 +14,10 @@
 package com.facebook.presto.split;
 
 import com.facebook.presto.common.Page;
-import com.facebook.presto.common.block.Block;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.google.common.primitives.Ints;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
@@ -67,10 +65,7 @@ public class MappedPageSource
         if (nextPage == null) {
             return null;
         }
-        Block[] blocks = Arrays.stream(delegateFieldIndex)
-                .mapToObj(nextPage::getBlock)
-                .toArray(Block[]::new);
-        return new Page(nextPage.getPositionCount(), blocks);
+        return nextPage.extractChannels(delegateFieldIndex);
     }
 
     @Override


### PR DESCRIPTION
Adds two new utility methods to `Page`:
- `copyPositions(int[] retainedPositions, int offset, int length)` which mirrors `getRegion`
- `extractChannels(int[] channels)` which creates a new page with arbitrary channel selection / reordering

The follow up commit then updates various operators and classes that explicitly created and manipulated Block arrays to use equivalent Page methods that avoid extra defensive copies.

```
== NO RELEASE NOTE ==
```
