### PR TITLE
Export slim query info to file upon PoS query completion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
         <module>presto-benchmark-runner</module>
         <module>presto-spark-classloader-interface</module>
         <module>presto-spark-base</module>
+        <module>presto-spark-common</module>
         <module>presto-spark</module>
         <module>presto-spark-package</module>
         <module>presto-spark-launcher</module>
@@ -519,6 +520,12 @@
             <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-spark</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-spark-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
@@ -131,7 +131,7 @@ public final class QueryResourceUtil
         }
     }
 
-    private static Set<String> globalUniqueNodes(StageInfo stageInfo)
+    public static Set<String> globalUniqueNodes(StageInfo stageInfo)
     {
         if (stageInfo == null) {
             return ImmutableSet.of();

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -48,6 +48,11 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spark-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spi</artifactId>
         </dependency>
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -221,6 +221,7 @@ public class PrestoSparkModule
         jsonCodecBinder(binder).bindJsonCodec(StageInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(OperatorStats.class);
         jsonCodecBinder(binder).bindJsonCodec(QueryInfo.class);
+        jsonCodecBinder(binder).bindJsonCodec(PrestoSparkQueryInfo.class);
 
         // index manager
         binder.bind(IndexManager.class).in(Scopes.SINGLETON);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -165,7 +165,7 @@ public class PrestoSparkQueryExecutionFactory
     private final QueryMonitor queryMonitor;
     private final JsonCodec<TaskInfo> taskInfoJsonCodec;
     private final JsonCodec<PrestoSparkTaskDescriptor> sparkTaskDescriptorJsonCodec;
-    private final JsonCodec<QueryInfo> queryInfoJsonCodec;
+    private final JsonCodec<PrestoSparkQueryInfo> queryInfoJsonCodec;
     private final TransactionManager transactionManager;
     private final AccessControl accessControl;
     private final Metadata metadata;
@@ -188,7 +188,7 @@ public class PrestoSparkQueryExecutionFactory
             QueryMonitor queryMonitor,
             JsonCodec<TaskInfo> taskInfoJsonCodec,
             JsonCodec<PrestoSparkTaskDescriptor> sparkTaskDescriptorJsonCodec,
-            JsonCodec<QueryInfo> queryInfoJsonCodec,
+            JsonCodec<PrestoSparkQueryInfo> queryInfoJsonCodec,
             TransactionManager transactionManager,
             AccessControl accessControl,
             Metadata metadata,
@@ -338,7 +338,10 @@ public class PrestoSparkQueryExecutionFactory
                         Optional.empty(),
                         warningCollector);
                 queryMonitor.queryCompletedEvent(queryInfo);
-                queryInfoOutputPath.ifPresent(path -> writeQueryInfo(path, queryInfo, queryInfoJsonCodec));
+                queryInfoOutputPath.ifPresent(path -> writeQueryInfo(
+                        path,
+                        PrestoSparkQueryInfo.createFromQueryInfo(queryInfo),
+                        queryInfoJsonCodec));
             }
             catch (RuntimeException eventFailure) {
                 log.error(eventFailure, "Error publishing query immediate failure event");
@@ -519,7 +522,10 @@ public class PrestoSparkQueryExecutionFactory
                 false);
     }
 
-    private static void writeQueryInfo(Path queryInfoOutputPath, QueryInfo queryInfo, JsonCodec<QueryInfo> queryInfoJsonCodec)
+    private static void writeQueryInfo(
+            Path queryInfoOutputPath,
+            PrestoSparkQueryInfo queryInfo,
+            JsonCodec<PrestoSparkQueryInfo> queryInfoJsonCodec)
     {
         try {
             Files.write(queryInfoOutputPath, queryInfoJsonCodec.toJsonBytes(queryInfo));
@@ -550,7 +556,7 @@ public class PrestoSparkQueryExecutionFactory
 
         private final JsonCodec<TaskInfo> taskInfoJsonCodec;
         private final JsonCodec<PrestoSparkTaskDescriptor> sparkTaskDescriptorJsonCodec;
-        private final JsonCodec<QueryInfo> queryInfoJsonCodec;
+        private final JsonCodec<PrestoSparkQueryInfo> queryInfoJsonCodec;
         private final PrestoSparkRddFactory rddFactory;
         private final TableWriteInfo tableWriteInfo;
         private final TransactionManager transactionManager;
@@ -574,7 +580,7 @@ public class PrestoSparkQueryExecutionFactory
                 Optional<String> sparkQueueName,
                 JsonCodec<TaskInfo> taskInfoJsonCodec,
                 JsonCodec<PrestoSparkTaskDescriptor> sparkTaskDescriptorJsonCodec,
-                JsonCodec<QueryInfo> queryInfoJsonCodec,
+                JsonCodec<PrestoSparkQueryInfo> queryInfoJsonCodec,
                 PrestoSparkRddFactory rddFactory,
                 TableWriteInfo tableWriteInfo,
                 TransactionManager transactionManager,
@@ -790,7 +796,10 @@ public class PrestoSparkQueryExecutionFactory
                     warningCollector);
 
             queryMonitor.queryCompletedEvent(queryInfo);
-            queryInfoOutputPath.ifPresent(path -> writeQueryInfo(path, queryInfo, queryInfoJsonCodec));
+            queryInfoOutputPath.ifPresent(path -> writeQueryInfo(
+                    path,
+                    PrestoSparkQueryInfo.createFromQueryInfo(queryInfo),
+                    queryInfoJsonCodec));
         }
 
         private void processShuffleStats()

--- a/presto-spark-common/pom.xml
+++ b/presto-spark-common/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.240-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-spark-common</artifactId>
+    <name>presto-spark-common</name>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>

--- a/presto-spark-common/src/main/java/com/facebook/presto/spark/PrestoSparkQueryInfo.java
+++ b/presto-spark-common/src/main/java/com/facebook/presto/spark/PrestoSparkQueryInfo.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.execution.ExecutionFailureInfo;
+import com.facebook.presto.execution.QueryInfo;
+import com.facebook.presto.execution.QueryStats;
+import com.facebook.presto.execution.StageInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Optional;
+
+import static com.facebook.presto.server.protocol.QueryResourceUtil.globalUniqueNodes;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class PrestoSparkQueryInfo
+{
+    // the following fields are based on com.facebook.presto.jdbc.QueryStats,
+    // with the following fields removed:
+    //  - queued
+    //  - queuedSplits
+    //  - runningSplits
+    //  - completedSplits: duplciate of totalSplits in Presto-on-Spark
+    //  - queuedTimeMillis
+    //  - rootStage: it can be too verbose
+    private final String queryId;
+    private final String state;
+    private final int nodes;
+    private final int totalSplits;
+    private final long cpuTimeMillis;
+    private final long wallTimeMillis;
+    private final long elapsedTimeMillis;
+    private final long processedRows;
+    private final long processedBytes;
+    private final long peakMemoryBytes;
+    private final long peakTotalMemoryBytes;
+    private final long peakTaskTotalMemoryBytes;
+
+    private final Optional<ExecutionFailureInfo> failureInfo;
+
+    @JsonCreator
+    public PrestoSparkQueryInfo(
+            String queryId,
+            String state,
+            int nodes,
+            int totalSplits,
+            long cpuTimeMillis,
+            long wallTimeMillis,
+            long elapsedTimeMillis,
+            long processedRows,
+            long processedBytes,
+            long peakMemoryBytes,
+            long peakTotalMemoryBytes,
+            long peakTaskTotalMemoryBytes,
+            Optional<ExecutionFailureInfo> failureInfo)
+    {
+        this.queryId = requireNonNull(queryId, "queryId is null");
+        this.state = requireNonNull(state, "state is null");
+        this.nodes = nodes;
+        this.totalSplits = totalSplits;
+        this.cpuTimeMillis = cpuTimeMillis;
+        this.wallTimeMillis = wallTimeMillis;
+        this.elapsedTimeMillis = elapsedTimeMillis;
+        this.processedRows = processedRows;
+        this.processedBytes = processedBytes;
+        this.peakMemoryBytes = peakMemoryBytes;
+        this.peakTotalMemoryBytes = peakTotalMemoryBytes;
+        this.peakTaskTotalMemoryBytes = peakTaskTotalMemoryBytes;
+
+        this.failureInfo = requireNonNull(failureInfo, "failureInfo is null");
+    }
+
+    @JsonProperty
+    public String getQueryId()
+    {
+        return queryId;
+    }
+
+    @JsonProperty
+    public String getState()
+    {
+        return state;
+    }
+
+    @JsonProperty
+    public int getNodes()
+    {
+        return nodes;
+    }
+
+    @JsonProperty
+    public int getTotalSplits()
+    {
+        return totalSplits;
+    }
+
+    @JsonProperty
+    public long getCpuTimeMillis()
+    {
+        return cpuTimeMillis;
+    }
+
+    @JsonProperty
+    public long getWallTimeMillis()
+    {
+        return wallTimeMillis;
+    }
+
+    @JsonProperty
+    public long getElapsedTimeMillis()
+    {
+        return elapsedTimeMillis;
+    }
+
+    @JsonProperty
+    public long getProcessedRows()
+    {
+        return processedRows;
+    }
+
+    @JsonProperty
+    public long getProcessedBytes()
+    {
+        return processedBytes;
+    }
+
+    @JsonProperty
+    public long getPeakMemoryBytes()
+    {
+        return peakMemoryBytes;
+    }
+
+    @JsonProperty
+    public long getPeakTotalMemoryBytes()
+    {
+        return peakTotalMemoryBytes;
+    }
+
+    @JsonProperty
+    public long getPeakTaskTotalMemoryBytes()
+    {
+        return peakTaskTotalMemoryBytes;
+    }
+
+    @JsonProperty
+    public Optional<ExecutionFailureInfo> getFailureInfo()
+    {
+        return failureInfo;
+    }
+
+    public static PrestoSparkQueryInfo createFromQueryInfo(QueryInfo queryInfo)
+    {
+        QueryStats queryStats = queryInfo.getQueryStats();
+        StageInfo outputStage = queryInfo.getOutputStage().orElse(null);
+
+        return new PrestoSparkQueryInfo(
+                queryInfo.getQueryId().getId(),
+                queryInfo.getState().name(),
+                globalUniqueNodes(outputStage).size(),
+                queryStats.getTotalDrivers(),
+                queryStats.getTotalCpuTime().toMillis(),
+                queryStats.getTotalScheduledTime().toMillis(),
+                queryStats.getElapsedTime().toMillis(),
+                queryStats.getRawInputPositions(),
+                queryStats.getRawInputDataSize().toBytes(),
+                queryStats.getPeakUserMemoryReservation().toBytes(),
+                queryStats.getPeakTotalMemoryReservation().toBytes(),
+                queryStats.getPeakTaskTotalMemory().toBytes(),
+                Optional.ofNullable(queryInfo.getFailureInfo()));
+    }
+}


### PR DESCRIPTION
Presto-on-Spark supports exporting JSON serialized QueryInfo since
670ecb5dd26da8ecbe0233c6c60502e5c93cf2d5. In practice, we found full
QueryInfo can frequently be too verbose (e.g. >16MB). Thus we export a
slim version instead.

Test plan - test with a query, and see the following 
```
{"queryId":"20200807_031720_00000_g5vxr","state":"FINISHED","nodes":1,"totalSplits":16441,"cpuTimeMillis":7451871,"wallTimeMillis":39090156,"elapsedTimeMillis":120011,"processedRows":39079360449,"processedBytes":6094416586,"peakMemoryBytes":0,"peakTotalMemoryBytes":0,"peakTaskTotalMemoryBytes":0}
```

Related PR is https://github.com/prestodb/presto/pull/14825

```
== NO RELEASE NOTE ==
```
