### PR TITLE
Batch presto spark rows

### DIFF
--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -157,6 +157,16 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -204,6 +214,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
@@ -17,13 +17,17 @@ import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
 import io.airlift.units.DataSize;
 
+import javax.validation.constraints.NotNull;
+
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
 
 public class PrestoSparkConfig
 {
     private boolean sparkPartitionCountAutoTuneEnabled = true;
     private int initialSparkPartitionCount = 16;
     private DataSize maxSplitsDataSizePerSparkPartition = new DataSize(2, GIGABYTE);
+    private DataSize shuffleOutputTargetAverageRowSize = new DataSize(1, KILOBYTE);
 
     public boolean isSparkPartitionCountAutoTuneEnabled()
     {
@@ -61,6 +65,20 @@ public class PrestoSparkConfig
     public PrestoSparkConfig setMaxSplitsDataSizePerSparkPartition(DataSize maxSplitsDataSizePerSparkPartition)
     {
         this.maxSplitsDataSizePerSparkPartition = maxSplitsDataSizePerSparkPartition;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getShuffleOutputTargetAverageRowSize()
+    {
+        return shuffleOutputTargetAverageRowSize;
+    }
+
+    @Config("spark.shuffle-output-target-average-row-size")
+    @ConfigDescription("Target average size for row entries produced by Presto on Spark for shuffle")
+    public PrestoSparkConfig setShuffleOutputTargetAverageRowSize(DataSize shuffleOutputTargetAverageRowSize)
+    {
+        this.shuffleOutputTargetAverageRowSize = shuffleOutputTargetAverageRowSize;
         return this;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -819,33 +819,44 @@ public class PrestoSparkQueryExecutionFactory
         private void logShuffleStatsSummary(ShuffleStatsKey key, List<PrestoSparkShuffleStats> statsList)
         {
             long totalProcessedRows = 0;
+            long totalProcessedRowBatches = 0;
             long totalProcessedBytes = 0;
             long totalElapsedWallTimeMills = 0;
             for (PrestoSparkShuffleStats stats : statsList) {
                 totalProcessedRows += stats.getProcessedRows();
+                totalProcessedRowBatches += stats.getProcessedRowBatches();
                 totalProcessedBytes += stats.getProcessedBytes();
                 totalElapsedWallTimeMills += stats.getElapsedWallTimeMills();
             }
             long totalElapsedWallTimeSeconds = totalElapsedWallTimeMills / 1000;
             long rowsPerSecond = totalProcessedRows;
+            long rowBatchesPerSecond = totalProcessedRowBatches;
             long bytesPerSecond = totalProcessedBytes;
             if (totalElapsedWallTimeSeconds > 0) {
                 rowsPerSecond = totalProcessedRows / totalElapsedWallTimeSeconds;
+                rowBatchesPerSecond = totalProcessedRowBatches / totalElapsedWallTimeSeconds;
                 bytesPerSecond = totalProcessedBytes / totalElapsedWallTimeSeconds;
             }
             long averageRowSize = 0;
             if (totalProcessedRows > 0) {
                 averageRowSize = totalProcessedBytes / totalProcessedRows;
             }
+            long averageRowBatchSize = 0;
+            if (totalProcessedRowBatches > 0) {
+                averageRowBatchSize = totalProcessedBytes / totalProcessedRowBatches;
+            }
             log.info(
-                    "Fragment: %s, Operation: %s, Rows: %s, Size: %s, Avg Row Size: %s, Time: %s, %srows/s, %s/s",
+                    "Fragment: %s, Operation: %s, Rows: %s, Row Batches: %s, Size: %s, Avg Row Size: %s, Avg Row Batch Size: %s, Time: %s, %s rows/s, %s batches/s, %s/s",
                     key.getFragmentId(),
                     key.getOperation(),
                     totalProcessedRows,
+                    totalProcessedRowBatches,
                     DataSize.succinctBytes(totalProcessedBytes),
                     DataSize.succinctBytes(averageRowSize),
+                    DataSize.succinctBytes(averageRowBatchSize),
                     Duration.succinctDuration(totalElapsedWallTimeMills, MILLISECONDS),
                     rowsPerSecond,
+                    rowBatchesPerSecond,
                     DataSize.succinctBytes(bytesPerSecond));
         }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
@@ -22,8 +22,8 @@ import javax.inject.Inject;
 
 import java.util.List;
 
-import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
+import static com.facebook.presto.spi.session.PropertyMetadata.dataSizeProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
 
 public class PrestoSparkSessionProperties
@@ -31,6 +31,7 @@ public class PrestoSparkSessionProperties
     public static final String SPARK_PARTITION_COUNT_AUTO_TUNE_ENABLED = "spark_partition_count_auto_tune_enabled";
     public static final String SPARK_INITIAL_PARTITION_COUNT = "spark_initial_partition_count";
     public static final String MAX_SPLITS_DATA_SIZE_PER_SPARK_PARTITION = "max_splits_data_size_per_spark_partition";
+    public static final String SHUFFLE_OUTPUT_TARGET_AVERAGE_ROW_SIZE = "shuffle_output_target_average_row_size";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -48,15 +49,16 @@ public class PrestoSparkSessionProperties
                         "Initial partition count for Spark RDD when reading table",
                         prestoSparkConfig.getInitialSparkPartitionCount(),
                         false),
-                new PropertyMetadata<>(
+                dataSizeProperty(
                         MAX_SPLITS_DATA_SIZE_PER_SPARK_PARTITION,
                         "Maximal size in bytes for splits assigned to one partition",
-                        VARCHAR,
-                        DataSize.class,
                         prestoSparkConfig.getMaxSplitsDataSizePerSparkPartition(),
-                        false,
-                        value -> DataSize.valueOf((String) value),
-                        DataSize::toString));
+                        false),
+                dataSizeProperty(
+                        SHUFFLE_OUTPUT_TARGET_AVERAGE_ROW_SIZE,
+                        "Target average size for row entries produced by Presto on Spark for shuffle",
+                        prestoSparkConfig.getShuffleOutputTargetAverageRowSize(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -77,5 +79,10 @@ public class PrestoSparkSessionProperties
     public static DataSize getMaxSplitsDataSizePerSparkPartition(Session session)
     {
         return session.getSystemProperty(MAX_SPLITS_DATA_SIZE_PER_SPARK_PARTITION, DataSize.class);
+    }
+
+    public static DataSize getShuffleOutputTargetAverageRowSize(Session session)
+    {
+        return session.getSystemProperty(SHUFFLE_OUTPUT_TARGET_AVERAGE_ROW_SIZE, DataSize.class);
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowBatch.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowBatch.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spark.execution;
 
 import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
+import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
@@ -27,7 +28,12 @@ import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.util.Arrays.fill;
 import static java.util.Objects.requireNonNull;
 
 public class PrestoSparkRowBatch
@@ -35,19 +41,22 @@ public class PrestoSparkRowBatch
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(PrestoSparkRowBatch.class).instanceSize();
 
-    private static final int DEFAULT_TARGET_SIZE = 1024 * 1024;
+    private static final int MIN_TARGET_SIZE_IN_BYTES = 1024 * 1024;
+    private static final int MAX_TARGET_SIZE_IN_BYTES = 10 * 1024 * 1024;
     private static final int DEFAULT_EXPECTED_ROWS_COUNT = 10000;
     private static final int REPLICATED_ROW_PARTITION_ID = -1;
+    private static final short MULTI_ROW_ENTRY_MAX_SIZE_IN_BYTES = 10 * 1024;
+    private static final short MULTI_ROW_ENTRY_MAX_ROW_COUNT = 10 * 1024;
 
     private final int partitionCount;
     private final int rowCount;
     private final byte[] rowData;
     private final int[] rowPartitions;
     private final int[] rowOffsets;
-    private final int totalSize;
+    private final int totalSizeInBytes;
     private final long retainedSizeInBytes;
 
-    private PrestoSparkRowBatch(int partitionCount, int rowCount, byte[] rowData, int[] rowPartitions, int[] rowOffsets, int totalSize)
+    private PrestoSparkRowBatch(int partitionCount, int rowCount, byte[] rowData, int[] rowPartitions, int[] rowOffsets, int totalSizeInBytes)
     {
         this.partitionCount = partitionCount;
         this.rowCount = rowCount;
@@ -58,12 +67,12 @@ public class PrestoSparkRowBatch
                 + sizeOf(rowData)
                 + sizeOf(rowPartitions)
                 + sizeOf(rowOffsets);
-        this.totalSize = totalSize;
+        this.totalSizeInBytes = totalSizeInBytes;
     }
 
     public RowTupleSupplier createRowTupleSupplier()
     {
-        return new RowTupleSupplier(partitionCount, rowCount, rowData, rowPartitions, rowOffsets, totalSize);
+        return new RowTupleSupplier(partitionCount, rowCount, rowData, rowPartitions, rowOffsets, totalSizeInBytes);
     }
 
     public long getRetainedSizeInBytes()
@@ -77,14 +86,38 @@ public class PrestoSparkRowBatch
         return rowCount;
     }
 
-    public static PrestoSparkRowBatchBuilder builder(int partitionCount)
+    public static PrestoSparkRowBatchBuilder builder(int partitionCount, int targetAverageRowSizeInBytes)
     {
-        return new PrestoSparkRowBatchBuilder(partitionCount, DEFAULT_TARGET_SIZE, DEFAULT_EXPECTED_ROWS_COUNT);
+        checkArgument(partitionCount > 0, "partitionCount must be greater then zero: %s", partitionCount);
+        int targetSizeInBytes = partitionCount * targetAverageRowSizeInBytes;
+        targetSizeInBytes = max(targetSizeInBytes, MIN_TARGET_SIZE_IN_BYTES);
+        targetSizeInBytes = min(targetSizeInBytes, MAX_TARGET_SIZE_IN_BYTES);
+        targetAverageRowSizeInBytes = min(targetSizeInBytes / partitionCount, targetAverageRowSizeInBytes);
+        return builder(
+                partitionCount,
+                targetSizeInBytes,
+                DEFAULT_EXPECTED_ROWS_COUNT,
+                targetAverageRowSizeInBytes,
+                MULTI_ROW_ENTRY_MAX_SIZE_IN_BYTES,
+                MULTI_ROW_ENTRY_MAX_ROW_COUNT);
     }
 
-    public static PrestoSparkRowBatchBuilder builder(int partitionCount, int targetSizeInBytes, int expectedRowsCount)
+    @VisibleForTesting
+    static PrestoSparkRowBatchBuilder builder(
+            int partitionCount,
+            int targetSizeInBytes,
+            int expectedRowsCount,
+            int targetAverageRowSizeInBytes,
+            int maxEntrySizeInBytes,
+            int maxRowsPerEntry)
     {
-        return new PrestoSparkRowBatchBuilder(partitionCount, targetSizeInBytes, expectedRowsCount);
+        return new PrestoSparkRowBatchBuilder(
+                partitionCount,
+                targetSizeInBytes,
+                expectedRowsCount,
+                targetAverageRowSizeInBytes,
+                maxEntrySizeInBytes,
+                maxRowsPerEntry);
     }
 
     public static class PrestoSparkRowBatchBuilder
@@ -93,20 +126,32 @@ public class PrestoSparkRowBatch
 
         private final int partitionCount;
         private final int targetSizeInBytes;
+        private final int targetAverageRowSizeInBytes;
+        private final int maxEntrySizeInBytes;
+        private final int maxRowsPerEntry;
         private final DynamicSliceOutput sliceOutput;
         private int[] rowOffsets;
-        private int totalSize;
+        private int totalSizeInBytes;
         private int[] rowPartitions;
         private int rowCount;
 
         private int currentRowOffset;
         private boolean openEntry;
 
-        private PrestoSparkRowBatchBuilder(int partitionCount, int targetSizeInBytes, int expectedRowsCount)
+        private PrestoSparkRowBatchBuilder(
+                int partitionCount,
+                int targetSizeInBytes,
+                int expectedRowsCount,
+                int targetAverageRowSizeInBytes,
+                int maxEntrySizeInBytes,
+                int maxRowsPerEntry)
         {
             checkArgument(partitionCount > 0, "partitionCount must be greater then zero: %s", partitionCount);
             this.partitionCount = partitionCount;
             this.targetSizeInBytes = targetSizeInBytes;
+            this.targetAverageRowSizeInBytes = targetAverageRowSizeInBytes;
+            this.maxEntrySizeInBytes = maxEntrySizeInBytes;
+            this.maxRowsPerEntry = maxRowsPerEntry;
             sliceOutput = new DynamicSliceOutput((int) (targetSizeInBytes * 1.2f));
             rowOffsets = new int[expectedRowsCount];
             rowPartitions = new int[expectedRowsCount];
@@ -132,6 +177,7 @@ public class PrestoSparkRowBatch
             checkState(!openEntry, "previous entry must be closed before creating a new entry");
             openEntry = true;
             currentRowOffset = sliceOutput.size();
+            sliceOutput.writeShort(1);
             return sliceOutput;
         }
 
@@ -157,7 +203,7 @@ public class PrestoSparkRowBatch
             rowPartitions[rowCount] = partitionId;
 
             rowCount++;
-            totalSize += sliceOutput.size() - currentRowOffset;
+            totalSizeInBytes += sliceOutput.size() - currentRowOffset;
         }
 
         private static int[] ensureCapacity(int[] array, int capacity)
@@ -171,13 +217,91 @@ public class PrestoSparkRowBatch
         public PrestoSparkRowBatch build()
         {
             checkState(!openEntry, "entry must be closed before creating a row batch");
+
+            if (rowCount == 0) {
+                return createDirectRowBatch();
+            }
+
+            int averageRowSize = totalSizeInBytes / rowCount;
+            if (averageRowSize < targetAverageRowSizeInBytes) {
+                return createGroupedRowBatch();
+            }
+
+            return createDirectRowBatch();
+        }
+
+        private PrestoSparkRowBatch createDirectRowBatch()
+        {
             return new PrestoSparkRowBatch(
                     partitionCount,
                     rowCount,
                     sliceOutput.getUnderlyingSlice().byteArray(),
                     rowPartitions,
                     rowOffsets,
-                    totalSize);
+                    totalSizeInBytes);
+        }
+
+        private PrestoSparkRowBatch createGroupedRowBatch()
+        {
+            RowIndex rowIndex = RowIndex.create(rowCount, partitionCount, rowPartitions);
+            byte[] data = sliceOutput.getUnderlyingSlice().byteArray();
+
+            DynamicSliceOutput output = new DynamicSliceOutput((int) (totalSizeInBytes * 1.2f));
+            int expectedEntriesCount = (int) ((totalSizeInBytes / targetAverageRowSizeInBytes) * 1.2f);
+            int[] entryOffsets = new int[expectedEntriesCount];
+            int[] entryPartitions = new int[expectedEntriesCount];
+            int entriesCount = 0;
+            for (int partition = REPLICATED_ROW_PARTITION_ID; partition < partitionCount; partition++) {
+                while (rowIndex.hasNextRow(partition)) {
+                    // start entry
+                    short currentEntrySize = 0;
+                    short currentEntryRowCount = 0;
+                    int currentEntryOffset = output.size();
+                    // Reserve space for the row count, the actual row count will be set later
+                    output.writeShort(0);
+
+                    entryOffsets = ensureCapacity(entryOffsets, entriesCount + 1);
+                    entryOffsets[entriesCount] = currentEntryOffset;
+                    entryPartitions = ensureCapacity(entryPartitions, entriesCount + 1);
+                    entryPartitions[entriesCount] = partition;
+
+                    while (rowIndex.hasNextRow(partition)) {
+                        int row = rowIndex.peekRow(partition);
+                        int followingRow = row + 1;
+                        int rowOffset = rowOffsets[row];
+                        int followingRowOffset = followingRow < rowCount ? rowOffsets[followingRow] : totalSizeInBytes;
+                        int rowSize = followingRowOffset - rowOffset;
+
+                        verify(rowSize >= 2, "rowSize is expected to be greater than or equal to 2: %s", rowSize);
+
+                        // skip the rows count
+                        rowOffset += 2;
+                        rowSize -= 2;
+
+                        if (currentEntryRowCount > 0 && (currentEntrySize + rowSize > maxEntrySizeInBytes || currentEntryRowCount + 1 > maxRowsPerEntry)) {
+                            break;
+                        }
+
+                        output.writeBytes(data, rowOffset, rowSize);
+                        currentEntrySize += rowSize;
+                        currentEntryRowCount++;
+
+                        rowIndex.nextRow(partition);
+                    }
+
+                    // entry is done
+                    output.getUnderlyingSlice().setShort(currentEntryOffset, currentEntryRowCount);
+                    entriesCount++;
+                }
+            }
+
+            return new PrestoSparkRowBatch(
+                    partitionCount,
+                    entriesCount,
+                    output.getUnderlyingSlice().byteArray(),
+                    entryPartitions,
+                    entryOffsets,
+                    output.size());
         }
     }
 
@@ -187,25 +311,27 @@ public class PrestoSparkRowBatch
         private final int rowCount;
         private final int[] rowPartitions;
         private final int[] rowOffsets;
-        private final int totalSize;
+        private final int totalSizeInBytes;
 
         private int remainingReplicasCount;
         private int currentRow;
         private final ByteBuffer rowData;
         private final MutablePartitionId mutablePartitionId;
+        private final PrestoSparkMutableRow row;
         private final Tuple2<MutablePartitionId, PrestoSparkMutableRow> tuple;
 
-        private RowTupleSupplier(int partitionCount, int rowCount, byte[] rowData, int[] rowPartitions, int[] rowOffsets, int totalSize)
+        private RowTupleSupplier(int partitionCount, int rowCount, byte[] rowData, int[] rowPartitions, int[] rowOffsets, int totalSizeInBytes)
         {
             this.partitionCount = partitionCount;
             this.rowCount = rowCount;
             this.rowPartitions = requireNonNull(rowPartitions, "rowPartitions is null");
             this.rowOffsets = requireNonNull(rowOffsets, "rowSizes is null");
-            this.totalSize = totalSize;
+            this.totalSizeInBytes = totalSizeInBytes;
 
             this.rowData = ByteBuffer.wrap(requireNonNull(rowData, "rowData is null"));
+            this.rowData.order(LITTLE_ENDIAN);
             mutablePartitionId = new MutablePartitionId();
-            PrestoSparkMutableRow row = new PrestoSparkMutableRow();
+            row = new PrestoSparkMutableRow();
             row.setBuffer(this.rowData);
             tuple = new Tuple2<>(mutablePartitionId, row);
         }
@@ -219,10 +345,13 @@ public class PrestoSparkRowBatch
 
             int currentRowOffset = rowOffsets[currentRow];
             int nextRow = currentRow + 1;
-            int nextRowOffset = nextRow < rowCount ? rowOffsets[nextRow] : totalSize;
+            int nextRowOffset = nextRow < rowCount ? rowOffsets[nextRow] : totalSizeInBytes;
             int rowSize = nextRowOffset - currentRowOffset;
             rowData.limit(currentRowOffset + rowSize);
             rowData.position(currentRowOffset);
+
+            short rowsCount = rowData.getShort(currentRowOffset);
+            row.setPositionCount(rowsCount);
 
             int partition = rowPartitions[currentRow];
             if (partition == REPLICATED_ROW_PARTITION_ID) {
@@ -240,6 +369,92 @@ public class PrestoSparkRowBatch
                 currentRow++;
             }
             return tuple;
+        }
+    }
+
+    /*
+     * Partitions rows into disjoint sets based on the partitions assigned
+     *
+     * int[] rowIndex - links rows that belong for the same partition
+     *
+     * For example for 3 rows with partitions assigned [2, 1, 2, 1] the
+     * row index will look like:
+     *
+     * [2, 3, -1, -1]
+     *
+     * int[] nextRow - contains the pointers to the next row for each partition:
+     *
+     * [-1, 1, 0]
+     *
+     * note: there's no rows with partition 0
+     *
+     * To get all rows for a single partition first we check what is the tip of the
+     * list of rows for that partition at the moment:
+     *
+     * int row = nextRow[partition]
+     *
+     * And then we iterate over the linked list to get all the rows that belong to
+     * the same partition:
+     *
+     * while (rowIndex[row] != -1)
+     *      row = rowIndex[row]
+     */
+    public static class RowIndex
+    {
+        private static final int NIL = -1;
+
+        private final int[] nextRow;
+        private final int[] rowIndex;
+
+        public static RowIndex create(int rowCount, int partitionCount, int[] partitions)
+        {
+            // one more slot for replicated partition
+            int[] nextRow = new int[partitionCount + 1];
+            fill(nextRow, NIL);
+            int[] rowIndex = new int[rowCount];
+            fill(rowIndex, NIL);
+
+            for (int row = rowCount - 1; row >= 0; row--) {
+                int partition = partitions[row];
+                int partitionIndex = getPartitionIndex(partition, nextRow);
+                int currentPointer = nextRow[partitionIndex];
+                nextRow[partitionIndex] = row;
+                rowIndex[row] = currentPointer;
+            }
+
+            return new RowIndex(nextRow, rowIndex);
+        }
+
+        private RowIndex(int[] nextRow, int[] rowIndex)
+        {
+            this.nextRow = requireNonNull(nextRow, "nextRow is null");
+            this.rowIndex = requireNonNull(rowIndex, "rowIndex is null");
+        }
+
+        public boolean hasNextRow(int partition)
+        {
+            return peekRow(partition) != NIL;
+        }
+
+        public int peekRow(int partition)
+        {
+            return nextRow[getPartitionIndex(partition, nextRow)];
+        }
+
+        public int nextRow(int partition)
+        {
+            int partitionIndex = getPartitionIndex(partition, nextRow);
+            int result = nextRow[partitionIndex];
+            nextRow[partitionIndex] = rowIndex[result];
+            return result;
+        }
+
+        private static int getPartitionIndex(int partition, int[] nextRow)
+        {
+            if (partition == REPLICATED_ROW_PARTITION_ID) {
+                return nextRow.length - 1;
+            }
+            return partition;
         }
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
@@ -31,6 +31,7 @@ import java.util.zip.InflaterOutputStream;
 import static com.facebook.presto.common.block.BlockUtil.compactArray;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.io.ByteStreams.toByteArray;
+import static java.lang.Math.toIntExact;
 
 public class PrestoSparkUtils
 {
@@ -52,7 +53,7 @@ public class PrestoSparkUtils
         return new SerializedPage(
                 Slices.wrappedBuffer(prestoSparkSerializedPage.getBytes()),
                 prestoSparkSerializedPage.getPageCodecMarkers(),
-                prestoSparkSerializedPage.getPositionCount(),
+                toIntExact(prestoSparkSerializedPage.getPositionCount()),
                 prestoSparkSerializedPage.getUncompressedSizeInBytes());
     }
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
 
 public class TestPrestoSparkConfig
 {
@@ -32,7 +33,8 @@ public class TestPrestoSparkConfig
         assertRecordedDefaults(ConfigAssertions.recordDefaults(PrestoSparkConfig.class)
                 .setSparkPartitionCountAutoTuneEnabled(true)
                 .setInitialSparkPartitionCount(16)
-                .setMaxSplitsDataSizePerSparkPartition(new DataSize(2, GIGABYTE)));
+                .setMaxSplitsDataSizePerSparkPartition(new DataSize(2, GIGABYTE))
+                .setShuffleOutputTargetAverageRowSize(new DataSize(1, KILOBYTE)));
     }
 
     @Test
@@ -42,11 +44,13 @@ public class TestPrestoSparkConfig
                 .put("spark.partition-count-auto-tune-enabled", "false")
                 .put("spark.initial-partition-count", "128")
                 .put("spark.max-splits-data-size-per-partition", "4GB")
+                .put("spark.shuffle-output-target-average-row-size", "10kB")
                 .build();
         PrestoSparkConfig expected = new PrestoSparkConfig()
                 .setSparkPartitionCountAutoTuneEnabled(false)
                 .setInitialSparkPartitionCount(128)
-                .setMaxSplitsDataSizePerSparkPartition(new DataSize(4, GIGABYTE));
+                .setMaxSplitsDataSizePerSparkPartition(new DataSize(4, GIGABYTE))
+                .setShuffleOutputTargetAverageRowSize(new DataSize(10, KILOBYTE));
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestPrestoSparkRowBatch.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestPrestoSparkRowBatch.java
@@ -16,56 +16,92 @@ package com.facebook.presto.spark.execution;
 import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
 import com.facebook.presto.spark.execution.PrestoSparkRowBatch.PrestoSparkRowBatchBuilder;
+import com.facebook.presto.spark.execution.PrestoSparkRowBatch.RowIndex;
 import com.facebook.presto.spark.execution.PrestoSparkRowBatch.RowTupleSupplier;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.SliceOutput;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.testng.annotations.Test;
 import scala.Tuple2;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.IntStream;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.Integer.BYTES;
+import static java.lang.Integer.MAX_VALUE;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class TestPrestoSparkRowBatch
 {
+    private static final int REPLICATED_ROW_PARTITION_ID = -1;
+
+    private static final int DEFAULT_TARGET_SIZE = 1024 * 1024;
+    private static final int DEFAULT_EXPECTED_ROWS = 10000;
+    private static final int NO_TARGET_ENTRY_SIZE_REQUIREMENT = 0;
+    private static final int UNLIMITED_MAX_ENTRY_ROW_COUNT = MAX_VALUE;
+    private static final int UNLIMITED_MAX_ENTRY_SIZE = MAX_VALUE;
+
     @Test
     public void testRoundTrip()
     {
         assertRoundTrip(ImmutableList.of());
-        assertRoundTrip(ImmutableList.of(createTuple(1, "row_data_1")));
-        assertRoundTrip(ImmutableList.of(createTuple(1, "")));
-        assertRoundTrip(ImmutableList.of(createTuple(1, ""), createTuple(1, "")));
-        assertRoundTrip(ImmutableList.of(createTuple(1, ""), createTuple(1, ""), createTuple(1, "")));
-        assertRoundTrip(ImmutableList.of(createTuple(1, "row_data_1"), createTuple(1, "row_data_2")));
-        assertRoundTrip(ImmutableList.of(createTuple(1, "row_data_1"), createTuple(2, "row_data_2")));
-        assertRoundTrip(ImmutableList.of(createTuple(1, "row_data_1"), createTuple(2, "row_data_2")));
+        assertRoundTrip(ImmutableList.of(
+                createRow(1, "row_data_1")));
+        assertRoundTrip(ImmutableList.of(
+                createRow(1, "")));
+        assertRoundTrip(ImmutableList.of(
+                createRow(1, ""),
+                createRow(1, "")));
+        assertRoundTrip(ImmutableList.of(
+                createRow(1, ""),
+                createRow(1, ""),
+                createRow(1, "")));
+        assertRoundTrip(ImmutableList.of(
+                createRow(1, "row_data_1"),
+                createRow(1, "row_data_2")));
+        assertRoundTrip(ImmutableList.of(
+                createRow(1, "row_data_1"),
+                createRow(2, "row_data_2")));
+        assertRoundTrip(ImmutableList.of(
+                createRow(1, "row_data_1"),
+                createRow(2, "row_data_2")));
         assertRoundTrip(IntStream.range(0, 4)
-                .mapToObj(i -> createTuple(i, "row_data_" + i))
+                .mapToObj(i -> createRow(i, "row_data_" + i))
                 .collect(toImmutableList()));
         assertRoundTrip(IntStream.range(0, 5)
-                .mapToObj(i -> createTuple(i, "row_data"))
+                .mapToObj(i -> createRow(i, "row_data"))
                 .collect(toImmutableList()));
         assertRoundTrip(IntStream.range(0, 20)
-                .mapToObj(i -> createTuple(i, ""))
+                .mapToObj(i -> createRow(i, ""))
                 .collect(toImmutableList()));
         assertRoundTrip(IntStream.range(0, 20)
-                .mapToObj(i -> createTuple(0, ""))
+                .mapToObj(i -> createRow(0, ""))
                 .collect(toImmutableList()));
     }
 
     @Test
     public void testBuilderFull()
     {
-        PrestoSparkRowBatchBuilder builder = PrestoSparkRowBatch.builder(10, 5, 10);
+        PrestoSparkRowBatchBuilder builder = PrestoSparkRowBatch.builder(
+                10,
+                5,
+                10,
+                NO_TARGET_ENTRY_SIZE_REQUIREMENT,
+                UNLIMITED_MAX_ENTRY_SIZE,
+                UNLIMITED_MAX_ENTRY_ROW_COUNT);
         assertFalse(builder.isFull());
         assertTrue(builder.isEmpty());
-        addRow(createTuple(1, "12345"), builder);
+        addRow(builder, createRow(1, "12345"));
         assertTrue(builder.isFull());
         assertFalse(builder.isEmpty());
     }
@@ -73,151 +109,391 @@ public class TestPrestoSparkRowBatch
     @Test
     public void testReplicatedRows()
     {
-        PrestoSparkRowBatchBuilder builder = PrestoSparkRowBatch.builder(1);
-        addReplicatedRow(createRow("replicated"), builder);
-        assertContains(builder.build(), ImmutableList.of(createTuple(0, "replicated")));
-
-        builder = PrestoSparkRowBatch.builder(2);
-        addReplicatedRow(createRow("replicated"), builder);
-        assertContains(builder.build(), ImmutableList.of(createTuple(1, "replicated"), createTuple(0, "replicated")));
-
-        builder = PrestoSparkRowBatch.builder(3);
-        addReplicatedRow(createRow("replicated"), builder);
-        assertContains(builder.build(), ImmutableList.of(createTuple(2, "replicated"), createTuple(1, "replicated"), createTuple(0, "replicated")));
-
-        builder = PrestoSparkRowBatch.builder(2);
-        addReplicatedRow(createRow("replicated"), builder);
-        addRow(createTuple(101, "non_replicated_1"), builder);
-        assertContains(builder.build(), ImmutableList.of(
-                createTuple(1, "replicated"),
-                createTuple(0, "replicated"),
-                createTuple(101, "non_replicated_1")));
-
-        builder = PrestoSparkRowBatch.builder(2);
-        addRow(createTuple(202, "non_replicated_22"), builder);
-        addReplicatedRow(createRow("replicated"), builder);
-        assertContains(builder.build(), ImmutableList.of(
-                createTuple(202, "non_replicated_22"),
-                createTuple(1, "replicated"),
-                createTuple(0, "replicated")));
-
-        builder = PrestoSparkRowBatch.builder(2);
-        addRow(createTuple(202, "non_replicated_22"), builder);
-        addReplicatedRow(createRow("replicated"), builder);
-        addRow(createTuple(101, "non_replicated_1"), builder);
-        assertContains(builder.build(), ImmutableList.of(
-                createTuple(202, "non_replicated_22"),
-                createTuple(1, "replicated"),
-                createTuple(0, "replicated"),
-                createTuple(101, "non_replicated_1")));
-
-        builder = PrestoSparkRowBatch.builder(2);
-        addRow(createTuple(202, "non_replicated_22"), builder);
-        addReplicatedRow(createRow("replicated"), builder);
-        addReplicatedRow(createRow("replicated"), builder);
-        addRow(createTuple(101, "non_replicated_1"), builder);
-        assertContains(builder.build(), ImmutableList.of(
-                createTuple(202, "non_replicated_22"),
-                createTuple(1, "replicated"),
-                createTuple(0, "replicated"),
-                createTuple(1, "replicated"),
-                createTuple(0, "replicated"),
-                createTuple(101, "non_replicated_1")));
+        assertRoundTrip(
+                ImmutableList.of(
+                        createReplicatedRow("replicated")),
+                1,
+                ImmutableList.of(
+                        createRow(0, "replicated")));
+        assertRoundTrip(
+                ImmutableList.of(
+                        createReplicatedRow("replicated")),
+                2,
+                ImmutableList.of(
+                        createRow(0, "replicated"),
+                        createRow(1, "replicated")));
+        assertRoundTrip(
+                ImmutableList.of(
+                        createReplicatedRow("replicated")),
+                3,
+                ImmutableList.of(
+                        createRow(0, "replicated"),
+                        createRow(1, "replicated"),
+                        createRow(2, "replicated")));
+        assertRoundTrip(
+                ImmutableList.of(
+                        createReplicatedRow("replicated")),
+                3,
+                ImmutableList.of(
+                        createRow(0, "replicated"),
+                        createRow(1, "replicated"),
+                        createRow(2, "replicated")));
+        assertRoundTrip(
+                ImmutableList.of(
+                        createReplicatedRow("replicated"),
+                        createRow(1, "non_replicated_1")),
+                3,
+                ImmutableList.of(
+                        createRow(0, "replicated"),
+                        createRow(1, "replicated"),
+                        createRow(2, "replicated"),
+                        createRow(1, "non_replicated_1")));
+        assertRoundTrip(
+                ImmutableList.of(
+                        createRow(2, "non_replicated_22"),
+                        createReplicatedRow("replicated")),
+                3,
+                ImmutableList.of(
+                        createRow(0, "replicated"),
+                        createRow(1, "replicated"),
+                        createRow(2, "replicated"),
+                        createRow(2, "non_replicated_22")));
+        assertRoundTrip(
+                ImmutableList.of(
+                        createRow(1, "non_replicated_22"),
+                        createReplicatedRow("replicated"),
+                        createRow(0, "non_replicated_1")),
+                2,
+                ImmutableList.of(
+                        createRow(0, "replicated"),
+                        createRow(1, "replicated"),
+                        createRow(1, "non_replicated_22"),
+                        createRow(0, "non_replicated_1")));
+        assertRoundTrip(
+                ImmutableList.of(
+                        createRow(1, "non_replicated_22"),
+                        createReplicatedRow("replicated1"),
+                        createReplicatedRow("replicated2"),
+                        createRow(0, "non_replicated_1")),
+                2,
+                ImmutableList.of(
+                        createRow(0, "replicated1"),
+                        createRow(1, "replicated1"),
+                        createRow(0, "replicated2"),
+                        createRow(1, "replicated2"),
+                        createRow(1, "non_replicated_22"),
+                        createRow(0, "non_replicated_1")));
     }
 
-    private static void assertRoundTrip(List<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> rows)
+    @Test
+    public void testRowIndex()
     {
-        PrestoSparkRowBatchBuilder builder = PrestoSparkRowBatch.builder(10);
+        assertRowIndex(new int[] {}, new int[][] {}, new int[] {});
+        assertRowIndex(new int[] {}, new int[][] {new int[] {}, new int[] {}}, new int[] {});
+        assertRowIndex(new int[] {0}, new int[][] {new int[] {0}, new int[] {}}, new int[] {});
+        assertRowIndex(new int[] {1}, new int[][] {new int[] {}, new int[] {0}}, new int[] {});
+        assertRowIndex(new int[] {0, 1}, new int[][] {new int[] {0}, new int[] {1}}, new int[] {});
+        assertRowIndex(new int[] {0, 1, 1, 0, 0, 1}, new int[][] {new int[] {0, 3, 4}, new int[] {1, 2, 5}}, new int[] {});
+        assertRowIndex(new int[] {0, 1, 1, 0, 0, 1}, new int[][] {new int[] {0, 3, 4}, new int[] {1, 2, 5}, new int[] {}}, new int[] {});
+        assertRowIndex(new int[] {0, 1, 1, 2, 0, 2, 0, 1, 2}, new int[][] {new int[] {0, 4, 6}, new int[] {1, 2, 7}, new int[] {3, 5, 8}}, new int[] {});
+        assertRowIndex(new int[] {1, 1, 1, 2, 1, 2, 1, 1, 2}, new int[][] {new int[] {}, new int[] {0, 1, 2, 4, 6, 7}, new int[] {3, 5, 8}}, new int[] {});
+        assertRowIndex(new int[] {-1}, new int[][] {}, new int[] {0});
+        assertRowIndex(new int[] {-1, -1}, new int[][] {}, new int[] {0, 1});
+        assertRowIndex(new int[] {0, 1, -1}, new int[][] {new int[] {0}, new int[] {1}}, new int[] {2});
+        assertRowIndex(new int[] {1, 1, 1, 2, -1, 1, 2, 1, 1, 2, -1}, new int[][] {new int[] {}, new int[] {0, 1, 2, 5, 7, 8}, new int[] {3, 6, 9}}, new int[] {4, 10});
+    }
+
+    @Test
+    public void testMultiRowEntries()
+    {
+        Row row01 = createRow(0, "p0_1");
+        Row row02 = createRow(0, "p0_11");
+        Row row03 = createRow(0, "p0_111");
+        Row row11 = createRow(1, "p1_1");
+        Row row21 = createRow(2, "p2_1");
+
+        List<Row> rows = ImmutableList.of(row01, row02, row03, row11, row21);
+
+        assertEntries(
+                rows,
+                3,
+                4,
+                UNLIMITED_MAX_ENTRY_SIZE,
+                UNLIMITED_MAX_ENTRY_ROW_COUNT,
+                ImmutableList.of(
+                        ImmutableList.of(row01),
+                        ImmutableList.of(row02),
+                        ImmutableList.of(row03),
+                        ImmutableList.of(row11),
+                        ImmutableList.of(row21)));
+        assertEntries(
+                rows,
+                3,
+                11,
+                UNLIMITED_MAX_ENTRY_SIZE,
+                UNLIMITED_MAX_ENTRY_ROW_COUNT,
+                ImmutableList.of(
+                        ImmutableList.of(row01, row02, row03),
+                        ImmutableList.of(row11),
+                        ImmutableList.of(row21)));
+        assertEntries(
+                rows,
+                3,
+                11,
+                UNLIMITED_MAX_ENTRY_ROW_COUNT,
+                2,
+                ImmutableList.of(
+                        ImmutableList.of(row01, row02),
+                        ImmutableList.of(row03),
+                        ImmutableList.of(row11),
+                        ImmutableList.of(row21)));
+        assertEntries(
+                rows,
+                3,
+                11,
+                18,
+                UNLIMITED_MAX_ENTRY_ROW_COUNT,
+                ImmutableList.of(
+                        ImmutableList.of(row01, row02),
+                        ImmutableList.of(row03),
+                        ImmutableList.of(row11),
+                        ImmutableList.of(row21)));
+        assertEntries(
+                rows,
+                4,
+                10,
+                0,
+                UNLIMITED_MAX_ENTRY_ROW_COUNT,
+                ImmutableList.of(
+                        ImmutableList.of(row01),
+                        ImmutableList.of(row02),
+                        ImmutableList.of(row03),
+                        ImmutableList.of(row11),
+                        ImmutableList.of(row21)));
+        assertEntries(
+                rows,
+                3,
+                10,
+                UNLIMITED_MAX_ENTRY_SIZE,
+                0,
+                ImmutableList.of(
+                        ImmutableList.of(row01),
+                        ImmutableList.of(row02),
+                        ImmutableList.of(row03),
+                        ImmutableList.of(row11),
+                        ImmutableList.of(row21)));
+    }
+
+    private static void assertRoundTrip(List<Row> rows)
+    {
+        // replicated rows are not allowed
+        assertThat(rows).allMatch(row -> row.getPartition() >= 0);
+        assertRoundTrip(rows, 20, rows);
+    }
+
+    private static void assertRoundTrip(List<Row> inputRows, int partitionCount, List<Row> expectedOutputRows)
+    {
+        PrestoSparkRowBatchBuilder singleRowEntryBuilder = PrestoSparkRowBatch.builder(
+                partitionCount,
+                DEFAULT_TARGET_SIZE,
+                DEFAULT_EXPECTED_ROWS,
+                0,
+                UNLIMITED_MAX_ENTRY_SIZE,
+                UNLIMITED_MAX_ENTRY_ROW_COUNT);
+        assertRoundTrip(singleRowEntryBuilder, inputRows, partitionCount, expectedOutputRows);
+
+        PrestoSparkRowBatchBuilder multiRowEntryBuilder = PrestoSparkRowBatch.builder(
+                partitionCount,
+                DEFAULT_TARGET_SIZE,
+                DEFAULT_EXPECTED_ROWS,
+                1024,
+                UNLIMITED_MAX_ENTRY_SIZE,
+                UNLIMITED_MAX_ENTRY_ROW_COUNT);
+        assertRoundTrip(multiRowEntryBuilder, inputRows, partitionCount, expectedOutputRows);
+    }
+
+    private static void assertRoundTrip(PrestoSparkRowBatchBuilder builder, List<Row> inputRows, int partitionCount, List<Row> expectedOutputRows)
+    {
+        assertThat(inputRows).allMatch(row -> row.getPartition() < partitionCount);
         assertTrue(builder.isEmpty());
-        rows.forEach(row -> addRow(row, builder));
+        for (Row row : inputRows) {
+            addRow(builder, row);
+        }
         assertFalse(builder.isFull());
         PrestoSparkRowBatch rowBatch = builder.build();
-        assertContains(rowBatch, rows);
+        assertContains(rowBatch, expectedOutputRows);
     }
 
-    private static void addRow(Tuple2<MutablePartitionId, PrestoSparkMutableRow> row, PrestoSparkRowBatchBuilder builder)
+    private static void assertEntries(
+            List<Row> rows,
+            int partitionCount,
+            int targetEntrySize,
+            int maxEntrySize,
+            int maxRowsPerEntry,
+            List<List<Row>> expectedEntries)
+    {
+        PrestoSparkRowBatchBuilder builder = PrestoSparkRowBatch.builder(
+                partitionCount,
+                DEFAULT_TARGET_SIZE,
+                DEFAULT_EXPECTED_ROWS,
+                targetEntrySize,
+                maxEntrySize,
+                maxRowsPerEntry);
+        assertTrue(builder.isEmpty());
+        for (Row row : rows) {
+            addRow(builder, row);
+        }
+        assertFalse(builder.isFull());
+
+        PrestoSparkRowBatch rowBatch = builder.build();
+
+        List<List<Row>> actualEntries = getEntries(rowBatch);
+        assertEquals(actualEntries, expectedEntries);
+    }
+
+    private static void addRow(PrestoSparkRowBatchBuilder builder, Row row)
     {
         SliceOutput output = builder.beginRowEntry();
-        ByteBuffer buffer = row._2.getBuffer();
-        output.writeBytes(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
-        builder.closeEntryForNonReplicatedRow(row._1.getPartition());
+        byte[] data = row.getData().getBytes(UTF_8);
+        int bufferSize = data.length + BYTES;
+        ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
+        buffer.order(LITTLE_ENDIAN);
+        buffer.putInt(data.length);
+        buffer.put(data);
+        output.writeBytes(buffer.array(), 0, bufferSize);
+        if (row.isReplicated()) {
+            builder.closeEntryForReplicatedRow();
+        }
+        else {
+            builder.closeEntryForNonReplicatedRow(row.getPartition());
+        }
     }
 
-    private static void addReplicatedRow(PrestoSparkMutableRow row, PrestoSparkRowBatchBuilder builder)
+    private static void assertContains(PrestoSparkRowBatch rowBatch, List<Row> expected)
     {
-        SliceOutput output = builder.beginRowEntry();
-        ByteBuffer buffer = row.getBuffer();
-        output.writeBytes(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
-        builder.closeEntryForReplicatedRow();
+        List<List<Row>> entries = getEntries(rowBatch);
+        List<Row> rows = entries.stream()
+                .flatMap(List::stream)
+                .collect(toImmutableList());
+        assertThat(rows)
+                .containsExactlyInAnyOrder(expected.toArray(new Row[0]));
     }
 
-    private static Tuple2<MutablePartitionId, PrestoSparkMutableRow> createTuple(int partition, String data)
+    private static List<List<Row>> getEntries(PrestoSparkRowBatch rowBatch)
     {
-        MutablePartitionId mutablePartitionId = new MutablePartitionId();
-        mutablePartitionId.setPartition(partition);
-        return new Tuple2<>(mutablePartitionId, createRow(data));
-    }
-
-    private static PrestoSparkMutableRow createRow(String data)
-    {
-        PrestoSparkMutableRow mutableRow = new PrestoSparkMutableRow();
-        mutableRow.setBuffer(ByteBuffer.wrap(data.getBytes(UTF_8)));
-        return mutableRow;
-    }
-
-    private static void assertContains(PrestoSparkRowBatch rowBatch, List<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> expected)
-    {
+        ImmutableList.Builder<List<Row>> entries = ImmutableList.builder();
         RowTupleSupplier rowTupleSupplier = rowBatch.createRowTupleSupplier();
-        ImmutableList.Builder<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> actual = ImmutableList.builder();
         while (true) {
             Tuple2<MutablePartitionId, PrestoSparkMutableRow> next = rowTupleSupplier.getNext();
             if (next == null) {
                 break;
             }
-            actual.add(copy(next));
+            ImmutableList.Builder<Row> entry = ImmutableList.builder();
+            int partition = next._1.getPartition();
+            PrestoSparkMutableRow mutableRow = next._2;
+            ByteBuffer buffer = mutableRow.getBuffer();
+            buffer.order(LITTLE_ENDIAN);
+            short rowCount = buffer.getShort();
+            assertEquals(mutableRow.getPositionCount(), rowCount);
+            for (int i = 0; i < rowCount; i++) {
+                entry.add(new Row(partition, readRowData(buffer)));
+            }
+            entries.add(entry.build());
         }
-        assertTupleEquals(actual.build(), expected);
+        return entries.build();
     }
 
-    private static void assertTupleEquals(
-            List<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> actual,
-            List<Tuple2<MutablePartitionId, PrestoSparkMutableRow>> expected)
+    private static String readRowData(ByteBuffer buffer)
     {
-        assertEquals(actual.size(), expected.size());
-        for (int i = 0; i < actual.size(); i++) {
-            assertTupleEquals(actual.get(i), expected.get(i));
+        int size = buffer.getInt();
+        String data = new String(buffer.array(), buffer.arrayOffset() + buffer.position(), size, UTF_8);
+        buffer.position(buffer.position() + size);
+        return data;
+    }
+
+    private static Row createRow(int partition, String data)
+    {
+        return new Row(partition, data);
+    }
+
+    private static Row createReplicatedRow(String data)
+    {
+        return new Row(REPLICATED_ROW_PARTITION_ID, data);
+    }
+
+    private static class Row
+    {
+        private final int partition;
+        private final String data;
+
+        private Row(int partition, String data)
+        {
+            this.partition = partition;
+            this.data = requireNonNull(data, "data is null");
+        }
+
+        public int getPartition()
+        {
+            return partition;
+        }
+
+        public String getData()
+        {
+            return data;
+        }
+
+        public boolean isReplicated()
+        {
+            return partition == REPLICATED_ROW_PARTITION_ID;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Row row = (Row) o;
+            return partition == row.partition &&
+                    Objects.equals(data, row.data);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(partition, data);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("partition", partition)
+                    .add("data", data)
+                    .toString();
         }
     }
 
-    private static void assertTupleEquals(Tuple2<MutablePartitionId, PrestoSparkMutableRow> actual, Tuple2<MutablePartitionId, PrestoSparkMutableRow> expected)
+    private static void assertRowIndex(int[] partitions, int[][] expected, int[] expectedReplicated)
     {
-        assertEquals(actual._1.getPartition(), expected._1.getPartition());
-        ByteBuffer actualBuffer = actual._2.getBuffer();
-        String actualData = new String(actualBuffer.array(), actualBuffer.arrayOffset() + actualBuffer.position(), actualBuffer.remaining());
-        ByteBuffer expectedBuffer = expected._2.getBuffer();
-        String expectedData = new String(expectedBuffer.array(), expectedBuffer.arrayOffset() + expectedBuffer.position(), expectedBuffer.remaining());
-        assertEquals(actualData, expectedData);
-    }
+        RowIndex rowIndex = RowIndex.create(partitions.length, expected.length, partitions);
+        int[][] actual = new int[expected.length][];
+        for (int partition = 0; partition < expected.length; partition++) {
+            IntArrayList partitionRows = new IntArrayList();
+            while (rowIndex.hasNextRow(partition)) {
+                partitionRows.add(rowIndex.nextRow(partition));
+            }
+            actual[partition] = partitionRows.toIntArray();
+        }
+        assertThat(actual).isEqualTo(expected);
 
-    private static Tuple2<MutablePartitionId, PrestoSparkMutableRow> copy(Tuple2<MutablePartitionId, PrestoSparkMutableRow> tuple)
-    {
-        return new Tuple2<>(copy(tuple._1), copy(tuple._2));
-    }
-
-    private static PrestoSparkMutableRow copy(PrestoSparkMutableRow mutableRow)
-    {
-        PrestoSparkMutableRow copy = new PrestoSparkMutableRow();
-        ByteBuffer bufferCopy = ByteBuffer.allocate(mutableRow.getBuffer().remaining());
-        bufferCopy.put(mutableRow.getBuffer());
-        bufferCopy.position(0);
-        copy.setBuffer(bufferCopy);
-        return copy;
-    }
-
-    private static MutablePartitionId copy(MutablePartitionId mutablePartitionId)
-    {
-        MutablePartitionId copy = new MutablePartitionId();
-        copy.setPartition(mutablePartitionId.getPartition());
-        return copy;
+        IntArrayList replicatedRows = new IntArrayList();
+        while (rowIndex.hasNextRow(REPLICATED_ROW_PARTITION_ID)) {
+            replicatedRows.add(rowIndex.nextRow(REPLICATED_ROW_PARTITION_ID));
+        }
+        assertThat(replicatedRows.toIntArray()).isEqualTo(expectedReplicated);
     }
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfInitializer.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfInitializer.java
@@ -38,7 +38,8 @@ public class PrestoSparkConfInitializer
                 PrestoSparkMutableRow.class,
                 PrestoSparkSerializedPage.class,
                 SerializedPrestoSparkTaskDescriptor.class,
-                SerializedTaskInfo.class
+                SerializedTaskInfo.class,
+                PrestoSparkShuffleStats.class
         });
     }
 

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMutableRow.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMutableRow.java
@@ -38,6 +38,8 @@ public class PrestoSparkMutableRow
     private int offset;
     private int length;
 
+    private int positionCount;
+
     public ByteBuffer getBuffer()
     {
         return buffer;
@@ -81,6 +83,11 @@ public class PrestoSparkMutableRow
         return this;
     }
 
+    public void setPositionCount(int positionCount)
+    {
+        this.positionCount = positionCount;
+    }
+
     @Override
     public void write(Kryo kryo, Output output)
     {
@@ -113,9 +120,9 @@ public class PrestoSparkMutableRow
     }
 
     @Override
-    public long getRowCount()
+    public long getPositionCount()
     {
-        return 1;
+        return positionCount;
     }
 
     @Override

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkSerializedPage.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkSerializedPage.java
@@ -38,7 +38,8 @@ public class PrestoSparkSerializedPage
         return bytes;
     }
 
-    public int getPositionCount()
+    @Override
+    public long getPositionCount()
     {
         return positionCount;
     }
@@ -51,12 +52,6 @@ public class PrestoSparkSerializedPage
     public byte getPageCodecMarkers()
     {
         return pageCodecMarkers;
-    }
-
-    @Override
-    public long getRowCount()
-    {
-        return positionCount;
     }
 
     @Override

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkShuffleStats.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkShuffleStats.java
@@ -27,6 +27,7 @@ public class PrestoSparkShuffleStats
     private final int taskId;
     private final Operation operation;
     private final long processedRows;
+    private final long processedRowBatches;
     private final long processedBytes;
     private final long elapsedWallTimeMills;
 
@@ -35,6 +36,7 @@ public class PrestoSparkShuffleStats
             int taskId,
             Operation operation,
             long processedRows,
+            long processedRowBatches,
             long processedBytes,
             long elapsedWallTimeMills)
     {
@@ -43,6 +45,8 @@ public class PrestoSparkShuffleStats
         this.operation = requireNonNull(operation, "operation is null");
         checkArgument(processedRows >= 0, "processedRows must be greater than or equal to zero: %s", processedRows);
         this.processedRows = processedRows;
+        checkArgument(processedRowBatches >= 0, "processedRowBatches must be greater than or equal to zero: %s", processedRowBatches);
+        this.processedRowBatches = processedRowBatches;
         checkArgument(processedBytes >= 0, "processedBytes must be greater than or equal to zero: %s", processedBytes);
         this.processedBytes = processedBytes;
         checkArgument(elapsedWallTimeMills >= 0, "elapsedWallTimeMills must be greater than or equal to zero: %s", elapsedWallTimeMills);
@@ -67,6 +71,11 @@ public class PrestoSparkShuffleStats
     public long getProcessedRows()
     {
         return processedRows;
+    }
+
+    public long getProcessedRowBatches()
+    {
+        return processedRowBatches;
     }
 
     public long getProcessedBytes()

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskOutput.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskOutput.java
@@ -15,7 +15,7 @@ package com.facebook.presto.spark.classloader_interface;
 
 public interface PrestoSparkTaskOutput
 {
-    long getRowCount();
+    long getPositionCount();
 
     long getSize();
 }


### PR DESCRIPTION
Producing tiny rows to the shuffle has significant performance implications, as the shuffle algorithm has non zero cost of appending a row. By grouping multiple rows for a single partition together into a single row batch increases shuffle efficiency and allows to achieve higher shuffle throughput.

```
== NO RELEASE NOTE ==
```
