### PR TITLE
Allow procedures to have optional arguments with default values

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingProcedures.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingProcedures.java
@@ -97,6 +97,30 @@ public final class TestingProcedures
     }
 
     @UsedByGeneratedCode
+    public void optionals(ConnectorSession session, String x)
+    {
+        tester.recordCalled("optionals", x);
+    }
+
+    @UsedByGeneratedCode
+    public void optionals2(ConnectorSession session, String x, String y)
+    {
+        tester.recordCalled("optionals2", x, y);
+    }
+
+    @UsedByGeneratedCode
+    public void optionals3(ConnectorSession session, String x, String y, String z)
+    {
+        tester.recordCalled("optionals3", x, y, z);
+    }
+
+    @UsedByGeneratedCode
+    public void optionals4(ConnectorSession session, String x, String y, String z, String v)
+    {
+        tester.recordCalled("optionals4", x, y, z, v);
+    }
+
+    @UsedByGeneratedCode
     public void error()
     {
         tester.recordCalled("error");
@@ -124,6 +148,20 @@ public final class TestingProcedures
                         new Argument("x", BIGINT))))
                 .add(procedure(schema, "test_session_last", "sessionLast", ImmutableList.of(
                         new Argument("x", VARCHAR))))
+                .add(procedure(schema, "test_optionals", "optionals", ImmutableList.of(
+                        new Argument("x", VARCHAR, false, "hello"))))
+                .add(procedure(schema, "test_optionals2", "optionals2", ImmutableList.of(
+                        new Argument("x", VARCHAR),
+                        new Argument("y", VARCHAR, false, "world"))))
+                .add(procedure(schema, "test_optionals3", "optionals3", ImmutableList.of(
+                        new Argument("x", VARCHAR, false, "this"),
+                        new Argument("y", VARCHAR, false, "is"),
+                        new Argument("z", VARCHAR, false, "default"))))
+                .add(procedure(schema, "test_optionals4", "optionals4", ImmutableList.of(
+                        new Argument("x", VARCHAR),
+                        new Argument("y", VARCHAR),
+                        new Argument("z", VARCHAR, false, "z default"),
+                        new Argument("v", VARCHAR, false, "v default"))))
                 .add(procedure(schema, "test_exception", "exception", ImmutableList.of()))
                 .add(procedure(schema, "test_error", "error", ImmutableList.of()))
                 .build();

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestProcedureCreation.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestProcedureCreation.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.tests;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Test(singleThreaded = true)
+public class TestProcedureCreation
+{
+    @Test
+    public void shouldThrowExceptionWhenOptionalArgumentIsNotLast()
+    {
+        assertThatThrownBy(() -> createTestProcedure(ImmutableList.of(
+                new Procedure.Argument("name", VARCHAR, false, null),
+                new Procedure.Argument("name2", VARCHAR, true, null))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Optional arguments should follow required ones");
+
+        assertThatThrownBy(() -> createTestProcedure(ImmutableList.of(
+                new Procedure.Argument("name", VARCHAR, true, null),
+                new Procedure.Argument("name2", VARCHAR, true, null),
+                new Procedure.Argument("name3", VARCHAR, true, null),
+                new Procedure.Argument("name4", VARCHAR, false, null),
+                new Procedure.Argument("name5", VARCHAR, true, null))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Optional arguments should follow required ones");
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenArgumentNameRepeates()
+    {
+        assertThatThrownBy(() -> createTestProcedure(ImmutableList.of(
+                new Procedure.Argument("name", VARCHAR, false, null),
+                new Procedure.Argument("name", VARCHAR, true, null))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Duplicate argument name: 'name'");
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenProcedureIsNonVoid()
+    {
+        assertThatThrownBy(() -> new Procedure(
+                "schema",
+                "name",
+                ImmutableList.of(),
+                methodHandle(Procedures.class, "funWithoutArguments")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Method must return void");
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenMethodHandleIsNull()
+    {
+        assertThatThrownBy(() -> new Procedure(
+                "schema",
+                "name",
+                ImmutableList.of(),
+                null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("methodHandle is null");
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenMethodHandleHasVarargs()
+    {
+        assertThatThrownBy(() -> new Procedure(
+                "schema",
+                "name",
+                ImmutableList.of(),
+                methodHandle(Procedures.class, "funWithVarargs", String[].class)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Method must have fixed arity");
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenArgumentCountDoesntMatch()
+    {
+        assertThatThrownBy(() -> new Procedure(
+                "schema",
+                "name",
+                ImmutableList.of(
+                        new Procedure.Argument("name", VARCHAR, true, null),
+                        new Procedure.Argument("name2", VARCHAR, true, null),
+                        new Procedure.Argument("name3", VARCHAR, true, null)),
+                methodHandle(Procedures.class, "fun1", ConnectorSession.class, Object.class)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Method parameter count must match arguments");
+    }
+
+    private static Procedure createTestProcedure(List<Procedure.Argument> arguments)
+    {
+        int argumentsCount = arguments.size();
+        String functionName = "fun" + argumentsCount;
+
+        Class<?>[] clazzes = new Class<?>[argumentsCount + 1];
+        clazzes[0] = ConnectorSession.class;
+
+        for (int i = 0; i < argumentsCount; i++) {
+            clazzes[i + 1] = Object.class;
+        }
+
+        return new Procedure(
+                "schema",
+                "name",
+                arguments,
+                methodHandle(Procedures.class, functionName, clazzes));
+    }
+
+    public static class Procedures
+    {
+        public void fun0(ConnectorSession session) {}
+
+        public void fun1(ConnectorSession session, Object arg1) {}
+
+        public void fun2(ConnectorSession session, Object arg1, Object arg2) {}
+
+        public void fun2(Object arg1, Object arg2) {}
+
+        public void fun3(ConnectorSession session, Object arg1, Object arg2, Object arg3) {}
+
+        public void fun4(ConnectorSession session, Object arg1, Object arg2, Object arg3, Object arg4) {}
+
+        public void fun5(ConnectorSession session, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) {}
+
+        public String funWithoutArguments()
+        {
+            return "";
+        }
+
+        public void funWithVarargs(String... arguments) {}
+    }
+}


### PR DESCRIPTION
Cherry pick https://github.com/prestosql/presto/commit/7a7404d78c8477a509378fbaddca6e1f1499689d

This change allows procedures to be defined with optional arguments or default values for arguments

```
== RELEASE NOTES ==

General Changes
* Allow procedures to have optional arguments with default values
```


