### PR TITLE
Upgrade joda-time to 2.10.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.drift.version>1.25</dep.drift.version>
-        <dep.joda.version>2.10.5</dep.joda.version>
+        <dep.joda.version>2.10.6</dep.joda.version>
         <dep.tempto.version>1.50</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>

--- a/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
+++ b/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
@@ -2236,3 +2236,4 @@
 2227 Asia/Famagusta
 2228 Europe/Saratov
 2229 Asia/Qostanay
+2230 America/Nuuk

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimeZoneKey.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimeZoneKey.java
@@ -213,7 +213,7 @@ public class TestTimeZoneKey
             hasher.putString(timeZoneKey.getId(), StandardCharsets.UTF_8);
         }
         // Zone file should not (normally) be changed, so let's make this more difficult
-        assertEquals(hasher.hash().asLong(), -972834036790299986L, "zone-index.properties file contents changed!");
+        assertEquals(hasher.hash().asLong(), -3809591333307967388L, "zone-index.properties file contents changed!");
     }
 
     public void assertTimeZoneNotSupported(String zoneId)


### PR DESCRIPTION
TZ database added `America/Nuuk` timezone in [2020a release](https://data.iana.org/time-zones/tzdb/NEWS) and on systems with `2020a` version of tz database and `2.10.5` version of `joda-time`, the `com.facebook.presto.util.TestTimeZoneUtils:test` test fails (the stack trace of the failure included below). Upgrading `joda-time` and adding the new timezone to `zone-index.properties` makes the tests pass and presto build on my system (Linux Mint 19.1 with tz database 2020a).

```
com.facebook.presto.common.type.TimeZoneNotSupportedException: Time zone not supported: America/Nuuk
	at com.facebook.presto.common.type.TimeZoneKey.getTimeZoneKey(TimeZoneKey.java:131)
	at com.facebook.presto.common.type.DateTimeEncoding.packDateTimeWithZone(DateTimeEncoding.java:36)
	at com.facebook.presto.util.DateTimeZoneIndex.packDateTimeWithZone(DateTimeZoneIndex.java:79)
	at com.facebook.presto.util.TestTimeZoneUtils.assertTimeZone(TestTimeZoneUtils.java:70)
	at com.facebook.presto.util.TestTimeZoneUtils.test(TestTimeZoneUtils.java:57)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1177)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
``` 

```
== RELEASE NOTES ==

General Changes
* Upgrade joda-time to 2.10.6
```
